### PR TITLE
Remove Support Ukraine banner from RocksDB website

### DIFF
--- a/docs/_layouts/home.html
+++ b/docs/_layouts/home.html
@@ -1,15 +1,6 @@
 <!DOCTYPE html>
 <html>
   {% include head.html %}
-  <div class="socialBanner">
-    <div>
-      Support Ukraine 🇺🇦 
-      <a href="https://opensource.facebook.com/support-ukraine">
-        Help Provide Humanitarian Aid to Ukraine
-      </a>
-      .
-    </div>
-  </div>
   <body>
     {% include nav.html alwayson=true %}
     <div class="navPusher">


### PR DESCRIPTION
Summary: Remove the Support Ukraine socialBanner div from the RocksDB docs homepage layout.

Differential Revision: D96559640


