### PR TITLE
Fix deadlock error false positive in stress test

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -929,6 +929,11 @@ Status StressTest::CommitTxn(Transaction& txn, ThreadState* thread) {
   return s;
 }
 
+bool StressTest::IsExpectedTxnLockTimeout(const Status& s) {
+  return (s.IsDeadlock() || s.IsTimedOut()) &&
+         (FLAGS_use_multiget || FLAGS_use_multi_get_entity);
+}
+
 Status StressTest::ExecuteTransaction(WriteOptions& write_opts,
                                       ThreadState* thread,
                                       std::function<Status(Transaction&)>&& ops,

--- a/db_stress_tool/db_stress_test_base.h
+++ b/db_stress_tool/db_stress_test_base.h
@@ -33,6 +33,11 @@ class StressTest {
            !status_to_io_status(Status(error_s)).GetDataLoss();
   }
 
+  // Returns true if the status is a transaction lock conflict (deadlock or
+  // timeout) that is expected when MaybeAddKeyToTxnForRYW writes to the same
+  // key space without acquiring the stress-test-level mutex.
+  static bool IsExpectedTxnLockTimeout(const Status& s);
+
   StressTest();
 
   virtual ~StressTest() {}


### PR DESCRIPTION
Summary:

Fix deadlock error false positive in stress test. TestDelete could trigger similar deadlock issue found earlier.

Test Plan:

Stress test

Reviewers:

Subscribers:

Tasks:

Tags: