### PR TITLE
C API `rocksdb_fifo_compaction_options_t` from `rocksdb_options_t`

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -5474,6 +5474,14 @@ void rocksdb_options_set_fifo_compaction_options(
   opt->rep.compaction_options_fifo = fifo->rep;
 }
 
+rocksdb_fifo_compaction_options_t* rocksdb_options_get_fifo_compaction_options(
+    rocksdb_options_t* opt) {
+  rocksdb_fifo_compaction_options_t* result =
+      new rocksdb_fifo_compaction_options_t;
+  result->rep = opt->rep.compaction_options_fifo;
+  return result;
+}
+
 void rocksdb_options_set_compaction_pri(rocksdb_options_t* opt, int pri) {
   opt->rep.compaction_pri = static_cast<ROCKSDB_NAMESPACE::CompactionPri>(pri);
 }

--- a/db/c_test.c
+++ b/db/c_test.c
@@ -3604,6 +3604,22 @@ int main(int argc, char** argv) {
     CheckCondition(
         1 == rocksdb_fifo_compaction_options_get_use_kv_ratio_compaction(fco));
 
+    rocksdb_options_set_fifo_compaction_options(options, fco);
+    {
+      rocksdb_fifo_compaction_options_t* fco2 =
+          rocksdb_options_get_fifo_compaction_options(options);
+      CheckCondition(
+          100000 ==
+          rocksdb_fifo_compaction_options_get_max_table_files_size(fco2));
+      CheckCondition(
+          200000 ==
+          rocksdb_fifo_compaction_options_get_max_data_files_size(fco2));
+      CheckCondition(
+          1 ==
+          rocksdb_fifo_compaction_options_get_use_kv_ratio_compaction(fco2));
+      rocksdb_fifo_compaction_options_destroy(fco2);
+    }
+
     rocksdb_fifo_compaction_options_destroy(fco);
   }
 

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -2032,6 +2032,8 @@ rocksdb_options_set_universal_compaction_options(
     rocksdb_options_t*, rocksdb_universal_compaction_options_t*);
 extern ROCKSDB_LIBRARY_API void rocksdb_options_set_fifo_compaction_options(
     rocksdb_options_t* opt, rocksdb_fifo_compaction_options_t* fifo);
+extern ROCKSDB_LIBRARY_API rocksdb_fifo_compaction_options_t*
+rocksdb_options_get_fifo_compaction_options(rocksdb_options_t* opt);
 extern ROCKSDB_LIBRARY_API void rocksdb_options_set_ratelimiter(
     rocksdb_options_t* opt, rocksdb_ratelimiter_t* limiter);
 extern ROCKSDB_LIBRARY_API void rocksdb_options_set_atomic_flush(


### PR DESCRIPTION
Allow creating FIFO compaction options, `rocksdb_fifo_compaction_options_t`, from options, `rocksdb_options_t`.

For applications that modify the FIFO compaction options at runtime, it is useful to be able to load the current value at startup.