### PR TITLE
Restore blob_dump_tool compression support (partially revert PR #14266)

### DIFF
--- a/include/rocksdb/utilities/ldb_cmd.h
+++ b/include/rocksdb/utilities/ldb_cmd.h
@@ -75,6 +75,7 @@ class LDBCommand {
   static const std::string ARG_BLOB_FILE_STARTING_LEVEL;
   static const std::string ARG_PREPOPULATE_BLOB_CACHE;
   static const std::string ARG_DECODE_BLOB_INDEX;
+  static const std::string ARG_DUMP_UNCOMPRESSED_BLOBS;
   static const std::string ARG_READ_TIMESTAMP;
   static const std::string ARG_GET_WRITE_UNIX_TIME;
 

--- a/tools/blob_dump.cc
+++ b/tools/blob_dump.cc
@@ -27,10 +27,12 @@ int main(int argc, char** argv) {
       {"file", required_argument, nullptr, 'f'},
       {"show_key", optional_argument, nullptr, 'k'},
       {"show_blob", optional_argument, nullptr, 'b'},
+      {"show_uncompressed_blob", optional_argument, nullptr, 'r'},
       {"show_summary", optional_argument, nullptr, 's'},
   };
   DisplayType show_key = DisplayType::kRaw;
   DisplayType show_blob = DisplayType::kNone;
+  DisplayType show_uncompressed_blob = DisplayType::kNone;
   bool show_summary = false;
   std::string file;
   while (true) {
@@ -45,6 +47,7 @@ int main(int argc, char** argv) {
                 "Usage: blob_dump --file=filename "
                 "[--show_key[=none|raw|hex|detail]] "
                 "[--show_blob[=none|raw|hex|detail]] "
+                "[--show_uncompressed_blob[=none|raw|hex|detail]] "
                 "[--show_summary]\n");
         return 0;
       case 'f':
@@ -70,6 +73,17 @@ int main(int argc, char** argv) {
           show_blob = DisplayType::kHex;
         }
         break;
+      case 'r':
+        if (optarg) {
+          if (display_types.count(arg_str) == 0) {
+            fprintf(stderr, "Unrecognized blob display type.\n");
+            return -1;
+          }
+          show_uncompressed_blob = display_types.at(arg_str);
+        } else {
+          show_uncompressed_blob = DisplayType::kHex;
+        }
+        break;
       case 's':
         show_summary = true;
         break;
@@ -79,7 +93,8 @@ int main(int argc, char** argv) {
     }
   }
   BlobDumpTool tool;
-  Status s = tool.Run(file, show_key, show_blob, show_summary);
+  Status s =
+      tool.Run(file, show_key, show_blob, show_uncompressed_blob, show_summary);
   if (!s.ok()) {
     fprintf(stderr, "Failed: %s\n", s.ToString().c_str());
     return -1;

--- a/tools/ldb_cmd_impl.h
+++ b/tools/ldb_cmd_impl.h
@@ -47,6 +47,7 @@ class DBFileDumperCommand : public LDBCommand {
 
  private:
   bool decode_blob_index_;
+  bool dump_uncompressed_blobs_;
 };
 
 class DBLiveFilesMetadataDumperCommand : public LDBCommand {
@@ -108,6 +109,7 @@ class DBDumperCommand : public LDBCommand {
   bool print_stats_;
   std::string path_;
   bool decode_blob_index_;
+  bool dump_uncompressed_blobs_;
 
   static const std::string ARG_COUNT_ONLY;
   static const std::string ARG_COUNT_DELIM;

--- a/tools/ldb_test.py
+++ b/tools/ldb_test.py
@@ -2,7 +2,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 
 import glob
-
 import os
 import os.path
 import re
@@ -99,7 +98,9 @@ class LDBTestCase(unittest.TestCase):
         Uses the default test db.
         """
         self.assertRunOKFull(
-            "{} {}".format(self.dbParam(self.DB_NAME), params), expectedOutput, unexpected
+            "{} {}".format(self.dbParam(self.DB_NAME), params),
+            expectedOutput,
+            unexpected,
         )
 
     def assertRunFAIL(self, params):
@@ -186,11 +187,15 @@ class LDBTestCase(unittest.TestCase):
 
     def writeExternSst(self, params, inputDumpFile, outputSst):
         return 0 == run_err_null(
-            "cat {} | ./ldb write_extern_sst {} {}".format(inputDumpFile, outputSst, params)
+            "cat {} | ./ldb write_extern_sst {} {}".format(
+                inputDumpFile, outputSst, params
+            )
         )
 
     def ingestExternSst(self, params, inputSst):
-        return 0 == run_err_null("./ldb ingest_extern_sst {} {}".format(inputSst, params))
+        return 0 == run_err_null(
+            "./ldb ingest_extern_sst {} {}".format(inputSst, params)
+        )
 
     def testStringBatchPut(self):
         print("Running testStringBatchPut...")
@@ -312,8 +317,12 @@ class LDBTestCase(unittest.TestCase):
         self.assertRunOK("get --hex 0x6131", "0x6231")
         self.assertRunOK("get a2", "b2")
         self.assertRunOK("get --hex 0x6132", "0x6232")
-        self.assertRunOK("multi_get --hex 0x6131 0x6132", "0x6131 ==> 0x6231\n0x6132 ==> 0x6232")
-        self.assertRunOK("multi_get --hex 0x6131 0xBEEF", "0x6131 ==> 0x6231\nKey not found: 0xBEEF")
+        self.assertRunOK(
+            "multi_get --hex 0x6131 0x6132", "0x6131 ==> 0x6231\n0x6132 ==> 0x6232"
+        )
+        self.assertRunOK(
+            "multi_get --hex 0x6131 0xBEEF", "0x6131 ==> 0x6231\nKey not found: 0xBEEF"
+        )
         self.assertRunOK("get --key_hex 0x6132", "b2")
         self.assertRunOK("get --key_hex --value_hex 0x6132", "0x6232")
         self.assertRunOK("get --value_hex a2", "0x6232")
@@ -540,7 +549,9 @@ class LDBTestCase(unittest.TestCase):
             "'b' seq:2, type:1 => val\nInternal keys in range: 2",
         )
         self.assertRunOK(
-            "idump --input_key_hex --from={} --to={}".format(hex(ord("a")), hex(ord("b"))),
+            "idump --input_key_hex --from={} --to={}".format(
+                hex(ord("a")), hex(ord("b"))
+            ),
             "'a' seq:1, type:1 => val\nInternal keys in range: 1",
         )
 
@@ -626,7 +637,9 @@ class LDBTestCase(unittest.TestCase):
         self.assertRunFAIL("checkconsistency")
 
     def dumpLiveFiles(self, params, dumpFile):
-        return 0 == run_err_null("./ldb dump_live_files {} > {}".format(params, dumpFile))
+        return 0 == run_err_null(
+            "./ldb dump_live_files {} > {}".format(params, dumpFile)
+        )
 
     def testDumpLiveFiles(self):
         print("Running testDumpLiveFiles...")
@@ -651,7 +664,7 @@ class LDBTestCase(unittest.TestCase):
         # Call the dump_live_files function with the edited dbPath name.
         self.assertTrue(
             self.dumpLiveFiles(
-                "--db=%s --decode_blob_index" % dbPath,
+                "--db=%s --decode_blob_index --dump_uncompressed_blobs" % dbPath,
                 dumpFilePath,
             )
         )
@@ -919,7 +932,7 @@ class LDBTestCase(unittest.TestCase):
         expected_pattern = re.compile(regex)
         blob_files = self.getBlobFiles(dbPath)
         self.assertTrue(len(blob_files) >= 1)
-        cmd = "dump --path=%s"
+        cmd = "dump --path=%s --dump_uncompressed_blobs"
         self.assertRunOKFull(
             (cmd) % (blob_files[0]), expected_pattern, unexpected=False, isPattern=True
         )

--- a/utilities/blob_db/blob_dump_tool.h
+++ b/utilities/blob_db/blob_dump_tool.h
@@ -28,7 +28,8 @@ class BlobDumpTool {
   BlobDumpTool();
 
   Status Run(const std::string& filename, DisplayType show_key,
-             DisplayType show_blob, bool show_summary);
+             DisplayType show_blob, DisplayType show_uncompressed_blob,
+             bool show_summary);
 
  private:
   std::unique_ptr<RandomAccessFileReader> reader_;
@@ -36,11 +37,14 @@ class BlobDumpTool {
   size_t buffer_size_;
 
   Status Read(uint64_t offset, size_t size, Slice* result);
-  Status DumpBlobLogHeader(uint64_t* offset);
+  Status DumpBlobLogHeader(uint64_t* offset, CompressionType* compression);
   Status DumpBlobLogFooter(uint64_t file_size, uint64_t* footer_offset);
   Status DumpRecord(DisplayType show_key, DisplayType show_blob,
-                    uint64_t* offset, uint64_t* total_records,
-                    uint64_t* total_key_size, uint64_t* total_blob_size);
+                    DisplayType show_uncompressed_blob, bool show_summary,
+                    CompressionType compression, uint64_t* offset,
+                    uint64_t* total_records, uint64_t* total_key_size,
+                    uint64_t* total_blob_size,
+                    uint64_t* total_uncompressed_blob_size);
   void DumpSlice(const Slice s, DisplayType type);
 
   template <class T>


### PR DESCRIPTION
Summary:
PR #14266 ("Remove compression support") removed compression-related functionality from blob_dump_tool and ldb commands. While this was valid for the legacy stacked BlobDB (which no longer supports compression), the integrated blob storage (`enable_blob_files`) uses the same blob file format and fully supports compression via `blob_compression_type`.

This partial revert restores the ability to view uncompressed blob data from compressed blob files, which is essential for debugging and analysis of integrated blob storage.

Restored functionality:
- `blob_dump --show_uncompressed_blob` option
- `ldb dump --dump_uncompressed_blobs` option
- `ldb dump_live_files --dump_uncompressed_blobs` option
- Related ldb_test.py test coverage

The decompression implementation in utilities/blob_db/blob_dump_tool.cc has been updated to use the modern
`GetBuiltinV2CompressionManager()->GetDecompressorOptimizeFor()` API.

Suggested follow-up:
* Tests for blob_dump (or integrate it into sst_dump/ldb?)

Test Plan:
Restored ldb_test.py
Some manual testing