### PR TITLE
Enable building Java binaries with async IO support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1181,9 +1181,12 @@ clean-rocks:
 	$(FIND) . -name "*.[oda]" -exec rm -f {} \;
 	$(FIND) . -type f \( -name "*.gcda" -o -name "*.gcno" \) -exec rm -f {} \;
 
-clean-rocksjava: clean-rocks
+clean-rocksjava: clean-rocks clean-rocksjava-build-cache-volumes
 	rm -rf jl jls
 	cd java && $(MAKE) clean
+
+clean-rocksjava-build-cache-volumes:
+	docker volume rm rocksdb_getdeps_x86_64 rocksdb-local-build-x86_64 rocksdb-local-build-arm64v8 rocksdb_getdeps_arm64v8
 
 clean-not-downloaded-rocksjava:
 	cd java && $(MAKE) clean-not-downloaded
@@ -2103,7 +2106,7 @@ SHA256_CMD = sha256sum
 
 ZLIB_VER ?= 1.3.1
 ZLIB_SHA256 ?= 9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23
-ZLIB_DOWNLOAD_BASE ?= http://zlib.net
+ZLIB_DOWNLOAD_BASE ?= http://zlib.net/fossils
 BZIP2_VER ?= 1.0.8
 BZIP2_SHA256 ?= ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269
 BZIP2_DOWNLOAD_BASE ?= http://sourceware.org/pub/bzip2
@@ -2205,7 +2208,8 @@ libsnappy.a: snappy-$(SNAPPY_VER).tar.gz
 	-rm -rf snappy-$(SNAPPY_VER)
 	tar xvzf snappy-$(SNAPPY_VER).tar.gz
 	mkdir snappy-$(SNAPPY_VER)/build
-	cd snappy-$(SNAPPY_VER)/build && CFLAGS='$(ARCHFLAG) ${JAVA_STATIC_DEPS_CCFLAGS} ${EXTRA_CFLAGS}' CXXFLAGS='$(ARCHFLAG) ${JAVA_STATIC_DEPS_CXXFLAGS} ${EXTRA_CXXFLAGS}' LDFLAGS='${JAVA_STATIC_DEPS_LDFLAGS} ${EXTRA_LDFLAGS}' cmake -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DSNAPPY_BUILD_BENCHMARKS=OFF -DSNAPPY_BUILD_TESTS=OFF ${PLATFORM_CMAKE_FLAGS} .. && $(MAKE) ${SNAPPY_MAKE_TARGET}
+	# Use a CXX wrapper to build snappy with RTTI support
+	cd snappy-$(SNAPPY_VER)/build && CFLAGS='$(ARCHFLAG) ${JAVA_STATIC_DEPS_CCFLAGS} ${EXTRA_CFLAGS}' CXXFLAGS='$(ARCHFLAG) ${JAVA_STATIC_DEPS_CXXFLAGS} ${EXTRA_CXXFLAGS}' REAL_CXX='$(CXX)' CXX='$(CURDIR)/build_tools/cxx-rtti-wrap.sh' LDFLAGS='${JAVA_STATIC_DEPS_LDFLAGS} ${EXTRA_LDFLAGS}' cmake -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DSNAPPY_BUILD_BENCHMARKS=OFF -DSNAPPY_BUILD_TESTS=OFF ${PLATFORM_CMAKE_FLAGS} .. && $(MAKE) ${SNAPPY_MAKE_TARGET}
 	cp snappy-$(SNAPPY_VER)/build/libsnappy.a .
 
 lz4-$(LZ4_VER).tar.gz:
@@ -2339,7 +2343,18 @@ rocksdbjavastaticdockerx86:
 
 rocksdbjavastaticdockerx86_64:
 	mkdir -p java/target
-	docker run --rm --name rocksdb_linux_x64-be --platform linux/amd64 --attach stdin --attach stdout --attach stderr --volume $(HOME)/.m2:/root/.m2:ro --volume `pwd`:/rocksdb-host:ro --volume /rocksdb-local-build --volume `pwd`/java/target:/rocksdb-java-target --env DEBUG_LEVEL=$(DEBUG_LEVEL) --env J=$(J) evolvedbinary/rocksjava:centos7_x64-be /rocksdb-host/java/crossbuild/docker-build-linux.sh
+	docker run --rm --name rocksdb_linux_x64-be \
+		--platform linux/amd64 \
+	  --attach stdin --attach stdout --attach stderr \
+	  --volume $(HOME)/.m2:/root/.m2:ro \
+	  --volume `pwd`:/rocksdb-host:ro \
+	  --volume rocksdb-local-build-x86_64:/rocksdb-local-build \
+	  --volume `pwd`/java/target:/rocksdb-java-target \
+	  --mount type=volume,src=rocksdb_getdeps_x86_64,dst=/getdeps-scratch \
+	  --env GETDEPS_SCRATCH_PATH=/getdeps-scratch \
+	  --env DEBUG_LEVEL=$(DEBUG_LEVEL) --env J=$(J) \
+		mirgee/rocksjava-centos9-pydev-x86_64:latest \
+	  /rocksdb-host/java/crossbuild/docker-build-linux.sh
 
 rocksdbjavastaticdockerppc64le:
 	mkdir -p java/target
@@ -2347,7 +2362,18 @@ rocksdbjavastaticdockerppc64le:
 
 rocksdbjavastaticdockerarm64v8:
 	mkdir -p java/target
-	docker run --rm --name rocksdb_linux_arm64v8-be --platform linux/aarch64 --attach stdin --attach stdout --attach stderr --volume $(HOME)/.m2:/root/.m2:ro --volume `pwd`:/rocksdb-host:ro --volume /rocksdb-local-build --volume `pwd`/java/target:/rocksdb-java-target --env DEBUG_LEVEL=$(DEBUG_LEVEL) --env J=$(J) evolvedbinary/rocksjava:centos7_arm64v8-be /rocksdb-host/java/crossbuild/docker-build-linux.sh
+	docker run --rm --name rocksdb_linux_arm64v8-be \
+		--platform linux/aarch64 \
+		--attach stdin --attach stdout --attach stderr \
+		--volume $(HOME)/.m2:/root/.m2:ro \
+		--volume `pwd`:/rocksdb-host:ro \
+		--volume rocksdb-local-build-arm64v8:/rocksdb-local-build \
+		--volume `pwd`/java/target:/rocksdb-java-target \
+		--mount type=volume,src=rocksdb_getdeps_arm64v8,dst=/getdeps-scratch \
+		--env GETDEPS_SCRATCH_PATH=/getdeps-scratch \
+		--env DEBUG_LEVEL=$(DEBUG_LEVEL) --env J=$(J) \
+		mirgee/rocksjava-centos9-pydev-arm64:latest \
+		/rocksdb-host/java/crossbuild/docker-build-linux.sh
 
 rocksdbjavastaticdockers390x:
 	mkdir -p java/target

--- a/build_tools/build_detect_platform
+++ b/build_tools/build_detect_platform
@@ -631,6 +631,8 @@ EOF
 EOF
         if [ "$?" = 0 ]; then
             PLATFORM_LDFLAGS="$PLATFORM_LDFLAGS -luring"
+            JAVA_LDFLAGS="$JAVA_LDFLAGS -luring"
+            JAVA_STATIC_LDFLAGS="$JAVA_STATIC_LDFLAGS -luring"
             COMMON_FLAGS="$COMMON_FLAGS -DROCKSDB_IOURING_PRESENT"
         fi
     fi
@@ -768,13 +770,13 @@ rm -f test.o test_dl.o
 # Get the path for the folly installation dir
 if [ "$USE_FOLLY" ]; then
   if [ "$FOLLY_DIR" ]; then
-    FOLLY_PATH=`cd $FOLLY_DIR && $PYTHON build/fbcode_builder/getdeps.py show-inst-dir folly`
+    FOLLY_PATH=`cd "$FOLLY_DIR" && $PYTHON build/fbcode_builder/getdeps.py show-inst-dir folly --scratch-path "${GETDEPS_SCRATCH_PATH:-/tmp}"`
   fi
 fi
 if [ "$USE_FOLLY_LITE" ]; then
   if [ "$FOLLY_DIR" ]; then
-    BOOST_SOURCE_PATH=`cd $FOLLY_DIR && $PYTHON build/fbcode_builder/getdeps.py show-source-dir boost`
-    FMT_SOURCE_PATH=`cd $FOLLY_DIR && $PYTHON build/fbcode_builder/getdeps.py show-source-dir fmt`
+    BOOST_SOURCE_PATH=`cd $FOLLY_DIR && $PYTHON build/fbcode_builder/getdeps.py show-source-dir boost --scratch-path "${GETDEPS_SCRATCH_PATH:-/tmp}"`
+    FMT_SOURCE_PATH=`cd $FOLLY_DIR && $PYTHON build/fbcode_builder/getdeps.py show-source-dir fmt --scratch-path "${GETDEPS_SCRATCH_PATH:-/tmp}"`
   fi
 fi
 

--- a/build_tools/centos9_image/Dockerfile
+++ b/build_tools/centos9_image/Dockerfile
@@ -1,0 +1,33 @@
+FROM quay.io/centos/centos:stream9
+SHELL ["/bin/bash", "-euxo", "pipefail", "-c"]
+
+RUN dnf -y update \
+ && dnf -y install --setopt=install_weak_deps=False --nodocs dnf-plugins-core \
+ && dnf config-manager --set-enabled crb \
+ && dnf -y install --setopt=install_weak_deps=False --nodocs epel-release \
+ && dnf -y install --setopt=install_weak_deps=False --nodocs \
+      gcc gcc-c++ make \
+      m4 perl-core \
+      hostname \
+      git curl-minimal ca-certificates \
+      which findutils \
+      tar gzip bzip2 \
+      wget \
+      cmake \
+      python3 \
+      help2man \
+      liburing-devel \
+      patchelf binutils-devel \
+      jemalloc-devel \
+      libaio-devel \
+      # Added because failing to build libunwind tests and unable to modify the manifest
+      libunwind-devel \
+      # Gflags headers are needed to build glog
+      gflags-devel \
+      openssl-devel \
+      java-1.8.0-openjdk-devel \
+ && dnf -y clean all \
+ && rm -rf /var/cache/dnf
+
+ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk
+ENV PATH="$JAVA_HOME/bin:$PATH"

--- a/build_tools/cxx-rtti-wrap.sh
+++ b/build_tools/cxx-rtti-wrap.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euox pipefail
+
+args=()
+for a in "$@"; do
+  case "$a" in
+    -fno-rtti|-fno-exceptions) continue ;;
+  esac
+  args+=("$a")
+done
+
+# Force policy at the end (last flag wins)
+exec "${REAL_CXX:-g++}" "${args[@]}" -frtti -fexceptions

--- a/folly.mk
+++ b/folly.mk
@@ -47,13 +47,17 @@ ifneq ($(strip $(FOLLY_PATH)),)
 	# Add -ldl at the end as gcc resolves a symbol in a library by searching only in libraries specified later
 	# in the command line
 
-	PLATFORM_LDFLAGS += $(FOLLY_PATH)/lib/libfolly.a $(BOOST_PATH)/lib/libboost_context.a $(BOOST_PATH)/lib/libboost_filesystem.a $(BOOST_PATH)/lib/libboost_atomic.a $(BOOST_PATH)/lib/libboost_program_options.a $(BOOST_PATH)/lib/libboost_regex.a $(BOOST_PATH)/lib/libboost_system.a $(BOOST_PATH)/lib/libboost_thread.a $(DBL_CONV_PATH)/lib/libdouble-conversion.a $(LIBEVENT_PATH)/lib/libevent.a $(LIBSODIUM_PATH)/lib/libsodium.a -ldl
+	FOLLY_PLATFORM_LDFLAGS := $(FOLLY_PATH)/lib/libfolly.a $(BOOST_PATH)/lib/libboost_context.a $(BOOST_PATH)/lib/libboost_filesystem.a $(BOOST_PATH)/lib/libboost_atomic.a $(BOOST_PATH)/lib/libboost_program_options.a $(BOOST_PATH)/lib/libboost_regex.a $(BOOST_PATH)/lib/libboost_system.a $(BOOST_PATH)/lib/libboost_thread.a $(DBL_CONV_PATH)/lib/libdouble-conversion.a $(LIBEVENT_PATH)/lib/libevent.a $(LIBSODIUM_PATH)/lib/libsodium.a -liberty -ldl
 ifneq ($(DEBUG_LEVEL),0)
-	PLATFORM_LDFLAGS += $(FMT_LIB_PATH)/libfmtd.a $(GLOG_LIB_PATH)/libglogd.so $(GFLAGS_PATH)/lib/libgflags_debug.so.2.2
+	FOLLY_PLATFORM_LDFLAGS += $(FMT_LIB_PATH)/libfmtd.a $(GLOG_LIB_PATH)/libglogd.so $(GFLAGS_PATH)/lib/libgflags_debug.so.2.2
 else
-	PLATFORM_LDFLAGS += $(FMT_LIB_PATH)/libfmt.a $(GLOG_LIB_PATH)/libglog.so $(GFLAGS_PATH)/lib/libgflags.so.2.2
+	FOLLY_PLATFORM_LDFLAGS += $(FMT_LIB_PATH)/libfmt.a $(GLOG_LIB_PATH)/libglog.so $(GFLAGS_PATH)/lib/libgflags.so.2.2
 endif
-	PLATFORM_LDFLAGS += -Wl,-rpath=$(GLOG_LIB_PATH) -Wl,-rpath=$(GFLAGS_PATH)/lib
+	FOLLY_PLATFORM_LDFLAGS += -Wl,-rpath=$(GLOG_LIB_PATH) -Wl,-rpath=$(GFLAGS_PATH)/lib
+	PLATFORM_LDFLAGS += $(FOLLY_PLATFORM_LDFLAGS)
+	JAVA_LDFLAGS += $(PLATFORM_LDFLAGS)
+	JAVA_STATIC_LDFLAGS += $(FOLLY_PLATFORM_LDFLAGS)
+
 endif
 	PLATFORM_CCFLAGS += -DUSE_FOLLY -DFOLLY_NO_CONFIG
 	PLATFORM_CXXFLAGS += -DUSE_FOLLY -DFOLLY_NO_CONFIG
@@ -98,7 +102,7 @@ endif  # FMT_SOURCE_PATH
 	PLATFORM_LDFLAGS += -lglog
 endif
 
-FOLLY_COMMIT_HASH = 3b0eed0a128c484a2b077546c3e08c824a311357
+FOLLY_COMMIT_HASH = baa57f9c03187474855a383400f18109429b3aa3
 
 # For public CI runs, checkout folly in a way that can build with RocksDB.
 # This is mostly intended as a test-only simulation of Meta-internal folly
@@ -120,7 +124,7 @@ checkout_folly:
 	@cd third-party/folly && \
 		DOWNLOAD_DIR=`$(PYTHON) build/fbcode_builder/getdeps.py show-inst-dir | sed 's|/installed/.*|/downloads|'` && \
 		mkdir -p "$$DOWNLOAD_DIR" && \
-		CACHE_DIR="/tmp/rocksdb-getdeps-cache" && \
+		CACHE_DIR="$${GETDEPS_SCRATCH_PATH:-/tmp}/rocksdb-getdeps-cache" && \
 		mkdir -p "$$CACHE_DIR" && \
 		echo "Restoring cached downloads..." && \
 		if ls "$$CACHE_DIR"/*.tar.gz "$$CACHE_DIR"/*.tar.xz "$$CACHE_DIR"/*.zip >/dev/null 2>&1; then \
@@ -129,11 +133,11 @@ checkout_folly:
 		echo "Handling known unreliable downloads with fallback mirrors..." && \
 		$(PYTHON) ../../build_tools/getdeps_fallback_mirror.py "$$DOWNLOAD_DIR" "$$CACHE_DIR" build/fbcode_builder/manifests
 	@# NOTE: boost and fmt source will be needed for any build including `USE_FOLLY_LITE` builds as those depend on those headers
-	cd third-party/folly && GETDEPS_USE_WGET=1 $(PYTHON) build/fbcode_builder/getdeps.py fetch boost && GETDEPS_USE_WGET=1 $(PYTHON) build/fbcode_builder/getdeps.py fetch fmt
+	cd third-party/folly && GETDEPS_USE_WGET=1 $(PYTHON) build/fbcode_builder/getdeps.py fetch boost --scratch-path $${GETDEPS_SCRATCH_PATH:-/tmp} && GETDEPS_USE_WGET=1 $(PYTHON) build/fbcode_builder/getdeps.py fetch fmt --scratch-path $${GETDEPS_SCRATCH_PATH:-/tmp}
 	@# Update cache with any new downloads
 	@cd third-party/folly && \
-		DOWNLOAD_DIR=`$(PYTHON) build/fbcode_builder/getdeps.py show-inst-dir | sed 's|/installed/.*|/downloads|'` && \
-		CACHE_DIR="/tmp/rocksdb-getdeps-cache" && \
+		DOWNLOAD_DIR=`$(PYTHON) build/fbcode_builder/getdeps.py show-inst-dir --scratch-path $${GETDEPS_SCRATCH_PATH:-/tmp} | sed 's|/installed/.*|/downloads|'` && \
+		CACHE_DIR="$${GETDEPS_SCRATCH_PATH:-/tmp}/rocksdb-getdeps-cache" && \
 		if ls "$$DOWNLOAD_DIR"/*.tar.gz "$$DOWNLOAD_DIR"/*.tar.xz "$$DOWNLOAD_DIR"/*.zip >/dev/null 2>&1; then \
 			cp -n "$$DOWNLOAD_DIR"/*.tar.gz "$$DOWNLOAD_DIR"/*.tar.xz "$$DOWNLOAD_DIR"/*.zip "$$CACHE_DIR/" 2>/dev/null || true; \
 		fi
@@ -147,8 +151,23 @@ ifneq ($(DEBUG_LEVEL),0)
 FOLLY_BUILD_FLAGS += --build-type Debug
 endif
 
+# Propagate RocksDB target selection flags to folly to build with the 
+# same intrinsics mode.
+ifeq ($(ARMCRC_SOURCE),1)
+  ARCH_CFLAGS   := $(filter -march=% -mcpu=% -mtune=%,$(CFLAGS))
+  ARCH_CXXFLAGS := $(filter -march=% -mcpu=% -mtune=%,$(CXXFLAGS))
+else
+# On non-arm, RocksDB doesn't end up using the target selection flags
+# from CFLAGS / CXXFLAGS
+  ARCH_CFLAGS   :=
+  ARCH_CXXFLAGS :=
+endif
+
+FOLLY_CFLAGS   := -fPIC $(ARCH_CFLAGS)
+FOLLY_CXXFLAGS := -fPIC -DHAVE_CXX11_ATOMIC $(ARCH_CXXFLAGS)
+
 build_folly:
-	FOLLY_INST_PATH=`cd third-party/folly && $(PYTHON) build/fbcode_builder/getdeps.py show-inst-dir`; \
+	FOLLY_INST_PATH=`cd third-party/folly && $(PYTHON) build/fbcode_builder/getdeps.py show-inst-dir --scratch-path $${GETDEPS_SCRATCH_PATH:-/tmp}`; \
 	if [ "$$FOLLY_INST_PATH" ]; then \
 		rm -rf $${FOLLY_INST_PATH}/../../*; \
 	else \
@@ -156,10 +175,10 @@ build_folly:
 		false; \
 	fi
 	cd third-party/folly && \
-		CXXFLAGS=" $(CXX_M_FLAGS) -DHAVE_CXX11_ATOMIC " GETDEPS_USE_WGET=1 $(PYTHON) build/fbcode_builder/getdeps.py build $(FOLLY_BUILD_FLAGS)
+		CFLAGS="$(FOLLY_CFLAGS)" CXXFLAGS="$(CXX_M_FLAGS) $(FOLLY_CXXFLAGS)" GETDEPS_USE_WGET=1 $(PYTHON) build/fbcode_builder/getdeps.py build --allow-system-packages --scratch-path $${GETDEPS_SCRATCH_PATH:-/tmp} --extra-cmake-defines="{\"CMAKE_POSITION_INDEPENDENT_CODE\":\"ON\"}" $(FOLLY_BUILD_FLAGS)
 	@# In the folly build, glog and gflags are only built as dynamic libraries,
 	@# not static. This patchelf command is needed to reliably have the glog
 	@# library find its dependency gflags, because apparently the rpath of the
 	@# final binary is not used in resolving that transitive dependency.
-	FOLLY_INST_PATH=`cd third-party/folly && $(PYTHON) build/fbcode_builder/getdeps.py show-inst-dir`; \
+	FOLLY_INST_PATH=`cd third-party/folly && $(PYTHON) build/fbcode_builder/getdeps.py show-inst-dir --scratch-path $${GETDEPS_SCRATCH_PATH:-/tmp}`; \
 	cd "$$FOLLY_INST_PATH" && patchelf --add-rpath $$PWD/../gflags-*/lib ../glog-*/lib*/libglog*.so.*.*.*

--- a/java/crossbuild/docker-build-linux.sh
+++ b/java/crossbuild/docker-build-linux.sh
@@ -1,43 +1,77 @@
 #!/usr/bin/env bash
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 
-set -e
-#set -x
+set -euox pipefail
 
-# Set job parallelism to 1 (none) if it is not defined in the environment
-if [ -z "${J}" ]; then
-  J=1
-fi
+: "${J:=1}"
 
-# just in-case this is run outside Docker
 mkdir -p /rocksdb-local-build
 
 rm -rf /rocksdb-local-build/*
 cp -r /rocksdb-host/* /rocksdb-local-build
 cd /rocksdb-local-build
 
-# Use scl devtoolset if available
+GETDEPS_SCRATCH_PATH="${GETDEPS_SCRATCH_PATH:-/getdeps-scratch}"
+PY="${PYTHON:-python3}"
+
+TOOLSET=""
 if hash scl 2>/dev/null; then
-  if scl --list | grep -q 'devtoolset-8'; then
-    # CentOS 6+
-    scl enable devtoolset-8 'make clean-not-downloaded'
-    scl enable devtoolset-8 "PORTABLE=1 J=$J make -j$J rocksdbjavastatic"
-  elif scl --list | grep -q 'devtoolset-7'; then
-    # CentOS 6+
-    scl enable devtoolset-7 'make clean-not-downloaded'
-    scl enable devtoolset-7 "PORTABLE=1 J=$J make -j$J rocksdbjavastatic"
-  elif scl --list | grep -q 'devtoolset-2'; then
-    # CentOS 5 or 6
-    scl enable devtoolset-2 'make clean-not-downloaded'
-    scl enable devtoolset-2 "PORTABLE=1 J=$J make -j$J rocksdbjavastatic"
-  else
-    echo "Could not find devtoolset"
-    exit 1;
-  fi
-else
-  make clean-not-downloaded
-  PORTABLE=1 make -j$J rocksdbjavastatic
+  for ts in devtoolset-12 devtoolset-11 devtoolset-8 devtoolset-7 devtoolset-2; do
+    if scl --list 2>/dev/null | grep -q "$ts"; then
+      TOOLSET="$ts"
+      break
+    fi
+  done
 fi
 
-cp java/target/librocksdbjni-linux*.so java/target/rocksdbjni-*-linux*.jar java/target/rocksdbjni-*-linux*.jar.sha1 /rocksdb-java-target
+run() {
+  local cmd="GETDEPS_SCRATCH_PATH='${GETDEPS_SCRATCH_PATH}' PYTHON='${PY}' $*"
 
+  if [[ -n "${TOOLSET}" ]]; then
+    scl enable "${TOOLSET}" "${cmd}"
+  else
+    bash -lc "${cmd}"
+  fi
+}
+
+get_folly_path() {
+  (
+    cd third-party/folly
+    "${PY}" build/fbcode_builder/getdeps.py show-inst-dir \
+      --scratch-path "${GETDEPS_SCRATCH_PATH}"
+  )
+}
+
+have_folly() {
+  [[ -d "$1/include/folly" && -f "$1/lib/libfolly.a" ]]
+}
+
+run "make clean-not-downloaded"
+run "make checkout_folly"
+
+FOLLY_PATH="$(get_folly_path)"
+echo "Using FOLLY_PATH=$FOLLY_PATH"
+
+BUILD_VARS=(
+  "GETDEPS_SCRATCH_PATH=$GETDEPS_SCRATCH_PATH"
+  "FOLLY_PATH=$FOLLY_PATH"
+  "USE_COROUTINES=1"
+  "LIB_MODE=static"
+  "PORTABLE=1"
+  "J=$J"
+)
+
+if have_folly "$FOLLY_PATH"; then
+  echo "Reusing prebuilt folly at $FOLLY_PATH"
+else
+  run "GETDEPS_SCRATCH_PATH=$GETDEPS_SCRATCH_PATH make build_folly"
+
+  have_folly "$FOLLY_PATH" || { echo "Bad FOLLY_PATH: $FOLLY_PATH"; exit 1; }
+fi
+
+run "${BUILD_VARS[*]} make rocksdbjavastatic"
+
+cp java/target/librocksdbjni-linux*.so \
+   java/target/rocksdbjni-*-linux*.jar \
+   java/target/rocksdbjni-*-linux*.jar.sha1 \
+   /rocksdb-java-target

--- a/java/pom.xml.template
+++ b/java/pom.xml.template
@@ -2,7 +2,7 @@
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.rocksdb</groupId>
+    <groupId>${rocksdb.groupId}</groupId>
     <artifactId>rocksdbjni</artifactId>
     <version>${ROCKSDB_JAVA_VERSION}</version>  <!-- this will be replaced by the Makefile's rocksdbjavageneratepom target -->
 
@@ -62,6 +62,7 @@
         <project.build.source>1.8</project.build.source>
         <project.build.target>1.8</project.build.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <rocksdb.groupId>org.rocksdb</rocksdb.groupId>
     </properties>
 
     <build>
@@ -69,7 +70,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.2</version>
+                <version>3.11.0</version>
                 <configuration>
                     <source>${project.build.source}</source>
                     <target>${project.build.target}</target>
@@ -82,7 +83,7 @@
                 <version>2.18.1</version>
                 <configuration>
                     <argLine>${argLine} -ea -Xcheck:jni -Djava.library.path=${project.build.directory}</argLine>
-                    <useManifestOnlyJar>false</useManifestOnlyJar>  
+                    <useManifestOnlyJar>false</useManifestOnlyJar>
                     <useSystemClassLoader>false</useSystemClassLoader>
                     <additionalClasspathElements>
                         <additionalClasspathElement>${project.build.directory}/*</additionalClasspathElement>
@@ -109,9 +110,17 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.gmaven</groupId>
-                <artifactId>groovy-maven-plugin</artifactId>
-                <version>2.0</version>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
+                <version>3.0.2</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.groovy</groupId>
+                        <artifactId>groovy</artifactId>
+                        <version>4.0.15</version>
+                        <scope>runtime</scope>
+                    </dependency>
+                </dependencies>
                 <executions>
                     <execution>
                         <phase>process-classes</phase>
@@ -119,23 +128,22 @@
                             <goal>execute</goal>
                         </goals>
                         <configuration>
-                            <defaults>
-                                <name>Xenu</name>
-                            </defaults>
-                            <source>
-                                String fileContents = new File(project.basedir.absolutePath + '/../include/rocksdb/version.h').getText('UTF-8')
-                                matcher = (fileContents =~ /(?s).*ROCKSDB_MAJOR ([0-9]+).*?/)
-                                String major_version = matcher.getAt(0).getAt(1)
-                                matcher = (fileContents =~ /(?s).*ROCKSDB_MINOR ([0-9]+).*?/)
-                                String minor_version = matcher.getAt(0).getAt(1)
-                                matcher = (fileContents =~ /(?s).*ROCKSDB_PATCH ([0-9]+).*?/)
-                                String patch_version = matcher.getAt(0).getAt(1)
-                                String version = String.format('%s.%s.%s', major_version, minor_version, patch_version)
-                                // Set version to be used in pom.properties
-                                project.version = version
-                                // Set version to be set as jar name
-                                project.build.finalName = project.artifactId + "-" + version
-                            </source>
+                            <scripts>
+                                <script>
+                                    String fileContents = new File(project.basedir.absolutePath + '/../include/rocksdb/version.h').getText('UTF-8')
+                                    matcher = (fileContents =~ /(?s).*ROCKSDB_MAJOR ([0-9]+).*?/)
+                                    String major_version = matcher.getAt(0).getAt(1)
+                                    matcher = (fileContents =~ /(?s).*ROCKSDB_MINOR ([0-9]+).*?/)
+                                    String minor_version = matcher.getAt(0).getAt(1)
+                                    matcher = (fileContents =~ /(?s).*ROCKSDB_PATCH ([0-9]+).*?/)
+                                    String patch_version = matcher.getAt(0).getAt(1)
+                                    String version = String.format('%s.%s.%s', major_version, minor_version, patch_version)
+                                    // Set version to be used in pom.properties
+                                    project.version = version
+                                    // Set version to be set as jar name
+                                    project.build.finalName = project.artifactId + "-" + version
+                                </script>
+                            </scripts>
                         </configuration>
                     </execution>
                 </executions>
@@ -146,39 +154,218 @@
                 <version>4.7.2.1</version>
                 <configuration>
                     <excludeFilterFile>spotbugs-exclude.xml</excludeFilterFile>
-                </configuration>          
+                </configuration>
                 <dependencies>
                   <!-- overwrite dependency on spotbugs if you want to specify the version of spotbugs -->
-                  <dependency>
-                    <groupId>com.github.spotbugs</groupId>
-                    <artifactId>spotbugs</artifactId>
-                    <version>4.7.3</version>
-                  </dependency>
+                    <dependency>
+                        <groupId>com.github.spotbugs</groupId>
+                        <artifactId>spotbugs</artifactId>
+                        <version>4.7.3</version>
+                    </dependency>
                 </dependencies>
-              </plugin>
-              <plugin>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-pmd-plugin</artifactId>
                 <version>3.20.0</version>
                 <executions>
-                  <execution>
-                    <goals>
-                      <goal>check</goal>
-                      <goal>cpd-check</goal>
-                    </goals>
-                  </execution>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                            <goal>cpd-check</goal>
+                        </goals>
+                    </execution>
                 </executions>
                 <configuration>
                     <rulesets>
                       <!-- A rule set, that comes bundled with PMD -->
-                      <ruleset>/pmd-rules.xml</ruleset>
+                        <ruleset>/pmd-rules.xml</ruleset>
                       <!-- A rule set, that comes bundled with PMD -->
                       <!-- <ruleset>/category/java/errorprone.xml</ruleset> -->
                     </rulesets>
-                  </configuration>          
-              </plugin>
-      </plugins>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>1.6.0</version>
+                <configuration>
+                    <updatePomFile>true</updatePomFile>
+                    <flattenMode>ossrh</flattenMode>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>flatten.clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <properties>
+                <central.serverId>central</central.serverId>
+            </properties>
+            <build>
+                <plugins>
+
+                    <!-- Produce sources jar -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>3.3.0</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!-- Produce javadoc jar -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>3.6.3</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!-- Copy/Stage native libs so classifier jars can be built deterministically -->
+                    <plugin>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <version>3.3.1</version>
+                        <executions>
+
+                            <!-- Copy all built natives into the main jar -->
+                            <execution>
+                                <id>copy-natives-into-main-jar</id>
+                                <phase>process-resources</phase>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+                                    <resources>
+                                        <resource>
+                                            <directory>${project.build.directory}</directory>
+                                            <includes>
+                                                <include>librocksdbjni-*.so</include>
+                                                <include>librocksdbjni-*.jnilib</include>
+                                                <include>rocksdbjni*.dll</include>
+                                            </includes>
+                                            <filtering>false</filtering>
+                                        </resource>
+                                    </resources>
+                                </configuration>
+                            </execution>
+
+                            <!-- Stage linux64 glibc natives for classifier jar -->
+                            <execution>
+                                <id>stage-linux64-natives</id>
+                                <phase>process-resources</phase>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${project.build.directory}/staging/linux64</outputDirectory>
+                                    <resources>
+                                        <resource>
+                                            <directory>${project.build.directory}</directory>
+                                            <includes>
+                                                <include>librocksdbjni-linux*.so</include>
+                                            </includes>
+                                            <excludes>
+                                                <exclude>librocksdbjni-linux-*-musl.so</exclude>
+                                            </excludes>
+                                            <filtering>false</filtering>
+                                        </resource>
+                                    </resources>
+                                </configuration>
+                            </execution>
+
+                        </executions>
+                    </plugin>
+
+                    <!-- Build classifier jars -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <version>3.3.0</version>
+                        <executions>
+                            <execution>
+                                <id>jar-linux64</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                                <configuration>
+                                    <classifier>linux64</classifier>
+                                    <classesDirectory>${project.build.directory}/staging/linux64</classesDirectory>
+                                    <includes>
+                                        <include>**/*</include>
+                                    </includes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!-- Sign artifacts (required for Central) -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>3.2.7</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!-- Publish to Maven Central via Sonatype Central Portal -->
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.7.0</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>${central.serverId}</publishingServerId>
+                            <autoPublish>true</autoPublish>
+                            <waitUntil>published</waitUntil>
+                        </configuration>
+                    </plugin>
+
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
     <dependencies>
         <dependency>
@@ -211,15 +398,15 @@
             <version>1.10.19</version>
             <scope>test</scope>
         </dependency>
-   </dependencies>
+    </dependencies>
 
-   <reporting>
-    <plugins>
-        <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-jxr-plugin</artifactId>
-            <version>3.3.0</version>
-        </plugin>
-    </plugins>
-  </reporting>
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jxr-plugin</artifactId>
+                <version>3.3.0</version>
+            </plugin>
+        </plugins>
+    </reporting>
 </project>

--- a/java/rocksjni/portal.h
+++ b/java/rocksjni/portal.h
@@ -4302,8 +4302,15 @@ class WriteTypeJni : public JavaClass {
    *
    * @return A reference to the enum field value or a nullptr if
    *     the enum field value could not be retrieved
+   *
+   * Note: "LOG" is defined as a macro by glog (transitively included via
+   * Folly), which would mangle this method declaration. The pragmas
+   * temporarily suppress the macro so the method can be declared.
    */
+#pragma push_macro("LOG")
+#undef LOG
   static jobject LOG(JNIEnv* env) { return getEnum(env, "LOG"); }
+#pragma pop_macro("LOG")
 
   // Returns the equivalent org.rocksdb.WBWIRocksIterator.WriteType for the
   // provided C++ ROCKSDB_NAMESPACE::WriteType enum


### PR DESCRIPTION
This is the minimal viable change set to build RocksDB JNI with support for coroutines and async IO, statically linked with Folly and its dependencies.

The docker image used for cross-compilation was updated to CentOS 9.

Build artifacts are persisted in Docker volumes across runs to enable faster iteration during changes to the build process.

The PR contains multiple workarounds, where proper solution would require more extensive changes or changes to 3rd party code (changing `fbcode_builder` manifests, renaming, precarious logic change, etc.).

Successfully tested on x86_64 and armv8 platforms in [the Besu project](https://github.com/hyperledger/besu).

We would appreciate collaboration on publishing binaries with async IO support in the official RocksDB JNI release.

Related:
https://github.com/facebook/rocksdb/issues/14295
https://github.com/facebook/rocksdb/pull/13510