### PR TITLE
Fix uninitialized wal_in_db_path_ in read-only and compacted DB open paths

### DIFF
--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -3213,7 +3213,7 @@ class DBImpl : public DB {
   // installed to MANIFEST first.
   InstrumentedCondVar atomic_flush_install_cv_;
 
-  bool wal_in_db_path_;
+  bool wal_in_db_path_ = false;
   std::atomic<uint64_t> max_total_wal_size_;
 
   BlobFileCompletionCallback blob_callback_;

--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -94,6 +94,44 @@ TEST_F(DBTest2, OpenForReadOnlyWithColumnFamilies) {
   ASSERT_NOK(env_->FileExists(dbname));
 }
 
+// Regression test: wal_in_db_path_ was not initialized in the read-only DB
+// open path, causing UBSan "invalid-bool-load" when CloseHelper calls
+// PurgeObsoleteFiles -> DeleteObsoleteFileImpl which reads wal_in_db_path_.
+TEST_F(DBTest2, ReadOnlyDBWalInDbPathInitialized) {
+  // Create a normal DB with some data and WAL files
+  Options options = CurrentOptions();
+  options.create_if_missing = true;
+  DestroyAndReopen(options);
+  ASSERT_OK(Put("key1", "value1"));
+  ASSERT_OK(Flush());
+  ASSERT_OK(Put("key2", "value2"));
+  Close();
+
+  // Reopen as read-only — wal_in_db_path_ must be properly initialized.
+  // Before the fix, closing this DB would read an uninitialized bool in
+  // DeleteObsoleteFileImpl, which UBSan catches as undefined behavior.
+  std::unique_ptr<DB> db_ptr;
+  ASSERT_OK(DB::OpenForReadOnly(options, dbname_, &db_ptr));
+  std::string value;
+  ASSERT_OK(db_ptr->Get(ReadOptions(), "key1", &value));
+  ASSERT_EQ("value1", value);
+  // Close the read-only DB — this triggers PurgeObsoleteFiles which reads
+  // wal_in_db_path_. Under UBSan, an uninitialized bool here would fail.
+  db_ptr.reset();
+
+  // Also test the column-families variant
+  std::vector<ColumnFamilyDescriptor> column_families;
+  column_families.emplace_back(kDefaultColumnFamilyName,
+                               ColumnFamilyOptions(options));
+  std::vector<ColumnFamilyHandle*> handles;
+  ASSERT_OK(DB::OpenForReadOnly(DBOptions(options), dbname_, column_families,
+                                &handles, &db_ptr));
+  for (auto* h : handles) {
+    delete h;
+  }
+  db_ptr.reset();
+}
+
 class PartitionedIndexTestListener : public EventListener {
  public:
   void OnFlushCompleted(DB* /*db*/, const FlushJobInfo& info) override {


### PR DESCRIPTION
Summary:

wal_in_db_path_ was declared without an in-class initializer in DBImpl. While DB::Open, OpenAsSecondary, and OpenAsFollower all explicitly set this field, OpenForReadOnly and CompactedDBImpl::Open did not.

This was harmless until recently because CloseHelper() only calls PurgeObsoleteFiles when opened_successfully_ is true, and read-only DBs previously did not set opened_successfully_. After #14322 added opened_successfully_ = true to the read-only path, CloseHelper now executes PurgeObsoleteFiles -> DeleteObsoleteFileImpl, which reads wal_in_db_path_ to decide whether WAL files should be deleted in the foreground. Reading an uninitialized bool is undefined behavior, caught by UBSan as "invalid-bool-load" in the secondary_cache_crash_test.

Fixed by adding an in-class initializer (= false) to wal_in_db_path_. The default of false means WAL deletions use foreground deletion, which is safe for read-only DBs that don't write WALs. The existing DB::Open path continues to set the correct value explicitly.

Test:
- Added regression test ReadOnlyDBWalInDbPathInitialized in db_test2
- Ran test 5 times without failure
- Ran all OpenForReadOnly tests (3 tests pass)

Task:
T257988006