### PR TITLE
Add UserValueChecksum interface for end-to-end value integrity checks

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -179,6 +179,7 @@ cpp_library_wrapper(name="rocksdb_lib", srcs=[
         "options/options.cc",
         "options/options_helper.cc",
         "options/options_parser.cc",
+        "options/user_value_checksum.cc",
         "port/mmap.cc",
         "port/port_posix.cc",
         "port/stack_trace.cc",
@@ -5016,6 +5017,12 @@ cpp_unittest_wrapper(name="db_test2",
 
 cpp_unittest_wrapper(name="db_universal_compaction_test",
             srcs=["db/db_universal_compaction_test.cc"],
+            deps=[":rocksdb_test_lib"],
+            extra_compiler_flags=[])
+
+
+cpp_unittest_wrapper(name="db_user_value_checksum_test",
+            srcs=["db/db_user_value_checksum_test.cc"],
             deps=[":rocksdb_test_lib"],
             extra_compiler_flags=[])
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -852,6 +852,7 @@ set(SOURCES
         options/options.cc
         options/options_helper.cc
         options/options_parser.cc
+        options/user_value_checksum.cc
         port/mmap.cc
         port/stack_trace.cc
         table/adaptive/adaptive_table_factory.cc
@@ -1410,6 +1411,7 @@ if(WITH_TESTS)
         db/db_encryption_test.cc
         db/db_etc3_test.cc
         db/db_flush_test.cc
+        db/db_user_value_checksum_test.cc
         db/db_inplace_update_test.cc
         db/db_io_failure_test.cc
         db/db_iter_test.cc

--- a/Makefile
+++ b/Makefile
@@ -1504,6 +1504,9 @@ db_dynamic_level_test: $(OBJ_DIR)/db/db_dynamic_level_test.o $(TEST_LIBRARY) $(L
 db_flush_test: $(OBJ_DIR)/db/db_flush_test.o $(TEST_LIBRARY) $(LIBRARY)
 	$(AM_LINK)
 
+db_user_value_checksum_test: $(OBJ_DIR)/db/db_user_value_checksum_test.o $(TEST_LIBRARY) $(LIBRARY)
+	$(AM_LINK)
+
 db_inplace_update_test: $(OBJ_DIR)/db/db_inplace_update_test.o $(TEST_LIBRARY) $(LIBRARY)
 	$(AM_LINK)
 

--- a/db/builder.cc
+++ b/db/builder.cc
@@ -22,6 +22,7 @@
 #include "db/output_validator.h"
 #include "db/range_del_aggregator.h"
 #include "db/table_cache.h"
+#include "db/user_value_checksum_helper.h"
 #include "db/version_edit.h"
 #include "file/file_util.h"
 #include "file/filename.h"
@@ -469,17 +470,21 @@ Status BuildTable(
           /*largest_compaction_key*/ nullptr,
           /*allow_unprepared_value*/ false));
       s = it->status();
-      if (s.ok() && paranoid_file_checks) {
+      const auto& user_value_checksum = tboptions.ioptions.user_value_checksum;
+      const bool verify_user_checksum_on_flush =
+          user_value_checksum &&
+          mutable_cf_options.verify_user_value_checksum_on_flush;
+
+      const bool need_iteration =
+          paranoid_file_checks || verify_user_checksum_on_flush;
+      if (s.ok() && need_iteration) {
         OutputValidator file_validator(tboptions.internal_comparator,
-                                       /*enable_hash=*/true);
-        for (it->SeekToFirst(); it->Valid(); it->Next()) {
-          // Generate a rolling 64-bit hash of the key and values
-          file_validator.Add(it->key(), it->value()).PermitUncheckedError();
-        }
-        s = it->status();
-        if (s.ok() && !output_validator.CompareValidator(file_validator)) {
-          s = Status::Corruption("Paranoid checksums do not match");
-        }
+                                       /*enable_hash=*/paranoid_file_checks);
+        s = IterateAndValidateOutput(
+            it.get(), paranoid_file_checks ? &file_validator : nullptr,
+            paranoid_file_checks ? &output_validator : nullptr,
+            verify_user_checksum_on_flush ? user_value_checksum.get() : nullptr,
+            ioptions.stats, "flush output verification");
       }
     }
   }

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -31,6 +31,7 @@
 #include "db/log_writer.h"
 #include "db/merge_helper.h"
 #include "db/range_del_aggregator.h"
+#include "db/user_value_checksum_helper.h"
 #include "db/version_edit.h"
 #include "db/version_set.h"
 #include "file/file_util.h"
@@ -937,6 +938,18 @@ Status CompactionJob::VerifyOutputFiles() {
              !!(verify_output_flags &
                 VerifyOutputFlags::kEnableForLocalCompaction));
 
+        const auto& ioptions = compact_->compaction->immutable_options();
+        const auto& user_value_checksum = ioptions.user_value_checksum;
+        // Skip user value checksum on the primary for remote compactions
+        // because the remote worker already verified checksums via
+        // CompactionServiceCompactionJob::VerifyUserValueChecksumsOnOutputFiles.
+        const bool should_verify_user_checksum =
+            user_value_checksum &&
+            !subcompaction_state.compaction_job_stats.is_remote_compaction &&
+            compact_->compaction->mutable_cf_options()
+                .verify_user_value_checksum_on_compaction;
+
+        // Block checksum verification (non-iterating check).
         if (should_verify) {
           const bool should_verify_block_checksum =
               !!(verify_output_flags & VerifyOutputFlags::kVerifyBlockChecksum);
@@ -948,30 +961,15 @@ Status CompactionJob::VerifyOutputFiles() {
               db_options_.file_checksum_gen_factory != nullptr &&
               output_file.meta.file_checksum != kUnknownFileChecksum;
           if (should_verify_block_checksum) {
+            const bool need_iteration =
+                should_verify_iteration || should_verify_user_checksum;
             assert(table_reader_ptr != nullptr);
-            // If verifying iteration as well, verify meta blocks here only to
-            // avoid redundant checks on data blocks
+            // If iterating data blocks anyway (for output validation or
+            // user-value checksum), verify only meta blocks here to avoid
+            // redundant reads of data blocks.
             s = table_reader_ptr->VerifyChecksum(
                 verification_read_options, TableReaderCaller::kCompaction,
-                /*meta_blocks_only=*/should_verify_iteration);
-          }
-          if (s.ok() && should_verify_iteration) {
-            OutputValidator validator(cfd->internal_comparator(),
-                                      /*_enable_hash=*/true);
-            for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
-              s = validator.Add(iter->key(), iter->value());
-              if (!s.ok()) {
-                break;
-              }
-            }
-            if (s.ok()) {
-              s = iter->status();
-            }
-            if (s.ok() && !validator.CompareValidator(output_file.validator)) {
-              s = Status::Corruption(
-                  "Key-value checksum of compaction output doesn't match what "
-                  "was computed when written");
-            }
+                /*meta_blocks_only=*/need_iteration);
           }
           if (s.ok() && should_verify_file_checksum) {
             std::string file_checksum;
@@ -991,6 +989,22 @@ Status CompactionJob::VerifyOutputFiles() {
                   "File checksum mismatch for compaction output file " + fname);
             }
           }
+        }
+
+        // Unified iteration loop for output validation and/or user checksum.
+        const bool should_verify_iteration =
+            should_verify &&
+            !!(verify_output_flags & VerifyOutputFlags::kVerifyIteration);
+        const bool need_iteration =
+            should_verify_iteration || should_verify_user_checksum;
+        if (s.ok() && need_iteration) {
+          OutputValidator validator(cfd->internal_comparator(),
+                                    /*_enable_hash=*/should_verify_iteration);
+          s = IterateAndValidateOutput(
+              iter, should_verify_iteration ? &validator : nullptr,
+              should_verify_iteration ? &output_file.validator : nullptr,
+              should_verify_user_checksum ? user_value_checksum.get() : nullptr,
+              stats_, "compaction output verification");
         }
       }
 

--- a/db/compaction/compaction_job.h
+++ b/db/compaction/compaction_job.h
@@ -238,6 +238,10 @@ class CompactionJob {
 
   CompactionJobStats* job_stats_;
 
+  const FileOptions& file_options_for_read() const {
+    return file_options_for_read_;
+  }
+
  private:
   friend class CompactionJobTestBase;
 
@@ -728,6 +732,12 @@ class CompactionServiceCompactionJob : private CompactionJob {
  private:
   // Get table file name in output_path
   std::string GetTableFileName(uint64_t file_number) override;
+  // Verify user value checksums on output files in output_path_.
+  // Unlike VerifyOutputFiles() which uses the table cache (resolving paths
+  // via cf_paths), this method opens files directly from output_path_ which
+  // is necessary for remote compaction where output files are in a separate
+  // directory from the DB.
+  Status VerifyUserValueChecksumsOnOutputFiles();
   // Specific the compaction output path, otherwise it uses default DB path
   const std::string output_path_;
 

--- a/db/compaction/compaction_service_job.cc
+++ b/db/compaction/compaction_service_job.cc
@@ -10,10 +10,13 @@
 
 #include "db/compaction/compaction_job.h"
 #include "db/compaction/compaction_state.h"
+#include "db/user_value_checksum_helper.h"
+#include "file/random_access_file_reader.h"
 #include "logging/logging.h"
 #include "monitoring/iostats_context_imp.h"
 #include "monitoring/thread_status_util.h"
 #include "options/options_helper.h"
+#include "rocksdb/file_checksum.h"
 #include "rocksdb/utilities/options_type.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -350,6 +353,73 @@ void CompactionServiceCompactionJob::Prepare(
                          compaction_progress_writer);
 }
 
+Status CompactionServiceCompactionJob::VerifyUserValueChecksumsOnOutputFiles() {
+  ColumnFamilyData* cfd = compact_->compaction->column_family_data();
+  const auto& ioptions = compact_->compaction->immutable_options();
+  const auto& mutable_cf_options = compact_->compaction->mutable_cf_options();
+  const auto& user_value_checksum = ioptions.user_value_checksum;
+  const bool should_verify =
+      user_value_checksum &&
+      mutable_cf_options.verify_user_value_checksum_on_compaction;
+  if (!should_verify) {
+    return Status::OK();
+  }
+
+  assert(compact_->sub_compact_states.size() == 1);
+  SubcompactionState* sub_compact = compact_->sub_compact_states.data();
+
+  for (const auto& output_file : sub_compact->GetOutputs()) {
+    std::string fname =
+        MakeTableFileName(output_path_, output_file.meta.fd.GetNumber());
+
+    // Open the output file directly from the output path.
+    // Use file_options_for_read() but override file checksum fields since
+    // we're only reading for user value checksum validation, not for
+    // file-level checksum handoff.
+    std::unique_ptr<FSRandomAccessFile> file;
+    FileOptions fopts = file_options_for_read();
+    fopts.file_checksum_func_name = kNoFileChecksumFuncName;
+    fopts.file_checksum = "";
+    IOStatus io_s =
+        ioptions.fs->NewRandomAccessFile(fname, fopts, &file, nullptr);
+    if (!io_s.ok()) {
+      return io_s;
+    }
+    std::unique_ptr<RandomAccessFileReader> file_reader(
+        new RandomAccessFileReader(std::move(file), fname));
+
+    // Open the table
+    ReadOptions read_options;
+    read_options.verify_checksums = true;
+    std::unique_ptr<TableReader> table_reader;
+    Status s = mutable_cf_options.table_factory->NewTableReader(
+        read_options,
+        TableReaderOptions(ioptions, mutable_cf_options.prefix_extractor,
+                           mutable_cf_options.compression_manager.get(), fopts,
+                           cfd->internal_comparator(),
+                           mutable_cf_options.block_protection_bytes_per_key),
+        std::move(file_reader), output_file.meta.fd.GetFileSize(),
+        &table_reader, /*prefetch_index_and_filter_in_cache=*/false);
+    if (!s.ok()) {
+      return s;
+    }
+
+    // Iterate and validate user value checksums
+    std::unique_ptr<InternalIterator> iter(
+        table_reader->NewIterator(read_options, /*prefix_extractor=*/nullptr,
+                                  /*arena=*/nullptr, /*skip_filters=*/false,
+                                  TableReaderCaller::kCompactionRefill));
+    s = IterateAndValidateOutput(iter.get(), /*output_validator=*/nullptr,
+                                 /*reference_validator=*/nullptr,
+                                 user_value_checksum.get(), stats_,
+                                 "remote compaction output verification");
+    if (!s.ok()) {
+      return s;
+    }
+  }
+  return Status::OK();
+}
+
 Status CompactionServiceCompactionJob::Run() {
   AutoThreadOperationStageUpdater stage_updater(
       ThreadStatus::STAGE_COMPACTION_RUN);
@@ -399,6 +469,10 @@ Status CompactionServiceCompactionJob::Run() {
   }
   if (status.ok()) {
     status = io_s;
+  }
+
+  if (status.ok()) {
+    status = VerifyUserValueChecksumsOnOutputFiles();
   }
 
   LogFlush(db_options_.info_log);

--- a/db/compaction/compaction_service_test.cc
+++ b/db/compaction/compaction_service_test.cc
@@ -6,8 +6,11 @@
 #include "db/db_test_util.h"
 #include "file/file_util.h"
 #include "port/stack_trace.h"
+#include "rocksdb/user_value_checksum.h"
 #include "rocksdb/utilities/options_util.h"
 #include "table/unique_id_impl.h"
+#include "util/coding.h"
+#include "util/crc32c.h"
 #include "utilities/merge_operators/string_append/stringappend.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -110,6 +113,7 @@ class MyTestCompactionService : public CompactionService {
     options_override.prefix_extractor = options_.prefix_extractor;
     options_override.table_factory = options_.table_factory;
     options_override.sst_partitioner_factory = options_.sst_partitioner_factory;
+    options_override.user_value_checksum = options_.user_value_checksum;
     options_override.statistics = statistics_;
     options_override.info_log = options_.info_log;
     if (!listeners_.empty()) {
@@ -2892,6 +2896,136 @@ TEST_F(ResumableCompactionKeyTypeTest, CancelAndResumeWithTimedPut) {
 
   VerifyResumeBytes();
 }
+// UserValueChecksum implementation for compaction service test.
+// Value format: [user_data][4-byte CRC32c checksum]
+class CompactionServiceTestChecksum : public UserValueChecksum {
+ public:
+  const char* Name() const override { return "CompactionServiceTestChecksum"; }
+
+  Status Validate(const Slice& /*key*/, const Slice& value,
+                  ChecksumValueType /*value_type*/) const override {
+    if (value.size() < sizeof(uint32_t)) {
+      return Status::Corruption("Value too small for checksum");
+    }
+    size_t data_sz = value.size() - sizeof(uint32_t);
+    uint32_t stored = DecodeFixed32(value.data() + data_sz);
+    uint32_t computed = crc32c::Value(value.data(), data_sz);
+    if (stored != computed) {
+      return Status::Corruption("CRC32c checksum mismatch");
+    }
+    return Status::OK();
+  }
+
+  static std::string MakeValue(const std::string& data) {
+    std::string result = data;
+    uint32_t crc = crc32c::Value(data.data(), data.size());
+    PutFixed32(&result, crc);
+    return result;
+  }
+
+  static std::string MakeCorruptValue(const std::string& data) {
+    std::string result = data;
+    PutFixed32(&result, 0xDEADBEEF);  // bad checksum
+    return result;
+  }
+};
+
+TEST_F(CompactionServiceTest, UserValueChecksum) {
+  Options options = CurrentOptions();
+  options.disable_auto_compactions = true;
+  auto checksum = std::make_shared<CompactionServiceTestChecksum>();
+  options.user_value_checksum = checksum;
+  options.verify_user_value_checksum_on_compaction = true;
+  ReopenWithCompactionService(&options);
+
+  // Write checksummed values and flush to create L0 files
+  for (int i = 0; i < 20; i++) {
+    ASSERT_OK(Put(Key(i), CompactionServiceTestChecksum::MakeValue(
+                              "value" + std::to_string(i))));
+  }
+  ASSERT_OK(Flush());
+
+  for (int i = 0; i < 20; i++) {
+    ASSERT_OK(Put(Key(i), CompactionServiceTestChecksum::MakeValue(
+                              "value_new" + std::to_string(i))));
+  }
+  ASSERT_OK(Flush());
+
+  // Trigger remote compaction
+  auto my_cs = GetCompactionService();
+  uint64_t comp_num = my_cs->GetCompactionNum();
+  ASSERT_OK(db_->CompactRange(CompactRangeOptions(), nullptr, nullptr));
+  ASSERT_GE(my_cs->GetCompactionNum(), comp_num + 1);
+
+  // Verify the compaction succeeded (checksums validated on remote side)
+  CompactionServiceResult result;
+  my_cs->GetResult(&result);
+  ASSERT_OK(result.status);
+  ASSERT_TRUE(result.stats.is_remote_compaction);
+
+  // Verify that user value checksum validation actually ran on the remote
+  // compactor by checking the statistics counters.
+  ASSERT_GE(GetCompactorStatistics()->getTickerCount(
+                USER_VALUE_CHECKSUM_COMPUTE_COUNT),
+            20);
+  ASSERT_EQ(GetCompactorStatistics()->getTickerCount(
+                USER_VALUE_CHECKSUM_MISMATCH_COUNT),
+            0);
+
+  // Verify that the primary host did NOT redundantly re-validate user value
+  // checksums — the remote worker already did it.
+  ASSERT_EQ(
+      GetPrimaryStatistics()->getTickerCount(USER_VALUE_CHECKSUM_COMPUTE_COUNT),
+      0);
+
+  // Verify data is intact
+  for (int i = 0; i < 20; i++) {
+    auto val = Get(Key(i));
+    ASSERT_EQ(val, CompactionServiceTestChecksum::MakeValue("value_new" +
+                                                            std::to_string(i)));
+  }
+}
+
+TEST_F(CompactionServiceTest, UserValueChecksumCorruption) {
+  Options options = CurrentOptions();
+  options.disable_auto_compactions = true;
+  auto checksum = std::make_shared<CompactionServiceTestChecksum>();
+  options.user_value_checksum = checksum;
+  options.verify_user_value_checksum_on_compaction = true;
+  // Disable flush verification so corrupt values survive to L0 files
+  options.verify_user_value_checksum_on_flush = false;
+  ReopenWithCompactionService(&options);
+
+  // Write two overlapping L0 files with corrupt checksums.
+  // Overlapping keys across flushes prevent trivial move.
+  for (int i = 0; i < 20; i++) {
+    ASSERT_OK(Put(Key(i), CompactionServiceTestChecksum::MakeCorruptValue(
+                              "value" + std::to_string(i))));
+  }
+  ASSERT_OK(Flush());
+
+  for (int i = 0; i < 20; i++) {
+    ASSERT_OK(Put(Key(i), CompactionServiceTestChecksum::MakeCorruptValue(
+                              "value_new" + std::to_string(i))));
+  }
+  ASSERT_OK(Flush());
+
+  // Trigger remote compaction — should fail due to corrupt checksums
+  auto my_cs = GetCompactionService();
+  Status s = db_->CompactRange(CompactRangeOptions(), nullptr, nullptr);
+  ASSERT_NOK(s);
+
+  // Verify the remote compactor detected corruption
+  CompactionServiceResult result;
+  my_cs->GetResult(&result);
+  ASSERT_TRUE(result.status.IsCorruption()) << result.status.ToString();
+
+  // Verify mismatch counter was incremented on the compactor
+  ASSERT_GT(GetCompactorStatistics()->getTickerCount(
+                USER_VALUE_CHECKSUM_MISMATCH_COUNT),
+            0);
+}
+
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {

--- a/db/db_impl/db_impl_secondary.cc
+++ b/db/db_impl/db_impl_secondary.cc
@@ -1544,6 +1544,7 @@ Status DB::OpenAndCompact(
       cf.options.table_factory = override_options.table_factory;
       cf.options.sst_partitioner_factory =
           override_options.sst_partitioner_factory;
+      cf.options.user_value_checksum = override_options.user_value_checksum;
       cf.options.table_properties_collector_factories =
           override_options.table_properties_collector_factories;
 

--- a/db/db_user_value_checksum_test.cc
+++ b/db/db_user_value_checksum_test.cc
@@ -1,0 +1,818 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include "db/db_test_util.h"
+#include "port/stack_trace.h"
+#include "rocksdb/merge_operator.h"
+#include "rocksdb/sst_file_writer.h"
+#include "rocksdb/user_value_checksum.h"
+#include "test_util/testutil.h"
+#include "util/coding.h"
+#include "util/crc32c.h"
+#include "util/random.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+// Shared CRC32c trailing checksum validation logic.
+// Value format: [user_data][4-byte CRC32c checksum]
+inline Status ValidateTrailingCRC32c(const Slice& value) {
+  if (value.size() < 4) {
+    return Status::Corruption("Value too small for checksum");
+  }
+  size_t data_sz = value.size() - 4;
+  uint32_t stored = DecodeFixed32(value.data() + data_sz);
+  uint32_t computed = crc32c::Value(value.data(), data_sz);
+  if (stored != computed) {
+    return Status::Corruption("CRC32c checksum mismatch");
+  }
+  return Status::OK();
+}
+
+// Test UserValueChecksum implementation: value format is
+// [user_data][4-byte CRC32c checksum]
+class TestUserValueChecksum : public UserValueChecksum {
+ public:
+  const char* Name() const override { return "TestUserValueChecksum"; }
+
+  Status Validate(const Slice& /*key*/, const Slice& value,
+                  ChecksumValueType /*value_type*/) const override {
+    return ValidateTrailingCRC32c(value);
+  }
+
+  // Helper to create a checksummed value
+  static std::string MakeValue(const std::string& data) {
+    std::string result = data;
+    uint32_t crc = crc32c::Value(data.data(), data.size());
+    PutFixed32(&result, crc);
+    return result;
+  }
+
+  // Helper to create a corrupt value (wrong checksum)
+  static std::string MakeCorruptValue(const std::string& data) {
+    std::string result = data;
+    PutFixed32(&result, 0xDEADBEEF);  // bad checksum
+    return result;
+  }
+};
+
+// Merge operator that preserves CRC32c checksums
+class ChecksumPreservingMergeOp : public MergeOperator {
+ public:
+  bool FullMergeV3(const MergeOperationInputV3& merge_in,
+                   MergeOperationOutputV3* merge_out) const override {
+    // Concatenate all values, then recompute checksum
+    std::string merged_data;
+    if (auto* existing = std::get_if<Slice>(&merge_in.existing_value)) {
+      if (existing->size() >= 4) {
+        // Strip old checksum
+        merged_data.assign(existing->data(), existing->size() - 4);
+      }
+    }
+    for (const auto& operand : merge_in.operand_list) {
+      if (operand.size() >= 4) {
+        merged_data.append(operand.data(), operand.size() - 4);
+      }
+    }
+    // Recompute checksum
+    std::string result = merged_data;
+    uint32_t crc = crc32c::Value(result.data(), result.size());
+    PutFixed32(&result, crc);
+    merge_out->new_value = std::move(result);
+    return true;
+  }
+
+  const char* Name() const override { return "ChecksumPreservingMergeOp"; }
+};
+
+// UserValueChecksum that always validates successfully.
+class AlwaysValidChecksum : public UserValueChecksum {
+ public:
+  const char* Name() const override { return "AlwaysValidChecksum"; }
+
+  Status Validate(const Slice& /*key*/, const Slice& /*value*/,
+                  ChecksumValueType /*value_type*/) const override {
+    return Status::OK();
+  }
+};
+
+class UserValueChecksumTest : public DBTestBase {
+ public:
+  UserValueChecksumTest()
+      : DBTestBase("db_user_value_checksum_test", /*env_do_fsync=*/false) {}
+
+  // Write two overlapping L0 files with corrupt or valid values.
+  // Used by tests that need a non-trivial compaction input.
+  void WriteOverlappingL0Files(bool corrupt = true) {
+    auto make = corrupt ? TestUserValueChecksum::MakeCorruptValue
+                        : TestUserValueChecksum::MakeValue;
+    ASSERT_OK(Put("key1", make("value1")));
+    ASSERT_OK(Put("key2", make("value2")));
+    ASSERT_OK(Flush());
+    ASSERT_OK(Put("key1", make("value1b")));
+    ASSERT_OK(Put("key3", make("value3")));
+    ASSERT_OK(Flush());
+  }
+};
+
+TEST_F(UserValueChecksumTest, FlushValidationCorruptAndValid) {
+  for (bool corrupt : {false, true}) {
+    SCOPED_TRACE(corrupt ? "corrupt" : "valid");
+    Options options = CurrentOptions();
+    options.user_value_checksum = std::make_shared<TestUserValueChecksum>();
+    options.verify_user_value_checksum_on_flush = true;
+    options.statistics = CreateDBStatistics();
+    DestroyAndReopen(options);
+
+    auto make = corrupt ? TestUserValueChecksum::MakeCorruptValue
+                        : TestUserValueChecksum::MakeValue;
+    ASSERT_OK(Put("key1", make("value1")));
+    ASSERT_OK(Put("key2", make("value2")));
+    ASSERT_OK(Put("key3", make("value3")));
+
+    Status s = Flush();
+    if (corrupt) {
+      ASSERT_TRUE(s.IsCorruption()) << s.ToString();
+    } else {
+      ASSERT_OK(s);
+      ASSERT_GE(
+          options.statistics->getTickerCount(USER_VALUE_CHECKSUM_COMPUTE_COUNT),
+          3);
+      ASSERT_EQ(options.statistics->getTickerCount(
+                    USER_VALUE_CHECKSUM_MISMATCH_COUNT),
+                0);
+      ASSERT_EQ(Get("key1"), TestUserValueChecksum::MakeValue("value1"));
+      ASSERT_EQ(Get("key2"), TestUserValueChecksum::MakeValue("value2"));
+    }
+  }
+}
+
+TEST_F(UserValueChecksumTest, CompactionOutputVerificationVariants) {
+  struct TestCase {
+    const char* label;
+    VerifyOutputFlags flags;
+    bool paranoid_file_checks;
+    bool corrupt;
+    bool expect_corruption;
+    int min_checksum_count;  // 0 = don't check
+  };
+  TestCase cases[] = {
+      {"ParanoidCorrupt", VerifyOutputFlags::kVerifyNone,
+       /*paranoid_file_checks=*/true,
+       /*corrupt=*/true,
+       /*expect_corruption=*/true,
+       /*min_checksum_count=*/0},
+      {"ParanoidValid", VerifyOutputFlags::kVerifyNone,
+       /*paranoid_file_checks=*/true,
+       /*corrupt=*/false,
+       /*expect_corruption=*/false,
+       /*min_checksum_count=*/2},
+      {"BlockChecksumCorrupt",
+       VerifyOutputFlags::kVerifyBlockChecksum |
+           VerifyOutputFlags::kEnableForLocalCompaction,
+       /*paranoid_file_checks=*/false,
+       /*corrupt=*/true,
+       /*expect_corruption=*/true,
+       /*min_checksum_count=*/0},
+      {"BlockChecksumValid",
+       VerifyOutputFlags::kVerifyBlockChecksum |
+           VerifyOutputFlags::kEnableForLocalCompaction,
+       /*paranoid_file_checks=*/false,
+       /*corrupt=*/false,
+       /*expect_corruption=*/false,
+       /*min_checksum_count=*/2},
+      {"StandaloneCorrupt", VerifyOutputFlags::kVerifyNone,
+       /*paranoid_file_checks=*/false,
+       /*corrupt=*/true,
+       /*expect_corruption=*/true,
+       /*min_checksum_count=*/0},
+      {"StandaloneValid", VerifyOutputFlags::kVerifyNone,
+       /*paranoid_file_checks=*/false,
+       /*corrupt=*/false,
+       /*expect_corruption=*/false,
+       /*min_checksum_count=*/3},
+  };
+  for (const auto& tc : cases) {
+    SCOPED_TRACE(tc.label);
+    Options options = CurrentOptions();
+    options.user_value_checksum = std::make_shared<TestUserValueChecksum>();
+    options.verify_user_value_checksum_on_compaction = true;
+    options.verify_user_value_checksum_on_flush = false;
+    options.disable_auto_compactions = true;
+    options.verify_output_flags = tc.flags;
+    options.paranoid_file_checks = tc.paranoid_file_checks;
+    options.statistics = CreateDBStatistics();
+    DestroyAndReopen(options);
+
+    ASSERT_NO_FATAL_FAILURE(WriteOverlappingL0Files(tc.corrupt));
+    Status s = db_->CompactRange(CompactRangeOptions(), nullptr, nullptr);
+    if (tc.expect_corruption) {
+      ASSERT_TRUE(s.IsCorruption()) << s.ToString();
+    } else {
+      ASSERT_OK(s);
+      if (tc.min_checksum_count > 0) {
+        ASSERT_GE(options.statistics->getTickerCount(
+                      USER_VALUE_CHECKSUM_COMPUTE_COUNT),
+                  tc.min_checksum_count);
+      }
+      ASSERT_EQ(options.statistics->getTickerCount(
+                    USER_VALUE_CHECKSUM_MISMATCH_COUNT),
+                0);
+    }
+  }
+}
+
+TEST_F(UserValueChecksumTest, FlushOnlyEnabled) {
+  Options options = CurrentOptions();
+  options.user_value_checksum = std::make_shared<TestUserValueChecksum>();
+  options.verify_user_value_checksum_on_flush = true;
+  options.verify_user_value_checksum_on_compaction = false;
+  options.level0_file_num_compaction_trigger = 2;
+  DestroyAndReopen(options);
+
+  ASSERT_OK(Put("key1", TestUserValueChecksum::MakeValue("value1")));
+  ASSERT_OK(Flush());
+  ASSERT_OK(Put("key2", TestUserValueChecksum::MakeValue("value2")));
+  ASSERT_OK(Flush());
+
+  // Compaction should succeed even though compaction checksum is disabled
+  ASSERT_OK(dbfull()->TEST_WaitForCompact());
+}
+
+TEST_F(UserValueChecksumTest, DisabledByDefault) {
+  Options options = CurrentOptions();
+  options.user_value_checksum = std::make_shared<TestUserValueChecksum>();
+  // Both flags default to false
+  DestroyAndReopen(options);
+
+  // Put a value with a CORRUPT checksum — flush should still succeed since
+  // validation is disabled, proving it is truly skipped
+  ASSERT_OK(Put("key1", TestUserValueChecksum::MakeCorruptValue("bad_data")));
+  ASSERT_OK(Flush());
+}
+
+TEST_F(UserValueChecksumTest, NullValidator) {
+  Options options = CurrentOptions();
+  // user_value_checksum defaults to nullptr
+  options.verify_user_value_checksum_on_flush = true;
+  options.verify_user_value_checksum_on_compaction = true;
+  DestroyAndReopen(options);
+
+  // Should work fine — flags are true but no validator is set
+  ASSERT_OK(Put("key1", "plain_value"));
+  ASSERT_OK(Flush());
+}
+
+TEST_F(UserValueChecksumTest, EmptyValueSkipped) {
+  Options options = CurrentOptions();
+  options.user_value_checksum = std::make_shared<TestUserValueChecksum>();
+  options.verify_user_value_checksum_on_flush = true;
+  DestroyAndReopen(options);
+
+  // Put an empty value — should be skipped during validation
+  ASSERT_OK(Put("key1", ""));
+  ASSERT_OK(Put("key2", TestUserValueChecksum::MakeValue("value2")));
+  ASSERT_OK(Flush());
+
+  ASSERT_EQ(Get("key1"), "");
+  ASSERT_EQ(Get("key2"), TestUserValueChecksum::MakeValue("value2"));
+}
+
+TEST_F(UserValueChecksumTest, DeleteSkipped) {
+  Options options = CurrentOptions();
+  options.user_value_checksum = std::make_shared<TestUserValueChecksum>();
+  options.verify_user_value_checksum_on_flush = true;
+  DestroyAndReopen(options);
+
+  ASSERT_OK(Put("key1", TestUserValueChecksum::MakeValue("value1")));
+  ASSERT_OK(Delete("key1"));
+  ASSERT_OK(Flush());
+
+  ASSERT_EQ(Get("key1"), "NOT_FOUND");
+}
+
+TEST_F(UserValueChecksumTest, MergeOperatorCompatible) {
+  Options options = CurrentOptions();
+  options.user_value_checksum = std::make_shared<TestUserValueChecksum>();
+  options.merge_operator = std::make_shared<ChecksumPreservingMergeOp>();
+  options.verify_user_value_checksum_on_flush = true;
+  options.verify_user_value_checksum_on_compaction = true;
+  options.statistics = CreateDBStatistics();
+  DestroyAndReopen(options);
+
+  ASSERT_OK(Put("key1", TestUserValueChecksum::MakeValue("base")));
+  ASSERT_OK(Merge("key1", TestUserValueChecksum::MakeValue("operand")));
+  ASSERT_OK(Flush());
+
+  // Verify validation actually ran
+  ASSERT_GE(
+      options.statistics->getTickerCount(USER_VALUE_CHECKSUM_COMPUTE_COUNT), 1);
+  ASSERT_EQ(
+      options.statistics->getTickerCount(USER_VALUE_CHECKSUM_MISMATCH_COUNT),
+      0);
+
+  // The merge result should have a valid checksum
+  std::string value = Get("key1");
+  ASSERT_NE(value, "NOT_FOUND");
+
+  // Verify the merged value actually has a valid checksum
+  TestUserValueChecksum validator;
+  ASSERT_OK(validator.Validate("key1", value, ChecksumValueType::kValue));
+}
+
+TEST_F(UserValueChecksumTest, DynamicToggle) {
+  Options options = CurrentOptions();
+  options.user_value_checksum = std::make_shared<TestUserValueChecksum>();
+  options.verify_user_value_checksum_on_flush = false;
+  DestroyAndReopen(options);
+
+  // Start disabled
+  ASSERT_OK(Put("key1", "no_checksum_value"));
+  ASSERT_OK(Flush());
+
+  // Enable via SetOptions
+  ASSERT_OK(
+      dbfull()->SetOptions({{"verify_user_value_checksum_on_flush", "true"}}));
+
+  // Prove the toggle works: write a corrupt value and verify flush fails
+  ASSERT_OK(Put("key2", TestUserValueChecksum::MakeCorruptValue("value2")));
+  Status s = Flush();
+  ASSERT_TRUE(s.IsCorruption()) << s.ToString();
+
+  // Reopen since the DB is in error state after corruption
+  Reopen(options);
+
+  // Re-enable and verify valid checksums pass after toggle
+  ASSERT_OK(
+      dbfull()->SetOptions({{"verify_user_value_checksum_on_flush", "true"}}));
+  ASSERT_OK(Put("key3", TestUserValueChecksum::MakeValue("value3")));
+  ASSERT_OK(Flush());
+}
+
+TEST_F(UserValueChecksumTest, CorruptChecksumWithParanoidChecks) {
+  Options options = CurrentOptions();
+  options.user_value_checksum = std::make_shared<TestUserValueChecksum>();
+  options.verify_user_value_checksum_on_flush = true;
+  options.paranoid_file_checks = true;
+  DestroyAndReopen(options);
+
+  // Write values with corrupt checksums
+  ASSERT_OK(Put("key1", TestUserValueChecksum::MakeCorruptValue("value1")));
+
+  // Flush should fail — both paranoid_file_checks and user checksum
+  // verification are enabled, and they share the same iteration pass
+  Status s = Flush();
+  ASSERT_TRUE(s.IsCorruption()) << s.ToString();
+}
+
+// Test that TimedPut (kTypeValuePreferredSeqno) values are correctly
+// unpacked before checksum validation. The helper strips the trailing
+// uint64 seqno before calling Validate().
+TEST_F(UserValueChecksumTest, TimedPutValidationCorruptAndValid) {
+  for (bool corrupt : {false, true}) {
+    SCOPED_TRACE(corrupt ? "corrupt" : "valid");
+    Options options = CurrentOptions();
+    options.user_value_checksum = std::make_shared<TestUserValueChecksum>();
+    options.verify_user_value_checksum_on_flush = true;
+    DestroyAndReopen(options);
+
+    WriteBatch batch;
+    std::string val = corrupt
+                          ? TestUserValueChecksum::MakeCorruptValue("timed_val")
+                          : TestUserValueChecksum::MakeValue("timed_val");
+    ASSERT_OK(batch.TimedPut(db_->DefaultColumnFamily(), "timed_key", val,
+                             /*write_unix_time=*/1000));
+    ASSERT_OK(db_->Write(WriteOptions(), &batch));
+
+    Status s = Flush();
+    if (corrupt) {
+      ASSERT_TRUE(s.IsCorruption()) << s.ToString();
+    } else {
+      ASSERT_OK(s);
+    }
+  }
+}
+
+// UserValueChecksum that validates wide-column entities by checking for a
+// "checksum" column containing a CRC32c over the "data" column.
+class WideColumnChecksum : public UserValueChecksum {
+ public:
+  const char* Name() const override { return "WideColumnChecksum"; }
+
+  Status Validate(const Slice& /*key*/, const Slice& value,
+                  ChecksumValueType /*value_type*/) const override {
+    return ValidateTrailingCRC32c(value);
+  }
+
+  Status ValidateWideColumns(const Slice& /*key*/,
+                             const WideColumns& columns) const override {
+    // Look for "data" and "checksum" columns
+    Slice data_val;
+    Slice checksum_val;
+    bool has_data = false;
+    bool has_checksum = false;
+    for (const auto& col : columns) {
+      if (col.name() == "data") {
+        data_val = col.value();
+        has_data = true;
+      } else if (col.name() == "checksum") {
+        checksum_val = col.value();
+        has_checksum = true;
+      }
+    }
+    if (!has_data || !has_checksum) {
+      return Status::OK();  // No data/checksum columns — skip
+    }
+    if (checksum_val.size() != sizeof(uint32_t)) {
+      return Status::Corruption("Checksum column wrong size");
+    }
+    uint32_t stored = DecodeFixed32(checksum_val.data());
+    uint32_t computed = crc32c::Value(data_val.data(), data_val.size());
+    if (stored != computed) {
+      return Status::Corruption("Wide-column CRC32c checksum mismatch");
+    }
+    return Status::OK();
+  }
+};
+
+// Test that PutEntity (wide-column) values are validated during flush
+// via the ValidateWideColumns() callback.
+TEST_F(UserValueChecksumTest, PutEntityValidation) {
+  // Test 1: Valid entity with AlwaysValidChecksum (default ValidateWideColumns
+  // returns OK)
+  {
+    Options opts = CurrentOptions();
+    opts.user_value_checksum = std::make_shared<AlwaysValidChecksum>();
+    opts.verify_user_value_checksum_on_flush = true;
+    DestroyAndReopen(opts);
+
+    WideColumns cols{{kDefaultWideColumnName, "default_val"},
+                     {"col1", "val1"},
+                     {"col2", "val2"}};
+    ASSERT_OK(db_->PutEntity(WriteOptions(), db_->DefaultColumnFamily(),
+                             "entity_key", cols));
+    ASSERT_OK(Flush());
+  }
+
+  // Test 2: Valid entity with WideColumnChecksum — data/checksum columns match
+  {
+    Options opts = CurrentOptions();
+    opts.user_value_checksum = std::make_shared<WideColumnChecksum>();
+    opts.verify_user_value_checksum_on_flush = true;
+    DestroyAndReopen(opts);
+
+    std::string data_value = "hello_world";
+    uint32_t crc = crc32c::Value(data_value.data(), data_value.size());
+    std::string checksum_bytes;
+    PutFixed32(&checksum_bytes, crc);
+
+    WideColumns cols{{"checksum", checksum_bytes}, {"data", data_value}};
+    ASSERT_OK(db_->PutEntity(WriteOptions(), db_->DefaultColumnFamily(),
+                             "entity_key", cols));
+    ASSERT_OK(Flush());
+  }
+
+  // Test 3: Invalid entity with WideColumnChecksum — wrong checksum
+  {
+    Options opts = CurrentOptions();
+    opts.user_value_checksum = std::make_shared<WideColumnChecksum>();
+    opts.verify_user_value_checksum_on_flush = true;
+    DestroyAndReopen(opts);
+
+    std::string data_value = "hello_world";
+    std::string bad_checksum;
+    PutFixed32(&bad_checksum, 0xDEADBEEF);
+
+    WideColumns cols{{"checksum", bad_checksum}, {"data", data_value}};
+    ASSERT_OK(db_->PutEntity(WriteOptions(), db_->DefaultColumnFamily(),
+                             "entity_key", cols));
+    Status s = Flush();
+    ASSERT_TRUE(s.IsCorruption()) << s.ToString();
+  }
+}
+
+// Test dynamic toggle of verify_user_value_checksum_on_compaction.
+TEST_F(UserValueChecksumTest, DynamicCompactionToggle) {
+  Options options = CurrentOptions();
+  options.user_value_checksum = std::make_shared<TestUserValueChecksum>();
+  options.verify_user_value_checksum_on_flush = false;
+  options.verify_user_value_checksum_on_compaction = false;
+  options.disable_auto_compactions = true;
+  options.paranoid_file_checks = true;
+  DestroyAndReopen(options);
+
+  // Write corrupt values and flush (no flush verification)
+  ASSERT_NO_FATAL_FAILURE(WriteOverlappingL0Files(/*corrupt=*/true));
+
+  // Enable compaction checksum via SetOptions
+  ASSERT_OK(dbfull()->SetOptions(
+      {{"verify_user_value_checksum_on_compaction", "true"}}));
+
+  // Compaction should now detect corrupt checksums
+  Status s = db_->CompactRange(CompactRangeOptions(), nullptr, nullptr);
+  ASSERT_TRUE(s.IsCorruption()) << s.ToString();
+}
+
+// Test that user value checksum validation works correctly after DB reopen.
+TEST_F(UserValueChecksumTest, ReopenPreservesValidation) {
+  Options options = CurrentOptions();
+  options.user_value_checksum = std::make_shared<TestUserValueChecksum>();
+  options.verify_user_value_checksum_on_flush = true;
+  options.verify_user_value_checksum_on_compaction = true;
+  DestroyAndReopen(options);
+
+  // Write data and flush
+  ASSERT_OK(Put("key1", TestUserValueChecksum::MakeValue("value1")));
+  ASSERT_OK(Flush());
+
+  // Reopen with same options
+  Reopen(options);
+
+  // Verify data from before reopen
+  ASSERT_EQ(Get("key1"), TestUserValueChecksum::MakeValue("value1"));
+
+  // Verify validation still works after reopen: corrupt value should fail
+  ASSERT_OK(Put("key2", TestUserValueChecksum::MakeCorruptValue("value2")));
+  Status s = Flush();
+  ASSERT_TRUE(s.IsCorruption()) << s.ToString();
+}
+
+// Test that corrupt values written before a crash are detected during
+// recovery flush (WAL replay path via WriteLevel0TableForRecovery).
+TEST_F(UserValueChecksumTest, RecoveryFlushCorruptAndValid) {
+  for (bool corrupt : {false, true}) {
+    SCOPED_TRACE(corrupt ? "corrupt" : "valid");
+    Options options = CurrentOptions();
+    options.user_value_checksum = std::make_shared<TestUserValueChecksum>();
+    options.verify_user_value_checksum_on_flush = true;
+    options.avoid_flush_during_recovery = false;
+    DestroyAndReopen(options);
+
+    // Write valid data and flush to establish a stable baseline
+    ASSERT_OK(Put("key1", TestUserValueChecksum::MakeValue("value1")));
+    ASSERT_OK(Flush());
+
+    // Write a value to WAL (not flushed) — corrupt or valid
+    auto make = corrupt ? TestUserValueChecksum::MakeCorruptValue
+                        : TestUserValueChecksum::MakeValue;
+    ASSERT_OK(Put("key2", make("value2")));
+
+    // Simulate crash by reopening without clean shutdown
+    Status s = TryReopen(options);
+    if (corrupt) {
+      ASSERT_TRUE(s.IsCorruption()) << s.ToString();
+    } else {
+      ASSERT_OK(s);
+      ASSERT_EQ(Get("key1"), TestUserValueChecksum::MakeValue("value1"));
+      ASSERT_EQ(Get("key2"), TestUserValueChecksum::MakeValue("value2"));
+    }
+  }
+}
+
+// Test that blob values (kTypeBlobIndex) are correctly skipped during
+// user value checksum validation.
+TEST_F(UserValueChecksumTest, BlobValueSkipped) {
+  Options options = CurrentOptions();
+  options.user_value_checksum = std::make_shared<TestUserValueChecksum>();
+  options.verify_user_value_checksum_on_flush = true;
+  options.verify_user_value_checksum_on_compaction = true;
+  // Enable blob files to produce kTypeBlobIndex entries
+  options.enable_blob_files = true;
+  options.min_blob_size = 0;  // All values go to blob files
+  options.disable_auto_compactions = true;
+  DestroyAndReopen(options);
+
+  // Write values that will become blob references. The blob value content
+  // is stored in the blob file; the SST contains a blob index (which has
+  // no user checksum). Validation should skip these.
+  ASSERT_OK(Put("key1", TestUserValueChecksum::MakeValue("blob_value1")));
+  ASSERT_OK(Put("key2", TestUserValueChecksum::MakeValue("blob_value2")));
+  ASSERT_OK(Flush());
+
+  // Verify data is readable (blob references resolved transparently)
+  ASSERT_EQ(Get("key1"), TestUserValueChecksum::MakeValue("blob_value1"));
+  ASSERT_EQ(Get("key2"), TestUserValueChecksum::MakeValue("blob_value2"));
+}
+
+// Test that SingleDelete entries are correctly skipped during validation.
+TEST_F(UserValueChecksumTest, SingleDeleteSkipped) {
+  Options options = CurrentOptions();
+  options.user_value_checksum = std::make_shared<TestUserValueChecksum>();
+  options.verify_user_value_checksum_on_flush = true;
+  DestroyAndReopen(options);
+
+  ASSERT_OK(Put("key1", TestUserValueChecksum::MakeValue("value1")));
+  ASSERT_OK(db_->SingleDelete(WriteOptions(), "key1"));
+  ASSERT_OK(Flush());
+
+  ASSERT_EQ(Get("key1"), "NOT_FOUND");
+}
+
+// Test that DeleteRange entries are correctly skipped during validation.
+TEST_F(UserValueChecksumTest, DeleteRangeSkipped) {
+  Options options = CurrentOptions();
+  options.user_value_checksum = std::make_shared<TestUserValueChecksum>();
+  options.verify_user_value_checksum_on_flush = true;
+  DestroyAndReopen(options);
+
+  ASSERT_OK(Put("key1", TestUserValueChecksum::MakeValue("value1")));
+  ASSERT_OK(Put("key3", TestUserValueChecksum::MakeValue("value3")));
+  ASSERT_OK(db_->DeleteRange(WriteOptions(), db_->DefaultColumnFamily(), "key1",
+                             "key2"));
+  ASSERT_OK(Flush());
+
+  ASSERT_EQ(Get("key1"), "NOT_FOUND");
+  ASSERT_EQ(Get("key3"), TestUserValueChecksum::MakeValue("value3"));
+}
+
+// Test that ingested SST files bypass user checksum validation during
+// ingestion but are validated during subsequent compaction.
+TEST_F(UserValueChecksumTest, IngestExternalFileBypass) {
+  Options options = CurrentOptions();
+  options.user_value_checksum = std::make_shared<TestUserValueChecksum>();
+  options.verify_user_value_checksum_on_flush = true;
+  options.verify_user_value_checksum_on_compaction = true;
+  options.disable_auto_compactions = true;
+  options.paranoid_file_checks = true;
+  DestroyAndReopen(options);
+
+  // Create an SST file with a value that has NO valid checksum
+  std::string sst_file = dbname_ + "/ingest.sst";
+  SstFileWriter sst_writer(EnvOptions(), options);
+  ASSERT_OK(sst_writer.Open(sst_file));
+  // Write a value without a valid CRC32c checksum
+  ASSERT_OK(sst_writer.Put("ingest_key", "no_checksum_value"));
+  ASSERT_OK(sst_writer.Finish());
+
+  // Ingestion should succeed — user checksum is NOT validated here
+  IngestExternalFileOptions ingest_opts;
+  ASSERT_OK(db_->IngestExternalFile({sst_file}, ingest_opts));
+
+  // Verify the ingested data is readable
+  ASSERT_EQ(Get("ingest_key"), "no_checksum_value");
+
+  // Write another L0 file with overlapping key to force non-trivial compaction
+  ASSERT_OK(Put("ingest_key", TestUserValueChecksum::MakeValue("new_value")));
+  ASSERT_OK(Flush());
+
+  // Compaction should succeed because the ingested value without checksum
+  // will be superseded by the newer value with a valid checksum
+  ASSERT_OK(db_->CompactRange(CompactRangeOptions(), nullptr, nullptr));
+}
+
+// Test that ingested SST files with corrupt checksums are detected during
+// subsequent compaction. This verifies the end-to-end path: ingest bypasses
+// validation, but compaction catches corruption.
+TEST_F(UserValueChecksumTest,
+       IngestExternalFileCorruptionDetectedOnCompaction) {
+  Options options = CurrentOptions();
+  options.user_value_checksum = std::make_shared<TestUserValueChecksum>();
+  options.verify_user_value_checksum_on_flush = false;
+  options.verify_user_value_checksum_on_compaction = true;
+  options.disable_auto_compactions = true;
+  options.paranoid_file_checks = true;
+  options.num_levels = 3;
+  DestroyAndReopen(options);
+
+  // Pre-populate L1 with data covering the ingested key range.
+  ASSERT_OK(Put("key1", TestUserValueChecksum::MakeValue("l1_value1")));
+  ASSERT_OK(Put("key2", TestUserValueChecksum::MakeValue("l1_value2")));
+  ASSERT_OK(Flush());
+  // Move L0 file to L1
+  ASSERT_OK(db_->CompactRange(CompactRangeOptions(), nullptr, nullptr));
+
+  // Create an SST file with corrupt checksums
+  std::string sst_file = dbname_ + "/ingest_corrupt.sst";
+  SstFileWriter sst_writer(EnvOptions(), options);
+  ASSERT_OK(sst_writer.Open(sst_file));
+  ASSERT_OK(
+      sst_writer.Put("key1", TestUserValueChecksum::MakeCorruptValue("bad1")));
+  ASSERT_OK(
+      sst_writer.Put("key2", TestUserValueChecksum::MakeCorruptValue("bad2")));
+  ASSERT_OK(sst_writer.Finish());
+
+  // Ingest to L0 (bypasses user checksum validation)
+  IngestExternalFileOptions ingest_opts;
+  ASSERT_OK(db_->IngestExternalFile({sst_file}, ingest_opts));
+
+  // Compact: ingested L0 file merges with L1 data, triggering
+  // user checksum verification on the output — should detect corruption
+  Status s = db_->CompactRange(CompactRangeOptions(), nullptr, nullptr);
+  ASSERT_TRUE(s.IsCorruption()) << s.ToString();
+}
+
+// Randomized test: write random keys and values of varying sizes with valid
+// CRC32c checksums, flush, and compact.
+TEST_F(UserValueChecksumTest, RandomizedValueSizes) {
+  uint32_t seed = static_cast<uint32_t>(
+      std::chrono::system_clock::now().time_since_epoch().count());
+  SCOPED_TRACE("seed=" + std::to_string(seed));
+  Random rnd(seed);
+
+  Options options = CurrentOptions();
+  options.user_value_checksum = std::make_shared<TestUserValueChecksum>();
+  options.verify_user_value_checksum_on_flush = true;
+  options.verify_user_value_checksum_on_compaction = true;
+  options.disable_auto_compactions = true;
+  DestroyAndReopen(options);
+
+  // Generate random keys and values of varying sizes (1-1024 bytes)
+  constexpr int kNumKeys = 50;
+  for (int i = 0; i < kNumKeys; i++) {
+    int key_len = 1 + rnd.Uniform(64);
+    int val_len = 1 + rnd.Uniform(1024);
+    std::string key = rnd.RandomString(key_len);
+    std::string val_data = rnd.RandomString(val_len);
+    std::string val = TestUserValueChecksum::MakeValue(val_data);
+    ASSERT_OK(Put(key, val));
+  }
+  ASSERT_OK(Flush());
+
+  // Write a second batch with some overlapping keys
+  for (int i = 0; i < kNumKeys; i++) {
+    int key_len = 1 + rnd.Uniform(64);
+    int val_len = 1 + rnd.Uniform(1024);
+    std::string key = rnd.RandomString(key_len);
+    std::string val_data = rnd.RandomString(val_len);
+    std::string val = TestUserValueChecksum::MakeValue(val_data);
+    ASSERT_OK(Put(key, val));
+  }
+  ASSERT_OK(Flush());
+
+  // Compact — should succeed with all valid checksums
+  ASSERT_OK(db_->CompactRange(CompactRangeOptions(), nullptr, nullptr));
+}
+
+TEST_F(UserValueChecksumTest, StatisticsCounters) {
+  Options options = CurrentOptions();
+  options.statistics = CreateDBStatistics();
+  options.user_value_checksum = std::make_shared<TestUserValueChecksum>();
+  options.verify_user_value_checksum_on_flush = true;
+  options.verify_user_value_checksum_on_compaction = true;
+  options.disable_auto_compactions = true;
+  DestroyAndReopen(options);
+
+  // Write valid checksummed values
+  for (int i = 0; i < 10; i++) {
+    ASSERT_OK(Put("key" + std::to_string(i), TestUserValueChecksum::MakeValue(
+                                                 "value" + std::to_string(i))));
+  }
+  ASSERT_OK(Flush());
+
+  // Flush should have validated all 10 entries
+  ASSERT_GE(
+      options.statistics->getTickerCount(USER_VALUE_CHECKSUM_COMPUTE_COUNT),
+      10);
+  ASSERT_EQ(
+      options.statistics->getTickerCount(USER_VALUE_CHECKSUM_MISMATCH_COUNT),
+      0);
+
+  // Write another batch and flush for compaction input
+  for (int i = 0; i < 10; i++) {
+    ASSERT_OK(
+        Put("key" + std::to_string(i),
+            TestUserValueChecksum::MakeValue("value_new" + std::to_string(i))));
+  }
+  ASSERT_OK(Flush());
+
+  uint64_t count_before =
+      options.statistics->getTickerCount(USER_VALUE_CHECKSUM_COMPUTE_COUNT);
+
+  // Compact — should validate all output entries
+  ASSERT_OK(db_->CompactRange(CompactRangeOptions(), nullptr, nullptr));
+
+  ASSERT_GT(
+      options.statistics->getTickerCount(USER_VALUE_CHECKSUM_COMPUTE_COUNT),
+      count_before);
+  ASSERT_EQ(
+      options.statistics->getTickerCount(USER_VALUE_CHECKSUM_MISMATCH_COUNT),
+      0);
+}
+
+TEST_F(UserValueChecksumTest, StatisticsCountersMismatch) {
+  Options options = CurrentOptions();
+  options.statistics = CreateDBStatistics();
+  options.user_value_checksum = std::make_shared<TestUserValueChecksum>();
+  options.verify_user_value_checksum_on_flush = true;
+  DestroyAndReopen(options);
+
+  // Write a value with an invalid checksum
+  ASSERT_OK(Put("key1", TestUserValueChecksum::MakeCorruptValue("bad_value")));
+
+  // Flush should fail due to checksum mismatch
+  Status s = Flush();
+  ASSERT_NOK(s);
+
+  ASSERT_GE(
+      options.statistics->getTickerCount(USER_VALUE_CHECKSUM_MISMATCH_COUNT),
+      1);
+}
+
+}  // namespace ROCKSDB_NAMESPACE
+
+int main(int argc, char** argv) {
+  ROCKSDB_NAMESPACE::port::InstallStackTraceHandler();
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/db/user_value_checksum_helper.h
+++ b/db/user_value_checksum_helper.h
@@ -1,0 +1,147 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+
+#include "db/dbformat.h"
+#include "db/output_validator.h"
+#include "db/wide/wide_column_serialization.h"
+#include "monitoring/statistics_impl.h"
+#include "rocksdb/slice.h"
+#include "rocksdb/statistics.h"
+#include "rocksdb/status.h"
+#include "rocksdb/user_value_checksum.h"
+#include "seqno_to_time_mapping.h"
+#include "table/internal_iterator.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+// Validate user-defined value checksum for a single key-value entry.
+// Skips entries that should not be validated: deletion markers, blob indices,
+// empty values. For kTypeValuePreferredSeqno (TimedPut), the packed value
+// is unpacked before validation. For kTypeMerge, the value type is passed
+// as kMergeOperand so implementations can distinguish merge operands from
+// resolved values.
+//
+// Returns:
+//   Status::OK()        - entry was validated or skipped (not applicable)
+//   Status::Corruption() - checksum mismatch detected
+inline Status ValidateUserValueChecksum(const UserValueChecksum& checksum,
+                                        const Slice& ikey,
+                                        const Slice& raw_value) {
+  ParsedInternalKey pikey;
+  if (!ParseInternalKey(ikey, &pikey, /*log_err_key=*/false).ok()) {
+    // Malformed internal key — skip validation for this entry.
+    // The existing OutputValidator or block checksum verification
+    // will catch this corruption through hash mismatches.
+    return Status::OK();
+  }
+
+  // Skip deletion markers and blob indices — these have no user value
+  // content to validate.
+  if (pikey.type == kTypeDeletion || pikey.type == kTypeSingleDeletion ||
+      pikey.type == kTypeRangeDeletion ||
+      pikey.type == kTypeDeletionWithTimestamp ||
+      pikey.type == kTypeBlobIndex) {
+    return Status::OK();
+  }
+
+  Slice value = raw_value;
+  if (value.empty()) {
+    return Status::OK();
+  }
+
+  // For kTypeValuePreferredSeqno (TimedPut), unpack the value by stripping
+  // the trailing sequence number.
+  if (pikey.type == kTypeValuePreferredSeqno) {
+    // Bounds check: packed value must be at least sizeof(uint64_t) bytes.
+    // A shorter value is structurally malformed (missing trailing seqno).
+    if (value.size() < sizeof(uint64_t)) {
+      return Status::Corruption(
+          "TimedPut value too small to contain packed sequence number");
+    }
+    value = ParsePackedValueForValue(value);
+    if (value.empty()) {
+      return Status::OK();
+    }
+  }
+
+  // For kTypeWideColumnEntity (PutEntity), deserialize the wide columns
+  // and call ValidateWideColumns() instead of Validate().
+  if (pikey.type == kTypeWideColumnEntity) {
+    WideColumns columns;
+    Slice input = value;
+    Status deserialize_s = WideColumnSerialization::Deserialize(input, columns);
+    if (!deserialize_s.ok()) {
+      return Status::Corruption(
+          "Failed to deserialize wide-column entity for checksum validation",
+          deserialize_s.getState());
+    }
+    return checksum.ValidateWideColumns(pikey.user_key, columns);
+  }
+
+  // Determine value type: merge operands vs resolved values.
+  ChecksumValueType value_type = (pikey.type == kTypeMerge)
+                                     ? ChecksumValueType::kMergeOperand
+                                     : ChecksumValueType::kValue;
+
+  return checksum.Validate(pikey.user_key, value, value_type);
+}
+
+// Iterates over all entries in the given iterator, optionally computing an
+// OutputValidator hash and/or validating user value checksums. Returns the
+// first error encountered, or iter->status() if iteration completes.
+//
+// Parameters:
+//   iter                - SeekToFirst is called internally
+//   output_validator     - if non-null, validator.Add() is called per entry
+//   reference_validator  - if non-null (and output_validator is non-null),
+//                          CompareValidator is called after iteration to
+//                          verify the hash matches
+//   user_value_checksum  - if non-null, ValidateUserValueChecksum() is called
+//                          per entry with stats recording
+//   stats               - Statistics object for RecordTick (may be null)
+//   context             - string for corruption message (e.g. "compaction
+//                          output verification")
+inline Status IterateAndValidateOutput(
+    InternalIterator* iter, OutputValidator* output_validator,
+    const OutputValidator* reference_validator,
+    const UserValueChecksum* user_value_checksum, Statistics* stats,
+    const char* context) {
+  Status s;
+  for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
+    if (output_validator) {
+      s = output_validator->Add(iter->key(), iter->value());
+      if (!s.ok()) {
+        break;
+      }
+    }
+    if (user_value_checksum) {
+      s = ValidateUserValueChecksum(*user_value_checksum, iter->key(),
+                                    iter->value());
+      RecordTick(stats, USER_VALUE_CHECKSUM_COMPUTE_COUNT);
+      if (!s.ok()) {
+        RecordTick(stats, USER_VALUE_CHECKSUM_MISMATCH_COUNT);
+        s = Status::Corruption(
+            std::string("User-defined value checksum mismatch during ") +
+                context,
+            s.getState());
+        break;
+      }
+    }
+  }
+  if (s.ok()) {
+    s = iter->status();
+  }
+  if (s.ok() && output_validator && reference_validator &&
+      !output_validator->CompareValidator(*reference_validator)) {
+    s = Status::Corruption(
+        "Key-value checksum of output doesn't match what was computed when "
+        "written");
+  }
+  return s;
+}
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/db_stress_tool/batched_ops_stress.cc
+++ b/db_stress_tool/batched_ops_stress.cc
@@ -18,6 +18,49 @@ class BatchedOpsStressTest : public StressTest {
 
   bool IsStateTracked() const override { return false; }
 
+ private:
+  static bool UserValueChecksumEnabled() {
+    return FLAGS_verify_user_value_checksum_on_flush ||
+           FLAGS_verify_user_value_checksum_on_compaction;
+  }
+
+  // Append a suffix character to a value while maintaining CRC32c integrity.
+  // When checksum is enabled, strips the trailing CRC32c from value_body,
+  // appends the suffix, and recomputes CRC32c.
+  // Result format: [data][suffix][CRC32c] (checksum enabled)
+  //                [data][CRC32c][suffix]  (checksum disabled, original
+  //                behavior)
+  static std::string BuildValueWithSuffix(const std::string& value_body,
+                                          const std::string& suffix) {
+    if (UserValueChecksumEnabled() && value_body.size() >= sizeof(uint32_t)) {
+      std::string result(value_body, 0, value_body.size() - sizeof(uint32_t));
+      result += suffix;
+      uint32_t crc = crc32c::Value(result.data(), result.size());
+      PutFixed32(&result, crc);
+      return result;
+    }
+    return value_body + suffix;
+  }
+
+  // Return the position of the suffix character within a value.
+  // With checksum: [data][suffix][CRC32c] → offset = size - 5
+  // Without:       [data][suffix]         → offset = size - 1
+  static size_t SuffixOffset(size_t value_size) {
+    if (UserValueChecksumEnabled()) {
+      assert(value_size > sizeof(uint32_t));
+      return value_size - sizeof(uint32_t) - 1;
+    }
+    return value_size - 1;
+  }
+
+  // Number of trailing bytes to ignore when comparing values across the
+  // 10 batched copies (the suffix char differs, and with checksum the
+  // CRC32c also differs because it covers the suffix).
+  static size_t SuffixAndChecksumSize() {
+    return UserValueChecksumEnabled() ? sizeof(uint32_t) + 1 : 1;
+  }
+
+ public:
   // Given a key K and value V, this puts ("0"+K, V+"0"), ("1"+K, V+"1"), ...,
   // ("9"+K, V+"9") in DB atomically i.e in a single batch.
   // Also refer BatchedOpsStressTest::TestGet
@@ -51,7 +94,7 @@ class BatchedOpsStressTest : public StressTest {
       // at the beginning of the value for all types of stress tests (e.g.
       // batched, non-batched, CF consistency).
       const std::string k = num + key_body;
-      const std::string v = value_body + num;
+      const std::string v = BuildValueWithSuffix(value_body, num);
       if (FLAGS_use_put_entity_one_in > 0 &&
           (value_base % FLAGS_use_put_entity_one_in) == 0) {
         if (FLAGS_use_attribute_group) {
@@ -178,14 +221,14 @@ class BatchedOpsStressTest : public StressTest {
         assert(!values[i].empty());
 
         const char expected = keys[i].front();
-        const char actual = values[i].back();
+        const char actual = values[i][SuffixOffset(values[i].size())];
 
         if (expected != actual) {
           fprintf(stderr, "get error expected = %c actual = %c\n", expected,
                   actual);
         }
 
-        values[i].pop_back();  // get rid of the differing character
+        values[i].resize(SuffixOffset(values[i].size()));  // strip suffix + CRC
 
         thread->stats.AddGets(1, 1);
       }
@@ -251,14 +294,14 @@ class BatchedOpsStressTest : public StressTest {
           assert(!values[i].empty());
 
           const char expected = keys[i][0];
-          const char actual = values[i][values[i].size() - 1];
+          const char actual = values[i][SuffixOffset(values[i].size())];
 
           if (expected != actual) {
             fprintf(stderr, "multiget error expected = %c actual = %c\n",
                     expected, actual);
           }
 
-          values[i].remove_suffix(1);  // get rid of the differing character
+          values[i].remove_suffix(SuffixAndChecksumSize());
 
           thread->stats.AddGets(1, 1);
         }
@@ -362,7 +405,7 @@ class BatchedOpsStressTest : public StressTest {
         for (const auto& column : columns) {
           const Slice& value = column.value();
 
-          if (value.empty() || value[value.size() - 1] != expected) {
+          if (value.empty() || value[SuffixOffset(value.size())] != expected) {
             fprintf(stderr,
                     "%s: incorrect column value for key "
                     "%s, entity %s, column value %s, expected %c\n",
@@ -462,7 +505,8 @@ class BatchedOpsStressTest : public StressTest {
             for (const auto& column : columns) {
               const Slice& value = column.value();
 
-              if (value.empty() || value[value.size() - 1] != expected) {
+              if (value.empty() ||
+                  value[SuffixOffset(value.size())] != expected) {
                 fprintf(stderr,
                         "MultiGetEntity (AttributeGroup) error: incorrect "
                         "column value for key "
@@ -525,7 +569,8 @@ class BatchedOpsStressTest : public StressTest {
             for (const auto& column : columns) {
               const Slice& value = column.value();
 
-              if (value.empty() || value[value.size() - 1] != expected) {
+              if (value.empty() ||
+                  value[SuffixOffset(value.size())] != expected) {
                 fprintf(stderr,
                         "MultiGetEntity error: incorrect column value for key "
                         "%s, entity %s, column value %s, expected %c\n",
@@ -635,14 +680,14 @@ class BatchedOpsStressTest : public StressTest {
         assert(!values[i].empty());
 
         const char expected = prefixes[i].front();
-        const char actual = values[i].back();
+        const char actual = values[i][SuffixOffset(values[i].size())];
 
         if (expected != actual) {
           fprintf(stderr, "prefix scan error expected = %c actual = %c\n",
                   expected, actual);
         }
 
-        values[i].pop_back();  // get rid of the differing character
+        values[i].resize(SuffixOffset(values[i].size()));  // strip suffix + CRC
 
         // make sure all values are equivalent
         if (values[i] != values[0]) {
@@ -690,7 +735,8 @@ class BatchedOpsStressTest : public StressTest {
 
   void ContinuouslyVerifyDb(ThreadState* /* thread */) const override {}
 
-  // Compare columns ignoring the last character of column values
+  // Compare columns ignoring the trailing suffix character (and optional
+  // CRC32c checksum that also differs because it covers the suffix).
   bool CompareColumns(const WideColumns& lhs, const WideColumns& rhs) {
     if (lhs.size() != rhs.size()) {
       return false;
@@ -705,8 +751,10 @@ class BatchedOpsStressTest : public StressTest {
         return false;
       }
 
-      if (lhs[i].value().difference_offset(rhs[i].value()) <
-          lhs[i].value().size() - 1) {
+      size_t ignore = SuffixAndChecksumSize();
+      size_t cmp_len =
+          lhs[i].value().size() > ignore ? lhs[i].value().size() - ignore : 0;
+      if (lhs[i].value().difference_offset(rhs[i].value()) < cmp_len) {
         return false;
       }
     }

--- a/db_stress_tool/db_stress_common.cc
+++ b/db_stress_tool/db_stress_common.cc
@@ -275,6 +275,7 @@ static CompactionServiceOptionsOverride CreateOverrideOptions(
       .compaction_filter_factory = options.compaction_filter_factory,
       .prefix_extractor = options.prefix_extractor,
       .sst_partitioner_factory = options.sst_partitioner_factory,
+      .user_value_checksum = options.user_value_checksum,
       .listeners = options.listeners,
       .statistics = options.statistics,
       .table_properties_collector_factories =
@@ -582,6 +583,15 @@ size_t GenerateValue(uint32_t rand, char* v, size_t max_sz) {
   PutUnaligned(reinterpret_cast<uint32_t*>(v), rand);
   for (size_t i = sizeof(uint32_t); i < value_sz; i++) {
     v[i] = (char)(rand ^ i);
+  }
+  if (FLAGS_verify_user_value_checksum_on_flush ||
+      FLAGS_verify_user_value_checksum_on_compaction) {
+    // Append a trailing 4-byte CRC32c checksum for user value checksum
+    // validation. The checksum covers the original value bytes.
+    uint32_t crc = crc32c::Value(v, value_sz);
+    assert(value_sz + sizeof(uint32_t) <= max_sz);
+    EncodeFixed32(v + value_sz, crc);
+    value_sz += sizeof(uint32_t);
   }
   v[value_sz] = '\0';
   return value_sz;  // the size of the value set.

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -52,6 +52,7 @@
 #include "rocksdb/slice.h"
 #include "rocksdb/slice_transform.h"
 #include "rocksdb/statistics.h"
+#include "rocksdb/user_value_checksum.h"
 #include "rocksdb/utilities/backup_engine.h"
 #include "rocksdb/utilities/checkpoint.h"
 #include "rocksdb/utilities/db_ttl.h"
@@ -337,6 +338,8 @@ DECLARE_int32(approximate_size_one_in);
 DECLARE_bool(best_efforts_recovery);
 DECLARE_bool(skip_verifydb);
 DECLARE_bool(paranoid_file_checks);
+DECLARE_bool(verify_user_value_checksum_on_flush);
+DECLARE_bool(verify_user_value_checksum_on_compaction);
 DECLARE_uint64(batch_protection_bytes_per_key);
 DECLARE_uint32(memtable_protection_bytes_per_key);
 DECLARE_uint32(block_protection_bytes_per_key);
@@ -461,6 +464,7 @@ DECLARE_double(compaction_on_deletion_ratio);
 
 constexpr long KB = 1024;
 constexpr int kRandomValueMaxFactor = 3;
+// Max value buffer size (including optional trailing 4-byte CRC32c checksum).
 constexpr int kValueMaxLen = 100;
 constexpr uint32_t kLargePrimeForCommonFactorSkew = 1872439133;
 
@@ -800,6 +804,51 @@ std::vector<int64_t> GenerateNKeys(ThreadState* thread, int num_keys,
 
 size_t GenerateValue(uint32_t rand, char* v, size_t max_sz);
 uint32_t GetValueBase(Slice s);
+
+// UserValueChecksum implementation for stress testing. Validates a trailing
+// 4-byte CRC32c checksum that is appended by GenerateValue() when
+// verify_user_value_checksum_on_flush or
+// verify_user_value_checksum_on_compaction is true.
+class StressTestUserValueChecksum : public UserValueChecksum {
+ public:
+  const char* Name() const override { return "StressTestUserValueChecksum"; }
+
+  Status Validate(const Slice& /*key*/, const Slice& value,
+                  ChecksumValueType /*value_type*/) const override {
+    return ValidateCrc32c(value);
+  }
+
+  Status ValidateWideColumns(const Slice& /*key*/,
+                             const WideColumns& columns) const override {
+    // Validate the default column, which contains the full value with
+    // trailing CRC32c checksum (same format as plain Put values).
+    for (const auto& col : columns) {
+      if (col.name() == kDefaultWideColumnName) {
+        Slice value = col.value();
+        if (value.empty()) {
+          return Status::OK();
+        }
+        return ValidateCrc32c(value);
+      }
+    }
+    // No default column — skip validation
+    return Status::OK();
+  }
+
+ private:
+  static Status ValidateCrc32c(const Slice& value) {
+    if (value.size() < sizeof(uint32_t)) {
+      return Status::Corruption("Value too small for CRC32c checksum");
+    }
+    size_t data_sz = value.size() - sizeof(uint32_t);
+    uint32_t stored = DecodeFixed32(value.data() + data_sz);
+    uint32_t computed = crc32c::Value(value.data(), data_sz);
+    if (stored != computed) {
+      return Status::Corruption("CRC32c checksum mismatch");
+    }
+    return Status::OK();
+  }
+};
 
 WideColumns GenerateWideColumns(uint32_t value_base, const Slice& slice);
 WideColumns GenerateExpectedWideColumns(uint32_t value_base,

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -1177,6 +1177,18 @@ DEFINE_bool(paranoid_file_checks, true,
             "After writing every SST file, reopen it and read all the keys "
             "and validate checksums");
 
+DEFINE_bool(verify_user_value_checksum_on_flush,
+            ROCKSDB_NAMESPACE::AdvancedColumnFamilyOptions()
+                .verify_user_value_checksum_on_flush,
+            "Verify user-defined value checksums during flush. "
+            "Implicitly enables trailing CRC32c checksum generation.");
+
+DEFINE_bool(verify_user_value_checksum_on_compaction,
+            ROCKSDB_NAMESPACE::AdvancedColumnFamilyOptions()
+                .verify_user_value_checksum_on_compaction,
+            "Verify user-defined value checksums during compaction. "
+            "Implicitly enables trailing CRC32c checksum generation.");
+
 DEFINE_uint64(batch_protection_bytes_per_key, 0,
               "If nonzero, enables integrity protection in `WriteBatch` at the "
               "specified number of bytes per key. Currently the only supported "

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -4639,6 +4639,15 @@ void InitializeOptionsFromFlags(
 
   options.best_efforts_recovery = FLAGS_best_efforts_recovery;
   options.paranoid_file_checks = FLAGS_paranoid_file_checks;
+  if (FLAGS_verify_user_value_checksum_on_flush ||
+      FLAGS_verify_user_value_checksum_on_compaction) {
+    options.user_value_checksum =
+        std::make_shared<StressTestUserValueChecksum>();
+  }
+  options.verify_user_value_checksum_on_flush =
+      FLAGS_verify_user_value_checksum_on_flush;
+  options.verify_user_value_checksum_on_compaction =
+      FLAGS_verify_user_value_checksum_on_compaction;
 
   if (FLAGS_user_timestamp_size > 0) {
     CheckAndSetOptionsForUserTimestamp(options);

--- a/db_stress_tool/db_stress_tool.cc
+++ b/db_stress_tool/db_stress_tool.cc
@@ -202,9 +202,22 @@ int db_stress_tool(int argc, char** argv) {
   } else if (FLAGS_active_width == 0) {
     FLAGS_active_width = FLAGS_max_key;
   }
-  if (FLAGS_value_size_mult * kRandomValueMaxFactor > kValueMaxLen) {
-    fprintf(stderr, "Error: value_size_mult can be at most %d\n",
-            kValueMaxLen / kRandomValueMaxFactor);
+  const bool user_value_checksum_enabled =
+      FLAGS_verify_user_value_checksum_on_flush ||
+      FLAGS_verify_user_value_checksum_on_compaction;
+  int effective_max_value_len = kValueMaxLen;
+  if (user_value_checksum_enabled) {
+    // Reserve space for the trailing 4-byte CRC32c checksum that
+    // GenerateValue() appends.
+    effective_max_value_len -= static_cast<int>(sizeof(uint32_t));
+  }
+  if (FLAGS_value_size_mult * kRandomValueMaxFactor >=
+      effective_max_value_len) {
+    fprintf(stderr, "Error: value_size_mult can be at most %d%s\n",
+            effective_max_value_len / kRandomValueMaxFactor,
+            user_value_checksum_enabled
+                ? " (reduced due to user value checksum overhead)"
+                : "");
     exit(1);
   }
   if (FLAGS_use_merge && FLAGS_nooverwritepercent == 100) {

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -823,6 +823,34 @@ struct AdvancedColumnFamilyOptions {
   // Dynamically changeable through SetOptions() API
   bool paranoid_file_checks = false;
 
+  // When true and user_value_checksum is set in ColumnFamilyOptions, validate
+  // user-defined value checksums during flush. After the SST file is written
+  // and synced, the file is read back and each value is validated using the
+  // UserValueChecksum interface. On checksum failure, the flush is retried.
+  // If the retry also fails, the DB enters read-only mode.
+  //
+  // The application is responsible for ensuring that merge operators and
+  // compaction filters produce values with valid checksums.
+  //
+  // Default: false
+  //
+  // Dynamically changeable through SetOptions() API
+  bool verify_user_value_checksum_on_flush = false;
+
+  // When true and user_value_checksum is set in ColumnFamilyOptions, validate
+  // user-defined value checksums during compaction. After each output SST file
+  // is written and synced, the file is read back and each value is validated
+  // using the UserValueChecksum interface. On checksum failure, the compaction
+  // is retried. If the retry also fails, the DB enters read-only mode.
+  //
+  // The application is responsible for ensuring that merge operators and
+  // compaction filters produce values with valid checksums.
+  //
+  // Default: false
+  //
+  // Dynamically changeable through SetOptions() API
+  bool verify_user_value_checksum_on_compaction = false;
+
   // Bitmask enum for output verification option.
   //
   // Default: 0 (kVerifyNone)

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -58,6 +58,7 @@ class InternalKeyComparator;
 class WalFilter;
 class FileSystem;
 class UserDefinedIndexFactory;
+class UserValueChecksum;
 class IODispatcher;
 
 struct Options;
@@ -130,6 +131,22 @@ struct ColumnFamilyOptions : public AdvancedColumnFamilyOptions {
   // opening the DB in this case.
   // Default: nullptr
   std::shared_ptr<MergeOperator> merge_operator = nullptr;
+
+  // User-defined value checksum validator. When set, allows RocksDB to
+  // validate user-embedded checksums in values during compaction and flush.
+  // The validation is performed by reading back the SST file after it is
+  // written and synced to disk, providing end-to-end integrity protection.
+  //
+  // The checksum must be embedded in the value by the application before
+  // writing to RocksDB. The Validate() method is called for each value
+  // during the read-back verification phase.
+  //
+  // If a MergeOperator is also configured, the merge operator must produce
+  // values with valid checksums. A compatibility test is run at DB::Open
+  // time; if it fails, validation is disabled with a warning.
+  //
+  // Default: nullptr (disabled)
+  std::shared_ptr<UserValueChecksum> user_value_checksum = nullptr;
 
   // A single CompactionFilter instance to call into during compaction.
   // Allows an application to modify/delete a key-value during background
@@ -2889,6 +2906,7 @@ struct CompactionServiceOptionsOverride {
   std::shared_ptr<const SliceTransform> prefix_extractor = nullptr;
   std::shared_ptr<TableFactory> table_factory;
   std::shared_ptr<SstPartitionerFactory> sst_partitioner_factory = nullptr;
+  std::shared_ptr<UserValueChecksum> user_value_checksum = nullptr;
 
   // Only subsets of events are triggered in remote compaction worker, like:
   // `OnTableFileCreated`, `OnTableFileCreationStarted`,

--- a/include/rocksdb/statistics.h
+++ b/include/rocksdb/statistics.h
@@ -583,6 +583,13 @@ enum Tickers : uint32_t {
   // # of prefetch requests that were blocked waiting for memory
   PREFETCH_MEMORY_REQUESTS_BLOCKED,
 
+  // Number of user value checksum validations performed during flush and
+  // compaction output verification.
+  USER_VALUE_CHECKSUM_COMPUTE_COUNT,
+  // Number of user value checksum mismatches detected during flush and
+  // compaction output verification.
+  USER_VALUE_CHECKSUM_MISMATCH_COUNT,
+
   TICKER_ENUM_MAX
 };
 

--- a/include/rocksdb/user_value_checksum.h
+++ b/include/rocksdb/user_value_checksum.h
@@ -1,0 +1,154 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "rocksdb/customizable.h"
+#include "rocksdb/rocksdb_namespace.h"
+#include "rocksdb/slice.h"
+#include "rocksdb/status.h"
+#include "rocksdb/wide_columns.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+// UserValueChecksum allows applications to provide an end-to-end value
+// integrity check. The application computes a checksum over the value content
+// and embeds it within the value itself (e.g., as a trailing checksum).
+// During compaction and flush, after the SST file is written to disk, the
+// file is read back and each value is validated using this interface.
+//
+// Usage:
+// 1. Subclass UserValueChecksum and implement Validate().
+// 2. Set user_value_checksum in ColumnFamilyOptions.
+// 3. Enable verify_user_value_checksum_on_flush and/or
+//    verify_user_value_checksum_on_compaction.
+// 4. Ensure all values written to RocksDB (via Put, Merge results, etc.)
+//    contain a valid embedded checksum.
+//
+// Thread safety: The Validate() method must be thread-safe. It will be called
+// concurrently from multiple compaction and flush threads. Since it is a const
+// method that only reads the key and value, this is typically trivial.
+//
+// Application responsibility for merge operators and compaction filters:
+// If a MergeOperator is configured, the application must ensure that the
+// merge operator produces values with valid checksums. If a CompactionFilter
+// modifies values (returns kChangeValue or kChangeWideColumnEntity), the
+// modified values must also contain valid checksums. Violations will be
+// caught at flush/compaction time when verification is enabled, and will
+// cause the flush or compaction to fail.
+//
+// Note: Validation is NOT performed for files created via SstFileWriter
+// or ingested via IngestExternalFile(). The application must ensure that
+// values written through these paths contain valid checksums. Ingested
+// files will be validated during subsequent compaction if
+// verify_user_value_checksum_on_compaction is enabled.
+//
+// Remote compaction: If using CompactionService (remote compaction), the
+// UserValueChecksum implementation must be registered in the remote
+// worker's ObjectRegistry for CreateFromString() to reconstruct it.
+// Without registration, validation will be silently skipped on remote
+// workers.
+//
+// Exceptions MUST NOT propagate out of overridden functions into RocksDB,
+// because RocksDB is not exception-safe. This could cause undefined behavior
+// including data loss, unreported corruption, deadlocks, and more.
+
+// Indicates the origin of the value passed to UserValueChecksum::Validate().
+enum class ChecksumValueType : uint8_t {
+  // A fully resolved value: from Put(), TimedPut(), or a resolved merge
+  // result. The value is expected to contain a valid embedded checksum.
+  kValue = 0,
+  // An unresolved merge operand: the raw bytes passed to Merge() that have
+  // not yet been combined with a base value. These appear in flush output
+  // and non-bottommost compaction output. The application may choose to
+  // validate or skip these depending on whether merge operands follow the
+  // checksum format.
+  kMergeOperand = 1,
+};
+
+class UserValueChecksum : public Customizable {
+ public:
+  virtual ~UserValueChecksum() {}
+  static const char* Type() { return "UserValueChecksum"; }
+  static Status CreateFromString(const ConfigOptions& config_options,
+                                 const std::string& name,
+                                 std::shared_ptr<UserValueChecksum>* result);
+
+  // Returns a name that identifies this checksum implementation.
+  const char* Name() const override = 0;
+
+  // Validate the integrity of a value. The checksum is expected to be
+  // embedded within the value by the application (e.g., as trailing bytes).
+  //
+  // key:        The user key (without internal key suffix).
+  // value:      The complete value as stored by the application, including
+  //             the embedded checksum.
+  // value_type: Indicates the origin of the value. See ChecksumValueType.
+  //             kValue: a fully resolved value (from Put, TimedPut, or a
+  //                     resolved merge result).
+  //             kMergeOperand: an unresolved merge operand (raw bytes from
+  //                     Merge() not yet combined with a base value).
+  //             Implementations may choose to skip validation for merge
+  //             operands if they do not follow the checksum format.
+  //
+  // Return Status::OK() if the checksum is valid (or validation is skipped).
+  // Return Status::Corruption() if the checksum does not match.
+  //
+  // Performance: This method is called for every key-value entry during
+  // output verification. It should be lightweight (e.g., a simple checksum
+  // comparison) to avoid blocking compaction and flush.
+  //
+  // Note: Implementations must validate value size before accessing embedded
+  // checksums. Non-empty values of any size (including 1 byte) may be passed.
+  // For example, if the checksum format requires a 4-byte trailing CRC,
+  // Validate() must check value.size() >= 4 before reading the checksum
+  // bytes, and return Corruption for values that are too small.
+  //
+  // This method is NOT called for:
+  //   - Deletion markers (no value content)
+  //   - Empty values (value.size() == 0)
+  //   - Blob index entries (internal references)
+  //
+  // This method IS called for:
+  //   - Plain values (from Put) — with kValue
+  //   - Resolved merge results — with kValue
+  //   - Unresolved merge operands — with kMergeOperand
+  //   - TimedPut values (from WriteBatch::TimedPut) — with kValue.
+  //     The trailing internal sequence number is stripped before the value
+  //     is passed to Validate(). Only the user value portion is validated.
+  //
+  // This method is NOT called for wide-column entities (PutEntity).
+  // Wide-column entities are validated via ValidateWideColumns() instead.
+  virtual Status Validate(const Slice& key, const Slice& value,
+                          ChecksumValueType value_type) const = 0;
+
+  // Validate the integrity of a wide-column entity (from PutEntity).
+  //
+  // key:     The user key (without internal key suffix).
+  // columns: The deserialized wide columns (sorted by column name).
+  //          Each WideColumn has a name() and value() accessor.
+  //          The default column (from Put-style writes that get merged into
+  //          wide-column format) has an empty name (kDefaultWideColumnName).
+  //
+  // Return Status::OK() if the checksum is valid.
+  // Return Status::Corruption() if the checksum does not match.
+  //
+  // A typical use case is storing user data in one column and a checksum
+  // in another column, then validating them here.
+  //
+  // The default implementation returns Status::OK() (no validation),
+  // so existing implementations that do not use PutEntity are unaffected.
+  //
+  // Thread safety: same requirements as Validate().
+  virtual Status ValidateWideColumns(const Slice& /*key*/,
+                                     const WideColumns& /*columns*/) const {
+    return Status::OK();
+  }
+};
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/monitoring/statistics.cc
+++ b/monitoring/statistics.cc
@@ -296,6 +296,10 @@ const std::vector<std::pair<Tickers, std::string>> TickersNameMap = {
     {PREFETCH_MEMORY_BYTES_RELEASED, "rocksdb.prefetch.memory.bytes.released"},
     {PREFETCH_MEMORY_REQUESTS_BLOCKED,
      "rocksdb.prefetch.memory.requests.blocked"},
+    {USER_VALUE_CHECKSUM_COMPUTE_COUNT,
+     "rocksdb.user.value.checksum.compute.count"},
+    {USER_VALUE_CHECKSUM_MISMATCH_COUNT,
+     "rocksdb.user.value.checksum.mismatch.count"},
 };
 
 const std::vector<std::pair<Histograms, std::string>> HistogramsNameMap = {

--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -27,6 +27,7 @@
 #include "rocksdb/merge_operator.h"
 #include "rocksdb/options.h"
 #include "rocksdb/table.h"
+#include "rocksdb/user_value_checksum.h"
 #include "rocksdb/utilities/object_registry.h"
 #include "rocksdb/utilities/options_type.h"
 #include "util/cast_util.h"
@@ -402,6 +403,16 @@ static std::unordered_map<std::string, OptionTypeInfo>
           OptionTypeFlags::kMutable}},
         {"paranoid_file_checks",
          {offsetof(struct MutableCFOptions, paranoid_file_checks),
+          OptionType::kBoolean, OptionVerificationType::kNormal,
+          OptionTypeFlags::kMutable}},
+        {"verify_user_value_checksum_on_flush",
+         {offsetof(struct MutableCFOptions,
+                   verify_user_value_checksum_on_flush),
+          OptionType::kBoolean, OptionVerificationType::kNormal,
+          OptionTypeFlags::kMutable}},
+        {"verify_user_value_checksum_on_compaction",
+         {offsetof(struct MutableCFOptions,
+                   verify_user_value_checksum_on_compaction),
           OptionType::kBoolean, OptionVerificationType::kNormal,
           OptionTypeFlags::kMutable}},
         {"verify_output_flags",
@@ -924,6 +935,11 @@ static std::unordered_map<std::string, OptionTypeInfo>
                    memtable_batch_lookup_optimization),
           OptionType::kBoolean, OptionVerificationType::kNormal,
           OptionTypeFlags::kNone}},
+        {"user_value_checksum",
+         OptionTypeInfo::AsCustomSharedPtr<UserValueChecksum>(
+             offsetof(struct ImmutableCFOptions, user_value_checksum),
+             OptionVerificationType::kByNameAllowFromNull,
+             OptionTypeFlags::kAllowNull)},
 };
 
 const std::string OptionsHelper::kCFOptionsName = "ColumnFamilyOptions";
@@ -1062,6 +1078,7 @@ ImmutableCFOptions::ImmutableCFOptions(const ColumnFamilyOptions& cf_options)
       compaction_thread_limiter(cf_options.compaction_thread_limiter),
       sst_partitioner_factory(cf_options.sst_partitioner_factory),
       blob_cache(cf_options.blob_cache),
+      user_value_checksum(cf_options.user_value_checksum),
       persist_user_defined_timestamps(
           cf_options.persist_user_defined_timestamps),
       cf_allow_ingest_behind(cf_options.cf_allow_ingest_behind),
@@ -1231,6 +1248,10 @@ void MutableCFOptions::Dump(Logger* log) const {
                  max_sequential_skip_in_iterations);
   ROCKS_LOG_INFO(log, "                     paranoid_file_checks: %d",
                  paranoid_file_checks);
+  ROCKS_LOG_INFO(log, "  verify_user_value_checksum_on_flush: %d",
+                 verify_user_value_checksum_on_flush);
+  ROCKS_LOG_INFO(log, "  verify_user_value_checksum_on_compaction: %d",
+                 verify_user_value_checksum_on_compaction);
   ROCKS_LOG_INFO(log, "                       report_bg_io_stats: %d",
                  report_bg_io_stats);
   ROCKS_LOG_INFO(log, "                              compression: %d",

--- a/options/cf_options.h
+++ b/options/cf_options.h
@@ -81,6 +81,8 @@ struct ImmutableCFOptions {
 
   std::shared_ptr<Cache> blob_cache;
 
+  std::shared_ptr<UserValueChecksum> user_value_checksum;
+
   bool persist_user_defined_timestamps;
 
   bool cf_allow_ingest_behind;
@@ -163,6 +165,10 @@ struct MutableCFOptions {
         max_sequential_skip_in_iterations(
             options.max_sequential_skip_in_iterations),
         paranoid_file_checks(options.paranoid_file_checks),
+        verify_user_value_checksum_on_flush(
+            options.verify_user_value_checksum_on_flush),
+        verify_user_value_checksum_on_compaction(
+            options.verify_user_value_checksum_on_compaction),
         report_bg_io_stats(options.report_bg_io_stats),
         compression(options.compression),
         bottommost_compression(options.bottommost_compression),
@@ -232,6 +238,8 @@ struct MutableCFOptions {
         prepopulate_blob_cache(PrepopulateBlobCache::kDisable),
         max_sequential_skip_in_iterations(0),
         paranoid_file_checks(false),
+        verify_user_value_checksum_on_flush(false),
+        verify_user_value_checksum_on_compaction(false),
         report_bg_io_stats(false),
         compression(Snappy_Supported() ? kSnappyCompression : kNoCompression),
         bottommost_compression(kDisableCompressionOption),
@@ -338,6 +346,8 @@ struct MutableCFOptions {
   // Misc options
   uint64_t max_sequential_skip_in_iterations;
   bool paranoid_file_checks;
+  bool verify_user_value_checksum_on_flush;
+  bool verify_user_value_checksum_on_compaction;
   bool report_bg_io_stats;
   CompressionType compression;
   CompressionType bottommost_compression;

--- a/options/options.cc
+++ b/options/options.cc
@@ -29,6 +29,7 @@
 #include "rocksdb/sst_partitioner.h"
 #include "rocksdb/table.h"
 #include "rocksdb/table_properties.h"
+#include "rocksdb/user_value_checksum.h"
 #include "rocksdb/wal_filter.h"
 #include "table/block_based/block_based_table_factory.h"
 #include "util/compression.h"
@@ -87,6 +88,10 @@ AdvancedColumnFamilyOptions::AdvancedColumnFamilyOptions(const Options& options)
       strict_max_successive_merges(options.strict_max_successive_merges),
       optimize_filters_for_hits(options.optimize_filters_for_hits),
       paranoid_file_checks(options.paranoid_file_checks),
+      verify_user_value_checksum_on_flush(
+          options.verify_user_value_checksum_on_flush),
+      verify_user_value_checksum_on_compaction(
+          options.verify_user_value_checksum_on_compaction),
       force_consistency_checks(options.force_consistency_checks),
       report_bg_io_stats(options.report_bg_io_stats),
       disallow_memtable_writes(options.disallow_memtable_writes),
@@ -406,6 +411,14 @@ void ColumnFamilyOptions::Dump(Logger* log) const {
                    optimize_filters_for_hits);
   ROCKS_LOG_HEADER(log, "               Options.paranoid_file_checks: %d",
                    paranoid_file_checks);
+  ROCKS_LOG_HEADER(log, "  Options.verify_user_value_checksum_on_flush: %d",
+                   verify_user_value_checksum_on_flush);
+  ROCKS_LOG_HEADER(log,
+                   "  Options.verify_user_value_checksum_on_compaction: %d",
+                   verify_user_value_checksum_on_compaction);
+  ROCKS_LOG_HEADER(
+      log, "               Options.user_value_checksum: %s",
+      user_value_checksum ? user_value_checksum->Name() : "nullptr");
   ROCKS_LOG_HEADER(log, "               Options.force_consistency_checks: %d",
                    force_consistency_checks);
   ROCKS_LOG_HEADER(log, "               Options.report_bg_io_stats: %d",

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -299,6 +299,10 @@ void UpdateColumnFamilyOptions(const MutableCFOptions& moptions,
   cf_opts->max_sequential_skip_in_iterations =
       moptions.max_sequential_skip_in_iterations;
   cf_opts->paranoid_file_checks = moptions.paranoid_file_checks;
+  cf_opts->verify_user_value_checksum_on_flush =
+      moptions.verify_user_value_checksum_on_flush;
+  cf_opts->verify_user_value_checksum_on_compaction =
+      moptions.verify_user_value_checksum_on_compaction;
   cf_opts->report_bg_io_stats = moptions.report_bg_io_stats;
   cf_opts->compression = moptions.compression;
   cf_opts->compression_opts = moptions.compression_opts;

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -539,6 +539,8 @@ TEST_F(OptionsSettableTest, ColumnFamilyOptionsAllFieldsSettable) {
       {offsetof(struct ColumnFamilyOptions, comparator), sizeof(Comparator*)},
       {offsetof(struct ColumnFamilyOptions, merge_operator),
        sizeof(std::shared_ptr<MergeOperator>)},
+      {offsetof(struct ColumnFamilyOptions, user_value_checksum),
+       sizeof(std::shared_ptr<UserValueChecksum>)},
       {offsetof(struct ColumnFamilyOptions, compaction_filter),
        sizeof(const CompactionFilter*)},
       {offsetof(struct ColumnFamilyOptions, compaction_filter_factory),
@@ -585,6 +587,7 @@ TEST_F(OptionsSettableTest, ColumnFamilyOptionsAllFieldsSettable) {
   options->compaction_options_universal = CompactionOptionsUniversal();
   options->num_levels = 42;  // Initialize options for MutableCF
   options->compaction_filter = nullptr;
+  options->user_value_checksum = nullptr;
   options->sst_partitioner_factory = nullptr;
 
   char* new_options_ptr = new char[sizeof(ColumnFamilyOptions)];
@@ -647,6 +650,8 @@ TEST_F(OptionsSettableTest, ColumnFamilyOptionsAllFieldsSettable) {
       "memtable_insert_with_hint_prefix_extractor=rocksdb.CappedPrefix.13;"
       "check_flush_compaction_key_order=false;"
       "paranoid_file_checks=true;"
+      "verify_user_value_checksum_on_flush=true;"
+      "verify_user_value_checksum_on_compaction=true;"
       "force_consistency_checks=true;"
       "inplace_update_num_locks=7429;"
       "experimental_mempurge_threshold=0.0001;"

--- a/options/user_value_checksum.cc
+++ b/options/user_value_checksum.cc
@@ -1,0 +1,19 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include "rocksdb/user_value_checksum.h"
+
+#include "rocksdb/utilities/customizable_util.h"
+#include "rocksdb/utilities/object_registry.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+Status UserValueChecksum::CreateFromString(
+    const ConfigOptions& config_options, const std::string& name,
+    std::shared_ptr<UserValueChecksum>* result) {
+  return LoadSharedObject<UserValueChecksum>(config_options, name, result);
+}
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/src.mk
+++ b/src.mk
@@ -168,6 +168,7 @@ LIB_SOURCES =                                                   \
   options/options.cc                                            \
   options/options_helper.cc                                     \
   options/options_parser.cc                                     \
+  options/user_value_checksum.cc                                \
   port/mmap.cc                                                  \
   port/port_posix.cc                                            \
   port/win/env_default.cc                                       \
@@ -503,6 +504,7 @@ TEST_MAIN_SOURCES =                                                     \
   db/db_encryption_test.cc                                              \
   db/db_etc3_test.cc                                                    \
   db/db_flush_test.cc                                                   \
+  db/db_user_value_checksum_test.cc                                     \
   db/db_follower_test.cc						                                    \
   db/db_readonly_with_timestamp_test.cc                                 \
   db/db_with_timestamp_basic_test.cc                                    \

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -254,7 +254,7 @@ default_params = {
     "bloom_before_level": lambda: random.choice(
         [random.randint(-1, 2), random.randint(-1, 10), 0x7FFFFFFF - 1, 0x7FFFFFFF]
     ),
-    "value_size_mult": 32,
+    "value_size_mult": 31,
     "verification_only": 0,
     "verify_checksum": 1,
     "write_buffer_size": lambda: random.choice([1024 * 1024, 4 * 1024 * 1024]),
@@ -334,6 +334,8 @@ default_params = {
     "get_property_one_in": lambda: random.choice([100000, 1000000]),
     "get_properties_of_all_tables_one_in": lambda: random.choice([100000, 1000000]),
     "paranoid_file_checks": lambda: random.choice([0, 1, 1, 1]),
+    "verify_user_value_checksum_on_flush": lambda: random.choice([0, 0, 0, 1]),
+    "verify_user_value_checksum_on_compaction": lambda: random.choice([0, 0, 0, 1]),
     "max_write_buffer_size_to_maintain": lambda: random.choice(
         [0, 1024 * 1024, 2 * 1024 * 1024, 4 * 1024 * 1024, 8 * 1024 * 1024]
     ),
@@ -1511,6 +1513,16 @@ def blackbox_crash_main(args, unknown_args):
     dbname = get_dbname("blackbox")
     exit_time = time.time() + cmd_params["duration"]
 
+    # User value checksum flags must be consistent across iterations because
+    # enabling checksum on a DB whose values were written without checksums
+    # causes false-positive corruption during compaction output verification.
+    for flag in (
+        "verify_user_value_checksum_on_flush",
+        "verify_user_value_checksum_on_compaction",
+    ):
+        if flag in cmd_params and callable(cmd_params[flag]):
+            cmd_params[flag] = cmd_params[flag]()
+
     print(
         "Running blackbox-crash-test with \n"
         + "interval_between_crash="
@@ -1573,6 +1585,16 @@ def blackbox_crash_main(args, unknown_args):
 def whitebox_crash_main(args, unknown_args):
     cmd_params = gen_cmd_params(args)
     dbname = get_dbname("whitebox")
+
+    # User value checksum flags must be consistent across iterations because
+    # enabling checksum on a DB whose values were written without checksums
+    # causes false-positive corruption during compaction output verification.
+    for flag in (
+        "verify_user_value_checksum_on_flush",
+        "verify_user_value_checksum_on_compaction",
+    ):
+        if flag in cmd_params and callable(cmd_params[flag]):
+            cmd_params[flag] = cmd_params[flag]()
 
     cur_time = time.time()
     exit_time = cur_time + cmd_params["duration"]

--- a/unreleased_history/new_features/user_value_checksum.md
+++ b/unreleased_history/new_features/user_value_checksum.md
@@ -1,0 +1,1 @@
+Added `UserValueChecksum` interface that allows applications to provide end-to-end value integrity checks. User-embedded checksums are validated during flush and compaction output verification by reading back the SST file after it is written. Controlled by `verify_user_value_checksum_on_flush` and `verify_user_value_checksum_on_compaction` options.


### PR DESCRIPTION
Add UserValueChecksum interface for end-to-end value integrity checks

Introduce a pluggable UserValueChecksum interface that allows applications
to attach and verify checksums on user values during flush and compaction
output verification. This catches silent data corruption (e.g., from buggy
merge operators or compaction filters) before it is persisted to SST files.

Key components:
- `UserValueChecksum` abstract class with `Validate`/`ValidateWideColumns` methods
- New options: `user_value_checksum`, `verify_user_value_checksum_on_flush`,
  `verify_user_value_checksum_on_compaction` (dynamically mutable)
- Statistics counters: `USER_VALUE_CHECKSUM_COMPUTE_COUNT` and
  `USER_VALUE_CHECKSUM_MISMATCH_COUNT`
- Validation in flush (`builder.cc`) and compaction output verification
  (`compaction_job.cc`), integrated into existing iteration loops
- Remote compaction support via `VerifyUserValueChecksumsOnOutputFiles()`
  which opens output files directly from the remote output path
- Helper (`user_value_checksum_helper.h`) handles all value types: plain
  values, TimedPut (unpacks trailing seqno), wide columns, merge operands;
  skips deletions, blob indices, and empty values
- `db_stress` support with CRC32c-based checksum validator
- Comprehensive test coverage including corrupt/valid flush and compaction,
  dynamic toggle, `paranoid_file_checks` integration, standalone user
  checksum loop, TimedPut/WideColumn/merge/SingleDelete/DeleteRange/blob,
  ingest external file, recovery flush, randomized sizes, and statistics
  counter assertions to verify validation actually runs