### PR TITLE
docs: add core engine documentation — compaction, sst_table_format

### DIFF
--- a/docs/components/compaction/01_overview.md
+++ b/docs/components/compaction/01_overview.md
@@ -1,0 +1,129 @@
+# Compaction Overview
+
+**Files:** `db/compaction/compaction.h`, `db/compaction/compaction.cc`, `db/compaction/compaction_picker.h`, `db/compaction/compaction_picker.cc`, `db/compaction/compaction_job.h`, `db/compaction/compaction_job.cc`, `include/rocksdb/advanced_options.h`
+
+## What Is Compaction
+
+Compaction is the background process that maintains the LSM-tree structure by merging SST files across levels. Its primary goals are:
+
+- **Reclaim space**: Remove obsolete key versions, deleted keys, and expired entries
+- **Reduce read amplification**: Consolidate data so reads need to examine fewer files
+- **Enforce level size targets**: Keep each level within its configured byte budget
+- **Apply compaction filters**: Execute user-defined transformations or deletions during the merge
+
+RocksDB supports three compaction styles, configured via `compaction_style` in `ColumnFamilyOptions` (see `include/rocksdb/advanced_options.h`):
+
+| Style | Enum Value | Picker Class | Strategy |
+|-------|-----------|--------------|----------|
+| Level | `kCompactionStyleLevel` | `LevelCompactionPicker` | Size-based per-level targets with sorted, non-overlapping files per level (L1+) |
+| Universal | `kCompactionStyleUniversal` | `UniversalCompactionPicker` | Size-tiered: merges sorted runs based on size ratios and space amplification |
+| FIFO | `kCompactionStyleFIFO` | `FIFOCompactionPicker` | Delete oldest files when total size exceeds a threshold |
+| None | `kCompactionStyleNone` | `NullCompactionPicker` | No automatic compaction; manual `CompactFiles()` only |
+
+## Compaction Pipeline
+
+Every compaction begins with picking, but execution varies by type. `DBImpl::BackgroundCompaction()` in `db/db_impl/db_impl_compaction_flush.cc` dispatches to different execution paths:
+
+**Phase 1: Pick** -- `CompactionPicker::PickCompaction()` examines `VersionStorageInfo` and selects input files. The result is a `Compaction` object containing metadata about what to compact. This runs under the DB mutex.
+
+**Phase 2: Execute** -- The execution path depends on the compaction type:
+
+| Path | Condition | What Happens |
+|------|-----------|--------------|
+| FIFO deletion | `deletion_compaction()` is true | Input files are deleted directly via `VersionEdit`. No data is read or written. |
+| FIFO temperature-change trivial copy | `is_trivial_copy_compaction()` is true | Files are copied to new file numbers with the target temperature. No merge. |
+| Trivial move | `IsTrivialMove()` is true | `PerformTrivialMove()` updates MANIFEST only. No data is read or written. |
+| Full merge compaction | All other cases | `CompactionJob` executes the merge (see below). |
+
+Only the full merge path uses `CompactionJob`, which has three sub-phases:
+
+1. `Prepare()` (mutex held): Divide the key range into subcompaction boundaries, set up sequence-number-to-time mapping
+2. `Run()` (mutex released): Execute subcompactions in parallel. Each subcompaction reads input files through a `CompactionMergingIterator`, processes keys through `CompactionIterator` (dedup, deletion, merge, filter), and writes output SST files via `CompactionOutputs`
+3. `Install()` (mutex held): Apply the `VersionEdit` via `LogAndApply()` to install the new version
+
+**Phase 3: Cleanup** -- Input files are released and their `being_compacted` flag is cleared. Compaction scores are recomputed.
+
+## Compaction Triggers
+
+Compaction is triggered by different mechanisms depending on the compaction style. For leveled compaction, the triggers are evaluated in the following priority order by `LevelCompactionBuilder::SetupInitialFiles()` (see `db/compaction/compaction_picker_level.cc`):
+
+| Priority | Trigger | Compaction Reason | Description |
+|----------|---------|-------------------|-------------|
+| 1 | Score >= 1.0 | `kLevelL0FilesNum` (L0) or `kLevelMaxLevelSize` (L1+) | Level exceeds its size target or L0 file count threshold |
+| 2 | Intra-L0 | `kLevelL0FilesNum` | When L0-to-base is blocked, compact within L0 to reduce file count |
+| 3 | Marked for compaction | `kFilesMarkedForCompaction` | Files flagged by table property collectors |
+| 4 | Bottommost files | `kBottommostFiles` | Bottommost files with obsolete tombstones |
+| 5 | TTL | `kRoundRobinTtl` or `kTtl` | Files with data older than configured TTL |
+| 6 | Periodic | `kPeriodicCompaction` | Files older than `periodic_compaction_seconds` |
+| 7 | Forced blob GC | `kForcedBlobGC` | Files with high blob garbage ratio |
+
+## Compaction Score Calculation
+
+Compaction scores determine which levels need compaction and in what order. Scores are computed by `VersionStorageInfo::ComputeCompactionScore()` in `db/version_set.cc`. A score >= 1.0 indicates the level needs compaction.
+
+### L0 Score
+
+For leveled compaction, the L0 score considers both file count and size:
+
+- **File count component**: `num_sorted_runs / level0_file_num_compaction_trigger`
+- **Size component** (with `level_compaction_dynamic_level_bytes`):
+  - If L0 total size >= `max_bytes_for_level_base`, score is at least 1.01
+  - If L0 total size > actual base level size, score is `L0_size / max(base_level_size, base_level_target)`
+  - Scores above 1.0 are scaled by 10x for prioritization granularity
+
+- **Size component** (without dynamic level bytes): `total_size / max_bytes_for_level_base`
+
+The L0 score is the maximum of the file count and size components.
+
+### L1+ Score
+
+For levels 1 and above, the score depends on whether dynamic level bytes is enabled:
+
+- **Without dynamic level bytes**: `level_bytes_no_compacting / MaxBytesForLevel(level)`
+- **With dynamic level bytes**:
+  - If level is below target: `level_bytes_no_compacting / MaxBytesForLevel(level)` (less than 1.0, so no compaction triggered)
+  - If level is at or above target: `level_bytes_no_compacting / (MaxBytesForLevel(level) + total_downcompact_bytes) * 10.0`. The `total_downcompact_bytes` term accounts for data being compacted down from higher levels, de-prioritizing compaction from a level that is about to receive significant incoming data
+  - If the level is an unnecessary level (exists below the computed base level), its score is boosted to at least `10.0 * (1.001 + 0.001 * depth)` to drain the level
+
+Scores are sorted in descending order so the highest-priority level is processed first. Only files not currently `being_compacted` are counted toward a level's byte total.
+
+## The Compaction Object
+
+A `Compaction` object is a metadata container created by `CompactionPicker` and consumed by `CompactionJob`. See `Compaction` in `db/compaction/compaction.h`.
+
+Key properties:
+
+| Property | Description |
+|----------|-------------|
+| `inputs_` | Input files organized by level, as `vector<CompactionInputFiles>` |
+| `start_level_` / `output_level_` | Source and destination levels |
+| `target_output_file_size_` | Target size for each output file |
+| `max_compaction_bytes_` | Maximum total compaction size (limits grandparent overlap) |
+| `grandparents_` | Files at `output_level_ + 1`, used for output file splitting |
+| `score_` | The compaction score that triggered this compaction |
+| `compaction_reason_` | Why this compaction was triggered (see `CompactionReason` enum) |
+| `bottommost_level_` | True if no data in the key range exists below the output level |
+| `deletion_compaction_` | True if the compaction can be done by just deleting input files |
+
+### CompactionInputFiles
+
+Input files are grouped by level using the `CompactionInputFiles` struct (see `db/compaction/compaction.h`):
+
+- `level`: The physical level number
+- `files`: Vector of `FileMetaData*` pointers to the input files
+- `atomic_compaction_unit_boundaries`: Boundaries for range tombstone truncation where neighboring SSTs on the same level share user-key boundaries
+
+### Tracking Running Compactions
+
+`CompactionPicker` tracks running compactions via `RegisterCompaction()` / `UnregisterCompaction()` to prevent conflicts:
+
+- `level0_compactions_in_progress_`: An ordered set tracking L0 compactions. For leveled compaction, at most one L0-to-base compaction runs at a time. However, `PickSizeBasedIntraL0Compaction()` can still pick an intra-L0 compaction while an L0-to-base compaction is running.
+- `compactions_in_progress_`: An unordered set tracking all running compactions across all levels. Used by `FilesRangeOverlapWithCompaction()` to detect output-range conflicts.
+
+## Interactions With Other Components
+
+- **Flush**: Flush produces L0 files that trigger compaction. After each flush, compaction scores are recomputed.
+- **Version Management**: Compaction reads from a pinned `Version`, produces `VersionEdit`s, and installs a new Version via `LogAndApply()`.
+- **Write Flow**: When compaction falls behind, `WriteController` throttles or stalls writes. The `estimated_compaction_needed_bytes` metric drives write delay decisions.
+- **SST Format**: `CompactionJob` reads SST files via `TableReader` iterators and writes new ones via the configured `table_factory`.
+- **Cache**: Compaction reads typically bypass the block cache (`fill_cache=false`) to avoid polluting it with cold data being compacted.

--- a/docs/components/compaction/02_leveled_compaction.md
+++ b/docs/components/compaction/02_leveled_compaction.md
@@ -1,0 +1,106 @@
+# Leveled Compaction
+
+**Files:** `db/compaction/compaction_picker_level.h`, `db/compaction/compaction_picker_level.cc`, `db/compaction/compaction_picker.h`, `db/compaction/compaction_picker.cc`, `db/version_set.cc`, `include/rocksdb/advanced_options.h`
+
+## How Leveled Compaction Works
+
+Leveled compaction organizes data into a hierarchy of levels where each level (L1 and below) maintains sorted, non-overlapping SST files. L0 is the exception -- files flushed from memtable are placed in L0 and may overlap with each other.
+
+The key principle is that each level has a target size. When a level exceeds its target, one or more files are selected and merged with overlapping files in the next level. This produces new sorted, non-overlapping files at the next level.
+
+### Level Structure
+
+| Level | Overlap | Sorted | Target Size |
+|-------|---------|--------|-------------|
+| L0 | Files may overlap | Files sorted internally, but not across files | Bounded by file count (`level0_file_num_compaction_trigger`) |
+| L1 (base level) | Non-overlapping | Globally sorted | `max_bytes_for_level_base` (or dynamically computed) |
+| L2..Ln-1 | Non-overlapping | Globally sorted | Previous level target * `max_bytes_for_level_multiplier` |
+| Ln (last level) | Non-overlapping | Globally sorted | Unbounded (holds the bulk of data) |
+
+With `level_compaction_dynamic_level_bytes=true` (see `ColumnFamilyOptions` in `include/rocksdb/advanced_options.h`), the base level may not be L1. See the Dynamic Levels chapter for details.
+
+## The Picking Algorithm
+
+`LevelCompactionPicker::PickCompaction()` delegates to `LevelCompactionBuilder::PickCompaction()` in `db/compaction/compaction_picker_level.cc`. The algorithm proceeds in four steps:
+
+### Step 1: SetupInitialFiles
+
+This selects the start level and initial file(s) to compact. The algorithm iterates through levels sorted by descending compaction score:
+
+1. For each level with score >= 1.0, attempt to pick a file via `PickFileToCompact()`:
+   - L0 compacts to the base level (`vstorage->base_level()`)
+   - L1+ compact to the next level (`start_level + 1`)
+2. If L0 picking fails (e.g., another L0 compaction is running), attempt intra-L0 compaction via `PickIntraL0Compaction()`
+3. If no score-based compaction is needed (all scores < 1.0), fall back to secondary triggers (files marked for compaction, bottommost files, TTL, periodic, blob GC)
+
+Important: If L0-to-base compaction was skipped, base-level-to-next compactions are also skipped to prevent L0-to-base starvation.
+
+### Step 2: SetupOtherL0FilesIfNeeded
+
+If the initial file is from L0 and the output is not L0 (i.e., not intra-L0), `GetOverlappingL0Files()` pulls in all L0 files that overlap the initial file's key range. This is necessary because L0 files can overlap each other, and compacting just one could leave stale versions in remaining L0 files.
+
+### Step 3: SetupOtherInputsIfNeeded
+
+This expands the compaction to include files from the output level:
+
+1. If round-robin compaction priority is active, `SetupOtherFilesWithRoundRobinExpansion()` attempts to add more consecutive files from the start level
+2. `SetupOtherInputs()` (in `compaction_picker.cc`) finds overlapping files at the output level, optionally re-expands the start-level inputs to include more files without increasing the output-level file set, and computes grandparent files
+3. The method checks for conflicts with running compactions via `FilesRangeOverlapWithCompaction()`
+
+### Step 4: GetCompaction
+
+Creates the final `Compaction` object with all inputs, compression settings, and target file sizes. After creation, the compaction is registered and compaction scores are recomputed.
+
+## L0 Compaction Specifics
+
+L0 receives special treatment because its files may overlap:
+
+- **Single L0-to-base compaction at a time**: Leveled compaction allows at most one L0-to-base compaction concurrently. This is enforced by checking `level0_compactions_in_progress_` in `CompactionPicker`. However, a size-based intra-L0 compaction can still run concurrently with an L0-to-base compaction (see below).
+- **L0 trivial move**: Before normal picking, `TryPickL0TrivialMove()` attempts to move non-overlapping L0 files directly to the base level. This is attempted when: the base level is not empty, `compression_per_level` is not configured, and there is only one DB path. Files are scanned oldest-to-newest, accumulating non-overlapping files that have no overlap with the base level.
+- **Intra-L0 compaction**: When L0-to-base is blocked, intra-L0 compaction merges L0 files to reduce file count. Two strategies are used:
+  - **Cost-based** (`PickIntraL0Compaction()`): Requires `level0_file_num_compaction_trigger + 2` files. Uses `PickCostBasedIntraL0Compaction()` which finds the longest span of non-compacting L0 files where work-per-deleted-file decreases.
+  - **Size-based** (`PickSizeBasedIntraL0Compaction()`): Triggered when L0 compensated size is small relative to the base level (less than `base_level_size / (2 * max_bytes_for_level_multiplier)`). This avoids inefficient L0-to-base compactions when the write amplification would be too high.
+
+## Clean Cut Expansion
+
+A critical invariant is that compaction inputs must form a "clean cut" -- no version of any user key can be partially included across input files. `ExpandInputsToCleanCut()` (in `compaction_picker.cc`) enforces this:
+
+1. Scans files at the input level in both directions from the initially selected files
+2. Adds any file whose user-key range touches the boundary of already-selected files
+3. Repeats until no more expansions are needed or a conflict is found (e.g., a file being compacted)
+
+This prevents a compaction from splitting different versions of the same user key across levels, which would cause incorrect read results.
+
+## Output File Splitting
+
+When writing output files, `CompactionOutputs::ShouldStopBefore()` decides when to start a new output file. The criteria include:
+
+| Criterion | Description |
+|-----------|-------------|
+| Target file size | When `estimated_file_size >= max_output_file_size()` |
+| Grandparent overlap | When overlap with grandparent files (output_level + 1) plus current file size exceeds `max_compaction_bytes` |
+| Grandparent pre-cut | Adaptive threshold (50-90% of target size) at grandparent boundaries to produce more uniform file sizes |
+| Grandparent skippable boundary | Cut when crossing a grandparent boundary if the resulting file would be > 1/8 of target size |
+| SST partitioner | User-provided `SstPartitioner` callback requests a split |
+| Round-robin split key | Split at the compact cursor position for round-robin policy |
+| TTL-based cutting | Isolate age ranges for TTL-driven compaction |
+
+The grandparent pre-cut and skippable boundary heuristics implement the "compaction output file alignment" optimization (always enabled for leveled compaction since RocksDB 9.0). By cutting output files at next-level file boundaries, the algorithm avoids redundant re-compaction of partially overlapping data in future compactions. On average, this reduces compaction write amplification by approximately 12% in benchmarks, at the cost of more varied file sizes (50%-200% of `target_file_size_base`). The optimization only applies to non-bottommost-level files.
+
+The grandparent overlap tracking is important for controlling future compaction cost: if an output file overlaps too many grandparent files, the next compaction of that file will be expensive.
+
+## Key Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `level0_file_num_compaction_trigger` | 4 | Number of L0 files to trigger compaction |
+| `max_bytes_for_level_base` | 256 MB | Target size for the base level |
+| `max_bytes_for_level_multiplier` | 10.0 | Size multiplier between adjacent levels |
+| `level_compaction_dynamic_level_bytes` | true | Dynamically adjust base level and level targets |
+| `max_compaction_bytes` | `target_file_size_base * 25` | Maximum bytes in a single compaction |
+| `target_file_size_base` | 64 MB | Target size for output SST files at L1 |
+| `target_file_size_multiplier` | 1 | Multiplier for target file size per level |
+| `compaction_pri` | `kMinOverlappingRatio` | File selection priority within a level |
+| `num_levels` | 7 | Total number of levels in the LSM-tree |
+
+All options are defined in `ColumnFamilyOptions` in `include/rocksdb/advanced_options.h`.

--- a/docs/components/compaction/03_file_selection_and_priority.md
+++ b/docs/components/compaction/03_file_selection_and_priority.md
@@ -1,0 +1,100 @@
+# File Selection and Priority
+
+**Files:** `include/rocksdb/advanced_options.h`, `db/version_set.cc`, `db/compaction/compaction_picker_level.cc`, `db/compaction/file_pri.h`
+
+## CompactionPri Options
+
+The `compaction_pri` option (see `CompactionPri` enum in `include/rocksdb/advanced_options.h`) controls which file within a level is selected first for compaction. The default is `kMinOverlappingRatio`.
+
+| Priority | Enum | Sorting Criterion | Best For |
+|----------|------|-------------------|----------|
+| By compensated size | `kByCompensatedSize` | Largest `compensated_file_size` first | General workloads; slightly favors files with many deletions |
+| Oldest largest seq | `kOldestLargestSeqFirst` | Smallest `largest_seqno` first | Hot-key workloads where recently updated files should be skipped |
+| Oldest smallest seq | `kOldestSmallestSeqFirst` | Smallest `smallest_seqno` first | Random-write workloads where compacting the oldest data reduces write amplification |
+| Min overlapping ratio | `kMinOverlappingRatio` | Smallest ratio of overlapping bytes in next level to file size | Most workloads; minimizes write amplification by picking files that overlap least with the next level |
+| Round robin | `kRoundRobin` | Next file after the compact cursor | Workloads that benefit from uniform compaction coverage across the key space |
+
+## How File Ordering Works
+
+File ordering is computed by `VersionStorageInfo::UpdateFilesByCompactionPri()` in `db/version_set.cc`. For each level (except the last), files are sorted according to the active `compaction_pri` into the `files_by_compaction_pri_` vector. The picker then iterates this vector to find the first eligible file.
+
+### kByCompensatedSize
+
+Uses `std::partial_sort` to find the top `kNumberFilesToSort` files sorted by `compensated_file_size` in descending order. The compensated file size adds a bonus for files with many deletions (tombstones), encouraging their compaction to reclaim space sooner.
+
+### kOldestLargestSeqFirst
+
+Fully sorts files by `largest_seqno` in ascending order. Files whose most recent update is oldest are compacted first. This is useful for workloads with temporal locality where recently written files are likely to be updated again.
+
+### kOldestSmallestSeqFirst
+
+Fully sorts files by `smallest_seqno` in ascending order. Files containing the oldest data are compacted first. With random writes, this tends to produce slightly better write amplification than `kOldestLargestSeqFirst`.
+
+### kMinOverlappingRatio
+
+Implemented by `SortFileByOverlappingRatio()` in `db/version_set.cc`. For each file, the algorithm:
+
+1. Scans files in the next level to compute `overlapping_bytes` (total size of next-level files whose key range overlaps this file)
+2. Computes a score: `overlapping_bytes * 1024 / compensated_file_size / ttl_boost_score`
+3. Uses `std::partial_sort` to sort by this score in ascending order (lowest overlap ratio first)
+
+**TTL boosting**: When TTL is configured, `FileTtlBooster` (see `db/compaction/file_pri.h`) gives higher priority to files approaching their TTL expiration. The boost activates after a file has aged past half the TTL and increases linearly. Different levels begin boosting at staggered thresholds, with deeper levels starting earlier, to avoid cascading compactions.
+
+**Tie-breaking**: When two files have the same overlap ratio, the file whose smallest key sorts first (by `InternalKeyComparator`) is preferred. This makes the algorithm deterministic and helps trivial move extend to adjacent files.
+
+**Marked-for-compaction priority**: Files with `marked_for_compaction=true` are sorted before unmarked files, regardless of their overlap ratio.
+
+### kRoundRobin
+
+Implemented by `SortFileByRoundRobin()` in `db/version_set.cc`. Uses a compact cursor that tracks the key position where the last compaction for this level ended:
+
+1. Find the file whose smallest key is at or after the compact cursor
+2. Rotate the file order so this file comes first, followed by files with larger keys, wrapping around to files with the smallest keys
+
+The compact cursor is stored per-level in `VersionStorageInfo::compact_cursor_` and updated after each compaction at that level.
+
+For L0, round-robin only applies when L0 files are non-overlapping. If L0 files overlap, the round-robin ordering falls back to the natural file order.
+
+## The File Picking Process
+
+`LevelCompactionBuilder::PickFileToCompact()` in `db/compaction/compaction_picker_level.cc` iterates through the priority-sorted file list:
+
+1. Skip files that are already being compacted (`being_compacted == true`)
+2. For round-robin priority, if any file is being compacted, the picker stops immediately (the cursor cannot advance past an in-progress compaction)
+3. Add the candidate file to `start_level_inputs_`
+4. Call `ExpandInputsToCleanCut()` to ensure the input set respects user-key boundaries
+5. Check `FilesRangeOverlapWithCompaction()` to verify the candidate does not conflict with running compactions at the output level
+6. If the output level has no overlapping files, attempt `TryExtendNonL0TrivialMove()` to include additional adjacent files for a multi-file trivial move
+7. If valid, record the candidate as the compaction input
+
+The `NextCompactionIndex` optimization (for non-round-robin priorities) remembers which file index was tried last, so subsequent calls skip already-examined files.
+
+## Round-Robin Expansion
+
+When round-robin priority picks a file for a score-based compaction (`kLevelMaxLevelSize`), `SetupOtherFilesWithRoundRobinExpansion()` attempts to include additional consecutive files from the start level. This produces larger compactions that can bring the level closer to its target in one operation.
+
+The expansion obeys five constraints:
+
+1. **Consecutive files only**: Files must be adjacent in the sorted order; stop at any gap or compacting file
+2. **Max compaction bytes**: Total input (start level + output level) must not exceed `max_compaction_bytes`
+3. **Level target**: Stop expanding once enough bytes are included to bring the level below its `MaxBytesForLevel()` target
+4. **Trivial move preference**: If the initial file has no overlap with the output level, attempt trivial move extension instead
+5. **Clean cut**: Each expansion step must produce a clean cut (no split user keys)
+
+## Intra-L0 File Selection
+
+When L0-to-base compaction is blocked, the picker falls back to intra-L0 compaction. Two variants exist:
+
+### Cost-Based Intra-L0
+
+`PickCostBasedIntraL0Compaction()` (see `db/compaction/compaction_picker.cc`) finds the longest span of L0 files (starting from the newest) where:
+- At least `kMinFilesForIntraL0Compaction` (4) files are included
+- No file in the span is currently being compacted
+- Total compensated size does not exceed `max_compaction_bytes`
+- Adding each file reduces the cost (work per deleted file)
+
+This is triggered when L0 has at least `level0_file_num_compaction_trigger + 2` files.
+
+### Size-Based Intra-L0
+
+`PickSizeBasedIntraL0Compaction()` compacts L0 files when the base level is large relative to L0. The condition is: `base_level_size > L0_compensated_size * max(10, max_bytes_for_level_multiplier) * 2`. This avoids L0-to-base compactions that would have high write amplification due to the large size disparity.

--- a/docs/components/compaction/04_dynamic_levels.md
+++ b/docs/components/compaction/04_dynamic_levels.md
@@ -1,0 +1,92 @@
+# Dynamic Level Size Calculation
+
+**Files:** `db/version_set.cc`, `include/rocksdb/advanced_options.h`
+
+## Motivation
+
+Without dynamic level bytes, the level size targets are fixed: L1 = `max_bytes_for_level_base`, L2 = L1 * `max_bytes_for_level_multiplier`, and so on. This creates a problem when the database is small or growing: the lower levels may be mostly empty while data accumulates in levels that are already below their fixed targets, leading to wasted compaction work and space amplification.
+
+Dynamic level bytes (enabled via `level_compaction_dynamic_level_bytes` in `ColumnFamilyOptions`, see `include/rocksdb/advanced_options.h`) solves this by computing level targets from the actual data size, working backwards from the largest level. This ensures the multiplier ratio is maintained from the bottom up, and the base level (the level L0 compacts into) adjusts automatically.
+
+## The Algorithm
+
+`VersionStorageInfo::CalculateBaseBytes()` in `db/version_set.cc` implements the dynamic level calculation. The algorithm works in several stages:
+
+### Stage 1: Find Maximum Level Size
+
+Scan all non-L0 levels to find:
+- `max_level_size`: The largest level by total file size
+- `first_non_empty_level`: The first level after L0 that contains any files
+
+### Stage 2: Determine Base Level
+
+Working backward from the largest level, divide by `max_bytes_for_level_multiplier` at each step to compute what the base level's target would be if the last level's target equals `max_level_size`:
+
+- Compute `base_bytes_max = max_bytes_for_level_base`
+- Compute `base_bytes_min = base_bytes_max / max_bytes_for_level_multiplier`
+- Iteratively divide `cur_level_size` by `max_bytes_for_level_multiplier` from `num_levels - 2` down to `first_non_empty_level`
+
+Two cases emerge:
+
+**Case 1 -- Small database** (`cur_level_size <= base_bytes_min`): The data is small enough that even with the multiplier applied, the base level target is below `base_bytes_min`. In this case, the base level is set to `first_non_empty_level` with target `base_bytes_min + 1`. All levels between L1 and the base level are marked as unnecessary.
+
+**Case 2 -- Normal database** (`cur_level_size > base_bytes_min`): Starting from `first_non_empty_level`, walk upward while `cur_level_size > base_bytes_max` to find where the base level should be. The base level is set to the highest level where the computed target fits within `base_bytes_max`.
+
+### Stage 3: Compute Level Targets
+
+Starting from the base level, apply the multiplier to compute each level's target:
+
+- `level_max_bytes_[base_level] = base_level_size`
+- `level_max_bytes_[i] = level_max_bytes_[i-1] * max_bytes_for_level_multiplier` for `i > base_level`
+- Each level target is clamped to be at least `base_bytes_max` to prevent an hourglass shape where L1+ targets are smaller than L0
+
+Levels below the base level have their targets set to `uint64_t::max` (infinity). While this means the normal score calculation (`level_size / target_size`) produces a near-zero score, `ComputeCompactionScore()` explicitly boosts scores for unnecessary levels (see Stage 4 below), so non-empty unnecessary levels ARE proactively drained.
+
+### Stage 4: Identify Unnecessary Levels
+
+Levels between L1 and the base level are "unnecessary" -- they exist from a time when the database was larger or had different settings. The `lowest_unnecessary_level_` field tracks the deepest such level. During compaction score computation, these levels receive boosted scores (at least `10.0 * (1.001 + 0.001 * depth)`) to drain them efficiently.
+
+Note: When `preclude_last_level_data_seconds > 0` (per-key-placement), the proximal level (last level - 1) is never considered unnecessary, since it serves as the output destination for recent data.
+
+## How Base Level Changes Over Time
+
+As the database grows, the base level can shift:
+
+1. **Empty database**: Base level = `num_levels - 1` (last level). L0 compacts directly to the last level.
+2. **Small database**: Base level moves upward as data grows. For example, with `max_bytes_for_level_multiplier=10` and `max_bytes_for_level_base=256MB`, the base shifts from L6 to L5 when the last level exceeds `max_bytes_for_level_base` (256 MB). This is because the algorithm divides the last level size by the multiplier to compute the implied base level target; when that target exceeds `max_bytes_for_level_base`, a new intermediate level is needed.
+3. **Large database**: Base level stabilizes at L1 when the data is large enough that all intermediate levels are needed to maintain the multiplier ratio.
+
+This progression means that early in a database's life, L0 compacts to a high level with few intermediate merges, giving low write amplification. As the database grows, more levels become active and write amplification increases toward the steady-state theoretical minimum.
+
+## Score Computation with Dynamic Levels
+
+The compaction score computation in `ComputeCompactionScore()` (see `db/version_set.cc`) has dynamic-level-specific logic:
+
+### L0 Score Adjustments
+
+- If L0 total size >= `max_bytes_for_level_base`, the score is at least 1.01. This ensures L0 data is compacted down even when the file count is below the trigger.
+- If L0 total size > the actual base level size, the score is boosted to `L0_size / max(base_level_size, base_level_target)`. This prioritizes L0-to-base compaction when L0 is growing faster than the base level can absorb.
+- Scores above 1.0 are scaled by 10x to provide prioritization granularity.
+
+### L1+ Score Adjustments
+
+- When the level is below its target, the standard ratio `level_size / target_size` applies (score < 1.0, no compaction).
+- When the level is at or above its target, the score incorporates `total_downcompact_bytes` -- the estimated bytes being compacted down from all levels above: `level_size / (target_size + total_downcompact_bytes) * 10.0`. This de-prioritizes a level that is about to receive incoming data, preventing compaction pile-ups.
+- Unnecessary levels receive boosted scores to ensure they are drained. The boost includes a small per-level offset to prioritize draining the deepest unnecessary level first.
+
+## Impact on Compression
+
+With dynamic level bytes, `compression_per_level` indexing changes: `compression_per_level[0]` applies to L0, and `compression_per_level[i]` (for i > 0) applies to `base_level + i - 1`, not physical level i. This ensures that the compression settings follow the logical level structure rather than the physical level numbers. See `GetCompressionType()` in `db/compaction/compaction_picker.cc`.
+
+## Configuration
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `level_compaction_dynamic_level_bytes` | `true` | Enable dynamic level byte computation |
+| `max_bytes_for_level_base` | 256 MB | Target size for the base level |
+| `max_bytes_for_level_multiplier` | 10.0 | Size ratio between adjacent levels |
+| `max_bytes_for_level_multiplier_additional` | all 1 | Per-level multiplier adjustments (ignored when dynamic level bytes is enabled) |
+
+All options are defined in `ColumnFamilyOptions` in `include/rocksdb/advanced_options.h`.
+
+Important: When dynamic level bytes is enabled, `max_bytes_for_level_multiplier_additional` is not used. The level multiplier is uniform across all levels.

--- a/docs/components/compaction/05_trivial_move.md
+++ b/docs/components/compaction/05_trivial_move.md
@@ -1,0 +1,95 @@
+# Trivial Move Optimization
+
+**Files:** `db/compaction/compaction.h`, `db/compaction/compaction.cc`, `db/compaction/compaction_picker_level.cc`, `db/db_impl/db_impl_compaction_flush.cc`
+
+## What Is Trivial Move
+
+Trivial move is an optimization where SST files are moved from one level to the next by simply updating metadata in the MANIFEST, without reading or rewriting the file contents. This is significantly faster than a normal compaction because it avoids all I/O for reading, merging, and writing data.
+
+A trivial move updates only the `VersionEdit`: input files are deleted from the source level and added to the destination level with the same file number and metadata. The physical file on disk does not move.
+
+## Conditions for Trivial Move
+
+`Compaction::IsTrivialMove()` in `db/compaction/compaction.cc` determines whether a compaction qualifies as a trivial move. All of the following conditions must be met:
+
+### Basic Requirements
+
+| Condition | Reason |
+|-----------|--------|
+| `start_level != output_level` | Same-level compaction is for applying filters, not moving |
+| Only one input level (`num_input_levels() == 1`) | Multi-level input requires merging |
+| Input path ID matches output path ID | Cross-path moves are not supported |
+| Input compression matches output compression | Rewriting would be needed to change compression |
+| Not a per-key-placement compaction | Per-key-placement requires inspecting each key |
+| Not a temperature change compaction | Temperature changes typically require rewriting the file |
+
+### L0-Specific Requirements
+
+| Condition | Reason |
+|-----------|--------|
+| L0 files are non-overlapping, or `l0_files_might_overlap_ == false` | Overlapping L0 files require merging to maintain sorted order at the output level |
+
+### Manual Compaction Requirements
+
+| Condition | Reason |
+|-----------|--------|
+| No compaction filter configured | Manual compaction with a filter must process every key |
+
+### Grandparent Overlap Check
+
+For each input file, the method checks that `file_size + TotalFileSize(grandparent_files)` does not exceed `max_compaction_bytes`. This prevents creating a file at the output level that would later require an expensive compaction due to excessive overlap with the level below (grandparent level).
+
+### SST Partitioner Check
+
+If an `SstPartitioner` is configured, each input file must pass `CanDoTrivialMove(smallest_user_key, largest_user_key)`. This allows the partitioner to veto trivial moves for files that would violate partitioning constraints.
+
+### Universal Compaction
+
+For universal compaction, trivial move is controlled by `compaction_options_universal.allow_trivial_move` (see `CompactionOptionsUniversal` in `include/rocksdb/advanced_options.h`). When enabled, `is_trivial_move_` is set by the universal compaction picker based on whether input files are non-overlapping.
+
+## L0 Trivial Move
+
+`LevelCompactionBuilder::TryPickL0TrivialMove()` in `db/compaction/compaction_picker_level.cc` attempts to move L0 files directly to the base level without merging. The algorithm:
+
+1. **Preconditions**: Base level must exist (> 0), the base level must not be empty, `compression_per_level` must not be configured, and there must be only one DB path
+2. **Scan from oldest**: Iterate L0 files from oldest to newest
+3. **Accumulate non-overlapping**: For each file, check that it does not overlap with previously accumulated files (key ranges do not intersect) and does not overlap with any file in the base level
+4. **Stop at first overlap**: Once a file overlaps with the accumulated set or with the base level, stop scanning
+5. **Sort by key range**: Sort the accumulated files by smallest key for consistency
+
+The requirement that the base level is non-empty avoids a surprising behavior: if the base level is empty, every L0 file would individually qualify for trivial move, but this would not reduce compaction debt since those files would need to be compacted eventually.
+
+## Non-L0 Trivial Move Extension
+
+When `PickFileToCompact()` selects a single file from L1+ that has no overlap with the output level, `TryExtendNonL0TrivialMove()` attempts to include additional adjacent files to move more data in a single operation:
+
+1. **Preconditions**: Only one file initially selected, single DB path (or empty paths), no `compression_per_level`
+2. **Expand right**: Add consecutive files toward larger keys, checking each that it has no overlap with the output level, does not cross a user-key boundary with the next file (clean cut), and is not being compacted
+3. **Expand left** (unless `only_expand_right`): Same checks in the decreasing key direction
+4. **Limits**: At most `kMaxMultiTrivialMove` (4) files total, and total size must not exceed `max_compaction_bytes`
+
+For round-robin compaction priority, expansion is right-only (`only_expand_right=true`) to maintain the cursor progression direction.
+
+## Execution
+
+When `IsTrivialMove()` returns true, `DBImpl::BackgroundCompaction()` bypasses `CompactionJob` entirely and calls `PerformTrivialMove()` in `db/db_impl/db_impl_compaction_flush.cc`:
+
+1. No `CompactionJob` object is created
+2. No data is read or written
+3. Input files are simply added to the `VersionEdit` as deletions from the source level and additions to the destination level
+4. File metadata (file number, size, key range, sequence numbers) is preserved unchanged
+5. `LogAndApply()` atomically installs the new version
+
+This makes trivial moves very cheap -- they complete in the time it takes to write a MANIFEST entry, regardless of the file size.
+
+## Limitations
+
+Trivial move cannot be used when:
+
+- **Compaction filter is needed**: Manual compaction with a configured `CompactionFilter` or `CompactionFilterFactory` must read and process every key
+- **Compression changes between levels**: If `compression_per_level` specifies different algorithms for the source and destination levels, the file must be rewritten
+- **Multiple DB paths**: When `db_paths` has multiple entries, the output path may differ from the input, requiring a file copy. The extension logic (`TryExtendNonL0TrivialMove`) also skips multi-path configurations since path prediction becomes complex
+- **Grandparent overlap is too large**: If moving a file would create excessive overlap with the grandparent level (exceeding `max_compaction_bytes`), the move is rejected to prevent future expensive compactions
+- **Per-key placement is active**: When `preclude_last_level_data_seconds > 0` and the output is the last level, keys need to be individually evaluated for placement, so trivial move is not possible
+- **SST partitioner vetoes**: A custom `SstPartitioner` can reject trivial moves for specific key ranges
+- **L0 files overlap**: For L0 trivial moves, all candidate files must be non-overlapping with each other and with the base level

--- a/docs/components/compaction/06_universal_compaction.md
+++ b/docs/components/compaction/06_universal_compaction.md
@@ -1,0 +1,185 @@
+# Universal Compaction
+
+**Files:** `db/compaction/compaction_picker_universal.h`, `db/compaction/compaction_picker_universal.cc`, `include/rocksdb/universal_compaction.h`, `include/rocksdb/advanced_options.h`
+
+## Overview
+
+Universal compaction is a size-tiered compaction strategy that organizes data into sorted runs ordered by recency. Unlike leveled compaction which maintains strict level-to-level size ratios, universal compaction merges sorted runs when their relative sizes exceed configurable thresholds. This approach trades higher space amplification for lower write amplification, making it suitable for write-heavy workloads.
+
+In universal compaction, each L0 file is an individual sorted run, while each non-L0 level is a single sorted run containing all files at that level. The compaction picker evaluates multiple strategies in priority order and selects the first applicable one.
+
+## Sorted Run Abstraction
+
+Universal compaction operates on sorted runs rather than individual files. The `SortedRun` struct in `UniversalCompactionBuilder` captures each run's metadata:
+
+| Field | Description |
+|-------|-------------|
+| `level` | 0 for L0 files, or the level number for non-L0 sorted runs |
+| `file` | Points to the `FileMetaData` for L0 files; null for non-L0 levels |
+| `size` | Actual file size (L0) or sum of all file sizes in the level |
+| `compensated_file_size` | Size adjusted for tombstone density (used by deletion-triggered compaction) |
+| `being_compacted` | Whether any file in this run is currently being compacted |
+| `level_has_marked_standalone_rangedel` | Whether this run contains a standalone range deletion file marked for compaction |
+
+Sorted runs are calculated by `CalculateSortedRuns()`, which iterates L0 files (each as its own sorted run) followed by non-L0 levels (each as one sorted run). The largest sorted run size is tracked as `max_run_size_`, used by the auto-tuning logic for `max_read_amp`.
+
+## Compaction Trigger and Priority
+
+`UniversalCompactionPicker::NeedsCompaction()` returns true if any of these conditions hold:
+- Compaction score at L0 is >= 1
+- Files are marked for periodic compaction
+- Files are marked for compaction (e.g., by `CompactOnDeleteCollector`)
+
+When `PickCompaction()` is called, `UniversalCompactionBuilder` evaluates strategies in this priority order:
+
+1. **Periodic compaction** -- recompact old data to apply compaction filters, enforce TTL, etc.
+2. **Size amplification reduction** -- full or incremental compaction when space amp exceeds threshold
+3. **Sorted run reduction (size ratio)** -- merge adjacent runs whose sizes satisfy the ratio test
+4. **Sorted run reduction (count)** -- merge runs when count exceeds the configured maximum
+5. **Delete-triggered compaction** -- compact files with high tombstone density
+
+The first strategy that returns a non-null `Compaction` wins. If none applies, no compaction is scheduled.
+
+## Strategy 1: Periodic Compaction
+
+Triggered when `VersionStorageInfo::FilesMarkedForPeriodicCompaction()` is non-empty (files older than `periodic_compaction_seconds`). Periodic compaction always attempts a full compaction: it starts from the oldest available sorted run and includes all runs up to the newest non-compacting run.
+
+The rationale is that since the largest (oldest) sorted run is typically included anyway, the incremental write amplification of a full compaction is modest. This ensures that compaction filters and TTL enforcement are applied to all data.
+
+If only the last sorted run (the oldest) is available and none of its files are actually marked for periodic compaction, the picker returns null to avoid unnecessary work.
+
+## Strategy 2: Size Amplification Reduction
+
+Size amplification is computed as: `candidate_size * 100 / base_sr_size`, where `candidate_size` is the total compensated size of all sorted runs except the base (oldest) sorted run, and `base_sr_size` is the raw (non-compensated) size of that base run. The use of compensated sizes for candidates inflates the contribution of files with many deletions, making them more likely to trigger compaction. Compaction is triggered when this ratio exceeds `max_size_amplification_percent` (see `CompactionOptionsUniversal` in `include/rocksdb/universal_compaction.h`, default: 200).
+
+**Important:** The default value of 200 means that a database with 100 bytes of user data may occupy up to 300 bytes of storage (200% additional storage).
+
+### L0 Exclusion for Write Stop Prevention
+
+When `reduce_file_locking` is enabled (default: true), the picker may exclude the newest L0 files from a size-amp compaction to prevent write stalls. The `MightExcludeNewL0sToReduceWriteStop()` method calculates how many L0 files can be excluded without significantly reducing the compaction's effectiveness:
+
+- Exclusion range is bounded by `min_merge_width` and `max_merge_width`
+- The remaining candidate size must stay above 90% of the original
+- The remaining size-amp ratio must still exceed `max_size_amplification_percent`
+
+This prevents a large size-amp compaction from locking all L0 files, which could trigger `level0_stop_writes_trigger` if new flushes arrive during compaction.
+
+### Preclude-Last-Level Interaction
+
+When `preclude_last_level_data_seconds > 0` and the database has more than 2 levels, the last sorted run is skipped for size-amp calculation if it resides at the last level. This prevents size-amp compaction from repeatedly recompacting cold data that has been moved to the last level by per-key placement.
+
+### Incremental Mode
+
+When `CompactionOptionsUniversal::incremental` is true (default: false), the picker attempts `PickIncrementalForReduceSizeAmp()` before falling back to a full compaction. Incremental mode uses a sliding window over the second-to-last level to find the key range with the lowest fanout (ratio of bottom-level data to upper-level data in the same key range).
+
+The fanout threshold is set to `base_sr_size / candidate_size * 1.8`, meaning incremental compaction is only chosen if its fanout is below 80% of what a full compaction would achieve. If no range meets this threshold, the picker falls back to full compaction.
+
+Incremental compaction limits `max_compaction_bytes` to `target_file_size_base / 2 * 3` for grandparent overlap alignment, and uses `max_compaction_bytes / 2` as the target sliding window size.
+
+## Strategy 3: Sorted Run Reduction by Size Ratio
+
+This is the core size-tiered compaction algorithm. It scans sorted runs from newest to oldest, accumulating candidates that satisfy the size ratio test:
+
+For each candidate run, the accumulated size (increased by `size_ratio` percent) must be at least as large as the next run's size:
+
+`candidate_size * (100 + size_ratio) / 100 >= next_run_size`
+
+The default `size_ratio` is 1 (see `CompactionOptionsUniversal` in `include/rocksdb/universal_compaction.h`), meaning a 1% tolerance.
+
+### Stop Styles
+
+Two stopping rules control how candidates are accumulated (see `CompactionStopStyle` in `include/rocksdb/universal_compaction.h`):
+
+| Style | Comparison | Description |
+|-------|------------|-------------|
+| `kCompactionStopStyleTotalSize` (default) | Total accumulated size vs. next file | Tends to create larger compactions, better space efficiency |
+| `kCompactionStopStyleSimilarSize` | Last picked file size vs. next file | Picks files of similar size, creates more uniform sorted runs |
+
+With `kCompactionStopStyleSimilarSize`, an additional check ensures the next candidate's size (increased by `size_ratio`) is at least as large as the current accumulated size, preventing a small file from being grouped with a much larger one.
+
+### Merge Width Constraints
+
+- `min_merge_width` (default: 2): Minimum number of sorted runs in a compaction
+- `max_merge_width` (default: UINT_MAX): Maximum number of sorted runs in a compaction
+
+A compaction is only formed when at least `min_merge_width` consecutive, non-compacting sorted runs pass the size ratio test.
+
+### Compression Decision
+
+When `compression_size_percent >= 0`, compression is conditionally enabled based on the ratio of data older than the compaction output to total data. If the older data exceeds `compression_size_percent` of total size, compression is disabled for that compaction output. When set to -1 (default), all output follows the configured compression type.
+
+## Strategy 4: Sorted Run Reduction by Count
+
+When the number of non-compacting sorted runs exceeds the configured maximum, compaction is triggered regardless of size ratio. This strategy uses `UINT_MAX` as the ratio (accepting any size combination) but limits the number of files to compact.
+
+### max_read_amp Configuration
+
+The `max_read_amp` option (see `CompactionOptionsUniversal` in `include/rocksdb/universal_compaction.h`) controls the maximum number of sorted runs:
+
+| Value | Behavior |
+|-------|----------|
+| -1 (default) | Falls back to `level0_file_num_compaction_trigger` |
+| 0 | Auto-tune based on DB size, `size_ratio`, and `write_buffer_size`. Computes the minimum number of levels such that the target size of the largest level reaches `max_run_size`. Only supported for `kCompactionStopStyleTotalSize`. |
+| N > 0 | Limit to N sorted runs. Must be >= `level0_file_num_compaction_trigger`. |
+
+The number of files to compact is: `num_non_compacted_runs - max_num_runs + 1`.
+
+## Strategy 5: Delete-Triggered Compaction
+
+Files marked for compaction (typically by `CompactOnDeleteCollector` due to high tombstone density) are compacted to reclaim space.
+
+### Single-Level Universal
+
+For `num_levels == 1`, delete-triggered compaction behaves like a size-amp compaction: it finds the first marked file and includes all subsequent sorted runs until hitting a compacting run or one with a marked standalone range deletion.
+
+### Multi-Level Universal
+
+For multi-level configurations, delete-triggered compaction picks the marked file and compacts it with overlapping files in the next non-empty level, similar to leveled compaction. If the start level is non-zero and all higher levels are empty, the compaction is skipped since it would be a trivial move that does not reclaim space.
+
+### Standalone Range Deletion Handling
+
+Files that are standalone range deletions (containing only range tombstones) receive special treatment via `ShouldSkipMarkedFile()`:
+
+- Skip if the file's largest sequence number is not yet visible to the earliest snapshot (let snapshot release trigger compaction later)
+- Skip if the succeeding sorted run also has marked standalone range deletions (prefer compacting from the start level first)
+
+## Output Level Selection
+
+The output level depends on which sorted runs are selected:
+
+- If the compaction includes all sorted runs through the oldest: output to `MaxOutputLevel()`
+- If the run after the last selected run is at L0: output to L0
+- Otherwise: output to the level just below the next unselected sorted run
+
+The `require_max_output_level` flag (used by bottom-priority background compactions) restricts output to the maximum output level. The `MeetsOutputLevelRequirements()` check ensures this constraint is satisfied.
+
+## Trivial Move Optimization
+
+When `allow_trivial_move` is true (default: false), the picker checks whether all input files across all input levels are non-overlapping via `IsInputFilesNonOverlapping()`. This uses a min-heap of file smallest keys to detect any overlapping boundaries. If non-overlapping, the compaction is marked as a trivial move, avoiding the merge step entirely.
+
+Trivial move is not applied to periodic compactions, since those need to rewrite data through the compaction pipeline to apply filters and update metadata.
+
+## Configuration Reference
+
+| Option | Location | Default | Description |
+|--------|----------|---------|-------------|
+| `size_ratio` | `CompactionOptionsUniversal` in `include/rocksdb/universal_compaction.h` | 1 | Percentage flexibility for size comparison |
+| `min_merge_width` | `CompactionOptionsUniversal` in `include/rocksdb/universal_compaction.h` | 2 | Minimum sorted runs per compaction |
+| `max_merge_width` | `CompactionOptionsUniversal` in `include/rocksdb/universal_compaction.h` | UINT_MAX | Maximum sorted runs per compaction |
+| `max_size_amplification_percent` | `CompactionOptionsUniversal` in `include/rocksdb/universal_compaction.h` | 200 | Size-amp threshold (percentage of additional storage) |
+| `compression_size_percent` | `CompactionOptionsUniversal` in `include/rocksdb/universal_compaction.h` | -1 | Compression threshold (-1 = always compress) |
+| `max_read_amp` | `CompactionOptionsUniversal` in `include/rocksdb/universal_compaction.h` | -1 | Max sorted runs (-1 = use trigger, 0 = auto-tune) |
+| `stop_style` | `CompactionOptionsUniversal` in `include/rocksdb/universal_compaction.h` | `kCompactionStopStyleTotalSize` | How to compare candidate sizes |
+| `allow_trivial_move` | `CompactionOptionsUniversal` in `include/rocksdb/universal_compaction.h` | false | Enable trivial move for non-overlapping files |
+| `incremental` | `CompactionOptionsUniversal` in `include/rocksdb/universal_compaction.h` | false | Enable incremental size-amp compaction |
+| `reduce_file_locking` | `CompactionOptionsUniversal` in `include/rocksdb/universal_compaction.h` | true | Exclude newest L0s from size-amp compaction to reduce write stalls |
+| `level0_file_num_compaction_trigger` | `ColumnFamilyOptions` in `include/rocksdb/advanced_options.h` | 4 | Minimum sorted runs before considering compaction |
+| `periodic_compaction_seconds` | `ColumnFamilyOptions` in `include/rocksdb/advanced_options.h` | 30 days (block-based table), 0 otherwise | Age threshold for periodic compaction. For universal compaction, `ttl` and `periodic_compaction_seconds` are folded: if one is zero the other wins, otherwise the stricter non-zero value is used. |
+
+## Interactions With Other Components
+
+- **Multi-level layout**: Universal compaction supports multiple levels (`num_levels > 1`). L0 files are individual sorted runs; levels 1+ each form a single sorted run. Output placement uses the level structure but the picker logic operates on sorted runs.
+- **Per-key placement**: When `preclude_last_level_data_seconds > 0`, recent data is placed at the proximal level (`last_level - 1`) and cold data at the last level. Size-amp compaction skips the last-level sorted run in this configuration.
+- **Ingest behind**: When `allow_ingest_behind` is true, the last level is reserved for ingested files and is excluded from `MaxOutputLevel()`.
+- **Subcompactions**: Universal compaction supports parallel subcompactions. The `ShouldFormSubcompactions()` method in `Compaction` determines whether to split the work.
+- **Compaction score**: The score is set from `VersionStorageInfo::CompactionScore(0)` and propagated to the `Compaction` object. After picking, scores are recomputed via `ComputeCompactionScore()`.

--- a/docs/components/compaction/07_fifo_compaction.md
+++ b/docs/components/compaction/07_fifo_compaction.md
@@ -1,0 +1,190 @@
+# FIFO Compaction
+
+**Files:** `db/compaction/compaction_picker_fifo.h`, `db/compaction/compaction_picker_fifo.cc`, `include/rocksdb/advanced_options.h`, `db/column_family.cc`, `db/db_impl/db_impl_compaction_flush.cc`
+
+## Overview
+
+FIFO compaction is the simplest compaction strategy in RocksDB. It treats the database as a fixed-capacity FIFO queue: when total data size exceeds a configured limit, the oldest SST files are deleted. FIFO compaction does not merge or rewrite data (except for optional intra-L0 compaction), making it extremely fast with near-zero write amplification. All data resides in L0.
+
+FIFO compaction is designed for time-series and cache-like workloads where data has a natural expiration and old data can be dropped without concern. It is not suitable for workloads requiring point lookups across the full key range, as read amplification grows linearly with the number of L0 files.
+
+## Compaction Strategies
+
+`FIFOCompactionPicker::PickCompaction()` evaluates four strategies in priority order:
+
+1. **TTL compaction** -- delete files whose data has expired based on time
+2. **Size compaction** -- delete oldest files when total size exceeds the configured limit
+3. **Intra-L0 compaction** -- merge small L0 files to reduce file count (only if no files were deleted)
+4. **Temperature change compaction** -- move files between temperature tiers
+
+The first strategy that returns a non-null `Compaction` wins. Only one compaction runs at a time -- if `level0_compactions_in_progress_` is non-empty, all strategies return null.
+
+## Strategy 1: TTL Compaction
+
+Triggered when `ttl > 0` (see `ColumnFamilyOptions` in `include/rocksdb/advanced_options.h`).
+
+### Workflow
+
+Step 1: Get the current time. If the system clock is unavailable, skip TTL compaction.
+
+Step 2: Iterate L0 files from oldest (rightmost in the file vector) to newest. For each file, estimate the newest key time:
+- Use `FileMetaData::TryGetNewestKeyTime()` if available
+- Fall back to `TableProperties::creation_time`
+- If neither is available (`kUnknownNewestKeyTime`), skip the file
+
+Step 3: If the estimated newest key time is older than `current_time - ttl`, mark the file for deletion.
+
+Step 4: After collecting expired files, check whether deleting them would bring total data below the capacity limit. If not, return null and fall through to size compaction. This prevents TTL compaction from deleting files when the database would still be over capacity, leaving size compaction to handle the more aggressive pruning.
+
+### Blob-Aware TTL Estimation
+
+When `max_data_files_size > 0`, TTL compaction estimates the effective remaining data after dropping expired SSTs. Each dropped SST is assumed to free a proportional share of blob data:
+
+`effective_remaining = remaining_sst + (remaining_sst / total_sst_all_levels) * total_blob`
+
+Note: The proportional calculation uses total SST across all levels (not just L0) as the reference, since `total_blob` covers all levels.
+
+## Strategy 2: Size Compaction
+
+Triggered when total data size exceeds the configured capacity limit.
+
+### Capacity Configuration
+
+| Option | Location | Default | Description |
+|--------|----------|---------|-------------|
+| `max_table_files_size` | `CompactionOptionsFIFO` in `include/rocksdb/advanced_options.h` | 1 GB | SST-only size limit |
+| `max_data_files_size` | `CompactionOptionsFIFO` in `include/rocksdb/advanced_options.h` | 0 | SST + blob combined size limit |
+
+When `max_data_files_size > 0`, it takes precedence over `max_table_files_size` for all FIFO compaction decisions. The effective size includes both SST and blob file sizes. When zero (default), only SST sizes are considered.
+
+### L0-Only Path
+
+When all data is in L0 (the steady-state for FIFO), files are deleted from oldest (rightmost) to newest until the remaining effective size drops below the limit:
+
+- With `max_data_files_size > 0`: each file is assumed to contribute `effective_size / num_files` of total data (proportional estimation)
+- Without blob-aware mode: each file contributes its actual file size
+
+### Migration Path (Non-L0 Levels)
+
+When migrating from leveled or universal compaction to FIFO, non-L0 levels may still contain data. Size compaction handles this by finding the last non-empty level and deleting files from there:
+
+- Files are deleted from left to right (smallest key first), since file creation time in non-L0 levels reflects compaction time rather than data insertion time
+- Files with smallest keys are assumed to correspond to older data in typical FIFO use cases
+- The proportional blob estimation applies the same way as in the L0 path
+
+The database eventually converges to the L0-only state as non-L0 files are purged.
+
+## Strategy 3: Intra-L0 Compaction
+
+Enabled when `CompactionOptionsFIFO::allow_compaction` is true (default: false). Intra-L0 compaction merges small L0 files to reduce file count, improving read performance. It only runs when neither TTL nor size compaction produced a result.
+
+Two algorithms are available, selected by `CompactionOptionsFIFO::use_kv_ratio_compaction`:
+
+### Cost-Based Algorithm (Default)
+
+The original intra-L0 compaction algorithm. It uses `PickCostBasedIntraL0Compaction()` (defined in the base `CompactionPicker` class) with:
+
+- **Minimum files**: `level0_file_num_compaction_trigger`
+- **Max file size**: `write_buffer_size * 1.1` -- prevents compacting files larger than approximately one memtable, avoiding the creation of excessively large L0 files that might never TTL-expire
+- **Max compaction bytes**: `max_compaction_bytes`
+- **Output file size limit**: 16 MB (hardcoded)
+
+### Ratio-Based Algorithm (BlobDB-Optimized)
+
+Enabled when `use_kv_ratio_compaction = true` and `max_data_files_size > 0`. This algorithm is designed for BlobDB workloads where SST files are much smaller than the total data (most data is in blob files).
+
+**Prerequisites:**
+- `allow_compaction = true` (master switch)
+- `max_data_files_size > 0` (needed to compute target file size)
+- `max_data_files_size >= max_table_files_size` (sanity check)
+- All data must be in L0 (non-L0 levels indicate migration in progress)
+- `level0_file_num_compaction_trigger > 1`
+
+If prerequisites are not met, the picker falls back to the cost-based algorithm.
+
+**Target file size computation:**
+
+When `max_compaction_bytes > 0` (user explicitly set), it is used directly as the target.
+
+When `max_compaction_bytes == 0` (default for FIFO), the target is auto-calculated:
+
+`target = max_data_files_size * sst_ratio / trigger`
+
+where `sst_ratio = total_sst / (total_sst + total_blob)` and `trigger` is `level0_file_num_compaction_trigger`.
+
+**Tiered merging:**
+
+The algorithm builds tier boundaries as a geometric sequence descending from `target`:
+
+`..., target/trigger^2, target/trigger, target`
+
+Boundaries are bounded below by 10 KB (`kMinTierBoundary`). For each boundary (smallest first), the algorithm scans L0 for batches of contiguous files smaller than the boundary. When a batch accumulates at least `boundary` bytes from at least 2 files, it is selected for compaction:
+
+- The output file size limit is set to the boundary value
+- A batch is capped at 2x the boundary to prevent tier-skipping
+- Output size targets produce uniform files for predictable FIFO trimming
+
+**Write amplification:** O(log(target/flush_size) / log(trigger)) per byte, compared to O(target / (trigger * flush_size)) for flat merging.
+
+**Steady-state L0 file count:** `trigger + k * (trigger - 1)`, where `k = ceil(log(target/flush_size) / log(trigger))`. This is higher than the trigger target because intermediate tier files accumulate while waiting for the next tier merge.
+
+## Strategy 4: Temperature Change Compaction
+
+Enabled when `CompactionOptionsFIFO::file_temperature_age_thresholds` is non-empty (see `FileTemperatureAge` in `include/rocksdb/advanced_options.h`).
+
+This strategy moves files between temperature tiers (e.g., hot to warm, warm to cold) based on their age. Temperature thresholds are defined as a vector of `{temperature, age}` pairs.
+
+### Workflow
+
+Step 1: Iterate L0 files from oldest to newest, estimating each file's newest key time using `FileMetaData::TryGetNewestKeyTime()` with the preceding file as context.
+
+Step 2: For each file older than the minimum age threshold, determine its target temperature by checking all thresholds in order (most aggressive first).
+
+Step 3: If the file's current temperature differs from its target, select it for a temperature-change compaction. Only one file is compacted per invocation.
+
+### Limitations
+
+- Only applies to single-level FIFO (`num_levels == 1`). Multi-level FIFO during migration is excluded.
+- Only one file per compaction (no batching).
+- When `allow_trivial_copy_when_change_temperature` is true (see `CompactionOptionsFIFO` in `include/rocksdb/advanced_options.h`), the file is copied to a new file number with the target temperature using a configurable buffer (`trivial_copy_buffer_size`, default 4096 bytes). This is a real I/O copy, not a metadata-only operation. The copy path bypasses `CompactionJob` and is handled directly in `DBImpl::BackgroundCompaction()`.
+- When `allow_trivial_copy_when_change_temperature` is false (default), the file is rewritten through the normal compaction pipeline.
+
+## Manual Compaction Support
+
+`FIFOCompactionPicker::PickCompactionForCompactRange()` delegates to `PickCompaction()` regardless of the specified key range, since FIFO compaction does not support range-based compaction. Both `input_level` and `output_level` must be 0.
+
+## MaxOutputLevel
+
+`FIFOCompactionPicker::MaxOutputLevel()` always returns 0, reflecting that FIFO compaction only operates in L0.
+
+## Configuration Reference
+
+| Option | Location | Default | Description |
+|--------|----------|---------|-------------|
+| `max_table_files_size` | `CompactionOptionsFIFO` in `include/rocksdb/advanced_options.h` | 1 GB | SST-only capacity limit |
+| `max_data_files_size` | `CompactionOptionsFIFO` in `include/rocksdb/advanced_options.h` | 0 | SST + blob capacity limit (overrides `max_table_files_size` when > 0) |
+| `allow_compaction` | `CompactionOptionsFIFO` in `include/rocksdb/advanced_options.h` | false | Enable intra-L0 compaction to reduce file count |
+| `use_kv_ratio_compaction` | `CompactionOptionsFIFO` in `include/rocksdb/advanced_options.h` | false | Use ratio-based intra-L0 algorithm (requires `allow_compaction` and `max_data_files_size > 0`) |
+| `file_temperature_age_thresholds` | `CompactionOptionsFIFO` in `include/rocksdb/advanced_options.h` | empty | Temperature tier age thresholds |
+| `allow_trivial_copy_when_change_temperature` | `CompactionOptionsFIFO` in `include/rocksdb/advanced_options.h` | false | When true, temperature-change compaction copies files instead of rewriting through the compaction pipeline |
+| `trivial_copy_buffer_size` | `CompactionOptionsFIFO` in `include/rocksdb/advanced_options.h` | 4096 | Buffer size for trivial copy (minimum 4 KiB) |
+| `ttl` | `ColumnFamilyOptions` in `include/rocksdb/advanced_options.h` | 30 days (block-based table), 0 otherwise | TTL in seconds. The raw default is a sentinel value; sanitization in `db/column_family.cc` sets the effective default to 30 days for block-based tables and 0 for other table formats. |
+| `level0_file_num_compaction_trigger` | `ColumnFamilyOptions` in `include/rocksdb/advanced_options.h` | 4 | Minimum files for intra-L0 compaction |
+| `max_compaction_bytes` | `ColumnFamilyOptions` in `include/rocksdb/advanced_options.h` | varies | For ratio-based FIFO: when 0, target is auto-calculated; when > 0, used as explicit target |
+
+## Key Design Properties
+
+| Property | Detail |
+|----------|--------|
+| No merge on deletion | TTL and size compaction produce deletion-only compactions (`CompactionReason::kFIFOTtl`, `kFIFOMaxSize`). Files are simply deleted without reading or rewriting data. |
+| Single compaction at a time | All strategies check `level0_compactions_in_progress_` and return null if a compaction is already running. |
+| L0-only steady state | In normal operation, all data is in L0. Non-L0 data exists only during migration from other compaction styles. |
+| Near-zero write amplification | Without intra-L0 compaction, data is written once (flush) and deleted when expired. With intra-L0, write amp increases by the tiered merge factor. |
+
+## Interactions With Other Components
+
+- **BlobDB**: With `max_data_files_size > 0`, FIFO compaction tracks both SST and blob file sizes for capacity decisions. Dropping an SST file also implicitly frees the blob data it references (garbage collection of unreferenced blob files happens separately).
+- **Tiered storage**: Temperature change compaction integrates with RocksDB's tiered storage support, moving files between storage tiers based on age.
+- **Write stalls**: FIFO compaction can trigger write stalls if L0 file count exceeds `level0_slowdown_writes_trigger` or `level0_stop_writes_trigger`. Enabling `allow_compaction` helps control file count.
+- **Snapshots**: FIFO compaction ignores snapshots -- files are deleted based on size/TTL regardless of whether any snapshot references them. This can cause snapshot reads to fail.
+- **Dynamic options**: `max_table_files_size`, `max_data_files_size`, `ttl`, `allow_compaction`, `use_kv_ratio_compaction`, and `file_temperature_age_thresholds` are all dynamically changeable via `SetOptions()`.

--- a/docs/components/compaction/08_compaction_job.md
+++ b/docs/components/compaction/08_compaction_job.md
@@ -1,0 +1,125 @@
+# CompactionJob Execution
+
+**Files:** `db/compaction/compaction_job.h`, `db/compaction/compaction_job.cc`, `db/compaction/compaction_state.h`, `db/compaction/compaction_outputs.h`, `db/compaction/compaction_outputs.cc`
+
+## Three-Phase Lifecycle
+
+Merge-style compactions (those not handled by trivial move, FIFO deletion, or FIFO trivial copy) are executed by a `CompactionJob` object. The lifecycle consists of three phases with distinct locking requirements:
+
+| Phase | Method | DB Mutex | Description |
+|-------|--------|----------|-------------|
+| 1. Prepare | `Prepare()` | Held | Partition into subcompactions, set up seqno-to-time mapping, compute placement thresholds |
+| 2. Run | `Run()` | Not held | Execute subcompactions in parallel, verify outputs, aggregate stats |
+| 3. Install | `Install()` | Held | Apply `VersionEdit` via `LogAndApply()`, update internal stats |
+
+## Prepare Phase
+
+`CompactionJob::Prepare()` performs the following steps:
+
+Step 1 -- **Determine write hint and bottommost status**: Queries `VersionStorageInfo` for the SST write lifetime hint and whether this compaction targets the bottommost level.
+
+Step 2 -- **Generate subcompaction boundaries**: If the compaction is eligible for subcompactions (see `Compaction::ShouldFormSubcompactions()` in `db/compaction/compaction.h`), calls `GenSubcompactionBoundaries()` to partition the key range. Otherwise, creates a single `SubcompactionState` covering the entire range.
+
+Step 3 -- **Build seqno-to-time mapping**: When `preserve_internal_time_seconds` or `preclude_last_level_data_seconds` is configured (see `MutableCFOptions` in `options/cf_options.h`), collects seqno-to-time entries from all input file table properties and computes:
+- `preserve_seqno_after_` -- minimum sequence number below which seqnos can be zeroed (combines time-based preservation with snapshot preservation)
+- `proximal_after_seqno_` -- threshold for per-key placement; keys with sequence numbers above this go to the proximal level
+
+Step 4 -- **Record options file number**: Captures the current options file number for remote compaction serialization.
+
+## Run Phase
+
+`CompactionJob::Run()` orchestrates the entire execution:
+
+Step 1 -- **Initialize**: Flush log buffer, log compaction parameters.
+
+Step 2 -- **Execute subcompactions**: `RunSubcompactions()` spawns N-1 threads (where N is the number of `SubcompactionState` objects), each running `ProcessKeyValueCompaction()`. The first subcompaction runs in the current thread.
+
+Step 3 -- **Clean up**: Remove empty output files from all subcompactions, release any extra reserved threads.
+
+Step 4 -- **Handle abort/pause**: If any subcompaction returned an abort or pause status (and no progress writer is set for resumable compaction), `CleanupAbortedSubcompactions()` deletes all output files.
+
+Step 5 -- **Sync output directories**: `FsyncWithDirOptions()` on the output and blob directories.
+
+Step 6 -- **Verify output files**: Optionally verifies output SST files by iterating them and comparing key-value checksums. Verification is parallelized across subcompactions. Controlled by `verify_output_flags` (see `MutableCFOptions` in `options/cf_options.h`) and legacy `paranoid_file_checks`.
+
+Step 7 -- **Aggregate stats**: Collects per-subcompaction stats into `CompactionStatsFull` and `CompactionJobStats`.
+
+Step 8 -- **Verify record counts**: Compares input record count (from table properties) against output records plus dropped records for consistency.
+
+## ProcessKeyValueCompaction
+
+`ProcessKeyValueCompaction()` is the per-subcompaction workhorse. It processes a single subcompaction from start to finish:
+
+Step 1 -- **Check for remote compaction**: If `compaction_service` is configured in `DBOptions`, attempts to offload via `ProcessKeyValueCompactionWithCompactionService()`. Falls back to local execution if the service returns `kUseLocal`.
+
+Step 2 -- **Set up compaction filter**: Obtains the filter from `CompactionFilter` or creates one via `CompactionFilterFactory` (the factory is called per-subcompaction, ensuring thread safety without requiring the filter itself to be thread-safe).
+
+Step 3 -- **Initialize read options and boundaries**: Sets up `ReadOptions` for compaction I/O, configures key boundaries with optional timestamp stripping, and creates internal key boundaries for the `ClippingIterator`.
+
+Step 4 -- **Create input iterator**: Calls `VersionSet::MakeInputIterator()` to build a `CompactionMergingIterator` over all input files, then wraps it in a `ClippingIterator` to enforce subcompaction key range bounds. Optionally wraps in a `BlobCountingIterator` for blob garbage tracking and a `HistoryTrimmingIterator` for timestamp-based trimming.
+
+Step 5 -- **Create CompactionIterator**: Wraps the input iterator in `CompactionIterator`, which handles deduplication, deletion, merge, filter invocation, and blob GC (see chapter 11).
+
+Step 6 -- **Process keys**: For each key emitted by `CompactionIterator`:
+- Determines placement: keys with `ikey.sequence > proximal_after_seqno_` go to the proximal level
+- Routes to `SubcompactionState::AddToOutput()`, which delegates to the appropriate `CompactionOutputs` instance
+- `CompactionOutputs::ShouldStopBefore()` decides when to close the current output file and open a new one
+
+Step 7 -- **Close output files**: Closes both normal and proximal-level output builders, adds range deletions.
+
+Step 8 -- **Finalize**: Updates per-subcompaction job stats, records I/O stats.
+
+## Install Phase
+
+`CompactionJob::Install()` runs under the DB mutex:
+
+Step 1 -- **Update internal stats**: Adds the compaction stats to `ColumnFamilyData::internal_stats_`.
+
+Step 2 -- **Install results**: `InstallCompactionResults()` builds a `VersionEdit` that deletes all input files and adds all output files, then calls `versions_->LogAndApply()` to atomically update the LSM state.
+
+Step 3 -- **Log completion**: Records compaction completion metrics including read/write amplification, bytes read/written, number of records, and compression type.
+
+## CompactionOutputs and File Splitting
+
+`CompactionOutputs` (see `db/compaction/compaction_outputs.h`) manages the output SST files for one output level within a subcompaction. Each `SubcompactionState` has two instances: one for the normal output level and one for the proximal level.
+
+### Output File Splitting Criteria
+
+`CompactionOutputs::ShouldStopBefore()` evaluates multiple criteria to decide when to close the current output file:
+
+| Criterion | Description |
+|-----------|-------------|
+| Target file size | Estimated output file size exceeds `max_output_file_size()` (from `Compaction` in `db/compaction/compaction.h`) |
+| TTL-based cutting | Isolates ranges with old `oldest_ancester_time` for TTL merge-down |
+| SST partitioner | User-provided `SstPartitioner` callback requests a file cut |
+| Round-robin split key | `local_output_split_key_` from the compaction cursor |
+| Grandparent overlap | Accumulated overlap with grandparent files (at output_level + 1) exceeds `max_compaction_bytes()` |
+| Grandparent boundary alignment | Dynamic threshold (50-90% of target size) based on number of grandparent boundaries crossed; cuts at grandparent boundaries to reduce future compaction work |
+
+### Grandparent Overlap Tracking
+
+Grandparent overlap tracking prevents unbounded read amplification in future compactions by limiting how much each output file overlaps with files at output_level + 1. The tracking uses:
+
+- `grandparent_index_` -- current position in the sorted grandparents vector
+- `grandparent_overlapped_bytes_` -- accumulated overlap for the current output file
+- `grandparent_boundary_switched_num_` -- number of grandparent file boundaries crossed
+
+The adaptive file-cutting heuristic (always enabled for leveled compaction since RocksDB 9.0) aligns output file boundaries with grandparent file boundaries. This reduces write amplification by approximately 12% according to benchmarks, because aligned boundaries avoid re-reading partially overlapping data in subsequent compactions.
+
+## Stats Aggregation
+
+`CompactionJob` maintains two stat structures:
+
+1. **`CompactionJobStats`** (`job_stats_` in `db/compaction/compaction_job.h`) -- public stats shared via `EventListener::OnCompactionCompleted()`. Aggregated from per-subcompaction `CompactionJobStats`.
+
+2. **`CompactionStatsFull`** (`internal_stats_` in `db/compaction/compaction_job.h`) -- internal per-level stats sent to `ColumnFamilyData::internal_stats_`. Has two parts: `output_level_stats` for the normal output level and `proximal_level_stats` for the proximal level. Each is aggregated from the `CompactionOutputs::stats_` of the corresponding output group across all subcompactions.
+
+## Compaction Resumption
+
+Compaction resumption allows a partially completed compaction to be restarted from where it left off, primarily for secondary/remote compaction flows:
+
+- `Prepare()` accepts a `CompactionProgress` parameter containing previously saved progress
+- `MaybeResumeSubcompactionProgressOnInputIterator()` seeks the input iterator past already-completed work
+- Progress is persisted to a separate compaction-progress log (not the MANIFEST) via `PersistSubcompactionProgress()`
+
+Important: Resumption is currently limited to a single subcompaction and is disabled for cases involving timestamps, file-boundary conditions, range-delete edge cases, adjacent output tables sharing a user key, and some lookahead states in the compaction iterator.

--- a/docs/components/compaction/09_subcompaction.md
+++ b/docs/components/compaction/09_subcompaction.md
@@ -1,0 +1,105 @@
+# Subcompaction Parallelism
+
+**Files:** `db/compaction/compaction_job.h`, `db/compaction/compaction_job.cc`, `db/compaction/subcompaction_state.h`, `db/compaction/compaction.h`
+
+## Overview
+
+Subcompaction parallelizes a single compaction job by partitioning the key range into non-overlapping segments and processing each segment in a separate thread. This is particularly valuable for L0-to-Lbase compactions where L0 files span the entire key range and cannot be parallelized at the file-picking level.
+
+By default, subcompaction is disabled (`max_subcompactions = 1`, see `DBOptions` in `include/rocksdb/options.h`).
+
+## When Subcompactions Are Used
+
+`Compaction::ShouldFormSubcompactions()` (see `db/compaction/compaction.h`) determines eligibility. PlainTable is always excluded. Subcompactions are employed when:
+
+| Compaction Style | Condition |
+|------------------|-----------|
+| Leveled (kRoundRobin) | Any compaction with output level > 0 (bypasses `max_subcompactions` check; subcompaction count may exceed `max_subcompactions`) |
+| Leveled (other pri) | `(start_level == 0 or manual compaction) and output_level > 0`, and `max_subcompactions > 1` |
+| Universal | `number_levels > 1 and output_level > 0`, and `max_subcompactions > 1` |
+| FIFO | Not applicable |
+
+The rationale: L0 files are usually overlapping, so L0-to-Lo compaction cannot be parallelized by picking non-overlapping file sets. Key-range partitioning via subcompaction is the only way to parallelize this critical path.
+
+## Boundary Generation Algorithm
+
+`CompactionJob::GenSubcompactionBoundaries()` partitions the compaction input into balanced segments.
+
+Step 1 -- **Collect anchor points**: For every input file between start_level and output_level, requests up to 128 anchor points from the `TableReader` via `ApproximateKeyAnchors()`. Each anchor point is a (user_key, range_size) pair that approximately evenly partitions the file. If a file cannot provide anchors, its largest key and file size are used as a single anchor.
+
+Step 2 -- **Sort and deduplicate**: All anchor points from all input files are merged, sorted by user key (using the column family's comparator without timestamps), and deduplicated.
+
+Step 3 -- **Compute target size**: The number of planned subcompactions is determined:
+- For round-robin priority with leveled compaction (`kRoundRobin`): initialized to the number of start-level input files (`c->num_input_files(0)`), then capped by `GetSubcompactionsLimit()` (which may be increased by acquiring extra threads via `AcquireSubcompactionResources()`)
+- For other priorities: `GetSubcompactionsLimit()`, which is `max(1, max_subcompactions) + extra_reserved_threads`
+
+The target range size per subcompaction is: `max(total_size / num_planned_subcompactions, MaxFileSizeForLevel(output_level))`. This ensures each subcompaction produces at least one reasonably-sized output file.
+
+Step 4 -- **Assign boundaries**: Iterates through sorted anchor points, accumulating range sizes. When the cumulative size exceeds the next threshold (multiples of `target_range_size`), the current anchor's user key becomes a subcompaction boundary. Stops when reaching `num_planned_subcompactions`.
+
+Step 5 -- **Release excess resources**: If fewer boundaries were generated than planned (because the input data is smaller than expected), releases extra reserved threads via `ShrinkSubcompactionResources()`.
+
+Note: Because anchor points from different input files can overlap (especially with L0 files), the accumulated range sizes are an approximation. The large number of anchor points (128 per file) mitigates this inaccuracy.
+
+## SubcompactionState
+
+`SubcompactionState` (see `db/compaction/subcompaction_state.h`) holds all per-subcompaction state:
+
+| Field | Description |
+|-------|-------------|
+| `start` / `end` | Key range boundaries as `std::optional<Slice>`, where `std::nullopt` means unbounded |
+| `status` / `io_status` | Per-subcompaction result status |
+| `compaction_job_stats` | Per-subcompaction job statistics |
+| `sub_job_id` | Unique subcompaction identifier within the job |
+| `compaction_outputs_` | Normal output level `CompactionOutputs` |
+| `proximal_level_outputs_` | Proximal level `CompactionOutputs` (for per-key placement) |
+| `current_outputs_` | Pointer that switches between the two output groups based on the current key's placement decision |
+| `range_del_agg_` | `CompactionRangeDelAggregator` shared between both output groups |
+
+Key Invariant: No two subcompactions may have overlapping key ranges. This is enforced during boundary generation and validated with assertions that compare adjacent boundaries using the column family comparator.
+
+### Output Routing
+
+`SubcompactionState::AddToOutput()` routes each key from `CompactionIterator` to the correct output group:
+
+1. For per-key placement compactions (`SupportsPerKeyPlacement()`), the caller passes `use_proximal_output` based on comparing the key's sequence number against `proximal_after_seqno_`
+2. The `current_outputs_` pointer switches to the appropriate `CompactionOutputs` instance
+3. The key is passed to `CompactionOutputs::AddToOutput()`, which handles file opening, key writing, and file splitting
+
+## Thread Execution Model
+
+`CompactionJob::RunSubcompactions()` manages the parallel execution:
+
+1. **Thread creation**: Creates N-1 new threads via `port::Thread`, each executing `ProcessKeyValueCompaction()` for subcompactions 1 through N-1
+2. **Current thread**: The first subcompaction (index 0) always runs in the calling thread for resource efficiency
+3. **Join**: Waits for all spawned threads to complete
+4. **Cleanup**: Removes empty outputs, releases reserved threads
+
+Important: Each subcompaction thread calls `ProcessKeyValueCompaction()` independently, creating its own input iterator, compaction iterator, and output builders. There is no shared mutable state between subcompaction threads during execution.
+
+## Resource Management for Round-Robin Priority
+
+When compaction priority is `kRoundRobin` with leveled compaction style, the number of subcompactions may exceed `max_subcompactions`. This is handled by dynamically reserving additional background threads:
+
+- `AcquireSubcompactionResources()` reserves threads from the environment's thread pool, respecting `max_background_compactions` limits
+- Reserved threads are tracked in `extra_num_subcompaction_threads_reserved_` and accounted against `bg_compaction_scheduled_` or `bg_bottom_compaction_scheduled_`
+- `ShrinkSubcompactionResources()` releases unused threads when fewer subcompactions are needed than planned
+- `ReleaseSubcompactionResources()` releases all reserved threads after subcompactions complete
+
+Important: Subcompaction threads are separate from the background compaction thread pool. Each compaction job can spawn up to `max_subcompactions` threads regardless of `max_background_jobs`. In the worst case, total compaction threads can reach `max_background_jobs * max_subcompactions`.
+
+## EventListener Integration
+
+If an `EventListener` is configured:
+- `OnSubcompactionBegin()` is called before each subcompaction starts processing keys
+- `OnSubcompactionCompleted()` is called after each subcompaction finishes
+- `OnCompactionCompleted()` is called after all subcompactions are aggregated and the result is installed
+
+Subcompaction notifications include a `SubcompactionJobInfo` structure with the column family, input/output levels, compaction reason, compression type, and per-subcompaction stats.
+
+## Configuration
+
+| Option | Default | Location | Description |
+|--------|---------|----------|-------------|
+| `max_subcompactions` | 1 (disabled) | `DBOptions` in `include/rocksdb/options.h` | Maximum number of subcompactions per compaction job |
+| `compaction_pri` | `kMinOverlappingRatio` | `AdvancedColumnFamilyOptions` in `include/rocksdb/advanced_options.h` | When set to `kRoundRobin`, subcompaction count may exceed `max_subcompactions` |

--- a/docs/components/compaction/10_remote_compaction.md
+++ b/docs/components/compaction/10_remote_compaction.md
@@ -1,0 +1,102 @@
+# Remote Compaction
+
+**Files:** `db/compaction/compaction_job.h`, `db/compaction/compaction_service_job.cc`, `include/rocksdb/options.h`
+
+## Overview
+
+Remote compaction offloads compaction execution to a separate process or host. The primary DB instance delegates the CPU-intensive merge work to a remote worker, then installs the resulting SST files locally. This separation provides performance benefits (isolating compaction CPU from serving reads/writes) and operational flexibility (scaling compaction workers independently).
+
+The user implements the communication layer; RocksDB provides the serialization format and execution framework.
+
+## Architecture
+
+The remote compaction architecture involves two participants:
+
+- **Primary host**: Owns the DB with write permission. Selects files for compaction, serializes the compaction request, and installs the result.
+- **Compaction worker**: Opens the DB in read-only mode, executes the compaction, and writes output SST files to a temporary location.
+
+## Four-Phase Protocol
+
+Step 1 -- **Schedule**: The primary calls `CompactionService::Schedule()` (see `include/rocksdb/options.h`) with a serialized `CompactionServiceInput`. The user's implementation sends this to a remote worker. Returns a `CompactionServiceJobInfo` containing a scheduled job identifier.
+
+Step 2 -- **Compact**: The worker opens the DB using `DB::OpenAndCompact()` with the received input. This creates a `CompactionServiceCompactionJob` (see `db/compaction/compaction_job.h`), which extends `CompactionJob` with a custom output path. The worker cannot modify the LSM tree; it only reads input files and writes output files.
+
+Step 3 -- **Wait and return**: The primary calls `CompactionService::Wait()` with the job identifier, blocking until the remote worker completes. The worker returns a serialized `CompactionServiceResult` containing output file metadata, stats, and status.
+
+Step 4 -- **Install and purge**: The primary renames the output SST files from the temporary location to the DB's SST directory, builds `FileMetaData` for each output file, and installs them via the normal `CompactionJob::Install()` path. Input files are then purged.
+
+## CompactionServiceInput
+
+`CompactionServiceInput` (see `db/compaction/compaction_job.h`) is the serializable input specification sent to the worker:
+
+| Field | Description |
+|-------|-------------|
+| `cf_name` | Column family name |
+| `snapshots` | Active snapshot sequence numbers |
+| `input_files` | SST file names for all input levels |
+| `output_level` | Target output level |
+| `db_id` | Database identifier (used for unique SST ID generation on the remote worker) |
+| `has_begin` / `begin` | Optional start key boundary for the subcompaction |
+| `has_end` / `end` | Optional end key boundary for the subcompaction |
+| `options_file_number` | Options file number for the worker to load DB/CF options |
+
+Serialization uses RocksDB's `OptionTypeInfo` framework, producing a string-based format similar to options file serialization.
+
+## CompactionServiceResult
+
+`CompactionServiceResult` (see `db/compaction/compaction_job.h`) contains the compaction output:
+
+| Field | Description |
+|-------|-------------|
+| `status` | Compaction execution status |
+| `output_files` | Vector of `CompactionServiceOutputFile` with per-file metadata |
+| `output_level` | Output level |
+| `output_path` | Location of output files on the worker |
+| `bytes_read` / `bytes_written` | I/O statistics |
+| `stats` | Job-level `CompactionJobStats` |
+| `internal_stats` | Per-level `CompactionStatsFull` for both output and proximal levels |
+
+Each `CompactionServiceOutputFile` carries complete file metadata: file name, size, sequence number range, internal key range, timestamps, checksums, unique ID, table properties, and whether it is a proximal-level output.
+
+## CompactionServiceCompactionJob
+
+`CompactionServiceCompactionJob` (see `db/compaction/compaction_job.h`) is a private subclass of `CompactionJob` used on the worker side. Key differences from a regular `CompactionJob`:
+
+- **Single subcompaction**: The worker processes exactly one subcompaction (the primary dispatches each subcompaction separately)
+- **Custom output path**: Overrides `GetTableFileName()` to write SSTs to the user-specified temporary directory
+- **No Install phase**: The worker only executes `Prepare()` and `Run()`. The primary handles installation.
+- **Read-only DB**: The worker opens the DB read-only; it cannot modify the MANIFEST or WAL
+- **Abort not supported**: Uses a static `kCompactionAbortedFalse` flag since abort signaling to remote workers is not yet implemented
+
+## Installation on the Primary
+
+When the primary receives a successful result, it performs installation in `ProcessKeyValueCompactionWithCompactionService()`:
+
+Step 1 -- **Rename files**: For each output file, allocates a new file number from `VersionSet`, renames the file from the worker's output path to the DB's SST directory. This requires the temporary output directory to be on the same filesystem as the DB (rename semantics).
+
+Step 2 -- **Build metadata**: Constructs `FileMetaData` from the `CompactionServiceOutputFile` fields and adds it to the appropriate `CompactionOutputs` (normal or proximal level).
+
+Step 3 -- **Set stats**: Copies per-level stats and job stats from the result into the subcompaction state.
+
+Step 4 -- **Notify service**: Calls `CompactionService::OnInstallation()` to inform the user's implementation of success or failure.
+
+## Fallback to Local Compaction
+
+The remote compaction path supports fallback at two points:
+
+- `Schedule()` may return `kUseLocal` if the service decides the compaction should run locally
+- `Wait()` may return `kUseLocal` if the remote execution fails in a recoverable way
+
+When either returns `kUseLocal`, `ProcessKeyValueCompaction()` falls back to local execution using the standard `CompactionIterator` path.
+
+## Output Verification
+
+The primary can verify remote compaction output files using `verify_output_flags` (see `MutableCFOptions` in `options/cf_options.h`). The `kEnableForRemoteCompaction` flag enables verification specifically for remote compaction outputs. Available verification modes include block checksum verification, full iteration verification, and file checksum verification.
+
+## Limitations
+
+- The temporary output directory must be on the same filesystem as the DB for atomic rename. If not, the user must copy files before returning from `Wait()`.
+- Each remote compaction processes a single subcompaction. The primary dispatches subcompactions individually.
+- `CompactionService::CancelAwaitingJobs()` allows cancellation of awaiting remote compaction jobs, but abort signaling to actively running remote workers is not yet supported.
+- Compaction resumption for remote compaction is supported but limited to a single subcompaction.
+- The user implements all communication (scheduling, waiting, result transfer). No built-in RPC transport is provided.

--- a/docs/components/compaction/11_compaction_iterator.md
+++ b/docs/components/compaction/11_compaction_iterator.md
@@ -1,0 +1,152 @@
+# CompactionIterator
+
+**Files:** `db/compaction/compaction_iterator.h`, `db/compaction/compaction_iterator.cc`, `db/compaction/clipping_iterator.h`, `db/merge_helper.h`, `db/merge_helper.cc`
+
+## Overview
+
+`CompactionIterator` is the core key-processing engine within compaction. It transforms a sorted stream of input keys (from the `CompactionMergingIterator`) into compacted output by applying deduplication, deletion processing, merge resolution, compaction filter invocation, blob garbage collection, and sequence number management.
+
+## Input Iterator Stack
+
+The input to `CompactionIterator` is constructed as a layered iterator stack:
+
+1. **CompactionMergingIterator**: Heap-merges all input files across all levels. Unlike the read-path `MergingIterator`, it emits range tombstone start keys as sentinel entries and skips file-boundary sentinel keys. Created via `VersionSet::MakeInputIterator()`.
+
+2. **ClippingIterator** (see `db/compaction/clipping_iterator.h`): Restricts the merged stream to the subcompaction's key range `[start, end)`. Both bounds are optional (unbounded). Delegates bound checking to the underlying iterator when possible, falling back to explicit key comparisons.
+
+3. **BlobCountingIterator** (optional): Tracks blob file references for garbage statistics.
+
+4. **HistoryTrimmingIterator** (optional): Filters keys based on `trim_ts` for timestamp-based history trimming.
+
+5. **SequenceIterWrapper**: Wraps the final iterator to count input entries. When `must_count_input_entries` is true, replaces `Seek()` with sequential `Next()` calls to maintain accurate counts (at the cost of performance).
+
+## Core State Machine
+
+`CompactionIterator::NextFromInput()` implements the main processing loop. For each input key, it determines whether to output, drop, or further process the key. The key decisions depend on:
+
+- Whether this is the same user key as the previous iteration
+- Which snapshot stripe the key falls in
+- The key's type (Put, Delete, SingleDelete, Merge, etc.)
+- Whether the key is covered by a range deletion
+
+### User Key Tracking
+
+The iterator tracks the current user key across iterations:
+
+| State Variable | Purpose |
+|----------------|---------|
+| `has_current_user_key_` | Whether we are processing the same user key as before |
+| `current_user_key_sequence_` | Sequence number of the current user key's first occurrence |
+| `current_user_key_snapshot_` | Earliest snapshot in which this key is visible |
+| `has_outputted_key_` | Whether we have already emitted a record for this user key in the current snapshot stripe |
+
+### Snapshot Visibility
+
+For each key, `findEarliestVisibleSnapshot()` scans the snapshot list to find the earliest snapshot that sees this key. The snapshot list is expected to be small, so a linear scan is used.
+
+The key rules:
+
+**Rule A -- Hidden by newer version**: If the current key's earliest visible snapshot is the same as (or earlier than) a previous key's snapshot, and this is not the first occurrence of the user key, the key is hidden and dropped.
+
+**Rule B -- Deletion processing**: A deletion marker can be dropped if:
+- The key does not exist beyond the output level (`KeyNotExistsBeyondOutputLevel()` in `Compaction`)
+- The delete is visible in the earliest snapshot
+- `allow_ingest_behind` is false
+
+**Rule C -- Bottommost deletion**: At the bottommost level, a deletion marker can be dropped along with all older versions of the same key in the same snapshot stripe, since no data exists below.
+
+## Key Type Processing
+
+### Put / Value Keys
+
+The first occurrence of a user key within a snapshot stripe is output. Subsequent occurrences in the same stripe are dropped by Rule A. The compaction filter (if configured) is invoked on the first committed version of each user key.
+
+### Delete and DeleteWithTimestamp
+
+Deletion markers are dropped when safe (Rules B and C). When a deletion is dropped, a count is recorded in `iter_stats_.num_record_drop_obsolete`. When a deletion cannot be dropped (key might exist below the output level, or snapshot visibility requires it), the deletion is output.
+
+When timestamp GC is enabled (`full_history_ts_low` is set), deletion markers with timestamps older than the threshold are eligible for GC. Deletion markers with newer timestamps are preserved.
+
+### SingleDelete
+
+SingleDelete processing requires lookahead: the iterator peeks at the next key to find the matching Put. The logic handles several cases:
+
+- **SD + Put in same snapshot stripe**: Both are dropped (compacted out)
+- **SD + Put across snapshot boundary**: The SingleDelete is output, and the Put is marked for output with its value cleared (Optimization 3 -- saves space while enabling future compaction)
+- **SD without matching Put**: If the key does not exist beyond the output level, the SingleDelete is dropped. Otherwise it is output.
+- **SD + SD (consecutive)**: The first is dropped; the second is handled in the next iteration
+- **SD + Delete**: Violates the SingleDelete contract. Behavior depends on `enforce_single_del_contracts` (see `ImmutableOptions` in `options/cf_options.h`): either returns a corruption error or logs a warning and drops the SingleDelete.
+
+### Merge
+
+When a `kTypeMerge` key is encountered, `MergeHelper::MergeUntil()` (see `db/merge_helper.h`) consumes all consecutive merge operands for the same user key (respecting snapshot boundaries) and produces a merged result:
+
+- If a base value (Put/Delete) is found within the same snapshot stripe, the merge is fully resolved
+- If merge operands span a snapshot boundary, partial merge results are output via `MergeOutputIterator`
+- If `MergeUntil()` returns `MergeInProgress`, the merge operands have been consumed but no base value was found; subsequent iterations handle the remaining base value
+
+### ValuePreferredSeqno (Timed Put)
+
+Keys of type `kTypeValuePreferredSeqno` carry a preferred sequence number. When safe (bottommost level or key does not exist beyond the output level, and the key is in the earliest snapshot), the iterator swaps the preferred sequence number in and converts the key to a regular `kTypeValue`. A range deletion check is performed both before and after the swap to ensure the swapped key would not become covered by a range tombstone.
+
+### Range Deletion Sentinels
+
+Keys flagged as range deletion sentinels (`IsDeleteRangeSentinelKey()`) are emitted immediately without any processing. The caller (`ProcessKeyValueCompaction`) handles them specially, routing range tombstone data to the `CompactionRangeDelAggregator`.
+
+## Compaction Filter
+
+`InvokeFilterIfNeeded()` applies the user-defined `CompactionFilter` to the first committed version of each user key. The filter is invoked for `kTypeValue`, `kTypeBlobIndex`, and `kTypeWideColumnEntity` keys. It is never invoked on deletion markers, merge operands (which are handled via `FilterMergeOperand`), or flush operations.
+
+Filter decisions and their effects:
+
+| Decision | Effect |
+|----------|--------|
+| `kKeep` | Key is output unchanged |
+| `kRemove` | Key type is changed to `kTypeDeletion` |
+| `kPurge` | Key type is changed to `kTypeSingleDeletion` |
+| `kChangeValue` | Value is replaced with filter-provided value |
+| `kRemoveAndSkipUntil` | Key is dropped and input iterator seeks past `skip_until` (older versions may reappear since no deletion marker is inserted) |
+| `kChangeWideColumnEntity` | Value is replaced with serialized wide columns |
+| `kChangeBlobIndex` | Blob index is replaced (stacked BlobDB only) |
+
+Important: Since RocksDB 6.0, compaction filters always run regardless of snapshots. Filtering a key may break snapshot repeatability.
+
+When a `CompactionFilterFactory` is configured, each subcompaction creates its own filter instance via the factory. This guarantees each filter is accessed from a single thread, avoiding the thread-safety requirement that applies to a single `CompactionFilter` instance shared across subcompactions.
+
+## Sequence Number Zeroing
+
+`PrepareOutput()` handles sequence number management for bottommost compactions. When a key is at the bottommost level, visible in the earliest snapshot, and its sequence number is at or below `preserve_seqno_after_`, the sequence number is zeroed. This enables more efficient key comparisons and reduces metadata overhead.
+
+The `preserve_seqno_after_` threshold (computed in `CompactionJob::Prepare()`) combines:
+- Time-based preservation (`preserve_internal_time_seconds`)
+- Snapshot-based preservation (earliest snapshot sequence number)
+
+When a key's sequence number is zeroed, `last_key_seq_zeroed_` is set to true, which affects subsequent SingleDelete processing (a SingleDelete following a zeroed key can be safely dropped).
+
+## Blob Processing
+
+`PrepareOutput()` also handles blob-related operations:
+
+### Large Value Extraction
+
+`ExtractLargeValueIfNeeded()` passes values to the `BlobFileBuilder`. If the value exceeds `min_blob_size` (see `AdvancedColumnFamilyOptions` in `include/rocksdb/advanced_options.h`), it is written to a blob file and the value is replaced with a `kTypeBlobIndex` reference.
+
+### Blob Garbage Collection
+
+`GarbageCollectBlobIfNeeded()` relocates blob values from old blob files. When `enable_blob_garbage_collection` is true, blobs in files older than the cutoff (computed from `blob_garbage_collection_age_cutoff`) are read, and their values are either re-extracted to new blob files or inlined back into the LSM tree depending on current settings.
+
+## Iteration Statistics
+
+`CompactionIterationStats` (see `db/compaction/compaction_iteration_stats.h`) tracks detailed per-subcompaction statistics:
+
+| Category | Statistics |
+|----------|-----------|
+| Input | `num_input_records`, `num_input_deletion_records`, `num_input_corrupt_records`, `num_input_timed_put_records` |
+| Dropped | `num_record_drop_user` (filter), `num_record_drop_hidden` (Rule A), `num_record_drop_obsolete` (deletion GC), `num_record_drop_range_del` |
+| SingleDelete | `num_single_del_mismatch`, `num_single_del_fallthru` |
+| Blob | `num_blobs_read`, `num_blobs_relocated`, `total_blob_bytes_read`, `total_blob_bytes_relocated` |
+| Filter | `total_filter_time` |
+
+## CompactionProxy
+
+`CompactionIterator` accesses compaction metadata through the `CompactionProxy` interface (see `db/compaction/compaction_iterator.h`), which abstracts the `Compaction` object. This allows tests to provide custom implementations via the second constructor that accepts a `std::unique_ptr<CompactionProxy>`. The production implementation, `RealCompaction`, simply delegates to the underlying `Compaction` object.

--- a/docs/components/compaction/12_compaction_filter.md
+++ b/docs/components/compaction/12_compaction_filter.md
@@ -1,0 +1,136 @@
+# CompactionFilter and CompactionFilterFactory
+
+**Files:** `include/rocksdb/compaction_filter.h`, `db/compaction/compaction_iterator.cc`, `include/rocksdb/options.h`, `db/builder.cc`, `db/flush_job.cc`
+
+## Overview
+
+CompactionFilter is a user-extensible interface that allows applications to inspect, modify, or drop key-value pairs during table file creation. The filter is invoked during compaction and optionally during flush, providing a mechanism for custom TTL expiration, data transformation, lazy deletion, and other application-specific key lifecycle management.
+
+## Configuration
+
+Two options control compaction filter behavior, both defined in `ColumnFamilyOptions` in `include/rocksdb/options.h`:
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `compaction_filter` | `const CompactionFilter*` | Singleton filter instance shared across all compactions. Must be thread-safe if multithreaded compaction is used. |
+| `compaction_filter_factory` | `shared_ptr<CompactionFilterFactory>` | Factory that creates a new filter per table file creation thread. Each filter is used by only one thread, so it does not need to be thread-safe. |
+
+If both are set, `compaction_filter` takes precedence over `compaction_filter_factory` during compaction. However, flush filtering is wired only through `CompactionFilterFactory`: the singleton `compaction_filter` does not participate in flush filtering. Flush filtering requires `CompactionFilterFactory::ShouldFilterTableFileCreation(kFlush)` to return true, and the filter is obtained via `CreateCompactionFilter()`. See `db/builder.cc` and `db/flush_job.cc` for the flush filter setup.
+
+## API Evolution
+
+CompactionFilter has evolved through three generations of filtering methods:
+
+| Method | Handles | Notes |
+|--------|---------|-------|
+| `Filter()` + `FilterMergeOperand()` | Plain values, merge operands separately | Original API. Limited decision set (keep or remove). |
+| `FilterV2()` | Plain values + merge operands (unified) | Adds `kRemoveAndSkipUntil`, `kChangeValue` decisions. Default implementation delegates to `Filter()`/`FilterMergeOperand()`. |
+| `FilterV3()` | Plain values + merge operands + wide-column entities | Adds `kChangeWideColumnEntity`, `kPurge` decisions. Default implementation delegates to `FilterV2()` for non-entity types and keeps all entities. |
+
+Applications should override the most recent API level they need. Overriding `FilterV3()` alone is sufficient -- there is no need to also override `FilterV2()` or `Filter()`.
+
+## Decision Types
+
+The `CompactionFilter::Decision` enum defines all possible filter outcomes, specified in `include/rocksdb/compaction_filter.h`:
+
+| Decision | Effect | Supported Types |
+|----------|--------|-----------------|
+| `kKeep` | Preserve the key-value as-is | All |
+| `kRemove` | Convert plain values and entities to a Delete tombstone; drop merge operands | All |
+| `kChangeValue` | Replace the value. Entities are converted to plain key-values. | All |
+| `kRemoveAndSkipUntil` | Drop the key and skip all keys in `[key, *skip_until)`. Keys are dropped regardless of type (no tombstone conversion). | All |
+| `kPurge` | Convert to a SingleDelete tombstone. Not supported for merge operands. | Values, entities |
+| `kChangeWideColumnEntity` | Change to a wide-column entity with specified columns. Only supported in `FilterV3()`. | Values, entities |
+| `kUndetermined` | Only valid from `FilterBlobByKey()`. Signals that the blob value must be read before deciding. | BlobDB keys only |
+
+## Invocation Flow
+
+The filter is invoked by `CompactionIterator::InvokeFilterIfNeeded()` in `db/compaction/compaction_iterator.cc`. The flow per key:
+
+Step 1: Check if a filter is configured. If not, skip.
+
+Step 2: Check the key type. Only `kTypeValue`, `kTypeBlobIndex`, and `kTypeWideColumnEntity` are passed to the filter. Merge operands, tombstones, and other internal types bypass filtering.
+
+Step 3: For BlobDB keys (`kTypeBlobIndex`), first call `FilterBlobByKey()` to attempt a key-only decision. If the result is `kUndetermined`, fetch the blob value from the blob file and proceed to `FilterV3()` with the resolved value.
+
+Step 4: Call `FilterV3()` with the key, value type, existing value or columns, and output parameters.
+
+Step 5: Apply the decision. For `kRemove`, the key type is changed to `kTypeDeletion`. For `kPurge`, it becomes `kTypeSingleDeletion`. For `kChangeValue`, the value is replaced. For `kRemoveAndSkipUntil`, the iterator advances past the skip range.
+
+Important: For `kRemoveAndSkipUntil`, if `*skip_until <= key`, the decision is silently converted to `kKeep` to avoid backward seeking.
+
+## Scope and Limitations
+
+- **Memtable data is not filtered.** By default, compaction filters only operate on SST file data during compaction. Data in the memtable is not passed through the filter. This means keys that should be filtered may still be flushed to SST files if they are in the memtable when a flush occurs. Using `CompactionFilterFactory::ShouldFilterTableFileCreation()` to enable filtering during flush addresses this for new flushes.
+- **Only the newest version is filtered.** If multiple versions of a key exist in the compaction input, only the newest version is passed to the filter. Older versions are handled by CompactionIterator's normal dedup logic.
+- **Deletion markers bypass the filter.** If the newest version of a key is a tombstone (Delete or SingleDelete), the filter is not invoked for that key.
+- **Ghost invocations.** The filter may be invoked on a key that was already deleted, if the deletion marker is in a different SST file not included in the current compaction's inputs.
+- **kRemoveAndSkipUntil does not insert tombstones.** Unlike `kRemove`, which converts keys to tombstones, `kRemoveAndSkipUntil` drops keys without leaving tombstones. This means older versions of skipped keys may reappear if they exist in lower levels.
+
+## CompactionFilter::Context
+
+Each filter invocation receives context about the table file being created, provided via `CompactionFilter::Context` in `include/rocksdb/compaction_filter.h`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `is_full_compaction` | `bool` | Whether this is a full compaction of all files |
+| `is_manual_compaction` | `bool` | Whether triggered by `CompactRange()` or `CompactFiles()` |
+| `input_start_level` | `int` | Lowest input level (`kUnknownStartLevel` if not applicable) |
+| `column_family_id` | `uint32_t` | Column family being compacted |
+| `reason` | `TableFileCreationReason` | Why the file is being created (compaction, flush, recovery, etc.) |
+| `input_table_properties` | `TablePropertiesCollection` | Properties of all input files |
+
+## CompactionFilterFactory
+
+`CompactionFilterFactory` (in `include/rocksdb/compaction_filter.h`) creates per-thread filter instances, avoiding the thread-safety requirement of the singleton `compaction_filter` option.
+
+Key methods:
+
+| Method | Description |
+|--------|-------------|
+| `ShouldFilterTableFileCreation(reason)` | Returns whether to apply filtering for the given `TableFileCreationReason`. Default: only for `kCompaction`. |
+| `CreateCompactionFilter(context)` | Creates a new filter instance for one table file creation thread. |
+
+The `ShouldFilterTableFileCreation()` method enables filtering during flush, recovery, and ingestion -- not just compaction. Override it to return `true` for other `TableFileCreationReason` values as needed.
+
+## Interaction with Snapshots
+
+CompactionFilter can delete or modify keys even when snapshots exist that reference those keys. The `IgnoreSnapshots()` method is deprecated and must return `true`. This means:
+
+- Repeatable reads are NOT guaranteed when a CompactionFilter is active.
+- Data visible through a snapshot may disappear after a compaction runs.
+- Applications using both snapshots and CompactionFilter must account for this behavior.
+
+## Interaction with Merge Operations
+
+When filtering merge operands:
+
+- A `kRemove` decision on a merge operand simply drops it (no tombstone conversion).
+- When using `TransactionDB`, filtering merge operands is not recommended. Dropped merge operands can cause `TransactionDB` to miss write conflicts, allowing transactions that should fail to commit successfully. Merge filtering logic should be implemented inside the `MergeOperator` instead.
+- Mixed `Put()` and `Merge()` sequences on the same key have partial guarantees: merge operands are guaranteed to pass through the filter, but `Put()` values may or may not.
+
+## Interaction with BlobDB
+
+For integrated BlobDB, when a key's value is stored in a blob file:
+
+1. `FilterBlobByKey()` is called first with only the key (no I/O).
+2. If the decision is `kUndetermined`, the blob value is fetched from the blob file.
+3. `FilterV3()` is then called with the resolved value and `value_type = kValue`.
+
+This two-phase approach allows applications to avoid blob reads when the key alone is sufficient to make a decision.
+
+## Thread Safety
+
+- A singleton `compaction_filter` (set via `ColumnFamilyOptions`) may be called from multiple threads concurrently and must be thread-safe.
+- Filters created by `CompactionFilterFactory` are each used by a single thread and do not need to be thread-safe. However, multiple filter instances may exist simultaneously.
+- Exceptions must NOT propagate out of filter methods. RocksDB is not exception-safe, and escaping exceptions cause undefined behavior including data loss and corruption.
+
+## Common Use Cases
+
+| Use Case | Approach |
+|----------|----------|
+| TTL expiration | Check timestamp embedded in key or value; return `kRemove` for expired entries |
+| Lazy deletion | Return `kRemove` for keys matching a deletion predicate |
+| Data migration | Return `kChangeValue` or `kChangeWideColumnEntity` to transform values |
+| Prefix cleanup | Return `kRemoveAndSkipUntil` to efficiently skip key ranges |
+| Conditional blob GC | Use `FilterBlobByKey()` to avoid reading blobs for keys that should be removed |

--- a/docs/components/compaction/13_sst_partitioner.md
+++ b/docs/components/compaction/13_sst_partitioner.md
@@ -1,0 +1,93 @@
+# SST Partitioner
+
+**Files:** `include/rocksdb/sst_partitioner.h`, `db/compaction/sst_partitioner.cc`, `db/compaction/compaction_outputs.cc`, `db/compaction/compaction.cc`
+
+## Overview
+
+SstPartitioner is a pluggable interface that controls how compaction splits output SST files at application-defined boundaries. Without a partitioner, compaction splits output files based on size targets and grandparent overlap. With a partitioner, compaction additionally splits at user-defined key boundaries, which can reduce write amplification when files are later promoted or compacted further.
+
+The primary use case is splitting SST files at key prefix boundaries so that files align with application-level partitions (e.g., tenant IDs, date ranges, geographic regions).
+
+## Configuration
+
+The partitioner factory is set via `sst_partitioner_factory` in `ColumnFamilyOptions` (see `include/rocksdb/options.h`). Use `NewSstPartitionerFixedPrefixFactory()` from `include/rocksdb/sst_partitioner.h` to create the built-in fixed-prefix partitioner.
+
+Note: This feature is marked as experimental in the options documentation.
+
+## SstPartitioner Interface
+
+Defined in `include/rocksdb/sst_partitioner.h`, the interface has two methods:
+
+| Method | Description |
+|--------|-------------|
+| `ShouldPartition(request)` | Called for each key during compaction. Returns `kRequired` to force a file split between the previous key and the current key, or `kNotRequired` to continue the current file. |
+| `CanDoTrivialMove(smallest, largest)` | Called during trivial move evaluation. Returns `true` if all keys in `[smallest, largest]` belong to the same partition, allowing trivial move. Returns `false` if a partition boundary exists within the range. |
+
+### PartitionerRequest
+
+The `PartitionerRequest` struct passed to `ShouldPartition()` contains:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `prev_user_key` | `const Slice*` | The last key written to the current output file |
+| `current_user_key` | `const Slice*` | The next key to be written |
+| `current_output_file_size` | `uint64_t` | Current output file size in bytes |
+
+### SstPartitioner::Context
+
+The factory receives context about the compaction when creating a partitioner:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `is_full_compaction` | `bool` | Whether all files are being compacted |
+| `is_manual_compaction` | `bool` | Whether triggered by manual compaction |
+| `output_level` | `int` | Target output level |
+| `smallest_user_key` | `Slice` | Smallest key in the compaction |
+| `largest_user_key` | `Slice` | Largest key in the compaction |
+
+## SstPartitionerFactory
+
+`SstPartitionerFactory` (in `include/rocksdb/sst_partitioner.h`) extends `Customizable` and creates `SstPartitioner` instances. Custom factories must implement:
+
+| Method | Description |
+|--------|-------------|
+| `CreatePartitioner(context)` | Creates a partitioner for the given compaction context |
+| `Name()` | Returns a unique name identifying this factory |
+
+## Built-in Implementation: SstPartitionerFixedPrefix
+
+RocksDB provides `SstPartitionerFixedPrefix` and its factory `SstPartitionerFixedPrefixFactory` for the common case of splitting at fixed-length key prefix boundaries.
+
+**Behavior**: Compares the first `len` bytes of the previous and current user keys. If they differ, returns `kRequired` to force a file split. For keys shorter than `len`, the entire key is used as the prefix.
+
+**CanDoTrivialMove**: Uses the same prefix comparison on the smallest and largest keys. Returns `true` (allow trivial move) only if both keys share the same prefix.
+
+Create via the factory function `NewSstPartitionerFixedPrefixFactory(prefix_len)` in `include/rocksdb/sst_partitioner.h`.
+
+## Integration with Compaction
+
+### Partitioner Creation
+
+During compaction, the `CompactionOutputs` constructor creates a partitioner via `Compaction::CreateSstPartitioner()` in `db/compaction/compaction.cc`. The partitioner is only created for non-L0 output levels -- the `CompactionOutputs` constructor sets `partitioner_` to `nullptr` when `output_level() == 0`, because L0 output files are never partitioned (L0 files can have overlapping key ranges). Additionally, `ShouldStopBefore()` has a secondary guard that returns false for L0 output regardless of the partitioner.
+
+### Output File Splitting
+
+The partitioner is checked in `CompactionOutputs::ShouldStopBefore()` in `db/compaction/compaction_outputs.cc`. The partitioner check occurs after TTL-based cutting but before size-based and grandparent-based checks. When the partitioner returns `kRequired`, the current output file is finalized and a new file is started.
+
+The `last_key_for_partitioner_` field tracks the previous key for the partitioner request. It is updated for every key including range deletion sentinel keys emitted by `CompactionMergingIterator`.
+
+### Interaction with Trivial Move
+
+During trivial move evaluation, the partitioner's `CanDoTrivialMove()` is called to verify that the file being moved does not span a partition boundary. If it does, trivial move is blocked and a full compaction is performed to split the file.
+
+### Interaction with Manual Compaction
+
+When `CompactRange()` is called with both `begin` and `end` specified and a partitioner is configured, the overlap check logic in `CompactRangeInternal()` consults the partitioner. If the partitioner indicates a partition boundary exists within `[begin, end]`, the overlap check uses file-level granularity instead of key-level granularity. This ensures that files spanning partition boundaries are included in the compaction even if the keys within those files do not overlap the specified range at the key level.
+
+## Design Considerations
+
+**Write amplification reduction**: By aligning SST file boundaries with application-defined partitions, trivial moves become more likely in future compactions. A file that maps entirely to one partition can be moved to the next level without re-reading and re-writing its contents.
+
+**File count impact**: Aggressive partitioning (short prefixes with high cardinality) creates more, smaller files. This increases metadata overhead and can impact read performance through more files to search. Balance partition granularity against the number of resulting files.
+
+**No L0 partitioning**: Partitioning is disabled for L0 output because L0 allows overlapping files. Partitioning L0 would not provide the trivial-move benefit since L0 files must be merged on compaction regardless.

--- a/docs/components/compaction/14_manual_compaction.md
+++ b/docs/components/compaction/14_manual_compaction.md
@@ -1,0 +1,142 @@
+# Manual Compaction
+
+**Files:** `include/rocksdb/db.h`, `include/rocksdb/options.h`, `db/db_impl/db_impl_compaction_flush.cc`
+
+## Overview
+
+Manual compaction allows applications to explicitly trigger compaction on a key range or a specific set of files, rather than relying solely on RocksDB's automatic background compaction. This is useful for forcing data compaction after bulk loading, applying compaction filters to existing data, reducing space amplification on demand, or enforcing SST partitioning boundaries.
+
+RocksDB provides two manual compaction APIs:
+
+| API | Purpose |
+|-----|---------|
+| `DB::CompactRange()` | Compact all data within a key range, potentially across multiple levels |
+| `DB::CompactFiles()` | Compact a specific set of input files to a specified output level |
+
+## CompactRange
+
+### API
+
+See `DB::CompactRange()` in `include/rocksdb/db.h`. Takes `CompactRangeOptions`, a `ColumnFamilyHandle`, and optional `begin`/`end` key range pointers.
+
+- `begin == nullptr`: treated as before all keys
+- `end == nullptr`: treated as after all keys
+- Both `nullptr`: compacts the entire database for that column family
+- When user-defined timestamps are enabled, `begin` and `end` should NOT contain timestamps
+
+### CompactRangeOptions
+
+Defined as `CompactRangeOptions` in `include/rocksdb/options.h`:
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `exclusive_manual_compaction` | `false` | If true, no other compaction runs concurrently with this manual compaction |
+| `change_level` | `false` | If true, after compaction, move files to `target_level` via `ReFitLevel()` |
+| `target_level` | `-1` | Target level when `change_level` is true |
+| `target_path_id` | `0` | Output path index within `db_paths` |
+| `bottommost_level_compaction` | `kIfHaveCompactionFilter` | Controls whether to compact the bottommost level (see below) |
+| `allow_write_stall` | `false` | If false, waits until the flush would not stall writes before flushing |
+| `max_subcompactions` | `0` | Override for `max_subcompactions` (0 means use DB option) |
+| `full_history_ts_low` | `nullptr` | Timestamp low bound for GC of user-defined timestamps |
+| `canceled` | `nullptr` | Atomic bool to cancel the compaction in progress |
+| `blob_garbage_collection_policy` | `kUseDefault` | Override blob GC policy (kForce, kDisable, or kUseDefault) |
+
+### Bottommost Level Compaction
+
+The `BottommostLevelCompaction` enum controls whether an additional intra-level compaction is performed at the final output level:
+
+| Value | Behavior |
+|-------|----------|
+| `kSkip` | Do not compact the bottommost level |
+| `kIfHaveCompactionFilter` | Compact bottommost only if a compaction filter is configured (default) |
+| `kForce` | Always compact the bottommost level |
+| `kForceOptimized` | Compact bottommost, but skip files that were already produced by this CompactRange (uses file number threshold) |
+
+### Execution Flow by Compaction Style
+
+**Level compaction**: CompactRange compacts data one level at a time, starting from the first level that overlaps the key range. For each level, it calls `RunManualCompaction()` to compact from that level to the next. After reaching the bottommost non-empty level, it optionally performs an intra-level compaction based on `bottommost_level_compaction`. With `level_compaction_dynamic_level_bytes`, L0 compacts to the base level (not necessarily L1).
+
+**Universal compaction**: CompactRange compacts all files together into the last level in a single `RunManualCompaction()` call with `kCompactAllLevels` as the input level. The key range `[begin, end]` is ignored -- universal compaction always compacts all files.
+
+**FIFO compaction**: CompactRange calls `RunManualCompaction()` with input level 0 and output level 0. The key range is ignored. The FIFO picker applies its normal selection strategy (TTL, size-based deletion).
+
+### Pre-Compaction Flush
+
+Before starting compaction, `CompactRange()` flushes the memtable to ensure all data is on disk. The flush is skipped only when both `begin` and `end` are specified and the range does not overlap with any memtable data (checked via `RangesOverlapWithMemtables()`).
+
+### Cancellation
+
+Manual compactions can be canceled through three mechanisms:
+
+1. **Per-call cancellation**: Set `CompactRangeOptions::canceled` to an `atomic<bool>*`, then set it to `true` from another thread.
+2. **Global pause**: Call `DB::DisableManualCompaction()`. This sets `manual_compaction_paused_` and overwrites the `canceled` pointer in `CompactRangeOptions`. Must be matched by `EnableManualCompaction()` calls.
+3. **Abort all**: Call `DB::AbortAllCompactions()`. This cancels both manual and automatic compactions.
+
+Canceled compactions return `Status::Incomplete(kManualCompactionPaused)`.
+
+Note: When `exclusive_manual_compaction` is used with `canceled`, cancellation may be delayed while waiting for automatic compactions to finish, as there is no mechanism to wake the exclusive-wait loop when `canceled` changes.
+
+## CompactFiles
+
+### API
+
+See `DB::CompactFiles()` in `include/rocksdb/db.h`. Takes `CompactionOptions`, a `ColumnFamilyHandle`, a vector of input file names, the output level, and optional output path ID, output file names, and compaction job info.
+
+### CompactionOptions
+
+Defined as `CompactionOptions` in `include/rocksdb/options.h`:
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `compression` | `kDisableCompressionOption` | Output compression type (deprecated -- uses CF options if disabled) |
+| `output_file_size_limit` | `MAX` | Maximum output file size (MAX means single output file) |
+| `max_subcompactions` | `0` | Override for `max_subcompactions` |
+| `canceled` | `nullptr` | Atomic bool for cancellation |
+| `output_temperature_override` | `kUnknown` | Override temperature for output files |
+| `allow_trivial_move` | `false` | Allow trivial move for non-overlapping files |
+
+### Differences from CompactRange
+
+| Aspect | CompactRange | CompactFiles |
+|--------|--------------|--------------|
+| Input selection | Key range | Explicit file list |
+| Flush | Flushes memtable first | No flush |
+| Multi-level | Iterates level by level | Single compaction |
+| Compaction picker | Uses picker's `CompactRange()` method | Uses `PickCompactionForCompactFiles()` |
+| DisableManualCompaction | Overwrites `canceled` | Does NOT overwrite `canceled` |
+| Bottommost option | Configurable | Not applicable |
+
+## RunManualCompaction Internal Flow
+
+`RunManualCompaction()` in `db/db_impl/db_impl_compaction_flush.cc` coordinates manual compaction execution:
+
+Step 1: Create a `ManualCompactionState` with the specified level range, key range, and options.
+
+Step 2: Add the manual compaction to the pending queue via `AddManualCompaction()`.
+
+Step 3: If `exclusive`, wait for all background compactions to finish.
+
+Step 4: In a loop, call `ColumnFamilyData::CompactRange()` to pick files and create a `Compaction` object. If there is a conflict with another running compaction, wait and retry.
+
+Step 5: Schedule the compaction on the appropriate thread pool. Bottommost-level compactions use the `BOTTOM` priority pool if it has threads configured.
+
+Step 6: Wait for the compaction to complete. If the compaction is marked `incomplete` (meaning the key range was only partially processed), loop back to pick the next batch.
+
+Step 7: Remove the manual compaction from the queue and signal other waiting compactions.
+
+## Thread Scheduling
+
+Manual compactions participate in the same thread pool as automatic compactions:
+
+- Non-bottommost compactions run on the `LOW` priority thread pool
+- Bottommost-level compactions run on the `BOTTOM` priority pool (if `GetBackgroundThreads(BOTTOM) > 0`), otherwise on `LOW`
+- When `exclusive_manual_compaction` is true, the manual compaction waits for all other compactions to drain before starting
+
+## Interaction with Automatic Compaction
+
+When a manual compaction is pending (`HasPendingManualCompaction()` returns true), automatic compaction scheduling behavior depends on the `exclusive` setting:
+
+- **Exclusive**: Automatic compactions are temporarily blocked via `MaybeScheduleFlushOrCompaction()` checks
+- **Non-exclusive**: Automatic compactions continue running. Manual compaction may conflict with automatic compaction on the same level, in which case the manual compaction waits and retries.
+
+After a manual compaction completes, `MaybeScheduleFlushOrCompaction()` is called to reschedule any automatic compactions that may have been preempted.

--- a/docs/components/compaction/15_disk_space_management.md
+++ b/docs/components/compaction/15_disk_space_management.md
@@ -1,0 +1,138 @@
+# Disk Space Management
+
+**Files:** `include/rocksdb/sst_file_manager.h`, `file/sst_file_manager_impl.h`, `file/sst_file_manager_impl.cc`, `file/delete_scheduler.h`, `file/delete_scheduler.cc`
+
+## Overview
+
+RocksDB provides disk space management through the `SstFileManager` system, which tracks all SST and blob files, enforces maximum disk usage limits, controls the rate of file deletion, and coordinates space reservation for compactions. This system prevents disk space exhaustion, reduces I/O spikes from bulk file deletions, and supports recovery from out-of-space errors.
+
+## SstFileManager
+
+`SstFileManager` is the public interface defined in `include/rocksdb/sst_file_manager.h`. It is created via `NewSstFileManager()` and shared across one or more DB instances via `DBOptions::sst_file_manager`.
+
+### Creation
+
+Created via `NewSstFileManager()` in `include/rocksdb/sst_file_manager.h`. Key parameters:
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `rate_bytes_per_sec` | 0 | Deletion rate limit in bytes/second. 0 disables rate limiting. Also applies to WAL file deletion. |
+| `max_trash_db_ratio` | 0.25 | When trash size exceeds this fraction of total DB size, new files are deleted immediately instead of being rate-limited |
+| `bytes_max_delete_chunk` | 64 MB | For large files, truncate by this chunk size rather than deleting the whole file at once. 0 means always delete whole files. |
+
+### Maximum Space Enforcement
+
+`SetMaxAllowedSpaceUsage()` sets a hard limit on total SST and blob file size. When the limit is reached:
+
+- `IsMaxAllowedSpaceReached()` returns true
+- Writes to the DB will fail
+- Setting `max_allowed_space` to 0 disables this check (default)
+
+`IsMaxAllowedSpaceReachedIncludingCompactions()` also accounts for estimated size of ongoing compactions (via `cur_compactions_reserved_size_`), providing a more conservative check.
+
+### Compaction Buffer
+
+`SetCompactionBufferSize()` reserves space that compactions should leave available for other operations (logging, flushing). This is checked during the `EnoughRoomForCompaction()` pre-compaction check.
+
+## File Tracking
+
+`SstFileManagerImpl` (in `file/sst_file_manager_impl.h`) maintains an internal map of all tracked files and their sizes:
+
+| Method | When Called | Description |
+|--------|------------|-------------|
+| `OnAddFile()` | After SST/blob file creation | Adds file to tracking map, updates total size |
+| `OnDeleteFile()` | After file deletion | Removes from tracking map, updates total size |
+| `OnMoveFile()` | After file rename/move | Updates tracking map (add new path, remove old) |
+| `OnUntrackFile()` | On DB close with unowned SFM | Removes without filesystem interaction |
+
+All tracking operations are protected by a mutex and are thread-safe.
+
+## Compaction Space Reservation
+
+Before a compaction starts, `DBImpl::EnoughRoomForCompaction()` in `db/db_impl/db_impl_compaction_flush.cc` calls `SstFileManagerImpl::EnoughRoomForCompaction()` to verify sufficient space:
+
+Step 1: Calculate the total input file size for the compaction (conservatively assuming all input data will be rewritten as output).
+
+Step 2: Check if `total_files_size_ + cur_compactions_reserved_size_ + size_added + compaction_buffer_size_` exceeds `max_allowed_space_`. If so, cancel the compaction.
+
+Step 3: For databases that have previously experienced a `NoSpace` error (soft error recovery), perform additional free-space checks by querying the filesystem via `GetFreeSpace()`.
+
+Step 4: If space is sufficient, add `size_added_by_compaction` to `cur_compactions_reserved_size_` to prevent concurrent compactions from over-committing.
+
+When a compaction completes, `OnCompactionCompletion()` subtracts the input file size from `cur_compactions_reserved_size_`.
+
+If space is insufficient, the compaction is canceled and the `COMPACTION_CANCELLED` ticker is incremented.
+
+## Rate-Limited File Deletion (DeleteScheduler)
+
+`DeleteScheduler` (in `file/delete_scheduler.h`) implements rate-limited file deletion to prevent I/O spikes when many SST files are deleted simultaneously (e.g., after compaction produces output files and the input files become obsolete).
+
+### Deletion Flow
+
+When a file needs to be deleted, `DeleteScheduler` decides between immediate and deferred deletion:
+
+**Immediate deletion** occurs when:
+- Rate limiting is disabled (`rate_bytes_per_sec_ <= 0`)
+- For accounted files: trash size exceeds `max_trash_db_ratio` of total DB size (unless `force_bg` is set)
+- For unaccounted files: the file has more than one hard link (unless `force_bg` is set)
+
+**Deferred (rate-limited) deletion** occurs otherwise:
+
+Step 1: Rename the file with a `.trash` extension via `MarkAsTrash()`.
+
+Step 2: Add to the deletion queue.
+
+Step 3: A background thread (`BackgroundEmptyTrash()`) processes the queue, sleeping between deletions to enforce the rate limit.
+
+### Chunked Deletion
+
+For large files (larger than `bytes_max_delete_chunk`), instead of deleting the entire file at once, the scheduler uses `ftruncate()` to remove one chunk at a time. This further smooths I/O impact. Chunked deletion only applies when the file has exactly one hard link. After each truncation, the file re-enters the queue for further truncation.
+
+Note: With chunked deletion enabled, partially truncated `.trash` files may exist on disk. These files should not be recovered directly without validation.
+
+### Rate Limiting Mechanism
+
+The background thread calculates a penalty (sleep time) as `total_deleted_bytes * 1000000 / rate_bytes_per_sec` microseconds. It then sleeps using a timed condition variable wait, which can be interrupted by:
+- New rate limit changes (detected at the top of each loop iteration)
+- Scheduler closing (destructor sets `closing_ = true`)
+
+### Trash Buckets
+
+`DeleteScheduler` supports grouping deletions into "trash buckets" via `NewTrashBucket()`. This allows callers to wait for a specific batch of deletions to complete using `WaitForEmptyTrashBucket()`, rather than waiting for all pending deletions.
+
+### Accounted vs Unaccounted Files
+
+| Type | Tracked by SstFileManager | Trash ratio check | Use case |
+|------|---------------------------|-------------------|----------|
+| Accounted | Yes | Subject to `max_trash_db_ratio` | Normal SST/blob files |
+| Unaccounted | No | Uses hard link count instead | WAL files, temporary files |
+
+## Error Recovery
+
+`SstFileManagerImpl` supports background error recovery for disk-full conditions:
+
+- `StartErrorRecovery()` registers an `ErrorHandler` for background polling when disk full is detected
+- A background thread periodically checks free disk space via `GetFreeSpace()`
+- For hard errors: recovery requires free space >= `reserved_disk_buffer_`
+- For soft errors: recovery requires free space >= `free_space_trigger_` (snapshot of reserved compaction size at error time)
+- `ReserveDiskBuffer()` is called by each DB instance to accumulate the minimum disk buffer needed for recovery
+
+## Interaction with Other Components
+
+| Component | Interaction |
+|-----------|-------------|
+| Compaction | `EnoughRoomForCompaction()` pre-check; `OnCompactionCompletion()` cleanup |
+| Flush | Output files tracked via `OnAddFile()` |
+| WAL | WAL file deletion rate is controlled by the same `rate_bytes_per_sec` setting |
+| DB Open/Close | Files tracked on open; `OnUntrackFile()` on close with shared SFM |
+| Multiple DB instances | A single SFM can be shared across instances to enforce aggregate space limits |
+
+## Key Configuration Recommendations
+
+| Scenario | Configuration |
+|----------|---------------|
+| Disk space is constrained | Set `max_allowed_space` to limit total file size |
+| I/O spikes from deletion | Set `rate_bytes_per_sec` to throttle deletions (e.g., 100 MB/s) |
+| Very large SST files | Use `bytes_max_delete_chunk` for chunked deletion |
+| Multiple DB instances | Share a single `SstFileManager` to coordinate space usage |
+| Post-error recovery | SFM automatically polls for free space and retries compactions |

--- a/docs/components/compaction/index.md
+++ b/docs/components/compaction/index.md
@@ -1,0 +1,48 @@
+# RocksDB Compaction
+
+## Overview
+
+Compaction is the background process that maintains the LSM-tree by merging SST files across levels. It reclaims space from obsolete key versions and deletions, reduces read amplification by consolidating data, and enforces level size targets. RocksDB supports three compaction styles -- leveled, universal, and FIFO -- each with distinct tradeoffs between write amplification, space amplification, and read amplification.
+
+**Key source files:** `db/compaction/compaction.h`, `db/compaction/compaction_job.h`, `db/compaction/compaction_job.cc`, `db/compaction/compaction_picker.h`, `db/compaction/compaction_picker_level.cc`, `db/compaction/compaction_picker_universal.cc`, `db/compaction/compaction_picker_fifo.cc`, `db/compaction/compaction_iterator.h`, `db/compaction/compaction_iterator.cc`, `include/rocksdb/advanced_options.h`
+
+## Chapters
+
+| Chapter | File | Summary |
+|---------|------|---------|
+| 1. Overview | [01_overview.md](01_overview.md) | Compaction pipeline (pick, execute, install), triggers, score calculation, the `Compaction` object, and component interactions. |
+| 2. Leveled Compaction | [02_leveled_compaction.md](02_leveled_compaction.md) | Level structure, the four-step picking algorithm, L0 handling, clean cut expansion, output file splitting, and key options. |
+| 3. File Selection and Priority | [03_file_selection_and_priority.md](03_file_selection_and_priority.md) | `CompactionPri` options (`kByCompensatedSize`, `kMinOverlappingRatio`, `kRoundRobin`, etc.), file ordering, TTL boosting, and the picking process. |
+| 4. Dynamic Level Size Calculation | [04_dynamic_levels.md](04_dynamic_levels.md) | `level_compaction_dynamic_level_bytes` algorithm, base level computation, unnecessary level draining, and impact on compression settings. |
+| 5. Trivial Move Optimization | [05_trivial_move.md](05_trivial_move.md) | Conditions for trivial move, L0 trivial move, non-L0 multi-file extension, execution fast path, and limitations. |
+| 6. Universal Compaction | [06_universal_compaction.md](06_universal_compaction.md) | Sorted run abstraction, five prioritized strategies (periodic, size-amp, size-ratio, count, delete-triggered), incremental mode, and configuration. |
+| 7. FIFO Compaction | [07_fifo_compaction.md](07_fifo_compaction.md) | TTL and size-based file deletion, intra-L0 compaction (cost-based and ratio-based), temperature change compaction, and BlobDB interaction. |
+| 8. CompactionJob Execution | [08_compaction_job.md](08_compaction_job.md) | Three-phase lifecycle (Prepare, Run, Install), `ProcessKeyValueCompaction`, output file splitting criteria, stats aggregation, and resumption. |
+| 9. Subcompaction Parallelism | [09_subcompaction.md](09_subcompaction.md) | Key-range partitioning via anchor points, `SubcompactionState`, thread execution model, and round-robin resource management. |
+| 10. Remote Compaction | [10_remote_compaction.md](10_remote_compaction.md) | Four-phase protocol (schedule, compact, wait, install), serialization format, worker execution, fallback to local, and output verification. |
+| 11. CompactionIterator | [11_compaction_iterator.md](11_compaction_iterator.md) | Input iterator stack, core state machine, snapshot visibility rules, key type processing (Put, Delete, SingleDelete, Merge), sequence number zeroing, and blob processing. |
+| 12. CompactionFilter | [12_compaction_filter.md](12_compaction_filter.md) | `CompactionFilter` and `CompactionFilterFactory` APIs, decision types, invocation flow, scope limitations, and interactions with snapshots, merges, and BlobDB. |
+| 13. SST Partitioner | [13_sst_partitioner.md](13_sst_partitioner.md) | `SstPartitioner` interface, fixed-prefix implementation, integration with output file splitting and trivial move. |
+| 14. Manual Compaction | [14_manual_compaction.md](14_manual_compaction.md) | `CompactRange` and `CompactFiles` APIs, bottommost level options, execution flow per compaction style, cancellation, and thread scheduling. |
+| 15. Disk Space Management | [15_disk_space_management.md](15_disk_space_management.md) | `SstFileManager`, compaction space reservation, rate-limited file deletion via `DeleteScheduler`, chunked deletion, and error recovery. |
+
+## Key Characteristics
+
+- **Three compaction styles**: Leveled (size-based per-level targets), universal (size-tiered sorted runs), FIFO (time/size-based deletion)
+- **Three-phase pipeline**: Pick (under mutex), execute (mutex released, parallelizable via subcompactions), install (under mutex)
+- **Dynamic level targets**: Base level and level sizes computed from actual data size, working backward from the largest level
+- **Trivial move**: Files moved between levels by metadata update only when no merge, compression change, or grandparent overlap issue
+- **Subcompaction parallelism**: Key-range partitioning via anchor points enables parallel execution within a single compaction job
+- **Remote compaction**: Offloads CPU-intensive merge work to separate processes via a user-implemented `CompactionService`
+- **Compaction filter**: User-defined key inspection, modification, or deletion during compaction (and optionally flush)
+- **SST partitioner**: User-defined output file splitting at application-level boundaries (e.g., key prefix)
+- **Disk space management**: `SstFileManager` enforces space limits, reserves space for compactions, and rate-limits file deletion
+- **Write flow integration**: `WriteController` throttles or stalls writes when compaction falls behind
+
+## Key Invariants
+
+- Compaction inputs must form a clean cut: no user key can be partially included across input files at the same level
+- L1+ levels maintain sorted, non-overlapping SST files; compaction output preserves this property
+- At most one L0-to-base compaction runs concurrently in leveled compaction (intra-L0 compaction may run in parallel)
+- No two subcompactions within a job may have overlapping key ranges
+- Deletion markers are only dropped when the key does not exist beyond the output level (or at the bottommost level)

--- a/docs/components/sst_table_format/01_overview.md
+++ b/docs/components/sst_table_format/01_overview.md
@@ -1,0 +1,105 @@
+# Table Format Overview
+
+**Files:** `table/format.h`, `table/format.cc`, `include/rocksdb/table.h`, `table/block_based/block_based_table_factory.cc`
+
+## Table Types
+
+RocksDB supports three SST file formats, each identified by a unique 8-byte magic number at the end of the file:
+
+| Format | Magic Number Source | Primary Use Case |
+|--------|-------------------|-----------------|
+| Block-based table | SHA1 of `rocksdb.table.block_based` | Default. General-purpose, optimized for disk/flash storage. |
+| Plain table | SHA1 of `rocksdb.table.plain` | Low-latency lookups on pure-memory or very low-latency media. |
+| Cuckoo table | SHA1 of `rocksdb.table.cuckoo` | Hash-based lookups with high space efficiency. |
+
+The block-based table is the standard format and the focus of this documentation. It organizes data into fixed-size blocks with prefix-compressed keys, supports bloom/ribbon filters for fast negative lookups, and provides a hierarchical index for efficient seeking.
+
+## Table Factory
+
+`BlockBasedTableFactory` (see `table/block_based/block_based_table_factory.cc`) is the factory that creates table builders and readers for block-based tables. It is configured via `BlockBasedTableOptions` (see `include/rocksdb/table.h`).
+
+Key responsibilities:
+- Create `BlockBasedTableBuilder` instances for writing new SST files
+- Create `BlockBasedTable` (reader) instances for reading SST files
+- Manage `TailPrefetchStats` to adaptively optimize tail prefetching during table open
+
+### TailPrefetchStats
+
+`TailPrefetchStats` tracks the effective size of data read from the tail of recently opened SST files. It maintains a circular buffer of up to 32 recorded sizes. When opening a new SST file, `GetSuggestedPrefetchSize()` computes the maximum historical prefetch size that wastes no more than 12.5% (1/8) of total read bytes, capped at 512KB. This adaptive approach avoids both under-prefetching (multiple I/Os to read footer + meta blocks) and over-prefetching (wasting bandwidth on large prefetches).
+
+## Format Versions
+
+The `format_version` field in `BlockBasedTableOptions` controls the on-disk encoding format. It is stored in the SST footer and determines how various structures are encoded.
+
+| Version | Key Features |
+|---------|-------------|
+| 2 | Minimum supported for read and write. Encodes index values using `IndexValue` with delta-encoded `BlockHandle`. |
+| 3 | Optimized encoding for block-based filter (now obsolete). |
+| 4 | Index blocks omit `value_length` varint since index values are self-describing (see `DecodeKeyV4()` in `table/block_based/block_util.h`). |
+| 5 | Full and partitioned filters use a different on-disk format with improved memory utilization (FastLocalBloom). Legacy bloom and block-based filter deprecated. |
+| 6 | Context-aware checksums. Footer includes its own checksum, `base_context_checksum`, and `metaindex_size`. Index handle moves from footer to metaindex block. |
+| 7 | `TableProperties::compression_name` format changed for `CompressionManager` compatibility. |
+
+The current latest version is 7 (see `kLatestBbtFormatVersion` in `table/format.h`).
+
+### Version Support Policy
+
+Format versions follow a deprecation protocol with two thresholds:
+
+- **Write minimum** (`kMinSupportedBbtFormatVersionForWrite`): Oldest version allowed for creating new SST files. Currently 2.
+- **Read minimum** (`kMinSupportedBbtFormatVersionForRead`): Oldest version that can be read. Currently 2.
+
+When phasing out old versions, the write minimum is increased first. After at least 6 months, the read minimum is increased and the old implementation code can be removed.
+
+### Version-Gated Features
+
+Several helper functions in `table/format.h` gate behavior on format version:
+
+| Function | Condition | Effect |
+|----------|-----------|--------|
+| `FormatVersionUsesContextChecksum()` | version >= 6 | Enables context-aware checksums using `base_context_checksum` |
+| `FormatVersionUsesIndexHandleInFooter()` | version < 6 | Stores index block handle in footer (legacy); version >= 6 moves it to metaindex |
+| `FormatVersionUsesCompressionManagerName()` | version >= 7 | Uses `CompressionManager` name format in table properties |
+
+## Checksum Types
+
+RocksDB supports multiple checksum algorithms for verifying block integrity, defined as `ChecksumType` in `include/rocksdb/table.h`:
+
+| Value | Name | Notes |
+|-------|------|-------|
+| 0x0 | `kNoChecksum` | No verification |
+| 0x1 | `kCRC32c` | CRC32c (hardware-accelerated on many platforms) |
+| 0x2 | `kxxHash` | xxHash 32-bit |
+| 0x3 | `kxxHash64` | xxHash 64-bit (truncated to 32 bits for storage) |
+| 0x4 | `kXXH3` | XXH3 (current default). Supported since RocksDB 6.27. |
+
+The default for new tables is `kXXH3` (see `BlockBasedTableOptions::checksum` in `include/rocksdb/table.h`).
+
+### Context-Aware Checksums (format_version >= 6)
+
+Standard checksums detect random corruption but may not detect misplaced data (e.g., blocks from another file or blocks at the wrong offset). Format version 6 introduces context-aware checksums via `ChecksumModifierForContext()` in `table/format.h`.
+
+Each SST file has a `base_context_checksum` stored in the footer (a per-file semi-random value generated at write time). For each block, a modifier is computed from `base_context_checksum` and the block's offset, then added to the standard checksum. This ensures that blocks from different files or at different offsets produce different checksums, detecting misplaced data with high probability.
+
+The modifier computation is designed to be:
+- Fast (no branches on the hot path; uses a bitmask to disable when `base_context_checksum == 0`)
+- Unique for nearby offsets (lower 32 bits of offset guarantee uniqueness within 4GB)
+- Non-linearly correlated (XOR mixing prevents systematic collision patterns)
+
+## Key Configuration Options
+
+The most important `BlockBasedTableOptions` fields for table format behavior:
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `block_size` | 4096 | Target uncompressed data block size in bytes |
+| `block_size_deviation` | 10 | Percentage threshold for closing a block early |
+| `block_restart_interval` | 16 | Keys between restart points for delta encoding |
+| `index_block_restart_interval` | 1 | Restart interval for index blocks |
+| `format_version` | 7 | On-disk format version |
+| `checksum` | `kXXH3` | Checksum algorithm for block verification |
+| `index_type` | `kBinarySearch` | Index block structure (binary search, hash, partitioned, or binary search with first key) |
+| `data_block_index_type` | `kDataBlockBinarySearch` | Data block index (binary search or binary+hash) |
+| `metadata_block_size` | 4096 | Target size for partitioned index/filter blocks |
+| `cache_index_and_filter_blocks` | false | Store index/filter in block cache vs. table reader memory |
+| `no_block_cache` | false | Disable block cache entirely |

--- a/docs/components/sst_table_format/02_block_based_format.md
+++ b/docs/components/sst_table_format/02_block_based_format.md
@@ -1,0 +1,175 @@
+# Block-Based Table File Layout
+
+**Files:** `table/format.h`, `table/format.cc`, `table/block_based/block_based_table_reader.h`, `table/block_based/block_based_table_reader.cc`, `table/block_based/block_type.h`
+
+## SST File Structure
+
+A block-based SST file is organized as a sequence of blocks followed by metadata, with the footer always at the very end:
+
+```
+[data block 0]
+[data block 1]
+...
+[data block N-1]
+[filter block]                   (full filter or partitioned filter blocks + filter index)
+[index block]                    (or partitioned index blocks + top-level index)
+[meta block: compression dictionary]
+[meta block: range deletions]
+[meta block: properties]
+[metaindex block]
+[Footer]
+```
+
+Each block (except in plain/cuckoo table formats) is followed by a 5-byte trailer: 1 byte for compression type + 4 bytes for checksum (see `BlockBasedTable::kBlockTrailerSize` in `table/block_based/block_based_table_reader.h`).
+
+## Block Types
+
+All block types are enumerated in `BlockType` (see `table/block_based/block_type.h`):
+
+| Type | Description | Compressed? |
+|------|-------------|-------------|
+| `kData` | User key-value data | Yes |
+| `kIndex` | Index entries mapping separator keys to data block handles | Yes (if `enable_index_compression=true`) |
+| `kFilter` | Bloom/ribbon filter bits | Never |
+| `kFilterPartitionIndex` | Top-level index for partitioned filters | Yes |
+| `kProperties` | Table properties (entry count, raw sizes, etc.) | Never |
+| `kCompressionDictionary` | Shared compression dictionary | Never |
+| `kRangeDeletion` | Range tombstone entries | Never |
+| `kMetaIndex` | Maps meta block names to BlockHandles | Never |
+| `kHashIndexPrefixes` / `kHashIndexMetadata` | Hash search support data | Never |
+| `kUserDefinedIndex` | User-defined index block | Never |
+
+Note: The `BlockTypeMaybeCompressed()` method in `BlockBasedTable` determines which block types may be compressed on the read path -- it excludes only `kFilter`, `kCompressionDictionary`, and `kUserDefinedIndex`. Other meta blocks (properties, range deletions, metaindex) are never compressed by the standard writer but the read path does not enforce this restriction.
+
+## BlockHandle
+
+`BlockHandle` (see `table/format.h`) is the fundamental pointer type for locating blocks within an SST file:
+
+| Field | Type | Encoding |
+|-------|------|----------|
+| `offset_` | `uint64_t` | varint64 -- byte offset of the block in the file |
+| `size_` | `uint64_t` | varint64 -- payload size, excluding the block trailer |
+
+Maximum encoded length is 20 bytes (`kMaxEncodedLength = 2 * kMaxVarint64Length`). A null handle is represented by `{offset=0, size=0}`. An uninitialized handle uses `{~0, ~0}` to distinguish from null.
+
+## IndexValue
+
+`IndexValue` (see `table/format.h`) represents the value stored in index blocks. It contains:
+
+- A `BlockHandle` pointing to a data block
+- An optional `first_internal_key` (the first key in the data block, used with `kBinarySearchWithFirstKey` index type)
+
+Index values support delta encoding for consecutive blocks: when a `previous_handle` is provided, only the signed delta of the size field is stored (as a varsigned int64), since the offset can be derived from `previous_handle.offset() + previous_handle.size() + kBlockTrailerSize`. This significantly reduces index block size.
+
+## Metaindex Block
+
+The metaindex block maps meta block names (as strings) to their `BlockHandle` locations. It is itself a key-value block using `MetaBlockIter` with bytewise comparator and restart interval of 1.
+
+Standard meta block names include:
+- `rocksdb.properties` -- table properties
+- `rocksdb.compression_dict` -- compression dictionary
+- `rocksdb.range_del` -- range deletion tombstones
+- `filter.` or `fullfilter.` or `partitionedfilter.` prefix -- filter blocks
+- `rocksdb.block_based_table_index_type` -- index type marker
+
+For format_version >= 6, the index block handle is also stored in the metaindex block (rather than in the footer).
+
+## Footer
+
+The `Footer` (see `table/format.h`) is a fixed-size structure at the end of every SST file. Its layout varies by format version:
+
+### Footer Layout (format_version >= 1, < 6)
+
+| Part | Content | Size |
+|------|---------|------|
+| Part 1 | `checksum_type` (1 byte) | 1 |
+| Part 2 | metaindex handle (varint64 x2) + index handle (varint64 x2) + zero padding | 40 |
+| Part 3 | `format_version` (uint32LE) + magic number (uint64LE) | 12 |
+| **Total** | | **53 bytes** |
+
+### Footer Layout (format_version >= 6)
+
+| Part | Content | Size |
+|------|---------|------|
+| Part 1 | `checksum_type` (1 byte) | 1 |
+| Part 2 | extended magic (4 bytes) + footer checksum (uint32LE) + `base_context_checksum` (uint32LE) + metaindex size (uint32LE) + zero padding (24 bytes) | 40 |
+| Part 3 | `format_version` (uint32LE) + magic number (uint64LE) | 12 |
+| **Total** | | **53 bytes** |
+
+Key differences in format_version >= 6:
+- The index handle is no longer stored in the footer; it moves to the metaindex block
+- A footer checksum protects the footer itself against corruption
+- The `base_context_checksum` enables context-aware block checksums
+- The metaindex size is stored as a uint32 (metaindex block must be immediately before the footer, limited to < 4GB)
+- The extended magic bytes (`0x3e 0x00 0x7a 0x00`) serve as a sentinel that would be interpreted as invalid (size-0) handles by older readers, providing graceful failure
+
+### Footer Reading
+
+`ReadFooterFromFile()` in `table/format.cc` reads the footer from the end of the file. The flow is:
+
+1. Read the last `Footer::kMaxEncodedLength` bytes (or the whole file if smaller)
+2. Detect the magic number at the end to determine the table type
+3. Parse `format_version` from Part 3
+4. Validate the format version against `IsSupportedFormatVersionForRead()`
+5. Parse Part 1 (checksum type)
+6. For format_version >= 6: verify footer checksum, extract `base_context_checksum` and metaindex size
+7. For format_version < 6: decode metaindex and index block handles from Part 2
+
+### FooterBuilder
+
+`FooterBuilder` (see `table/format.h`) constructs a serialized footer. For format_version 0 with non-block-based table magic numbers, it automatically uses legacy magic numbers for forward compatibility. For format_version >= 6, it requires a non-zero `base_context_checksum` when block checksums are used, and computes the footer checksum including the context modifier for the footer's own offset.
+
+## Block Trailer
+
+Every block on disk is followed by a trailer (see `kBlockTrailerSize` in `table/block_based/block_based_table_reader.h`):
+
+```
+[block payload: N bytes][compression_type: 1 byte][checksum: 4 bytes]
+```
+
+The `BlockHandle::size()` field stores `N` (payload only), not `N + 5`. The total on-disk size is `handle.size() + kBlockTrailerSize`.
+
+Key Invariant: The checksum is computed over the block payload bytes plus the compression type byte. For format_version >= 6, a context modifier (derived from `base_context_checksum` and the block's file offset) is added to the checksum. The checksum is verified before decompression, not after -- this means checksums detect storage corruption but do not validate decompressor output.
+
+## Table Open Workflow
+
+`BlockBasedTable::Open()` (see `table/block_based/block_based_table_reader.cc`) creates a table reader from an SST file. The sequence is:
+
+Step 1 -- **Prefetch tail**: For non-mmap reads, prefetch the tail of the file into a `FilePrefetchBuffer`. The prefetch size is determined adaptively from `TailPrefetchStats`, or uses `tail_size` if provided. L0 files and non-cached configurations prefetch more aggressively.
+
+Step 2 -- **Read footer**: `ReadFooterFromFile()` parses the footer, extracting magic number, format version, checksum type, and block handles.
+
+Step 3 -- **Read metaindex block**: Parse the metaindex block to locate all meta blocks.
+
+Step 4 -- **Read properties block**: Extract table properties including index type, filter type, compression name, global sequence number, and various statistics. This also determines `index_has_first_key`, `index_key_includes_seq`, `index_value_is_full`, and block restart intervals.
+
+Step 5 -- **Configure decompressor**: Based on `compression_name` from table properties and the optional `CompressionManager`, create the appropriate `Decompressor` for reading compressed blocks.
+
+Step 6 -- **Verify unique ID**: If `expected_unique_id` is provided, verify it matches the table's actual unique ID (derived from `db_id`, `db_session_id`, and `orig_file_number`).
+
+Step 7 -- **Set up cache keys**: Using table properties and session information, establish portable cache keys via `SetupBaseCacheKey()`.
+
+Step 8 -- **Read range deletion block**: If present, read and fragment range tombstones.
+
+Step 9 -- **Prefetch index and filter blocks**: Based on configuration, preload index and filter blocks into block cache or pin them in the table reader.
+
+## Rep Struct
+
+`BlockBasedTable::Rep` (see `table/block_based/block_based_table_reader.h`) holds all immutable state for an open table reader:
+
+| Field | Description |
+|-------|-------------|
+| `footer` | Parsed `Footer` structure |
+| `file` | `RandomAccessFileReader` for the SST file |
+| `index_reader` | Polymorphic index reader (binary search, hash, partitioned) |
+| `filter` | Filter block reader |
+| `uncompression_dict_reader` | Compression dictionary reader (for dictionary-compressed blocks) |
+| `decompressor` | `Decompressor` for block decompression |
+| `table_properties` | Shared table properties |
+| `global_seqno` | Sequence number override for ingested/bulk-loaded files |
+| `base_cache_key` | `OffsetableCacheKey` for constructing per-block cache keys |
+| `level` | LSM level of this file |
+| `immortal_table` | Whether the table reader should never be evicted |
+| `user_defined_timestamps_persisted` | Whether user timestamps are in the on-disk keys |
+| `data_block_restart_interval` | From table properties, used for per-KV checksum verification |
+| `separate_key_value_in_data_block` | Whether data blocks use separated KV storage |

--- a/docs/components/sst_table_format/03_data_blocks.md
+++ b/docs/components/sst_table_format/03_data_blocks.md
@@ -1,0 +1,175 @@
+# Data Block Structure
+
+**Files:** `table/block_based/block_builder.h`, `table/block_based/block_builder.cc`, `table/block_based/block.h`, `table/block_based/block.cc`, `table/block_based/data_block_footer.h`, `table/block_based/data_block_hash_index.h`
+
+## Block Format
+
+A data block stores a sorted sequence of key-value entries with prefix compression, followed by a restart array and a footer. The on-disk layout is:
+
+```
+[entry 0] [entry 1] ... [entry N-1]
+[values section]                     (optional, when separated KV is enabled)
+[data block hash index]              (optional, when kDataBlockBinaryAndHash)
+[values_section_offset: uint32]      (optional, when separated KV is enabled)
+[packed footer: uint32]
+```
+
+## Entry Format
+
+Each entry uses prefix (delta) compression relative to the previous key:
+
+| Field | Encoding | Description |
+|-------|----------|-------------|
+| `shared_bytes` | varint32 | Bytes shared with the previous key (0 at restart points) |
+| `unshared_bytes` | varint32 | Length of the non-shared key suffix |
+| `value_length` | varint32 | Value length (omitted for format_version >= 4 index blocks) |
+| `key_delta` | `char[unshared_bytes]` | Non-shared portion of the key |
+| `value` | `char[value_length]` | Value bytes |
+
+For index blocks with format_version >= 4, `value_length` is omitted because the value (an `IndexValue`) consists of one or two varints whose lengths are self-describing.
+
+## Restart Points
+
+Every `block_restart_interval` entries (default 16, see `BlockBasedTableOptions::block_restart_interval` in `include/rocksdb/table.h`), a restart point is recorded. At restart points, `shared_bytes = 0`, meaning the full key is stored without prefix compression. The restart array at the end of the block stores the byte offset of each restart point as a `uint32`:
+
+```
+[restart_offset_0: uint32] [restart_offset_1: uint32] ... [restart_offset_R-1: uint32]
+```
+
+Restart points enable binary search within a block: to seek to a key, first binary search the restart array to find the correct interval, then linear scan within that interval.
+
+## Data Block Footer
+
+`DataBlockFooter` (see `table/block_based/data_block_footer.h`) is a single `uint32` packed with metadata bits:
+
+| Bits | Field | Description |
+|------|-------|-------------|
+| 0-27 | `num_restarts` | Number of restart points (max 268,435,455) |
+| 28 | Separated KV | Whether keys and values are stored in separate sections |
+| 29 | `is_uniform` | Whether restart-point keys are uniformly distributed (enables interpolation search via `kAuto`) |
+| 30 | Reserved | Cannot be used without a format version bump (see forward compatibility note below) |
+| 31 | Hash index present | Whether a `DataBlockHashIndex` is appended |
+
+Important: When separated KV storage is enabled, an additional `uint32` storing `values_section_offset` is prepended before the packed footer.
+
+**Forward compatibility**: Bits 28-29 are safe for older RocksDB versions to encounter -- they will be interpreted as an extremely large `num_restarts`, which is caught as corruption. Bit 30, however, is special: `num_restarts` is multiplied by 4 (for restart array sizing), which causes unsigned overflow that silently passes the corruption check. Therefore, bit 30 cannot be used without a format version bump.
+
+## Separated KV Storage
+
+When `separate_key_value_in_data_block` is enabled (see `BlockBasedTableOptions` in `include/rocksdb/table.h`), keys and values are stored in separate sections within the block:
+
+```
+[key entries with prefix compression]
+[values section: all values concatenated]
+[restart array]
+[values_section_offset: uint32]
+[packed footer: uint32]
+```
+
+Value offsets are stored as varints only at restart points. For entries between restart points, the value offset is computed incrementally as `prev_offset + prev_value_length`. This reduces per-entry overhead while maintaining efficient random access via restart points.
+
+At restart points, the entry format gains an extra varint field:
+
+| Field | Standard | Separated KV (restart point) | Separated KV (non-restart) |
+|-------|----------|------------------------------|---------------------------|
+| shared_bytes | varint32 | varint32 (always 0) | varint32 |
+| unshared_bytes | varint32 | varint32 | varint32 |
+| value_length | varint32 | varint32 | varint32 |
+| value_offset | -- | varint32 | -- (computed) |
+| key_delta | bytes | bytes | bytes |
+| value | bytes (inline) | -- (in values section) | -- (in values section) |
+
+## Uniform Key Detection
+
+`BlockBuilder::ScanForUniformity()` in `table/block_based/block_builder.cc` runs at `Finish()` time to determine whether restart-point keys are uniformly distributed. It uses Welford's online algorithm (via the internal `UniformDataTracker` class) to incrementally compute the coefficient of variation (CV) of gaps between consecutive restart-point keys.
+
+The algorithm:
+1. Extract the first 8 bytes of each restart-point key (after the common prefix) as a `uint64_t` via `ReadBe64FromKey()`
+2. Compute inter-key gaps and track their running mean and variance
+3. Calculate CV = standard_deviation / mean
+4. If CV < `uniform_cv_threshold` (see `BlockBasedTableOptions::uniform_cv_threshold` in `include/rocksdb/table.h`), set the `is_uniform` flag in the footer
+
+Blocks marked as uniform enable interpolation search when `index_block_search_type = kAuto`. The `is_uniform` footer flag is relevant to both data and index blocks; index block iterators use it to choose between binary and interpolation search.
+
+## Data Block Hash Index
+
+When `data_block_index_type = kDataBlockBinaryAndHash` (see `BlockBasedTableOptions` in `include/rocksdb/table.h`), an in-block hash index is appended for O(1) point lookups within data blocks.
+
+The hash index maps `user_key -> restart_index`, allowing `DataBlockIter::SeekForGet()` to jump directly to the correct restart interval instead of binary searching. This is particularly beneficial for point lookups (`Get()`) where the key is known exactly.
+
+The hash table utilization ratio is controlled by `data_block_hash_table_util_ratio` (default 0.75). The hash index is only built when the block size does not exceed `kMaxBlockSizeSupportedByHashIndex`.
+
+## BlockBuilder
+
+`BlockBuilder` (see `table/block_based/block_builder.h`) constructs blocks by accumulating key-value pairs:
+
+### Construction
+
+The constructor configures:
+- `block_restart_interval` -- entries between restart points
+- `use_delta_encoding` -- whether to use prefix compression (true for data blocks)
+- `use_value_delta_encoding` -- whether to delta-encode values (used for index blocks)
+- `index_type` -- binary search or binary+hash
+- `use_separated_kv_storage` -- whether to store keys and values separately (corresponds to `separate_key_value_in_data_block` in `BlockBasedTableOptions`)
+- `uniform_cv_threshold` -- threshold for uniform key detection (-1.0 disables)
+
+### Key Methods
+
+| Method | Description |
+|--------|-------------|
+| `Add(key, value)` | Append a key-value pair with prefix compression. Keys must be added in sorted order. |
+| `AddWithLastKey(key, value, last_key)` | Faster version of `Add()` when the caller already knows the previous key. Avoids copying `last_key` into internal state. |
+| `Finish()` | Finalize the block: append values section (if separated KV), restart array, optional hash index, and packed footer. Returns the serialized block as a `Slice`. |
+| `Reset()` | Clear the builder for reuse. |
+| `CurrentSizeEstimate()` | Running size estimate including hash index overhead. |
+| `EstimateSizeAfterKV(key, value)` | Estimate the block size if a given key-value pair were added. Used by `FlushBlockPolicy` to decide when to cut a new block. |
+
+### Timestamp Stripping
+
+When user-defined timestamps are enabled but `persist_user_defined_timestamps` is false, `BlockBuilder` strips the timestamp from keys via `MaybeStripTimestampFromKey()`. The stripping logic differs for user keys vs. internal keys (which have 8 trailing bytes for sequence number and type).
+
+## Block (Reader)
+
+`Block` (see `table/block_based/block.h`) is the parsed in-memory representation of a block. It wraps `BlockContents` and provides iterator access.
+
+### Construction
+
+The `Block` constructor parses the footer from the end of the data to extract `num_restarts`, feature flags (hash index, uniform, separated KV), and the restart array offset. If the footer indicates corruption, the block's `size()` is set to 0 as an error marker, and `GetCorruptionStatus()` can be called for a detailed error.
+
+### Iterator Types
+
+`Block` provides three iterator factory methods, each returning a specialized iterator:
+
+| Iterator | Factory Method | Block Type | Key Format | Special Features |
+|----------|---------------|-----------|------------|------------------|
+| `DataBlockIter` | `NewDataIterator()` | Data blocks | Internal keys | Hash index seek via `SeekForGet()`, read-amp bitmap, `Prev()` caching |
+| `IndexBlockIter` | `NewIndexIterator()` | Index blocks | Internal or user keys | Delta-decoded `IndexValue`, first_key support, prefix index, interpolation search |
+| `MetaBlockIter` | `NewMetaIterator()` | Meta blocks | User keys (bytewise) | Bytewise comparator, no read-amp tracking. Metaindex uses restart_interval=1. |
+
+### Per-KV Checksum Protection
+
+`Block` supports per key-value checksum verification via `InitializeDataBlockProtectionInfo()`, `InitializeIndexBlockProtectionInfo()`, and `InitializeMetaIndexBlockProtectionInfo()`. When enabled, each key-value pair has a checksum computed using `ProtectionInfo64::ProtectKV()` (see `db/kv_checksum.h`). The checksums are stored contiguously and verified in `BlockIter::UpdateKey()` each time the iterator is positioned at a new key.
+
+## Block Search Algorithms
+
+The `BlockSearchType` enum (see `BlockBasedTableOptions` in `include/rocksdb/table.h`) controls how index blocks are searched:
+
+| Type | Description | Best For |
+|------|-------------|----------|
+| `kBinary` | Standard binary search on restart points, then linear scan within interval | General purpose (default) |
+| `kInterpolation` | Interpolation search that estimates the target position based on key values. Requires bytewise comparator. | Uniformly distributed keys |
+| `kAuto` | Uses interpolation search if the block's `is_uniform` footer flag is set; otherwise falls back to binary search. | Mixed workloads with both uniform and non-uniform blocks |
+
+Interpolation search provides O(log log N) expected complexity for uniformly distributed keys, compared to O(log N) for binary search. The `is_uniform` flag is determined at write time by `BlockBuilder::ScanForUniformity()`.
+
+## BlockIter Internals
+
+`BlockIter<TValue>` (see `table/block_based/block.h`) is the base template for all block iterators. Key design aspects:
+
+**Final override pattern**: All cursor-movement methods (`Seek`, `Next`, `Prev`, etc.) are declared `override final` and delegate to `*Impl()` methods in subclasses. The final methods always call `UpdateKey()` after the impl method, ensuring per-KV checksum verification and key preparation happen exactly once per cursor movement.
+
+**Global sequence number**: When `global_seqno` is set (for ingested/bulk-loaded files), `UpdateKey()` rewrites each key's sequence number to the global value, storing the modified key in `key_buf_`.
+
+**Timestamp padding**: When user-defined timestamps are enabled but not persisted, `pad_min_timestamp_` causes a minimum timestamp to be padded to each key during parsing, ensuring the key format matches what the comparator expects.
+
+**Prev() optimization in DataBlockIter**: `DataBlockIter` caches previously visited entries in `prev_entries_` during forward iteration. When `Prev()` is called, it can use these cached entries instead of re-parsing from the nearest restart point, avoiding redundant decompression of prefix-encoded keys.

--- a/docs/components/sst_table_format/04_block_fetcher.md
+++ b/docs/components/sst_table_format/04_block_fetcher.md
@@ -1,0 +1,135 @@
+# Block Reading, Caching, and Prefetching
+
+**Files:** `table/block_fetcher.h`, `table/block_fetcher.cc`, `table/format.h`, `table/format.cc`, `table/block_based/block_based_table_reader.h`, `table/block_based/block_based_table_reader.cc`
+
+## BlockFetcher Overview
+
+`BlockFetcher` (see `table/block_fetcher.h`) retrieves a single block from an SST file, handling checksum verification, decompression, caching, and memory management. It is the central component for all block I/O in the block-based table reader.
+
+## ReadBlockContents Workflow
+
+The main entry point is `BlockFetcher::ReadBlockContents()`. The flow is:
+
+Step 1 -- **Try uncompressed persistent cache**: If persistent cache is configured for uncompressed blocks, look up the block handle. On hit, return immediately with `kNoCompression`.
+
+Step 2 -- **Try prefetch buffer**: If a `FilePrefetchBuffer` is available, check if the block is already buffered. On hit, verify the trailer (checksum + compression type) and use the prefetched data.
+
+Step 3 -- **Try serialized persistent cache**: If persistent cache is configured for compressed blocks, look up the serialized block. On hit, process the trailer.
+
+Step 4 -- **Read from file**: If no cache hit, call `ReadBlock()` to issue an I/O read for `block_size_with_trailer_` bytes starting at `handle.offset()`. Supports three I/O modes:
+- **Direct I/O**: Reads into `direct_io_buf_` with alignment requirements
+- **FileSystem scratch**: Uses `FSReadRequest.fs_scratch` for filesystem-provided buffers
+- **Standard I/O**: Reads into `used_buf_` (stack buffer, heap buffer, or compressed buffer)
+
+Step 5 -- **Verify checksum**: `ProcessTrailerIfPresent()` extracts the compression type from the last byte of the block and, if `verify_checksums` is enabled, calls `VerifyBlockChecksum()` to validate the checksum.
+
+Step 6 -- **Retry on corruption**: If the filesystem supports `kVerifyAndReconstructRead` and the checksum fails, retry the read with `verify_and_reconstruct_read = true`.
+
+Step 7 -- **Decompress**: If `do_uncompress_` is true and the block is compressed, call `DecompressSerializedBlock()` to decompress into a new buffer.
+
+Step 8 -- **Get block contents**: If the block is uncompressed (or decompression is not requested), `GetBlockContents()` ensures the data is in the correct buffer (`heap_buf_` for ownership).
+
+Step 9 -- **Insert to persistent cache**: If `fill_cache` is set and persistent cache is configured for uncompressed blocks, insert the result.
+
+## Buffer Management
+
+`BlockFetcher` manages multiple buffers to minimize memory copies:
+
+| Buffer | Type | Used When |
+|--------|------|-----------|
+| `stack_buf_` | `char[5000]` | Block is small (< 5000 bytes) and will be decompressed or mmapped. Avoids heap allocation. |
+| `heap_buf_` | `CacheAllocationPtr` | Block is uncompressed and needs owned storage. |
+| `compressed_buf_` | `CacheAllocationPtr` | Block is compressed and `do_uncompress_` is false. Uses `memory_allocator_compressed_`. |
+| `direct_io_buf_` | `AlignedBuf` | Direct I/O reads require aligned buffers. |
+| `fs_buf_` | `FSAllocationPtr` | FileSystem-provided scratch buffer. |
+
+The `used_buf_` pointer tracks which buffer currently holds the data. `GetBlockContents()` handles all transitions between buffers:
+
+- **From stack buffer or prefetch buffer**: Copy to `heap_buf_` (stack data has limited lifetime, prefetch buffer may be reused)
+- **From compressed buffer**: If actually uncompressed and allocators differ, copy to `heap_buf_`; otherwise, move `compressed_buf_` to `heap_buf_`
+- **From direct I/O or FS scratch**: Copy to appropriate buffer based on compression status
+- **From mmap**: Data points directly into the mapped region; no copy needed
+
+## Checksum Verification
+
+`VerifyBlockChecksum()` in `table/format.cc` verifies a block's checksum:
+
+1. Extract the checksum type from the footer
+2. Compute the checksum over `block_data[0..block_size]` plus the compression type byte using `ComputeBuiltinChecksumWithLastByte()`
+3. For format_version >= 6: add the context modifier via `ChecksumModifierForContext(base_context_checksum, block_offset)` to the computed checksum
+4. Compare against the stored 4-byte checksum in the trailer
+5. On mismatch, return `Status::Corruption` with details including block type, file name, and offset
+
+Statistics counters `BLOCK_CHECKSUM_COMPUTE_COUNT` and `BLOCK_CHECKSUM_MISMATCH_COUNT` track verification activity.
+
+## Decompression
+
+When `BlockFetcher` needs to decompress a block, it uses `DecompressSerializedBlock()` in `table/format.cc`:
+
+1. The `Decompressor::Args` struct carries the compressed data, compression type, and optional working area
+2. `Decompressor::ExtractUncompressedSize()` reads the expected output size from the compressed data header
+3. `AllocateBlock()` allocates the output buffer using the provided `MemoryAllocator`
+4. `Decompressor::DecompressBlock()` performs the actual decompression
+5. The result is returned as a `BlockContents` with ownership of the allocated buffer
+
+A variant, `DecompressBlockData()`, handles blocks without a trailer (compression type is passed explicitly).
+
+## Block Retrieval Pipeline
+
+`BlockBasedTable::RetrieveBlock()` orchestrates the full block retrieval process including cache interaction:
+
+Step 1 -- **Check uncompressed block cache**: Look up the block by its cache key (constructed from `base_cache_key` + block offset). On hit, return the cached `CachableEntry`.
+
+Step 2 -- **Read from file**: Create a `BlockFetcher` and call `ReadBlockContents()`.
+
+Step 3 -- **Parse the block**: Create the appropriate block type (`Block`, `ParsedFullFilterBlock`, etc.) from the raw `BlockContents`.
+
+Step 4 -- **Insert into block cache**: If block cache is configured and `fill_cache` is set, insert the parsed block. Priority is determined by block type (index/filter blocks get high priority if `cache_index_and_filter_blocks_with_high_priority` is set).
+
+Step 5 -- **Return**: The block is returned as a `CachableEntry` that either references the cache entry or owns the block directly.
+
+`MaybeReadBlockAndLoadToCache()` is the variant that only attempts retrieval when caching is configured (otherwise returns empty).
+
+## MultiGet Block Retrieval
+
+For batched point lookups, `RetrieveMultipleBlocks()` reads multiple data blocks in a single pass:
+
+1. Sort block handles by offset for sequential I/O
+2. Coalesce adjacent blocks into larger reads when the gap between them is small
+3. Issue batched reads using `MultiRead()`
+4. Verify checksums and decompress each block
+5. Insert into block cache
+
+This batching reduces I/O syscall overhead and enables the filesystem to optimize sequential reads.
+
+## Prefetch Buffer Integration
+
+`FilePrefetchBuffer` works with `BlockFetcher` to avoid redundant I/O:
+
+- During table open, `PrefetchTail()` reads the tail of the SST file (footer + metaindex + index + filter) into a prefetch buffer
+- During iteration, the prefetch buffer provides readahead for sequential block reads
+- For compaction reads, prefetch buffers use larger readahead sizes configured via `ReadaheadParams`
+- `TryReadFromCache()` checks if the requested byte range is already buffered; if partially buffered, it may trigger additional readahead
+
+## Persistent Cache
+
+`BlockFetcher` supports an optional `PersistentCache` (see `BlockBasedTableOptions::persistent_cache` in `include/rocksdb/table.h`):
+
+- **Compressed mode**: Caches serialized blocks (with trailer) keyed by the table's base cache key combined with the block handle. Blocks are inserted after file read and before decompression.
+- **Uncompressed mode**: Caches decompressed block contents. Checked before any other source; inserted after successful decompression.
+
+Persistent cache is independent of the block cache and is intended for secondary storage tiers (e.g., local SSD caching for remote storage).
+
+## Performance Counters
+
+`BlockFetcher` updates perf counters by block type (see `RecordBlockReadBytePerfCounter()` in `table/block_fetcher.cc`):
+
+| Block Type | Counter |
+|------------|---------|
+| `kData` | `data_block_read_byte` |
+| `kFilter`, `kFilterPartitionIndex` | `filter_block_read_byte` |
+| `kCompressionDictionary` | `compression_dict_block_read_byte` |
+| `kIndex` | `index_block_read_byte` |
+| All others | `metadata_block_read_byte` |
+
+Additionally, `block_read_time`, `block_read_cpu_time`, `block_read_count`, and `block_decompress_time` are tracked.

--- a/docs/components/sst_table_format/05_table_builder.md
+++ b/docs/components/sst_table_format/05_table_builder.md
@@ -1,0 +1,142 @@
+# Table Building Pipeline
+
+**Files:** `table/block_based/block_based_table_builder.h`, `table/block_based/block_based_table_builder.cc`, `table/block_based/block_builder.h`, `table/table_builder.h`, `include/rocksdb/flush_block_policy.h`
+
+## Overview
+
+`BlockBasedTableBuilder` (see `table/block_based/block_based_table_builder.h`) builds a complete SST file by accumulating sorted key-value pairs into data blocks, compressing them, and writing metadata blocks, index, and footer. It is used by `FlushJob` (memtable flush) and `CompactionJob` (compaction) to produce output SST files.
+
+## Public API
+
+| Method | Description |
+|--------|-------------|
+| `Add(key, value)` | Add a key-value pair. Keys must be in sorted order (except `kTypeRangeDeletion` entries). |
+| `Finish()` | Finalize: flush last data block, write all metadata blocks and footer. |
+| `Abandon()` | Discard the builder without finishing. |
+| `NumEntries()` | Number of `Add()` calls so far. |
+| `FileSize()` | Bytes actually written to the file so far. |
+| `EstimatedFileSize()` | `FileSize()` plus estimated in-flight data (for parallel compression). |
+| `EstimatedTailSize()` | Estimated size of all blocks after data blocks (index + filter + metadata + footer). |
+| `GetTailSize()` | Actual tail size after `Finish()` completes. |
+| `GetTableProperties()` | Collected table properties. |
+
+## Builder States
+
+The builder operates in three states, tracked by `Rep::State`:
+
+| State | Description |
+|-------|-------------|
+| `kBuffered` | Initial state. KV pairs are buffered in memory for sampling purposes (compression ratio estimation, dictionary training). |
+| `kUnbuffered` | Normal streaming state. KV pairs are immediately written to data blocks and flushed to the file. |
+| `kClosed` | Terminal state. Set after `Finish()` or `Abandon()` completes. No further operations allowed. |
+
+The transition from `kBuffered` to `kUnbuffered` occurs in `MaybeEnterUnbuffered()` when the buffered data exceeds a size threshold. During transition, all buffered data is replayed into the block building pipeline.
+
+## Add() Workflow
+
+When `Add(key, value)` is called:
+
+Step 1 -- **Append to block builder**: The key-value pair is added to the current `BlockBuilder` using prefix compression.
+
+Step 2 -- **Update filter builder**: If a filter is configured, add the key to the filter builder.
+
+Step 3 -- **Check block size**: The `FlushBlockPolicy` (see `include/rocksdb/flush_block_policy.h`) determines if the current block is full. The default `FlushBlockBySizePolicy` triggers a flush when the block's estimated size reaches `block_size`, accounting for `block_size_deviation`.
+
+Step 4 -- **Flush if needed**: If the block is full, call `Flush()` which calls `EmitBlock()` to finalize and write the data block. In unbuffered mode, `index_builder->OnKeyAdded()` is called for the index entry. Note: the index entry for a data block is emitted in `EmitBlock()` once the next block's first key is known, not during `Add()`.
+
+## EmitBlock Workflow
+
+`EmitBlock()` (or `EmitBlockForParallel()` for parallel compression) handles the transition from a full data block to written output:
+
+Step 1 -- **Finish the block**: Call `BlockBuilder::Finish()` to append the restart array, optional hash index, and packed footer.
+
+Step 2 -- **Prepare index entry**: Create a `PreparedIndexEntry` with the last key of the current block and the first key of the next block. This is used by the index builder to compute the shortest separator key between adjacent blocks.
+
+Step 3 -- **Compress**: Call `CompressAndVerifyBlock()` to compress the block data.
+
+Step 4 -- **Write**: Call `WriteMaybeCompressedBlock()` to write the (possibly compressed) block to the file, appending the block trailer.
+
+Step 5 -- **Update index**: Add the block's separator key and `BlockHandle` to the index builder.
+
+## CompressAndVerifyBlock
+
+`CompressAndVerifyBlock()` handles compression with verification:
+
+1. **Compress**: Use the configured `Compressor` (data block or index block compressor) to compress the block data
+2. **Check ratio**: The maximum compressed output size is computed as `(max_compressed_bytes_per_kb * uncompressed_size) >> 10`. This limit is passed to the compressor; if compression cannot fit within it, the block is stored uncompressed. The `max_compressed_bytes_per_kb` value is sanitized to `min(1023, ...)`
+3. **Verify** (optional): If `CompressionOptions::verify_compression` is enabled, decompress the output and compare with the original to detect compressor bugs
+4. **Return**: The compression type and compressed data (or original data if compression was skipped)
+
+## WriteMaybeCompressedBlock
+
+This method writes a single block to the SST file:
+
+1. **Compute block trailer**: Determine the checksum over the block contents + compression type byte
+2. **Add context checksum**: For format_version >= 6, add the context modifier for the block's file offset
+3. **Write to file**: Write the block data, then the 5-byte trailer (compression type + checksum)
+4. **Update file offset**: Advance the writer's position
+5. **Optional cache insertion**: Insert the block into block cache if `prepopulate_block_cache` is configured
+
+## Finish() Sequence
+
+`Finish()` finalizes the SST file by writing all metadata after the data blocks:
+
+Step 1 -- **Flush remaining data block**: `Flush(nullptr)` writes the last partial data block.
+
+Step 2 -- **Enter unbuffered mode**: If still in buffered state, transition via `MaybeEnterUnbuffered()`.
+
+Step 3 -- **Stop parallel compression**: If active, wait for all workers to complete.
+
+Step 4 -- **Record tail start offset**: Mark where the tail (non-data) portion of the file begins.
+
+Step 5 -- **Write meta blocks** in this order:
+1. **Filter block**: `WriteFilterBlock()` -- finishes the filter builder and writes the filter (full or partitioned)
+2. **Index block**: `WriteIndexBlock()` -- finishes the index builder and writes the index (flat or partitioned)
+3. **Compression dictionary block**: `WriteCompressionDictBlock()` -- writes the serialized compression dictionary if present
+4. **Range deletion block**: `WriteRangeDelBlock()` -- writes accumulated range tombstones
+5. **Properties block**: `WritePropertiesBlock()` -- writes table properties including entry count, data size, index size, filter size, compression type, and custom collected properties
+
+Step 6 -- **Write metaindex block**: Build the metaindex mapping meta block names to their `BlockHandle` locations, and write it uncompressed.
+
+Step 7 -- **Write footer**: `WriteFooter()` constructs and writes the footer using `FooterBuilder`. For format_version >= 6, the index handle is placed in the metaindex rather than the footer.
+
+## Tail Size Estimation
+
+`EstimatedTailSize()` provides a conservative overestimate of the tail size, used to help `CompactionJob` decide when to close a file before reaching `target_file_size`. The estimate sums:
+
+1. Current index size estimate (from the index builder)
+2. Current filter size estimate (from the filter builder)
+3. Compression dictionary size
+4. Range deletion block size
+5. Properties block estimate (~2KB)
+6. Metaindex block estimate (~1KB)
+7. Footer size (`Footer::kMaxEncodedLength`)
+
+The tail size assertion (`r->tail_size <= last_estimated_tail_size`) verifies the estimate is conservative for compaction files with supported index/filter types.
+
+## Parallel Compression Integration
+
+When `CompressionOptions::parallel_threads > 1` (and conditions are met), `BlockBasedTableBuilder` spawns worker threads for parallel block compression:
+
+- **Ring buffer**: Emitted blocks are placed into a power-of-two ring buffer. Workers pick up blocks for compression and writing in order.
+- **File size estimation**: `EstimatedFileSize()` returns `FileSize() + estimated_inflight_size` where inflight size tracks uncompressed block sizes until compression completes, then compressed sizes until writing completes.
+- **Ordering guarantee**: Blocks are always written in emission order, even though compression may complete out of order. The `NextToWrite` counter ensures sequential writes.
+- **Auto-tuned parallelism**: Worker threads sleep when no work is available and wake when new blocks are emitted. The emit thread can perform compression work as quasi-work-stealing when the ring buffer is full.
+
+See the parallel compression chapter in the compression documentation for detailed architecture.
+
+## Table Properties Collection
+
+During table building, properties are collected via `InternalTblPropColl` implementations:
+
+- `BlockBasedTablePropertiesCollector` records block-based table specific properties: index type, whole key filtering, prefix filtering, and decoupled partitioned filters
+- User-provided `TablePropertiesCollector` instances are invoked for each key-value pair
+- Standard properties (entry count, raw key/value sizes, data block sizes, index sizes, filter sizes) are tracked in `Rep::props`
+
+The `compression_name` property records the compressor used, which the reader uses to select the appropriate `Decompressor` at open time.
+
+## Block Alignment
+
+When `BlockBasedTableOptions::block_align` is true, data blocks are padded with zeros to align to `block_size` boundaries. This enables direct I/O reads that are naturally aligned. Alignment is applied in `WriteMaybeCompressedBlock()` after writing the block trailer. `block_align` disables compression (compressed blocks have variable sizes that cannot be aligned).
+
+Note: `super_block_alignment_size` is a separate alignment option that pads blocks to a filesystem super-block boundary. Unlike `block_align`, it is compatible with compression but may force `skip_delta_encoding` for the corresponding index entry handles.

--- a/docs/components/sst_table_format/06_index_formats.md
+++ b/docs/components/sst_table_format/06_index_formats.md
@@ -1,0 +1,153 @@
+# Index Block Formats
+
+**Files:** `table/block_based/index_builder.h`, `table/block_based/index_builder.cc`, `table/block_based/index_reader_common.h`, `table/block_based/index_reader_common.cc`, `include/rocksdb/table.h`
+
+## Overview
+
+Index blocks map separator keys to `BlockHandle` values that point to data blocks within an SST file. Each index entry corresponds to one data block: the key is a separator that is greater than or equal to the last key in the data block and less than the first key in the next data block. The value is a `BlockHandle` encoding the offset and size of the data block.
+
+RocksDB supports four index types, selected via `BlockBasedTableOptions::index_type` (see `BlockBasedTableOptions` in `include/rocksdb/table.h`):
+
+| Index Type | Enum Value | Description | Builder Class |
+|-----------|------------|-------------|---------------|
+| Binary Search | `kBinarySearch` | Default. Single index block with sorted separators. | `ShortenedIndexBuilder` |
+| Hash Search | `kHashSearch` | Binary search plus prefix hash metadata for faster prefix seeks. | `HashIndexBuilder` |
+| Two-Level (Partitioned) | `kTwoLevelIndexSearch` | Multiple index partitions plus a top-level index. Reduces memory for large files. | `PartitionedIndexBuilder` |
+| Binary Search With First Key | `kBinarySearchWithFirstKey` | Like binary search, but stores each block's first key. Allows deferring data block reads. | `ShortenedIndexBuilder` (with `include_first_key=true`) |
+
+## Index Builder Architecture
+
+All index builders inherit from the `IndexBuilder` base class in `table/block_based/index_builder.h`. The factory method `IndexBuilder::CreateIndexBuilder()` in `index_builder.cc` instantiates the appropriate builder based on the configured `IndexType`.
+
+### Core Interface
+
+The builder accumulates index entries as data blocks are written. Two modes of operation are supported:
+
+**Sequential mode** (single-threaded): `AddIndexEntry()` is called with the last key of the current data block, the first key of the next data block (or nullptr for the last block), and the `BlockHandle` of the data block just written. The builder computes a separator key and adds the index entry.
+
+**Parallel compression mode** (multi-threaded): The work is split across three methods:
+1. `CreatePreparedIndexEntry()` -- allocates a holder for intermediate state
+2. `PrepareIndexEntry()` -- called from the "emit thread" to compute the separator key (does not need the BlockHandle yet)
+3. `FinishIndexEntry()` -- called from the "write thread" once the BlockHandle is known, completing the index entry
+
+This split enables background compression workers to prepare index entries before the final file offset is determined.
+
+### Index Size Estimation
+
+`CurrentIndexSizeEstimate()` provides a running estimate of the index size, used during table construction to determine when to cut files. Note that not all implementations provide accurate estimates -- `HashIndexBuilder::CurrentIndexSizeEstimate()` returns 0, so the estimate is implementation-dependent.
+
+## Binary Search Index (ShortenedIndexBuilder)
+
+The default index type. `ShortenedIndexBuilder` in `index_builder.h` builds a single index block with sorted separator keys.
+
+### Key Shortening
+
+Rather than storing the full last key of each data block, the builder computes a shorter separator key. The behavior is controlled by `BlockBasedTableOptions::index_shortening` (default `kShortenSeparators`):
+
+| Mode | Behavior |
+|------|----------|
+| `kShortenSeparators` | Shorten separators between blocks using `Comparator::FindShortestSeparator()`. Last block key uses `FindShortSuccessor()`. |
+| `kShortenSeparatorsAndSuccessor` | Also shorten the last block's key using `FindShortSuccessor()`. |
+| `kNoShortening` | Use the actual last key in each data block as the separator. Useful with `kBinarySearchWithFirstKey`. |
+
+The shortening logic is in `ShortenedIndexBuilder::FindShortestInternalKeySeparator()` and `FindShortInternalKeySuccessor()` in `index_builder.cc`. The algorithm extracts user keys from the internal keys, calls the comparator's `FindShortestSeparator()`, and if the user key was shortened, appends `kMaxSequenceNumber` to produce a valid internal key.
+
+### Sequence Number Stripping
+
+`ShortenedIndexBuilder` maintains two `BlockBuilder` instances: `index_block_builder_` (with sequence numbers) and `index_block_builder_without_seq_` (user keys only). The atomic flag `must_use_separator_with_seq_` tracks whether any separator requires the sequence number for correctness (which happens when two adjacent data blocks share the same user key but differ only in sequence number).
+
+At `Finish()`, the builder selects the appropriate block builder. If sequence numbers were never needed, the without-seq builder produces a smaller index block. This optimization is signaled by the `index_key_is_user_key` table property (format_version >= 3).
+
+### First Key Support
+
+When `index_type` is `kBinarySearchWithFirstKey`, the constructor sets `include_first_key=true`. The builder records each data block's first internal key via `OnKeyAdded()` and stores it in the `IndexValue` alongside the `BlockHandle`. This enables iterators to defer reading data blocks until the key is actually needed, reducing read amplification for short range scans.
+
+Important: When user-defined timestamps are not persisted, the first internal key is explicitly stripped of its timestamp before being stored in the index value.
+
+## Hash Search Index (HashIndexBuilder)
+
+`HashIndexBuilder` in `index_builder.h` wraps a `ShortenedIndexBuilder` as its primary index and adds two metadata blocks that enable prefix-based hash lookups.
+
+### Metadata Format
+
+The builder collects prefix information via `OnKeyAdded()`, which uses the configured `SliceTransform` (prefix extractor) to compute key prefixes. For each unique prefix, it records:
+- The prefix string itself (appended to `prefix_block_`)
+- Metadata: prefix length, restart index, and number of data blocks spanned (appended to `prefix_meta_block_`)
+
+At `Finish()`, these are emitted as two meta blocks:
+- `kHashIndexPrefixesBlock` -- concatenated prefix strings
+- `kHashIndexPrefixesMetadataBlock` -- per-prefix metadata (length, restart index, block count)
+
+The primary index remains a standard binary search index, so the hash metadata is purely supplementary. If the hash lookup fails or is inapplicable, the reader falls back to binary search.
+
+Note: `kHashSearch` requires `index_block_restart_interval == 1` (asserted in `CreateIndexBuilder()`).
+
+## Partitioned (Two-Level) Index (PartitionedIndexBuilder)
+
+For large SST files, `PartitionedIndexBuilder` in `index_builder.h` splits the index into multiple partitions, each containing a subset of index entries, plus a top-level index that maps separator keys to partition `BlockHandle`s.
+
+### On-Disk Layout
+
+```
+[index partition 0] [index partition 1] ... [index partition P-1] [top-level index]
+```
+
+Each partition is an independent index block built by a `ShortenedIndexBuilder`. The top-level index maps the last separator key of each partition to its `BlockHandle`.
+
+### Partition Sizing
+
+Partition boundaries are determined by a `FlushBlockPolicy` configured with `BlockBasedTableOptions::metadata_block_size` (default 4096 bytes). When the active sub-index builder's estimated size reaches the target, a new partition is started.
+
+Additionally, an external entity (such as the partitioned filter builder) can request a partition cut via `RequestPartitionCut()`. When coupled filter partitioning is used (deprecated behavior), filter and index partitions are aligned.
+
+### Build Workflow
+
+Step 1: As data blocks are added, `AddIndexEntry()` or `FinishIndexEntry()` delegates to the active `sub_index_builder_`. After each entry, `MaybeFlush()` checks the flush policy. If a flush is triggered, the completed partition is saved and a new `ShortenedIndexBuilder` is created via `MakeNewSubIndexBuilder()`.
+
+Step 2: `Finish()` is called repeatedly. Each call returns `Status::Incomplete()` along with the next partition's index block contents. The caller writes the partition to the SST file and provides its `BlockHandle` back to the next `Finish()` call. The final `Finish()` call returns `Status::OK()` with the top-level index block.
+
+Step 3: The top-level index entries are added as each partition's `BlockHandle` becomes known, using the same delta-encoding and sequence-number-stripping logic as the primary index.
+
+### Sequence Number Propagation
+
+The `must_use_separator_with_seq_` flag is propagated from sub-index builders to the top-level. If any partition requires sequence numbers, all partitions are rebuilt with sequence numbers at `Finish()` time. This ensures consistency across the entire index.
+
+### Size Estimation
+
+`PartitionedIndexBuilder::UpdateIndexSizeEstimate()` maintains a running estimate that accounts for completed partition sizes (tracked via `estimated_completed_partitions_size_`), the active partition size, and an estimated top-level index size (~70 bytes per partition entry). A 2x buffer is added for the expected next partition and top-level entry.
+
+## Index Reader Architecture
+
+On the read side, `IndexReaderCommon` in `index_reader_common.h` provides the base class for all index readers. It manages access to the index block, which may be:
+- Owned by the reader (pinned in memory)
+- Stored in the block cache (looked up on demand)
+- Both (cached and pinned)
+
+`GetOrReadIndexBlock()` handles the lookup: if the index block is owned, it returns a reference directly. Otherwise, it reads the block through the cache layer via `ReadIndexBlock()`.
+
+For partitioned indexes, `PartitionIndexReader` in `partitioned_index_reader.h` creates a two-level iterator. If all partitions are pinned (via `CacheDependencies()`), it uses `NewTwoLevelIterator()` with a `partition_map_` for direct access. Otherwise, it creates a `PartitionedIndexIterator` that loads partitions on demand.
+
+### Partition Caching
+
+`PartitionIndexReader::CacheDependencies()` prefetches all index partitions in a single sequential read, then loads each partition into the block cache. If all partitions are successfully cached, they are saved in `partition_map_` (an all-or-nothing map). This enables the fast path of `NewTwoLevelIterator()` which avoids per-partition cache lookups.
+
+## Configuration Reference
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `index_type` | `kBinarySearch` | Index block format (see `BlockBasedTableOptions` in `include/rocksdb/table.h`) |
+| `index_block_restart_interval` | 1 | Restart interval for index blocks. Increasing to 8-16 can halve index block size but increases CPU for lookups. |
+| `index_shortening` | `kShortenSeparators` | Controls separator key shortening behavior |
+| `metadata_block_size` | 4096 | Target size for index partitions (with `kTwoLevelIndexSearch`) |
+| `format_version` | 7 | Controls index encoding. Version >= 3 strips sequence numbers. Version >= 4 delta-encodes block handles. |
+
+## Format Version Evolution
+
+| Version | Index Change |
+|---------|-------------|
+| <= 2 | Index keys are full internal keys (`<user_key, seq>`). Values are full `BlockHandle` (`<offset, size>`). |
+| 3 (RocksDB 5.15) | Enables stripping sequence numbers from index keys when not needed. The `index_key_is_user_key` table property reflects whether stripping occurred. |
+| 4 (RocksDB 5.16) | Delta-encodes `BlockHandle` values. Only the first entry per restart interval stores full `(offset, size)`. Subsequent entries store `Varsignedint64(delta_size)` where `delta_size = current_size - previous_size`. Sets `index_value_is_delta_encoded` table property. |
+| 5 (RocksDB 6.6) | Full and partitioned filters use FastLocalBloom on-disk format. XXH3 becomes the default checksum type (independently of format_version). |
+
+Note: Format versions >= 3 are forward-incompatible -- SST files written with these versions cannot be read by older RocksDB releases.

--- a/docs/components/sst_table_format/07_filter_blocks.md
+++ b/docs/components/sst_table_format/07_filter_blocks.md
@@ -1,0 +1,97 @@
+# Filter Blocks
+
+**Files:** `table/block_based/filter_block.h`, `table/block_based/full_filter_block.h`, `table/block_based/full_filter_block.cc`, `table/block_based/filter_policy_internal.h`, `include/rocksdb/filter_policy.h`, `include/rocksdb/table.h`
+
+## Overview
+
+Filter blocks contain probabilistic data structures (Bloom or Ribbon filters) that enable fast negative lookups: given a key, the filter can definitively say "not present" or speculatively say "maybe present." A false positive is possible, but a false negative is not. This allows RocksDB to skip reading data blocks that cannot contain the target key, significantly reducing I/O for point lookups.
+
+RocksDB supports two filter block organizations:
+
+| Type | Description | Use Case |
+|------|-------------|----------|
+| Full Filter | A single filter block covering all keys in the SST file | Default when a filter policy is set |
+| Partitioned Filter | Multiple filter partitions with a top-level index | Large SST files where filter blocks are too big for cache |
+
+The deprecated block-based filter (one filter per data block range) has been removed from the write path. The reader still recognizes obsolete `filter.` meta-block prefixes for backward compatibility with old SST files.
+
+## Filter Policy Architecture
+
+The filter policy hierarchy is defined across `include/rocksdb/filter_policy.h` and `table/block_based/filter_policy_internal.h`.
+
+### Policy Hierarchy
+
+`FilterPolicy` (public API in `include/rocksdb/filter_policy.h`) is the base interface. Users create policies via:
+- `NewBloomFilterPolicy(bits_per_key)` -- creates a `BloomFilterPolicy`
+- `NewRibbonFilterPolicy(bloom_equivalent_bits_per_key, bloom_before_level)` -- creates a `RibbonFilterPolicy`
+
+`BuiltinFilterPolicy` in `filter_policy_internal.h` provides the ability to read any built-in filter format, regardless of the policy used to create it. This ensures backward compatibility: a `RibbonFilterPolicy` can read Bloom filters from older SST files, and vice versa.
+
+### Bloom vs Ribbon
+
+`BloomFilterPolicy` automatically selects between `LegacyBloomFilter` (format_version < 5) and `FastLocalBloom` (format_version >= 5) based on the build context. The fast local bloom implementation restricts probes to a single cache line for CPU efficiency, at a ~10% increase in false positive rate for a given bits-per-key setting.
+
+`RibbonFilterPolicy` offers ~30% space savings versus Bloom at the cost of more CPU during construction. It uses `bloom_before_level` to control the Bloom-to-Ribbon transition: with the default value of 0, Bloom is used only for flushes under Level/Universal compaction and Ribbon for all other levels. Setting `bloom_before_level` to `INT_MAX` means always Bloom; setting it to `-1` means always Ribbon except rare fallback cases.
+
+### FilterBitsBuilder and FilterBitsReader
+
+`FilterBitsBuilder` (in `filter_policy_internal.h`) accumulates keys during table construction and produces the filter bits at `Finish()`. Key methods:
+- `AddKey(key)` -- adds a single key
+- `AddKeyAndAlt(key, alt)` -- adds a key and its prefix as an alternate entry, with de-duplication between successive keys and alternates
+- `EstimateEntriesAdded()` -- returns the approximate number of unique entries
+- `Finish(buf)` -- produces the filter data
+- `CalculateSpace(num_entries)` -- estimates the filter size for a given number of entries
+- `MaybePostVerify(filter_content)` -- optional post-construction verification
+
+`FilterBitsReader` (also in `filter_policy_internal.h`) checks keys against a constructed filter:
+- `MayMatch(entry)` -- single key check
+- `MayMatch(num_keys, keys, may_match)` -- batch check for MultiGet
+
+## Full Filter Block
+
+### Builder (FullFilterBlockBuilder)
+
+`FullFilterBlockBuilder` in `full_filter_block.h` constructs a single filter for the entire SST file. During table construction, every key is passed to the builder via `Add()` or `AddWithPrevKey()`.
+
+**Key addition workflow:**
+
+Step 1: If a prefix extractor is configured and the key is in the extractor's domain, extract the prefix.
+
+Step 2: If `whole_key_filtering` is true, call `filter_bits_builder_->AddKeyAndAlt(key, prefix)` to add both the whole key and its prefix with de-duplication. If only prefix filtering, call `AddKey(prefix)`.
+
+Step 3: If no prefix extractor or the key is outside the domain, add only the whole key (if `whole_key_filtering` is true).
+
+At `Finish()`, the builder calls `filter_bits_builder_->Finish()` to produce the filter bits, which are written as a single meta block in the SST file.
+
+**Size estimation:** `CurrentFilterSizeEstimate()` returns a cached estimate updated via `UpdateFilterSizeEstimate()` when data blocks are finalized. The estimate uses `CalculateSpace()` on the current entry count plus a 2x-average buffer for the next data block.
+
+### Reader (FullFilterBlockReader)
+
+`FullFilterBlockReader` in `full_filter_block.h` wraps a `ParsedFullFilterBlock` (which holds the filter data and a `FilterBitsReader`).
+
+**Single-key lookup:** `KeyMayMatch(key)` checks `whole_key_filtering()` first -- if whole key filtering is disabled, it returns true (no filtering). Otherwise, it retrieves the filter block (from cache or by reading from file), obtains the `FilterBitsReader`, and calls `MayMatch(key)`.
+
+**Batch lookup:** `KeysMayMatch(range)` and `PrefixesMayMatch(range)` use the batch `MayMatch()` API. For prefix filtering, keys outside the prefix extractor's domain are skipped. The batch path collects keys/prefixes into an array and calls `filter_bits_reader->MayMatch(num_keys, keys, may_match)` in a single call, which is more CPU-efficient than individual checks.
+
+**Error handling:** If the filter block cannot be read (e.g., I/O error), the reader returns true (assume key may be present), ensuring correctness at the cost of a potential unnecessary data block read.
+
+## Filter Configuration
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `filter_policy` | nullptr | Filter policy to use (see `ColumnFamilyOptions` in `include/rocksdb/advanced_options.h`). nullptr means no filter. |
+| `whole_key_filtering` | true | Add whole keys to the filter in addition to prefixes (see `BlockBasedTableOptions` in `include/rocksdb/table.h`) |
+| `partition_filters` | false | Enable partitioned filters (requires `kTwoLevelIndexSearch`). See Chapter 08. |
+| `optimize_filters_for_memory` | true | Round filter sizes to jemalloc allocation classes to reduce internal fragmentation (format_version >= 5) |
+| `detect_filter_construct_corruption` | false | Verify filter integrity after construction |
+| `cache_index_and_filter_blocks` | false | Store filter blocks in the block cache instead of table reader memory (see `BlockBasedTableOptions` in `include/rocksdb/table.h`) |
+
+## Performance Considerations
+
+**Cache interaction:** When `cache_index_and_filter_blocks` is true, filter blocks compete with data blocks for cache space. A full filter for a large SST file can be many megabytes, potentially displacing useful data blocks. This was a key motivation for partitioned filters.
+
+**I/O tradeoffs:** Filter blocks serve two purposes: (1) reducing I/O by avoiding unnecessary data block reads, and (2) reducing CPU by avoiding index binary search and data block decompression. When the filter itself is not in memory, a filter check requires an additional I/O. The filter is net-positive for I/O only when a sufficient fraction of lookups target non-existent keys.
+
+**Bottom-level filters:** The bottom level of the LSM tree typically contains ~89% of total data. Its bloom filter consumes a proportional share of filter memory. For workloads where most lookups hit existing keys (e.g., with an external negative cache), bottom-level bloom filters may waste memory. `RibbonFilterPolicy::bloom_before_level` can be tuned to use more space-efficient Ribbon filters at the bottom level.
+
+**Memory fragmentation:** With `optimize_filters_for_memory` enabled (and format_version >= 5), filter sizes are rounded to match jemalloc allocation classes, recovering ~9.5% of otherwise wasted memory as a ~1/3 reduction in false positive rate.

--- a/docs/components/sst_table_format/08_partitioned_index_filter.md
+++ b/docs/components/sst_table_format/08_partitioned_index_filter.md
@@ -1,0 +1,134 @@
+# Partitioned Index and Filter Blocks
+
+**Files:** `table/block_based/partitioned_index_reader.h`, `table/block_based/partitioned_index_reader.cc`, `table/block_based/partitioned_filter_block.h`, `table/block_based/partitioned_filter_block.cc`, `table/block_based/index_builder.h`, `table/block_based/index_builder.cc`, `include/rocksdb/table.h`
+
+## Overview
+
+For large SST files, storing the entire index or filter as a single block creates problems: the block may be too large to cache efficiently, and loading it requires reading a large contiguous chunk from disk. Partitioned index and filters solve this by splitting these structures into smaller partition blocks, each individually cacheable, with a top-level index that maps key ranges to partition handles.
+
+Partitioned indexes are enabled by setting `BlockBasedTableOptions::index_type` to `kTwoLevelIndexSearch`. Partitioned filters are enabled by additionally setting `BlockBasedTableOptions::partition_filters` to true (which requires `kTwoLevelIndexSearch`).
+
+## Partitioned Index
+
+### On-Disk Layout
+
+```
+[index partition 0] [index partition 1] ... [index partition P-1] [top-level index]
+```
+
+Each index partition is a standard index block (built by `ShortenedIndexBuilder`) containing entries for a subset of data blocks. The top-level index maps the last separator key of each partition to its `BlockHandle`.
+
+### Build Workflow
+
+The `PartitionedIndexBuilder` in `index_builder.h` manages a list of sub-index builders (`entries_`). The active sub-builder (`sub_index_builder_`) accumulates entries until the flush policy triggers a partition cut.
+
+Step 1: `AddIndexEntry()` first calls `MaybeFlush()` (when `first_key_in_next_block` is available) to check if the current partition should be cut before adding the new entry. This means the flush decision is anchored to the previous block's separator, and the new entry goes into the partition after the cut. Then the entry is added to the active sub-index builder. The flush check is based on `metadata_block_size` (default 4096) via a `FlushBlockPolicy`.
+
+Step 2: When a partition is cut, the completed sub-builder is finalized and a new one is created via `MakeNewSubIndexBuilder()`. The flush policy is retargeted to monitor the new builder's block size.
+
+Step 3: `Finish()` is called in a loop. Each call finalizes the next partition and returns `Status::Incomplete()`. The caller writes the partition to the SST file and provides the resulting `BlockHandle`. On the next `Finish()` call, this handle is added to the top-level index. The final call returns `Status::OK()` with the top-level index block contents.
+
+### Read Workflow
+
+`PartitionIndexReader` in `partitioned_index_reader.h` provides two iteration modes:
+
+**Cached mode:** If `CacheDependencies()` has been called and all partitions are pinned in `partition_map_`, the reader creates a `TwoLevelIterator` backed by a `PartitionedIndexIteratorState` that resolves partition handles to cached blocks directly, avoiding per-partition cache lookups.
+
+**On-demand mode:** Otherwise, the reader creates a `PartitionedIndexIterator` that loads each partition from cache or disk as needed during iteration.
+
+### Partition Caching (CacheDependencies)
+
+`PartitionIndexReader::CacheDependencies()` in `partitioned_index_reader.cc` performs a bulk prefetch and cache load of all index partitions:
+
+Step 1: Read the top-level index block.
+
+Step 2: Iterate through the top-level index to determine the byte range covering all partitions. Prefetch this entire range in a single I/O via `FilePrefetchBuffer::Prefetch()`.
+
+Step 3: Iterate again, loading each partition via `MaybeReadBlockAndLoadToCache()`. If all partitions are successfully cached (and optionally pinned), they are saved in `partition_map_`.
+
+The saving is all-or-nothing: if any partition fails to cache, `partition_map_` remains empty and the on-demand path is used. This simplifies the iterator logic, which can assume either all partitions are available or none are.
+
+## Partitioned Filters
+
+### Filter Partitioning Modes
+
+Partitioned filters support two partitioning strategies, controlled by `BlockBasedTableOptions::decouple_partitioned_filters` (default true, and now deprecated as the permanent behavior):
+
+| Mode | Description |
+|------|-------------|
+| Decoupled (default) | Filter partitions are cut independently based on `keys_per_partition_`, computed from the `FilterBitsBuilder`'s `ApproximateNumEntries()` for `metadata_block_size`. |
+| Coupled (deprecated) | Filter partitions align with index partitions. `PartitionedFilterBlockBuilder` requests cuts via `PartitionedIndexBuilder::RequestPartitionCut()`, and the index builder signals back via `ShouldCutFilterBlock()`. |
+
+Important: Coupled mode (`decouple_partitioned_filters=false`) disables parallel compression because the tight coupling between filter and index partitioning creates ordering dependencies incompatible with concurrent block processing. Parallel compression is also disabled when `user_defined_index_factory` is set.
+
+### Build Workflow
+
+`PartitionedFilterBlockBuilder` in `partitioned_filter_block.h` extends `FullFilterBlockBuilder`. It inherits the same key addition logic but adds partition management.
+
+**Key addition (AddImpl):**
+
+Step 1: `DecideCutAFilterBlock()` checks if the current partition should be cut. In decoupled mode, this compares `EstimateEntriesAdded()` against `keys_per_partition_`. In coupled mode, it also consults `ShouldCutFilterBlock()` from the index builder.
+
+Step 2: If a cut is needed, `CutAFilterBlock()` finalizes the current partition:
+- Adds the next key's prefix to the current partition (to support prefix `Seek()` across partition boundaries)
+- Calls `filter_bits_builder_->Finish()` to produce the filter bits
+- Optionally post-verifies the filter
+- Stores the result in `filters_` along with a separator key
+- Adds the previous key's prefix to the new partition (to support prefix `SeekForPrev()` across partition boundaries)
+
+Step 3: The key is then added to the new partition's filter bits builder.
+
+**Prefix boundary handling:** The builder adds the next partition's first prefix to the current partition, and the previous partition's last prefix to the new partition. This ensures that prefix seeks and reverse prefix seeks work correctly at partition boundaries. Without this, a key whose prefix matches the boundary could land in the wrong partition during iteration.
+
+**Finish workflow:** `Finish()` works similarly to `PartitionedIndexBuilder::Finish()`:
+- Returns `Status::Incomplete()` with each filter partition's data
+- The caller writes the partition and provides its `BlockHandle`
+- On the next call, the handle is added to the top-level filter index
+- The final call returns `Status::OK()` with the top-level index block
+
+The top-level index uses the same `BlockBuilder` infrastructure as index blocks, with the same delta-encoding and sequence-number-stripping optimizations.
+
+### Read Workflow
+
+`PartitionedFilterBlockReader` in `partitioned_filter_block.h` performs two-level lookups:
+
+**Single-key lookup (MayMatch):**
+
+Step 1: Load the top-level filter index block via `GetOrReadFilterBlock()`.
+
+Step 2: `GetFilterPartitionHandle()` creates an `IndexBlockIter` over the top-level index and seeks to the given internal key to find the partition handle. If the key is beyond all partition keys, the reader seeks to the last partition (to handle prefix lookups near the end of the key space).
+
+Step 3: `GetFilterPartitionBlock()` loads the filter partition, first checking `filter_map_` for pinned partitions, then falling back to `RetrieveBlock()`.
+
+Step 4: A temporary `FullFilterBlockReader` is constructed with the loaded partition, and the filter check is delegated to it.
+
+**Batch lookup (MayMatch for MultiGet):**
+
+The reader groups keys by their target filter partition. For adjacent keys mapping to the same partition, a single partition load and batch filter check is performed via `MayMatchPartition()`. This avoids redundant partition loads for keys in the same range.
+
+### Filter Partition Caching
+
+`PartitionedFilterBlockReader::CacheDependencies()` performs a similar bulk prefetch and cache load of all filter partitions. Unlike the index reader's `partition_map_` (which is all-or-nothing), the filter reader's `filter_map_` can hold a subset of partitions if some cache insertions fail. This means the filter reader can serve some lookups from pinned partitions while falling back to on-demand loading for others.
+
+## Configuration Reference
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `index_type` | `kBinarySearch` | Must be `kTwoLevelIndexSearch` for partitioned index/filters (see `BlockBasedTableOptions` in `include/rocksdb/table.h`) |
+| `partition_filters` | false | Enable partitioned filters (requires `kTwoLevelIndexSearch`) |
+| `metadata_block_size` | 4096 | Target size for index and filter partitions |
+| `decouple_partitioned_filters` | true | Independent partition boundaries for index and filters (deprecated as permanent behavior) |
+| `cache_index_and_filter_blocks` | false | Store index/filter blocks in block cache. Note: partitioned index and filter partitions always use the block cache regardless of this setting. |
+| `pin_top_level_index_and_filter` | true | Pin top-level index and filter blocks when `cache_index_and_filter_blocks` is true |
+| `pin_l0_filter_and_index_blocks_in_cache` | false | Pin L0 filter and index blocks in cache to prevent eviction |
+
+## When to Use Partitioned Index and Filters
+
+Partitioned index and filters are most beneficial when:
+
+- **Large SST files** produce index/filter blocks that exceed block cache capacity or cause cache thrashing
+- **HDD workloads** where loading a large index block requires expensive sequential I/O -- smaller partitions reduce per-I/O cost
+- **Memory-constrained environments** where the total index/filter size exceeds available RAM
+- **Very large databases** (100TB+) where total index/filter size is measured in gigabytes
+
+Note: Partitioned metadata adds a small amount of overhead per lookup (one extra level of indirection). For workloads where index and filter blocks fit comfortably in cache, the standard single-block format may be slightly more efficient.

--- a/docs/components/sst_table_format/09_data_block_hash_index.md
+++ b/docs/components/sst_table_format/09_data_block_hash_index.md
@@ -1,0 +1,133 @@
+# Data Block Hash Index
+
+**Files:** `table/block_based/data_block_hash_index.h`, `table/block_based/data_block_hash_index.cc`, `table/block_based/block_builder.h`, `table/block_based/block.h`, `include/rocksdb/table.h`
+
+## Overview
+
+The data block hash index is an optional structure appended to data blocks that accelerates point lookups within a block. Without it, `DataBlockIter::SeekForGet()` performs a binary search over restart points, which incurs multiple CPU cache misses. The hash index maps keys to restart interval indices, enabling O(1) lookups in the common case.
+
+This feature reduces `DataBlockIter::SeekForGet()` CPU by ~21.8% and increases overall throughput by ~10% for purely cached workloads, at a cost of ~4.6% more space per data block.
+
+## Architecture
+
+### Block Format With Hash Index
+
+When the hash index is enabled, the data block format becomes:
+
+```
+[restart intervals] [restart index array] [hash index] [packed footer]
+```
+
+The hash index is placed between the restart index array and the packed footer. The packed footer uses a 28-bit `num_restarts` field with 4 feature bits in the upper nibble. Bit 31 signals the presence of the hash index: if set, the reader knows to parse the hash index before performing lookups.
+
+This format uses the `DataBlockFooter` layout where `num_restarts` is capped at `kMaxNumRestarts` (2^28 - 1). The upper 4 bits are reserved for feature flags (hash index present, separated KV, uniform key detection, and one reserved bit). See chapter 03 for the complete footer bit layout.
+
+### Hash Index Format
+
+The hash index consists of:
+
+```
+[bucket_0: uint8] [bucket_1: uint8] ... [bucket_N-1: uint8] [num_buckets: uint16]
+```
+
+Each bucket is a single byte storing one of three values:
+
+| Value | Name | Meaning |
+|-------|------|---------|
+| 0-253 | (restart index) | The restart interval containing the key |
+| 254 | `kCollision` | Multiple keys with different restart indices hashed to this bucket |
+| 255 | `kNoEntry` | No key hashed to this bucket. The key is likely not in this block, though the iterator may still check the last restart interval for boundary cases. |
+
+The `num_buckets` value is stored as a `uint16` at the end, and is always odd (the builder forces `num_buckets |= 1`) to improve hash distribution.
+
+## Builder (DataBlockHashIndexBuilder)
+
+`DataBlockHashIndexBuilder` in `data_block_hash_index.h` collects `(hash, restart_index)` pairs during block construction.
+
+### Initialization
+
+The builder is initialized via `Initialize(util_ratio)` where `util_ratio` is `BlockBasedTableOptions::data_block_hash_table_util_ratio` (default 0.75). The number of buckets per key is computed as `1 / util_ratio`. The `Valid()` method returns true only if the builder was initialized with a positive ratio and no restart index has exceeded the supported maximum.
+
+### Adding Keys
+
+`Add(key, restart_index)` computes `GetSliceHash(key)` and stores the pair. If `restart_index > kMaxRestartSupportedByHashIndex` (253), the builder marks itself invalid and the hash index will not be created for this block.
+
+### Building the Index
+
+`Finish(buffer)` appends the hash index to the block:
+
+Step 1: Compute `num_buckets` from `estimated_num_buckets_`, ensuring it is at least 1 and always odd.
+
+Step 2: Initialize all buckets to `kNoEntry` (255).
+
+Step 3: For each `(hash, restart_index)` pair, compute `bucket_idx = hash % num_buckets`. If the bucket is empty, store the restart index. If the bucket already has a different restart index, mark it as `kCollision` (254). If it already has the same restart index, no change needed.
+
+Step 4: Append the bucket array followed by `num_buckets` as a fixed 16-bit integer.
+
+## Reader (DataBlockHashIndex)
+
+`DataBlockHashIndex` in `data_block_hash_index.h` is the read-side structure. It is lightweight: just a `num_buckets_` field parsed from the block data.
+
+### Initialization
+
+`Initialize(data, size, map_offset)` reads `num_buckets` from the last 2 bytes of the hash index region and computes `map_offset` (the offset within the block where the bucket array starts). The caller uses `map_offset` to know where the hash index data begins.
+
+### Lookup
+
+`Lookup(data, map_offset, key)` computes `GetSliceHash(key) % num_buckets_` and returns the bucket value. The caller interprets the result:
+- A restart index (0-253): seek directly to that restart interval
+- `kCollision` (254): fall back to binary search
+- `kNoEntry` (255): key is definitely not in this block
+
+## Integration With DataBlockIter
+
+The `DataBlockIter` uses the hash index via `SeekForGet()`, which is the optimized point lookup path used by `BlockBasedTable::Get()`. When a hash index is present:
+
+Step 1: Hash the lookup key and call `DataBlockHashIndex::Lookup()`.
+
+Step 2: If the result is a valid restart index, seek directly to that restart interval and scan linearly for the key.
+
+Step 3: If the result is `kCollision`, fall back to binary search over restart points.
+
+Step 4: If the result is `kNoEntry`, the key is not in this block -- return immediately.
+
+For range lookups (`Seek()`, `SeekForPrev()`), the hash index is not used; the standard binary search path is always taken.
+
+## Limitations
+
+| Limitation | Detail |
+|-----------|--------|
+| Point lookup only | Range queries (`Seek`, `SeekForPrev`, `Next`, `Prev`) always use binary search |
+| Max 253 restart intervals | If a block has more than 253 restart intervals, the hash index is silently not created |
+| Max 64KB block size | Hash index uses `uint16` for bucket count and offsets, limiting supported block size to 64KB |
+| Comparator constraint | The comparator must never treat keys with different byte contents as equal (see below) |
+| Record type support | `SeekForGet()` supports `kTypeValue`, `kTypeDeletion`, `kTypeSingleDeletion`, `kTypeBlobIndex`, `kTypeWideColumnEntity`, `kTypeValuePreferredSeqno`, and `kTypeMerge`. For other record types, `SeekForGet()` falls back to standard `Seek()`. |
+
+### Comparator Constraint
+
+The hash index hashes the raw key bytes. If a comparator treats two keys with different byte sequences as equal (e.g., a numeric comparator where "16" and "0x10" are equivalent), the hash index will produce incorrect results: the keys hash to different buckets but compare equal.
+
+To guard against this, the `Comparator` interface provides `CanKeysWithDifferentByteContentsBeEqual()`. This method returns true by default (conservative), which disables the hash index. To use the hash index, the comparator must override this method to return false.
+
+The default bytewise comparator already returns false, so the hash index works out of the box for most RocksDB users.
+
+## Configuration
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `data_block_index_type` | `kDataBlockBinarySearch` | Set to `kDataBlockBinaryAndHash` to enable hash index (see `BlockBasedTableOptions` in `include/rocksdb/table.h`) |
+| `data_block_hash_table_util_ratio` | 0.75 | Ratio controlling hash table density. Lower values mean more buckets (fewer collisions) but more space overhead. |
+
+## Performance Tuning
+
+The `data_block_hash_table_util_ratio` controls the trade-off between space overhead, collision rate, and cache efficiency:
+
+| Util Ratio | Buckets per Key | Space Overhead | Collision Rate | Notes |
+|-----------|----------------|----------------|---------------|-------|
+| 1.0 | 1.0 | 1 byte/key | ~52% | Minimal space, many fallbacks to binary search |
+| 0.75 (default) | 1.33 | 1.33 bytes/key | Lower | Good balance |
+| 0.5 | 2.0 | 2 bytes/key | Low | Higher cache usage |
+
+**Cache interaction:** The hash index is appended to the data block and stored in the block cache as part of the block. Lower util ratios increase block size, which reduces effective cache capacity. If cache miss rates exceed ~40%, the extra I/O from reduced cache capacity can offset the CPU savings from hash lookups. A util ratio in the range 0.5-1.0 is recommended.
+
+**Compression interaction:** When compression is enabled, cache misses also require decompression, amplifying the CPU cost of reduced cache capacity. With aggressive compression, a higher util ratio (less space overhead) may be preferable.

--- a/docs/components/sst_table_format/10_plain_table.md
+++ b/docs/components/sst_table_format/10_plain_table.md
@@ -1,0 +1,161 @@
+# PlainTable Format
+
+**Files:** `table/plain/plain_table_factory.h`, `table/plain/plain_table_factory.cc`, `table/plain/plain_table_builder.h`, `table/plain/plain_table_builder.cc`, `table/plain/plain_table_reader.h`, `table/plain/plain_table_reader.cc`, `table/plain/plain_table_index.h`, `table/plain/plain_table_index.cc`, `table/plain/plain_table_key_coding.h`, `table/plain/plain_table_key_coding.cc`, `table/plain/plain_table_bloom.h`, `include/rocksdb/table.h`
+
+## Overview
+
+PlainTable is an SST file format optimized for memory-mapped (mmap) file systems such as tmpfs. Unlike the block-based table format, data is not organized into fixed-size blocks -- key-value pairs are written sequentially with lightweight encoding. This design eliminates block decompression overhead and enables fast random access when the file is memory-mapped.
+
+Important: PlainTable does not support compression or per-block checksums. It is designed for in-memory databases where data resides on fast storage (e.g., tmpfs, ramfs). Using PlainTable on disk-based file systems is not recommended.
+
+## Configuration Options
+
+PlainTable is configured via `PlainTableOptions` (see `include/rocksdb/table.h`).
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `user_key_len` | `uint32_t` | `kPlainTableVariableLength` | Fixed key length optimization. Set to `kPlainTableVariableLength` for variable-length keys. |
+| `bloom_bits_per_key` | `int` | 10 | Bloom filter bits per prefix (or per key in total-order mode). Set to 0 to disable. |
+| `hash_table_ratio` | `double` | 0.75 | Hash table utilization ratio (number of prefixes / number of buckets). Set to 0 to disable hash index and use binary search only. |
+| `index_sparseness` | `size_t` | 16 | Number of keys between consecutive index records within the same prefix. Controls trade-off between index size and linear search cost. |
+| `huge_page_tlb_size` | `size_t` | 0 | If > 0, allocate hash indexes and bloom filters from huge page TLB instead of malloc. |
+| `encoding_type` | `EncodingType` | `kPlain` | Key encoding strategy: `kPlain` (full keys) or `kPrefix` (prefix-compressed keys). |
+| `full_scan_mode` | `bool` | false | When true, no index is built. Point lookups and keyed `Seek()` are not supported. Sequential iteration via `SeekToFirst()` followed by `Next()` is the only supported access pattern. |
+| `store_index_in_file` | `bool` | false | When true, the hash index and bloom filter are computed during file building and stored in the SST file. On read, the index is loaded directly instead of being recomputed. |
+
+## File Layout
+
+PlainTable stores all data as a single contiguous region of key-value records, followed by optional metadata blocks:
+
+```
+[key-value record 0]
+[key-value record 1]
+...
+[key-value record N-1]
+[meta block: bloom filter]       (optional, when store_index_in_file=true and bloom enabled)
+[meta block: plain table index]  (optional, when store_index_in_file=true)
+[meta block: properties]
+[metaindex block]
+[Footer]
+```
+
+The footer uses `kPlainTableMagicNumber` (`0x8242229663bf9564`) with footer format version 0 (always, regardless of encoding type) and `kNoChecksum`. The table property `format_version` is set to 0 for `kPlain` encoding or 1 for `kPrefix` encoding, but this is separate from the footer format version.
+
+## Key Encoding
+
+PlainTable supports two key encoding types, controlled by `encoding_type` in `PlainTableOptions` (see `include/rocksdb/table.h`).
+
+### kPlain Encoding
+
+Each key-value record is written as:
+
+```
+[key_size (varint32)]  -- only for variable-length keys
+[internal_key]
+[value_size (varint32)]
+[value]
+```
+
+For fixed-length keys (`user_key_len != kPlainTableVariableLength`), the `key_size` field is omitted since the key length is known from table properties.
+
+### kPrefix Encoding
+
+Prefix encoding reduces key storage by sharing common prefixes between consecutive keys. Three encoding forms are used:
+
+1. **Full Key**: Written when the prefix changes or at the start. Encodes the entire internal key.
+2. **Prefix + Suffix**: Written when a key shares the same prefix as the previous full key. Only the prefix length and suffix bytes are stored.
+3. **Suffix Only**: Written when a key shares the same prefix as the previous prefix-encoded key. Only the suffix bytes are stored.
+
+Each key flag byte uses the top 2 bits for the type (full key = 00, prefix = 01, suffix = 10) and the lower 6 bits for size. If the size exceeds 63, a varint32 follows with the remaining length (actual_size - 63).
+
+### Internal Key Optimization
+
+For keys with sequence number 0 and value type, a special compact encoding is used: the internal key bytes are followed by a single byte `0xFF` instead of the full 8-byte sequence number and type field. This saves 7 bytes per key. See `kValueTypeSeqId0` in `PlainTableFactory` (see `table/plain/plain_table_factory.h`).
+
+## Hash-Based Index
+
+When `hash_table_ratio > 0` and a prefix extractor is configured, PlainTable builds a hash index for fast prefix-based lookups. The index is managed by `PlainTableIndex` and `PlainTableIndexBuilder` (see `table/plain/plain_table_index.h`).
+
+### Index Structure
+
+The index is an array of 32-bit entries, one per hash bucket. Each entry uses bit 31 as a flag:
+
+| Flag | Meaning |
+|------|---------|
+| 0 | Bucket contains a single prefix. The lower 31 bits are the file offset of the first record with that prefix. |
+| 1 | Bucket contains multiple prefixes or too many records for one prefix. The lower 31 bits point into a sub-index for binary search. |
+
+The sub-index region stores, for each multi-prefix bucket:
+
+```
+[num_records: varint32]
+[offset_0: fixedint32]
+[offset_1: fixedint32]
+...
+[offset_N-1: fixedint32]
+```
+
+where each offset points to a record in the data region. Offsets are in ascending order to support binary search.
+
+### File Size Limit
+
+Because offsets are stored as 31-bit values, PlainTable has a maximum file size of 2 GB (`kMaxFileSize = (1u << 31) - 1`). Files exceeding this limit are rejected during `PlainTableReader::Open()`.
+
+### Index Building
+
+**At write time** (when `store_index_in_file=true`): `PlainTableBuilder` collects key/prefix hashes during `Add()` and uses `PlainTableIndexBuilder` to construct the hash index. The index and optional bloom filter are written as meta blocks before the properties block.
+
+**At read time** (when index is not in file): `PlainTableReader::PopulateIndex()` scans the entire data region, builds `IndexRecord` entries via `PopulateIndexRecordList()`, and constructs the hash table in memory.
+
+### Lookup Flow
+
+Step 1: Hash the prefix to find the bucket.
+
+Step 2: Check the bucket flag:
+- If `kNoPrefixForBucket`: no matching prefix exists, return not found.
+- If `kDirectToFile`: single prefix, jump directly to that file offset.
+- If `kSubindex`: perform binary search in the sub-index to find the target offset.
+
+Step 3: Scan forward from the found offset, comparing keys until a match is found or the prefix changes.
+
+## Total-Order Mode
+
+When no prefix extractor is configured (`prefix_extractor = nullptr`), PlainTable operates in total-order mode. In this mode:
+
+- The hash table has a single bucket (index size = 1) that points to the start of the data.
+- Bloom filter operates on full user keys instead of prefixes.
+- `Seek()` with arbitrary keys is supported (unlike prefix mode, which only supports prefix-based seeks).
+- `SeekToFirst()` is always supported regardless of mode.
+
+Note: `SeekToLast()` and `SeekForPrev()` return `Status::NotSupported`. `Prev()` is not supported (asserts in debug builds, undefined behavior in release).
+
+## Bloom Filter
+
+PlainTable uses its own bloom filter implementation (`PlainTableBloomV1` in `table/plain/plain_table_bloom.h`), separate from the block-based table's bloom/ribbon filters.
+
+- In prefix mode: bloom filter is built on prefix hashes with `bloom_bits_per_key` bits per prefix.
+- In total-order mode: bloom filter is built on full user key hashes with `bloom_bits_per_key` bits per key.
+- The bloom filter uses 6 probes (hardcoded in `PlainTableBuilder`).
+
+When `store_index_in_file=true`, the bloom filter is serialized as a meta block and loaded directly on read. Otherwise, it is recomputed by scanning the data at open time.
+
+## Limitations
+
+| Limitation | Details |
+|-----------|---------|
+| No compression | Data is stored uncompressed. |
+| No checksums | Block-level checksums are not computed or verified. |
+| No range deletions | `Add()` returns `Status::NotSupported` for `kTypeRangeDeletion` entries. |
+| No `SeekToLast()` / `Prev()` | Reverse iteration is not supported. `Prev()` asserts in debug builds and has undefined behavior in release. |
+| No `SeekForPrev()` | Returns `Status::NotSupported`. |
+| Max file size 2 GB | Due to 31-bit offsets in the hash index. |
+| Requires mmap | Designed for `use_mmap_reads=true`. Non-mmap mode works but with reduced performance. |
+| Prefix extractor compatibility | When a prefix extractor was used to build the file, the same extractor must be provided when opening it (validated by name comparison). |
+| Max entries ~2^32 | Offsets are stored as `uint32_t`. |
+
+## Interactions With Other Components
+
+- **TableFactory**: `PlainTableFactory` (see `table/plain/plain_table_factory.h`) implements `TableFactory` to create `PlainTableBuilder` and `PlainTableReader` instances.
+- **Compaction**: PlainTable files participate in normal compaction. Compaction creates iterators with `total_order_seek=true` but typically only calls `SeekToFirst()`.
+- **Table Properties**: PlainTable stores encoding type, bloom version, and bloom block count as user-collected properties (see `PlainTablePropertyNames` in `table/plain/plain_table_factory.cc`).
+- **Seqno-to-time mapping**: Not yet supported for PlainTable (see `SetSeqnoTimeTableProperties()` in `table/plain/plain_table_builder.cc`).

--- a/docs/components/sst_table_format/11_cuckoo_table.md
+++ b/docs/components/sst_table_format/11_cuckoo_table.md
@@ -1,0 +1,141 @@
+# CuckooTable Format
+
+**Files:** `table/cuckoo/cuckoo_table_factory.h`, `table/cuckoo/cuckoo_table_builder.h`, `table/cuckoo/cuckoo_table_builder.cc`, `table/cuckoo/cuckoo_table_reader.h`, `table/cuckoo/cuckoo_table_reader.cc`, `include/rocksdb/table.h`
+
+## Overview
+
+CuckooTable is an SST file format optimized for fast point lookups using cuckoo hashing. Data is stored in a flat hash table where each bucket contains a fixed-size key-value pair. Lookups require checking at most `num_hash_func` x `cuckoo_block_size` locations, making them O(1) with excellent cache locality.
+
+CuckooTable is designed for read-heavy workloads with fixed-length keys and values. It trades space efficiency and write flexibility for extremely fast point lookups. Compared to PlainTable (which targets sub-microsecond latency with prefix iteration support), CuckooTable targets higher raw point-lookup throughput by reducing memory accesses per lookup to 1-2.
+
+## Configuration Options
+
+CuckooTable is configured via `CuckooTableOptions` (see `include/rocksdb/table.h`).
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `hash_table_ratio` | `double` | 0.9 | Hash table utilization. Smaller values mean more empty buckets and fewer collisions at the cost of larger files. |
+| `max_search_depth` | `uint32_t` | 100 | Maximum BFS depth when displacing elements during hash table construction. Higher values improve build success rate but increase build time. |
+| `cuckoo_block_size` | `uint32_t` | 5 | Number of consecutive buckets to check per hash function during lookup. Improves cache locality for lookups. Minimum is 1. |
+| `identity_as_first_hash` | `bool` | false | When true, treats the first 8 bytes of the user key as the hash value for the first hash function. Useful for integer keys. |
+| `use_module_hash` | `bool` | true | When true, uses modulo for hash-to-bucket mapping (better space efficiency). When false, uses bitwise AND (requires power-of-two table size, but faster). |
+
+## File Layout
+
+CuckooTable files consist of a flat hash table followed by metadata:
+
+```
+[bucket 0: key + value]
+[bucket 1: key + value]
+...
+[bucket T-1: key + value]
+[properties block]
+[metaindex block]
+[Footer]
+```
+
+where `T = hash_table_size + cuckoo_block_size - 1`. Each bucket has a fixed size of `key_size + value_size` bytes. Empty buckets are filled with an unused key (a key outside the range of all keys in the file).
+
+The footer uses `kCuckooTableMagicNumber` (`0x926789d0c5f17873`) with format version 1 and `kNoChecksum`.
+
+## Hash Function Selection
+
+CuckooTable uses multiple hash functions based on MurmurHash (see `CuckooHash()` in `table/cuckoo/cuckoo_table_factory.h`).
+
+The hash function for index `hash_cnt` computes:
+- If `hash_cnt == 0` and `identity_as_first_hash` is true: the first 8 bytes of the user key are used directly as the hash value.
+- Otherwise: `MurmurHash(user_key, seed)` where `seed = kCuckooMurmurSeedMultiplier * hash_cnt` and `kCuckooMurmurSeedMultiplier = 816922183`.
+
+The hash value is mapped to a bucket index using:
+- Modulo: `hash_value % table_size` (when `use_module_hash=true`)
+- Bitwise AND: `hash_value & (table_size - 1)` (when `use_module_hash=false`, requires power-of-two table size)
+
+## Build Workflow
+
+The builder (`CuckooTableBuilder` in `table/cuckoo/cuckoo_table_builder.h`) constructs the hash table in memory, then writes it to disk.
+
+Step 1 -- **Accumulate entries**: During `Add()`, `kTypeValue` entries are appended to an in-memory buffer (`kvs_`). Deleted keys are stored separately in `deleted_keys_`. The builder validates that all keys have the same size and all non-deletion values have the same size.
+
+Step 2 -- **Determine last-level optimization**: If the first key has sequence number 0, the file is treated as a last-level file. In this case, internal key metadata (sequence number + type, 8 bytes) is stripped, and only user keys are stored.
+
+Step 3 -- **Build hash table** (`MakeHashTable()`): For each entry, compute hash values using all hash functions and try to place it in an empty bucket. If all candidate buckets are occupied, invoke `MakeSpaceForKey()`.
+
+Step 4 -- **Collision resolution** (`MakeSpaceForKey()`): Uses BFS to find a chain of displacements that frees a bucket. The search explores buckets by computing alternative hash positions for currently placed elements, up to `max_search_depth` levels deep. If BFS fails, a new hash function is added (up to `max_num_hash_func`) and the search continues without rehashing existing entries.
+
+Step 5 -- **Determine unused key**: An unused key is computed by decrementing the smallest key or incrementing the largest key byte-by-byte until a key outside the range `[smallest, largest]` is found. This key fills empty buckets so the reader can distinguish empty from occupied slots.
+
+Step 6 -- **Write to file**: Buckets are written sequentially. Empty buckets get the unused key. Occupied buckets get the actual key + value. After the hash table, property block, metaindex block, and footer are appended.
+
+## Read Path
+
+The reader (`CuckooTableReader` in `table/cuckoo/cuckoo_table_reader.h`) requires mmap mode (`allow_mmap_reads=true`). The entire file is memory-mapped at open time.
+
+### Point Lookup
+
+`CuckooTableReader::Get()` performs:
+
+Step 1: For each hash function (0 to `num_hash_func - 1`):
+  - Compute the bucket offset using `CuckooHash()`.
+  - Check `cuckoo_block_size` consecutive buckets starting from that offset.
+  - If the bucket contains the unused key, stop (key not found).
+  - If the bucket's user key matches the target, extract the value and return.
+
+Step 2: If no match is found across all hash functions, the key does not exist.
+
+### Cache-Friendly Design
+
+CuckooTable's `cuckoo_block_size` is designed so that a cuckoo block (consecutive buckets checked per hash function) fits within a CPU cache line. This is the key optimization: rather than jumping to random memory locations for each hash function, the reader checks consecutive memory within a single cache line. With the default `cuckoo_block_size=5` and typical key-value sizes, most lookups are served from the first cuckoo block, reducing the typical number of cache misses to 1-2.
+
+`CuckooTableReader::Prepare()` prefetches the first cuckoo block (for hash function 0) into CPU cache using `PREFETCH` intrinsics. The prefetch covers cache lines spanning the cuckoo block, aligned to `CACHE_LINE_SIZE` boundaries. Since the majority of keys are found in the first cuckoo block, prefetching only this block provides the best cost-benefit ratio.
+
+### Iterator
+
+`CuckooTableIterator` supports ordered iteration by sorting all occupied bucket indices by user key at initialization time (`InitIfNeeded()`). This sort is deferred until the first seek or scan operation. The iterator supports `Seek()`, `SeekToFirst()`, `SeekToLast()`, `Next()`, and `Prev()`, but `SeekForPrev()` is not supported.
+
+For last-level files, the iterator reconstructs internal keys by wrapping user keys with sequence number 0 and `kTypeValue`.
+
+## Table Properties
+
+CuckooTable stores several custom properties (see `CuckooTablePropertyNames` in `table/cuckoo/cuckoo_table_builder.cc`):
+
+| Property | Description |
+|----------|-------------|
+| `kEmptyKey` | The unused key used to mark empty buckets |
+| `kNumHashFunc` | Number of hash functions used |
+| `kHashTableSize` | Number of buckets in the hash table |
+| `kValueLength` | Fixed value length |
+| `kIsLastLevel` | Whether the file uses user-key-only mode |
+| `kCuckooBlockSize` | Cuckoo block size |
+| `kIdentityAsFirstHash` | Whether identity hash was used |
+| `kUseModuleHash` | Whether modulo hashing was used |
+| `kUserKeyLength` | User key length |
+
+These properties are read by `CuckooTableReader` during file open to reconstruct the hash table parameters. A missing property causes a `Status::Corruption` error.
+
+## Limitations
+
+| Limitation | Details |
+|-----------|---------|
+| Fixed key and value lengths | All keys must have the same size. All non-deletion values must have the same size. Deletions are stored separately and the reader synthesizes dummy values for their buckets. |
+| No snapshots | Snapshot-based reads are not supported. |
+| No merge operations | Only `kTypeValue` and `kTypeDeletion` are supported. Other types return `Status::NotSupported`. |
+| No compression | Data is stored uncompressed. |
+| No checksums | No block-level checksums. |
+| No prefix bloom filters | Not supported by CuckooTable. |
+| Requires mmap | Reader requires `allow_mmap_reads=true`; otherwise returns `Status::InvalidArgument`. |
+| Max ~2^32 entries | Entry count is stored as `uint32_t`. |
+| No `SeekForPrev()` | Asserts in debug builds; undefined behavior in release. |
+| No `ApproximateOffsetOf()` / `ApproximateSize()` | Always returns 0. |
+| Memory-intensive build | All key-value pairs are buffered in memory during construction. |
+
+## Hash Table Sizing
+
+When `use_module_hash=true`: `hash_table_size = num_entries / max_hash_table_ratio`. The actual table has `hash_table_size + cuckoo_block_size - 1` buckets to accommodate block lookups near the end.
+
+When `use_module_hash=false`: `hash_table_size` starts at 2 and doubles as entries are added, ensuring it stays a power of two. The final size satisfies `hash_table_size >= num_entries / max_hash_table_ratio`.
+
+## Interactions With Other Components
+
+- **TableFactory**: `CuckooTableFactory` (see `table/cuckoo/cuckoo_table_factory.h`) implements `TableFactory` to create `CuckooTableBuilder` and `CuckooTableReader`.
+- **Compaction**: CuckooTable files participate in compaction, but the iterator must sort all keys at initialization, making it less efficient than block-based tables for large scans.
+- **Last-level optimization**: When the first key has sequence number 0, the builder strips internal key metadata, saving 8 bytes per key. The reader reconstructs internal keys as needed.

--- a/docs/components/sst_table_format/12_table_properties.md
+++ b/docs/components/sst_table_format/12_table_properties.md
@@ -1,0 +1,196 @@
+# Table Properties
+
+**Files:** `include/rocksdb/table_properties.h`, `table/table_properties.cc`, `table/meta_blocks.h`, `table/meta_blocks.cc`, `db/table_properties_collector.h`, `db/table_properties_collector.cc`
+
+## Overview
+
+Table properties are metadata stored in every SST file, providing information about the file's contents, configuration, and origin. Properties are stored in a dedicated meta block within the SST file and are accessible without reading the data blocks.
+
+RocksDB supports two categories of table properties:
+1. **Built-in properties**: Automatically collected by the table builder (entry counts, sizes, compression info, timestamps, etc.).
+2. **User-collected properties**: Custom properties collected via user-defined `TablePropertiesCollector` callbacks during table building.
+
+## TableProperties Struct
+
+The `TableProperties` struct (see `include/rocksdb/table_properties.h`) contains all built-in properties. Key fields:
+
+### Size and Count Properties
+
+| Property | Description |
+|----------|-------------|
+| `data_size` | Total size of all data blocks (compressed, on disk) |
+| `uncompressed_data_size` | Total uncompressed size of all data blocks |
+| `index_size` | Size of the index block |
+| `filter_size` | Size of the filter block |
+| `raw_key_size` | Total uncompressed, undelineated key size |
+| `raw_value_size` | Total uncompressed, undelineated value size |
+| `num_data_blocks` | Number of data blocks in the file |
+| `num_entries` | Total number of entries |
+| `num_deletions` | Number of deletion entries |
+| `num_merge_operands` | Number of merge operand entries |
+| `num_range_deletions` | Number of range deletion entries |
+| `num_filter_entries` | Number of unique entries added to filters |
+
+### Index Properties
+
+| Property | Description |
+|----------|-------------|
+| `index_partitions` | Number of index partitions (for `kTwoLevelIndexSearch`) |
+| `top_level_index_size` | Size of the top-level index (for `kTwoLevelIndexSearch`) |
+| `index_key_is_user_key` | Whether the index stores user keys (vs internal keys with sequence numbers) |
+| `index_value_is_delta_encoded` | Whether index values use delta encoding |
+
+### Format and Configuration
+
+| Property | Description |
+|----------|-------------|
+| `format_version` | SST format version |
+| `fixed_key_len` | Fixed key length (0 = variable length) |
+| `compression_name` | Compression algorithm identifier |
+| `compression_options` | Compression options used |
+| `data_block_restart_interval` | Restart interval for data blocks |
+| `index_block_restart_interval` | Restart interval for index blocks |
+| `separate_key_value_in_data_block` | Whether separated KV storage is used in data blocks |
+
+### Identity and Timestamp Properties
+
+| Property | Description |
+|----------|-------------|
+| `db_id` | Database identity (generated at DB creation) |
+| `db_session_id` | Session identity (changes every DB open) |
+| `db_host_id` | Host location identifier |
+| `orig_file_number` | File number at creation time |
+| `column_family_id` | Column family ID |
+| `column_family_name` | Column family name |
+| `creation_time` | Oldest ancestor time (see details below) |
+| `oldest_key_time` | Timestamp of the earliest key (0 = unknown) |
+| `newest_key_time` | Timestamp of the newest key (0 = unknown) |
+| `file_creation_time` | Actual SST file creation time (0 = unknown) |
+| `key_largest_seqno` | Largest sequence number in the file (UINT64_MAX = unknown) |
+| `key_smallest_seqno` | Smallest sequence number in the file (UINT64_MAX = unknown) |
+| `user_defined_timestamps_persisted` | Whether user-defined timestamps are persisted (default true) |
+
+### Compression Estimation
+
+| Property | Description |
+|----------|-------------|
+| `slow_compression_estimated_data_size` | Estimated data size with slow compression algorithm |
+| `fast_compression_estimated_data_size` | Estimated data size with fast compression algorithm |
+
+These estimates are populated when `ColumnFamilyOptions::sample_for_compression` is configured. They help users evaluate compression trade-offs without rebuilding the file.
+
+### Other Properties
+
+| Property | Description |
+|----------|-------------|
+| `comparator_name` | Name of the comparator |
+| `merge_operator_name` | Name of the merge operator ("nullptr" if none) |
+| `prefix_extractor_name` | Name of the prefix extractor ("nullptr" if none) |
+| `filter_policy_name` | Name of the filter policy (empty if none) |
+| `property_collectors_names` | Comma-separated names of property collector factories |
+| `seqno_to_time_mapping` | Delta-encoded sequence number to time mapping |
+| `tail_start_offset` | Offset where the "tail" (non-data blocks) begins |
+| `external_sst_file_global_seqno_offset` | Offset of the global seqno property value for ingested files (0 if not present) |
+
+### Creation Time Semantics
+
+The `creation_time` field has special semantics:
+- For flush output: the oldest key time in the file, or flush time if unavailable.
+- For compaction output: the oldest among all input files' oldest key times, since the output could be a chain of compactions from older SST files. Falls back to compaction output creation time if unavailable.
+
+## Property Serialization
+
+### Property Names
+
+Each built-in property has a string name defined in `TablePropertiesNames` (see `include/rocksdb/table_properties.h`). Names follow the pattern `rocksdb.<property>`, for example:
+- `rocksdb.data.size`
+- `rocksdb.num.entries`
+- `rocksdb.compression`
+- `rocksdb.creating.db.identity`
+
+### Storage Format
+
+Properties are stored in a meta block named `rocksdb.properties` within the SST file. The `PropertyBlockBuilder` (see `table/meta_blocks.h`) uses a `BlockBuilder` to serialize properties as key-value pairs in sorted order. Numeric properties are encoded as varint64. String properties are stored as raw bytes.
+
+### Write Workflow
+
+Step 1: During table building, the builder accumulates property values (entry counts, sizes, etc.).
+
+Step 2: At `Finish()` time:
+  - `PropertyBlockBuilder::AddTableProperty()` serializes all built-in properties.
+  - User-collected properties are added via `PropertyBlockBuilder::Add()`.
+  - `NotifyCollectTableCollectorsOnFinish()` calls `Finish()` on each `TablePropertiesCollector` to collect final user properties.
+
+Step 3: The property block is written to the SST file and its `BlockHandle` is recorded in the metaindex block under the key `rocksdb.properties`.
+
+### Read Workflow
+
+`ReadTableProperties()` (see `table/meta_blocks.h`) reads properties from an SST file:
+
+Step 1: Read the footer to find the metaindex block.
+
+Step 2: Read the metaindex block and look up the `rocksdb.properties` entry.
+
+Step 3: Read the properties block and parse each key-value pair into the `TableProperties` struct.
+
+## User-Collected Properties
+
+### TablePropertiesCollector
+
+`TablePropertiesCollector` (see `include/rocksdb/table_properties.h`) provides callbacks for users to collect custom properties during table building.
+
+| Method | Description |
+|--------|-------------|
+| `AddUserKey(key, value, type, seq, file_size)` | Called for each key-value pair added to the table. The `file_size` parameter reflects the current file size (data blocks written so far, excluding the current block being built). |
+| `BlockAdd(uncomp_bytes, comp_fast, comp_slow)` | Called after each data block is completed. Provides uncompressed and estimated compressed sizes. |
+| `Finish(properties)` | Called once when the table is complete. The collector writes its final properties to the provided map. |
+| `GetReadableProperties()` | Returns human-readable property values for logging. |
+| `NeedCompact()` | Returns true if the file should be further compacted. Used by compaction filters to trigger additional compaction. |
+
+Important: `TablePropertiesCollector` methods do not need to be thread-safe -- RocksDB creates exactly one collector per table and calls it sequentially. However, if `Finish()` returns a non-OK status, the collected properties are not written to the file.
+
+### TablePropertiesCollectorFactory
+
+`TablePropertiesCollectorFactory` (see `include/rocksdb/table_properties.h`) creates collector instances for each table file. The factory must be thread-safe since it is shared across concurrent table builds.
+
+The factory's `CreateTablePropertiesCollector()` method receives a `Context` with:
+- `column_family_id`: The column family of the table being built.
+- `level_at_creation`: The LSM level at file creation time (-1 if unknown).
+- `num_levels`: Total number of levels (-1 if unknown).
+- `last_level_inclusive_max_seqno_threshold`: Sequence number threshold for tiered storage eligibility.
+
+Returning `nullptr` from the factory declines collection for that file, reducing callback overhead.
+
+### Registration
+
+User collector factories are registered via `ColumnFamilyOptions::table_properties_collector_factories` (see `include/rocksdb/advanced_options.h`). Multiple factories can be registered, and each produces an independent collector for every table file.
+
+## Aggregation and Comparison
+
+`TableProperties` supports aggregation across multiple files:
+- `Add()`: Sums a subset of numeric fields from another `TableProperties` instance (not all fields are aggregated).
+- `GetAggregatablePropertiesAsMap()`: Returns numeric properties as a `map<string, uint64_t>` for external aggregation.
+
+For serialization and comparison:
+- `Serialize()` / `Parse()`: Convert to/from string representation.
+- `AreEqual()`: Compares two property instances field by field.
+
+## Approximate Memory Usage
+
+`ApproximateMemoryUsage()` provides an intentionally approximate estimate of the memory footprint of a `TableProperties` object. It includes the struct itself and most string/map members, but may omit some fields (e.g., `seqno_to_time_mapping`). This is used for memory accounting in the table cache.
+
+## Internal Property Collectors
+
+RocksDB includes internal property collectors (see `db/table_properties_collector.h`) that are active during table building:
+- **InternalTblPropColl**: The base class for internal collectors. Deletion counts and merge operand counts are tracked directly in `TableProperties` fields during table building, not via a separate collector. The old user-property accessors (`GetDeletedKeys()`, `GetMergeOperands()`) are deprecated.
+- **BlockBasedTablePropertiesCollector**: Records block-based table specific properties: index type, whole key filtering, prefix filtering, and decoupled partitioned filters.
+- **TimestampTablePropertiesCollector**: Active when timestamp-aware configurations are used.
+- **SstFileWriterPropertiesCollector**: Active when building external SST files via `SstFileWriter`.
+
+## Interactions With Other Components
+
+- **Table Builders**: All table formats (block-based, plain, cuckoo) write a properties meta block using `PropertyBlockBuilder`. Each format may add format-specific user-collected properties.
+- **Table Cache**: `TableCache::GetTableProperties()` retrieves properties without opening the full table reader.
+- **Compaction**: Compaction reads properties from input files (e.g., `creation_time`, `oldest_key_time`) to propagate to output files. The `NeedCompact()` signal from collectors can trigger additional compaction.
+- **SstFileWriter**: External SST files include version and global sequence number properties (see `ExternalSstFilePropertyNames` in `table/sst_file_writer_collectors.h`).
+- **sst_dump tool**: Reads and displays all table properties including user-collected properties.

--- a/docs/components/sst_table_format/13_sst_file_writer.md
+++ b/docs/components/sst_table_format/13_sst_file_writer.md
@@ -1,0 +1,136 @@
+# SstFileWriter
+
+**Files:** `include/rocksdb/sst_file_writer.h`, `table/sst_file_writer.cc`, `table/sst_file_writer_collectors.h`
+
+## Overview
+
+`SstFileWriter` creates external SST files that can be ingested into a RocksDB database via `DB::IngestExternalFile()`. This allows bulk loading of data without going through the normal write path (WAL, memtable, flush), making it significantly faster for large data imports.
+
+All keys written by `SstFileWriter` have sequence number 0. The files are assigned a global sequence number during ingestion.
+
+Important: `SstFileWriter` is NOT thread-safe. Each instance should be used from a single thread.
+
+## API
+
+`SstFileWriter` (see `include/rocksdb/sst_file_writer.h`) provides the following operations:
+
+### Construction
+
+The constructor accepts:
+- `EnvOptions`: File I/O configuration.
+- `Options`: Database options that determine the table format, compression, comparator, and other settings.
+- `ColumnFamilyHandle` (optional): Specifies the target column family. When provided, the column family ID and name are persisted in the file's table properties.
+- `invalidate_page_cache` (default true): Gives the OS a hint to drop file pages from page cache every 1 MB written.
+- `io_priority`: I/O priority for writes.
+
+### Operations
+
+| Method | Description |
+|--------|-------------|
+| `Open(file_path, temp)` | Create a new SST file at the given path. Optionally specify a `Temperature` hint. |
+| `Put(key, value)` | Add a key-value pair. |
+| `Put(key, timestamp, value)` | Add a key-value pair with a user-defined timestamp. |
+| `PutEntity(key, columns)` | Add a wide-column entity. |
+| `Merge(key, value)` | Add a merge operand. |
+| `Delete(key)` | Add a deletion tombstone. |
+| `Delete(key, timestamp)` | Add a deletion with a user-defined timestamp. |
+| `DeleteRange(begin, end)` | Add a range deletion tombstone. Range deletions do NOT delete point keys in the same file. |
+| `DeleteRange(begin, end, timestamp)` | Add a range deletion with a user-defined timestamp. |
+| `Finish(file_info)` | Finalize the file: flush the table builder, sync, and close. Optionally returns file metadata. |
+| `FileSize()` | Current file size in bytes. |
+
+### Key Ordering Requirements
+
+Point keys (Put, Merge, Delete) must be added in strictly ascending order according to the comparator. Range deletions may be added in any order, independent of point key ordering.
+
+### Timestamp Support
+
+When using a timestamp-aware comparator, `Put` and `Delete` overloads accept an explicit timestamp. When `Options::persist_user_defined_timestamps` is false, only the minimum timestamp is accepted, and timestamps are not persisted in the file. During `Finish()`, timestamps are stripped from the key bounds in `ExternalSstFileInfo` when not persisted.
+
+## File Creation Workflow
+
+Step 1 -- **Open**: `SstFileWriter::Open()` creates a writable file and initializes the table builder.
+
+Step 2 -- **Determine compression**: Compression type is selected using this priority:
+  1. `bottommost_compression` if set (not `kDisableCompressionOption`).
+  2. Last entry in `compression_per_level` if non-empty.
+  3. Global `compression` setting.
+
+This logic assumes external SST files will typically be ingested at or near the bottommost level.
+
+Step 3 -- **Create table builder**: The table builder is created via `table_factory->NewTableBuilder()` using the configured options. The builder type depends on the table factory (typically `BlockBasedTableBuilder`).
+
+Step 4 -- **Set up property collectors**: Two types of collectors are registered:
+  - `SstFileWriterPropertiesCollector`: Records the external SST file version and global sequence number.
+  - User-defined collectors from `Options::table_properties_collector_factories`.
+
+Step 5 -- **Add entries**: Each `Put()`, `Merge()`, `Delete()`, or `DeleteRange()` call adds an entry to the table builder with sequence number 0. The writer validates key ordering and tracks smallest/largest keys.
+
+Step 6 -- **Finish**: `Finish()` calls `builder->Finish()` to write the final data block, index, filter, and properties. Then it syncs the file, closes it, and computes the file checksum.
+
+## ExternalSstFileInfo
+
+`ExternalSstFileInfo` (see `include/rocksdb/sst_file_writer.h`) contains metadata about a completed SST file:
+
+| Field | Description |
+|-------|-------------|
+| `file_path` | Path to the SST file |
+| `smallest_key` | Smallest user key |
+| `largest_key` | Largest user key |
+| `smallest_range_del_key` | Smallest range deletion start key |
+| `largest_range_del_key` | Largest range deletion end key |
+| `file_checksum` | File checksum |
+| `file_checksum_func_name` | Name of the checksum function |
+| `sequence_number` | Sequence number (always 0 for external files) |
+| `file_size` | File size in bytes |
+| `num_entries` | Number of point entries |
+| `num_range_del_entries` | Number of range deletion entries |
+| `version` | External SST file format version (currently 2) |
+
+## External SST File Properties
+
+External SST files are identified by special properties stored in the properties block (see `ExternalSstFilePropertyNames` in `table/sst_file_writer_collectors.h`):
+
+| Property | Key | Value |
+|----------|-----|-------|
+| Version | `rocksdb.external_sst_file.version` | Fixed uint32 (currently 2) |
+| Global Seqno | `rocksdb.external_sst_file.global_seqno` | Fixed uint64 (0 at creation, updated during ingestion) |
+
+The static method `SstFileWriter::CreatedBySstFileWriter()` checks whether a `TableProperties` object contains the version property, indicating the file was created by `SstFileWriter`.
+
+### Global Sequence Number
+
+At creation, all keys have sequence number 0 and the global seqno property is set to 0. During ingestion (`DB::IngestExternalFile()`), RocksDB assigns a real sequence number. By default (`IngestExternalFileOptions::write_global_seqno = false`), the assigned sequence number is recorded in DB metadata only; the SST file itself is not modified. When the deprecated `write_global_seqno` option is set to true, the global seqno property is updated in-place within the file (using `external_sst_file_global_seqno_offset` from `TableProperties` to locate the value). In both cases, the table reader applies this global sequence number to all keys when reading.
+
+Note: `IngestExternalFileOptions::allow_db_generated_files` can preserve original sequence numbers entirely, bypassing the global seqno assignment.
+
+## Session Identity
+
+Each `SstFileWriter` instance generates its own `db_session_id` (via `DBImpl::GenerateDbSessionId()`). The `db_id` is set to `"SST Writer"`. Each file opened by the same `SstFileWriter` gets an incrementing `file_number` (starting from 1) to help construct unique cache keys.
+
+## Page Cache Invalidation
+
+When `invalidate_page_cache` is true (the default), the writer calls `WritableFileWriter::InvalidateCache()` approximately every 1 MB of data written (controlled by `kFadviseTrigger = 1024 * 1024`). This advises the OS to drop the file's pages from the page cache, reducing memory pressure during bulk loading. The final `Finish()` call also triggers invalidation.
+
+## Error Handling
+
+- If `Finish()` fails, the SST file is deleted from disk.
+- If the writer is destroyed without calling `Finish()`, `Abandon()` is called on the table builder to clean up resources.
+- Empty files (no entries and no range deletions) are rejected by `Finish()` with `Status::InvalidArgument`.
+
+## Limitations
+
+| Limitation | Details |
+|-----------|---------|
+| Not thread-safe | Each `SstFileWriter` must be used from a single thread. |
+| Keys must be sorted | Point keys must be added in strict ascending order. |
+| Sequence number is 0 | Real sequence numbers are assigned during ingestion. |
+| No WAL | Data is not written to WAL. Crash before ingestion loses the file. |
+| File format depends on table factory | The generated SST file format matches the configured `table_factory`. |
+
+## Interactions With Other Components
+
+- **IngestExternalFile**: `DB::IngestExternalFile()` is the primary consumer. It assigns sequence numbers, picks levels, and atomically adds the file to the LSM tree.
+- **Table Properties**: External SST files include the standard table properties plus the version and global seqno properties specific to external files.
+- **Compression**: Compression settings are derived from the column family options, with bottommost compression taking priority.
+- **Wide Columns**: `PutEntity()` serializes wide columns using `WideColumnSerialization::Serialize()` and stores them as `kTypeWideColumnEntity` entries.

--- a/docs/components/sst_table_format/index.md
+++ b/docs/components/sst_table_format/index.md
@@ -1,0 +1,45 @@
+# RocksDB SST Table Format
+
+## Overview
+
+RocksDB stores persistent data in Sorted String Table (SST) files. The default block-based table format organizes data into fixed-size blocks with prefix-compressed keys, supports bloom/ribbon filters for fast negative lookups, and provides multiple index formats for efficient seeking. Two alternative formats -- PlainTable (mmap-optimized) and CuckooTable (hash-based point lookups) -- serve specialized use cases.
+
+**Key source files:** `table/format.h`, `table/format.cc`, `include/rocksdb/table.h`, `table/block_based/block_based_table_builder.cc`, `table/block_based/block_based_table_reader.cc`, `table/block_based/block_builder.cc`, `table/block_based/block.cc`
+
+## Chapters
+
+| Chapter | File | Summary |
+|---------|------|---------|
+| 1. Overview | [01_overview.md](01_overview.md) | Table types (block-based, plain, cuckoo), format versions 2-7, checksum types, context-aware checksums, and key configuration options. |
+| 2. Block-Based File Layout | [02_block_based_format.md](02_block_based_format.md) | SST file structure, block types, BlockHandle/IndexValue encoding, footer layout, metaindex block, block trailer, and table open workflow. |
+| 3. Data Block Structure | [03_data_blocks.md](03_data_blocks.md) | Entry format with prefix compression, restart points, packed footer, separated KV storage, uniform key detection, and BlockBuilder/Block reader. |
+| 4. Block Reading and Caching | [04_block_fetcher.md](04_block_fetcher.md) | BlockFetcher workflow, buffer management, checksum verification, decompression, block retrieval pipeline, MultiGet batching, and prefetch buffer. |
+| 5. Table Building Pipeline | [05_table_builder.md](05_table_builder.md) | BlockBasedTableBuilder states, Add/EmitBlock/Finish workflows, compression verification, parallel compression integration, and tail size estimation. |
+| 6. Index Block Formats | [06_index_formats.md](06_index_formats.md) | Binary search, hash search, partitioned (two-level), and binary-search-with-first-key index types; key shortening, sequence number stripping, and index reader architecture. |
+| 7. Filter Blocks | [07_filter_blocks.md](07_filter_blocks.md) | Bloom and Ribbon filter policies, FilterBitsBuilder/Reader, full filter block builder and reader, whole-key and prefix filtering. |
+| 8. Partitioned Index and Filter | [08_partitioned_index_filter.md](08_partitioned_index_filter.md) | Two-level index/filter architecture, partition sizing, build and read workflows, CacheDependencies prefetching, and decoupled vs coupled partitioning. |
+| 9. Data Block Hash Index | [09_data_block_hash_index.md](09_data_block_hash_index.md) | In-block hash index for O(1) point lookups, hash table format with 1-byte buckets, collision handling, and integration with DataBlockIter::SeekForGet(). |
+| 10. PlainTable Format | [10_plain_table.md](10_plain_table.md) | Mmap-optimized format with sequential key-value records, hash-based prefix index, total-order mode, and limitations (no compression, no checksums). |
+| 11. CuckooTable Format | [11_cuckoo_table.md](11_cuckoo_table.md) | Cuckoo hashing for O(1) point lookups, cache-friendly block design, BFS collision resolution, and fixed key/value length requirement. |
+| 12. Table Properties | [12_table_properties.md](12_table_properties.md) | Built-in and user-collected properties, TablePropertiesCollector API, property serialization, aggregation, and internal collectors. |
+| 13. SstFileWriter | [13_sst_file_writer.md](13_sst_file_writer.md) | External SST file creation for bulk loading via IngestExternalFile(), key ordering requirements, global sequence number assignment, and page cache invalidation. |
+
+## Key Characteristics
+
+- **Block-based format is default**: Data organized into ~4KB blocks with prefix-compressed keys and 5-byte trailers (compression type + checksum)
+- **Seven format versions**: Version 2 (minimum) through 7 (latest, default), each adding encoding optimizations or integrity features
+- **Multiple checksum algorithms**: CRC32c, xxHash, xxHash64, XXH3 (default); context-aware checksums in format_version >= 6 detect misplaced blocks
+- **Four index types**: Binary search (default), hash search, partitioned two-level, and binary search with first key for deferred data block reads
+- **Bloom and Ribbon filters**: Probabilistic structures for fast negative lookups; partitioned filters for large SST files; Ribbon saves ~30% space vs Bloom
+- **Data block hash index**: Optional 1-byte-per-bucket hash index appended to data blocks for O(1) point lookups (~10% throughput improvement)
+- **Separated KV storage**: Optional layout storing keys and values in separate block sections, reducing per-entry overhead
+- **Parallel compression**: Multi-threaded block compression during flush/compaction via ring buffer architecture
+- **Three table formats**: Block-based (general purpose), PlainTable (mmap/memory), CuckooTable (hash-based point lookups)
+
+## Key Invariants
+
+- Checksum is computed over block payload + compression type byte, verified before decompression (not after)
+- For format_version >= 6, block checksums include a context modifier derived from a per-file random base_context_checksum and the block offset
+- Keys must be added in sorted order within each SST file; the table builder enforces this
+- The footer is always the last 53 bytes of the file, with the magic number at the very end
+- Index separator keys are >= last key in one data block and < first key in the next data block


### PR DESCRIPTION
Add deep-dive documentation for the two largest core engine components.

## compaction/ (15 chapters)
Leveled/universal/FIFO compaction styles, file selection and priority, dynamic level sizing, trivial move, CompactionJob execution, subcompaction parallelism, remote compaction, CompactionIterator, CompactionFilter, SST partitioner, manual compaction, disk space management.

## sst_table_format/ (13 chapters)
Block-based table format (file layout, data blocks, block fetcher, table builder), index formats (binary search, hash, two-level), filter blocks (full filter, partitioned filter, policy), data block hash index, PlainTable, CuckooTable, table properties, SST file writer.

Part 2 of 11 in the RocksDB AI documentation series.