### PR TITLE
2026 02 21 accelerate ci

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -17,9 +17,7 @@ Checks: "-*,\
   cert-err58-cpp,\
   cert-msc30-c,\
   cert-msc50-cpp,\
-  clang-analyzer-core.NullDereference,\
-  clang-analyzer-core.StackAddressEscape,\
-  clang-analyzer-deadcode.DeadStores,\
+  clang-analyzer-*,\
   clang-diagnostic-*,\
   -clang-diagnostic-missing-designated-field-initializers,\
   concurrency-mt-unsafe,\

--- a/.github/actions/setup-ccache/action.yml
+++ b/.github/actions/setup-ccache/action.yml
@@ -1,0 +1,49 @@
+name: setup-ccache
+description: Setup ccache for faster C++ compilation caching
+inputs:
+  cache-key-prefix:
+    description: Unique prefix for the cache key (e.g., 'build-linux')
+    required: true
+  portable:
+    description: Set PORTABLE=1 to disable -march=native (set to "false" for jobs linking pre-built Folly)
+    required: false
+    default: "true"
+runs:
+  using: composite
+  steps:
+    - name: Set ccache environment variables
+      run: |
+        echo "CCACHE_DIR=${{ github.workspace }}/.ccache" >> $GITHUB_ENV
+        echo "CCACHE_BASEDIR=${{ github.workspace }}" >> $GITHUB_ENV
+        echo "CCACHE_NOHASHDIR=true" >> $GITHUB_ENV
+        if [ "${{ inputs.portable }}" = "true" ]; then
+          echo "PORTABLE=1" >> $GITHUB_ENV
+        fi
+      shell: bash
+    - name: Restore ccache
+      uses: actions/cache@v4
+      with:
+        path: ${{ github.workspace }}/.ccache
+        key: ccache-${{ inputs.cache-key-prefix }}-${{ github.head_ref || github.ref }}-${{ github.sha }}
+        restore-keys: |-
+          ccache-${{ inputs.cache-key-prefix }}-${{ github.head_ref || github.ref }}-
+          ccache-${{ inputs.cache-key-prefix }}-refs/heads/main-
+    - name: Install ccache
+      run: |
+        if [ "$RUNNER_OS" = "macOS" ]; then
+          which ccache || brew install ccache
+        else
+          which ccache || (apt-get update && apt-get install -y ccache)
+        fi
+      shell: bash
+    - name: Add ccache to PATH
+      run: |
+        if [ "$RUNNER_OS" = "macOS" ]; then
+          echo "$(brew --prefix ccache)/libexec" >> $GITHUB_PATH
+        else
+          echo "/usr/lib/ccache" >> $GITHUB_PATH
+        fi
+      shell: bash
+    - name: Zero ccache stats
+      run: ccache -z
+      shell: bash

--- a/.github/actions/windows-build-steps/action.yml
+++ b/.github/actions/windows-build-steps/action.yml
@@ -4,16 +4,15 @@ runs:
   steps:
   - name: Add msbuild to PATH
     uses: microsoft/setup-msbuild@v1.3.1
-  - name: Cache ccache directory
-    id: ccache-cache
-    uses: actions/cache@v4
-    with:
-      path: C:\a\rocksdb\rocksdb\.ccache
-      key: rocksdb-build-${{ runner.os }}-${{ runner.arch }}-ccache-${{ hashFiles('CMakeLists.txt', 'cmake/**/*.cmake') }}-v1
   - name: ccache
     uses: hendrikmuhs/ccache-action@v1.2
     with:
       max-size: "10GB"
+  - name: Configure ccache
+    shell: pwsh
+    run: |
+      ccache --set-config=base_dir=C:\a\rocksdb\rocksdb
+      ccache --set-config=hash_dir=false
   - name: Custom steps
     env:
       THIRDPARTY_HOME: ${{ github.workspace }}/thirdparty

--- a/.github/workflows/pr-jobs.yml
+++ b/.github/workflows/pr-jobs.yml
@@ -92,7 +92,14 @@ jobs:
     steps:
     - uses: actions/checkout@v4.1.0
     - uses: "./.github/actions/pre-steps"
+    - uses: "./.github/actions/setup-ccache"
+      with:
+        cache-key-prefix: build-linux
     - run: make V=1 J=32 -j32 check
+    - name: Print ccache stats
+      run: ccache -s
+      if: always()
+      shell: bash
     - uses: "./.github/actions/post-steps"
   build-linux-cmake-mingw:
     if: needs.config.outputs.only_job == 'build-linux-cmake-mingw' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
@@ -105,6 +112,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4.1.0
     - uses: "./.github/actions/pre-steps"
+    - uses: "./.github/actions/setup-ccache"
+      with:
+        cache-key-prefix: cmake-mingw
     - run: update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix
     - name: Build cmake-mingw
       run: |-
@@ -113,12 +123,16 @@ jobs:
         which java && java -version
         which javac && javac -version
         mkdir build && cd build && cmake -DJNI=1 -DWITH_GFLAGS=OFF .. -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++ -DCMAKE_SYSTEM_NAME=Windows && make -j4 rocksdb rocksdbjni
+    - name: Print ccache stats
+      run: ccache -s
+      if: always()
+      shell: bash
     - uses: "./.github/actions/post-steps"
   build-linux-make-with-folly:
     if: needs.config.outputs.only_job == 'build-linux-make-with-folly' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
-      labels: 16-core-ubuntu
+      labels: 32-core-ubuntu
     container:
       image: ghcr.io/facebook/rocksdb_ubuntu:22.1
       options: --shm-size=16gb
@@ -127,12 +141,20 @@ jobs:
     - uses: "./.github/actions/pre-steps"
     - uses: "./.github/actions/cache-getdeps-downloads"
     - uses: "./.github/actions/setup-folly"
+    - uses: "./.github/actions/setup-ccache"
+      with:
+        cache-key-prefix: make-with-folly
+        portable: "false"
     - uses: "./.github/actions/cache-folly"
       id: cache-folly
     - uses: "./.github/actions/build-folly"
       with:
         cache-hit: ${{ steps.cache-folly.outputs.cache-hit }}
-    - run: USE_FOLLY=1 LIB_MODE=static V=1 make -j32 check
+    - run: USE_FOLLY=1 LIB_MODE=static V=1 make -j64 check
+    - name: Print ccache stats
+      run: ccache -s
+      if: always()
+      shell: bash
     - uses: "./.github/actions/post-steps"
   build-linux-make-with-folly-lite-no-test:
     if: needs.config.outputs.only_job == 'build-linux-make-with-folly-lite-no-test' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
@@ -147,13 +169,20 @@ jobs:
     - uses: "./.github/actions/pre-steps"
     - uses: "./.github/actions/cache-getdeps-downloads"
     - uses: "./.github/actions/setup-folly"
+    - uses: "./.github/actions/setup-ccache"
+      with:
+        cache-key-prefix: make-folly-lite
     - run: USE_FOLLY_LITE=1 EXTRA_CXXFLAGS=-DGLOG_USE_GLOG_EXPORT V=1 make -j32 all
+    - name: Print ccache stats
+      run: ccache -s
+      if: always()
+      shell: bash
     - uses: "./.github/actions/post-steps"
   build-linux-cmake-with-folly-coroutines:
     if: needs.config.outputs.only_job == 'build-linux-cmake-with-folly-coroutines' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
-      labels: 16-core-ubuntu
+      labels: 32-core-ubuntu
     container:
       image: ghcr.io/facebook/rocksdb_ubuntu:22.1
       options: --shm-size=16gb
@@ -162,12 +191,20 @@ jobs:
     - uses: "./.github/actions/pre-steps"
     - uses: "./.github/actions/cache-getdeps-downloads"
     - uses: "./.github/actions/setup-folly"
+    - uses: "./.github/actions/setup-ccache"
+      with:
+        cache-key-prefix: cmake-folly-coroutines
+        portable: "false"
     - uses: "./.github/actions/cache-folly"
       id: cache-folly
     - uses: "./.github/actions/build-folly"
       with:
         cache-hit: ${{ steps.cache-folly.outputs.cache-hit }}
-    - run: "(mkdir build && cd build && cmake -DUSE_COROUTINES=1 -DWITH_GFLAGS=1 -DROCKSDB_BUILD_SHARED=0 .. && make VERBOSE=1 -j20 && ctest -j20)"
+    - run: "(mkdir build && cd build && cmake -DUSE_COROUTINES=1 -DWITH_GFLAGS=1 -DROCKSDB_BUILD_SHARED=0 .. && make VERBOSE=1 -j64 && ctest -j64)"
+    - name: Print ccache stats
+      run: ccache -s
+      if: always()
+      shell: bash
     - uses: "./.github/actions/post-steps"
   build-linux-cmake-with-benchmark-no-thread-status:
     if: needs.config.outputs.only_job == 'build-linux-cmake-with-benchmark-no-thread-status' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
@@ -180,7 +217,14 @@ jobs:
     steps:
     - uses: actions/checkout@v4.1.0
     - uses: "./.github/actions/pre-steps"
+    - uses: "./.github/actions/setup-ccache"
+      with:
+        cache-key-prefix: cmake-benchmark
     - run: mkdir build && cd build && cmake -DWITH_GFLAGS=1 -DWITH_BENCHMARK=1 -DCMAKE_CXX_FLAGS=-DNROCKSDB_THREAD_STATUS .. && make VERBOSE=1 -j20 && ctest -j20
+    - name: Print ccache stats
+      run: ccache -s
+      if: always()
+      shell: bash
     - uses: "./.github/actions/post-steps"
   build-linux-encrypted_env-no_compression:
     if: needs.config.outputs.only_job == 'build-linux-encrypted_env-no_compression' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
@@ -193,8 +237,15 @@ jobs:
     steps:
     - uses: actions/checkout@v4.1.0
     - uses: "./.github/actions/pre-steps"
+    - uses: "./.github/actions/setup-ccache"
+      with:
+        cache-key-prefix: encrypted-env-no-compression
     - run: ENCRYPTED_ENV=1 ROCKSDB_DISABLE_SNAPPY=1 ROCKSDB_DISABLE_ZLIB=1 ROCKSDB_DISABLE_BZIP=1 ROCKSDB_DISABLE_LZ4=1 ROCKSDB_DISABLE_ZSTD=1 make V=1 J=32 -j32 check
     - run: "./sst_dump --help | grep -E -q 'Supported built-in compression types: kNoCompression$' # Verify no compiled in compression\n"
+    - name: Print ccache stats
+      run: ccache -s
+      if: always()
+      shell: bash
     - uses: "./.github/actions/post-steps"
   # ======================== Linux No Test Runs ======================= #
   build-linux-release:
@@ -207,6 +258,9 @@ jobs:
       options: --shm-size=16gb
     steps:
     - uses: actions/checkout@v4.1.0
+    - uses: "./.github/actions/setup-ccache"
+      with:
+        cache-key-prefix: release
     - run: make V=1 -j32 LIB_MODE=shared release
     - run: ls librocksdb.so
     - run: "./trace_analyzer --version" # A tool dependent on gflags that can run in release build
@@ -223,6 +277,10 @@ jobs:
     - run: USE_RTTI=1 make V=1 -j32 release
     - run: ls librocksdb.a
     - run: if ./trace_analyzer --version; then false; else true; fi
+    - name: Print ccache stats
+      run: ccache -s
+      if: always()
+      shell: bash
     - uses: "./.github/actions/post-steps"
   build-linux-clang-13-no_test_run:
     if: needs.config.outputs.only_job == 'build-linux-clang-13-no_test_run' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
@@ -235,11 +293,18 @@ jobs:
     steps:
     - uses: actions/checkout@v4.1.0
     - uses: "./.github/actions/pre-steps"
+    - uses: "./.github/actions/setup-ccache"
+      with:
+        cache-key-prefix: clang-13
     # FIXME: get back to "all microbench" targets
     - run: CC=clang-13 CXX=clang++-13 USE_CLANG=1 EXTRA_CXXFLAGS=-stdlib=libc++ EXTRA_LDFLAGS=-stdlib=libc++ make -j32 shared_lib
     - run: make clean
     # FIXME: get back to "release" target
     - run: CC=clang-13 CXX=clang++-13 USE_CLANG=1 EXTRA_CXXFLAGS=-stdlib=libc++ EXTRA_LDFLAGS=-stdlib=libc++ DEBUG_LEVEL=0 make -j32 shared_lib
+    - name: Print ccache stats
+      run: ccache -s
+      if: always()
+      shell: bash
     - uses: "./.github/actions/post-steps"
   build-linux-clang-18-no_test_run:
     if: needs.config.outputs.only_job == 'build-linux-clang-18-no_test_run' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
@@ -252,9 +317,16 @@ jobs:
     steps:
     - uses: actions/checkout@v4.1.0
     - uses: "./.github/actions/pre-steps"
+    - uses: "./.github/actions/setup-ccache"
+      with:
+        cache-key-prefix: clang-18
     - run: CC=clang-18 CXX=clang++-18 USE_CLANG=1 make -j32 all microbench
     - run: make clean
     - run: CC=clang-18 CXX=clang++-18 USE_CLANG=1 DEBUG_LEVEL=0 make -j32 release
+    - name: Print ccache stats
+      run: ccache -s
+      if: always()
+      shell: bash
     - uses: "./.github/actions/post-steps"
   build-linux-gcc-14-no_test_run:
     if: needs.config.outputs.only_job == 'build-linux-gcc-14-no_test_run' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
@@ -267,30 +339,17 @@ jobs:
     steps:
     - uses: actions/checkout@v4.1.0
     - uses: "./.github/actions/pre-steps"
+    - uses: "./.github/actions/setup-ccache"
+      with:
+        cache-key-prefix: gcc-14
     - run: CC=gcc-14 CXX=g++-14 V=1 make -j32 all microbench
+    - name: Print ccache stats
+      run: ccache -s
+      if: always()
+      shell: bash
     - uses: "./.github/actions/post-steps"
 
   # ======================== Linux Other Checks ======================= #
-  build-linux-clang18-clang-analyze:
-    if: needs.config.outputs.only_job == 'build-linux-clang18-clang-analyze' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
-    needs: config
-    runs-on:
-      labels: 16-core-ubuntu
-    container:
-      image: ghcr.io/facebook/rocksdb_ubuntu:24.0
-      options: --shm-size=16gb
-    steps:
-    - uses: actions/checkout@v4.1.0
-    - uses: "./.github/actions/pre-steps"
-    - run: CC=clang-18 CXX=clang++-18 ROCKSDB_DISABLE_ALIGNED_NEW=1 CLANG_ANALYZER="/usr/bin/clang++-18" CLANG_SCAN_BUILD=scan-build-18 USE_CLANG=1 make V=1 -j32 analyze
-    - uses: "./.github/actions/post-steps"
-    - name: compress test report
-      run: tar -cvzf scan_build_report.tar.gz scan_build_report
-      if: failure()
-    - uses: actions/upload-artifact@v4.0.0
-      with:
-        name: scan-build-report
-        path: scan_build_report.tar.gz
 
   build-linux-unity-and-headers:
     if: needs.config.outputs.only_job == 'build-linux-unity-and-headers' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
@@ -303,9 +362,16 @@ jobs:
     steps:
     - uses: actions/checkout@v4.1.0
     - run: apt-get update -y && apt-get install -y libgflags-dev
+    - uses: "./.github/actions/setup-ccache"
+      with:
+        cache-key-prefix: unity-headers
     - name: Unity build
       run: make V=1 -j8 unity_test
     - run: make V=1 -j8 -k check-headers
+    - name: Print ccache stats
+      run: ccache -s
+      if: always()
+      shell: bash
     - uses: "./.github/actions/post-steps"
   build-linux-mini-crashtest:
     if: needs.config.outputs.only_job == 'build-linux-mini-crashtest' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
@@ -318,7 +384,14 @@ jobs:
     steps:
     - uses: actions/checkout@v4.1.0
     - uses: "./.github/actions/pre-steps"
+    - uses: "./.github/actions/setup-ccache"
+      with:
+        cache-key-prefix: mini-crashtest
     - run: ulimit -S -n `ulimit -H -n` && make V=1 -j8 CRASH_TEST_EXT_ARGS='--duration=960 --max_key=2500000' blackbox_crash_test_with_atomic_flush
+    - name: Print ccache stats
+      run: ccache -s
+      if: always()
+      shell: bash
     - uses: "./.github/actions/post-steps"
   # ======================= Linux with Sanitizers ===================== #
   build-linux-clang18-asan-ubsan:
@@ -332,7 +405,14 @@ jobs:
     steps:
     - uses: actions/checkout@v4.1.0
     - uses: "./.github/actions/pre-steps"
+    - uses: "./.github/actions/setup-ccache"
+      with:
+        cache-key-prefix: clang18-asan-ubsan
     - run: COMPILE_WITH_ASAN=1 COMPILE_WITH_UBSAN=1 CC=clang-18 CXX=clang++-18 ROCKSDB_DISABLE_ALIGNED_NEW=1 USE_CLANG=1 make V=1 -j40 check
+    - name: Print ccache stats
+      run: ccache -s
+      if: always()
+      shell: bash
     - uses: "./.github/actions/post-steps"
   build-linux-clang18-mini-tsan:
     if: needs.config.outputs.only_job == 'build-linux-clang18-mini-tsan' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
@@ -345,7 +425,14 @@ jobs:
     steps:
     - uses: actions/checkout@v4.1.0
     - uses: "./.github/actions/pre-steps"
+    - uses: "./.github/actions/setup-ccache"
+      with:
+        cache-key-prefix: clang18-tsan
     - run: COMPILE_WITH_TSAN=1 CC=clang-18 CXX=clang++-18 ROCKSDB_DISABLE_ALIGNED_NEW=1 USE_CLANG=1 make V=1 -j32 check
+    - name: Print ccache stats
+      run: ccache -s
+      if: always()
+      shell: bash
     - uses: "./.github/actions/post-steps"
   build-linux-static_lib-alt_namespace-status_checked:
     if: needs.config.outputs.only_job == 'build-linux-static_lib-alt_namespace-status_checked' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
@@ -358,7 +445,14 @@ jobs:
     steps:
     - uses: actions/checkout@v4.1.0
     - uses: "./.github/actions/pre-steps"
+    - uses: "./.github/actions/setup-ccache"
+      with:
+        cache-key-prefix: static-alt-namespace
     - run: ASSERT_STATUS_CHECKED=1 TEST_UINT128_COMPAT=1 ROCKSDB_MODIFY_NPHASH=1 LIB_MODE=static OPT="-DROCKSDB_USE_STD_SEMAPHORES -DROCKSDB_NAMESPACE=alternative_rocksdb_ns" make V=1 -j24 check
+    - name: Print ccache stats
+      run: ccache -s
+      if: always()
+      shell: bash
     - uses: "./.github/actions/post-steps"
   # ========================= MacOS build only ======================== #
   build-macos:
@@ -372,11 +466,18 @@ jobs:
     - uses: maxim-lobanov/setup-xcode@v1.6.0
       with:
         xcode-version: 16.4.0
+    - uses: "./.github/actions/setup-ccache"
+      with:
+        cache-key-prefix: macos
     - uses: "./.github/actions/increase-max-open-files-on-macos"
     - uses: "./.github/actions/install-gflags-on-macos"
     - uses: "./.github/actions/pre-steps-macos"
     - name: Build
       run: ulimit -S -n `ulimit -H -n` && make V=1 J=16 -j8 all
+    - name: Print ccache stats
+      run: ccache -s
+      if: always()
+      shell: bash
     - uses: "./.github/actions/post-steps"
   # ========================= MacOS with Tests ======================== #
   build-macos-cmake:
@@ -391,6 +492,9 @@ jobs:
     - uses: maxim-lobanov/setup-xcode@v1.6.0
       with:
         xcode-version: 16.4.0
+    - uses: "./.github/actions/setup-ccache"
+      with:
+        cache-key-prefix: macos-cmake
     - uses: "./.github/actions/increase-max-open-files-on-macos"
     - uses: "./.github/actions/install-gflags-on-macos"
     - uses: "./.github/actions/pre-steps-macos"
@@ -410,6 +514,10 @@ jobs:
     - name: Run shard 3 out of 4 test shards
       run: ulimit -S -n `ulimit -H -n` && cd build && ctest -j8 -I 3,,4
       if: ${{ matrix.run_sharded_tests == 3 }}
+    - name: Print ccache stats
+      run: ccache -s
+      if: always()
+      shell: bash
     - uses: "./.github/actions/post-steps"
   # ======================== Windows with Tests ======================= #
   # NOTE: some windows jobs are in "nightly" to save resources
@@ -433,29 +541,22 @@ jobs:
       image: ghcr.io/facebook/rocksdb_ubuntu:22.1
       options: --shm-size=16gb
     steps:
-    # The docker image is intentionally based on an OS that has an older GLIBC version.
-    # That GLIBC is incompatibile with GitHub's actions/checkout. Thus we implement a manual checkout step.
-    # NOTE: replaced evolvedbinary/rocksjava:centos7_x64-be with ghcr.io/facebook/rocksdb_ubuntu:22.1
-    # until a more appropriate docker image with C++20 support is made.
-    - name: Checkout
-      env:
-        GH_TOKEN: ${{ github.token }}
-      run: |
-        chown `whoami` . || true
-        git clone --no-checkout https://oath2:$GH_TOKEN@github.com/${{ github.repository }}.git .
-        git -c protocol.version=2 fetch --update-head-ok --no-tags --prune --no-recurse-submodules --depth=1 origin +${{ github.sha }}:${{ github.ref }}
-        git checkout --progress --force ${{ github.ref }}
-        git log -1 --format='%H'
+    - uses: actions/checkout@v4.1.0
     - uses: "./.github/actions/pre-steps"
+    - uses: "./.github/actions/setup-ccache"
+      with:
+        cache-key-prefix: java
     - name: Set Java Environment
       run: |-
         echo "JAVA_HOME=${JAVA_HOME}"
         which java && java -version
         which javac && javac -version
     - name: Test RocksDBJava
-    # NOTE: replaced scl enable devtoolset-7 'make V=1 J=8 -j8 jtest'
       run: make V=1 J=8 -j8 jtest
-    # post-steps skipped because of compatibility issues with docker image
+    - name: Print ccache stats
+      run: ccache -s
+      if: always()
+      shell: bash
   build-linux-java-static:
     if: needs.config.outputs.only_job == 'build-linux-java-static' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
@@ -465,29 +566,22 @@ jobs:
       image: ghcr.io/facebook/rocksdb_ubuntu:22.1
       options: --shm-size=16gb
     steps:
-    # The docker image is intentionally based on an OS that has an older GLIBC version.
-    # That GLIBC is incompatibile with GitHub's actions/checkout. Thus we implement a manual checkout step.
-    # NOTE: replaced evolvedbinary/rocksjava:centos7_x64-be with ghcr.io/facebook/rocksdb_ubuntu:22.1
-    # until a more appropriate docker image with C++20 support is made.
-    - name: Checkout
-      env:
-        GH_TOKEN: ${{ github.token }}
-      run: |
-        chown `whoami` . || true
-        git clone --no-checkout https://oath2:$GH_TOKEN@github.com/${{ github.repository }}.git .
-        git -c protocol.version=2 fetch --update-head-ok --no-tags --prune --no-recurse-submodules --depth=1 origin +${{ github.sha }}:${{ github.ref }}
-        git checkout --progress --force ${{ github.ref }}
-        git log -1 --format='%H'
+    - uses: actions/checkout@v4.1.0
     - uses: "./.github/actions/pre-steps"
+    - uses: "./.github/actions/setup-ccache"
+      with:
+        cache-key-prefix: java-static
     - name: Set Java Environment
       run: |-
         echo "JAVA_HOME=${JAVA_HOME}"
         which java && java -version
         which javac && javac -version
     - name: Build RocksDBJava Static Library
-    # NOTE: replaced scl enable devtoolset-7 'make V=1 J=8 -j8 rocksdbjavastatic'
       run: make V=1 J=8 -j8 rocksdbjavastatic
-    # post-steps skipped because of compatibility issues with docker image
+    - name: Print ccache stats
+      run: ccache -s
+      if: always()
+      shell: bash
   build-macos-java:
     if: needs.config.outputs.only_job == 'build-macos-java' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
@@ -500,6 +594,9 @@ jobs:
     - uses: maxim-lobanov/setup-xcode@v1.6.0
       with:
         xcode-version: 16.4.0
+    - uses: "./.github/actions/setup-ccache"
+      with:
+        cache-key-prefix: macos-java
     - uses: "./.github/actions/increase-max-open-files-on-macos"
     - uses: "./.github/actions/install-gflags-on-macos"
     - uses: "./.github/actions/install-jdk8-on-macos"
@@ -511,6 +608,10 @@ jobs:
         which javac && javac -version
     - name: Test RocksDBJava
       run: make V=1 J=16 -j16 jtest
+    - name: Print ccache stats
+      run: ccache -s
+      if: always()
+      shell: bash
     - uses: "./.github/actions/post-steps"
   build-macos-java-static:
     if: needs.config.outputs.only_job == 'build-macos-java-static' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
@@ -523,6 +624,9 @@ jobs:
     - uses: maxim-lobanov/setup-xcode@v1.6.0
       with:
         xcode-version: 16.4.0
+    - uses: "./.github/actions/setup-ccache"
+      with:
+        cache-key-prefix: macos-java-static
     - uses: "./.github/actions/increase-max-open-files-on-macos"
     - uses: "./.github/actions/install-gflags-on-macos"
     - uses: "./.github/actions/install-jdk8-on-macos"
@@ -534,6 +638,10 @@ jobs:
         which javac && javac -version
     - name: Build RocksDBJava x86 and ARM Static Libraries
       run: make V=1 J=16 -j16 rocksdbjavastaticosx
+    - name: Print ccache stats
+      run: ccache -s
+      if: always()
+      shell: bash
     - uses: "./.github/actions/post-steps"
   build-macos-java-static-universal:
     if: needs.config.outputs.only_job == 'build-macos-java-static-universal' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
@@ -546,6 +654,9 @@ jobs:
     - uses: maxim-lobanov/setup-xcode@v1.6.0
       with:
         xcode-version: 16.4.0
+    - uses: "./.github/actions/setup-ccache"
+      with:
+        cache-key-prefix: macos-java-static-universal
     - uses: "./.github/actions/increase-max-open-files-on-macos"
     - uses: "./.github/actions/install-gflags-on-macos"
     - uses: "./.github/actions/install-jdk8-on-macos"
@@ -557,6 +668,10 @@ jobs:
         which javac && javac -version
     - name: Build RocksDBJava Universal Binary Static Library
       run: make V=1 J=16 -j16 rocksdbjavastaticosx_ub
+    - name: Print ccache stats
+      run: ccache -s
+      if: always()
+      shell: bash
     - uses: "./.github/actions/post-steps"
   build-linux-java-pmd:
     if: needs.config.outputs.only_job == 'build-linux-java-pmd' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
@@ -593,6 +708,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.0
       - uses: "./.github/actions/pre-steps"
-      - run: sudo apt-get update && sudo apt-get install -y build-essential
+      - run: sudo apt-get update && sudo apt-get install -y build-essential ccache
+      - uses: "./.github/actions/setup-ccache"
+        with:
+          cache-key-prefix: arm
       - run: ROCKSDBTESTS_PLATFORM_DEPENDENT=only make V=1 J=4 -j4 all_but_some_tests check_some
+      - name: Print ccache stats
+        run: ccache -s
+        if: always()
+        shell: bash
       - uses: "./.github/actions/post-steps"


### PR DESCRIPTION
    Accelerate CI: ccache integration, replace scan-build, upgrade runners
    
    1. ccache integration via reusable composite action (setup-ccache)
       - Created .github/actions/setup-ccache/action.yml
       - Applied to 13+ Linux compilation jobs in pr-jobs.yml
       - PORTABLE=1 by default to avoid illegal instruction errors on
         heterogeneous runners; disabled for jobs linking pre-built Folly
       - On cache hit, reducing compilation from 20+ min to ~2-5 min per job
       - ccache placed before Folly build so Folly compilation also
         benefits from cache on Folly cache misses
    
    2. Replace scan-build with clang-tidy (30+ min -> seconds)
       - Removed build-linux-clang18-clang-analyze job from pr-jobs.yml
       - Expanded .clang-tidy to enable all clang-analyzer-* checks,
         matching scan-build's full coverage
       - Existing clang-tidy-comment.yml workflow now handles both
         clang-tidy and clang-analyzer checks on changed files only
    
    3. Upgrade Folly job runners for faster builds and tests
       - build-linux-make-with-folly: 16-core -> 32-core, -j32 -> -j64
       - build-linux-cmake-with-folly-coroutines: 16-core -> 32-core,
         -j20 -> -j64 (both make and ctest)