### PR TITLE
Disable more features in stress test when trie UDI is enabled

### DIFF
--- a/db_stress_tool/db_stress_tool.cc
+++ b/db_stress_tool/db_stress_tool.cc
@@ -270,6 +270,14 @@ int db_stress_tool(int argc, char** argv) {
               "which is unsafe with mmap'd reads.\n");
       exit(1);
     }
+    if (FLAGS_enable_blob_files ||
+        FLAGS_allow_setting_blob_options_dynamically) {
+      fprintf(stderr,
+              "Error: use_trie_index is incompatible with BlobDB. "
+              "BlobDB writes kTypeBlobIndex entries in SSTs which are "
+              "non-Put types, not supported by user-defined index.\n");
+      exit(1);
+    }
   }
 
   if (FLAGS_read_only) {

--- a/table/block_based/user_defined_index_wrapper.h
+++ b/table/block_based/user_defined_index_wrapper.h
@@ -121,10 +121,13 @@ class UserDefinedIndexBuilderWrapper : public IndexBuilder {
         // - kTypeDeletion, kTypeSingleDeletion, kTypeRangeDeletion (deletes)
         // - kTypeMerge (merge operands)
         // - kTypeWideColumnEntity (PutEntity)
+        // - kTypeBlobIndex (BlobDB stores values in blob files)
         // This makes UDI incompatible with:
         // - Delete/Merge/SingleDelete/DeleteRange operations
         // - TransactionDB (ROLLBACK writes DELETE entries to undo changes)
+        // - BlobDB (writes kTypeBlobIndex entries during flush)
         // See T257683723 for analysis of TransactionDB incompatibility.
+        // See T258398372 for analysis of BlobDB incompatibility.
         if (status_.ok() && pkey.type != ValueType::kTypeValue) {
           status_ = Status::InvalidArgument(
               "user_defined_index_factory only supported with Puts");

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -914,11 +914,20 @@ def finalize_and_sanitize(src_params):
         dest_params["test_ingest_standalone_range_deletion_one_in"] = 0
         # Parallel compression is incompatible with UDI
         dest_params["compression_parallel_threads"] = 1
-        # Trie UDI has a known issue with prefix scanning where certain prefix
-        # patterns cause "SeekToFirst not supported" errors. Disable prefix
-        # scanning and redistribute its percentage to reads.
+        # Trie UDI does not support SeekToFirst/SeekToLast. Prefix scanning
+        # calls SeekToFirst internally, so disable it. Additionally,
+        # LevelIterator::SkipEmptyFileForward() calls SeekToFirst() when
+        # Next() crosses file boundaries, so general iteration (iterpercent)
+        # also fails with trie UDI. Redistribute both to reads.
         dest_params["readpercent"] += dest_params.get("prefixpercent", 0)
         dest_params["prefixpercent"] = 0
+        dest_params["readpercent"] += dest_params.get("iterpercent", 0)
+        dest_params["iterpercent"] = 0
+        # BlobDB writes kTypeBlobIndex entries in SSTs instead of kTypeValue,
+        # which violates UDI's Put-only restriction. Also disable dynamic
+        # blob options to prevent SetOptions from re-enabling blob files.
+        dest_params["enable_blob_files"] = 0
+        dest_params["allow_setting_blob_options_dynamically"] = 0
 
     # Multi-key operations are not currently compatible with transactions or
     # timestamp.


### PR DESCRIPTION
Summary:
Address 2 compatibility issue of UDI:

A:
Trie UDI (UserDefinedIndex) does not support SeekToFirst/SeekToLast. The crash test already disabled prefix scanning (prefixpercent=0) when use_trie_index=1, but iteration (iterpercent) was still enabled.

During iteration, LevelIterator::SkipEmptyFileForward() internally calls file_iter_.SeekToFirst() when Next() crosses SST file boundaries within a level. This propagates to UserDefinedIndexIteratorWrapper::SeekToFirst() which returns NotSupported, causing "Iterator diverged from control iterator" / "VerifyIterator failed" errors across many crash test variants.

B:
BlobDB is incompatible with trie UDI (user-defined index). When BlobDB is enabled (`enable_blob_files=1`), the flush job stores large values in separate blob files and writes `kTypeBlobIndex` entries in the SST instead of `kTypeValue`. The UDI builder (`UserDefinedIndexBuilderWrapper::OnKeyAdded()`) rejects any entry whose type is not `kTypeValue`, causing the flush to fail with `"user_defined_index_factory only supported with Puts"`.

Once the flush fails, the DB enters background error state, and all subsequent `Write()` calls fail with the same error -- printed as the repeated `"multiput error: ..."` messages from
`BatchedOpsStressTest::TestPut`. Eventually, `ProcessStatus` encounters this error and triggers `assert(false)`.