### PR TITLE
Rename IsExpectedTxnLockTimeout to IsExpectedTxnError

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -930,7 +930,7 @@ Status StressTest::CommitTxn(Transaction& txn, ThreadState* thread) {
   return s;
 }
 
-bool StressTest::IsExpectedTxnLockTimeout(const Status& s) {
+bool StressTest::IsExpectedTxnError(const Status& s) {
   if ((s.IsDeadlock() || s.IsTimedOut()) &&
       (FLAGS_use_multiget || FLAGS_use_multi_get_entity)) {
     return true;

--- a/db_stress_tool/db_stress_test_base.h
+++ b/db_stress_tool/db_stress_test_base.h
@@ -34,10 +34,11 @@ class StressTest {
            !status_to_io_status(Status(error_s)).GetDataLoss();
   }
 
-  // Returns true if the status is a transaction lock conflict (deadlock or
-  // timeout) that is expected when MaybeAddKeyToTxnForRYW writes to the same
-  // key space without acquiring the stress-test-level mutex.
-  static bool IsExpectedTxnLockTimeout(const Status& s);
+  // Returns true if the status is an expected transactional error, including
+  // lock conflicts (deadlock or timeout) from MaybeAddKeyToTxnForRYW writing
+  // to the same key space without the stress-test-level mutex, and TryAgain
+  // from optimistic transactions when conflict detection retries are exhausted.
+  static bool IsExpectedTxnError(const Status& s);
 
   StressTest();
 

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -1908,7 +1908,7 @@ class NonBatchedOpsStressTest : public StressTest {
     } while (!s.ok() && IsErrorInjectedAndRetryable(s) &&
              initial_wal_write_may_succeed);
 
-    if (IsExpectedTxnLockTimeout(s)) {
+    if (IsExpectedTxnError(s)) {
       pending_expected_value.Rollback();
       return Status::OK();
     }
@@ -2013,7 +2013,7 @@ class NonBatchedOpsStressTest : public StressTest {
       } while (!s.ok() && IsErrorInjectedAndRetryable(s) &&
                initial_wal_write_may_succeed);
 
-      if (IsExpectedTxnLockTimeout(s)) {
+      if (IsExpectedTxnError(s)) {
         pending_expected_value.Rollback();
         return Status::OK();
       }
@@ -2085,7 +2085,7 @@ class NonBatchedOpsStressTest : public StressTest {
       } while (!s.ok() && IsErrorInjectedAndRetryable(s) &&
                initial_wal_write_may_succeed);
 
-      if (IsExpectedTxnLockTimeout(s)) {
+      if (IsExpectedTxnError(s)) {
         pending_expected_value.Rollback();
         return Status::OK();
       }
@@ -3225,7 +3225,7 @@ class NonBatchedOpsStressTest : public StressTest {
           assert(false);
       }
 
-      if (IsExpectedTxnLockTimeout(s)) {
+      if (IsExpectedTxnError(s)) {
         return;
       }
 


### PR DESCRIPTION
Summary:

The function handles more than just lock timeouts — it also covers TryAgain from optimistic transactions. Rename it and update the comment to reflect its broader scope.