### PR TITLE
Fix crash test failures when use_trie_index conflicts with txn options

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -904,6 +904,8 @@ def finalize_and_sanitize(src_params):
         # TransactionDB ROLLBACK writes DELETE entries to WAL to undo
         # uncommitted changes. These DELETEs violate UDI's Put-only restriction.
         dest_params["use_txn"] = 0
+        dest_params["use_optimistic_txn"] = 0
+        dest_params["test_multi_ops_txns"] = 0
         # Trie UDI uses zero-copy pointers into block data, which is
         # incompatible with mmap_read.
         dest_params["mmap_read"] = 0


### PR DESCRIPTION
Summary:
The trie UDI sanitization in db_crashtest.py disables use_txn because TransactionDB ROLLBACK writes DELETE entries that violate UDI's Put-only restriction. However, it was not clearing use_optimistic_txn or test_multi_ops_txns, which both require use_txn to be true.

Since use_trie_index is randomly enabled with 1/8 probability, the optimistic_txn and multiops_txn crash tests would intermittently fail with:
- "You cannot set use_optimistic_txn true while use_txn is false"
- "-use_txn must be true if -test_multi_ops_txns"

Fix by also setting use_optimistic_txn=0 and test_multi_ops_txns=0 in the trie UDI sanitization block alongside the existing use_txn=0.

Test Plan:
Watch crash test CI results