### PR TITLE
Fix SIGTRAP in Striped::Get with libc++ bounds checks

### DIFF
--- a/util/mutexlock.h
+++ b/util/mutexlock.h
@@ -171,7 +171,8 @@ class Striped {
   using Unwrapped = typename Unwrap<T>::type;
   Unwrapped& Get(const Key& key, uint64_t seed = 0) {
     size_t index = FastRangeGeneric(hash_(key, seed), stripe_count_);
-    return Unwrap<T>::Go(data_[index]);
+    assert(index < stripe_count_);
+    return Unwrap<T>::Go(*(data_.get() + index));
   }
 
   size_t ApproximateMemoryUsage() const {


### PR DESCRIPTION
## Summary

Fix a macOS `SIGTRAP` seen during DB reopen after forced process termination.

The trap occurs in libc++ checked `unique_ptr<T[]>::operator[]` on the `Striped::Get` path used by `TableCache::FindTable`.

## Root cause

`Striped::Get` used `data_[index]`, which calls `std::unique_ptr<T[]>::operator[]`.

## Change

In `util/mutexlock.h`, update `Striped::Get` to:

- add defensive `assert(index < stripe_count_)` for explicit debug-time index invariant checking
- use `*(data_.get() + index)` instead of `data_[index]` to avoid the libc++ checked `unique_ptr<T[]>::operator[]` trap path

## Validation

- Baseline reproduces with Clang/libc++ 21.1.8 + Snappy 1.2.2 + Zstd 1.5.7 (`sigtrap` after first kill cycle).
- With this patch, repeated runs on the same stack show `sigtrap=0` (`killed` only).
- Cross-check with Clang/libc++ 16.0.6 + Snappy 1.2.1 + Zstd 1.5.6 remains non-repro (`killed` only).

## References

- SurrealDB issue context: https://github.com/surrealdb/surrealdb/issues/6953
- Minimal repro repository: https://github.com/smissingham/rocksdb-cpp-sigtrap-repro
- Repro CI workflow runs: https://github.com/smissingham/rocksdb-cpp-sigtrap-repro/actions/workflows/repro.yml
