### PR TITLE
Fix `ldb dump` swallowing errors, but `ldb scan` for compatibility test

### DIFF
--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -2630,6 +2630,13 @@ void DBDumperCommand::DoDumpCommand() {
     }
   }
 
+  // Check for iterator errors that may have occurred during iteration
+  st = iter->status();
+  if (!st.ok()) {
+    exec_state_ =
+        LDBCommandExecuteResult::Failed("Iterator error: " + st.ToString());
+  }
+
   if (num_buckets > 1 && is_db_ttl_) {
     PrintBucketCounts(bucket_counts, ttl_start, ttl_end, bucket_size,
                       num_buckets);

--- a/tools/verify_random_db.sh
+++ b/tools/verify_random_db.sh
@@ -33,9 +33,10 @@ fi
 
 set -e
 echo == Dumping data from $db_dir to $db_dump
-./ldb dump --db=$db_dir $extra_params > $db_dump
+# NOTE: old versions of `ldb dump` could swallow errors, so we use `scan`
+./ldb scan --db=$db_dir $extra_params > $db_dump
 
 echo == Dumping data from $base_db_dir to $base_db_dump
-./ldb dump --db=$base_db_dir $extra_params > $base_db_dump
+./ldb scan --db=$base_db_dir $extra_params > $base_db_dump
 
 diff $db_dump $base_db_dump


### PR DESCRIPTION
Summary: This fixes a longstanding bug in which `ldb dump` swallows iterator errors. This can affect check_format_compatible.sh test results; if lucky, it will misleadingly look like a data mismatch instead of an outright failure. If unlucky, it could cause a test false negative.

However the compatibility test uses old versions of ldb, so the best way to improve the test (for the foreseeable future) is to replace `ldb dump` with `ldb scan`.

Test Plan: manual