### PR TITLE
Disable mmap_read with trie index to fix SIGSEGV

### DIFF
--- a/db_stress_tool/db_stress_tool.cc
+++ b/db_stress_tool/db_stress_tool.cc
@@ -255,14 +255,19 @@ int db_stress_tool(int argc, char** argv) {
               "use_timed_put_one_in > 0\n");
       exit(1);
     }
-    // TransactionDB uses internal marker types (kTypeBeginPrepareXID,
-    // kTypeEndPrepareXID, kTypeCommitXID, etc.) which are non-Put types.
-    // These are incompatible with UDI which only supports kTypeValue.
     if (FLAGS_use_txn) {
       fprintf(stderr,
               "Error: use_trie_index is incompatible with use_txn. "
-              "TransactionDB uses internal marker types that are not "
-              "supported by user-defined index.\n");
+              "TransactionDB rollback is executed as delete operation during "
+              "crash recovery, which are non-Put types, not supported by "
+              "user-defined index.\n");
+      exit(1);
+    }
+    if (FLAGS_mmap_read) {
+      fprintf(stderr,
+              "Error: use_trie_index is incompatible with mmap_read. "
+              "The trie index uses zero-copy pointers into block data "
+              "which is unsafe with mmap'd reads.\n");
       exit(1);
     }
   }

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -902,6 +902,9 @@ def finalize_and_sanitize(src_params):
         # TransactionDB ROLLBACK writes DELETE entries to WAL to undo
         # uncommitted changes. These DELETEs violate UDI's Put-only restriction.
         dest_params["use_txn"] = 0
+        # Trie UDI uses zero-copy pointers into block data, which is
+        # incompatible with mmap_read.
+        dest_params["mmap_read"] = 0
         # Redistribute delete/delrange percents to write percent
         dest_params["writepercent"] += dest_params["delpercent"]
         dest_params["writepercent"] += dest_params["delrangepercent"]


### PR DESCRIPTION
The trie-based UDI (LoudsTrie/Bitvector) stores zero-copy reinterpret_cast pointers into the serialized UDI block data. When mmap_read is enabled, the block data resides in memory-mapped file pages. If the SST file's mmap mapping is later invalidated (e.g. through table cache eviction or DB reopen), the trie's internal pointers become dangling, causing SIGSEGV.

For now, disable mmap_read when use_trie_index is enabled:
- db_crashtest.py: force mmap_read=0 when use_trie_index=1
- db_stress_tool.cc: reject the combination with an error message

The proper fix, involve loading index then fix the pointer address.