### PR TITLE
Block TransactionDB when UDI (use_trie_index) is enabled

### DIFF
--- a/db_stress_tool/db_stress_tool.cc
+++ b/db_stress_tool/db_stress_tool.cc
@@ -255,6 +255,16 @@ int db_stress_tool(int argc, char** argv) {
               "use_timed_put_one_in > 0\n");
       exit(1);
     }
+    // TransactionDB uses internal marker types (kTypeBeginPrepareXID,
+    // kTypeEndPrepareXID, kTypeCommitXID, etc.) which are non-Put types.
+    // These are incompatible with UDI which only supports kTypeValue.
+    if (FLAGS_use_txn) {
+      fprintf(stderr,
+              "Error: use_trie_index is incompatible with use_txn. "
+              "TransactionDB uses internal marker types that are not "
+              "supported by user-defined index.\n");
+      exit(1);
+    }
   }
 
   if (FLAGS_read_only) {

--- a/table/block_based/user_defined_index_wrapper.h
+++ b/table/block_based/user_defined_index_wrapper.h
@@ -107,6 +107,14 @@ class UserDefinedIndexBuilderWrapper : public IndexBuilder {
             "compression");
       } else {
         status_ = ParseInternalKey(key, &pkey, /*lof_err_key*/ false);
+        // UDI only supports kTypeValue (Put) entries. Non-Put types include:
+        // - kTypeDeletion, kTypeSingleDeletion, kTypeRangeDeletion (deletes)
+        // - kTypeMerge (merge operands)
+        // - kTypeWideColumnEntity (PutEntity)
+        // This makes UDI incompatible with:
+        // - Delete/Merge/SingleDelete/DeleteRange operations
+        // - TransactionDB (ROLLBACK writes DELETE entries to undo changes)
+        // See T257683723 for analysis of TransactionDB incompatibility.
         if (status_.ok() && pkey.type != ValueType::kTypeValue) {
           status_ = Status::InvalidArgument(
               "user_defined_index_factory only supported with Puts");
@@ -117,11 +125,9 @@ class UserDefinedIndexBuilderWrapper : public IndexBuilder {
       return;
     }
 
-    // Pass the user key to the UDI. We don't expect multiple entries with
-    // different sequence numbers for the same key in the file. RocksDB may
-    // enforce it in the future by allowing UDIs only for read only
-    // bulkloaded use cases, and only allow ingestion of files with
-    // sequence number 0.
+    // Pass the user key to the UDI. UDI is designed for ingest-only use cases
+    // where files contain only Put entries with unique keys. We don't expect
+    // multiple entries with different sequence numbers for the same key.
     user_defined_index_builder_->OnKeyAdded(
         pkey.user_key, UserDefinedIndexBuilder::ValueType::kValue,
         value.value());

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -898,6 +898,9 @@ def finalize_and_sanitize(src_params):
         dest_params["use_timed_put_one_in"] = 0
         dest_params["use_get_entity"] = 0
         dest_params["use_multi_get_entity"] = 0
+        # TransactionDB ROLLBACK writes DELETE entries to WAL to undo
+        # uncommitted changes. These DELETEs violate UDI's Put-only restriction.
+        dest_params["use_txn"] = 0
         # Redistribute delete/delrange percents to write percent
         dest_params["writepercent"] += dest_params["delpercent"]
         dest_params["writepercent"] += dest_params["delrangepercent"]


### PR DESCRIPTION
User-Defined Index (UDI) only supports kTypeValue (Put) entries. TransactionDB is incompatible because transaction ROLLBACK operations write DELETE entries to the WAL to undo uncommitted changes.

Evidence from crash DB analysis (T257683723):
- All SST files had 0 deletions, 0 merges, 0 range deletions
- WAL file 012653.log contained DELETE entries from ROLLBACK: 322982,DELETE(2) ROLLBACK(0x7869643334333837) 322987,DELETE(8) ROLLBACK(0x7869643334333935) 322989,DELETE(8) ROLLBACK(0x7869643334343031) 322993,DELETE(9) ROLLBACK(0x7869643334343035) 322996,DELETE(4) ROLLBACK(0x7869643334333939)

Root cause chain:
1. TransactionDB ROLLBACK writes DELETE entries to WAL
2. During recovery/Open(), WAL entries are replayed into memtable
3. During flush, memtable (containing DELETEs) triggers UDI builder
4. UDI builder rejects DELETE: pkey.type != kTypeValue
5. Error: "user_defined_index_factory only supported with Puts"

This change adds:
1. Validation in db_stress_tool.cc to reject use_trie_index + use_txn
2. Sanitization in db_crashtest.py to set use_txn=0 when use_trie_index=1

Test: ./db_stress --use_trie_index=1 --use_txn=1 --delpercent=0 \
      --delrangepercent=0 --readpercent=30 --prefixpercent=20 \
      --writepercent=40 --iterpercent=10 --customopspercent=0
      # Now correctly rejects with clear error message