### PR TITLE
Fix memory leak in ExportColumnFamily for empty column families (#14458)

### DIFF
--- a/utilities/checkpoint/checkpoint_impl.cc
+++ b/utilities/checkpoint/checkpoint_impl.cc
@@ -419,8 +419,8 @@ Status CheckpointImpl::ExportColumnFamily(
         live_file_metadata.largest = file_metadata.largest;
         result_metadata->files.push_back(live_file_metadata);
       }
-      *metadata = result_metadata;
     }
+    *metadata = result_metadata;
     ROCKS_LOG_INFO(db_options.info_log, "[%s] Export succeeded.",
                    cf_name.c_str());
   } else {

--- a/utilities/checkpoint/checkpoint_test.cc
+++ b/utilities/checkpoint/checkpoint_test.cc
@@ -434,6 +434,28 @@ TEST_F(CheckpointTest, ExportColumnFamilyWithLinks) {
   }
 }
 
+TEST_F(CheckpointTest, ExportEmptyColumnFamily) {
+  // Verify that exporting a column family with no levels (empty CF) does not
+  // leak the allocated ExportImportFilesMetaData and correctly sets *metadata.
+  auto options = CurrentOptions();
+  options.create_if_missing = true;
+  CreateAndReopenWithCF({}, options);
+
+  // Do NOT put any data — the default CF has no levels.
+
+  Checkpoint* checkpoint;
+  ASSERT_OK(Checkpoint::Create(db_.get(), &checkpoint));
+
+  ASSERT_OK(checkpoint->ExportColumnFamily(db_->DefaultColumnFamily(),
+                                           export_path_, &metadata_));
+  // metadata_ must be set even when the CF has no files.
+  ASSERT_NE(metadata_, nullptr);
+  ASSERT_EQ(metadata_->files.size(), 0);
+  ASSERT_EQ(metadata_->db_comparator_name, options.comparator->Name());
+
+  delete checkpoint;
+}
+
 TEST_F(CheckpointTest, ExportColumnFamilyNegativeTest) {
   // Create a database
   auto options = CurrentOptions();


### PR DESCRIPTION
Summary:

In `CheckpointImpl::ExportColumnFamily()`, the assignment
`*metadata = result_metadata` is inside the `for` loop over
`db_metadata.levels`. If the column family has no levels, the loop body
never executes, so the `new ExportImportFilesMetaData()` is leaked and
the caller receives a nullptr despite a success status.

Fix: Move `*metadata = result_metadata` outside the loop.

Reviewed By: anand1976

Differential Revision: D95303457


