### PR TITLE
Fix null pointer crash in WriteUnpreparedTxn::GetIterator

### DIFF
--- a/utilities/transactions/write_unprepared_transaction_test.cc
+++ b/utilities/transactions/write_unprepared_transaction_test.cc
@@ -728,6 +728,37 @@ TEST_P(WriteUnpreparedTransactionTest, UntrackedKeys) {
   delete txn;
 }
 
+TEST_P(WriteUnpreparedTransactionTest, GetIteratorReturnsErrorOnNullDbIter) {
+  // Test that GetIterator returns an error iterator instead of crashing
+  // when NewIterator returns nullptr. Without the fix, the nullptr is
+  // passed to NewIteratorWithBase(), causing a null pointer dereference.
+  WriteOptions write_options;
+  ReadOptions read_options;
+  TransactionOptions txn_options;
+  Transaction* txn = db->BeginTransaction(write_options, txn_options);
+  ASSERT_NE(txn, nullptr);
+
+  // Use a SyncPoint to force NewIterator to return nullptr
+  SyncPoint::GetInstance()->SetCallBack(
+      "WriteUnpreparedTxn::GetIterator:AfterNewIterator",
+      [](void* arg) {
+        Iterator** iter_ptr = static_cast<Iterator**>(arg);
+        delete *iter_ptr;
+        *iter_ptr = nullptr;
+      });
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  Iterator* iter = txn->GetIterator(read_options);
+  // Should get an error iterator, not a crash
+  ASSERT_NE(iter, nullptr);
+  ASSERT_TRUE(iter->status().IsCorruption());
+  delete iter;
+
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+  delete txn;
+}
+
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {

--- a/utilities/transactions/write_unprepared_txn.cc
+++ b/utilities/transactions/write_unprepared_txn.cc
@@ -6,6 +6,7 @@
 #include "utilities/transactions/write_unprepared_txn.h"
 
 #include "db/db_impl/db_impl.h"
+#include "rocksdb/iterator.h"
 #include "util/cast_util.h"
 #include "utilities/transactions/write_unprepared_txn_db.h"
 #include "utilities/write_batch_with_index/write_batch_with_index_internal.h"
@@ -1040,6 +1041,12 @@ Iterator* WriteUnpreparedTxn::GetIterator(const ReadOptions& options,
   // Make sure to get iterator from WriteUnprepareTxnDB, not the root db.
   Iterator* db_iter = wupt_db_->NewIterator(options, column_family, this);
   assert(db_iter);
+  TEST_SYNC_POINT_CALLBACK(
+      "WriteUnpreparedTxn::GetIterator:AfterNewIterator", &db_iter);
+  if (db_iter == nullptr) {
+    return NewErrorIterator(
+        Status::Corruption("Could not create iterator for transaction"));
+  }
 
   auto iter =
       write_batch_.NewIteratorWithBase(column_family, db_iter, &options);


### PR DESCRIPTION
Summary:
`WriteUnpreparedTxnDB::NewIterator()` can return nullptr when
`largest_validated_seq_` exceeds the snapshot sequence and `unprep_seqs_`
is non-empty. The caller `WriteUnpreparedTxn::GetIterator()` only guards
against this with `assert(db_iter)`, which is a no-op in release builds.
The null pointer is then passed to `NewIteratorWithBase()`, causing a crash.

Fix: Add an explicit null check and return a NewErrorIterator with a
Corruption status.

Differential Revision: D95303545


