### PR TITLE
fix portable build for cmake pr job

### DIFF
--- a/.github/actions/build-folly/action.yml
+++ b/.github/actions/build-folly/action.yml
@@ -9,7 +9,7 @@ runs:
   steps:
   - name: Build folly and dependencies
     if: ${{ inputs.cache-hit != 'true' }}
-    run: make build_folly
+    run: PORTABLE=1 make build_folly
     shell: bash
   - name: Skip folly build (using cached version)
     if: ${{ inputs.cache-hit == 'true' }}

--- a/.github/actions/cache-folly/action.yml
+++ b/.github/actions/cache-folly/action.yml
@@ -30,4 +30,4 @@ runs:
       # - The docker image, which may not always be specified/known
       # - Hash of folly.mk, which includes the folly repository commit hash
       # NOTE: this is still only intended for DEBUG folly builds
-      key: folly-build-${{ runner.os }}-${{ runner.arch }}-${{ github.job_container.image }}-${{ steps.extract-folly-hash.outputs.hash }}
+      key: folly-build-${{ runner.os }}-${{ runner.arch }}-${{ github.job_container.image }}-${{ steps.extract-folly-hash.outputs.hash }}-portable

--- a/.github/workflows/pr-jobs.yml
+++ b/.github/workflows/pr-jobs.yml
@@ -144,7 +144,6 @@ jobs:
     - uses: "./.github/actions/setup-ccache"
       with:
         cache-key-prefix: make-with-folly
-        portable: "false"
     - uses: "./.github/actions/cache-folly"
       id: cache-folly
     - uses: "./.github/actions/build-folly"
@@ -194,7 +193,6 @@ jobs:
     - uses: "./.github/actions/setup-ccache"
       with:
         cache-key-prefix: cmake-folly-coroutines
-        portable: "false"
     - uses: "./.github/actions/cache-folly"
       id: cache-folly
     - uses: "./.github/actions/build-folly"


### PR DESCRIPTION
Summary:

-march=native in cmake builds causes SIGILL after cache hits
Issue: PORTABLE=1 env var only works for Makefile builds. cmake ignores it and injects -march=native via its own CPU detection. Since ccache hashes the flag string literally, a cache compiled on an AVX-512 runner and restored on a non-AVX-512 runner produces a SIGILL crash.
Fix: Added -DPORTABLE=ON to build-linux-cmake-with-benchmark-no-thread-status and build-linux-cmake-with-folly-coroutines cmake commands.

Test:

Github CI