### PR TITLE
Disable iteration in crash test when trie UDI is enabled

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -914,11 +914,15 @@ def finalize_and_sanitize(src_params):
         dest_params["test_ingest_standalone_range_deletion_one_in"] = 0
         # Parallel compression is incompatible with UDI
         dest_params["compression_parallel_threads"] = 1
-        # Trie UDI has a known issue with prefix scanning where certain prefix
-        # patterns cause "SeekToFirst not supported" errors. Disable prefix
-        # scanning and redistribute its percentage to reads.
+        # Trie UDI does not support SeekToFirst/SeekToLast. Prefix scanning
+        # calls SeekToFirst internally, so disable it. Additionally,
+        # LevelIterator::SkipEmptyFileForward() calls SeekToFirst() when
+        # Next() crosses file boundaries, so general iteration (iterpercent)
+        # also fails with trie UDI. Redistribute both to reads.
         dest_params["readpercent"] += dest_params.get("prefixpercent", 0)
         dest_params["prefixpercent"] = 0
+        dest_params["readpercent"] += dest_params.get("iterpercent", 0)
+        dest_params["iterpercent"] = 0
 
     # Multi-key operations are not currently compatible with transactions or
     # timestamp.


### PR DESCRIPTION
Summary:
Trie UDI (UserDefinedIndex) does not support SeekToFirst/SeekToLast.
The crash test already disabled prefix scanning (prefixpercent=0) when
use_trie_index=1, but iteration (iterpercent) was still enabled.

During iteration, LevelIterator::SkipEmptyFileForward() internally calls
file_iter_.SeekToFirst() when Next() crosses SST file boundaries within
a level. This propagates to UserDefinedIndexIteratorWrapper::SeekToFirst()
which returns NotSupported, causing "Iterator diverged from control
iterator" / "VerifyIterator failed" errors across many crash test variants.

Fixed by also setting iterpercent=0 when use_trie_index=1 and
redistributing the percentage to reads, matching the existing pattern
for prefixpercent.

Differential Revision: D95410767


