### PR TITLE
Fix flaky BackgroundJobPressure test 

### DIFF
--- a/db/listener_test.cc
+++ b/db/listener_test.cc
@@ -1710,10 +1710,9 @@ TEST_F(EventListenerTest, BackgroundJobPressure) {
     ASSERT_FALSE(s.compaction_speedup_active);
     ASSERT_LT(s.write_stall_proximity_pct, 100);
   }
-  // Latest: flush completed
-  const auto& latest1 = snapshots.back();
-  ASSERT_EQ(latest1.flush_running, 0);
-  ASSERT_EQ(latest1.flush_scheduled, 0);
+  // Note: we don't assert flush_running/flush_scheduled == 0 here because
+  // MaybeScheduleFlushOrCompaction() runs before the pressure callback and
+  // may schedule new flush work, making flush counts non-deterministic.
 
   // Phase 2: Build pressure — flush past slowdown trigger (4 L0 SST files).
   // Compaction is blocked, so L0 SST files pile up.
@@ -1759,10 +1758,6 @@ TEST_F(EventListenerTest, BackgroundJobPressure) {
 
   snapshots = listener->GetSnapshots();
   CheckInvariants(snapshots);
-  for (const auto& s : snapshots) {
-    ASSERT_EQ(s.flush_running, 0);
-    ASSERT_EQ(s.flush_scheduled, 0);
-  }
   // Latest: all compactions finished, healthy
   const auto& latest3 = snapshots.back();
   ASSERT_EQ(latest3.compaction_running, 0);


### PR DESCRIPTION
**Context/Summary:**
Remove assertions on flush_running/flush_scheduled from the BackgroundJobPressure listener test. These checks are inherently racy because Flush() can return before the background thread fires the pressure callback.

The race: when BackgroundCallFlush re-acquires the DB mutex after cleanup (line 3661), COERCE_CONTEXT_SWITCH=1 or others may call bg_cv_->SignalAll() and sleep before actually acquiring the lock. This spurious signal wakes WaitForFlushMemTables(), which sees the flush is already installed and returns — so Flush() "completes" seen as foreground in test. The test then starts the next Put()+Flush(), scheduling new flush work. When the previous background thread finally wakes and captures the pressure snapshot, it sees the newly scheduled flush (flush_scheduled > 0). If the race happens on the last flush, its callback may not have fired at all by the time the test reads GetSnapshots(), so snapshots.back() can also show stale data.

The remaining assertions (compaction counts, speedup, write stall proximity) are not affected: compaction is blocked by sleeping_task in Phase 1-2, and Phase 3 uses TEST_WaitForCompact() whose wait condition (bg_*_scheduled_ counts) is only satisfied after the mutex is re-acquired and callbacks have fired.

**Test Plan:**
  COERCE_CONTEXT_SWITCH=1 make -j56 listener_test
  Before: ~22/50 failures at line 1715 (flush_running != 0)
  After:  50/50 pass