### PR TITLE
stop using portable folly build for nightly job

### DIFF
--- a/.github/actions/build-folly/action.yml
+++ b/.github/actions/build-folly/action.yml
@@ -9,7 +9,7 @@ runs:
   steps:
   - name: Build folly and dependencies
     if: ${{ inputs.cache-hit != 'true' }}
-    run: PORTABLE=1 make build_folly
+    run: make build_folly
     shell: bash
   - name: Skip folly build (using cached version)
     if: ${{ inputs.cache-hit == 'true' }}

--- a/.github/actions/cache-folly/action.yml
+++ b/.github/actions/cache-folly/action.yml
@@ -30,4 +30,4 @@ runs:
       # - The docker image, which may not always be specified/known
       # - Hash of folly.mk, which includes the folly repository commit hash
       # NOTE: this is still only intended for DEBUG folly builds
-      key: folly-build-${{ runner.os }}-${{ runner.arch }}-${{ github.job_container.image }}-${{ steps.extract-folly-hash.outputs.hash }}-portable
+      key: folly-build-${{ runner.os }}-${{ runner.arch }}-${{ github.job_container.image }}-${{ steps.extract-folly-hash.outputs.hash }}-${{ env.PORTABLE == '1' && 'portable' || 'native' }}


### PR DESCRIPTION
Summary:

The nightly build had a flag for portable build on folly, but rocksdb does not. This causes link error. Fix this by removing portable build flag in folly build in nightly run. Nightly run will always build without cache using native flag. Only PR jobs uses cache.

Test:

nightly run