### PR TITLE
Added comment for PutFixed64 function explaining little/big-endian ha…

### DIFF
--- a/util/coding.h
+++ b/util/coding.h
@@ -138,6 +138,8 @@ inline void PutFixed32(std::string* dst, uint32_t value) {
   }
 }
 
+// PutFixed64: Appends a 64-bit unsigned integer to the given string in fixed-size little-endian format.
+// If the system is little-endian, it appends directly. Otherwise, it encodes the integer into a buffer first.
 inline void PutFixed64(std::string* dst, uint64_t value) {
   if (port::kLittleEndian) {
     dst->append(const_cast<const char*>(reinterpret_cast<char*>(&value)),


### PR DESCRIPTION
### What
Added a descriptive comment for the `PutFixed64` function in `util/coding.h`.

### Why
This function appends a 64-bit unsigned integer to a string in a fixed-size format.
- Handles both little-endian and big-endian systems.
- Original code is correct, but it lacked documentation for future developers.

### How
- Added a clear comment above the function explaining its behavior and system-specific handling.

### Impact
- No logic changes.
- Improves code readability and maintainability.
- Beginner-friendly contribution for understanding RocksDB codebase.