### PR TITLE
Refactor MultiScan to use MultiScanIndexIterator

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -208,6 +208,7 @@ cpp_library_wrapper(name="rocksdb_lib", srcs=[
         "table/block_based/hash_index_reader.cc",
         "table/block_based/index_builder.cc",
         "table/block_based/index_reader_common.cc",
+        "table/block_based/multi_scan_index_iterator.cc",
         "table/block_based/parsed_full_filter_block.cc",
         "table/block_based/partitioned_filter_block.cc",
         "table/block_based/partitioned_index_iterator.cc",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -843,6 +843,7 @@ set(SOURCES
         table/block_based/block_based_table_builder.cc
         table/block_based/block_based_table_factory.cc
         table/block_based/block_based_table_iterator.cc
+        table/block_based/multi_scan_index_iterator.cc
         table/block_based/block_based_table_reader.cc
         table/block_based/block_builder.cc
         table/block_based/block_cache.cc

--- a/src.mk
+++ b/src.mk
@@ -183,6 +183,7 @@ LIB_SOURCES =                                                   \
   table/block_based/block_based_table_builder.cc                \
   table/block_based/block_based_table_factory.cc                \
   table/block_based/block_based_table_iterator.cc               \
+  table/block_based/multi_scan_index_iterator.cc                \
   table/block_based/block_based_table_reader.cc                 \
   table/block_based/block_builder.cc                            \
   table/block_based/block_cache.cc                              \

--- a/table/block_based/block_based_table_iterator.cc
+++ b/table/block_based/block_based_table_iterator.cc
@@ -40,8 +40,11 @@ void BlockBasedTableIterator::SeekImpl(const Slice* target,
   if (!multi_scan_status_.ok()) {
     return;
   }
-  if (multi_scan_) {
-    SeekMultiScan(target);
+
+  // MultiScan requires an explicit seek key — SeekToFirst() is not supported
+  if (multi_scan_read_set_ && !target) {
+    multi_scan_status_ = Status::InvalidArgument("No seek key for MultiScan");
+    RecordTick(table_->GetStatistics(), MULTISCAN_SEEK_ERRORS);
     return;
   }
 
@@ -67,7 +70,7 @@ void BlockBasedTableIterator::SeekImpl(const Slice* target,
       read_options_.auto_readahead_size &&
       (read_options_.iterate_upper_bound || read_options_.prefix_same_as_start);
 
-  if (autotune_readaheadsize &&
+  if (autotune_readaheadsize && !multi_scan_read_set_ &&
       table_->get_rep()->table_options.block_cache.get() &&
       direction_ == IterDirection::kForward) {
     readahead_cache_lookup_ = true;
@@ -97,8 +100,10 @@ void BlockBasedTableIterator::SeekImpl(const Slice* target,
   //  In case of readahead_cache_lookup_, index_iter_ could change to find the
   //  readahead size in BlockCacheLookupForReadAheadSize so it needs to
   //  reseek.
-  if (IsIndexAtCurr() && block_iter_points_to_real_block_ &&
-      block_iter_.Valid()) {
+  // MultiScan must always go through index_iter_->Seek() so that
+  // MultiScanIndexIterator can update its scan range tracking state.
+  if (!multi_scan_read_set_ && IsIndexAtCurr() &&
+      block_iter_points_to_real_block_ && block_iter_.Valid()) {
     // Reseek.
     prev_block_offset_ = index_iter_->value().handle.offset();
 
@@ -152,7 +157,7 @@ void BlockBasedTableIterator::SeekImpl(const Slice* target,
   } else {
     // Need to use the data block.
     if (!same_block) {
-      if (read_options_.async_io && async_prefetch) {
+      if (read_options_.async_io && async_prefetch && !multi_scan_read_set_) {
         AsyncInitDataBlock(/*is_first_pass=*/true);
         if (async_read_in_progress_) {
           // Status::TryAgain indicates asynchronous request for retrieval of
@@ -163,6 +168,10 @@ void BlockBasedTableIterator::SeekImpl(const Slice* target,
         }
       } else {
         InitDataBlock();
+        if (multi_scan_read_set_ && !block_iter_points_to_real_block_) {
+          // MultiScan InitDataBlock failed (e.g., prefetch limit or IO error)
+          return;
+        }
       }
     } else {
       // When the user does a reseek, the iterate_upper_bound might have
@@ -184,12 +193,19 @@ void BlockBasedTableIterator::SeekImpl(const Slice* target,
   CheckOutOfBound();
 
   if (target) {
-    assert(!Valid() || icomp_.Compare(*target, key()) <= 0);
+    // MultiScan uses user-key separators in its index, so after a reseek
+    // with the same user key but a different sequence number (e.g., from
+    // max_sequential_skip_in_iterations), the data block entry may appear
+    // "before" the target in internal key order. The user-key invariant
+    // still holds and the iteration is correct because DBIter will skip
+    // remaining same-user-key entries.
+    assert(multi_scan_read_set_ || !Valid() ||
+           icomp_.Compare(*target, key()) <= 0);
   }
 }
 
 void BlockBasedTableIterator::SeekForPrev(const Slice& target) {
-  multi_scan_.reset();
+  ResetMultiScan();
   direction_ = IterDirection::kBackward;
   ResetBlockCacheLookupVar();
   is_out_of_bound_ = false;
@@ -264,7 +280,7 @@ void BlockBasedTableIterator::SeekForPrev(const Slice& target) {
 }
 
 void BlockBasedTableIterator::SeekToLast() {
-  multi_scan_.reset();
+  ResetMultiScan();
   direction_ = IterDirection::kBackward;
   ResetBlockCacheLookupVar();
   is_out_of_bound_ = false;
@@ -290,7 +306,7 @@ void BlockBasedTableIterator::SeekToLast() {
 void BlockBasedTableIterator::Next() {
   assert(Valid());
   if (is_at_first_key_from_index_ && !MaterializeCurrentBlock()) {
-    assert(!multi_scan_);
+    assert(!multi_scan_read_set_);
     return;
   }
   assert(block_iter_points_to_real_block_);
@@ -311,9 +327,8 @@ bool BlockBasedTableIterator::NextAndGetResult(IterateResult* result) {
 }
 
 void BlockBasedTableIterator::Prev() {
-  assert(!multi_scan_);
-  if ((readahead_cache_lookup_ && !IsIndexAtCurr()) || multi_scan_) {
-    multi_scan_.reset();
+  if ((readahead_cache_lookup_ && !IsIndexAtCurr()) || multi_scan_read_set_) {
+    ResetMultiScan();
     // In case of readahead_cache_lookup_, index_iter_ has moved forward. So we
     // need to reseek the index_iter_ to point to current block by using
     // block_iter_'s key.
@@ -358,6 +373,41 @@ void BlockBasedTableIterator::Prev() {
 }
 
 void BlockBasedTableIterator::InitDataBlock() {
+  // MultiScan path: load block from ReadSet
+  if (multi_scan_read_set_) {
+    BlockHandle data_block_handle = index_iter_->value().handle;
+    if (!block_iter_points_to_real_block_ ||
+        data_block_handle.offset() != prev_block_offset_) {
+      if (block_iter_points_to_real_block_) {
+        ResetDataIter();
+      }
+      size_t rs_idx = multi_scan_index_iter_->current_read_set_index();
+      if (rs_idx >= prefetch_max_idx_) {
+        if (multi_scan_index_iter_->GetMaxPrefetchSize() == 0) {
+          // max_prefetch_size is not set, treat as end of file
+          return;
+        } else {
+          // max_prefetch_size is set, treat as error
+          multi_scan_status_ = Status::PrefetchLimitReached();
+          return;
+        }
+      }
+      CachableEntry<Block> block_entry;
+      multi_scan_status_ =
+          multi_scan_read_set_->ReadIndex(rs_idx, &block_entry);
+      if (!multi_scan_status_.ok()) {
+        return;
+      }
+      table_->NewDataBlockIterator<DataBlockIter>(read_options_, block_entry,
+                                                  &block_iter_, Status::OK());
+      block_iter_points_to_real_block_ = true;
+      prev_block_offset_ = data_block_handle.offset();
+      CheckDataBlockWithinUpperBound();
+    }
+    return;
+  }
+
+  // Regular path
   BlockHandle data_block_handle;
   bool is_in_cache = false;
   bool use_block_cache_for_lookup = true;
@@ -580,10 +630,6 @@ void BlockBasedTableIterator::FindKeyForward() {
 }
 
 void BlockBasedTableIterator::FindBlockForward() {
-  if (multi_scan_) {
-    FindBlockForwardInMultiScan();
-    return;
-  }
   // TODO the while loop inherits from two-level-iterator. We don't know
   // whether a block can be empty so it can be replaced by an "if".
   do {
@@ -594,8 +640,14 @@ void BlockBasedTableIterator::FindBlockForward() {
     //  index_iter_ can point to different block in case of
     //  readahead_cache_lookup_. readahead_cache_lookup_ will be handle the
     //  upper_bound check.
+    // MultiScan handles scan range boundaries via IsScanRangeExhausted()
+    // after index_iter_->Next(), so we must not use the
+    // next_block_is_out_of_bound mechanism which can prematurely terminate
+    // a scan range when the block separator >= iterate_upper_bound but
+    // valid keys still remain in the current range's blocks.
     bool next_block_is_out_of_bound =
-        IsIndexAtCurr() && read_options_.iterate_upper_bound != nullptr &&
+        !multi_scan_read_set_ && IsIndexAtCurr() &&
+        read_options_.iterate_upper_bound != nullptr &&
         block_iter_points_to_real_block_ &&
         block_upper_bound_check_ == BlockUpperBound::kUpperBoundInCurBlock;
 
@@ -626,6 +678,18 @@ void BlockBasedTableIterator::FindBlockForward() {
         if (is_index_out_of_bound_) {
           next_block_is_out_of_bound = is_index_out_of_bound_;
           is_index_out_of_bound_ = false;
+        }
+        // MultiScan: detect scan range boundary after Next()
+        if (multi_scan_index_iter_ &&
+            multi_scan_index_iter_->IsScanRangeExhausted()) {
+          if (multi_scan_index_iter_->HasMoreScanRanges()) {
+            // More ranges remain — signal out-of-bound so DBIter/LevelIter
+            // will trigger the next Seek for the next scan range.
+            is_out_of_bound_ = true;
+          }
+          // For last range: index_iter_->Valid() is false, so we fall
+          // through to the !Valid() return below. LevelIterator advances.
+          return;
         }
       } else {
         // Skip Next as index_iter_ already points to correct index when it
@@ -658,6 +722,10 @@ void BlockBasedTableIterator::FindBlockForward() {
       }
     }
     InitDataBlock();
+    if (multi_scan_read_set_ && !block_iter_points_to_real_block_) {
+      // MultiScan InitDataBlock failed (prefetch limit or IO error)
+      return;
+    }
     block_iter_.SeekToFirst();
   } while (!block_iter_.Valid());
 }
@@ -941,7 +1009,7 @@ void BlockBasedTableIterator::BlockCacheLookupForReadAheadSize(
 // end key. These Seeks will be handled properly, as long as the target is
 // moving forward.
 void BlockBasedTableIterator::Prepare(const MultiScanArgs* multiscan_opts) {
-  assert(!multi_scan_);
+  assert(!multi_scan_read_set_);
   RecordTick(table_->GetStatistics(), MULTISCAN_PREPARE_CALLS);
   StopWatch sw(table_->get_rep()->ioptions.clock, table_->GetStatistics(),
                MULTISCAN_PREPARE_MICROS);
@@ -951,8 +1019,8 @@ void BlockBasedTableIterator::Prepare(const MultiScanArgs* multiscan_opts) {
     RecordTick(table_->GetStatistics(), MULTISCAN_PREPARE_ERRORS);
     return;
   }
-  if (multi_scan_) {
-    multi_scan_.reset();
+  if (multi_scan_read_set_) {
+    multi_scan_read_set_.reset();
     multi_scan_status_ = Status::InvalidArgument("Prepare already called");
     RecordTick(table_->GetStatistics(), MULTISCAN_PREPARE_ERRORS);
     return;
@@ -1016,323 +1084,25 @@ void BlockBasedTableIterator::Prepare(const MultiScanArgs* multiscan_opts) {
     return;
   }
 
-  // Successful Prepare, init related states so the iterator reads from prepared
-  // blocks. Note: data_block_separators keeps full size for seek logic.
-  multi_scan_ = std::make_unique<MultiScanState>(
-      table_->get_rep()->ioptions.env->GetFileSystem(), multiscan_opts,
-      std::move(read_set), std::move(data_block_separators),
-      std::move(block_index_ranges_per_scan), prefetch_max_idx,
-      table_->GetStatistics());
+  // Successful Prepare. Create MultiScanIndexIterator and swap it in as
+  // the index iterator. The original index_iter_ is saved for restoration
+  // on backward operations.
+  // Note: data_block_separators keeps full size for seek logic, even though
+  // only blocks up to prefetch_max_idx are actually prefetched.
+  auto multi_scan_idx_iter = std::make_unique<MultiScanIndexIterator>(
+      std::move(scan_block_handles), std::move(data_block_separators),
+      std::move(block_index_ranges_per_scan), multiscan_opts, read_set,
+      prefetch_max_idx, icomp_, table_->GetStatistics());
+  assert(multi_scan_idx_iter->status().ok());
+
+  multi_scan_read_set_ = std::move(read_set);
+  multi_scan_index_iter_ = multi_scan_idx_iter.get();
+  prefetch_max_idx_ = prefetch_max_idx;
+  original_index_iter_ = std::move(index_iter_);
+  index_iter_ = std::move(multi_scan_idx_iter);
 
   is_index_at_curr_block_ = false;
   block_iter_points_to_real_block_ = false;
-}
-
-void BlockBasedTableIterator::SeekMultiScan(const Slice* seek_target) {
-  assert(multi_scan_ && multi_scan_status_.ok());
-  // This is a MultiScan and Prepare() has been called.
-
-  // Reset out of bound on seek, if it is out of bound again, it will be set
-  // properly later in the code path
-  is_out_of_bound_ = false;
-
-  // Validate seek key with scan options
-  if (!seek_target) {
-    // start key must be set for multi-scan
-    multi_scan_status_ = Status::InvalidArgument("No seek key for MultiScan");
-    RecordTick(table_->GetStatistics(), MULTISCAN_SEEK_ERRORS);
-    return;
-  }
-
-  // Check the case where there is no range prepared on this table
-  if (multi_scan_->scan_opts->size() == 0) {
-    // out of bound
-    MarkPreparedRangeExhausted();
-    return;
-  }
-
-  // Check whether seek key is moving forward.
-  if (multi_scan_->prev_seek_key_.empty() ||
-      icomp_.Compare(*seek_target, multi_scan_->prev_seek_key_) > 0) {
-    // If seek key is empty or is larger than previous seek key, update the
-    // previous seek key. Otherwise use the previous seek key as the adjusted
-    // seek target moving forward. This prevents seek target going backward,
-    // which would visit pages that have been unpinned.
-    // This issue is caused by sub-optimal range delete handling inside merge
-    // iterator.
-    // TODO xingbo issues:14068 : Optimize the handling of range delete iterator
-    // inside merge iterator, so that it doesn't move seek key backward. After
-    // that we could return error if the key moves backward here.
-    multi_scan_->prev_seek_key_ = seek_target->ToString();
-  } else {
-    // Seek key is adjusted to previous one, we can return here directly.
-    return;
-  }
-
-  // There are 3 different Cases we need to handle:
-  // The following diagram explain different seek targets seeking at various
-  // position on the table, while the next_scan_idx points to the PreparedRange
-  // 2.
-  //
-  // next_scan_idx: -------------------┐
-  //                                   ▼
-  // table:     : __[PreparedRange 1]__[PreparedRange 2]__[PreparedRange 3]__
-  // Seek target: <----- Case 1 ------>▲<------------- Case 2 -------------->
-  //                                   │
-  //                                 Case 3
-  //
-  // Case 1: seek before the start of next prepared ranges. This could happen
-  //    due to too many delete tomestone triggered reseek or delete range.
-  // Case 2: seek after the start of next prepared range.
-  //    This could happen due to seek key adjustment from delete range file.
-  //    E.g. LSM has 3 levels, each level has only 1 file:
-  //    L1 : key :              0---10
-  //    L2 : Delete range key : 0-5
-  //    L3 : key :              0---10
-  //    When a range 2-8 was prepared, the prepared key would be 2 on L3 file,
-  //    but the seek key would be 5, as the seek key was updated by the largest
-  //    key of delete range. This causes all of the cases above to be possible,
-  //    when the ranges are adjusted in the above examples.
-  // Case 3: seek at the beginning of a prepared range (expected case)
-
-  // Allow reseek on the start of the last prepared range due to too many
-  // tombstone
-  multi_scan_->next_scan_idx =
-      std::min(multi_scan_->next_scan_idx,
-               multi_scan_->block_index_ranges_per_scan.size() - 1);
-
-  auto user_seek_target = ExtractUserKey(*seek_target);
-
-  auto compare_next_scan_start_result =
-      user_comparator_.CompareWithoutTimestamp(
-          user_seek_target, /*a_has_ts=*/true,
-          multi_scan_->scan_opts->GetScanRanges()[multi_scan_->next_scan_idx]
-              .range.start.value(),
-          /*b_has_ts=*/false);
-
-  if (compare_next_scan_start_result != 0) {
-    // The seek target is not exactly same as what was prepared.
-    if (compare_next_scan_start_result < 0) {
-      // Case 1:
-      if (multi_scan_->next_scan_idx == 0) {
-        // This should not happen, even when seek target is adjusted by delete
-        // range. The reason is that if the seek target is before the start key
-        // of the first prepared range, its end key needs to be >= the smallest
-        // key of this file, otherwise it is skipped in level iterator. If its
-        // end key is >= the smallest key of this file, then this range will be
-        // prepared for this file. As delete range could only adjust seek
-        // target forward, so it would never be before the start key of the
-        // first prepared range.
-        assert(false && "Seek target before the first prepared range");
-        MarkPreparedRangeExhausted();
-        return;
-      }
-      auto seek_target_before_previous_prepared_range =
-          user_comparator_.CompareWithoutTimestamp(
-              user_seek_target, /*a_has_ts=*/true,
-              multi_scan_->scan_opts
-                  ->GetScanRanges()[multi_scan_->next_scan_idx - 1]
-                  .range.start.value(),
-              /*b_has_ts=*/false) < 0;
-      // Not expected to happen
-      // This should never happen, the reason is that the
-      // multi_scan_->next_scan_idx is set to a non zero value is due to a seek
-      // target larger or equal to the start key of multi_scan_->next_scan_idx-1
-      // happened earlier. If a seek happens before the start key of
-      // multi_scan_->next_scan_idx-1, it would seek a key that is less than
-      // what was seeked before.
-      assert(!seek_target_before_previous_prepared_range);
-      if (seek_target_before_previous_prepared_range) {
-        multi_scan_status_ = Status::InvalidArgument(
-            "Seek target is before the previous prepared range at index " +
-            std::to_string(multi_scan_->next_scan_idx));
-        RecordTick(table_->GetStatistics(), MULTISCAN_SEEK_ERRORS);
-        return;
-      }
-      // It should only be possible to seek a key between the start of current
-      // prepared scan and start of next prepared range.
-      MultiScanUnexpectedSeekTarget(seek_target, &user_seek_target);
-    } else {
-      // Case 2:
-      MultiScanUnexpectedSeekTarget(seek_target, &user_seek_target);
-    }
-  } else {
-    // Case 2:
-    assert(multi_scan_->next_scan_idx <
-           multi_scan_->block_index_ranges_per_scan.size());
-
-    auto [cur_scan_start_idx, cur_scan_end_idx] =
-        multi_scan_->block_index_ranges_per_scan[multi_scan_->next_scan_idx];
-    // We should have the data block already loaded
-    ++multi_scan_->next_scan_idx;
-    if (cur_scan_start_idx >= cur_scan_end_idx) {
-      // No blocks are prepared for this range at current file.
-      MarkPreparedRangeExhausted();
-      return;
-    }
-
-    // max_sequential_skip_in_iterations can trigger a reseek on the start
-    // key of a scan range, even though the multiscan is already past
-    // `cur_scan_start_idx` (e.g., a user key spans multiple data blocks).
-    size_t block_idx =
-        std::max(cur_scan_start_idx, multi_scan_->cur_data_block_idx);
-    MultiScanSeekTargetFromBlock(seek_target, block_idx);
-  }
-}
-
-void BlockBasedTableIterator::MultiScanUnexpectedSeekTarget(
-    const Slice* seek_target, const Slice* user_seek_target) {
-  // linear search the block that contains the seek target, and unpin blocks
-  // that are before it.
-
-  // The logic here could be confusing when there is a delete range involved.
-  // E.g. we have an LSM with 3 levels, each level has only 1 file:
-  // L1: data file :    0---10
-  // L2: Delete range : 0-5
-  // L3: data file :    0---10
-  //
-  // MultiScan on ranges 1-2, 3-4, and 5-6.
-  // When user first do Seek(1), on level 2, due to delete range 0-5, the seek
-  // key is adjusted to 5 at level 3. Therefore, we will internally do Seek(5)
-  // and unpins all blocks until 5 at level 3. Then the next scan's blocks from
-  // 3-4 are unpinned at level 3. It is confusing that maybe block 3-4 should
-  // not be unpinned, as next scan would need it. But Seek(5) implies that these
-  // keys are all covered by some range deletion, so the next Seek(3) will also
-  // do Seek(5) internally, so the blocks from 3-4 could be safely unpinned.
-
-  // advance to the right prepared range
-  while (
-      multi_scan_->next_scan_idx <
-          multi_scan_->block_index_ranges_per_scan.size() &&
-      (user_comparator_.CompareWithoutTimestamp(
-           *user_seek_target, /*a_has_ts=*/true,
-           multi_scan_->scan_opts->GetScanRanges()[multi_scan_->next_scan_idx]
-               .range.start.value(),
-           /*b_has_ts=*/false) >= 0)) {
-    multi_scan_->next_scan_idx++;
-  }
-
-  // next_scan_idx is guaranteed to be higher than 0. If the seek key is before
-  // the start key of first prepared range, it is already handled by caller
-  // SeekMultiScan. It is equal, it would not call this funciton. If it is
-  // after, next_scan_idx would be advanced by the loop above.
-  assert(multi_scan_->next_scan_idx > 0);
-  // Get the current range
-  auto cur_scan_idx = multi_scan_->next_scan_idx - 1;
-  auto [cur_scan_start_idx, cur_scan_end_idx] =
-      multi_scan_->block_index_ranges_per_scan[cur_scan_idx];
-
-  if (cur_scan_start_idx >= cur_scan_end_idx) {
-    // No blocks are prepared for this range at current file.
-    MarkPreparedRangeExhausted();
-    return;
-  }
-
-  // Unpin all the blocks from multi_scan_->cur_data_block_idx to
-  // cur_scan_start_idx - these are wasted (prefetched but skipped)
-  for (auto unpin_block_idx = multi_scan_->cur_data_block_idx;
-       unpin_block_idx < cur_scan_start_idx; unpin_block_idx++) {
-    // Count as wasted if it was prefetched
-    if (unpin_block_idx < multi_scan_->prefetch_max_idx) {
-      multi_scan_->wasted_blocks_count++;
-    }
-    multi_scan_->read_set->ReleaseBlock(unpin_block_idx);
-  }
-
-  // Take the max here to ensure we don't move backwards.
-  size_t block_idx =
-      std::max(cur_scan_start_idx, multi_scan_->cur_data_block_idx);
-  auto const& data_block_separators = multi_scan_->data_block_separators;
-  while (block_idx < data_block_separators.size() &&
-         (user_comparator_.CompareWithoutTimestamp(
-              *user_seek_target, /*a_has_ts=*/true,
-              data_block_separators[block_idx],
-              /*b_has_ts=*/false) > 0)) {
-    // Unpin the blocks that are passed - count as wasted if prefetched
-    if (block_idx < multi_scan_->prefetch_max_idx) {
-      multi_scan_->wasted_blocks_count++;
-    }
-    multi_scan_->read_set->ReleaseBlock(block_idx);
-    block_idx++;
-  }
-
-  if (block_idx >= data_block_separators.size()) {
-    // All of the prepared blocks for this file is exhausted.
-    MarkPreparedRangeExhausted();
-    return;
-  }
-
-  // The current block may contain the data for the target key
-  MultiScanSeekTargetFromBlock(seek_target, block_idx);
-}
-
-void BlockBasedTableIterator::MultiScanSeekTargetFromBlock(
-    const Slice* seek_target, size_t block_idx) {
-  assert(multi_scan_->cur_data_block_idx <= block_idx);
-
-  if (!block_iter_points_to_real_block_ ||
-      multi_scan_->cur_data_block_idx != block_idx) {
-    if (block_iter_points_to_real_block_) {
-      // Should be scan in increasing key range.
-      // All blocks before cur_data_block_idx_ are not pinned anymore.
-      assert(multi_scan_->cur_data_block_idx < block_idx);
-    }
-
-    ResetDataIter();
-
-    if (MultiScanLoadDataBlock(block_idx)) {
-      return;
-    }
-  }
-
-  // Move current data block index forward until block_idx, meantime, unpin all
-  // the blocks in between - these are wasted (prefetched but skipped)
-  while (multi_scan_->cur_data_block_idx < block_idx) {
-    // Count as wasted if it was prefetched
-    if (multi_scan_->cur_data_block_idx < multi_scan_->prefetch_max_idx) {
-      multi_scan_->wasted_blocks_count++;
-    }
-    multi_scan_->read_set->ReleaseBlock(multi_scan_->cur_data_block_idx);
-    multi_scan_->cur_data_block_idx++;
-  }
-  block_iter_points_to_real_block_ = true;
-  block_iter_.Seek(*seek_target);
-  FindKeyForward();
-  CheckOutOfBound();
-}
-
-void BlockBasedTableIterator::FindBlockForwardInMultiScan() {
-  assert(multi_scan_);
-  assert(multi_scan_->next_scan_idx >= 1);
-  const auto cur_scan_end_idx = std::get<1>(
-      multi_scan_->block_index_ranges_per_scan[multi_scan_->next_scan_idx - 1]);
-  do {
-    if (!block_iter_.status().ok()) {
-      return;
-    }
-
-    // If is_out_of_bound_ is true, upper layer (LevelIterator) considers this
-    // level has reached iterate_upper_bound_ and will not continue to iterate
-    // into the next file. When we are doing the last scan within a MultiScan
-    // for this file, it may need to continue to scan into the next file, so
-    // we do not set is_out_of_bound_ in this case.
-    if (multi_scan_->cur_data_block_idx + 1 >= cur_scan_end_idx) {
-      MarkPreparedRangeExhausted();
-      return;
-    }
-    // Move to the next pinned data block
-    ResetDataIter();
-    // Unpin previous block via ReadSet
-    multi_scan_->read_set->ReleaseBlock(multi_scan_->cur_data_block_idx);
-    ++multi_scan_->cur_data_block_idx;
-
-    if (MultiScanLoadDataBlock(multi_scan_->cur_data_block_idx)) {
-      return;
-    }
-
-    block_iter_points_to_real_block_ = true;
-    block_iter_.SeekToFirst();
-  } while (!block_iter_.Valid());
 }
 
 constexpr auto kVerbose = false;

--- a/table/block_based/block_based_table_iterator.h
+++ b/table/block_based/block_based_table_iterator.h
@@ -14,6 +14,7 @@
 #include "table/block_based/block_based_table_reader.h"
 #include "table/block_based/block_based_table_reader_impl.h"
 #include "table/block_based/block_prefetcher.h"
+#include "table/block_based/multi_scan_index_iterator.h"
 #include "table/block_based/reader_common.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -72,7 +73,7 @@ class BlockBasedTableIterator : public InternalIteratorBase<Slice> {
   Slice key() const override {
     assert(Valid());
     if (is_at_first_key_from_index_) {
-      assert(!multi_scan_);
+      assert(!multi_scan_read_set_);
       return index_iter_->value().first_internal_key;
     } else {
       return block_iter_.key();
@@ -148,16 +149,13 @@ class BlockBasedTableIterator : public InternalIteratorBase<Slice> {
     // Prefix index set status to NotFound when the prefix does not exist.
     if (IsIndexAtCurr() && !index_iter_->status().ok() &&
         !index_iter_->status().IsNotFound()) {
-      assert(!multi_scan_);
       return index_iter_->status();
     } else if (block_iter_points_to_real_block_) {
       // This is the common case.
       return block_iter_.status();
     } else if (async_read_in_progress_) {
-      assert(!multi_scan_);
+      assert(!multi_scan_read_set_);
       return Status::TryAgain("Async read in progress");
-    } else if (multi_scan_) {
-      return multi_scan_status_;
     } else {
       return Status::OK();
     }
@@ -169,8 +167,6 @@ class BlockBasedTableIterator : public InternalIteratorBase<Slice> {
     } else if (block_upper_bound_check_ ==
                BlockUpperBound::kUpperBoundBeyondCurBlock) {
       assert(!is_out_of_bound_);
-      // MultiScan does not do block level upper bound check yet.
-      assert(!multi_scan_);
       return IterBoundCheck::kInbound;
     } else {
       return IterBoundCheck::kUnknown;
@@ -245,10 +241,10 @@ class BlockBasedTableIterator : public InternalIteratorBase<Slice> {
   std::unique_ptr<InternalIteratorBase<IndexValue>> index_iter_;
 
   bool TEST_IsBlockPinnedByMultiScan(size_t block_idx) {
-    if (!multi_scan_ || !multi_scan_->read_set) {
+    if (!multi_scan_read_set_) {
       return false;
     }
-    return multi_scan_->read_set->IsBlockAvailable(block_idx);
+    return multi_scan_read_set_->IsBlockAvailable(block_idx);
   }
 
  private:
@@ -380,26 +376,6 @@ class BlockBasedTableIterator : public InternalIteratorBase<Slice> {
   // See InternalIteratorBase::IsOutOfBound().
   bool is_out_of_bound_ = false;
 
-  // Mark prepared ranges as exhausted for multiscan.
-  void MarkPreparedRangeExhausted() {
-    assert(multi_scan_ != nullptr);
-    if (multi_scan_->next_scan_idx <
-        multi_scan_->block_index_ranges_per_scan.size()) {
-      // If there are more prepared ranges, we don't ResetDataIter() here,
-      // because next scan might be reading from the same block. ResetDataIter()
-      // will free the underlying block cache handle and we don't want the
-      // block to be unpinned.
-      // Set out of bound to mark the current prepared range as exhausted.
-      is_out_of_bound_ = true;
-    } else {
-      // This is the last prepared range of this file, there might be more
-      // data on next file. Reset data iterator to indicate the iterator is
-      // no longer valid on this file. Let LevelIter advance to the next file
-      // instead of ending the scan.
-      ResetDataIter();
-    }
-  }
-
   // During cache lookup to find readahead size, index_iter_ is iterated and it
   // can point to a different block.
   // If Prepare() is called, index_iter_ is used to prefetch data blocks for the
@@ -410,61 +386,31 @@ class BlockBasedTableIterator : public InternalIteratorBase<Slice> {
   // *** END States used by both regular scan and multiscan
 
   // *** BEGIN MultiScan related states ***
-  struct MultiScanState {
-    // For Aborting async I/Os in destructor.
-    const std::shared_ptr<FileSystem> fs;
-    const MultiScanArgs* scan_opts;
-    // ReadSet owns pinned data blocks and handles async I/O
-    std::shared_ptr<ReadSet> read_set;
-    // The separator of each data block.
-    // Its size is same as the number of block handles submitted to
-    // IODispatcher. The value of separator is larger than or equal to the last
-    // key in the corresponding data block.
-    std::vector<std::string> data_block_separators;
-    // Track previously seeked key in multi-scan.
-    // This is used to ensure that the seek key is keep moving forward, as
-    // blocks that are smaller than the seek key are unpinned from memory.
-    std::string prev_seek_key_;
-
-    // Indicies into block handles for data blocks for each scan range.
-    // inclusive start, exclusive end
-    std::vector<std::tuple<size_t, size_t>> block_index_ranges_per_scan;
-    size_t next_scan_idx;
-    size_t cur_data_block_idx;
-    size_t prefetch_max_idx;
-
-    // For tracking wasted prefetch blocks (prefetched but never read)
-    Statistics* statistics;
-    size_t wasted_blocks_count;
-
-    MultiScanState(
-        const std::shared_ptr<FileSystem>& _fs, const MultiScanArgs* _scan_opts,
-        std::shared_ptr<ReadSet>&& _read_set,
-        std::vector<std::string>&& _data_block_separators,
-        std::vector<std::tuple<size_t, size_t>>&& _block_index_ranges_per_scan,
-        size_t _prefetch_max_idx, Statistics* _statistics)
-        : fs(_fs),
-          scan_opts(_scan_opts),
-          read_set(std::move(_read_set)),
-          data_block_separators(std::move(_data_block_separators)),
-          block_index_ranges_per_scan(std::move(_block_index_ranges_per_scan)),
-          next_scan_idx(0),
-          cur_data_block_idx(0),
-          prefetch_max_idx(_prefetch_max_idx),
-          statistics(_statistics),
-          wasted_blocks_count(0) {}
-
-    ~MultiScanState() {
-      if (statistics && wasted_blocks_count > 0) {
-        RecordTick(statistics, MULTISCAN_PREFETCH_BLOCKS_WASTED,
-                   wasted_blocks_count);
-      }
-    }
-  };
-
   Status multi_scan_status_;
-  std::unique_ptr<MultiScanState> multi_scan_;
-  // *** END MultiScan related APIs and states ***
+  // ReadSet from IODispatcher, set during Prepare(). When non-null, MultiScan
+  // is active and index_iter_ points to a MultiScanIndexIterator.
+  std::shared_ptr<ReadSet> multi_scan_read_set_;
+  // Raw pointer into index_iter_ when it's a MultiScanIndexIterator.
+  MultiScanIndexIterator* multi_scan_index_iter_ = nullptr;
+  // Original index iterator saved during Prepare(), restored on backward ops.
+  std::unique_ptr<InternalIteratorBase<IndexValue>> original_index_iter_;
+  // Maximum prefetchable block index.
+  size_t prefetch_max_idx_ = 0;
+  // *** END MultiScan related states ***
+
+  // Reset MultiScan state and restore the original index iterator.
+  void ResetMultiScan() {
+    multi_scan_read_set_.reset();
+    multi_scan_index_iter_ = nullptr;
+    prefetch_max_idx_ = 0;
+    // Discard any MultiScan error (e.g. PrefetchLimitReached) since we're
+    // falling back to regular iteration.
+    multi_scan_status_.PermitUncheckedError();
+    multi_scan_status_ = Status::OK();
+    if (original_index_iter_) {
+      index_iter_ = std::move(original_index_iter_);
+    }
+  }
 
   void SeekSecondPass(const Slice* target);
 
@@ -582,46 +528,6 @@ class BlockBasedTableIterator : public InternalIteratorBase<Slice> {
   // *** END APIs relevant to auto tuning of readahead_size ***
 
   // *** BEGIN APIs relevant to multiscan ***
-
-  void SeekMultiScan(const Slice* target);
-
-  void FindBlockForwardInMultiScan();
-
-  void MultiScanSeekTargetFromBlock(const Slice* seek_target, size_t block_idx);
-  void MultiScanUnexpectedSeekTarget(const Slice* seek_target,
-                                     const Slice* user_seek_target);
-
-  // Return true, if there is an error, or end of file
-  bool MultiScanLoadDataBlock(size_t idx) {
-    if (idx >= multi_scan_->prefetch_max_idx) {
-      // TODO: Fix the max_prefetch_size support for multiple files.
-      // The goal is to limit the memory usage, prefetch could be done
-      // incrementally.
-      if (multi_scan_->scan_opts->max_prefetch_size == 0) {
-        // If max_prefetch_size is not set, treat this as end of file.
-        ResetDataIter();
-        assert(!is_out_of_bound_);
-        assert(!Valid());
-      } else {
-        // If max_prefetch_size is set, treat this as error.
-        multi_scan_status_ = Status::PrefetchLimitReached();
-      }
-      return true;
-    }
-
-    // Use ReadSet to get block (handles cache/async/sync transparently)
-    CachableEntry<Block> block_entry;
-    multi_scan_status_ = multi_scan_->read_set->ReadIndex(idx, &block_entry);
-    if (!multi_scan_status_.ok()) {
-      return true;
-    }
-
-    assert(block_entry.GetValue());
-    // Note that the block_iter_ takes ownership of the pinned data block
-    table_->NewDataBlockIterator<DataBlockIter>(read_options_, block_entry,
-                                                &block_iter_, Status::OK());
-    return false;
-  }
 
   Status CollectBlockHandles(
       const std::vector<ScanOptions>& scan_opts,

--- a/table/block_based/multi_scan_index_iterator.cc
+++ b/table/block_based/multi_scan_index_iterator.cc
@@ -1,0 +1,326 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include "table/block_based/multi_scan_index_iterator.h"
+
+#include "monitoring/statistics_impl.h"
+#include "rocksdb/options.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+MultiScanIndexIterator::MultiScanIndexIterator(
+    std::vector<BlockHandle>&& block_handles,
+    std::vector<std::string>&& data_block_separators,
+    std::vector<std::tuple<size_t, size_t>>&& block_index_ranges_per_scan,
+    const MultiScanArgs* scan_opts, std::shared_ptr<ReadSet> read_set,
+    size_t prefetch_max_idx, const InternalKeyComparator& icomp,
+    Statistics* statistics)
+    : block_handles_(std::move(block_handles)),
+      data_block_separators_(std::move(data_block_separators)),
+      block_index_ranges_per_scan_(std::move(block_index_ranges_per_scan)),
+      scan_opts_(scan_opts),
+      read_set_(std::move(read_set)),
+      prefetch_max_idx_(prefetch_max_idx),
+      icomp_(icomp),
+      user_comparator_(icomp.user_comparator()),
+      statistics_(statistics) {}
+
+MultiScanIndexIterator::~MultiScanIndexIterator() {
+  if (statistics_ && wasted_blocks_count_ > 0) {
+    RecordTick(statistics_, MULTISCAN_PREFETCH_BLOCKS_WASTED,
+               wasted_blocks_count_);
+  }
+  // Release any remaining pinned blocks
+  if (read_set_) {
+    for (size_t i = cur_idx_; i < block_handles_.size(); ++i) {
+      read_set_->ReleaseBlock(i);
+    }
+  }
+}
+
+void MultiScanIndexIterator::ReleaseBlocks(size_t from_idx, size_t to_idx) {
+  for (size_t i = from_idx; i < to_idx; ++i) {
+    if (i < prefetch_max_idx_) {
+      wasted_blocks_count_++;
+    }
+    read_set_->ReleaseBlock(i);
+  }
+}
+
+void MultiScanIndexIterator::Seek(const Slice& target) {
+  if (!status_.ok()) {
+    return;
+  }
+
+  // Reset scan range exhaustion flag on Seek
+  scan_range_exhausted_ = false;
+
+  // Check the case where there are no ranges prepared
+  if (scan_opts_->size() == 0) {
+    valid_ = false;
+    return;
+  }
+
+  // Enforce forward-only seek
+  if (!prev_seek_key_.empty() && icomp_.Compare(target, prev_seek_key_) <= 0) {
+    // Seek key is not moving forward — keep current position
+    return;
+  }
+  prev_seek_key_ = target.ToString();
+
+  const auto& scan_ranges = scan_opts_->GetScanRanges();
+  Slice user_seek_target = ExtractUserKey(target);
+
+  // Allow reseek on the start of the last prepared range
+  next_scan_idx_ =
+      std::min(next_scan_idx_, block_index_ranges_per_scan_.size() - 1);
+
+  auto compare_next_scan_start_result =
+      user_comparator_.CompareWithoutTimestamp(
+          user_seek_target, /*a_has_ts=*/true,
+          scan_ranges[next_scan_idx_].range.start.value(),
+          /*b_has_ts=*/false);
+
+  // There are 3 different Cases we need to handle:
+  // The following diagram explains different seek targets seeking at various
+  // positions on the table, while the next_scan_idx_ points to PreparedRange 2.
+  //
+  // next_scan_idx_: ------------------┐
+  //                                   ▼
+  // table:     : __[PreparedRange 1]__[PreparedRange 2]__[PreparedRange 3]__
+  // Seek target: <----- Case 1 ------>▲<------------- Case 2 -------------->
+  //                                   │
+  //                                 Case 3
+  //
+  // Case 1: seek before the start of next prepared range. This could happen
+  //    due to too many delete tombstones triggering reseek or delete range.
+  // Case 2: seek after the start of next prepared range.
+  //    This could happen due to seek key adjustment from delete range file.
+  // Case 3: seek at the beginning of a prepared range (expected case)
+
+  if (compare_next_scan_start_result < 0) {
+    // Case 1: Seek before the start of the next prepared range
+    if (next_scan_idx_ == 0) {
+      // Should not happen — seek before first prepared range
+      assert(false && "Seek target before the first prepared range");
+      valid_ = false;
+      return;
+    }
+    auto seek_target_before_previous_prepared_range =
+        user_comparator_.CompareWithoutTimestamp(
+            user_seek_target, /*a_has_ts=*/true,
+            scan_ranges[next_scan_idx_ - 1].range.start.value(),
+            /*b_has_ts=*/false) < 0;
+    assert(!seek_target_before_previous_prepared_range);
+    if (seek_target_before_previous_prepared_range) {
+      status_ = Status::InvalidArgument(
+          "Seek target is before the previous prepared range at index " +
+          std::to_string(next_scan_idx_));
+      RecordTick(statistics_, MULTISCAN_SEEK_ERRORS);
+      valid_ = false;
+      return;
+    }
+    // Seek within a gap — advance to the right scan range and find block
+    SeekToBlock(&user_seek_target);
+  } else if (compare_next_scan_start_result > 0) {
+    // Case 2: Seek after the start of the next prepared range
+    SeekToBlock(&user_seek_target);
+  } else {
+    // Case 3: Seek at the beginning of a prepared range (expected case)
+    assert(next_scan_idx_ < block_index_ranges_per_scan_.size());
+    auto [cur_scan_start_idx, cur_scan_end_idx] =
+        block_index_ranges_per_scan_[next_scan_idx_];
+    ++next_scan_idx_;
+
+    if (cur_scan_start_idx >= cur_scan_end_idx) {
+      // No blocks are prepared for this range at current file
+      SetExhausted();
+      return;
+    }
+
+    // max_sequential_skip_in_iterations can trigger a reseek on the start
+    // key of a scan range, even though we're already past cur_scan_start_idx
+    size_t block_idx = std::max(cur_scan_start_idx, cur_idx_);
+    SeekToBlockIdx(block_idx);
+  }
+}
+
+void MultiScanIndexIterator::SeekToBlock(const Slice* user_seek_target) {
+  const auto& scan_ranges = scan_opts_->GetScanRanges();
+
+  // Advance next_scan_idx_ past ranges whose start key <= seek target
+  while (next_scan_idx_ < block_index_ranges_per_scan_.size() &&
+         user_comparator_.CompareWithoutTimestamp(
+             *user_seek_target, /*a_has_ts=*/true,
+             scan_ranges[next_scan_idx_].range.start.value(),
+             /*b_has_ts=*/false) >= 0) {
+    next_scan_idx_++;
+  }
+
+  assert(next_scan_idx_ > 0);
+  auto cur_scan_idx = next_scan_idx_ - 1;
+  auto [cur_scan_start_idx, cur_scan_end_idx] =
+      block_index_ranges_per_scan_[cur_scan_idx];
+
+  if (cur_scan_start_idx >= cur_scan_end_idx) {
+    SetExhausted();
+    return;
+  }
+
+  // Release blocks from current position to cur_scan_start_idx (wasted)
+  ReleaseBlocks(cur_idx_, cur_scan_start_idx);
+
+  // Find the correct block within the range using linear search on separators
+  size_t block_idx = std::max(cur_scan_start_idx, cur_idx_);
+  while (block_idx < data_block_separators_.size() &&
+         user_comparator_.CompareWithoutTimestamp(
+             *user_seek_target, /*a_has_ts=*/true,
+             data_block_separators_[block_idx],
+             /*b_has_ts=*/false) > 0) {
+    if (block_idx < prefetch_max_idx_) {
+      wasted_blocks_count_++;
+    }
+    read_set_->ReleaseBlock(block_idx);
+    block_idx++;
+  }
+
+  if (block_idx >= data_block_separators_.size()) {
+    // All remaining blocks were released above. Update cur_idx_ so the
+    // destructor does not double-release them.
+    cur_idx_ = block_handles_.size();
+    SetExhausted();
+    return;
+  }
+
+  // Update cur_idx_ before calling SeekToBlockIdx since we've already
+  // released all blocks up to block_idx above. This prevents SeekToBlockIdx's
+  // ReleaseBlocks(cur_idx_, block_idx) from double-releasing.
+  cur_idx_ = block_idx;
+  SeekToBlockIdx(block_idx);
+}
+
+void MultiScanIndexIterator::SeekToBlockIdx(size_t block_idx) {
+  assert(cur_idx_ <= block_idx);
+
+  // Release any blocks between cur_idx_ and block_idx (wasted)
+  ReleaseBlocks(cur_idx_, block_idx);
+
+  cur_idx_ = block_idx;
+  valid_ = true;
+}
+
+void MultiScanIndexIterator::SetExhausted() {
+  scan_range_exhausted_ = true;
+  if (next_scan_idx_ < block_index_ranges_per_scan_.size()) {
+    // More ranges remain — signal out-of-bound for current range.
+    valid_ = true;
+    // Position at the start of the next range so that the next Seek()
+    // can find it. We need to be "valid" so that FindBlockForward sets
+    // is_out_of_bound_ = true.
+    auto [start, end] = block_index_ranges_per_scan_[next_scan_idx_];
+    if (start < end) {
+      cur_idx_ = start;
+      return;
+    }
+    valid_ = false;
+  } else {
+    // Last range — natural EOF. Don't set out-of-bound so LevelIterator
+    // advances to the next file.
+    valid_ = false;
+  }
+}
+
+void MultiScanIndexIterator::Next() {
+  assert(valid_);
+
+  // Release current block
+  read_set_->ReleaseBlock(cur_idx_);
+  ++cur_idx_;
+
+  // Check if we've crossed a scan range boundary
+  if (next_scan_idx_ > 0) {
+    auto cur_scan_end_idx =
+        std::get<1>(block_index_ranges_per_scan_[next_scan_idx_ - 1]);
+    if (cur_idx_ >= cur_scan_end_idx) {
+      // Current scan range is exhausted
+      SetExhausted();
+      return;
+    }
+  }
+
+  // Check prefetch limit
+  if (cur_idx_ >= prefetch_max_idx_) {
+    valid_ = false;
+    if (scan_opts_->max_prefetch_size > 0) {
+      status_ = Status::PrefetchLimitReached();
+    }
+    return;
+  }
+
+  // Still within current range, valid
+  valid_ = true;
+}
+
+void MultiScanIndexIterator::SeekToFirst() {
+  if (block_index_ranges_per_scan_.empty()) {
+    valid_ = false;
+    return;
+  }
+
+  cur_idx_ = 0;
+  next_scan_idx_ = 0;
+  prev_seek_key_.clear();
+  wasted_blocks_count_ = 0;
+  status_ = Status::OK();
+
+  auto [start, end] = block_index_ranges_per_scan_[0];
+  if (start >= end) {
+    valid_ = false;
+    return;
+  }
+  cur_idx_ = start;
+  next_scan_idx_ = 1;
+  valid_ = true;
+}
+
+void MultiScanIndexIterator::SeekForPrev(const Slice& /*target*/) {
+  valid_ = false;
+}
+
+void MultiScanIndexIterator::SeekToLast() { valid_ = false; }
+
+void MultiScanIndexIterator::Prev() { valid_ = false; }
+
+Slice MultiScanIndexIterator::key() const {
+  assert(valid_);
+  assert(cur_idx_ < data_block_separators_.size());
+
+  // Build internal key: user_key + pack(kMaxSequenceNumber, kValueTypeForSeek)
+  cur_key_buf_.clear();
+  AppendInternalKey(&cur_key_buf_,
+                    ParsedInternalKey(data_block_separators_[cur_idx_],
+                                      kMaxSequenceNumber, kValueTypeForSeek));
+  return Slice(cur_key_buf_);
+}
+
+Slice MultiScanIndexIterator::user_key() const {
+  assert(valid_);
+  assert(cur_idx_ < data_block_separators_.size());
+  return Slice(data_block_separators_[cur_idx_]);
+}
+
+IndexValue MultiScanIndexIterator::value() const {
+  assert(valid_);
+  assert(cur_idx_ < block_handles_.size());
+  // Return IndexValue with empty first_internal_key to disable
+  // is_at_first_key_from_index_ optimization
+  return IndexValue(block_handles_[cur_idx_], Slice());
+}
+
+uint64_t MultiScanIndexIterator::GetMaxPrefetchSize() const {
+  return scan_opts_->max_prefetch_size;
+}
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/table/block_based/multi_scan_index_iterator.h
+++ b/table/block_based/multi_scan_index_iterator.h
@@ -1,0 +1,133 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include "db/dbformat.h"
+#include "rocksdb/io_dispatcher.h"
+#include "table/format.h"
+#include "table/internal_iterator.h"
+#include "util/user_comparator_wrapper.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+class MultiScanArgs;
+class Statistics;
+
+// MultiScanIndexIterator wraps the block handle list produced by
+// Prepare()/CollectBlockHandles() and presents it as an
+// InternalIteratorBase<IndexValue>. This allows BlockBasedTableIterator
+// to use the same SeekImpl()/FindBlockForward() code path for both
+// regular iteration and MultiScan.
+//
+// The iterator supports forward-only Seek() and Next(). Seek targets must
+// be non-decreasing (enforced via prev_seek_key_). When a scan range is
+// exhausted, Next() jumps to the start of the next scan range. When all
+// ranges are exhausted, the iterator becomes invalid.
+class MultiScanIndexIterator : public InternalIteratorBase<IndexValue> {
+ public:
+  // scan_opts and icomp must outlive this iterator. read_set is shared.
+  MultiScanIndexIterator(
+      std::vector<BlockHandle>&& block_handles,
+      std::vector<std::string>&& data_block_separators,
+      std::vector<std::tuple<size_t, size_t>>&& block_index_ranges_per_scan,
+      const MultiScanArgs* scan_opts, std::shared_ptr<ReadSet> read_set,
+      size_t prefetch_max_idx, const InternalKeyComparator& icomp,
+      Statistics* statistics);
+
+  ~MultiScanIndexIterator() override;
+
+  // Non-copyable, non-movable.
+  MultiScanIndexIterator(const MultiScanIndexIterator&) = delete;
+  MultiScanIndexIterator& operator=(const MultiScanIndexIterator&) = delete;
+  MultiScanIndexIterator(MultiScanIndexIterator&&) = delete;
+  MultiScanIndexIterator& operator=(MultiScanIndexIterator&&) = delete;
+
+  // Forward-only seek. target must be >= prev_seek_key_.
+  void Seek(const Slice& target) override;
+
+  // Move to the next block. Handles scan range boundaries.
+  void Next() override;
+
+  // Move to the first block of the first scan range.
+  void SeekToFirst() override;
+
+  // Not supported — sets valid_ = false.
+  void SeekForPrev(const Slice& target) override;
+  void SeekToLast() override;
+  void Prev() override;
+
+  bool Valid() const override { return valid_; }
+
+  // Returns an internal key built from the current block's separator
+  // with kMaxSequenceNumber.
+  Slice key() const override;
+
+  // Returns the user key separator for the current block.
+  Slice user_key() const override;
+
+  // Returns IndexValue with the current block handle and empty
+  // first_internal_key (disables is_at_first_key_from_index_ optimization).
+  IndexValue value() const override;
+
+  Status status() const override { return status_; }
+
+  // Returns the current index into the block_handles/read_set arrays.
+  size_t current_read_set_index() const { return cur_idx_; }
+
+  // Returns the max_prefetch_size from scan options.
+  uint64_t GetMaxPrefetchSize() const;
+
+  // Returns true if the last Next() crossed a scan range boundary.
+  // Only valid immediately after Next(); reset to false on the next Seek().
+  bool IsScanRangeExhausted() const { return scan_range_exhausted_; }
+
+  // Returns true if there are more scan ranges after the current one.
+  bool HasMoreScanRanges() const {
+    return next_scan_idx_ < block_index_ranges_per_scan_.size();
+  }
+
+ private:
+  // Release blocks from from_idx (inclusive) to to_idx (exclusive),
+  // counting wasted prefetched blocks.
+  void ReleaseBlocks(size_t from_idx, size_t to_idx);
+
+  // Find the correct scan range and block for an unexpected seek target
+  // (target doesn't match expected scan range start).
+  void SeekToBlock(const Slice* user_seek_target);
+
+  // Position at block_idx after releasing any skipped blocks.
+  void SeekToBlockIdx(size_t block_idx);
+
+  // Mark the current scan range as exhausted. If more ranges remain,
+  // positions at the next range's start (stays valid for out-of-bound
+  // detection). If this is the last range, becomes invalid.
+  void SetExhausted();
+
+  std::vector<BlockHandle> block_handles_;
+  std::vector<std::string> data_block_separators_;
+  std::vector<std::tuple<size_t, size_t>> block_index_ranges_per_scan_;
+  const MultiScanArgs* scan_opts_;
+  std::shared_ptr<ReadSet> read_set_;
+  size_t prefetch_max_idx_;
+  const InternalKeyComparator& icomp_;
+  UserComparatorWrapper user_comparator_;
+  Statistics* statistics_;
+
+  size_t cur_idx_ = 0;
+  size_t next_scan_idx_ = 0;
+  bool valid_ = false;
+  Status status_;
+  std::string prev_seek_key_;
+  size_t wasted_blocks_count_ = 0;
+  bool scan_range_exhausted_ = false;
+  mutable std::string cur_key_buf_;
+};
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/util/io_dispatcher_imp.cc
+++ b/util/io_dispatcher_imp.cc
@@ -336,9 +336,24 @@ Status ReadSet::SyncRead(size_t block_index) {
   const auto& block_handle = job_->block_handles[block_index];
   auto* rep = job_->table->get_rep();
 
+  // Get dictionary-aware decompressor if available
+  UnownedPtr<Decompressor> decompressor = rep->decompressor.get();
+  CachableEntry<DecompressorDict> cached_dict;
+  if (rep->uncompression_dict_reader) {
+    Status s = rep->uncompression_dict_reader->GetOrReadUncompressionDictionary(
+        nullptr, job_->job_options.read_options, nullptr, nullptr,
+        &cached_dict);
+    if (!s.ok()) {
+      return s;
+    }
+    if (cached_dict.GetValue()) {
+      decompressor = cached_dict.GetValue()->decompressor_.get();
+    }
+  }
+
   return job_->table->RetrieveBlock<Block_kData>(
       /*prefetch_buffer=*/nullptr, job_->job_options.read_options, block_handle,
-      rep->decompressor.get(), &pinned_blocks_[block_index].As<Block_kData>(),
+      decompressor, &pinned_blocks_[block_index].As<Block_kData>(),
       /*get_context=*/nullptr, /*lookup_context=*/nullptr,
       /*for_compaction=*/false, /*use_cache=*/true,
       /*async_read=*/false, /*use_block_cache_for_lookup=*/true);


### PR DESCRIPTION
Summary:
Unify the MultiScan and regular iterator codepaths in BlockBasedTableIterator by introducing a MultiScanIndexIterator that implements InternalIteratorBase<IndexValue>. During Prepare(), the original index iterator is swapped out for a MultiScanIndexIterator that wraps the prefetched block handles and scan range metadata. This allows SeekImpl() and FindBlockForward() to use the same code flow for both regular and MultiScan operations, eliminating the need for separate MultiScan-specific methods (SeekMultiScan, FindBlockForwardInMultiScan, MultiScanSeekTargetFromBlock, MultiScanUnexpectedSeekTarget, MultiScanLoadDataBlock, MarkPreparedRangeExhausted).

Key changes:
- New MultiScanIndexIterator class that manages scan range tracking, block handle iteration, forward-only seek enforcement, and wasted block counting
- InitDataBlock() loads blocks from ReadSet when MultiScan is active
- FindBlockForward() detects scan range boundaries via IsScanRangeExhausted() after index_iter_->Next()
- Disabled reseek optimization for MultiScan so MultiScanIndexIterator::Seek() is always called to update scan range tracking state
- Removed MultiScanState struct and all MultiScan-specific methods from BlockBasedTableIterator
- No changes to CheckDataBlockWithinUpperBound or CheckOutOfBound — they work as-is through iterate_upper_bound
- multi_scan_status_ intentionally not checked in Valid() hot path to avoid performance regression; when status is non-OK, block_iter_points_to_real_block_ is already false
- Fixed pre-existing bug in ReadSet::SyncRead() that used the base decompressor without compression dictionary, causing ZSTD data corruption when blocks with dictionary compression needed synchronous fallback reads

Test plan -
- All MultiScan tests pass (buck test):
   - BlockBasedTableReaderMultiScan: 2688/2688 pass (including compression dictionary tests)
   - DBMultiScanIteratorTest: 32/32 pass

db_bench (release build, 5M keys, no compression, L5=8 files/60MB + L6=49 files/317MB, 3 runs each):
                Before (parent)     After (this diff)    Delta
readseq         2,426K ops/sec      2,454K ops/sec       +1.2%
seekrandom      49,053 ops/sec      50,008 ops/sec       +1.9%
multiscan       6,907 ops/sec       7,001 ops/sec        +1.4%
Setup: --batch_size=10 --seek_nexts=50 --multiscan_size=10 --multiscan_stride=100 --cache_size=512MB --duration=30
No regression in any benchmark.

