### PR TITLE
Support GetLiveFiles on secondary DB instances

### DIFF
--- a/db/db_impl/db_impl_secondary.h
+++ b/db/db_impl/db_impl_secondary.h
@@ -195,10 +195,11 @@ class DBImplSecondary : public DBImpl {
     return Status::NotSupported("Not supported operation in secondary mode.");
   }
 
-  Status GetLiveFiles(std::vector<std::string>&,
-                      uint64_t* /*manifest_file_size*/,
-                      bool /*flush_memtable*/ = true) override {
-    return Status::NotSupported("Not supported operation in secondary mode.");
+  Status GetLiveFiles(std::vector<std::string>& ret,
+                      uint64_t* manifest_file_size,
+                      bool /*flush_memtable*/) override {
+    return DBImpl::GetLiveFiles(ret, manifest_file_size,
+                                false /* flush_memtable */);
   }
 
   using DBImpl::Flush;

--- a/db/db_secondary_test.cc
+++ b/db/db_secondary_test.cc
@@ -1827,6 +1827,60 @@ TEST_F(DBSecondaryTestWithTimestamp, Iterators) {
   Close();
 }
 
+TEST_F(DBSecondaryTest, GetLiveFilesOnSecondary) {
+  Options options;
+  options.env = env_;
+  options.level0_file_num_compaction_trigger = 4;
+  Reopen(options);
+
+  // Write some data and flush to create SST files on the primary.
+  for (int i = 0; i < 3; ++i) {
+    ASSERT_OK(Put("key" + std::to_string(i), "value" + std::to_string(i)));
+    ASSERT_OK(Flush());
+  }
+
+  // Open secondary and verify GetLiveFiles works.
+  Options options1;
+  options1.env = env_;
+  options1.max_open_files = -1;
+  OpenSecondary(options1);
+
+  std::vector<std::string> live_files;
+  uint64_t manifest_size = 0;
+  ASSERT_OK(db_secondary_->GetLiveFiles(live_files, &manifest_size));
+  ASSERT_GT(live_files.size(), 0);
+  ASSERT_GT(manifest_size, 0);
+
+  // Should contain SST files, CURRENT, MANIFEST, and OPTIONS.
+  bool has_sst = false;
+  bool has_current = false;
+  bool has_manifest = false;
+  for (const auto& f : live_files) {
+    if (f.find(".sst") != std::string::npos) {
+      has_sst = true;
+    } else if (f.find("CURRENT") != std::string::npos) {
+      has_current = true;
+    } else if (f.find("MANIFEST") != std::string::npos) {
+      has_manifest = true;
+    }
+  }
+  ASSERT_TRUE(has_sst);
+  ASSERT_TRUE(has_current);
+  ASSERT_TRUE(has_manifest);
+
+  // Write more data on primary, catch up, and verify the file list updates.
+  ASSERT_OK(Put("key3", "value3"));
+  ASSERT_OK(Flush());
+
+  ASSERT_OK(db_secondary_->TryCatchUpWithPrimary());
+
+  std::vector<std::string> live_files_after;
+  uint64_t manifest_size_after = 0;
+  ASSERT_OK(
+      db_secondary_->GetLiveFiles(live_files_after, &manifest_size_after));
+  ASSERT_GT(live_files_after.size(), live_files.size());
+}
+
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Summary:
GetLiveFiles was previously blocked on secondary instances with
Status::NotSupported, even though the operation is safe to perform.

The only reason GetLiveFiles was originally blocked is that it defaults
to flushing the memtable (flush_memtable=true), which is a write
operation. However, the actual implementation in DBImpl::GetLiveFiles
(db_filesnapshot.cc) does two things:

1. Optionally flush the memtable — which we skip by passing
   flush_memtable=false. The secondary already overrides
   FlushForGetLiveFiles() as a no-op, so even if true were passed
   it would not actually flush.

2. Read live file state from versions_ under the mutex — this is
   purely read-only. It iterates the ColumnFamilySet to collect live
   table and blob file numbers, builds relative file paths for SST
   files, blob files, CURRENT, MANIFEST, and OPTIONS, and reads the
   manifest file size.

The secondary maintains its own VersionSet which it keeps up to date
via MANIFEST replay in TryCatchUpWithPrimary(). So all of this state
is valid and accurate — it reflects exactly which files the secondary
considers live at its current replay point.

This is the same approach used by DBImplReadOnly and CompactedDBImpl,
which both delegate to DBImpl::GetLiveFiles with flush_memtable=false.

Differential Revision: D97563143


