### PR TITLE
Pass statistics and fix null clock in SstFileReader::MultiGet

### DIFF
--- a/util/stop_watch.h
+++ b/util/stop_watch.h
@@ -112,6 +112,7 @@ class StopWatchNano {
     }
   }
   void Start() {
+    assert(clock_);
     if constexpr (use_cpu_time) {
       start_ = clock_->CPUNanos();
     } else {
@@ -119,6 +120,7 @@ class StopWatchNano {
     }
   }
   uint64_t ElapsedNanos(bool reset = false) {
+    assert(clock_);
     uint64_t now = 0;
     if constexpr (use_cpu_time) {
       now = clock_->CPUNanos();


### PR DESCRIPTION
**Summary:**
This is to sync an internal change of passing `Statistics*` to the GetContext constructor and collecting more stats as well as fix a bug this change created.

SstFileReader::MultiGet was passing nullptr for both `SystemClock*` and `Statistics*` to the GetContext constructor.  After  `Statistics*` was passed to the GetContext constructor (the internal change), this caused a segfault when a merge operation was triggered with statistics enabled, because the merge helper's StopWatchNano attempted to dereference the null clock pointer. Fix by passing `r->ioptions.clock` from the reader's options.

Additionally, add `assert(clock_)` guards to `StopWatchNano::Start()` and `ElapsedNanos()` to catch null clock bugs in debug builds. Can't do so in release build because it's on hot path. 

**Test Plan:**
- `./sst_file_reader_test --gtest_filter='SstFileReaderTableMultiGetTest.Basic'` exercises merge with statistics enabled, previously segfaulted without the fix with the clock, now passes.
- `./sst_file_reader_test` - all tests pass.