### PR TITLE
Add PerfLevel::kEnableTimeForWrite for write-only perf timing

### DIFF
--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -542,7 +542,7 @@ Status DBImpl::WriteImpl(const WriteOptions& write_options,
                               wal_used, log_ref, disable_memtable, seq_used);
   }
 
-  PERF_TIMER_GUARD(write_pre_and_post_process_time);
+  PERF_TIMER_FOR_WRITE_GUARD(write_pre_and_post_process_time);
   WriteThread::Writer w(write_options, my_batch, callback, user_write_cb,
                         log_ref, disable_memtable, batch_cnt,
                         pre_release_callback, post_memtable_callback,
@@ -763,7 +763,7 @@ Status DBImpl::WriteImpl(const WriteOptions& write_options,
       if (status.ok() && !write_options.disableWAL) {
         assert(wal_context.wal_file_number_size);
         wal_context.prev_size = wal_context.writer->file()->GetFileSize();
-        PERF_TIMER_GUARD(write_wal_time);
+        PERF_TIMER_FOR_WRITE_GUARD(write_wal_time);
         io_s = WriteGroupToWAL(write_group, wal_context.writer, wal_used,
                                wal_context.need_wal_sync,
                                wal_context.need_wal_dir_sync, last_sequence + 1,
@@ -771,7 +771,7 @@ Status DBImpl::WriteImpl(const WriteOptions& write_options,
       }
     } else {
       if (status.ok() && !write_options.disableWAL) {
-        PERF_TIMER_GUARD(write_wal_time);
+        PERF_TIMER_FOR_WRITE_GUARD(write_wal_time);
         // LastAllocatedSequence is increased inside WriteToWAL under
         // wal_write_mutex_ to ensure ordered events in WAL
         io_s = ConcurrentWriteGroupToWAL(write_group, wal_used, &last_sequence,
@@ -973,7 +973,7 @@ Status DBImpl::PipelinedWriteImpl(const WriteOptions& write_options,
                                   UserWriteCallback* user_write_cb,
                                   uint64_t* wal_used, uint64_t log_ref,
                                   bool disable_memtable, uint64_t* seq_used) {
-  PERF_TIMER_GUARD(write_pre_and_post_process_time);
+  PERF_TIMER_FOR_WRITE_GUARD(write_pre_and_post_process_time);
   StopWatch write_sw(immutable_db_options_.clock, stats_, DB_WRITE);
 
   WriteContext write_context;
@@ -1052,7 +1052,7 @@ Status DBImpl::PipelinedWriteImpl(const WriteOptions& write_options,
     io_s.PermitUncheckedError();  // Allow io_s to be uninitialized
 
     if (w.status.ok() && !write_options.disableWAL) {
-      PERF_TIMER_GUARD(write_wal_time);
+      PERF_TIMER_FOR_WRITE_GUARD(write_wal_time);
       stats->AddDBStats(InternalStats::kIntStatsWriteDoneBySelf, 1);
       RecordTick(stats_, WRITE_DONE_BY_SELF, 1);
       if (wal_write_group.size > 1) {
@@ -1170,7 +1170,7 @@ Status DBImpl::UnorderedWriteMemtable(const WriteOptions& write_options,
                                       WriteCallback* callback, uint64_t log_ref,
                                       SequenceNumber seq,
                                       const size_t sub_batch_cnt) {
-  PERF_TIMER_GUARD(write_pre_and_post_process_time);
+  PERF_TIMER_FOR_WRITE_GUARD(write_pre_and_post_process_time);
   StopWatch write_sw(immutable_db_options_.clock, stats_, DB_WRITE);
 
   WriteThread::Writer w(write_options, my_batch, callback,
@@ -1229,7 +1229,7 @@ Status DBImpl::WriteImplWALOnly(
     const uint64_t log_ref, uint64_t* seq_used, const size_t sub_batch_cnt,
     PreReleaseCallback* pre_release_callback, const AssignOrder assign_order,
     const PublishLastSeq publish_last_seq, const bool disable_memtable) {
-  PERF_TIMER_GUARD(write_pre_and_post_process_time);
+  PERF_TIMER_FOR_WRITE_GUARD(write_pre_and_post_process_time);
   WriteThread::Writer w(write_options, my_batch, callback, user_write_cb,
                         log_ref, disable_memtable, sub_batch_cnt,
                         pre_release_callback);
@@ -1339,7 +1339,7 @@ Status DBImpl::WriteImplWALOnly(
 
   PERF_TIMER_STOP(write_pre_and_post_process_time);
 
-  PERF_TIMER_GUARD(write_wal_time);
+  PERF_TIMER_FOR_WRITE_GUARD(write_wal_time);
   // LastAllocatedSequence is increased inside WriteToWAL under
   // wal_write_mutex_ to ensure ordered events in WAL
   size_t seq_inc = 0 /* total_count */;
@@ -1500,7 +1500,7 @@ Status DBImpl::PreprocessWrite(const WriteOptions& write_options,
     status = error_handler_.GetBGError();
   }
 
-  PERF_TIMER_GUARD(write_scheduling_flushes_compactions_time);
+  PERF_TIMER_FOR_WRITE_GUARD(write_scheduling_flushes_compactions_time);
 
   if (UNLIKELY(status.ok() &&
                wals_total_size_.LoadRelaxed() > GetMaxTotalWalSize())) {
@@ -1540,7 +1540,7 @@ Status DBImpl::PreprocessWrite(const WriteOptions& write_options,
   }
 
   PERF_TIMER_STOP(write_scheduling_flushes_compactions_time);
-  PERF_TIMER_GUARD(write_pre_and_post_process_time);
+  PERF_TIMER_FOR_WRITE_GUARD(write_pre_and_post_process_time);
 
   if (UNLIKELY(status.ok() && (write_controller_.IsStopped() ||
                                write_controller_.NeedsDelay()))) {

--- a/db/perf_context_test.cc
+++ b/db/perf_context_test.cc
@@ -1136,6 +1136,49 @@ TEST_F(PerfContextTest, WriteMemtableTimePerfLevel) {
   ASSERT_EQ(perf_context.write_memtable_time, 0);
 }
 
+TEST_F(PerfContextTest, WriteTimePerfLevel) {
+  ASSERT_OK(DestroyDB(kDbName, Options()));
+  auto db = OpenDb();
+  PerfContext* perf_ctx = get_perf_context();
+
+  // At kEnableTimeForWrite: write-path timers should be collected
+  SetPerfLevel(PerfLevel::kEnableTimeForWrite);
+  perf_ctx->Reset();
+  ASSERT_OK(db->Put(WriteOptions(), "key1", "val1"));
+  ASSERT_GT(perf_ctx->write_wal_time, 0);
+  ASSERT_GT(perf_ctx->write_pre_and_post_process_time, 0);
+  // write_memtable_time is enabled at kEnableWait (below kEnableTimeForWrite)
+  ASSERT_GT(perf_ctx->write_memtable_time, 0);
+
+  // Read-path timers should still be zero at this level
+  perf_ctx->Reset();
+  ASSERT_OK(db->Put(WriteOptions(), "key2", "val2"));
+  std::string val;
+  ASSERT_OK(db->Get(ReadOptions(), "key2", &val));
+  ASSERT_EQ(perf_ctx->get_from_memtable_time, 0);
+  ASSERT_EQ(perf_ctx->get_snapshot_time, 0);
+
+  // At kEnableWait: write_wal_time should NOT be collected
+  SetPerfLevel(PerfLevel::kEnableWait);
+  perf_ctx->Reset();
+  ASSERT_OK(db->Put(WriteOptions(), "key3", "val3"));
+  ASSERT_EQ(perf_ctx->write_wal_time, 0);
+  ASSERT_EQ(perf_ctx->write_pre_and_post_process_time, 0);
+  ASSERT_EQ(perf_ctx->write_scheduling_flushes_compactions_time, 0);
+  // But wait-level write timers should still work
+  ASSERT_GT(perf_ctx->write_memtable_time, 0);
+
+  // At kEnableTimeExceptForMutex: both write and read timers collected
+  SetPerfLevel(PerfLevel::kEnableTimeExceptForMutex);
+  perf_ctx->Reset();
+  ASSERT_OK(db->Put(WriteOptions(), "key4", "val4"));
+  ASSERT_GT(perf_ctx->write_wal_time, 0);
+  ASSERT_GT(perf_ctx->write_pre_and_post_process_time, 0);
+  std::string value;
+  ASSERT_OK(db->Get(ReadOptions(), "key4", &value));
+  ASSERT_GT(perf_ctx->get_from_memtable_time, 0);
+}
+
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {

--- a/include/rocksdb/perf_context.h
+++ b/include/rocksdb/perf_context.h
@@ -193,6 +193,9 @@ struct PerfContextBase {
   // are enabled.
   //
   // total nanos spent on writing to WAL
+  // This metric, along with write_scheduling_flushes_compactions_time and
+  // write_pre_and_post_process_time, gets collected starting from
+  // PerfLevel::kEnableTimeForWrite
   uint64_t write_wal_time;
   // total nanos spent on writing to mem tables
   // This metric gets collected starting from PerfLevel::kEnableWait
@@ -201,8 +204,10 @@ struct PerfContextBase {
   uint64_t write_delay_time;
   // total nanos spent on switching memtable/wal and scheduling
   // flushes/compactions.
+  // This metric gets collected starting from PerfLevel::kEnableTimeForWrite
   uint64_t write_scheduling_flushes_compactions_time;
   // total nanos spent on writing a record, excluding the above four things
+  // This metric gets collected starting from PerfLevel::kEnableTimeForWrite
   uint64_t write_pre_and_post_process_time;
 
   // time spent waiting for other threads of the batch group

--- a/include/rocksdb/perf_level.h
+++ b/include/rocksdb/perf_level.h
@@ -37,17 +37,24 @@ enum PerfLevel : unsigned char {
   // external resources such as mutexes and IO.
   // These metrics usually have this pattern: "_[wait|delay]_*_[time|nanos]".
   kEnableWait = 3,
+  // Starts enabling time metrics for write operations that are not
+  // wait-related, such as WAL write time and scheduling time. Combined with
+  // kEnableWait, this level enables all write-path time metrics without the
+  // overhead of read-path timers.
+  // These metrics' names start with "write_" and have keywords "time" or
+  // "nanos".
+  kEnableTimeForWrite = 4,
   // Starts enabling metrics that measure the end to end time of an operation.
   // These metrics' names have keywords "time" or "nanos". Check other time
   // measuring metrics with similar but more specific naming conventions.
-  kEnableTimeExceptForMutex = 4,
+  kEnableTimeExceptForMutex = 5,
   // Starts enabling metrics that measure the cpu time of an operation. These
   // metrics' name usually this pattern "_cpu_*_[time|nanos]".
-  kEnableTimeAndCPUTimeExceptForMutex = 5,
+  kEnableTimeAndCPUTimeExceptForMutex = 6,
   // Starts enabling metrics that measure time for mutex. These metrics' name
   // usually have this pattern: "_[mutex|condition]_*_[time|nanos]".
-  kEnableTime = 6,
-  kOutOfBounds = 7  // N.B. Must always be the last value!
+  kEnableTime = 7,
+  kOutOfBounds = 8  // N.B. Must always be the last value!
 };
 
 // set the perf stats level for current thread

--- a/java/rocksjni/portal.h
+++ b/java/rocksjni/portal.h
@@ -6262,16 +6262,20 @@ class PerfLevelTypeJni {
         return 0x1;
       case ROCKSDB_NAMESPACE::PerfLevel::kEnableCount:
         return 0x2;
-      case ROCKSDB_NAMESPACE::PerfLevel::kEnableTimeExceptForMutex:
+      case ROCKSDB_NAMESPACE::PerfLevel::kEnableWait:
         return 0x3;
-      case ROCKSDB_NAMESPACE::PerfLevel::kEnableTimeAndCPUTimeExceptForMutex:
+      case ROCKSDB_NAMESPACE::PerfLevel::kEnableTimeForWrite:
         return 0x4;
-      case ROCKSDB_NAMESPACE::PerfLevel::kEnableTime:
+      case ROCKSDB_NAMESPACE::PerfLevel::kEnableTimeExceptForMutex:
         return 0x5;
+      case ROCKSDB_NAMESPACE::PerfLevel::kEnableTimeAndCPUTimeExceptForMutex:
+        return 0x6;
+      case ROCKSDB_NAMESPACE::PerfLevel::kEnableTime:
+        return 0x7;
       case ROCKSDB_NAMESPACE::PerfLevel::kOutOfBounds:
-        return 0x6;
+        return 0x8;
       default:
-        return 0x6;
+        return 0x8;
     }
   }
 
@@ -6284,13 +6288,17 @@ class PerfLevelTypeJni {
       case 0x2:
         return ROCKSDB_NAMESPACE::PerfLevel::kEnableCount;
       case 0x3:
-        return ROCKSDB_NAMESPACE::PerfLevel::kEnableTimeExceptForMutex;
+        return ROCKSDB_NAMESPACE::PerfLevel::kEnableWait;
       case 0x4:
+        return ROCKSDB_NAMESPACE::PerfLevel::kEnableTimeForWrite;
+      case 0x5:
+        return ROCKSDB_NAMESPACE::PerfLevel::kEnableTimeExceptForMutex;
+      case 0x6:
         return ROCKSDB_NAMESPACE::PerfLevel::
             kEnableTimeAndCPUTimeExceptForMutex;
-      case 0x5:
+      case 0x7:
         return ROCKSDB_NAMESPACE::PerfLevel::kEnableTime;
-      case 0x6:
+      case 0x8:
         return ROCKSDB_NAMESPACE::PerfLevel::kOutOfBounds;
       default:
         return ROCKSDB_NAMESPACE::PerfLevel::kOutOfBounds;

--- a/java/src/main/java/org/rocksdb/PerfLevel.java
+++ b/java/src/main/java/org/rocksdb/PerfLevel.java
@@ -19,25 +19,34 @@ public enum PerfLevel {
    */
   ENABLE_COUNT((byte) 2),
   /**
-   * Other than count stats, also enable time stats except for mutexes
+   * Other than count stats, also enable wait/delay time stats for
+   * user threads blocked in RocksDB
    */
-  ENABLE_TIME_EXCEPT_FOR_MUTEX((byte) 3),
-
+  ENABLE_WAIT((byte) 3),
+  /**
+   * Also enable time stats for write operations (WAL write time,
+   * scheduling time, etc.) without the overhead of read-path timers
+   */
+  ENABLE_TIME_FOR_WRITE((byte) 4),
+  /**
+   * Also enable time stats for all operations except for mutexes
+   */
+  ENABLE_TIME_EXCEPT_FOR_MUTEX((byte) 5),
   /**
    * Other than time, also measure CPU time counters. Still don't measure
    * time (neither wall time nor CPU time) for mutexes
    */
-  ENABLE_TIME_AND_CPU_TIME_EXCEPT_FOR_MUTEX((byte) 4),
+  ENABLE_TIME_AND_CPU_TIME_EXCEPT_FOR_MUTEX((byte) 6),
   /**
    * enable count and time stats
    */
-  ENABLE_TIME((byte) 5),
+  ENABLE_TIME((byte) 7),
 
   /**
    * Do not use
    * @deprecated It's here to just keep parity with C++ API.
    */
-  @Deprecated OUT_OF_BOUNDS((byte) 6);
+  @Deprecated OUT_OF_BOUNDS((byte) 8);
 
   PerfLevel(byte _value) {
     this._value = _value;

--- a/java/src/test/java/org/rocksdb/PerfLevelTest.java
+++ b/java/src/test/java/org/rocksdb/PerfLevelTest.java
@@ -55,8 +55,9 @@ public class PerfLevelTest {
 
   @Test
   public void testAllPerfLevels() {
-    for (PerfLevel level : new PerfLevel[] {DISABLE, ENABLE_COUNT, ENABLE_TIME_EXCEPT_FOR_MUTEX,
-             ENABLE_TIME_AND_CPU_TIME_EXCEPT_FOR_MUTEX, ENABLE_TIME}) {
+    for (PerfLevel level :
+        new PerfLevel[] {DISABLE, ENABLE_COUNT, ENABLE_WAIT, ENABLE_TIME_FOR_WRITE,
+            ENABLE_TIME_EXCEPT_FOR_MUTEX, ENABLE_TIME_AND_CPU_TIME_EXCEPT_FOR_MUTEX, ENABLE_TIME}) {
       db.setPerfLevel(level);
       assertThat(db.getPerfLevel()).isEqualTo(level);
     }

--- a/monitoring/perf_context_imp.h
+++ b/monitoring/perf_context_imp.h
@@ -29,6 +29,7 @@ extern thread_local PerfContext perf_context;
 #define PERF_CPU_TIMER_GUARD(metric, clock)
 #define PERF_CONDITIONAL_TIMER_FOR_MUTEX_GUARD(metric, condition, stats, \
                                                ticker_type)
+#define PERF_TIMER_FOR_WRITE_GUARD(metric)
 #define PERF_TIMER_FOR_WAIT_GUARD(metric)
 #define PERF_TIMER_MEASURE(metric)
 #define PERF_COUNTER_ADD(metric, value)
@@ -66,6 +67,11 @@ extern thread_local PerfContext perf_context;
   if (condition) {                                                             \
     perf_step_timer_##metric.Start();                                          \
   }
+
+#define PERF_TIMER_FOR_WRITE_GUARD(metric)                                     \
+  PerfStepTimer perf_step_timer_##metric(                                      \
+      &(perf_context.metric), nullptr, false, PerfLevel::kEnableTimeForWrite); \
+  perf_step_timer_##metric.Start();
 
 #define PERF_TIMER_FOR_WAIT_GUARD(metric)                                 \
   PerfStepTimer perf_step_timer_##metric(&(perf_context.metric), nullptr, \

--- a/unreleased_history/public_api_changes/perf_level_write_time.md
+++ b/unreleased_history/public_api_changes/perf_level_write_time.md
@@ -1,0 +1,1 @@
+Added `PerfLevel::kEnableTimeForWrite` (value 4). `PerfLevel` values above `kEnableWait` are shifted by 1: `kEnableTimeExceptForMutex` is now 5, `kEnableTimeAndCPUTimeExceptForMutex` is now 6, `kEnableTime` is now 7. Also fixed Java `PerfLevel` enum to include the previously missing `ENABLE_WAIT` level.


### PR DESCRIPTION
Add a new PerfLevel between kEnableWait (3) and kEnableTimeExceptForMutex (now 5) that enables write-path time metrics (write_wal_time, write_scheduling_flushes_compactions_time, write_pre_and_post_process_time) without the overhead of read-path timers like seek/iterator timing.

This allows users to inspect write latency details per session without paying the cost of read-path instrumentation, which is expensive due to high-frequency timer start/stop cycles in the merging iterator.

Also fixes the Java PerfLevel enum and JNI portal which were missing the kEnableWait level added in a prior release.

Made-with: Cursor