### PR TITLE
Disable prefix scanning when use_trie_index is enabled in crash test

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -911,6 +911,11 @@ def finalize_and_sanitize(src_params):
         dest_params["test_ingest_standalone_range_deletion_one_in"] = 0
         # Parallel compression is incompatible with UDI
         dest_params["compression_parallel_threads"] = 1
+        # Trie UDI has a known issue with prefix scanning where certain prefix
+        # patterns cause "SeekToFirst not supported" errors. Disable prefix
+        # scanning and redistribute its percentage to reads.
+        dest_params["readpercent"] += dest_params.get("prefixpercent", 0)
+        dest_params["prefixpercent"] = 0
 
     # Multi-key operations are not currently compatible with transactions or
     # timestamp.


### PR DESCRIPTION
The trie-based User Defined Index (UDI) has a bug in its iterator implementation that causes "Not implemented: SeekToFirst not supported" errors during prefix scanning. This causes assertion failures in BatchedOpsStressTest::TestPrefixScan and may cause silent wrong results in other prefix scan tests.

Until the trie index is fixed, disable prefix scanning when use_trie_index is enabled by setting prefixpercent=0 and redistributing the percentage to reads.

Test Plan:
- Reproduced: db_stress with --use_trie_index=1 --prefixpercent=5 crashes with assertion failure. Instrumentation revealed iterator status "Not implemented: SeekToFirst not supported" on prefix 0x35.
- Verified: db_stress with --use_trie_index=1 --prefixpercent=0 completes cleanly.