### PR TITLE
Checkpoint: fall back to copy on Windows when hard-link creation is unsupported

### DIFF
--- a/port/win/env_win.cc
+++ b/port/win/env_win.cc
@@ -833,8 +833,11 @@ IOStatus WinFileSystem::LinkFile(const std::string& src,
 
   if (!RX_CreateHardLink(RX_FN(target).c_str(), RX_FN(src).c_str(), NULL)) {
     DWORD lastError = GetLastError();
-    if (lastError == ERROR_NOT_SAME_DEVICE) {
-      return IOStatus::NotSupported("No cross FS links allowed");
+    if (lastError == ERROR_NOT_SAME_DEVICE ||
+        lastError == ERROR_INVALID_PARAMETER ||
+        lastError == ERROR_ACCESS_DENIED) {
+      return IOStatus::NotSupported(
+          "LinkFile is not supported by the underlying filesystem");
     }
 
     std::string text("Failed to link: ");

--- a/utilities/checkpoint/checkpoint_impl.cc
+++ b/utilities/checkpoint/checkpoint_impl.cc
@@ -356,8 +356,20 @@ Status CheckpointImpl::ExportColumnFamily(
           [&](const std::string& src_dirname, const std::string& fname) {
             ROCKS_LOG_INFO(db_options.info_log, "[%s] HardLinking %s",
                            cf_name.c_str(), fname.c_str());
-            return db_->GetEnv()->LinkFile(src_dirname + fname,
-                                           tmp_export_dir + fname);
+            Status link_status = db_->GetEnv()->LinkFile(
+                src_dirname + fname, tmp_export_dir + fname);
+            if (link_status.IsNotSupported()) {
+              ROCKS_LOG_INFO(db_options.info_log,
+                             "[%s] LinkFile not supported for %s. Falling back"
+                             " to copy.",
+                             cf_name.c_str(), fname.c_str());
+              Status copy_status = CopyFile(
+                  db_->GetFileSystem(), src_dirname + fname,
+                  Temperature::kUnknown, tmp_export_dir + fname,
+                  Temperature::kUnknown, 0, db_options.use_fsync, nullptr);
+              return copy_status;
+            }
+            return link_status;
           } /*link_file_cb*/,
           [&](const std::string& src_dirname, const std::string& fname) {
             ROCKS_LOG_INFO(db_options.info_log, "[%s] Copying %s",


### PR DESCRIPTION
## Summary
`CheckpointImpl::ExportColumnFamily()` currently assumes `Env::LinkFile()` works for checkpoint file export.

On Windows, `CreateHardLink` can fail with filesystem-specific errors (not only cross-device), such as `ERROR_INVALID_PARAMETER` / `ERROR_ACCESS_DENIED`, even when this should be treated as "hard links unsupported for this FS".

This change:
- Maps additional Windows hard-link failure codes to `Status::NotSupported` in `WinFileSystem::LinkFile`.
- In checkpoint export, falls back from hard-link to `CopyFile(...)` when `LinkFile` returns `NotSupported`.

## Why
Without this fallback, checkpoint export can fail on Windows filesystems where hard-link behavior is restricted or unavailable.  
With this patch, checkpoint creation remains functional by copying files when linking is not supported.

## Scope
- Windows-specific `LinkFile` error handling.
- Checkpoint export fallback path only.
- No behavior change where hard links are supported.