### PR TITLE
Add remaining IngestExternalFileOptions to C API

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -6832,6 +6832,17 @@ void rocksdb_ingestexternalfileoptions_set_move_files(
   opt->rep.move_files = move_files;
 }
 
+void rocksdb_ingestexternalfileoptions_set_link_files(
+    rocksdb_ingestexternalfileoptions_t* opt, unsigned char link_files) {
+  opt->rep.link_files = link_files;
+}
+
+void rocksdb_ingestexternalfileoptions_set_failed_move_fall_back_to_copy(
+    rocksdb_ingestexternalfileoptions_t* opt,
+    unsigned char failed_move_fall_back_to_copy) {
+  opt->rep.failed_move_fall_back_to_copy = failed_move_fall_back_to_copy;
+}
+
 void rocksdb_ingestexternalfileoptions_set_snapshot_consistency(
     rocksdb_ingestexternalfileoptions_t* opt,
     unsigned char snapshot_consistency) {
@@ -6855,10 +6866,45 @@ void rocksdb_ingestexternalfileoptions_set_ingest_behind(
   opt->rep.ingest_behind = ingest_behind;
 }
 
+void rocksdb_ingestexternalfileoptions_set_write_global_seqno(
+    rocksdb_ingestexternalfileoptions_t* opt,
+    unsigned char write_global_seqno) {
+  opt->rep.write_global_seqno = write_global_seqno;
+}
+
+void rocksdb_ingestexternalfileoptions_set_verify_checksums_before_ingest(
+    rocksdb_ingestexternalfileoptions_t* opt,
+    unsigned char verify_checksums_before_ingest) {
+  opt->rep.verify_checksums_before_ingest = verify_checksums_before_ingest;
+}
+
+void rocksdb_ingestexternalfileoptions_set_verify_checksums_readahead_size(
+    rocksdb_ingestexternalfileoptions_t* opt,
+    size_t verify_checksums_readahead_size) {
+  opt->rep.verify_checksums_readahead_size = verify_checksums_readahead_size;
+}
+
+void rocksdb_ingestexternalfileoptions_set_verify_file_checksum(
+    rocksdb_ingestexternalfileoptions_t* opt,
+    unsigned char verify_file_checksum) {
+  opt->rep.verify_file_checksum = verify_file_checksum;
+}
+
 void rocksdb_ingestexternalfileoptions_set_fail_if_not_bottommost_level(
     rocksdb_ingestexternalfileoptions_t* opt,
     unsigned char fail_if_not_bottommost_level) {
   opt->rep.fail_if_not_bottommost_level = fail_if_not_bottommost_level;
+}
+
+void rocksdb_ingestexternalfileoptions_set_allow_db_generated_files(
+    rocksdb_ingestexternalfileoptions_t* opt,
+    unsigned char allow_db_generated_files) {
+  opt->rep.allow_db_generated_files = allow_db_generated_files;
+}
+
+void rocksdb_ingestexternalfileoptions_set_fill_cache(
+    rocksdb_ingestexternalfileoptions_t* opt, unsigned char fill_cache) {
+  opt->rep.fill_cache = fill_cache;
 }
 
 void rocksdb_ingestexternalfileoptions_destroy(

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -2689,6 +2689,13 @@ extern ROCKSDB_LIBRARY_API void
 rocksdb_ingestexternalfileoptions_set_move_files(
     rocksdb_ingestexternalfileoptions_t* opt, unsigned char move_files);
 extern ROCKSDB_LIBRARY_API void
+rocksdb_ingestexternalfileoptions_set_link_files(
+    rocksdb_ingestexternalfileoptions_t* opt, unsigned char link_files);
+extern ROCKSDB_LIBRARY_API void
+rocksdb_ingestexternalfileoptions_set_failed_move_fall_back_to_copy(
+    rocksdb_ingestexternalfileoptions_t* opt,
+    unsigned char failed_move_fall_back_to_copy);
+extern ROCKSDB_LIBRARY_API void
 rocksdb_ingestexternalfileoptions_set_snapshot_consistency(
     rocksdb_ingestexternalfileoptions_t* opt,
     unsigned char snapshot_consistency);
@@ -2703,9 +2710,31 @@ extern ROCKSDB_LIBRARY_API void
 rocksdb_ingestexternalfileoptions_set_ingest_behind(
     rocksdb_ingestexternalfileoptions_t* opt, unsigned char ingest_behind);
 extern ROCKSDB_LIBRARY_API void
+rocksdb_ingestexternalfileoptions_set_write_global_seqno(
+    rocksdb_ingestexternalfileoptions_t* opt, unsigned char write_global_seqno);
+extern ROCKSDB_LIBRARY_API void
+rocksdb_ingestexternalfileoptions_set_verify_checksums_before_ingest(
+    rocksdb_ingestexternalfileoptions_t* opt,
+    unsigned char verify_checksums_before_ingest);
+extern ROCKSDB_LIBRARY_API void
+rocksdb_ingestexternalfileoptions_set_verify_checksums_readahead_size(
+    rocksdb_ingestexternalfileoptions_t* opt,
+    size_t verify_checksums_readahead_size);
+extern ROCKSDB_LIBRARY_API void
+rocksdb_ingestexternalfileoptions_set_verify_file_checksum(
+    rocksdb_ingestexternalfileoptions_t* opt,
+    unsigned char verify_file_checksum);
+extern ROCKSDB_LIBRARY_API void
 rocksdb_ingestexternalfileoptions_set_fail_if_not_bottommost_level(
     rocksdb_ingestexternalfileoptions_t* opt,
     unsigned char fail_if_not_bottommost_level);
+extern ROCKSDB_LIBRARY_API void
+rocksdb_ingestexternalfileoptions_set_allow_db_generated_files(
+    rocksdb_ingestexternalfileoptions_t* opt,
+    unsigned char allow_db_generated_files);
+extern ROCKSDB_LIBRARY_API void
+rocksdb_ingestexternalfileoptions_set_fill_cache(
+    rocksdb_ingestexternalfileoptions_t* opt, unsigned char fill_cache);
 
 extern ROCKSDB_LIBRARY_API void rocksdb_ingestexternalfileoptions_destroy(
     rocksdb_ingestexternalfileoptions_t* opt);


### PR DESCRIPTION
RocksDB's C++ API currently exposes a number of `IngestExternalFileOptions` that are not available to be set via the C API. 

This pull request adds setters for all the remaining `IngestExternalFileOptions` members:
- link_files
- failed_move_fall_back_to_copy
- write_global_seqno
- verify_checksums_before_ingest
- verify_checksums_readahead_size
- verify_file_checksum
- allow_db_generated_files
- fill_cache

This fixes #14437