### PR TITLE
feat(db): add rocksdb_options_{set,get}_allow_fallocate

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -5011,6 +5011,15 @@ unsigned char rocksdb_options_get_allow_mmap_writes(rocksdb_options_t* opt) {
   return opt->rep.allow_mmap_writes;
 }
 
+void rocksdb_options_set_allow_fallocate(rocksdb_options_t* opt,
+                                           unsigned char v) {
+  opt->rep.allow_fallocate = v;
+}
+
+unsigned char rocksdb_options_get_allow_fallocate(rocksdb_options_t* opt) {
+  return opt->rep.allow_fallocate;
+}
+
 void rocksdb_options_set_is_fd_close_on_exec(rocksdb_options_t* opt,
                                              unsigned char v) {
   opt->rep.is_fd_close_on_exec = v;

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -1844,6 +1844,10 @@ extern ROCKSDB_LIBRARY_API void rocksdb_options_set_allow_mmap_writes(
     rocksdb_options_t*, unsigned char);
 extern ROCKSDB_LIBRARY_API unsigned char rocksdb_options_get_allow_mmap_writes(
     rocksdb_options_t*);
+extern ROCKSDB_LIBRARY_API void rocksdb_options_set_allow_fallocate(
+    rocksdb_options_t*, unsigned char);
+extern ROCKSDB_LIBRARY_API unsigned char rocksdb_options_get_allow_fallocate(
+    rocksdb_options_t*);
 extern ROCKSDB_LIBRARY_API void rocksdb_options_set_use_direct_reads(
     rocksdb_options_t*, unsigned char);
 extern ROCKSDB_LIBRARY_API unsigned char rocksdb_options_get_use_direct_reads(


### PR DESCRIPTION
I am not sure why this was missing, but here I have added the necessary functions for setting and getting the `allow_fallocate` option over FFI.

## References

- [forgejo.ellis.link:continuwuation/continuwuity#1462](https://forgejo.ellis.link/continuwuation/continuwuity/issues/1462)
- [github.com:zaidoon1/rust-rocksdb#204](https://github.com/zaidoon1/rust-rocksdb/pull/204)