### PR TITLE
Fix unused parameter warning in ExtractUncompressedSize

### DIFF
--- a/util/compression.cc
+++ b/util/compression.cc
@@ -1550,6 +1550,7 @@ class BuiltinDecompressorV2SnappyOnly final : public BuiltinDecompressorV2 {
     args.uncompressed_size = uncompressed_length;
     return Status::OK();
 #else
+    (void)args;
     return Status::NotSupported("Snappy not supported in this build");
 #endif
   }


### PR DESCRIPTION
Fixes #14309. Adds (void)args cast to suppress unused parameter warning when Snappy is not supported.