### PR TITLE
Fix secondary DB stuck on stale versions when atomic_flush=true

### DIFF
--- a/db/compaction/compaction_service_test.cc
+++ b/db/compaction/compaction_service_test.cc
@@ -16,7 +16,7 @@ class MyTestCompactionService : public CompactionService {
  public:
   MyTestCompactionService(
       std::string db_path, Options& options,
-      std::shared_ptr<Statistics>& statistics,
+      std::shared_ptr<Statistics> statistics,
       std::vector<std::shared_ptr<EventListener>> listeners,
       std::vector<std::shared_ptr<TablePropertiesCollectorFactory>>
           table_properties_collector_factories)
@@ -2864,6 +2864,91 @@ TEST_F(ResumableCompactionKeyTypeTest, CancelAndResumeWithTimedPut) {
 
   VerifyResumeBytes();
 }
+
+TEST_F(CompactionServiceTest, AtomicFlushRemoteCompactionMissingFile) {
+  Options options = CurrentOptions();
+  options.disable_auto_compactions = true;
+  options.atomic_flush = true;
+  options.create_missing_column_families = true;
+  options.env = env_;
+  options.max_manifest_file_size = 1;
+  options.num_levels = 2;
+  options.max_background_jobs = 4;
+
+  auto my_cs = std::make_shared<MyTestCompactionService>(
+      dbname_, options, nullptr, remote_listeners,
+      remote_table_properties_collector_factories);
+  options.compaction_service = my_cs;
+
+  Close();
+  ASSERT_OK(DestroyDB(dbname_, options));
+
+  std::vector<ColumnFamilyDescriptor> cf_descs;
+  cf_descs.emplace_back(kDefaultColumnFamilyName, options);
+  cf_descs.emplace_back("cf_1", options);
+
+  ASSERT_OK(DB::Open(options, dbname_, cf_descs, &handles_, &db_));
+
+  WriteOptions wo;
+  wo.disableWAL = true;
+
+  // Atomic flush writes version edits for CF0 and CF1 as one atomic group
+  ASSERT_OK(db_->Put(wo, handles_[0], Key(1), "value1"));
+  ASSERT_OK(db_->Put(wo, handles_[1], Key(1), "value1"));
+  ASSERT_OK(db_->Flush(FlushOptions(), handles_));
+  ASSERT_EQ("1", FilesPerLevel(0));
+  ASSERT_EQ("1", FilesPerLevel(1));
+
+  // Add more L0 files so CompactRange has something to compact
+  ASSERT_OK(db_->Put(wo, handles_[0], Key(1), "value2"));
+  ASSERT_OK(Flush(0));
+  ASSERT_EQ("2", FilesPerLevel(0));
+  ASSERT_OK(db_->Put(wo, handles_[1], Key(1), "value2"));
+  ASSERT_OK(Flush(1));
+  ASSERT_EQ("2", FilesPerLevel(1));
+
+  auto pressure_token =
+      dbfull()->TEST_write_controler().GetCompactionPressureToken();
+
+  CompactRangeOptions cro;
+  cro.bottommost_level_compaction = BottommostLevelCompaction::kForce;
+
+  // Remote compaction on CF1 opens a secondary DB that reads the manifest.
+  // Sync point pauses secondary after it opens the manifest file but before
+  // reading records. The callback compacts CF0 locally, which deletes CF0's
+  // atomic-flushed SST and rotates the manifest. When the secondary resumes
+  // reading the manifest it already opened, CF0's file is gone, so the
+  // atomic group from the flush is incomplete in the secondary.
+  SyncPoint::GetInstance()->SetCallBack(
+      "ReactiveVersionSet::Recover:AfterMaybeSwitchManifest",
+      [&](void* /*arg*/) {
+        my_cs->OverrideStartStatus(CompactionServiceJobStatus::kUseLocal);
+        ASSERT_OK(db_->CompactRange(cro, handles_[0], nullptr, nullptr));
+        my_cs->ResetOverride();
+      });
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  // Without fix: secondary DB gets stuck → CompactRange fails with
+  //   "CompactionService failed to run the compaction job". The underlying
+  //   cause ("Cannot find matched SST files") is logged on the worker side.
+  // With fix: secondary DB opens successfully, remote compaction works.
+  ASSERT_OK(db_->CompactRange(cro, handles_[1], nullptr, nullptr));
+
+  // Verify both compactions ran (2 L0 files → 1 L1 file each)
+  ASSERT_EQ("0,1", FilesPerLevel(0));
+  ASSERT_EQ("0,1", FilesPerLevel(1));
+
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+
+  for (auto* h : handles_) {
+    if (h != db_->DefaultColumnFamily()) {
+      ASSERT_OK(db_->DestroyColumnFamilyHandle(h));
+    }
+  }
+  handles_.clear();
+}
+
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {

--- a/db/db_secondary_test.cc
+++ b/db/db_secondary_test.cc
@@ -118,6 +118,55 @@ void DBSecondaryTestBase::CheckFileTypeCounts(const std::string& dir,
 class DBSecondaryTest : public DBSecondaryTestBase {
  public:
   explicit DBSecondaryTest() : DBSecondaryTestBase("db_secondary_test") {}
+
+  // Verify cross-CF consistency via NewIterators(): all CFs return the same
+  // expected entries under a consistent snapshot.
+  void VerifySecondaryCrossCFConsistency(
+      const std::vector<std::pair<std::string, std::string>>& expected) {
+    ReadOptions ropts;
+    ropts.verify_checksums = true;
+    std::vector<Iterator*> iters;
+    ASSERT_OK(db_secondary_->NewIterators(
+        ropts, {handles_secondary_[0], handles_secondary_[1]}, &iters));
+    ASSERT_EQ(2u, iters.size());
+    for (int i = 0; i < 2; i++) {
+      iters[i]->SeekToFirst();
+      for (const auto& [key, value] : expected) {
+        ASSERT_TRUE(iters[i]->Valid());
+        ASSERT_EQ(key, iters[i]->key().ToString());
+        ASSERT_EQ(value, iters[i]->value().ToString());
+        iters[i]->Next();
+      }
+      ASSERT_FALSE(iters[i]->Valid());
+      ASSERT_OK(iters[i]->status());
+      delete iters[i];
+    }
+  }
+
+  // Count total SST files for a CF on the secondary via ColumnFamilyMetaData.
+  size_t SecondarySSTableCount(int cf_index) {
+    ColumnFamilyMetaData meta;
+    db_secondary_->GetColumnFamilyMetaData(handles_secondary_[cf_index], &meta);
+    size_t count = 0;
+    for (const auto& level : meta.levels) {
+      count += level.files.size();
+    }
+    return count;
+  }
+
+  // Pauses secondary manifest read; CompactRange(CF0) runs in between,
+  // deleting CF0's L0 SSTs, and causes incomplete atomic group on the
+  // secondary.
+  void SetupIncompleteAtomicGroupSyncPoints() {
+    SyncPoint::GetInstance()->SetCallBack(
+        "ReactiveVersionSet::Recover:AfterMaybeSwitchManifest",
+        [&](void* /*arg*/) {
+          CompactRangeOptions cro;
+          cro.bottommost_level_compaction = BottommostLevelCompaction::kForce;
+          ASSERT_OK(db_->CompactRange(cro, handles_[0], nullptr, nullptr));
+        });
+    SyncPoint::GetInstance()->EnableProcessing();
+  }
 };
 
 TEST_F(DBSecondaryTest, FailOpenIfLoggerCreationFail) {
@@ -1825,6 +1874,119 @@ TEST_F(DBSecondaryTestWithTimestamp, Iterators) {
   delete iters[0];
 
   Close();
+}
+
+// Multi-CF cross-CF consistency on secondary with atomic_flush and WAL
+// disabled.
+TEST_F(DBSecondaryTest, AtomicFlushSecondaryMultiCFConsistency) {
+  Options options;
+  options.env = env_;
+  options.atomic_flush = true;
+  options.disable_auto_compactions = true;
+  CreateAndReopenWithCF({"cf_1"}, options);
+
+  WriteOptions wo;
+  wo.disableWAL = true;
+  ASSERT_OK(db_->Put(wo, handles_[0], "key1", "val1"));
+  ASSERT_OK(db_->Put(wo, handles_[1], "key1", "val1"));
+  ASSERT_OK(dbfull()->Flush(FlushOptions(), handles_));
+
+  ASSERT_OK(db_->Put(wo, handles_[0], "key2", "val2"));
+  ASSERT_OK(db_->Put(wo, handles_[1], "key2", "val2"));
+  ASSERT_OK(dbfull()->Flush(FlushOptions(), handles_));
+
+  // Write to CF0 only, no flush. With WAL disabled, this should NOT be
+  // visible on the secondary — cross-CF consistency is based on flushed SSTs.
+  ASSERT_OK(db_->Put(wo, handles_[0], "key3", "val3"));
+
+  Options sec_options;
+  sec_options.env = env_;
+  sec_options.max_open_files = -1;
+  OpenSecondaryWithColumnFamilies({"cf_1"}, sec_options);
+  ASSERT_OK(db_secondary_->TryCatchUpWithPrimary());
+
+  // Secondary sees only the atomically flushed data, not the unflushed write.
+  VerifySecondaryCrossCFConsistency({{"key1", "val1"}, {"key2", "val2"}});
+}
+
+// CompactRange(CF0) races with secondary manifest read, creating an
+// incomplete atomic group whose versions are never installed. Without fix,
+// the secondary permanently serves stale data; in debug builds,
+// TryCatchUpWithPrimary crashes in ManifestTailer::OnColumnFamilyAdd
+// when it switches to the new manifest.
+TEST_F(DBSecondaryTest, AtomicFlushSecondaryIncompleteGroup) {
+  Options options;
+  options.env = env_;
+  options.atomic_flush = true;
+  options.disable_auto_compactions = true;
+  options.max_manifest_file_size = 1;
+  options.num_levels = 2;
+  options.create_if_missing = true;
+  options.create_missing_column_families = true;
+
+  // Open fresh DB to keep tuned_max_manifest_file_size_ small, ensuring
+  // CompactRange triggers manifest rotation.
+  Close();
+  ASSERT_OK(DestroyDB(dbname_, options));
+
+  std::vector<ColumnFamilyDescriptor> cf_descs;
+  cf_descs.emplace_back(kDefaultColumnFamilyName, options);
+  cf_descs.emplace_back("cf_1", options);
+  ASSERT_OK(DB::Open(options, dbname_, cf_descs, &handles_, &db_));
+
+  WriteOptions wo;
+  wo.disableWAL = true;
+
+  ASSERT_OK(db_->Put(wo, handles_[0], "key1", "val1"));
+  ASSERT_OK(db_->Put(wo, handles_[1], "key1", "val1"));
+  ASSERT_OK(dbfull()->Flush(FlushOptions(), handles_));
+
+  ASSERT_OK(db_->Put(wo, handles_[0], "key2", "val2"));
+  ASSERT_OK(Flush(0));
+  ASSERT_OK(db_->Put(wo, handles_[1], "key2", "val2"));
+  ASSERT_OK(Flush(1));
+
+  SetupIncompleteAtomicGroupSyncPoints();
+
+  Options sec_options;
+  sec_options.env = env_;
+  sec_options.max_open_files = -1;
+  OpenSecondaryWithColumnFamilies({"cf_1"}, sec_options);
+
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+
+  // Without fix: NewIterators returns empty (no SSTs installed).
+  // With fix: incomplete group is cleared, versions install. But CF0's
+  // atomic-flush SST was deleted by CompactRange (new manifest not read yet),
+  // creating temporary cross-CF inconsistency: CF1 has data, CF0 doesn't.
+  ASSERT_GT(SecondarySSTableCount(1), 0u);
+  ASSERT_EQ(SecondarySSTableCount(0), 0u);
+  {
+    std::string val;
+    ASSERT_TRUE(
+        db_secondary_->Get(ReadOptions(), handles_secondary_[0], "key1", &val)
+            .IsNotFound());
+    ASSERT_OK(
+        db_secondary_->Get(ReadOptions(), handles_secondary_[1], "key1", &val));
+    ASSERT_EQ(val, "val1");
+  }
+
+  // TryCatchUpWithPrimary reads the new manifest with CompactRange results,
+  // restoring cross-CF consistency.
+  // Without fix: crashes in ManifestTailer::OnColumnFamilyAdd.
+  ASSERT_OK(db_secondary_->TryCatchUpWithPrimary());
+
+  VerifySecondaryCrossCFConsistency({{"key1", "val1"}, {"key2", "val2"}});
+
+  // Verify secondary continues functioning after recovery.
+  ASSERT_OK(db_->Put(wo, handles_[0], "key3", "val3"));
+  ASSERT_OK(db_->Put(wo, handles_[1], "key3", "val3"));
+  ASSERT_OK(dbfull()->Flush(FlushOptions(), handles_));
+  ASSERT_OK(db_secondary_->TryCatchUpWithPrimary());
+
+  VerifySecondaryCrossCFConsistency(
+      {{"key1", "val1"}, {"key2", "val2"}, {"key3", "val3"}});
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/version_edit_handler.cc
+++ b/db/version_edit_handler.cc
@@ -1047,6 +1047,23 @@ Status ManifestTailer::Initialize() {
   return s;
 }
 
+Status ManifestTailer::OnAtomicGroupReplayEnd() {
+  Status s = VersionEditHandlerPointInTime::OnAtomicGroupReplayEnd();
+  // When the atomic group is incomplete (missing files from primary
+  // compaction racing with manifest rotation), clear the stale staging map
+  // so subsequent version creation routes to versions_ directly.
+  // Safe: all entries are nullptr while in_atomic_group_ is true.
+  if (s.ok() && atomic_update_versions_missing_ > 0) {
+    for ([[maybe_unused]] const auto& [cfid, version] :
+         atomic_update_versions_) {
+      assert(version == nullptr);
+    }
+    atomic_update_versions_.clear();
+    atomic_update_versions_missing_ = 0;
+  }
+  return s;
+}
+
 Status ManifestTailer::ApplyVersionEdit(VersionEdit& edit,
                                         ColumnFamilyData** cfd) {
   Status s = VersionEditHandler::ApplyVersionEdit(edit, cfd);

--- a/db/version_edit_handler.h
+++ b/db/version_edit_handler.h
@@ -390,6 +390,8 @@ class ManifestTailer : public VersionEditHandlerPointInTime {
 
   void CheckIterationResult(const log::Reader& reader, Status* s) override;
 
+  Status OnAtomicGroupReplayEnd() override;
+
   enum Mode : uint8_t {
     kRecovery = 0,
     kCatchUp = 1,

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -7932,6 +7932,8 @@ Status ReactiveVersionSet::Recover(
   log::Reader* reader = manifest_reader->get();
   assert(reader);
 
+  TEST_SYNC_POINT("ReactiveVersionSet::Recover:AfterMaybeSwitchManifest");
+
   manifest_tailer_.reset(new ManifestTailer(
       column_families, const_cast<ReactiveVersionSet*>(this), io_tracer_,
       read_options_, EpochNumberRequirement::kMightMissing));

--- a/unreleased_history/bug_fixes/fix_atomic_flush_secondary_db.md
+++ b/unreleased_history/bug_fixes/fix_atomic_flush_secondary_db.md
@@ -1,0 +1,1 @@
+Fix a bug where secondary/follower DB with `atomic_flush=true` could stop installing new versions, causing remote compaction to fail with "Cannot find matched SST files" errors and secondary DB to serve permanently stale data in release builds and crashing in debug builds.


### PR DESCRIPTION
### Context/Summary:
    
**Bug:** When `atomic_flush=true` and manifest rotation races with primary
    compaction, the secondary/follower DB can permanently stop installing
    new versions. Symptoms include remote compaction failing with "Cannot
    find matched SST files", secondary serving permanently stale data
    (release builds), and crashing on manifest switch (debug builds).
    
**Root cause:** `VersionEditHandlerPointInTime` uses a staging map
    (`atomic_update_versions_`) for all-or-nothing atomic group recovery.
    When the secondary reads a manifest where some SST files were already
    compacted away by the primary, the atomic group becomes permanently
    incomplete and the staging map is never cleared. All subsequent version
    creation — including force-creates in `OnAtomicGroupReplayBegin()` and
    `CheckIterationResult()` — routes through the stale staging map instead
    of `versions_`, so versions are trapped and never installed.
    
**Fix:** Override `OnAtomicGroupReplayEnd()` in `ManifestTailer` to clear
    the staging map when the atomic group is incomplete. This is safe
    because:
    - All staging map entries are nullptr (no versions are created while
      `in_atomic_group_` is true), so nothing is lost.
    - Pre-atomic-group versions are already saved in `versions_` by
      `OnAtomicGroupReplayBegin()`.
    - The all-or-nothing guarantee for primary best-effort recovery
      (`VersionEditHandlerPointInTime`) is preserved — only the subclass
      behavior changes.
    
The fix can create **temporary** cross-CF inconsistency on the secondary:
    when an incomplete atomic group is cleared, some CFs may have their
    versions installed while others don't (e.g., CF1 has data but CF0's
    atomic-flush SST was already deleted by CompactRange on the primary).
    This is mitigated by the next TryCatchUpWithPrimary call, which reads
    the updated manifest containing CompactRange results and restores
    cross-CF consistency.
    
    
   
**Test Plan:**
    - `CompactionServiceTest.AtomicFlushRemoteCompactionMissingFile`:
      end-to-end test triggering the bug via remote compaction timing.
      Without fix: remote compaction fails ("CompactionService failed to
      run the compaction job"). With fix: compaction succeeds.
    - `DBSecondaryTest.AtomicFlushSecondaryIncompleteGroup`: reproduces
      the bug scenario (incomplete atomic group from CompactRange racing
      with secondary manifest read). Verifies SST installation, cross-CF
      consistency via NewIterators, and recovery via TryCatchUpWithPrimary.
      Without fix: crashes in ManifestTailer::OnColumnFamilyAdd.
    - `DBSecondaryTest.AtomicFlushSecondaryMultiCFConsistency`: baseline
      cross-CF consistency with atomic_flush + WAL disabled.
    