### PR TITLE
Remove duplicate src_temperature assignment in WorkItem move operator

### DIFF
--- a/utilities/backup/backup_engine.cc
+++ b/utilities/backup/backup_engine.cc
@@ -733,7 +733,6 @@ class BackupEngineImpl {
       src_checksum_hex = std::move(o.src_checksum_hex);
       db_id = std::move(o.db_id);
       db_session_id = std::move(o.db_session_id);
-      src_temperature = o.src_temperature;
       type = std::move(o.type);
       return *this;
     }


### PR DESCRIPTION
WorkItem::operator=(WorkItem&&) already assigns src_temperature via std::move at the beginning of the function. The redundant assignment between db_session_id and type was removed.