### PR TITLE
Add OnBackgroundJobPressureChanged listener callback

### DIFF
--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -799,6 +799,13 @@ TEST_F(DBCompactionTest, CompactRangeBottomPri) {
   // and one compact to L2 in bottom pri pool.
   int low_pri_count = 0;
   int bottom_pri_count = 0;
+  bool bottom_running_seen = false;
+  SyncPoint::GetInstance()->SetCallBack(
+      "BackgroundCallCompaction:1", [&](void*) {
+        if (dbfull()->TEST_NumRunningBottomCompactions() > 0) {
+          bottom_running_seen = true;
+        }
+      });
   SyncPoint::GetInstance()->SetCallBack(
       "ThreadPoolImpl::Impl::BGThread:BeforeRun", [&](void* arg) {
         Env::Priority* pri = static_cast<Env::Priority*>(arg);
@@ -817,6 +824,7 @@ TEST_F(DBCompactionTest, CompactRangeBottomPri) {
   ASSERT_OK(dbfull()->CompactRange(CompactRangeOptions(), nullptr, nullptr));
   ASSERT_EQ(1, low_pri_count);
   ASSERT_EQ(1, bottom_pri_count);
+  ASSERT_TRUE(bottom_running_seen);
   ASSERT_EQ("0,0,2", FilesPerLevel(0));
 
   // Recompact bottom most level uses bottom pool

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -472,7 +472,7 @@ Status DBImpl::ResumeImpl(DBRecoverContext context) {
 void DBImpl::WaitForBackgroundWork() {
   // Wait for background work to finish
   while (bg_bottom_compaction_scheduled_ || bg_compaction_scheduled_ ||
-         bg_flush_scheduled_) {
+         bg_flush_scheduled_ || bg_pressure_callback_in_progress_) {
     bg_cv_.Wait();
   }
 }
@@ -561,6 +561,7 @@ Status DBImpl::CloseHelper() {
   // Wait for background work to finish
   while (bg_bottom_compaction_scheduled_ || bg_compaction_scheduled_ ||
          bg_flush_scheduled_ || bg_purge_scheduled_ ||
+         bg_pressure_callback_in_progress_ ||
          bg_async_file_open_state_ == AsyncFileOpenState::kScheduled ||
          pending_purge_obsolete_files_ ||
          error_handler_.IsRecoveryInProgress()) {

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1248,6 +1248,7 @@ class DBImpl : public DB {
 
   int TEST_BGCompactionsAllowed() const;
   int TEST_BGFlushesAllowed() const;
+  int TEST_NumRunningBottomCompactions() const;
   size_t TEST_GetWalPreallocateBlockSize(uint64_t write_buffer_size) const;
   void TEST_WaitForPeriodicTaskRun(std::function<void()> callback) const;
   SeqnoToTimeMapping TEST_GetSeqnoToTimeMapping() const;
@@ -2431,6 +2432,9 @@ class DBImpl : public DB {
 
   void MaybeScheduleFlushOrCompaction();
 
+  BackgroundJobPressure CaptureBackgroundJobPressure() const;
+  void NotifyOnBackgroundJobPressureChanged();
+
   struct FlushRequest {
     FlushReason flush_reason;
     // A map from column family to flush to largest memtable id to persist for
@@ -3073,6 +3077,9 @@ class DBImpl : public DB {
   // stores the number of compactions are currently running
   int num_running_compactions_ = 0;
 
+  // stores the number of BOTTOM-priority compactions currently running
+  int num_running_bottom_compactions_ = 0;
+
   // number of background memtable flush jobs, submitted to the HIGH pool
   int bg_flush_scheduled_ = 0;
 
@@ -3081,6 +3088,9 @@ class DBImpl : public DB {
 
   // number of background obsolete file purge jobs, submitted to the HIGH pool
   int bg_purge_scheduled_ = 0;
+
+  // number of pressure callbacks currently in progress (for destructor safety)
+  int bg_pressure_callback_in_progress_ = 0;
 
   enum class AsyncFileOpenState : uint8_t {
     kNotScheduled = 0,  // Async file opening has not been scheduled.

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -3145,6 +3145,93 @@ DBImpl::BGJobLimits DBImpl::GetBGJobLimits(int max_background_flushes,
   return res;
 }
 
+BackgroundJobPressure DBImpl::CaptureBackgroundJobPressure() const {
+  mutex_.AssertHeld();
+
+  BackgroundJobPressure snapshot;
+
+  // Compaction: LOW + BOTTOM combined (matches RocksDB's scheduling check)
+  snapshot.compaction_scheduled =
+      bg_compaction_scheduled_ + bg_bottom_compaction_scheduled_;
+  snapshot.compaction_running = num_running_compactions_;
+
+  // Per-priority breakdown for pool-specific expansion
+  assert(num_running_compactions_ >= num_running_bottom_compactions_);
+  snapshot.compaction_low_scheduled = bg_compaction_scheduled_;
+  snapshot.compaction_low_running =
+      std::max(0, num_running_compactions_ - num_running_bottom_compactions_);
+  snapshot.compaction_bottom_scheduled = bg_bottom_compaction_scheduled_;
+  snapshot.compaction_bottom_running = num_running_bottom_compactions_;
+
+  // Flush
+  snapshot.flush_scheduled = bg_flush_scheduled_;
+  snapshot.flush_running = num_running_flushes_;
+
+  snapshot.compaction_speedup_active =
+      write_controller_.NeedSpeedupCompaction();
+
+  // Compute write_stall_proximity_pct: max across all CFs.
+  // Uses the same inputs as RecalculateWriteStallConditions() in
+  // column_family.cc:
+  //   - l0_delay_trigger_count(): sorted run count used for write stall
+  //     decisions. Equals NumLevelFiles(0) for level compaction; for universal
+  //     compaction, also counts non-empty levels from L1+ as sorted runs.
+  //   - estimated_compaction_needed_bytes(): pending compaction bytes.
+  // Prefers slowdown/soft triggers (gradual); falls back to stop/hard triggers.
+  // level0_slowdown_writes_trigger is sanitized to always be > 0;
+  // soft_pending_compaction_bytes_limit can be 0 (disabled).
+  int max_proximity = 0;
+  for (auto cfd : *versions_->GetColumnFamilySet()) {
+    if (cfd->IsDropped() || !cfd->initialized()) {
+      continue;
+    }
+    const auto* vstorage = cfd->current()->storage_info();
+    const auto& mutable_cf_options = cfd->GetCurrentMutableCFOptions();
+
+    int l0_proximity = 0;
+    int l0_trigger = mutable_cf_options.level0_slowdown_writes_trigger > 0
+                         ? mutable_cf_options.level0_slowdown_writes_trigger
+                         : mutable_cf_options.level0_stop_writes_trigger;
+    if (l0_trigger > 0) {
+      l0_proximity = static_cast<int>(
+          100.0 * vstorage->l0_delay_trigger_count() / l0_trigger);
+    }
+
+    int bytes_proximity = 0;
+    uint64_t bytes_limit =
+        mutable_cf_options.soft_pending_compaction_bytes_limit > 0
+            ? mutable_cf_options.soft_pending_compaction_bytes_limit
+            : mutable_cf_options.hard_pending_compaction_bytes_limit;
+    if (bytes_limit > 0) {
+      bytes_proximity = static_cast<int>(
+          100.0 *
+          static_cast<double>(vstorage->estimated_compaction_needed_bytes()) /
+          static_cast<double>(bytes_limit));
+    }
+
+    max_proximity =
+        std::max(max_proximity, std::max(l0_proximity, bytes_proximity));
+  }
+  snapshot.write_stall_proximity_pct = max_proximity;
+
+  return snapshot;
+}
+
+void DBImpl::NotifyOnBackgroundJobPressureChanged() {
+  mutex_.AssertHeld();
+  if (immutable_db_options_.listeners.empty()) {
+    return;
+  }
+  BackgroundJobPressure pressure = CaptureBackgroundJobPressure();
+  bg_pressure_callback_in_progress_++;
+  mutex_.Unlock();
+  for (const auto& listener : immutable_db_options_.listeners) {
+    listener->OnBackgroundJobPressureChanged(this, pressure);
+  }
+  mutex_.Lock();
+  bg_pressure_callback_in_progress_--;
+}
+
 void DBImpl::AddToCompactionQueue(ColumnFamilyData* cfd) {
   assert(!cfd->queued_for_compaction());
   cfd->Ref();
@@ -3580,6 +3667,9 @@ void DBImpl::BackgroundCallFlush(Env::Priority thread_pri) {
     bg_flush_scheduled_--;
     // See if there's more work to be done
     MaybeScheduleFlushOrCompaction();
+
+    NotifyOnBackgroundJobPressureChanged();
+
     atomic_flush_install_cv_.SignalAll();
     bg_cv_.SignalAll();
     // IMPORTANT: there should be no code after calling SignalAll. This call may
@@ -3604,6 +3694,9 @@ void DBImpl::BackgroundCallCompaction(PrepickedCompaction* prepicked_compaction,
     InstrumentedMutexLock l(&mutex_);
 
     num_running_compactions_++;
+    if (bg_thread_pri == Env::Priority::BOTTOM) {
+      num_running_bottom_compactions_++;
+    }
 
     std::unique_ptr<std::list<uint64_t>::iterator>
         pending_outputs_inserted_elem(new std::list<uint64_t>::iterator(
@@ -3686,10 +3779,14 @@ void DBImpl::BackgroundCallCompaction(PrepickedCompaction* prepicked_compaction,
     } else {
       assert(bg_thread_pri == Env::Priority::BOTTOM);
       bg_bottom_compaction_scheduled_--;
+      assert(num_running_bottom_compactions_ > 0);
+      num_running_bottom_compactions_--;
     }
 
     // See if there's more work to be done
     MaybeScheduleFlushOrCompaction();
+
+    NotifyOnBackgroundJobPressureChanged();
 
     if (prepicked_compaction != nullptr &&
         prepicked_compaction->task_token != nullptr) {

--- a/db/db_impl/db_impl_debug.cc
+++ b/db/db_impl/db_impl_debug.cc
@@ -282,6 +282,11 @@ int DBImpl::TEST_BGFlushesAllowed() const {
   return GetBGJobLimits().max_flushes;
 }
 
+int DBImpl::TEST_NumRunningBottomCompactions() const {
+  mutex_.AssertHeld();
+  return num_running_bottom_compactions_;
+}
+
 SequenceNumber DBImpl::TEST_GetLastVisibleSequence() const {
   if (last_seq_same_as_publish_seq_) {
     return versions_->LastSequence();

--- a/db/listener_test.cc
+++ b/db/listener_test.cc
@@ -1643,6 +1643,134 @@ TEST_F(EventListenerTest, BlobDBFileTest) {
   blob_event_listener->CheckCounters();
 }
 
+class BackgroundJobPressureTestListener : public EventListener {
+ public:
+  void OnBackgroundJobPressureChanged(
+      DB* /*db*/, const BackgroundJobPressure& snapshot) override {
+    std::lock_guard<std::mutex> lock(mu_);
+    snapshots_.push_back(snapshot);
+  }
+
+  std::vector<BackgroundJobPressure> GetSnapshots() {
+    std::lock_guard<std::mutex> lock(mu_);
+    return snapshots_;
+  }
+
+  void Reset() {
+    std::lock_guard<std::mutex> lock(mu_);
+    snapshots_.clear();
+  }
+
+ private:
+  std::mutex mu_;
+  std::vector<BackgroundJobPressure> snapshots_;
+};
+
+TEST_F(EventListenerTest, BackgroundJobPressure) {
+  auto listener = std::make_shared<BackgroundJobPressureTestListener>();
+  Options options = CurrentOptions();
+  options.create_if_missing = true;
+  options.max_background_jobs = 8;
+  options.disable_auto_compactions = false;
+  options.level0_slowdown_writes_trigger = 4;
+  options.level0_stop_writes_trigger = 100;
+  options.level0_file_num_compaction_trigger = 4;
+  options.listeners.push_back(listener);
+  DestroyAndReopen(options);
+
+  // Structural invariant checked on every snapshot.
+  auto CheckInvariants = [](const std::vector<BackgroundJobPressure>& snaps) {
+    ASSERT_GT(snaps.size(), 0u);
+    for (const auto& s : snaps) {
+      ASSERT_EQ(s.compaction_scheduled,
+                s.compaction_low_scheduled + s.compaction_bottom_scheduled);
+      ASSERT_EQ(s.compaction_running,
+                s.compaction_low_running + s.compaction_bottom_running);
+    }
+  };
+
+  // Block compaction so L0 files accumulate.
+  env_->SetBackgroundThreads(1, Env::Priority::LOW);
+  test::SleepingBackgroundTask sleeping_task;
+  env_->Schedule(&test::SleepingBackgroundTask::DoSleepTask, &sleeping_task,
+                 Env::Priority::LOW);
+  sleeping_task.WaitUntilSleeping();
+
+  // Phase 1: No pressure — 3 SST files (below slowdown trigger=4).
+  for (int i = 0; i < 3; i++) {
+    ASSERT_OK(Put("k" + std::to_string(i), std::string(100, 'x')));
+    ASSERT_OK(Flush());
+  }
+
+  auto snapshots = listener->GetSnapshots();
+  CheckInvariants(snapshots);
+  for (const auto& s : snapshots) {
+    ASSERT_EQ(s.compaction_running, 0);
+    ASSERT_EQ(s.compaction_scheduled, 0);
+    ASSERT_FALSE(s.compaction_speedup_active);
+    ASSERT_LT(s.write_stall_proximity_pct, 100);
+  }
+  // Latest: flush completed
+  const auto& latest1 = snapshots.back();
+  ASSERT_EQ(latest1.flush_running, 0);
+  ASSERT_EQ(latest1.flush_scheduled, 0);
+
+  // Phase 2: Build pressure — flush past slowdown trigger (4 L0 SST files).
+  // Compaction is blocked, so L0 SST files pile up.
+  listener->Reset();
+  {
+    FlushOptions fo;
+    fo.allow_write_stall = true;
+    for (int i = 3; i < 10; i++) {
+      ASSERT_OK(Put("k" + std::to_string(i), std::string(100, 'x')));
+      ASSERT_OK(db_->Flush(fo));
+    }
+  }
+
+  snapshots = listener->GetSnapshots();
+  CheckInvariants(snapshots);
+  for (const auto& s : snapshots) {
+    ASSERT_EQ(s.compaction_running, 0);
+  }
+  // Scan history: pressure indicators appear as L0 SST files accumulate
+  bool found_speedup = false;
+  bool found_compaction_scheduled = false;
+  bool found_high_proximity = false;
+  for (const auto& s : snapshots) {
+    if (s.compaction_speedup_active) {
+      found_speedup = true;
+    }
+    if (s.compaction_scheduled > 0) {
+      found_compaction_scheduled = true;
+    }
+    if (s.write_stall_proximity_pct >= 100) {
+      found_high_proximity = true;
+    }
+  }
+  ASSERT_TRUE(found_speedup);
+  ASSERT_TRUE(found_compaction_scheduled);
+  ASSERT_TRUE(found_high_proximity);
+
+  // Phase 3: Relieve pressure — unblock compaction, wait for completion.
+  listener->Reset();
+  sleeping_task.WakeUp();
+  sleeping_task.WaitUntilDone();
+  ASSERT_OK(dbfull()->TEST_WaitForCompact());
+
+  snapshots = listener->GetSnapshots();
+  CheckInvariants(snapshots);
+  for (const auto& s : snapshots) {
+    ASSERT_EQ(s.flush_running, 0);
+    ASSERT_EQ(s.flush_scheduled, 0);
+  }
+  // Latest: all compactions finished, healthy
+  const auto& latest3 = snapshots.back();
+  ASSERT_EQ(latest3.compaction_running, 0);
+  ASSERT_EQ(latest3.compaction_scheduled, 0);
+  ASSERT_FALSE(latest3.compaction_speedup_active);
+  ASSERT_LT(latest3.write_stall_proximity_pct, 100);
+}
+
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {

--- a/db_stress_tool/db_stress_listener.h
+++ b/db_stress_tool/db_stress_listener.h
@@ -226,6 +226,13 @@ class DbStressListener : public EventListener {
     RandomSleep();
   }
 
+  void OnBackgroundJobPressureChanged(
+      DB* /*db*/, const BackgroundJobPressure& pressure) override {
+    RandomSleep();
+    std::lock_guard<std::mutex> lk(bg_pressure_mu_);
+    last_bg_pressure_ = pressure;
+  }
+
   void OnFileReadFinish(const FileOperationInfo& info) override {
     // Even empty callback is valuable because sometimes some locks are
     // released in order to make the callback.
@@ -366,6 +373,8 @@ class DbStressListener : public EventListener {
   std::atomic<int> num_pending_file_creations_;
   UniqueIdVerifier unique_ids_;
   SharedState* shared_;
+  mutable std::mutex bg_pressure_mu_;
+  BackgroundJobPressure last_bg_pressure_;
 };
 }  // namespace ROCKSDB_NAMESPACE
 #endif  // GFLAGS

--- a/include/rocksdb/listener.h
+++ b/include/rocksdb/listener.h
@@ -554,6 +554,34 @@ struct IOErrorInfo {
   uint64_t offset;
 };
 
+// EXPERIMENTAL — under active development, fields may change.
+// Point-in-time snapshot of background job pressure for one DB: how busy
+// compaction and flush are, and how close the DB is to write-stalling.
+struct BackgroundJobPressure {
+  // Compaction scheduling (LOW + BOTTOM priority combined)
+  int compaction_scheduled = 0;
+  int compaction_running = 0;
+
+  // Per-priority compaction breakdown
+  int compaction_low_scheduled = 0;
+  int compaction_low_running = 0;
+  int compaction_bottom_scheduled = 0;
+  int compaction_bottom_running = 0;
+
+  // Flush scheduling
+  int flush_scheduled = 0;
+  int flush_running = 0;
+
+  // How close the DB is to a write stall, as a percentage (0 = healthy,
+  // 100 = at stall threshold). Can exceed 100 when already stalling.
+  // Max across all column families based on write-stall triggers.
+  int write_stall_proximity_pct = 0;
+  // Whether RocksDB has activated compaction speedup due to write pressure
+  bool compaction_speedup_active = false;
+
+  bool operator==(const BackgroundJobPressure&) const = default;
+};
+
 // EventListener class contains a set of callback functions that will
 // be called when specific RocksDB event happens such as flush.  It can
 // be used as a building block for developing custom features such as
@@ -869,6 +897,17 @@ class EventListener : public Customizable {
   // A callback function for RocksDB which will be called whenever an IO error
   // happens. ShouldBeNotifiedOnFileIO should be set to true to get a callback.
   virtual void OnIOError(const IOErrorInfo& /*info*/) {}
+
+  // EXPERIMENTAL
+  // Called after a flush or compaction background job completes, providing a
+  // snapshot of current background job scheduling pressure and write-stall
+  // proximity. Fires on the background thread that completed the job, without
+  // holding db_mutex_. This callback fires on every completion, even if
+  // pressure values have not changed from the previous call.
+  // Implementations should not run for an extended period of time before
+  // returning, as this blocks RocksDB background work.
+  virtual void OnBackgroundJobPressureChanged(
+      DB* /*db*/, const BackgroundJobPressure& /*pressure*/) {}
 
   ~EventListener() override {}
 };


### PR DESCRIPTION
**Summary:**
Add a new EventListener callback `OnBackgroundJobPressureChanged` that fires after every flush or compaction background job completes (in the future it may be called at more sites and got renamed). The callback delivers a `BackgroundJobPressure` snapshot containing:
- Compaction scheduling counters (scheduled/running, combined and per-priority LOW/BOTTOM breakdown)
- Flush scheduling counters (scheduled/running)
- Write stall proximity percentage (0=healthy, 100=at stall threshold, can exceed 100 when stalling)
- Whether compaction speedup is active

`CaptureBackgroundJobPressure()` reads scheduling counters and computes write stall proximity from L0 sorted run count and pending compaction bytes (same inputs as `RecalculateWriteStallConditions()`). TODO: add memory-related write stall triggers later.

Introduces `num_running_bottom_compactions_` counter to track BOTTOM- priority compactions separately from LOW, enabling per-pool breakdown in the pressure snapshot.

The callback fires on the background thread after counter decrements and `MaybeScheduleFlushOrCompaction()`, so the snapshot reflects post- completion state. Uses the same mutex unlock/lock pattern as `NotifyOnFlushCompleted`. A `bg_pressure_callback_in_progress_` counter ensures destructor safety since the callback fires after `bg_flush_scheduled_`/`bg_compaction_scheduled_` are decremented.

**Test Plan:**
- listener_test BackgroundJobPressure: 3-phase test verifying no pressure, pressure build-up (speedup, scheduling, proximity), and pressure relief after compaction completes
- db_compaction_test CompactRangeBottomPri: verifies num_running_bottom_compactions_ 
- db_stress_tool exercises the callback with RandomSleep() to expose races. 