### PR TITLE
Fix stress test failure with trie index

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -1985,9 +1985,15 @@ Status StressTest::TestIterateImpl(ThreadState* thread,
 
     Slice key(key_str);
 
-    // SeekToFirst and SeekToLast require backward scan support.
+    // UserDefinedIndexIterator only supports Seek(target) + Next() - it
+    // requires a target key for seeks. SeekToFirst/SeekToLast have no target
+    // key, and SeekForPrev/Prev are not supported. Check if UDI is being used
+    // either via ReadOptions or CF-level configuration.
+    const bool using_udi =
+        (ro.table_index_factory != nullptr) || (udi_factory_ != nullptr);
     const bool support_seek_first_or_last =
-        expect_total_order && FLAGS_test_backward_scan;
+        expect_total_order && FLAGS_test_backward_scan && !using_udi;
+    const bool support_seek_for_prev = FLAGS_test_backward_scan && !using_udi;
 
     // Write-prepared and Write-unprepared and multi-cf-iterator do not support
     // Refresh() yet.
@@ -2012,7 +2018,7 @@ Status StressTest::TestIterateImpl(ThreadState* thread,
       cmp_iter->SeekToLast();
       last_op = kLastOpSeekToLast;
       op_logs += "STL ";
-    } else if (FLAGS_test_backward_scan && thread->rand.OneIn(8)) {
+    } else if (support_seek_for_prev && thread->rand.OneIn(8)) {
       iter->SeekForPrev(key);
       cmp_iter->SeekForPrev(key);
       last_op = kLastOpSeekForPrev;


### PR DESCRIPTION
    Fix stress test to check UDI usage for unsupported iterator ops
    
    UserDefinedIndexIterator only supports Seek(target) + Next() - it requires
    a target key for all seeks. The following operations are not supported:
    - SeekToFirst() - no target key
    - SeekToLast() - no target key
    - SeekForPrev() - not in UDI interface
    - Prev() - not in UDI interface
    
    This fix checks for UDI usage at both levels:
    1. ReadOptions level: ro.table_index_factory != nullptr
    2. CF/table level: udi_factory_ != nullptr (BlockBasedTableOptions)
    
    This is future-proof for any UDI implementation, not just trie index.