### PR TITLE
Support UDI as primary index

### DIFF
--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -184,6 +184,7 @@ DECLARE_int32(data_block_index_type);
 DECLARE_int32(index_block_search_type);
 DECLARE_double(uniform_cv_threshold);
 DECLARE_bool(use_trie_index);
+DECLARE_bool(use_udi_as_primary_index);
 DECLARE_bool(test_backward_scan);
 DECLARE_string(db);
 DECLARE_string(secondaries_base);

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -646,7 +646,16 @@ DEFINE_double(uniform_cv_threshold,
 DEFINE_bool(use_trie_index, false,
             "Use trie-based user defined index (UDI) for SST files. "
             "Compatible with all operation types (Put, Delete, Merge, etc.) "
-            "and all iteration directions (forward and reverse).");
+            "and all iteration directions (forward and reverse). "
+            "Combined with use_udi_as_primary_index to control whether the "
+            "UDI is the primary or secondary index.");
+
+DEFINE_bool(use_udi_as_primary_index, false,
+            "When use_trie_index is enabled, use the UDI as the primary "
+            "index. The standard binary search index is not populated -- "
+            "all reads automatically go through the UDI. When false, the "
+            "UDI is a secondary index and reads require "
+            "ReadOptions::table_index_factory to be set.");
 
 DEFINE_bool(test_backward_scan, true,
             "Test backward iteration (Prev, SeekForPrev) in stress tests.");

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -1002,10 +1002,9 @@ void StressTest::OperateDb(ThreadState* thread) {
   read_opts.allow_unprepared_value = FLAGS_allow_unprepared_value;
   read_opts.auto_refresh_iterator_with_snapshot =
       FLAGS_auto_refresh_iterator_with_snapshot;
-  if (FLAGS_use_trie_index && udi_factory_) {
+  if (FLAGS_use_trie_index && !FLAGS_use_udi_as_primary_index && udi_factory_) {
     read_opts.table_index_factory = udi_factory_.get();
   }
-
   WriteOptions write_opts;
   if (FLAGS_rate_limit_auto_wal_flush) {
     write_opts.rate_limiter_priority = Env::IO_USER;
@@ -4405,6 +4404,9 @@ void InitializeOptionsFromFlags(
       fLU64::FLAGS_super_block_alignment_space_overhead_ratio;
   if (udi_factory) {
     block_based_options.user_defined_index_factory = udi_factory;
+    if (FLAGS_use_udi_as_primary_index) {
+      block_based_options.use_udi_as_primary_index = true;
+    }
   }
   options.table_factory.reset(NewBlockBasedTableFactory(block_based_options));
   options.db_write_buffer_size = FLAGS_db_write_buffer_size;

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -2304,9 +2304,15 @@ struct ReadOptions {
   // block based table index. The table_factory used for the column family
   // must support building/reading this index.
   //
-  // All iterator operations are supported: forward scans (SeekToFirst, Seek,
-  // Next), reverse scans (SeekToLast, SeekForPrev, Prev), and point lookups
-  // (Get). Leave this null to use the native block-based table index.
+  // The UDI framework supports all iterator operations: forward scans
+  // (SeekToFirst, Seek, Next), reverse scans (SeekToLast, SeekForPrev, Prev),
+  // and point lookups (Get). Concrete UDI implementations may impose their
+  // own restrictions -- check the specific implementation's documentation.
+  //
+  // When BlockBasedTableOptions::use_udi_as_primary_index is true, this field
+  // does not need to be set -- all reads automatically use the UDI. This field
+  // is only needed when the UDI is a secondary index and you want to
+  // explicitly select it for reads.
   const UserDefinedIndexFactory* table_index_factory = nullptr;
 
   // *** END options only relevant to iterators or scans ***

--- a/include/rocksdb/table.h
+++ b/include/rocksdb/table.h
@@ -539,6 +539,54 @@ struct BlockBasedTableOptions {
 
   // EXPERIMENTAL
   //
+  // When true and user_defined_index_factory is set, the UDI becomes the
+  // primary index. The standard binary search index is not populated with
+  // real entries -- only a minimal stub is written to satisfy the SST footer
+  // format.
+  // This saves CPU during SST creation and space in every SST file.
+  //
+  // When the UDI is primary:
+  // - All reads automatically use the UDI (ReadOptions::table_index_factory
+  //   does not need to be set)
+  // - The standard index block contains only a stub -- it cannot be used for
+  //   reads. SST files written with this option can only be read by RocksDB
+  //   versions that support UDI-primary mode
+  // - Partitioned index (kTwoLevelIndexSearch) and partitioned filters are
+  //   incompatible with this option
+  // - fail_if_no_udi_on_open is automatically enforced to prevent silent
+  //   data loss if these SSTs are opened without UDI support
+  //
+  // Recommended migration path:
+  //
+  // 1. Deploy with user_defined_index_factory set but
+  //    use_udi_as_primary_index=false (secondary mode). New SSTs are written
+  //    with both indexes. Reads still use the standard index by default. This
+  //    is zero-risk -- rollback by removing user_defined_index_factory.
+  //
+  // 2. Validate reads through the UDI by setting
+  //    ReadOptions::table_index_factory on a subset of reads. Compare results
+  //    against the standard index to build confidence.
+  //
+  // 3. Compact the entire DB to rewrite all pre-existing SSTs (from before
+  //    step 1) into SSTs with both indexes. All SSTs must have a UDI block
+  //    before proceeding -- use_udi_as_primary_index will refuse to open
+  //    SSTs without one.
+  //
+  // 4. Enable use_udi_as_primary_index=true. New SSTs use UDI only. Old SSTs
+  //    (from step 1/3) still have both indexes and are read through the UDI
+  //    automatically.
+  //
+  // Rollback from step 4: you must compact the entire DB with
+  // use_udi_as_primary_index=false to rewrite all SSTs with both indexes
+  // before removing user_defined_index_factory. Without this, SSTs written
+  // in primary mode have a stub standard index and cannot be read without
+  // UDI support.
+  //
+  // Default: false (UDI is built alongside the standard index as a secondary)
+  bool use_udi_as_primary_index = false;
+
+  // EXPERIMENTAL
+  //
   // Return an error Status if a user_defined_index_factory is configured,
   // but there's no corresponding UDI block in the SST file being opened.
   bool fail_if_no_udi_on_open = false;

--- a/include/rocksdb/table_properties.h
+++ b/include/rocksdb/table_properties.h
@@ -46,6 +46,7 @@ struct TablePropertiesNames {
   static const std::string kTopLevelIndexSize;
   static const std::string kIndexKeyIsUserKey;
   static const std::string kIndexValueIsDeltaEncoded;
+  static const std::string kUDIIsPrimaryIndex;
   static const std::string kFilterSize;
   static const std::string kRawKeySize;
   static const std::string kRawValueSize;
@@ -238,6 +239,8 @@ struct TableProperties {
   uint64_t index_key_is_user_key = 0;
   // Whether delta encoding is used to encode the index values.
   uint64_t index_value_is_delta_encoded = 0;
+  // Whether the UDI is the primary index (standard index is a stub).
+  uint64_t udi_is_primary_index = 0;
   // the size of filter block.
   uint64_t filter_size = 0;
   // total raw (uncompressed, undelineated) key size

--- a/include/rocksdb/user_defined_index.h
+++ b/include/rocksdb/user_defined_index.h
@@ -127,6 +127,15 @@ class UserDefinedIndexBuilder {
   // The memory backing the contents should not be freed until this builder
   // object is destructed.
   virtual Status Finish(Slice* index_contents) = 0;
+
+  // Returns an estimate of the current serialized index size in bytes.
+  // Used for compaction file size estimation when the UDI is the primary
+  // index (no standard index builder to delegate to).
+  //
+  // The default implementation returns 0. Concrete implementations should
+  // override this to provide a meaningful estimate for optimal compaction
+  // file sizing.
+  virtual uint64_t EstimatedSize() const { return 0; }
 };
 
 // The interface for iterating the user defined index. This will be

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -208,6 +208,7 @@ TEST_F(OptionsSettableTest, BlockBasedTableOptionsAllFieldsSettable) {
       "initial_auto_readahead_size=0;"
       "num_file_reads_for_auto_readahead=0;"
       "fail_if_no_udi_on_open=true;"
+      "use_udi_as_primary_index=true;"
       "separate_key_value_in_data_block=true;"
       "uniform_cv_threshold=0.2",
       new_bbto));
@@ -296,7 +297,8 @@ TEST_F(OptionsSettableTest, TablePropertiesAllFieldsSettable) {
       "external_sst_file_global_seqno_offset=0;num_merge_operands=0;index_key_"
       "is_user_key=0;key_largest_seqno=18446744073709551615;key_smallest_seqno="
       "18;data_block_restart_interval=16;index_block_restart_interval=1;"
-      "separate_key_value_in_data_block=0;num_uniform_blocks=0;",
+      "separate_key_value_in_data_block=0;num_uniform_blocks=0;"
+      "udi_is_primary_index=0;",
       new_tp));
 
   // All bytes are set from the parse

--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -1265,12 +1265,29 @@ struct BlockBasedTableBuilder::Rep {
 
     // If user_defined_index_factory is provided, wrap the index builder with
     // UserDefinedIndexWrapper
+    if (table_options.use_udi_as_primary_index &&
+        table_options.user_defined_index_factory == nullptr) {
+      SetStatus(Status::InvalidArgument(
+          "use_udi_as_primary_index requires user_defined_index_factory to "
+          "be set"));
+    }
     if (table_options.user_defined_index_factory != nullptr) {
       if (tbo.moptions.compression_opts.parallel_threads > 1 ||
           tbo.moptions.bottommost_compression_opts.parallel_threads > 1) {
         SetStatus(
             Status::InvalidArgument("user_defined_index_factory not supported "
                                     "with parallel compression"));
+      } else if (table_options.use_udi_as_primary_index &&
+                 table_options.index_type ==
+                     BlockBasedTableOptions::kTwoLevelIndexSearch) {
+        SetStatus(Status::InvalidArgument(
+            "use_udi_as_primary_index is incompatible with partitioned index "
+            "(kTwoLevelIndexSearch)"));
+      } else if (table_options.use_udi_as_primary_index &&
+                 table_options.partition_filters) {
+        SetStatus(Status::InvalidArgument(
+            "use_udi_as_primary_index is incompatible with partitioned "
+            "filters"));
       } else {
         std::unique_ptr<UserDefinedIndexBuilder> user_defined_index_builder;
         UserDefinedIndexOption udi_options;
@@ -1284,7 +1301,8 @@ struct BlockBasedTableBuilder::Rep {
             index_builder = std::make_unique<UserDefinedIndexBuilderWrapper>(
                 std::string(table_options.user_defined_index_factory->Name()),
                 std::move(index_builder), std::move(user_defined_index_builder),
-                &internal_comparator, ts_sz, persist_user_defined_timestamps);
+                &internal_comparator, ts_sz, persist_user_defined_timestamps,
+                table_options.use_udi_as_primary_index);
           }
         }
       }
@@ -2486,8 +2504,15 @@ void BlockBasedTableBuilder::WritePropertiesBlock(
     }
     rep_->props.index_key_is_user_key =
         !rep_->index_builder->separator_is_key_plus_seq();
-    rep_->props.index_value_is_delta_encoded =
-        rep_->use_delta_encoding_for_index_values;
+    if (rep_->table_options.use_udi_as_primary_index &&
+        rep_->table_options.user_defined_index_factory != nullptr) {
+      rep_->props.udi_is_primary_index = 1;
+      // The standard index is a stub -- these properties don't apply.
+      rep_->props.index_value_is_delta_encoded = 0;
+    } else {
+      rep_->props.index_value_is_delta_encoded =
+          rep_->use_delta_encoding_for_index_values;
+    }
     if (rep_->sampled_input_data_bytes.LoadRelaxed() > 0) {
       rep_->props.slow_compression_estimated_data_size = static_cast<uint64_t>(
           static_cast<double>(

--- a/table/block_based/block_based_table_factory.cc
+++ b/table/block_based/block_based_table_factory.cc
@@ -430,6 +430,9 @@ static struct BlockBasedTableTypeInfo {
         {"fail_if_no_udi_on_open",
          {offsetof(struct BlockBasedTableOptions, fail_if_no_udi_on_open),
           OptionType::kBoolean, OptionVerificationType::kNormal}},
+        {"use_udi_as_primary_index",
+         {offsetof(struct BlockBasedTableOptions, use_udi_as_primary_index),
+          OptionType::kBoolean, OptionVerificationType::kNormal}},
     };
   }
 } block_based_table_type_info;
@@ -938,6 +941,9 @@ std::string BlockBasedTableFactory::GetPrintableOptions() const {
            table_options_.user_defined_index_factory == nullptr
                ? "nullptr"
                : table_options_.user_defined_index_factory->Name());
+  ret.append(buffer);
+  snprintf(buffer, kBufferSize, "  use_udi_as_primary_index: %d\n",
+           table_options_.use_udi_as_primary_index);
   ret.append(buffer);
   snprintf(buffer, kBufferSize, "  fail_if_no_udi_on_open: %d\n",
            table_options_.fail_if_no_udi_on_open);

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -1322,7 +1322,8 @@ Status BlockBasedTable::PrefetchIndexAndFilterBlocks(
     if (!s.ok()) {
       RecordTick(rep_->ioptions.statistics.get(),
                  SST_USER_DEFINED_INDEX_LOAD_FAIL_COUNT);
-      if (table_options.fail_if_no_udi_on_open) {
+      if (table_options.fail_if_no_udi_on_open ||
+          table_options.use_udi_as_primary_index) {
         ROCKS_LOG_ERROR(rep_->ioptions.logger,
                         "Failed to find the the UDI block %s in file %s; %s",
                         udi_name.c_str(), rep_->file->file_name().c_str(),
@@ -1363,8 +1364,20 @@ Status BlockBasedTable::PrefetchIndexAndFilterBlocks(
             udi_option, rep_->udi_block.GetValue()->data, udi_reader);
         if (s.ok()) {
           if (udi_reader) {
+            // Determine primary UDI mode:
+            // - udi_written_as_primary: SST was built with UDI-primary (stub
+            //   standard index). Affects CacheDependencies/EraseFromCache.
+            // - udi_use_as_primary: Use UDI for reads by default. True if
+            //   the SST was written as primary OR the config says primary
+            //   (enables reading old dual-index SSTs through the UDI too).
+            bool udi_written_as_primary =
+                (rep_->table_properties &&
+                 rep_->table_properties->udi_is_primary_index != 0);
+            bool udi_is_primary = udi_written_as_primary ||
+                                  table_options.use_udi_as_primary_index;
             index_reader = std::make_unique<UserDefinedIndexReaderWrapper>(
-                udi_name, std::move(index_reader), std::move(udi_reader));
+                udi_name, std::move(index_reader), std::move(udi_reader),
+                udi_is_primary, udi_written_as_primary);
           } else {
             s = Status::Corruption("Failed to create UDI reader for " +
                                    udi_name + " in file " +

--- a/table/block_based/user_defined_index_wrapper.h
+++ b/table/block_based/user_defined_index_wrapper.h
@@ -31,11 +31,12 @@ class UserDefinedIndexBuilderWrapper : public IndexBuilder {
       std::unique_ptr<IndexBuilder> internal_index_builder,
       std::unique_ptr<UserDefinedIndexBuilder> user_defined_index_builder,
       const InternalKeyComparator* comparator, size_t ts_sz,
-      bool persist_user_defined_timestamps)
+      bool persist_user_defined_timestamps, bool udi_is_primary = false)
       : IndexBuilder(comparator, ts_sz, persist_user_defined_timestamps),
         name_(name),
         internal_index_builder_(std::move(internal_index_builder)),
-        user_defined_index_builder_(std::move(user_defined_index_builder)) {}
+        user_defined_index_builder_(std::move(user_defined_index_builder)),
+        udi_is_primary_(udi_is_primary) {}
 
   ~UserDefinedIndexBuilderWrapper() override = default;
 
@@ -80,6 +81,12 @@ class UserDefinedIndexBuilderWrapper : public IndexBuilder {
           first_key_in_next_block ? &pkey_first.user_key : nullptr, handle,
           separator_scratch, ctx);
     }
+    // When UDI is primary, skip the standard index builder -- only the UDI
+    // index is populated. Return an empty Slice since the standard separator
+    // is not computed.
+    if (udi_is_primary_) {
+      return Slice();
+    }
     return internal_index_builder_->AddIndexEntry(
         last_key_in_current_block, first_key_in_next_block, block_handle,
         separator_scratch, skip_delta_encoding);
@@ -112,11 +119,13 @@ class UserDefinedIndexBuilderWrapper : public IndexBuilder {
 
   void OnKeyAdded(const Slice& key,
                   const std::optional<Slice>& value) override {
-    // Always forward to internal index builder first. It relies on receiving
+    // When UDI is secondary, forward to the internal builder which needs
     // OnKeyAdded for every key to maintain state (e.g.,
-    // current_block_first_internal_key_) needed by AddIndexEntry, which is
-    // always forwarded regardless of UDI status.
-    internal_index_builder_->OnKeyAdded(key, value);
+    // current_block_first_internal_key_). When UDI is primary, skip it --
+    // the internal builder is not populated.
+    if (!udi_is_primary_) {
+      internal_index_builder_->OnKeyAdded(key, value);
+    }
 
     ParsedInternalKey pkey;
     if (status_.ok()) {
@@ -172,24 +181,39 @@ class UserDefinedIndexBuilderWrapper : public IndexBuilder {
       udi_finished_ = true;
     }
 
-    // Finish the internal index builder
+    // Finish the internal index builder. When UDI is primary, the internal
+    // builder was never populated (no AddIndexEntry/OnKeyAdded calls), so it
+    // produces a minimal stub index block. This stub satisfies the SST footer
+    // format requirement for an index block handle.
     status_ = internal_index_builder_->Finish(index_blocks,
                                               last_partition_block_handle);
     if (!status_.ok()) {
       return status_;
     }
 
-    index_size_ = internal_index_builder_->IndexSize();
+    if (udi_is_primary_) {
+      // Use the UDI's serialized size as the index size.
+      index_size_ = user_defined_index_builder_->EstimatedSize();
+    } else {
+      index_size_ = internal_index_builder_->IndexSize();
+    }
     return status_;
   }
 
   size_t IndexSize() const override { return index_size_; }
 
   uint64_t CurrentIndexSizeEstimate() const override {
+    if (udi_is_primary_) {
+      return user_defined_index_builder_->EstimatedSize();
+    }
     return internal_index_builder_->CurrentIndexSizeEstimate();
   }
 
   bool separator_is_key_plus_seq() override {
+    if (udi_is_primary_) {
+      // UDI always uses user keys (no internal key trailer).
+      return false;
+    }
     return internal_index_builder_->separator_is_key_plus_seq();
   }
 
@@ -223,6 +247,7 @@ class UserDefinedIndexBuilderWrapper : public IndexBuilder {
   std::unique_ptr<UserDefinedIndexBuilder> user_defined_index_builder_;
   Status status_;
   bool udi_finished_ = false;
+  bool udi_is_primary_ = false;
 };
 
 class UserDefinedIndexIteratorWrapper
@@ -356,49 +381,78 @@ class UserDefinedIndexIteratorWrapper
 
 class UserDefinedIndexReaderWrapper : public BlockBasedTable::IndexReader {
  public:
+  // @udi_is_primary: use UDI for all reads (default dispatch).
+  // @udi_written_as_primary: SST was built with UDI-primary (stub standard
+  //   index). When true, CacheDependencies/EraseFromCache skip the standard
+  //   reader. When false (old SSTs with both indexes), the standard reader
+  //   still holds cache entries that need cleanup.
   UserDefinedIndexReaderWrapper(
       const std::string& name,
       std::unique_ptr<BlockBasedTable::IndexReader>&& reader,
-      std::unique_ptr<UserDefinedIndexReader>&& udi_reader)
+      std::unique_ptr<UserDefinedIndexReader>&& udi_reader,
+      bool udi_is_primary = false, bool udi_written_as_primary = false)
       : name_(name),
         reader_(std::move(reader)),
-        udi_reader_(std::move(udi_reader)) {}
+        udi_reader_(std::move(udi_reader)),
+        udi_is_primary_(udi_is_primary),
+        udi_written_as_primary_(udi_written_as_primary) {}
 
   InternalIteratorBase<IndexValue>* NewIterator(
       const ReadOptions& read_options, bool disable_prefix_seek,
       IndexBlockIter* iter, GetContext* get_context,
       BlockCacheLookupContext* lookup_context) override {
-    if (!read_options.table_index_factory) {
-      return reader_->NewIterator(read_options, disable_prefix_seek, iter,
-                                  get_context, lookup_context);
+    // Determine whether to use the UDI for this read:
+    // 1. UDI is primary -- always use it (no standard index to fall back to)
+    // 2. ReadOptions::table_index_factory is set -- use it (explicit request)
+    // 3. Neither -- fall through to the standard index
+    bool use_udi = udi_is_primary_;
+    if (!use_udi && read_options.table_index_factory) {
+      if (name_ == read_options.table_index_factory->Name()) {
+        use_udi = true;
+      } else {
+        return NewErrorInternalIterator<IndexValue>(Status::InvalidArgument(
+            "Bad index name: " +
+            std::string(read_options.table_index_factory->Name()) +
+            ". Only supported UDI is " + name_));
+      }
     }
-    if (name_ != read_options.table_index_factory->Name()) {
-      return NewErrorInternalIterator<IndexValue>(Status::InvalidArgument(
-          "Bad index name: " +
-          std::string(read_options.table_index_factory->Name()) +
-          ". Only supported UDI is " + name_));
+
+    if (use_udi) {
+      std::unique_ptr<UserDefinedIndexIterator> udi_iter =
+          udi_reader_->NewIterator(read_options);
+      if (udi_iter) {
+        return new UserDefinedIndexIteratorWrapper(std::move(udi_iter));
+      }
+      return NewErrorInternalIterator<IndexValue>(
+          Status::NotFound("Could not create UDI iterator"));
     }
-    std::unique_ptr<UserDefinedIndexIterator> udi_iter =
-        udi_reader_->NewIterator(read_options);
-    if (udi_iter) {
-      return new UserDefinedIndexIteratorWrapper(std::move(udi_iter));
-    }
-    return NewErrorInternalIterator<IndexValue>(
-        Status::NotFound("Could not create UDI iterator"));
+
+    return reader_->NewIterator(read_options, disable_prefix_seek, iter,
+                                get_context, lookup_context);
   }
 
   Status CacheDependencies(const ReadOptions& ro, bool pin,
                            FilePrefetchBuffer* tail_prefetch_buffer) override {
+    if (udi_written_as_primary_) {
+      // SST was built with UDI-primary -- the standard index is a stub with
+      // no partitions to cache. The UDI block is already pinned.
+      return Status::OK();
+    }
     return reader_->CacheDependencies(ro, pin, tail_prefetch_buffer);
   }
 
   size_t ApproximateMemoryUsage() const override {
-    return reader_->ApproximateMemoryUsage() +
-           udi_reader_->ApproximateMemoryUsage();
+    size_t usage = udi_reader_->ApproximateMemoryUsage();
+    // Always include the standard reader's memory -- it's allocated regardless
+    // of primary mode (it holds the stub or full index block).
+    usage += reader_->ApproximateMemoryUsage();
+    return usage;
   }
 
   void EraseFromCacheBeforeDestruction(
       uint32_t uncache_aggressiveness) override {
+    // Always clean up the standard reader's cache entries. Even for
+    // UDI-primary SSTs, the stub index block may be cached.
     reader_->EraseFromCacheBeforeDestruction(uncache_aggressiveness);
   }
 
@@ -406,5 +460,7 @@ class UserDefinedIndexReaderWrapper : public BlockBasedTable::IndexReader {
   std::string name_;
   std::unique_ptr<BlockBasedTable::IndexReader> reader_;
   std::unique_ptr<UserDefinedIndexReader> udi_reader_;
+  bool udi_is_primary_ = false;
+  bool udi_written_as_primary_ = false;
 };
 }  // namespace ROCKSDB_NAMESPACE

--- a/table/meta_blocks.cc
+++ b/table/meta_blocks.cc
@@ -91,6 +91,9 @@ void PropertyBlockBuilder::AddTableProperty(const TableProperties& props) {
   Add(TablePropertiesNames::kIndexKeyIsUserKey, props.index_key_is_user_key);
   Add(TablePropertiesNames::kIndexValueIsDeltaEncoded,
       props.index_value_is_delta_encoded);
+  if (props.udi_is_primary_index != 0) {
+    Add(TablePropertiesNames::kUDIIsPrimaryIndex, props.udi_is_primary_index);
+  }
   Add(TablePropertiesNames::kNumEntries, props.num_entries);
   Add(TablePropertiesNames::kNumFilterEntries, props.num_filter_entries);
   Add(TablePropertiesNames::kDeletedKeys, props.num_deletions);
@@ -286,6 +289,8 @@ Status ParsePropertiesBlock(
        &new_table_properties->index_key_is_user_key},
       {TablePropertiesNames::kIndexValueIsDeltaEncoded,
        &new_table_properties->index_value_is_delta_encoded},
+      {TablePropertiesNames::kUDIIsPrimaryIndex,
+       &new_table_properties->udi_is_primary_index},
       {TablePropertiesNames::kFilterSize, &new_table_properties->filter_size},
       {TablePropertiesNames::kRawKeySize, &new_table_properties->raw_key_size},
       {TablePropertiesNames::kRawValueSize,

--- a/table/table_properties.cc
+++ b/table/table_properties.cc
@@ -278,6 +278,8 @@ const std::string TablePropertiesNames::kIndexKeyIsUserKey =
     "rocksdb.index.key.is.user.key";
 const std::string TablePropertiesNames::kIndexValueIsDeltaEncoded =
     "rocksdb.index.value.is.delta.encoded";
+const std::string TablePropertiesNames::kUDIIsPrimaryIndex =
+    "rocksdb.udi.is.primary.index";
 const std::string TablePropertiesNames::kFilterSize = "rocksdb.filter.size";
 const std::string TablePropertiesNames::kRawKeySize = "rocksdb.raw.key.size";
 const std::string TablePropertiesNames::kRawValueSize =
@@ -371,6 +373,10 @@ static std::unordered_map<std::string, OptionTypeInfo>
           OptionTypeFlags::kNone}},
         {"index_value_is_delta_encoded",
          {offsetof(struct TableProperties, index_value_is_delta_encoded),
+          OptionType::kUInt64T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"udi_is_primary_index",
+         {offsetof(struct TableProperties, udi_is_primary_index),
           OptionType::kUInt64T, OptionVerificationType::kNormal,
           OptionTypeFlags::kNone}},
         {"filter_size",

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -246,6 +246,12 @@ default_params = {
     # use_trie_index must be the same across invocations so that all SSTs
     # in a DB are opened with matching table options
     "use_trie_index": random.choice([0, 0, 0, 0, 0, 0, 0, 1]),
+    # use_udi_as_primary_index must be the same across invocations (like
+    # use_trie_index) so that SSTs written in primary mode can be read on
+    # reopen. A lambda would re-randomize per invocation, potentially
+    # causing open failures when a primary-mode SST is opened without the
+    # primary flag.
+    "use_udi_as_primary_index": random.choice([0, 1]),
     # use_put_entity_one_in has to be the same across invocations for verification to work, hence no lambda
     "use_put_entity_one_in": random.choice([0] * 7 + [1, 5, 10]),
     "use_attribute_group": lambda: random.randint(0, 1),
@@ -936,6 +942,9 @@ def finalize_and_sanitize(src_params):
         dest_params["mmap_read"] = 0
         # Parallel compression is incompatible with UDI
         dest_params["compression_parallel_threads"] = 1
+    else:
+        # use_udi_as_primary_index requires use_trie_index
+        dest_params["use_udi_as_primary_index"] = 0
 
     # Multi-key operations are not currently compatible with transactions or
     # timestamp.

--- a/utilities/trie_index/trie_index_db_test.cc
+++ b/utilities/trie_index/trie_index_db_test.cc
@@ -146,8 +146,12 @@ MakeStressLikeSqfcFactory() {
   return factory;
 }
 
-class TrieIndexDBTest : public testing::Test {
+// Parameterized on UDI mode: false = secondary, true = primary.
+// All tests run in both modes to ensure full coverage.
+class TrieIndexDBTest : public testing::TestWithParam<bool> {
  protected:
+  bool IsPrimaryMode() const { return GetParam(); }
+
   void SetUp() override {
     trie_factory_ = std::make_shared<TrieIndexFactory>();
     dbname_ = test::PerThreadDBPath("trie_index_db_test");
@@ -162,13 +166,26 @@ class TrieIndexDBTest : public testing::Test {
     EXPECT_OK(DestroyDB(dbname_, last_options_));
   }
 
-  // Opens a DB with the trie UDI factory configured. Caller should set
-  // options_ fields before calling this. An optional block_size overrides
-  // the default to force more data blocks in the SST.
+  // Opens a DB using the parameterized UDI mode.
   Status OpenDB(int block_size = 0) {
+    return OpenDBImpl(block_size, IsPrimaryMode());
+  }
+
+  // Explicitly opens as primary -- used by the backward compatibility test.
+  Status OpenDBPrimary(int block_size = 0) {
+    return OpenDBImpl(block_size, /*udi_primary=*/true);
+  }
+
+  // Explicitly opens as secondary -- used by the backward compatibility test.
+  Status OpenDBSecondary(int block_size = 0) {
+    return OpenDBImpl(block_size, /*udi_primary=*/false);
+  }
+
+  Status OpenDBImpl(int block_size, bool udi_primary) {
     options_.create_if_missing = true;
     BlockBasedTableOptions table_options;
     table_options.user_defined_index_factory = trie_factory_;
+    table_options.use_udi_as_primary_index = udi_primary;
     if (block_size > 0) {
       table_options.block_size = block_size;
     }
@@ -177,14 +194,20 @@ class TrieIndexDBTest : public testing::Test {
     return DB::Open(options_, dbname_, &db_);
   }
 
-  // Returns a ReadOptions that routes reads through the standard binary
-  // search index (the default when table_index_factory is null).
+  // Returns a ReadOptions for the standard index. In secondary mode, this
+  // is a bare ReadOptions (no table_index_factory). In primary mode, this
+  // also returns a bare ReadOptions -- which routes through the trie anyway,
+  // making the dual-index comparison a trie-vs-trie sanity check.
   ReadOptions StandardIndexReadOptions() const { return ReadOptions(); }
 
-  // Returns a ReadOptions that routes reads through the trie UDI index.
+  // Returns a ReadOptions that routes reads through the trie. In primary
+  // mode, a bare ReadOptions already uses the trie, so table_index_factory
+  // is not set. In secondary mode, table_index_factory is set explicitly.
   ReadOptions TrieIndexReadOptions() const {
     ReadOptions ro;
-    ro.table_index_factory = trie_factory_.get();
+    if (!IsPrimaryMode()) {
+      ro.table_index_factory = trie_factory_.get();
+    }
     return ro;
   }
 
@@ -545,7 +568,7 @@ class TrieIndexDBTest : public testing::Test {
 // Flush tests
 // ============================================================================
 
-TEST_F(TrieIndexDBTest, FlushWithAllOperationTypes) {
+TEST_P(TrieIndexDBTest, FlushWithAllOperationTypes) {
   // Write every supported operation type via the DB API, flush, and verify
   // reads return correct results through both the standard binary search index
   // and the trie UDI. This exercises the full path from memtable through
@@ -559,7 +582,7 @@ TEST_F(TrieIndexDBTest, FlushWithAllOperationTypes) {
   ASSERT_OK(db_->Put(WriteOptions(), "key_01_put", "val_put"));
   // kTypeMerge
   ASSERT_OK(db_->Merge(WriteOptions(), "key_02_merge", "val_merge"));
-  // kTypeDeletion (bare tombstone — no prior value for this key)
+  // kTypeDeletion (bare tombstone -- no prior value for this key)
   ASSERT_OK(db_->Delete(WriteOptions(), "key_03_del"));
   // kTypeSingleDeletion (preceded by a Put; both cancel out with no snapshot)
   ASSERT_OK(db_->Put(WriteOptions(), "key_04_sdel", "val_sdel"));
@@ -574,12 +597,12 @@ TEST_F(TrieIndexDBTest, FlushWithAllOperationTypes) {
   ASSERT_OK(db_->Flush(FlushOptions()));
 
   // Scan via both indexes. Expected visible keys after flush:
-  //   key_01_put    — Put (visible)
-  //   key_02_merge  — Merge single operand (visible)
-  //   key_03_del    — bare Delete tombstone (hidden by DBIter)
-  //   key_04_sdel   — Put + SingleDelete cancel out (hidden)
-  //   key_05_entity — PutEntity (visible)
-  //   key_06_put    — Put (visible)
+  //   key_01_put    -- Put (visible)
+  //   key_02_merge  -- Merge single operand (visible)
+  //   key_03_del    -- bare Delete tombstone (hidden by DBIter)
+  //   key_04_sdel   -- Put + SingleDelete cancel out (hidden)
+  //   key_05_entity -- PutEntity (visible)
+  //   key_06_put    -- Put (visible)
   {
     std::vector<std::string> expected = {"key_01_put", "key_02_merge",
                                          "key_05_entity", "key_06_put"};
@@ -596,7 +619,7 @@ TEST_F(TrieIndexDBTest, FlushWithAllOperationTypes) {
   ASSERT_NO_FATAL_FAILURE(VerifyGetBothIndexes("key_06_put", "val_put2"));
 }
 
-TEST_F(TrieIndexDBTest, TimedPutFlush) {
+TEST_P(TrieIndexDBTest, TimedPutFlush) {
   // TimedPut produces kTypeValuePreferredSeqno entries during flush when
   // preclude_last_level_data_seconds > 0. The UDI wrapper strips the packed
   // preferred seqno suffix via ParsePackedValueForValue() before forwarding
@@ -628,12 +651,12 @@ TEST_F(TrieIndexDBTest, TimedPutFlush) {
 
   ASSERT_OK(db_->Flush(FlushOptions()));
 
-  // Point lookups via both indexes — the packed seqno must be transparent.
+  // Point lookups via both indexes -- the packed seqno must be transparent.
   ASSERT_NO_FATAL_FAILURE(VerifyGetBothIndexes("key_01_put", "val_put"));
   ASSERT_NO_FATAL_FAILURE(VerifyGetBothIndexes("key_02_timed", "val_timed"));
   ASSERT_NO_FATAL_FAILURE(VerifyGetBothIndexes("key_03_merge", "val_merge"));
 
-  // Scan via both indexes — all three keys visible in order.
+  // Scan via both indexes -- all three keys visible in order.
   {
     std::vector<std::pair<std::string, std::string>> expected = {
         {"key_01_put", "val_put"},
@@ -647,7 +670,7 @@ TEST_F(TrieIndexDBTest, TimedPutFlush) {
 // Compaction tests
 // ============================================================================
 
-TEST_F(TrieIndexDBTest, CompactionWithMixedOpsAndSnapshots) {
+TEST_P(TrieIndexDBTest, CompactionWithMixedOpsAndSnapshots) {
   // Multiple flushes followed by compaction with a snapshot held. The snapshot
   // forces compaction to preserve multiple versions of the same user key,
   // exercising the UDI builder's handling of duplicate user keys with different
@@ -698,7 +721,7 @@ TEST_F(TrieIndexDBTest, CompactionWithMixedOpsAndSnapshots) {
   db_->ReleaseSnapshot(snap);
 }
 
-TEST_F(TrieIndexDBTest, CompactionWithAllOperationTypes) {
+TEST_P(TrieIndexDBTest, CompactionWithAllOperationTypes) {
   // Exercises all operation types (Put, Delete, Merge, SingleDelete, PutEntity)
   // across two flushes with a snapshot, then compacts. Verified through both
   // indexes. This ensures the UDI builder handles the full range of value types
@@ -768,7 +791,7 @@ TEST_F(TrieIndexDBTest, CompactionWithAllOperationTypes) {
   db_->ReleaseSnapshot(snap);
 }
 
-TEST_F(TrieIndexDBTest, TimedPutCompaction) {
+TEST_P(TrieIndexDBTest, TimedPutCompaction) {
   // Verifies that kTypeValuePreferredSeqno entries survive compaction and the
   // UDI builder correctly strips the packed seqno during compaction output.
   // Verified through both indexes.
@@ -822,7 +845,7 @@ TEST_F(TrieIndexDBTest, TimedPutCompaction) {
   db_->ReleaseSnapshot(snap);
 }
 
-TEST_F(TrieIndexDBTest, CrossFlushSingleDelete) {
+TEST_P(TrieIndexDBTest, CrossFlushSingleDelete) {
   // Verifies that a SingleDelete in a later SST correctly cancels a Put from
   // an earlier SST after compaction with the trie UDI active. Verified through
   // both indexes.
@@ -860,7 +883,7 @@ TEST_F(TrieIndexDBTest, CrossFlushSingleDelete) {
 // Iteration tests
 // ============================================================================
 
-TEST_F(TrieIndexDBTest, ReverseIteration) {
+TEST_P(TrieIndexDBTest, ReverseIteration) {
   // Verifies that reverse iteration (SeekToLast, Prev, SeekForPrev) works
   // correctly with mixed operation types through BOTH the standard binary
   // search index and the trie UDI index.
@@ -907,7 +930,7 @@ TEST_F(TrieIndexDBTest, ReverseIteration) {
   ASSERT_NO_FATAL_FAILURE(
       VerifySeekForPrevBothIndexes("key_04", "key_04", "v4"));
 
-  // SeekForPrev to a deleted key — should land on key_02.
+  // SeekForPrev to a deleted key -- should land on key_02.
   ASSERT_NO_FATAL_FAILURE(
       VerifySeekForPrevBothIndexes("key_03", "key_02", "m1"));
 
@@ -915,10 +938,10 @@ TEST_F(TrieIndexDBTest, ReverseIteration) {
   ASSERT_NO_FATAL_FAILURE(
       VerifySeekForPrevBothIndexes("key_04_5", "key_04", "v4"));
 
-  // SeekForPrev before all keys — should be invalid.
+  // SeekForPrev before all keys -- should be invalid.
   ASSERT_NO_FATAL_FAILURE(VerifySeekForPrevNotFoundBothIndexes("key_00"));
 
-  // Prev from a Seek position in the middle of the range — both indexes.
+  // Prev from a Seek position in the middle of the range -- both indexes.
   for (const auto& ro : {StandardIndexReadOptions(), TrieIndexReadOptions()}) {
     SCOPED_TRACE(ro.table_index_factory ? "trie index" : "standard index");
     std::unique_ptr<Iterator> iter(db_->NewIterator(ro));
@@ -948,7 +971,7 @@ TEST_F(TrieIndexDBTest, ReverseIteration) {
 // DeleteRange test
 // ============================================================================
 
-TEST_F(TrieIndexDBTest, DeleteRangeWithTrieUDI) {
+TEST_P(TrieIndexDBTest, DeleteRangeWithTrieUDI) {
   // Verifies that DeleteRange (kTypeRangeDeletion) works correctly alongside
   // the trie UDI. Range deletions go to a separate range_del_block (not
   // through OnKeyAdded), but we verify that reads correctly filter out
@@ -965,7 +988,7 @@ TEST_F(TrieIndexDBTest, DeleteRangeWithTrieUDI) {
     ASSERT_OK(db_->Put(WriteOptions(), key_buf, val_buf));
   }
 
-  // DeleteRange [key_04, key_08) — deletes key_04 through key_07.
+  // DeleteRange [key_04, key_08) -- deletes key_04 through key_07.
   ASSERT_OK(db_->DeleteRange(WriteOptions(), db_->DefaultColumnFamily(),
                              "key_04", "key_08"));
 
@@ -991,7 +1014,7 @@ TEST_F(TrieIndexDBTest, DeleteRangeWithTrieUDI) {
 // DB reopen test
 // ============================================================================
 
-TEST_F(TrieIndexDBTest, ReopenWithMixedOperationTypes) {
+TEST_P(TrieIndexDBTest, ReopenWithMixedOperationTypes) {
   // Writes all operation types, flushes, closes the DB, reopens, and verifies
   // all data reads correctly from cold SST files through both indexes. This
   // exercises the read path on a freshly opened DB where no memtable data
@@ -1038,7 +1061,7 @@ TEST_F(TrieIndexDBTest, ReopenWithMixedOperationTypes) {
 // Ingest external file test
 // ============================================================================
 
-TEST_F(TrieIndexDBTest, IngestExternalFileWithTrieUDI) {
+TEST_P(TrieIndexDBTest, IngestExternalFileWithTrieUDI) {
   // Creates an SST with SstFileWriter using the trie UDI, then ingests it
   // into a live DB that also has trie UDI configured. Verifies that both the
   // existing DB data and the ingested data are correctly readable through both
@@ -1074,11 +1097,11 @@ TEST_F(TrieIndexDBTest, IngestExternalFileWithTrieUDI) {
   IngestExternalFileOptions ingest_opts;
   ASSERT_OK(db_->IngestExternalFile({sst_path}, ingest_opts));
 
-  // Point lookups via both indexes — combined DB + ingested data.
+  // Point lookups via both indexes -- combined DB + ingested data.
   ASSERT_NO_FATAL_FAILURE(VerifyGetBothIndexes("key_01", "db_val1"));
   ASSERT_NO_FATAL_FAILURE(VerifyGetBothIndexes("key_02", "ingest_val2"));
   ASSERT_NO_FATAL_FAILURE(VerifyGetBothIndexes("key_03", "ingest_merge3"));
-  // key_04: ingested Delete tombstone, no prior value — NotFound.
+  // key_04: ingested Delete tombstone, no prior value -- NotFound.
   ASSERT_NO_FATAL_FAILURE(VerifyGetNotFoundBothIndexes("key_04"));
   ASSERT_NO_FATAL_FAILURE(VerifyGetBothIndexes("key_05", "db_val5"));
   ASSERT_NO_FATAL_FAILURE(VerifyGetBothIndexes("key_06", "ingest_val6"));
@@ -1095,7 +1118,7 @@ TEST_F(TrieIndexDBTest, IngestExternalFileWithTrieUDI) {
 // WriteBatch test
 // ============================================================================
 
-TEST_F(TrieIndexDBTest, WriteBatchWithMixedOperations) {
+TEST_P(TrieIndexDBTest, WriteBatchWithMixedOperations) {
   // Verifies that a single WriteBatch containing multiple operation types
   // (Put, Delete, Merge, SingleDelete, PutEntity) works correctly with the
   // trie UDI. Verified through both indexes. Real-world workloads typically
@@ -1113,7 +1136,7 @@ TEST_F(TrieIndexDBTest, WriteBatchWithMixedOperations) {
   ASSERT_OK(wb.Put(db_->DefaultColumnFamily(), "key_01_put", "batch_put"));
   ASSERT_OK(wb.Delete(db_->DefaultColumnFamily(), "key_02_del"));
   ASSERT_OK(wb.Merge(db_->DefaultColumnFamily(), "key_03_merge", "batch_m"));
-  // Put + SingleDelete within the same batch — they cancel out.
+  // Put + SingleDelete within the same batch -- they cancel out.
   ASSERT_OK(wb.Put(db_->DefaultColumnFamily(), "key_04_sd", "sd_target"));
   ASSERT_OK(wb.SingleDelete(db_->DefaultColumnFamily(), "key_04_sd"));
   ASSERT_OK(wb.PutEntity(db_->DefaultColumnFamily(), "key_05_entity",
@@ -1144,7 +1167,7 @@ TEST_F(TrieIndexDBTest, WriteBatchWithMixedOperations) {
 // Large-scale test
 // ============================================================================
 
-TEST_F(TrieIndexDBTest, LargeMixedOperationsAcrossBlocks) {
+TEST_P(TrieIndexDBTest, LargeMixedOperationsAcrossBlocks) {
   // Large-scale test with many keys of different operation types and a small
   // block size. This stresses block boundary handling in the trie UDI across
   // Put, Delete, Merge, SingleDelete, and PutEntity entries. Verified through
@@ -1178,7 +1201,7 @@ TEST_F(TrieIndexDBTest, LargeMixedOperationsAcrossBlocks) {
       expected_visible.push_back(key);
     } else if (type <= 5) {
       ASSERT_OK(db_->Delete(WriteOptions(), key));
-      // Bare tombstone — not visible.
+      // Bare tombstone -- not visible.
     } else if (type <= 7) {
       char val_buf[32];
       snprintf(val_buf, sizeof(val_buf), "merge_%06d", i);
@@ -1187,7 +1210,7 @@ TEST_F(TrieIndexDBTest, LargeMixedOperationsAcrossBlocks) {
     } else if (type == 8) {
       ASSERT_OK(db_->Put(WriteOptions(), key, "to_be_deleted"));
       ASSERT_OK(db_->SingleDelete(WriteOptions(), key));
-      // Put + SingleDelete cancel — not visible.
+      // Put + SingleDelete cancel -- not visible.
     } else {
       ASSERT_OK(db_->PutEntity(WriteOptions(), db_->DefaultColumnFamily(), key,
                                WideColumns{{"", "entity_val"}}));
@@ -1197,7 +1220,7 @@ TEST_F(TrieIndexDBTest, LargeMixedOperationsAcrossBlocks) {
 
   ASSERT_OK(db_->Flush(FlushOptions()));
 
-  // Scan via both indexes — verify exactly the expected visible keys.
+  // Scan via both indexes -- verify exactly the expected visible keys.
   ASSERT_NO_FATAL_FAILURE(VerifyScanBothIndexes(expected_visible));
 
   // Spot-check: Seek to every 10th visible key via both indexes.
@@ -1217,7 +1240,7 @@ TEST_F(TrieIndexDBTest, LargeMixedOperationsAcrossBlocks) {
 // Seqno side-table tests (same user key spanning data block boundaries)
 // ============================================================================
 
-TEST_F(TrieIndexDBTest, SameUserKeyAcrossBlockBoundaries) {
+TEST_P(TrieIndexDBTest, SameUserKeyAcrossBlockBoundaries) {
   // Forces the same user key to appear in multiple data blocks by writing many
   // versions with snapshots held to prevent garbage collection, using a tiny
   // block_size. This exercises the trie's seqno side-table: the trie stores
@@ -1266,7 +1289,7 @@ TEST_F(TrieIndexDBTest, SameUserKeyAcrossBlockBoundaries) {
     ASSERT_NO_FATAL_FAILURE(VerifyScanBothIndexes(snaps[i], expected));
   }
 
-  // Seek to the key through the trie index with each snapshot — the trie's
+  // Seek to the key through the trie index with each snapshot -- the trie's
   // post-seek correction must advance through overflow blocks to find the
   // correct version for each seqno.
   for (int i = 0; i < kNumVersions; i++) {
@@ -1281,7 +1304,7 @@ TEST_F(TrieIndexDBTest, SameUserKeyAcrossBlockBoundaries) {
   }
 }
 
-TEST_F(TrieIndexDBTest, SameUserKeyPutThenDeleteAcrossBlocks) {
+TEST_P(TrieIndexDBTest, SameUserKeyPutThenDeleteAcrossBlocks) {
   // Same user key with a Put followed by a Delete, where both entries land in
   // different data blocks. A snapshot pins the Put version. After compaction,
   // the current view shows NotFound while the snapshot view shows the Put.
@@ -1323,7 +1346,7 @@ TEST_F(TrieIndexDBTest, SameUserKeyPutThenDeleteAcrossBlocks) {
   db_->ReleaseSnapshot(snap);
 }
 
-TEST_F(TrieIndexDBTest, SameUserKeyManyVersionsSeekCorrectness) {
+TEST_P(TrieIndexDBTest, SameUserKeyManyVersionsSeekCorrectness) {
   // Writes many versions of three different keys (with snapshots), using a
   // tiny block_size to force same-user-key block boundaries. Verifies that
   // Seek + Get through the trie index returns the correct version for each
@@ -1374,7 +1397,7 @@ TEST_F(TrieIndexDBTest, SameUserKeyManyVersionsSeekCorrectness) {
   }
 }
 
-TEST_F(TrieIndexDBTest,
+TEST_P(TrieIndexDBTest,
        AutoPrefixBoundsSnapshotIteratorMatchesStandardIndexWithHiddenVersions) {
   options_.compression = kNoCompression;
   options_.disable_auto_compactions = true;
@@ -1447,7 +1470,7 @@ TEST_F(TrieIndexDBTest,
   db_->ReleaseSnapshot(snapshot);
 }
 
-TEST_F(TrieIndexDBTest, AutoRefreshSnapshotNextAcrossSameUserKeyBoundaries) {
+TEST_P(TrieIndexDBTest, AutoRefreshSnapshotNextAcrossSameUserKeyBoundaries) {
   options_.create_if_missing = true;
   options_.disable_auto_compactions = true;
 
@@ -1539,7 +1562,7 @@ TEST_F(TrieIndexDBTest, AutoRefreshSnapshotNextAcrossSameUserKeyBoundaries) {
   }
 }
 
-TEST_F(TrieIndexDBTest,
+TEST_P(TrieIndexDBTest,
        AutoRefreshSnapshotNextAfterCompactionAcrossSameUserKeyBoundaries) {
   options_.create_if_missing = true;
   options_.disable_auto_compactions = true;
@@ -1626,7 +1649,7 @@ TEST_F(TrieIndexDBTest,
   }
 }
 
-TEST_F(TrieIndexDBTest,
+TEST_P(TrieIndexDBTest,
        AutoRefreshSnapshotStressLikeSingleCfCoalescingIterator) {
   auto sqfc_factory = MakeStressLikeSqfcFactory();
 
@@ -1740,7 +1763,7 @@ TEST_F(TrieIndexDBTest,
 // MultiGet test
 // ============================================================================
 
-TEST_F(TrieIndexDBTest, MultiGetWithTrieUDI) {
+TEST_P(TrieIndexDBTest, MultiGetWithTrieUDI) {
   // Verifies that the batched MultiGet API works correctly with the trie UDI.
   // MultiGet is a separate code path from single Get and uses batched block
   // lookups, so it needs dedicated testing.
@@ -1789,7 +1812,7 @@ TEST_F(TrieIndexDBTest, MultiGetWithTrieUDI) {
 // WAL replay / crash recovery test
 // ============================================================================
 
-TEST_F(TrieIndexDBTest, WALReplayRecovery) {
+TEST_P(TrieIndexDBTest, WALReplayRecovery) {
   // Writes data without flushing, then closes and reopens the DB. The data
   // must be recovered from the WAL and then flushed. This tests that the trie
   // UDI builder handles entries replayed from the WAL correctly.
@@ -1798,14 +1821,14 @@ TEST_F(TrieIndexDBTest, WALReplayRecovery) {
   // WAL is enabled by default (WriteOptions::disableWAL = false).
   ASSERT_OK(OpenDB());
 
-  // Write data — do NOT flush. Data lives only in the WAL + memtable.
+  // Write data -- do NOT flush. Data lives only in the WAL + memtable.
   ASSERT_OK(db_->Put(WriteOptions(), "wal_key_01", "wal_val_01"));
   ASSERT_OK(db_->Merge(WriteOptions(), "wal_key_02", "wal_merge"));
   ASSERT_OK(db_->Put(WriteOptions(), "wal_key_03", "wal_val_03"));
   ASSERT_OK(db_->Delete(WriteOptions(), "wal_key_03"));
   ASSERT_OK(db_->Put(WriteOptions(), "wal_key_04", "wal_val_04"));
 
-  // Close and reopen — triggers WAL replay.
+  // Close and reopen -- triggers WAL replay.
   ASSERT_OK(db_->Close());
   db_.reset();
   ASSERT_OK(OpenDB());
@@ -1834,7 +1857,7 @@ TEST_F(TrieIndexDBTest, WALReplayRecovery) {
 // Multiple column families test
 // ============================================================================
 
-TEST_F(TrieIndexDBTest, MultipleColumnFamilies) {
+TEST_P(TrieIndexDBTest, MultipleColumnFamilies) {
   // Opens a DB with multiple column families, each using the trie UDI. Writes
   // different data to each CF, flushes, and verifies reads through both indexes
   // for each CF. This tests that the UDI builder/reader are correctly isolated
@@ -1975,7 +1998,7 @@ TEST_F(TrieIndexDBTest, MultipleColumnFamilies) {
 //
 // We run with both the standard index and the trie index and compare.
 // ---------------------------------------------------------------------------
-TEST_F(TrieIndexDBTest, BatchedPrefixScan) {
+TEST_P(TrieIndexDBTest, BatchedPrefixScan) {
   // Small block size to force many data blocks (and thus many trie entries).
   ASSERT_OK(OpenDB(/*block_size=*/256));
 
@@ -2021,7 +2044,7 @@ TEST_F(TrieIndexDBTest, BatchedPrefixScan) {
 
 // Same as above but with multiple flushes, compaction, and a DB reopen
 // in between to simulate the crash-recovery path.
-TEST_F(TrieIndexDBTest, BatchedPrefixScanAfterReopen) {
+TEST_P(TrieIndexDBTest, BatchedPrefixScanAfterReopen) {
   ASSERT_OK(OpenDB(/*block_size=*/256));
 
   const int kNumBatches = 100;
@@ -2069,7 +2092,7 @@ TEST_F(TrieIndexDBTest, BatchedPrefixScanAfterReopen) {
 
 // Test with overwrites: multiple writes to the same key body, ensuring
 // the latest value is consistent across all prefixes.
-TEST_F(TrieIndexDBTest, BatchedPrefixScanWithOverwrites) {
+TEST_P(TrieIndexDBTest, BatchedPrefixScanWithOverwrites) {
   ASSERT_OK(OpenDB(/*block_size=*/256));
 
   const int kNumKeys = 50;
@@ -2116,7 +2139,7 @@ TEST_F(TrieIndexDBTest, BatchedPrefixScanWithOverwrites) {
 // Stress-like test: write + delete + rewrite many keys, flush between rounds,
 // then verify prefix scan consistency. Simulates the crash test pattern that
 // triggered failures.
-TEST_F(TrieIndexDBTest, BatchedPrefixScanStressLike) {
+TEST_P(TrieIndexDBTest, BatchedPrefixScanStressLike) {
   ASSERT_OK(OpenDB(/*block_size=*/4096));
 
   const int kMaxKey = 10000;
@@ -2174,7 +2197,7 @@ TEST_F(TrieIndexDBTest, BatchedPrefixScanStressLike) {
   }
 }
 
-TEST_F(TrieIndexDBTest, PrefixIterationWithTrieIndex) {
+TEST_P(TrieIndexDBTest, PrefixIterationWithTrieIndex) {
   // Verifies that prefix iteration (total_order_seek=false with a prefix
   // extractor) returns identical results through the trie and standard indexes.
   options_.prefix_extractor.reset(NewFixedPrefixTransform(4));
@@ -2273,7 +2296,7 @@ TEST_F(TrieIndexDBTest, PrefixIterationWithTrieIndex) {
   }
 }
 
-TEST_F(TrieIndexDBTest, PrefixIterationWithUpperBound) {
+TEST_P(TrieIndexDBTest, PrefixIterationWithUpperBound) {
   options_.prefix_extractor.reset(NewFixedPrefixTransform(4));
   options_.disable_auto_compactions = true;
   ASSERT_OK(OpenDB(/*block_size=*/128));
@@ -2337,7 +2360,7 @@ TEST_F(TrieIndexDBTest, PrefixIterationWithUpperBound) {
   }
 }
 
-TEST_F(TrieIndexDBTest, PrefixIterationDirectionSwitchStress) {
+TEST_P(TrieIndexDBTest, PrefixIterationDirectionSwitchStress) {
   options_.prefix_extractor.reset(NewFixedPrefixTransform(3));
   options_.disable_auto_compactions = true;
   ASSERT_OK(OpenDB(/*block_size=*/64));
@@ -2409,7 +2432,7 @@ TEST_F(TrieIndexDBTest, PrefixIterationDirectionSwitchStress) {
   }
 }
 
-TEST_F(TrieIndexDBTest, PrefixIterationWithDeletesAndMerges) {
+TEST_P(TrieIndexDBTest, PrefixIterationWithDeletesAndMerges) {
   options_.prefix_extractor.reset(NewFixedPrefixTransform(3));
   options_.merge_operator = MergeOperators::CreateStringAppendOperator();
   options_.disable_auto_compactions = true;
@@ -2473,7 +2496,7 @@ TEST_F(TrieIndexDBTest, PrefixIterationWithDeletesAndMerges) {
   ASSERT_EQ(std_rev.size(), 4u);
 }
 
-TEST_F(TrieIndexDBTest, PrefixIterationAfterCompaction) {
+TEST_P(TrieIndexDBTest, PrefixIterationAfterCompaction) {
   options_.prefix_extractor.reset(NewFixedPrefixTransform(3));
   ASSERT_OK(OpenDB(/*block_size=*/128));
 
@@ -2515,7 +2538,7 @@ TEST_F(TrieIndexDBTest, PrefixIterationAfterCompaction) {
   }
 }
 
-TEST_F(TrieIndexDBTest, PrefixIterationWithSnapshots) {
+TEST_P(TrieIndexDBTest, PrefixIterationWithSnapshots) {
   options_.prefix_extractor.reset(NewFixedPrefixTransform(3));
   options_.disable_auto_compactions = true;
   ASSERT_OK(OpenDB(/*block_size=*/128));
@@ -2564,7 +2587,7 @@ TEST_F(TrieIndexDBTest, PrefixIterationWithSnapshots) {
   db_->ReleaseSnapshot(snap2);
 }
 
-TEST_F(TrieIndexDBTest, PrefixIterationEmptyPrefix) {
+TEST_P(TrieIndexDBTest, PrefixIterationEmptyPrefix) {
   options_.prefix_extractor.reset(NewFixedPrefixTransform(3));
   ASSERT_OK(OpenDB());
 
@@ -2588,7 +2611,7 @@ TEST_F(TrieIndexDBTest, PrefixIterationEmptyPrefix) {
   }
 }
 
-TEST_F(TrieIndexDBTest, PrefixIterationWithLowerBound) {
+TEST_P(TrieIndexDBTest, PrefixIterationWithLowerBound) {
   options_.prefix_extractor.reset(NewFixedPrefixTransform(3));
   options_.disable_auto_compactions = true;
   ASSERT_OK(OpenDB(/*block_size=*/128));
@@ -2633,7 +2656,7 @@ TEST_F(TrieIndexDBTest, PrefixIterationWithLowerBound) {
   }
 }
 
-TEST_F(TrieIndexDBTest, PrefixIterationWithDeleteRange) {
+TEST_P(TrieIndexDBTest, PrefixIterationWithDeleteRange) {
   options_.prefix_extractor.reset(NewFixedPrefixTransform(3));
   options_.disable_auto_compactions = true;
   ASSERT_OK(OpenDB(/*block_size=*/128));
@@ -2686,7 +2709,7 @@ TEST_F(TrieIndexDBTest, PrefixIterationWithDeleteRange) {
             ReversePrefixScan(TrieIndexReadOptions()));
 }
 
-TEST_F(TrieIndexDBTest, PrefixIterationMemtablePlusSST) {
+TEST_P(TrieIndexDBTest, PrefixIterationMemtablePlusSST) {
   options_.prefix_extractor.reset(NewFixedPrefixTransform(3));
   options_.disable_auto_compactions = true;
   ASSERT_OK(OpenDB(/*block_size=*/128));
@@ -2749,10 +2772,10 @@ TEST_F(TrieIndexDBTest, PrefixIterationMemtablePlusSST) {
 // iterators to desynchronize.
 //
 // The standard ShortenedIndexBuilder (with default kShortenSeparators mode)
-// does NOT call FindShortSuccessor on the last block — it uses the last key
+// does NOT call FindShortSuccessor on the last block -- it uses the last key
 // as-is. The fix makes the trie builder match this behavior.
 // ---------------------------------------------------------------------------
-TEST_F(TrieIndexDBTest, LastBlockSeparatorNotShortened) {
+TEST_P(TrieIndexDBTest, LastBlockSeparatorNotShortened) {
   // Use a small block size so each key lands in its own block.
   ASSERT_OK(OpenDB(/*block_size=*/32));
 
@@ -2799,7 +2822,7 @@ TEST_F(TrieIndexDBTest, LastBlockSeparatorNotShortened) {
 
 // Variant: tests that when deletes remove the last key, seeking past the last
 // remaining key correctly returns "not found" with both indexes.
-TEST_F(TrieIndexDBTest, LastBlockSeparatorWithDeletes) {
+TEST_P(TrieIndexDBTest, LastBlockSeparatorWithDeletes) {
   ASSERT_OK(OpenDB(/*block_size=*/32));
 
   // Write and flush initial data.
@@ -2818,7 +2841,7 @@ TEST_F(TrieIndexDBTest, LastBlockSeparatorWithDeletes) {
     SCOPED_TRACE(ro.table_index_factory ? "trie index" : "standard index");
     std::unique_ptr<Iterator> iter(db_->NewIterator(ro));
 
-    // Seek to the deleted key — should skip it and land on nothing (it was
+    // Seek to the deleted key -- should skip it and land on nothing (it was
     // the last key).
     iter->Seek(std::string("9\xff\xff", 3));
     ASSERT_TRUE(!iter->Valid())
@@ -2826,7 +2849,7 @@ TEST_F(TrieIndexDBTest, LastBlockSeparatorWithDeletes) {
         << iter->key().ToString(true);
     ASSERT_OK(iter->status());
 
-    // Seek to a key between "5bbb" and the deleted key — should find "5bbb"
+    // Seek to a key between "5bbb" and the deleted key -- should find "5bbb"
     // or nothing depending on order. Actually, "6" > "5bbb" and "6" <
     // "9\xff\xff", so seeking "6" should find nothing since there's no key
     // >= "6" that's still alive.
@@ -2857,7 +2880,7 @@ TEST_F(TrieIndexDBTest, LastBlockSeparatorWithDeletes) {
 
 // Single-entry SST: the trie has exactly one leaf. Validates that Seek,
 // SeekToFirst, Next, and Get all work with a one-block, one-key SST.
-TEST_F(TrieIndexDBTest, SingleEntrySST) {
+TEST_P(TrieIndexDBTest, SingleEntrySST) {
   ASSERT_OK(OpenDB());
   ASSERT_OK(db_->Put(WriteOptions(), "only_key", "only_val"));
   ASSERT_OK(db_->Flush(FlushOptions()));
@@ -2874,10 +2897,10 @@ TEST_F(TrieIndexDBTest, SingleEntrySST) {
   ASSERT_NO_FATAL_FAILURE(
       VerifySeekBothIndexes("only_key", "only_key", "only_val"));
 
-  // Seek before the key — should land on it.
+  // Seek before the key -- should land on it.
   ASSERT_NO_FATAL_FAILURE(VerifySeekBothIndexes("a", "only_key", "only_val"));
 
-  // Seek past the key — should be invalid.
+  // Seek past the key -- should be invalid.
   for (const auto& ro : {StandardIndexReadOptions(), TrieIndexReadOptions()}) {
     SCOPED_TRACE(ro.table_index_factory ? "trie index" : "standard index");
     std::unique_ptr<Iterator> iter(db_->NewIterator(ro));
@@ -2889,14 +2912,14 @@ TEST_F(TrieIndexDBTest, SingleEntrySST) {
 
 // Deletion-only SST: flush a Put, then flush a Delete for that key so the
 // second SST contains only a tombstone. After compaction, the key is gone.
-TEST_F(TrieIndexDBTest, DeletionOnlySST) {
+TEST_P(TrieIndexDBTest, DeletionOnlySST) {
   ASSERT_OK(OpenDB());
 
   // Flush 1: a real Put.
   ASSERT_OK(db_->Put(WriteOptions(), "del_target", "val"));
   ASSERT_OK(db_->Flush(FlushOptions()));
 
-  // Flush 2: only a Delete — this creates an SST whose only entry is a
+  // Flush 2: only a Delete -- this creates an SST whose only entry is a
   // tombstone (the trie still builds an index for the block containing it).
   ASSERT_OK(db_->Delete(WriteOptions(), "del_target"));
   ASSERT_OK(db_->Flush(FlushOptions()));
@@ -2917,7 +2940,7 @@ TEST_F(TrieIndexDBTest, DeletionOnlySST) {
 // land in the same SST, possibly spanning multiple blocks. Validates that
 // the trie's same-key-run handling (seqno-based separators) works at the
 // DB level through both indexes.
-TEST_F(TrieIndexDBTest, AllSameKeySST) {
+TEST_P(TrieIndexDBTest, AllSameKeySST) {
   options_.disable_auto_compactions = true;
   // Small block size to force multiple blocks for the same user key.
   ASSERT_OK(OpenDB(/*block_size=*/32));
@@ -2949,7 +2972,7 @@ TEST_F(TrieIndexDBTest, AllSameKeySST) {
         VerifyScanBothIndexes(snaps[i], {{"same_key", expected}}));
   }
 
-  // Seek with earliest snapshot — should find the earliest version.
+  // Seek with earliest snapshot -- should find the earliest version.
   ASSERT_NO_FATAL_FAILURE(
       VerifySeekBothIndexes(snaps[0], "same_key", "same_key", "val_0"));
 
@@ -2960,7 +2983,7 @@ TEST_F(TrieIndexDBTest, AllSameKeySST) {
 
 // Operations on a completely empty DB: nothing should crash, and after
 // creating + deleting all data, the DB should correctly return nothing.
-TEST_F(TrieIndexDBTest, EmptyDBOperations) {
+TEST_P(TrieIndexDBTest, EmptyDBOperations) {
   ASSERT_OK(OpenDB());
 
   // Get / Seek / SeekToFirst on empty memtable (no SSTs yet).
@@ -2996,7 +3019,7 @@ TEST_F(TrieIndexDBTest, EmptyDBOperations) {
 
 // Focused seek-pattern tests: before all data, between blocks, exact match,
 // after all data, and empty-key seek.
-TEST_F(TrieIndexDBTest, SeekEdgeCases) {
+TEST_P(TrieIndexDBTest, SeekEdgeCases) {
   ASSERT_OK(OpenDB(/*block_size=*/64));
 
   // Write keys with deliberate gaps.
@@ -3047,7 +3070,7 @@ TEST_F(TrieIndexDBTest, SeekEdgeCases) {
 }
 
 // PutEntity + GetEntity through the trie index read path.
-TEST_F(TrieIndexDBTest, GetEntityWithTrieUDI) {
+TEST_P(TrieIndexDBTest, GetEntityWithTrieUDI) {
   ASSERT_OK(OpenDB());
 
   // PutEntity with wide columns.
@@ -3095,7 +3118,7 @@ TEST_F(TrieIndexDBTest, GetEntityWithTrieUDI) {
 
 // Multiple overlapping L0 SSTs: the level iterator must coordinate trie
 // iterators across multiple SST files with overlapping key ranges.
-TEST_F(TrieIndexDBTest, OverlappingL0SSTs) {
+TEST_P(TrieIndexDBTest, OverlappingL0SSTs) {
   options_.disable_auto_compactions = true;
   ASSERT_OK(OpenDB(/*block_size=*/128));
 
@@ -3151,7 +3174,7 @@ TEST_F(TrieIndexDBTest, OverlappingL0SSTs) {
 }
 
 // CompactRange with a sub-range: only part of the key space is compacted.
-TEST_F(TrieIndexDBTest, CompactRangeSubset) {
+TEST_P(TrieIndexDBTest, CompactRangeSubset) {
   options_.disable_auto_compactions = true;
   ASSERT_OK(OpenDB(/*block_size=*/128));
 
@@ -3180,7 +3203,7 @@ TEST_F(TrieIndexDBTest, CompactRangeSubset) {
 }
 
 // Write keys, delete all of them, compact. The DB should be empty.
-TEST_F(TrieIndexDBTest, AllKeysDeletedCompaction) {
+TEST_P(TrieIndexDBTest, AllKeysDeletedCompaction) {
   ASSERT_OK(OpenDB());
 
   for (int i = 0; i < 20; i++) {
@@ -3214,7 +3237,7 @@ TEST_F(TrieIndexDBTest, AllKeysDeletedCompaction) {
 
 // Keys with special byte values: 0x00, 0xFF, embedded nulls, very short keys.
 // These exercise trie byte-traversal edge cases.
-TEST_F(TrieIndexDBTest, BinaryKeyEdgeCases) {
+TEST_P(TrieIndexDBTest, BinaryKeyEdgeCases) {
   ASSERT_OK(OpenDB(/*block_size=*/64));
 
   // All keys in sorted order (BytewiseComparator).
@@ -3266,7 +3289,7 @@ TEST_F(TrieIndexDBTest, BinaryKeyEdgeCases) {
 }
 
 // Puts with empty string values.
-TEST_F(TrieIndexDBTest, EmptyValuePuts) {
+TEST_P(TrieIndexDBTest, EmptyValuePuts) {
   ASSERT_OK(OpenDB());
 
   ASSERT_OK(db_->Put(WriteOptions(), "key1", ""));
@@ -3285,7 +3308,7 @@ TEST_F(TrieIndexDBTest, EmptyValuePuts) {
 
 // Zlib compression: data blocks are compressed, UDI block is not.
 // Verifies that reads through the trie index work with compressed data.
-TEST_F(TrieIndexDBTest, CompressionZlib) {
+TEST_P(TrieIndexDBTest, CompressionZlib) {
   if (!Zlib_Supported()) {
     ROCKSDB_GTEST_SKIP("Zlib not linked");
     return;
@@ -3318,7 +3341,7 @@ TEST_F(TrieIndexDBTest, CompressionZlib) {
 
 // Iterator stability: an iterator pinned to a snapshot should not see data
 // written after the iterator was created, even after flush.
-TEST_F(TrieIndexDBTest, IteratorStabilityDuringFlush) {
+TEST_P(TrieIndexDBTest, IteratorStabilityDuringFlush) {
   ASSERT_OK(OpenDB());
 
   ASSERT_OK(db_->Put(WriteOptions(), "key1", "v1"));
@@ -3360,7 +3383,7 @@ TEST_F(TrieIndexDBTest, IteratorStabilityDuringFlush) {
 
 // iterate_upper_bound without prefix scan: the iterator should stop at the
 // upper bound.
-TEST_F(TrieIndexDBTest, IteratorUpperBound) {
+TEST_P(TrieIndexDBTest, IteratorUpperBound) {
   ASSERT_OK(OpenDB(/*block_size=*/64));
 
   for (const auto& k : {"aa", "bb", "cc", "dd", "ee", "ff"}) {
@@ -3412,7 +3435,7 @@ TEST_F(TrieIndexDBTest, IteratorUpperBound) {
 
 // Combined snapshot + upper_bound: iterator sees the snapshot's view of data,
 // bounded by iterate_upper_bound.
-TEST_F(TrieIndexDBTest, IteratorSnapshotAndUpperBound) {
+TEST_P(TrieIndexDBTest, IteratorSnapshotAndUpperBound) {
   ASSERT_OK(OpenDB());
 
   ASSERT_OK(db_->Put(WriteOptions(), "key_a", "old_a"));
@@ -3453,7 +3476,7 @@ TEST_F(TrieIndexDBTest, IteratorSnapshotAndUpperBound) {
 }
 
 // VerifyChecksum goes through SeekToFirst+Next on the index iterator.
-TEST_F(TrieIndexDBTest, VerifyChecksumWithTrieUDI) {
+TEST_P(TrieIndexDBTest, VerifyChecksumWithTrieUDI) {
   ASSERT_OK(OpenDB(/*block_size=*/128));
 
   for (int i = 0; i < 50; i++) {
@@ -3472,7 +3495,7 @@ TEST_F(TrieIndexDBTest, VerifyChecksumWithTrieUDI) {
 
 // Many small SSTs from frequent flushes: exercises trie iteration across
 // many L0 files without compaction.
-TEST_F(TrieIndexDBTest, ManySmallSSTs) {
+TEST_P(TrieIndexDBTest, ManySmallSSTs) {
   options_.disable_auto_compactions = true;
   ASSERT_OK(OpenDB());
 
@@ -3507,7 +3530,7 @@ TEST_F(TrieIndexDBTest, ManySmallSSTs) {
 }
 
 // Merge values accumulate across multiple compaction rounds.
-TEST_F(TrieIndexDBTest, MergeAcrossMultipleCompactions) {
+TEST_P(TrieIndexDBTest, MergeAcrossMultipleCompactions) {
   options_.merge_operator = MergeOperators::CreateStringAppendOperator();
   ASSERT_OK(OpenDB());
 
@@ -3536,7 +3559,14 @@ TEST_F(TrieIndexDBTest, MergeAcrossMultipleCompactions) {
 
 // Graceful degradation: reopen a DB that was written with UDI, but without
 // the UDI factory configured. Reads should fall back to the standard index.
-TEST_F(TrieIndexDBTest, ReopenWithoutTrieUDI) {
+TEST_P(TrieIndexDBTest, ReopenWithoutTrieUDI) {
+  // In primary mode, the standard index is a stub -- reopening without UDI
+  // is expected to fail because there's no usable index. This test is only
+  // meaningful in secondary mode where both indexes are populated.
+  if (IsPrimaryMode()) {
+    ROCKSDB_GTEST_SKIP("Not applicable in primary mode");
+    return;
+  }
   ASSERT_OK(OpenDB());
 
   ASSERT_OK(db_->Put(WriteOptions(), "key_a", "val_a"));
@@ -3564,7 +3594,14 @@ TEST_F(TrieIndexDBTest, ReopenWithoutTrieUDI) {
 
 // Mixed SSTs: some written with UDI, some without. Both should be readable
 // through both index paths.
-TEST_F(TrieIndexDBTest, MixedSSTsWithAndWithoutUDI) {
+TEST_P(TrieIndexDBTest, MixedSSTsWithAndWithoutUDI) {
+  // This test mixes SSTs with and without UDI by reopening without UDI.
+  // In primary mode, the standard index is a stub, so SSTs written in
+  // primary mode can't be read without UDI. Only meaningful in secondary.
+  if (IsPrimaryMode()) {
+    ROCKSDB_GTEST_SKIP("Not applicable in primary mode");
+    return;
+  }
   options_.disable_auto_compactions = true;
 
   // Phase 1: Write with UDI → SST1 has UDI + standard index.
@@ -3604,10 +3641,11 @@ TEST_F(TrieIndexDBTest, MixedSSTsWithAndWithoutUDI) {
 }
 
 // TransactionDB commit: Put + Delete inside a transaction, then commit.
-TEST_F(TrieIndexDBTest, TransactionCommit) {
+TEST_P(TrieIndexDBTest, TransactionCommit) {
   options_.create_if_missing = true;
   BlockBasedTableOptions table_options;
   table_options.user_defined_index_factory = trie_factory_;
+  table_options.use_udi_as_primary_index = IsPrimaryMode();
   options_.table_factory.reset(NewBlockBasedTableFactory(table_options));
   last_options_ = options_;
 
@@ -3637,10 +3675,11 @@ TEST_F(TrieIndexDBTest, TransactionCommit) {
 // TransactionDB rollback: writes should be discarded. Rollback writes DELETE
 // entries to WAL. Verifies the UDI builder correctly handles DELETE entries
 // replayed from the WAL during recovery.
-TEST_F(TrieIndexDBTest, TransactionRollback) {
+TEST_P(TrieIndexDBTest, TransactionRollback) {
   options_.create_if_missing = true;
   BlockBasedTableOptions table_options;
   table_options.user_defined_index_factory = trie_factory_;
+  table_options.use_udi_as_primary_index = IsPrimaryMode();
   options_.table_factory.reset(NewBlockBasedTableFactory(table_options));
   last_options_ = options_;
 
@@ -3675,7 +3714,7 @@ TEST_F(TrieIndexDBTest, TransactionRollback) {
 // total_order_seek with prefix_extractor: a common stress-test configuration.
 // With total_order_seek=true, SeekToFirst and full forward scan should work
 // correctly even when a prefix extractor is configured.
-TEST_F(TrieIndexDBTest, TotalOrderSeekWithPrefixExtractor) {
+TEST_P(TrieIndexDBTest, TotalOrderSeekWithPrefixExtractor) {
   options_.prefix_extractor.reset(NewFixedPrefixTransform(3));
   ASSERT_OK(OpenDB(/*block_size=*/128));
 
@@ -3733,7 +3772,7 @@ TEST_F(TrieIndexDBTest, TotalOrderSeekWithPrefixExtractor) {
 // 5. Snapshot before large DeleteRange, verify snapshot preserves state
 // 6. Re-insert into deleted ranges, compact, and re-verify
 // ============================================================================
-TEST_F(TrieIndexDBTest, MultiLevelDeleteRangeRandomized) {
+TEST_P(TrieIndexDBTest, MultiLevelDeleteRangeRandomized) {
   uint32_t seed = static_cast<uint32_t>(
       std::chrono::system_clock::now().time_since_epoch().count());
   SCOPED_TRACE("seed=" + std::to_string(seed));
@@ -3847,11 +3886,11 @@ TEST_F(TrieIndexDBTest, MultiLevelDeleteRangeRandomized) {
   ASSERT_OK(db_->Flush(FlushOptions()));
   ASSERT_NO_FATAL_FAILURE(verify_scan_consistency());
 
-  // Phase 5: Full compaction — all range tombstones should be resolved.
+  // Phase 5: Full compaction -- all range tombstones should be resolved.
   ASSERT_OK(db_->CompactRange(CompactRangeOptions(), nullptr, nullptr));
   ASSERT_NO_FATAL_FAILURE(verify_scan_consistency());
 
-  // Phase 6: Point lookups for a sample of keys — both indexes must agree.
+  // Phase 6: Point lookups for a sample of keys -- both indexes must agree.
   for (int i = 0; i < kMaxKey; i += 7) {
     std::string key = format_key(i);
     std::string std_val;
@@ -3869,8 +3908,8 @@ TEST_F(TrieIndexDBTest, MultiLevelDeleteRangeRandomized) {
 // Reverse iteration / direction switching tests
 // ============================================================================
 
-TEST_F(TrieIndexDBTest, ScanAfterCompactionWithDeletes) {
-  // Forward and reverse scans after compaction with deletions — verifies that
+TEST_P(TrieIndexDBTest, ScanAfterCompactionWithDeletes) {
+  // Forward and reverse scans after compaction with deletions -- verifies that
   // both scan directions produce correct results on compacted SSTs through
   // both indexes.
   options_.merge_operator = MergeOperators::CreateStringAppendOperator();
@@ -3906,7 +3945,7 @@ TEST_F(TrieIndexDBTest, ScanAfterCompactionWithDeletes) {
   ASSERT_NO_FATAL_FAILURE(VerifyScanBothIndexes(expected));
 }
 
-TEST_F(TrieIndexDBTest, ScanLargeDatasetAcrossBlocks) {
+TEST_P(TrieIndexDBTest, ScanLargeDatasetAcrossBlocks) {
   // Forward and reverse scans on a larger dataset spanning many blocks.
   ASSERT_OK(OpenDB(/*block_size=*/128));
 
@@ -3925,8 +3964,8 @@ TEST_F(TrieIndexDBTest, ScanLargeDatasetAcrossBlocks) {
   ASSERT_NO_FATAL_FAILURE(VerifyScanBothIndexes(expected));
 }
 
-TEST_F(TrieIndexDBTest, SeekForPrevAfterCompaction) {
-  // SeekForPrev on a compacted dataset — verifies boundary correctness.
+TEST_P(TrieIndexDBTest, SeekForPrevAfterCompaction) {
+  // SeekForPrev on a compacted dataset -- verifies boundary correctness.
   ASSERT_OK(OpenDB(/*block_size=*/128));
 
   for (int i = 0; i < 100; i += 2) {
@@ -3939,7 +3978,7 @@ TEST_F(TrieIndexDBTest, SeekForPrevAfterCompaction) {
   ASSERT_OK(db_->Flush(FlushOptions()));
   ASSERT_OK(db_->CompactRange(CompactRangeOptions(), nullptr, nullptr));
 
-  // SeekForPrev to odd keys (not present) — should land on the previous even.
+  // SeekForPrev to odd keys (not present) -- should land on the previous even.
   for (int i = 1; i < 100; i += 2) {
     char target[16];
     char expected_key[16];
@@ -3952,7 +3991,7 @@ TEST_F(TrieIndexDBTest, SeekForPrevAfterCompaction) {
   }
 }
 
-TEST_F(TrieIndexDBTest, PrevAfterSeekToFirstBothIndexes) {
+TEST_P(TrieIndexDBTest, PrevAfterSeekToFirstBothIndexes) {
   // Prev immediately after SeekToFirst should invalidate the iterator.
   ASSERT_OK(OpenDB());
 
@@ -3974,7 +4013,7 @@ TEST_F(TrieIndexDBTest, PrevAfterSeekToFirstBothIndexes) {
   }
 }
 
-TEST_F(TrieIndexDBTest, ForwardThenReverseDirection) {
+TEST_P(TrieIndexDBTest, ForwardThenReverseDirection) {
   // Interleave forward and reverse iteration to test direction switching.
   ASSERT_OK(OpenDB(/*block_size=*/64));
 
@@ -4026,7 +4065,7 @@ TEST_F(TrieIndexDBTest, ForwardThenReverseDirection) {
   }
 }
 
-TEST_F(TrieIndexDBTest, SeekToLastSingleEntry) {
+TEST_P(TrieIndexDBTest, SeekToLastSingleEntry) {
   // SeekToLast on a single-entry SST.
   ASSERT_OK(OpenDB());
 
@@ -4047,7 +4086,7 @@ TEST_F(TrieIndexDBTest, SeekToLastSingleEntry) {
   }
 }
 
-TEST_F(TrieIndexDBTest, ScanWithSnapshots) {
+TEST_P(TrieIndexDBTest, ScanWithSnapshots) {
   // Forward and reverse scans at different snapshot points must produce
   // consistent results through both indexes.
   ASSERT_OK(OpenDB());
@@ -4079,7 +4118,7 @@ TEST_F(TrieIndexDBTest, ScanWithSnapshots) {
   db_->ReleaseSnapshot(snap1);
 }
 
-TEST_F(TrieIndexDBTest, SeekForPrevVariableLengthKeys) {
+TEST_P(TrieIndexDBTest, SeekForPrevVariableLengthKeys) {
   // Verifies SeekForPrev with variable-length keys that mimic
   // the stress test's key format: 8-byte big-endian key number followed by
   // optional padding bytes (0x78 = 'x'). Variable lengths exercise the
@@ -4133,7 +4172,7 @@ TEST_F(TrieIndexDBTest, SeekForPrevVariableLengthKeys) {
   }
   ASSERT_OK(db_->Flush(FlushOptions()));
 
-  // SeekForPrev for every key — trie must match standard index.
+  // SeekForPrev for every key -- trie must match standard index.
   for (const auto& key : keys) {
     std::string std_result, trie_result;
     {
@@ -4182,6 +4221,254 @@ TEST_F(TrieIndexDBTest, SeekForPrevVariableLengthKeys) {
         << "SeekForPrev(" << target << ") diverged";
   }
 }
+
+// ============================================================================
+// Primary UDI backward compatibility test -- uses explicit mode, not
+// parameterized, because it tests the upgrade path from secondary to primary.
+// ============================================================================
+
+TEST_P(TrieIndexDBTest, PrimaryUDIBackwardCompatibility) {
+  // Verifies that SSTs written with UDI as secondary (both indexes present)
+  // can be read correctly when the DB is reopened with
+  // use_udi_as_primary_index. This is the upgrade path: old SSTs have both
+  // indexes, new config says "use UDI as primary for all reads."
+  ASSERT_OK(OpenDBSecondary(/*block_size=*/128));
+
+  for (int i = 0; i < 50; i++) {
+    char key[16];
+    char val[16];
+    snprintf(key, sizeof(key), "key_%04d", i);
+    snprintf(val, sizeof(val), "val_%04d", i);
+    ASSERT_OK(db_->Put(WriteOptions(), key, val));
+  }
+  ASSERT_OK(db_->Flush(FlushOptions()));
+
+  // Verify via trie (secondary mode -- explicit ReadOptions).
+  auto trie_keys = ScanAllKeys(TrieIndexReadOptions());
+  ASSERT_EQ(trie_keys.size(), 50u);
+
+  // Close and reopen with primary UDI config.
+  EXPECT_OK(db_->Close());
+  db_.reset();
+  ASSERT_OK(OpenDBPrimary(/*block_size=*/128));
+
+  // Now all reads automatically use UDI -- no ReadOptions::table_index_factory.
+  ReadOptions ro;
+  std::vector<std::string> keys;
+  std::unique_ptr<Iterator> iter(db_->NewIterator(ro));
+  for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
+    keys.push_back(iter->key().ToString());
+  }
+  ASSERT_OK(iter->status());
+  ASSERT_EQ(keys, trie_keys);
+
+  // Point lookups also work.
+  std::string value;
+  ASSERT_OK(db_->Get(ro, "key_0025", &value));
+  ASSERT_EQ(value, "val_0025");
+}
+
+// ============================================================================
+// Migration path and rollback tests
+// ============================================================================
+
+TEST_P(TrieIndexDBTest, MigrationFullPath) {
+  // Tests the complete recommended migration path:
+  // Step 1: No UDI → Step 2: UDI secondary → Step 3: Compact all SSTs →
+  // Step 4: UDI primary
+
+  // Step 1: Start without UDI. Write some data.
+  ASSERT_OK(OpenDBWithoutUDI(/*block_size=*/128));
+  for (int i = 0; i < 30; i++) {
+    char key[16];
+    char val[16];
+    snprintf(key, sizeof(key), "key_%04d", i);
+    snprintf(val, sizeof(val), "val_%04d", i);
+    ASSERT_OK(db_->Put(WriteOptions(), key, val));
+  }
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  ASSERT_OK(db_->Close());
+  db_.reset();
+
+  // Step 2: Enable UDI as secondary. Write more data.
+  ASSERT_OK(OpenDBSecondary(/*block_size=*/128));
+  for (int i = 30; i < 50; i++) {
+    char key[16];
+    char val[16];
+    snprintf(key, sizeof(key), "key_%04d", i);
+    snprintf(val, sizeof(val), "val_%04d", i);
+    ASSERT_OK(db_->Put(WriteOptions(), key, val));
+  }
+  ASSERT_OK(db_->Flush(FlushOptions()));
+
+  // Verify reads work through both indexes for the new SST.
+  std::string value;
+  ASSERT_OK(db_->Get(TrieIndexReadOptions(), "key_0035", &value));
+  ASSERT_EQ(value, "val_0035");
+  // Old SST (no UDI) readable through standard index.
+  ASSERT_OK(db_->Get(ReadOptions(), "key_0010", &value));
+  ASSERT_EQ(value, "val_0010");
+
+  // Step 3: Compact everything to rewrite all SSTs with UDI.
+  // Use bottommost_level_compaction to ensure ALL SSTs are rewritten.
+  CompactRangeOptions cro;
+  cro.bottommost_level_compaction = BottommostLevelCompaction::kForce;
+  ASSERT_OK(db_->CompactRange(cro, nullptr, nullptr));
+
+  // After compaction, all data is in SSTs with both indexes.
+  auto all_keys = ScanAllKeys(TrieIndexReadOptions());
+  ASSERT_EQ(all_keys.size(), 50u);
+
+  // Reopen in secondary mode to ensure the MANIFEST is clean -- old SST
+  // files from step 1 (without UDI) are fully purged.
+  ASSERT_OK(db_->Close());
+  db_.reset();
+  ASSERT_OK(OpenDBSecondary(/*block_size=*/128));
+  ASSERT_EQ(ScanAllKeys(TrieIndexReadOptions()).size(), 50u);
+  ASSERT_OK(db_->Close());
+  db_.reset();
+
+  // Step 4: Enable UDI as primary.
+  ASSERT_OK(OpenDBPrimary(/*block_size=*/128));
+
+  // All reads go through UDI automatically -- no table_index_factory needed.
+  ReadOptions ro;
+  std::vector<std::string> keys;
+  std::unique_ptr<Iterator> iter(db_->NewIterator(ro));
+  for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
+    keys.push_back(iter->key().ToString());
+  }
+  ASSERT_OK(iter->status());
+  ASSERT_EQ(keys, all_keys);
+
+  // Point lookups from all original data.
+  ASSERT_OK(db_->Get(ro, "key_0000", &value));
+  ASSERT_EQ(value, "val_0000");
+  ASSERT_OK(db_->Get(ro, "key_0049", &value));
+  ASSERT_EQ(value, "val_0049");
+}
+
+TEST_P(TrieIndexDBTest, MigrationPrimaryRejectsPreUDISSTs) {
+  // Verifies that enabling use_udi_as_primary_index on a DB with SSTs
+  // that have no UDI block fails at open time (not silently).
+  options_.disable_auto_compactions = true;
+
+  // Write SSTs without UDI.
+  ASSERT_OK(OpenDBWithoutUDI(/*block_size=*/128));
+  ASSERT_OK(db_->Put(WriteOptions(), "key_a", "val_a"));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  ASSERT_OK(db_->Close());
+  db_.reset();
+
+  // Try to open with UDI as primary -- should fail because the SST has no
+  // UDI block.
+  Status s = OpenDBPrimary(/*block_size=*/128);
+  ASSERT_TRUE(s.IsCorruption()) << s.ToString();
+}
+
+TEST_P(TrieIndexDBTest, RollbackFromPrimaryToSecondary) {
+  // Tests the rollback path: primary → compact with secondary → remove UDI.
+
+  // Start in primary mode. Write data.
+  ASSERT_OK(OpenDBPrimary(/*block_size=*/128));
+  for (int i = 0; i < 30; i++) {
+    char key[16];
+    char val[16];
+    snprintf(key, sizeof(key), "key_%04d", i);
+    snprintf(val, sizeof(val), "val_%04d", i);
+    ASSERT_OK(db_->Put(WriteOptions(), key, val));
+  }
+  ASSERT_OK(db_->Flush(FlushOptions()));
+
+  // Verify data is readable in primary mode.
+  ReadOptions ro;
+  std::string value;
+  ASSERT_OK(db_->Get(ro, "key_0015", &value));
+  ASSERT_EQ(value, "val_0015");
+  ASSERT_OK(db_->Close());
+  db_.reset();
+
+  // Rollback step 1: Reopen as secondary (with UDI factory still set).
+  // The primary-mode SSTs are readable because udi_written_as_primary=true
+  // in the table property causes the reader to use the trie automatically.
+  ASSERT_OK(OpenDBSecondary(/*block_size=*/128));
+
+  // Verify the primary-mode SST is readable through both paths.
+  ASSERT_OK(db_->Get(TrieIndexReadOptions(), "key_0015", &value));
+  ASSERT_EQ(value, "val_0015");
+  // Default ReadOptions also works because udi_is_primary_=true for this SST.
+  ASSERT_OK(db_->Get(ReadOptions(), "key_0015", &value));
+  ASSERT_EQ(value, "val_0015");
+
+  // Full scan to verify all data is accessible.
+  auto all_keys = ScanAllKeys(ReadOptions());
+  ASSERT_EQ(all_keys.size(), 30u);
+
+  // Rollback step 2: Compact to rewrite all SSTs with both indexes.
+  CompactRangeOptions cro;
+  cro.bottommost_level_compaction = BottommostLevelCompaction::kForce;
+  ASSERT_OK(db_->CompactRange(cro, nullptr, nullptr));
+
+  // Verify data is readable through trie after compaction.
+  ASSERT_OK(db_->Get(TrieIndexReadOptions(), "key_0015", &value));
+  ASSERT_EQ(value, "val_0015");
+
+  // Reopen to ensure old SSTs are fully purged and only the compacted
+  // output (with both indexes) remains.
+  ASSERT_OK(db_->Close());
+  db_.reset();
+  ASSERT_OK(OpenDBSecondary(/*block_size=*/128));
+
+  // Now all SSTs were written by secondary mode -- standard index works.
+  ASSERT_OK(db_->Get(ReadOptions(), "key_0015", &value));
+  ASSERT_EQ(value, "val_0015");
+  ASSERT_EQ(ScanAllKeys(ReadOptions()), all_keys);
+  ASSERT_OK(db_->Close());
+  db_.reset();
+
+  // Rollback step 3: Remove UDI entirely. SSTs have both indexes so
+  // the standard index works.
+  ASSERT_OK(OpenDBWithoutUDI(/*block_size=*/128));
+  ASSERT_OK(db_->Get(ReadOptions(), "key_0015", &value));
+  ASSERT_EQ(value, "val_0015");
+  ASSERT_EQ(ScanAllKeys(ReadOptions()), all_keys);
+}
+
+TEST_P(TrieIndexDBTest, RollbackFromPrimaryWithoutCompactFails) {
+  // Verifies that removing UDI from primary-mode SSTs WITHOUT compacting
+  // first fails (the stub standard index has no entries).
+  options_.disable_auto_compactions = true;
+
+  // Write SSTs in primary mode.
+  ASSERT_OK(OpenDBPrimary(/*block_size=*/128));
+  ASSERT_OK(db_->Put(WriteOptions(), "key_a", "val_a"));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  ASSERT_OK(db_->Close());
+  db_.reset();
+
+  // Try to open without UDI -- the SST has a stub standard index.
+  // The open itself may succeed (the stub is valid), but reads return nothing.
+  Status s = OpenDBWithoutUDI(/*block_size=*/128);
+  if (s.ok()) {
+    // DB opened, but reads through the stub index find nothing.
+    std::string value;
+    Status get_s = db_->Get(ReadOptions(), "key_a", &value);
+    ASSERT_TRUE(get_s.IsNotFound()) << get_s.ToString();
+
+    // Scan returns nothing -- data is effectively lost.
+    std::unique_ptr<Iterator> iter(db_->NewIterator(ReadOptions()));
+    iter->SeekToFirst();
+    ASSERT_FALSE(iter->Valid());
+    ASSERT_OK(iter->status());
+  }
+  // If open failed, that's also acceptable -- the SST is unusable without UDI.
+}
+
+// Run all parameterized tests in both UDI modes:
+// - Secondary (false): UDI is secondary, reads require table_index_factory
+// - Primary (true): UDI is primary, all reads use the trie by default
+INSTANTIATE_TEST_CASE_P(SecondaryAndPrimaryUDI, TrieIndexDBTest,
+                        ::testing::Bool());
 
 }  // namespace trie_index
 }  // namespace ROCKSDB_NAMESPACE

--- a/utilities/trie_index/trie_index_factory.cc
+++ b/utilities/trie_index/trie_index_factory.cc
@@ -138,6 +138,7 @@ Slice TrieIndexBuilder::AddIndexEntry(const Slice& last_key_in_current_block,
     entry.tag = NonBoundaryTag();
   }
   entry.handle = handle;
+  total_separator_bytes_ += entry.separator_key.size();
   buffered_entries_.push_back(std::move(entry));
 
   return separator;
@@ -239,6 +240,14 @@ Status TrieIndexBuilder::Finish(Slice* index_contents) {
 // ============================================================================
 // TrieIndexIterator
 // ============================================================================
+
+uint64_t TrieIndexBuilder::EstimatedSize() const {
+  // Estimate the serialized trie size from the running counters. A LOUDS trie
+  // uses ~2.5 bits per node plus the label data, rank/select tables, and block
+  // handle arrays. For a rough estimate:
+  // ~3 bytes per unique key byte + 16 bytes per entry for handles/metadata.
+  return total_separator_bytes_ * 3 + buffered_entries_.size() * 16;
+}
 
 TrieIndexIterator::TrieIndexIterator(const LoudsTrie* trie,
                                      const Comparator* comparator,

--- a/utilities/trie_index/trie_index_factory.h
+++ b/utilities/trie_index/trie_index_factory.h
@@ -79,6 +79,9 @@ class TrieIndexBuilder final : public UserDefinedIndexBuilder {
   // Finalize the trie and return the serialized index data.
   Status Finish(Slice* index_contents) override;
 
+  // Returns an estimate of the current serialized index size.
+  uint64_t EstimatedSize() const override;
+
  private:
   const Comparator* comparator_;
   LoudsTrieBuilder trie_builder_;
@@ -117,6 +120,8 @@ class TrieIndexBuilder final : public UserDefinedIndexBuilder {
     TrieBlockHandle handle;
   };
   std::vector<BufferedEntry> buffered_entries_;
+  // Running total of separator key bytes for O(1) EstimatedSize().
+  uint64_t total_separator_bytes_ = 0;
 };
 
 // ============================================================================


### PR DESCRIPTION
Add use_udi_as_primary_index option to BlockBasedTableOptions. When
enabled, the UDI becomes the primary index — the standard binary search
index is not populated (only a stub is written for SST footer
compatibility). All reads automatically route through the UDI without
needing ReadOptions::table_index_factory.

Write path:
- UserDefinedIndexBuilderWrapper skips AddIndexEntry/OnKeyAdded on the
  internal builder when UDI is primary, saving ~50% of index build CPU
- The internal builder's Finish() still runs to produce a stub index
  block for the SST footer format
- New udi_is_primary_index table property marks primary-mode SSTs
- Validates incompatible options: partitioned index, partitioned filters,
  missing user_defined_index_factory

Read path:
- UserDefinedIndexReaderWrapper defaults to UDI when udi_is_primary_,
  even when ReadOptions::table_index_factory is null
- Distinguishes udi_is_primary_ (read dispatch) from
  udi_written_as_primary_ (cache lifecycle) to correctly handle old SSTs
  with both indexes opened under the new primary config
- CacheDependencies skips only for SSTs written as primary (stub index)
- EraseFromCacheBeforeDestruction always runs (stub may be cached)
- use_udi_as_primary_index automatically enforces fail_if_no_udi_on_open
  to prevent silent data loss if SSTs are opened by old RocksDB versions
  without UDI support

Public API:
- BlockBasedTableOptions::use_udi_as_primary_index (default: false)
- UserDefinedIndexBuilder::EstimatedSize() for compaction file sizing
  when standard builder is absent — O(1) via running counter

Stress test:
- New use_udi_as_primary_index flag, randomized by db_crashtest.py
- Both primary and secondary UDI modes exercised in crash tests

Tests:
- Parameterized TrieIndexDBTest on UDI mode (secondary vs primary) —
  all 66 tests run in both modes (132 total)
- PrimaryUDIBackwardCompatibility test for the upgrade path from
  secondary to primary

the first 3 commits is coming from https://github.com/facebook/rocksdb/pull/14466 , the last commit is for the primary index.