### PR TITLE
docs: add feature documentation — transaction, filter, snapshot

### DIFF
--- a/docs/components/filter/01_types_and_selection.md
+++ b/docs/components/filter/01_types_and_selection.md
@@ -1,0 +1,97 @@
+# Filter Types and Selection
+
+**Files:** `include/rocksdb/filter_policy.h`, `table/block_based/filter_policy.cc`, `table/block_based/filter_policy_internal.h`
+
+## FilterPolicy API
+
+The `FilterPolicy` class in `include/rocksdb/filter_policy.h` is the entry point for filter configuration. It defines three key methods:
+
+- `CompatibilityName()` -- returns a shared family name used to identify whether a filter on disk is readable by this policy. All built-in policies return `"rocksdb.BuiltinBloomFilter"`.
+- `GetBuilderWithContext(FilterBuildingContext&)` -- creates a `FilterBitsBuilder` for constructing filters during SST creation. Returns `nullptr` to indicate "no filter."
+- `GetFilterBitsReader(Slice& contents)` -- creates a `FilterBitsReader` for querying filters during reads.
+
+Users configure filters via `BlockBasedTableOptions::filter_policy`:
+
+```
+table_options.filter_policy.reset(NewBloomFilterPolicy(10.0));   // Bloom
+table_options.filter_policy.reset(NewRibbonFilterPolicy(10.0));  // Ribbon
+```
+
+## Available Filter Implementations
+
+| Implementation | Builder | Reader | Introduced | Notes |
+|---|---|---|---|---|
+| LegacyBloom | `LegacyBloomBitsBuilder` | `LegacyBloomBitsReader` | Original | Used when `format_version < 5`; 32-bit hash only |
+| FastLocalBloom | `FastLocalBloomBitsBuilder` | `FastLocalBloomBitsReader` | format_version 5 | Default for `NewBloomFilterPolicy`; 64-bit hash, AVX2 SIMD |
+| Standard128Ribbon | `Standard128RibbonBitsBuilder` | `Standard128RibbonBitsReader` | 6.15.0 | 30% space savings; fallback to Bloom on failure |
+| ReadOnlyBuiltin | (none -- returns nullptr) | All readers | 7.0 | Backward-compat policy for old OPTIONS files |
+
+## NewBloomFilterPolicy
+
+`NewBloomFilterPolicy(double bits_per_key)` in `include/rocksdb/filter_policy.h` creates a `BloomFilterPolicy` that selects the implementation based on `format_version`:
+
+- `format_version < 5` -- Uses `LegacyBloomBitsBuilder` (32-bit hash, locality-based probing)
+- `format_version >= 5` -- Uses `FastLocalBloomBitsBuilder` (64-bit hash, cache-local SIMD probing)
+
+**Bits-per-key sanitization:**
+- `< 0.5` -- rounds down to 0.0, meaning "generate no filter"
+- `0.5` to `< 1.0` -- rounds up to 1.0 (62% FP rate)
+- `>= 100.0` or NaN -- capped at 100.0
+
+Internally, bits-per-key is stored as `millibits_per_key` (thousandths of a bit) for fractional precision with `format_version >= 5`. Legacy format rounds to whole bits.
+
+## NewRibbonFilterPolicy
+
+`NewRibbonFilterPolicy(double bloom_equivalent_bits_per_key, int bloom_before_level)` creates a `RibbonFilterPolicy` that chooses between Ribbon and FastLocalBloom based on the `FilterBuildingContext`.
+
+### bloom_before_level Logic
+
+The `bloom_before_level` parameter controls the level threshold. The selection logic in `RibbonFilterPolicy::GetBuilderWithContext()` works as follows:
+
+Step 1 -- Determine `levelish` from context:
+- Flush (`TableFileCreationReason::kFlush`) -- `levelish = -1`
+- Known level -- `levelish = context.level_at_creation`
+- Unknown level or FIFO/None compaction style -- `levelish = INT_MAX - 1` (treated as bottommost)
+
+Step 2 -- Compare with threshold:
+- `levelish < bloom_before_level` -- Use FastLocalBloom
+- `levelish >= bloom_before_level` -- Use Ribbon
+
+| bloom_before_level | Behavior |
+|---|---|
+| `-1` | Always Ribbon (except some extreme/exceptional cases) |
+| `0` (default) | Bloom for flushes only; Ribbon for all compaction output |
+| `1` | Bloom for L0 (flush + intra-L0); Ribbon for L1+ |
+| `INT_MAX` | Always Bloom |
+
+This parameter is mutable at runtime via `SetOptions()`:
+`db->SetOptions({{"table_factory.filter_policy.bloom_before_level", "3"}});`
+
+## FilterBuildingContext
+
+`FilterBuildingContext` in `include/rocksdb/filter_policy.h` carries contextual information to `GetBuilderWithContext()`:
+
+| Field | Type | Purpose |
+|---|---|---|
+| `table_options` | `BlockBasedTableOptions&` | Current table options |
+| `compaction_style` | `CompactionStyle` | Level, Universal, FIFO, or None |
+| `num_levels` | `int` | Total LSM levels, or -1 if unknown |
+| `column_family_name` | `string` | CF name for the table |
+| `level_at_creation` | `int` | Target level for this SST, or -1 if unknown |
+| `is_bottommost` | `bool` | Whether this SST is in the bottommost sorted run |
+| `reason` | `TableFileCreationReason` | Flush, compaction, misc, etc. |
+
+Custom `FilterPolicy` implementations can use this context to make per-SST decisions (e.g., different FP rates for different levels).
+
+## Class Hierarchy
+
+The internal class hierarchy in `filter_policy_internal.h`:
+
+- `FilterPolicy` (public API)
+  - `BuiltinFilterPolicy` -- base for all built-in policies; implements `GetFilterBitsReader()` dispatch based on trailer byte
+    - `ReadOnlyBuiltinFilterPolicy` -- backward compatibility; does not build filters
+    - `BloomLikeFilterPolicy` -- shared base for Bloom and Ribbon; stores `millibits_per_key_`, `desired_one_in_fp_rate_`, and `aggregate_rounding_balance_`
+      - `BloomFilterPolicy` -- dispatches to Legacy or FastLocalBloom based on `format_version`
+      - `RibbonFilterPolicy` -- dispatches to Ribbon or FastLocalBloom based on `bloom_before_level`
+
+The reader dispatch is handled by `BuiltinFilterPolicy::GetBuiltinFilterBitsReader()`, which reads the metadata trailer byte to select the appropriate reader class. This means any built-in filter can be read regardless of which policy created it.

--- a/docs/components/filter/02_fast_local_bloom.md
+++ b/docs/components/filter/02_fast_local_bloom.md
@@ -1,0 +1,103 @@
+# FastLocalBloom Implementation
+
+**Files:** `util/bloom_impl.h`, `table/block_based/filter_policy.cc`
+
+## Overview
+
+FastLocalBloom is a cache-local Bloom filter where all probes for a single key land in one 64-byte cache line. This gives near-optimal accuracy for a cache-local design while enabling SIMD-accelerated queries via AVX2. It is the default SST filter implementation for `format_version >= 5`.
+
+## Design Principles
+
+**Cache locality:** Each key maps to a single 64-byte (512-bit) cache line via `FastRange32(h1, num_cache_lines)`. All probes for that key occur within that cache line, meaning a filter query touches exactly one cache line regardless of `num_probes`.
+
+**Two-hash scheme:** A 64-bit hash (from `GetSliceHash64` / XXH3) is split into two 32-bit halves:
+- `h1` (lower 32 bits) -- selects the cache line
+- `h2` (upper 32 bits) -- generates probe positions within the cache line via repeated multiplication by the golden ratio `0x9e3779b9`
+
+**FastRange32:** Uses fast integer multiplication `(uint64_t(h) * uint64_t(range)) >> 32` instead of modulo for mapping h1 to a cache line index. This is faster than `%` on modern CPUs and produces near-uniform distribution.
+
+## Probe Generation
+
+For each probe `i` (0 to `num_probes - 1`), the bit position within the 512-bit cache line is:
+
+```
+h *= 0x9e3779b9;  // golden ratio multiplication
+bitpos = h >> (32 - 9);  // top 9 bits = position 0-511
+```
+
+The top 9 bits are used because they have the best mixing from the multiplication. Each successive multiplication by the golden ratio produces a new quasi-independent probe position.
+
+## AVX2 SIMD Query Path
+
+The AVX2 query path in `FastLocalBloomImpl::HashMayMatchPrepared()` processes up to 8 probes simultaneously:
+
+Step 1 -- Load 8 copies of `h2` into a 256-bit vector.
+Step 2 -- Multiply by precomputed powers of the golden ratio (`0x9e3779b9^0` through `0x9e3779b9^7`) to generate 8 probe hashes simultaneously.
+Step 3 -- Extract 4-bit word addresses (top 4 bits of each 32-bit element) and 5-bit bit-within-word addresses.
+Step 4 -- Use `_mm256_permutevar8x32_epi32` + blend to gather the 8 probed 32-bit words from the cache line.
+Step 5 -- Build a bit mask from the bit addresses and apply a probe-count selector mask.
+Step 6 -- Check all probes with `_mm256_testc_si256`.
+
+For `num_probes > 8`, the process repeats in groups of 8, advancing h by `h *= 0xab25f4c1` (golden ratio to the 8th power).
+
+The non-SIMD fallback path uses a simple loop checking each probe sequentially, which is still fast due to cache locality.
+
+## Num Probes Selection
+
+`FastLocalBloomImpl::ChooseNumProbes()` selects the optimal number of probes based on `millibits_per_key`. The mapping is empirically tuned for the 512-bit cache-local design:
+
+| millibits_per_key range | num_probes |
+|---|---|
+| <= 2080 | 1 |
+| 2081 - 3580 | 2 |
+| 3581 - 5100 | 3 |
+| 5101 - 6640 | 4 |
+| 6641 - 8300 | 5 |
+| 8301 - 10070 | 6 |
+| 10071 - 11720 | 7 |
+| 11721 - 14001 | 8 |
+| 14002 - 16050 | 9 |
+| 16051 - 18300 | 10 |
+| 18301 - 22001 | 11 |
+| 22002 - 25501 | 12 |
+| 25502 - 50000 | (millibits_per_key - 1) / 2000 - 1 (yields 13-23) |
+| > 50000 | 24 (maximum) |
+
+Note: These thresholds differ from standard Bloom filter theory because cache-local filters have different optimal probe counts. For example, at 16 bits/key, the optimal is 9 probes (vs. 11 for standard Bloom).
+
+## FP Rate Characteristics
+
+The FP rate model combines two independent sources of false positives:
+
+1. **Filter FP rate** -- from the cache-local Bloom structure, modeled by `BloomMath::CacheLocalFpRate()` which accounts for variance in per-cache-line key counts (uses +/- 1 standard deviation approximation)
+2. **Fingerprint FP rate** -- from hash collisions in the 64-bit hash space, modeled by `BloomMath::FingerprintFpRate()`
+
+These are combined via `IndependentProbabilitySum(rate1, rate2) = rate1 + rate2 - rate1 * rate2`.
+
+At 10 bits/key with 6 probes and 512-bit blocks: ~0.957% FP rate (vs. 0.9535% theoretical optimum for cache-local Bloom, vs. 0.953% for standard Bloom).
+
+**Important:** The 64-bit hash avoids the accuracy degradation seen with LegacyBloom's 32-bit hash. With a 32-bit hash, the fingerprint FP rate becomes significant at ~40 million keys (at 10 bits/key). FastLocalBloom's 64-bit hash pushes this inflection point far beyond practical filter sizes.
+
+## Filter Size Alignment
+
+Filter payload size is always a multiple of 64 bytes (cache line size). The total encoded filter is `aligned_payload + 5` bytes (5-byte metadata trailer). This alignment is enforced by `FastLocalBloomBitsBuilder::CalculateSpace()` and `RoundDownUsableSpace()`.
+
+**Maximum supported filter size:** `0xffffffc0` bytes (~4 GB minus 64 bytes), limited by 32-bit `FastRange32` for cache line selection. Beyond 2^32 cache lines (256 GB), accuracy degrades abruptly.
+
+## Prefetching Strategy
+
+Both `AddAllEntries()` (construction) and batch `MayMatch()` (query) use software prefetching with a sliding window:
+
+- Construction uses an 8-entry ring buffer: prefetch the cache line for entry `i+8` while processing entry `i`
+- Batch query prefetches all cache lines first (`PrepareHash`), then checks all probes -- separating the prefetch from the check maximizes memory-level parallelism
+
+## LegacyBloom (Deprecated)
+
+`LegacyLocalityBloomImpl` in `util/bloom_impl.h` is the pre-format_version-5 implementation. It uses a 32-bit hash with locality-based block probing. Key differences:
+
+- **32-bit hash only** -- at 10 bits/key, the fingerprint FP rate becomes significant around ~40 million keys. A warning is logged at >= 3 million keys when the estimated FP rate exceeds 1.5x the expected rate
+- **Double-hashing probes** -- h += delta where delta = (h >> 17) | (h << 15), with a 1/512 chance of the increment being zero within the 512-bit cache-line address space, causing all probes to hit the same bit position
+- **No SIMD acceleration**
+- **Odd number of cache lines** -- forces odd `num_lines` to improve hash distribution
+
+LegacyBloom is still used when `NewBloomFilterPolicy` is configured with `format_version < 5`. At high bits/key (>= 14), a warning is logged recommending upgrade to `format_version >= 5`.

--- a/docs/components/filter/03_ribbon_filter.md
+++ b/docs/components/filter/03_ribbon_filter.md
@@ -1,0 +1,100 @@
+# Ribbon Filter Implementation
+
+**Files:** `table/block_based/filter_policy.cc`, `util/ribbon_config.h`, `util/ribbon_impl.h`, `util/ribbon_alg.h`
+
+## Overview
+
+Ribbon (Rapid Incremental Boolean Banding ON-the-fly) is a space-efficient alternative to Bloom filters. It saves ~30% space compared to Bloom at similar FP rates, at the cost of 3-4x CPU during construction and ~3x temporary memory usage. Query speed is comparable to Bloom.
+
+## How Ribbon Works
+
+Ribbon is fundamentally different from Bloom filters. Instead of setting bits in a bit array, it solves a linear system over GF(2) (binary field):
+
+1. Each key is hashed to a 128-bit coefficient row and a result value
+2. The system of equations is solved using Gaussian elimination (banding)
+3. The solution is stored as an interleaved array of coefficient blocks
+
+A query re-hashes the key and checks if the stored solution matches the expected result. If it does, the key "may be present." The FP rate is determined by the number of result bits per slot.
+
+## Construction: Standard128RibbonBitsBuilder
+
+The Ribbon builder in `filter_policy.cc` (`Standard128RibbonBitsBuilder`) uses 128-bit coefficient rows (`Unsigned128`). Construction proceeds:
+
+Step 1 -- Accumulate 64-bit hashes in the `XXPH3FilterBitsBuilder` base class (same hash accumulation as FastLocalBloom).
+
+Step 2 -- Calculate space: `CalculateSpaceAndSlots()` determines `num_slots` from `num_entries` using `BandingConfigHelper` lookup tables. The number of result bits per slot is derived from `desired_one_in_fp_rate_`.
+
+Step 3 -- Attempt banding: `banding.ResetAndFindSeedToSolve()` tries up to 256 different hash seeds (0-255) to find one where the linear system can be solved. Each seed has roughly a 1-in-20 chance of failure (`kOneIn20`).
+
+Step 4 -- Back-substitution: `soln.BackSubstFrom(banding)` computes the interleaved solution from the banding.
+
+Step 5 -- Write metadata trailer: seed (1 byte) + num_blocks (3 bytes, little-endian).
+
+## Bloom Fallback Conditions
+
+`Standard128RibbonBitsBuilder` contains an embedded `FastLocalBloomBitsBuilder bloom_fallback_` and falls back to Bloom in three cases:
+
+1. **Too many keys** -- More than `kMaxRibbonEntries` (950 million). The Ribbon implementation uses 32-bit slot indices.
+2. **Small filter** -- Fewer than 1024 slots, where Bloom is more space-efficient than Ribbon.
+3. **Construction failure** -- All 256 seed attempts fail to solve the linear system (~extremely rare, probability roughly (1/20)^256).
+4. **Cache reservation failure** -- If the block cache cannot accommodate the temporary banding memory (`status_banding_cache_res.IsMemoryLimit()`).
+
+Fallback is transparent: the entries are swapped to `bloom_fallback_` via `SwapEntriesWith()`, and the resulting filter is a valid FastLocalBloom. Readers handle it automatically via the metadata trailer byte discriminator.
+
+## Space Efficiency
+
+Ribbon achieves ~30% space savings by using near-information-theoretic-minimum bits per key:
+
+| Target FP Rate | Bloom bits/key | Ribbon bits/key | Savings |
+|---|---|---|---|
+| 1% | 10 | ~7 | 30% |
+| 0.1% | 14.3 | ~10 | 30% |
+
+The space saving comes from Ribbon's ability to use fractional result bits. The actual bits per slot varies: `GetBytesForOneInFpRate()` computes the exact byte count needed for a given number of slots and target FP rate, mixing `b` and `b+1` result bits per slot.
+
+## Query: Standard128RibbonBitsReader
+
+The reader stores a `SerializableInterleavedSolution` and a `StandardHasher`. Query proceeds:
+
+Step 1 -- Hash the key to a 64-bit value with `GetSliceHash64()`.
+Step 2 -- Apply the stored seed to produce a seeded hash.
+Step 3 -- Compute the coefficient row and expected result.
+Step 4 -- Check against the stored solution.
+
+**Batch query optimization:** `MayMatch(num_keys, ...)` separates the prepare phase (computing segment_num, num_columns, start_bits) from the query phase, similar to FastLocalBloom's prefetching strategy. This is implemented via `ribbon::InterleavedPrepareQuery()` and `ribbon::InterleavedFilterQuery()`.
+
+## Configuration
+
+Ribbon is configured indirectly through `bloom_equivalent_bits_per_key`:
+
+```
+// 10.0 bloom-equivalent bits/key -> ~1% FP rate, ~7 actual bits/key
+auto policy = NewRibbonFilterPolicy(10.0, /*bloom_before_level=*/1);
+```
+
+The `desired_one_in_fp_rate_` is computed from the Bloom FP rate at the specified bits/key:
+`desired_one_in_fp_rate_ = 1.0 / CacheLocalFpRate(bits_per_key, num_probes, 512)`
+
+This means specifying the same `bits_per_key` for Bloom and Ribbon gives the same FP rate, but Ribbon uses fewer actual bits.
+
+## Interleaved Solution Format
+
+The on-disk format uses interleaved solution blocks. Each block contains 128 slots (matching the 128-bit coefficient row width). The number of blocks is stored in the 3-byte metadata trailer field.
+
+**Alignment:** Solution data is rounded down to multiples of 16 bytes (segment size) by `RoundDownUsableSpace()`.
+
+**Maximum entries:** ~950 million (`kMaxRibbonEntries`), limited by 32-bit `num_slots` and 24-bit `num_blocks` in the metadata trailer.
+
+## When to Use Ribbon
+
+**Cost model:** The break-even point for Ribbon vs. Bloom is roughly when a filter lives in memory for ~1 hour. Filters living longer than that save more in memory cost than they spend in extra construction CPU. Since L0 data typically lives minutes and deeper levels live days to weeks, the hybrid strategy is almost always profitable. A DB would need to sustain 20+ DWPD for data to have an average lifetime short enough to make Ribbon unprofitable.
+
+**Recommended for:**
+- Lower LSM levels (L1+) where files are larger and longer-lived, amortizing the construction cost
+- Space-constrained deployments where 30% filter space savings matter
+- Using the hybrid strategy: `NewRibbonFilterPolicy(10.0, 1)` for Bloom in L0, Ribbon in L1+
+
+**Not recommended for:**
+- Flush-heavy workloads where construction CPU is the bottleneck
+- Very small SST files where Ribbon falls back to Bloom anyway (< 1024 slots)
+- Environments where RocksDB < 6.15.0 might read the data (Ribbon is not forward-compatible)

--- a/docs/components/filter/04_full_filter_blocks.md
+++ b/docs/components/filter/04_full_filter_blocks.md
@@ -1,0 +1,68 @@
+# Full Filter Blocks
+
+**Files:** `table/block_based/full_filter_block.h`, `table/block_based/full_filter_block.cc`, `table/block_based/filter_policy_internal.h`
+
+## Overview
+
+A full filter is a single filter block covering all keys in an SST file. It is the default filter structure (as opposed to partitioned filters). One filter lookup per query, one cache entry per filter.
+
+## Construction: FullFilterBlockBuilder
+
+`FullFilterBlockBuilder` wraps a `FilterBitsBuilder` and handles key/prefix addition during SST file creation.
+
+### Key Addition Workflow
+
+When `Add(key)` is called during table building:
+
+Step 1 -- Check if prefix extraction applies: if `prefix_extractor_` is set and the key is in-domain, extract the prefix.
+
+Step 2 -- Choose addition strategy:
+- If `whole_key_filtering_ == true` and prefix is available: call `filter_bits_builder_->AddKeyAndAlt(key, prefix)` to add both, with automatic deduplication
+- If `whole_key_filtering_ == false` and prefix is available: call `filter_bits_builder_->AddKey(prefix)` for prefix-only filtering
+- If `whole_key_filtering_ == true` and no prefix: call `filter_bits_builder_->AddKey(key)` for whole-key-only filtering
+
+Step 3 -- After all keys are added, Finish() calls filter_bits_builder_->Finish(buf, &status) to generate the filter bits. Post-verification (if detect_filter_construct_corruption is enabled) happens later in the table builder's WriteMaybeCompressedBlock(), not inside Finish().
+
+### AddWithPrevKey
+
+AddWithPrevKey(key, prev_key) in FullFilterBlockBuilder ignores the previous key and simply delegates to Add(). The prev_key parameter is unused in the full filter path. In contrast, PartitionedFilterBlockBuilder::AddWithPrevKey uses the previous key to make partition-cutting decisions.
+
+### Size Estimation
+
+CurrentFilterSizeEstimate() returns the estimated filter size based on filter_bits_builder_->CalculateSpace(EstimateEntriesAdded()). This is used by the table builder to estimate SST file size.
+
+UpdateFilterSizeEstimate() caches this value as a plain size_t. Note: The partitioned filter builder uses RelaxedAtomic for its equivalent field because it can be called from background worker threads during parallel compression. The full filter builder does not require this atomicity.
+
+## Reading: FullFilterBlockReader
+
+`FullFilterBlockReader` wraps a cached `ParsedFullFilterBlock` which contains the `FilterBitsReader` instance.
+
+### Single-Key Query
+
+`KeyMayMatch(key, ...)` and `PrefixMayMatch(prefix, ...)` follow the same pattern:
+
+Step 1 -- Load the filter block from cache via `GetOrReadFilterBlock()`.
+Step 2 -- Extract the `FilterBitsReader` from the cached `ParsedFullFilterBlock`.
+Step 3 -- Call `filter_bits_reader->MayMatch(entry)`.
+Step 4 -- Update performance counters: `bloom_sst_hit_count` (maybe present) or `bloom_sst_miss_count` (definitely absent).
+
+### MultiGet Batch Query
+
+`KeysMayMatch(MultiGetRange*, ...)` and `PrefixesMayMatch(MultiGetRange*, ...)` optimize for batch operations:
+
+Step 1 -- Single cache lookup for the filter block (amortized across all keys in the batch).
+Step 2 -- Extract keys into a contiguous array.
+Step 3 -- Call `filter_bits_reader->MayMatch(num_keys, keys, may_match)` for batch query. This leverages the prefetch-then-check pattern in both FastLocalBloom and Ribbon readers.
+Step 4 -- Skip keys that definitely don't match via `range->SkipKey(iter)`.
+
+This batch approach amortizes the cache lookup cost and enables better memory-level parallelism during probe checking.
+
+## Filter Block Creation
+
+`FullFilterBlockReader::Create()` is called during table open to initialize the filter reader:
+
+Step 1 -- If prefetch or !use_cache, eagerly read the filter block. When !use_cache, the filter is loaded into a reader-owned CachableEntry outside the block cache. When use_cache is true, the filter is inserted into the block cache.
+Step 2 -- If use_cache && !pin, release the cache handle (block remains in cache but can be evicted).
+Step 3 -- If pin, keep the CachableEntry alive in the FullFilterBlockReader, preventing eviction for the table's lifetime.
+
+The `pin` flag is determined by `MetadataCacheOptions` or the deprecated `pin_l0_filter_and_index_blocks_in_cache` and `pin_top_level_index_and_filter` booleans.

--- a/docs/components/filter/05_partitioned_filter_blocks.md
+++ b/docs/components/filter/05_partitioned_filter_blocks.md
@@ -1,0 +1,126 @@
+# Partitioned Filter Blocks
+
+**Files:** `table/block_based/partitioned_filter_block.h`, `table/block_based/partitioned_filter_block.cc`
+
+## Overview
+
+Partitioned filters split a single large filter into multiple smaller partitions, each cached independently. This provides granular caching (only load the partition needed for the query) and memory efficiency (partial pinning, LRU eviction of individual partitions).
+
+## Configuration
+
+Partitioned filters require:
+```
+table_options.partition_filters = true;
+table_options.index_type = BlockBasedTableOptions::kTwoLevelIndexSearch;  // Required
+table_options.metadata_block_size = 4096;  // Target partition size
+```
+
+Note: partition_filters is silently sanitized to false if index_type is not kTwoLevelIndexSearch (e.g., kHashSearch). See BlockBasedTableFactory::InitializeOptions().
+
+## SST File Layout
+
+```
+Data Block 1 ... Data Block N
+Filter Partition 1 (kFilter block type)
+Filter Partition 2 (kFilter block type)
+...
+Filter Partition K (kFilter block type)
+Top-level Filter Index (maps key ranges to partition handles)
+Metaindex Block -> "partitionedfilter.rocksdb.BuiltinBloomFilter" -> top-level index handle
+Index Block
+Footer
+```
+
+Individual filter partitions are regular blocks (not separately named in the metaindex). Only the top-level index is referenced from the metaindex.
+
+## Construction: PartitionedFilterBlockBuilder
+
+`PartitionedFilterBlockBuilder` extends `FullFilterBlockBuilder` and manages partition cutting and cross-boundary prefix insertion.
+
+### Partition Cutting Decision
+
+`DecideCutAFilterBlock()` determines when to start a new partition:
+
+**Decoupled mode** (`decouple_from_index_partitions_ == true`, default): Cut based on `keys_per_partition_`, computed from `metadata_block_size` and bits-per-key. The filter partition size targets `metadata_block_size` independently from the index partition builder.
+
+**Coupled mode** (`decouple_from_index_partitions_ == false`, deprecated): Coordinate with `PartitionedIndexBuilder`. When the filter has enough keys, it requests the index builder to cut a partition via `RequestPartitionCut()`, and waits for `ShouldCutFilterBlock()` to approve.
+
+### Cross-Boundary Prefix Insertion
+
+**Key Invariant:** Each partition must include prefixes from adjacent partitions to ensure Seek/SeekForPrev correctness across boundaries.
+
+When cutting a partition in `CutAFilterBlock()`:
+
+Step 1 -- If the next key has a different prefix, add the next prefix to the *current* partition being finished. This ensures that a `Seek(prefix)` landing in this partition finds the prefix even if the first matching key is in the next partition.
+
+Step 2 -- After finishing the current partition and starting the next one, add the *previous* prefix to the new partition. This ensures `SeekForPrev` correctness.
+
+### Partition Storage
+
+Each completed partition is stored as a `FilterEntry`:
+- `ikey` -- the internal key separator after this partition (used for the top-level index)
+- `filter_owner` -- the filter data buffer
+- `filter` -- a `Slice` pointing into the buffer
+
+### Finish Workflow
+
+`PartitionedFilterBlockBuilder::Finish()` is called multiple times by the table builder -- once for each partition and once for the top-level index:
+
+Step 1 (repeated) -- Return the front partition filter from `filters_`. The table builder writes it as a block, getting back a `BlockHandle`.
+
+Step 2 -- On the next call, add the previous partition's handle to the top-level index via `index_on_filter_block_builder_`.
+
+Step 3 (final) -- When `filters_` is empty, return the serialized top-level index block.
+
+### Error Handling
+
+If any filter partition has a construction error (e.g., filter corruption detected), partitioned_filters_construction_status_ is set to the first non-OK status via UpdateIfOk(). Subsequent partitions are still built and enqueued, but Finish() returns the latched error status, causing WriteFilterBlock() to stop the table build. The build does not continue emitting always-true filters for subsequent partitions.
+
+## Reading: PartitionedFilterBlockReader
+
+### Single-Key Query
+
+`PartitionedFilterBlockReader::MayMatch()` adds an index lookup step:
+
+Step 1 -- Load the top-level filter index from cache.
+Step 2 -- Binary search the index to find the `BlockHandle` for the partition containing the key.
+Step 3 -- Load the filter partition from cache.
+Step 4 -- Delegate to `FullFilterBlockReader` for the actual filter query within the partition.
+
+### MultiGet Batch Query
+
+The batch path groups keys by partition to minimize cache lookups:
+
+Step 1 -- Load the top-level index.
+Step 2 -- Iterate over the index entries. For each partition, collect all keys in the `MultiGetRange` that fall within that partition's key range.
+Step 3 -- For each partition with matching keys, call `MayMatchPartition()` which loads the partition and batch-queries it using `FullFilterBlockReader::KeysMayMatch2()` or `PrefixesMayMatch()`.
+
+This avoids loading partitions that have no keys in the batch.
+
+## Partition Caching
+
+### CacheDependencies (Prefetching)
+
+`CacheDependencies()` is called during table open to optionally prefetch and pin all filter partitions:
+
+Step 1 -- Load the top-level index.
+Step 2 -- Determine the byte range covering all partitions (from first to last partition handle).
+Step 3 -- Issue a single `Prefetch()` call for the entire range.
+Step 4 -- Iterate through index entries, loading each partition into the block cache.
+Step 5 -- If `pin == true`, store the `CachableEntry` in `filter_map_` (keyed by block offset) to prevent eviction.
+
+### EraseFromCacheBeforeDestruction
+
+When a table is closed with `uncache_aggressiveness > 0`, `EraseFromCacheBeforeDestruction()` aggressively erases (not just unpins) cached partition entries. This is done by loading the top-level index and erasing each partition's cache entry.
+
+The pinned entries in `filter_map_` are released normally via `CachableEntry` destructor when the reader is destroyed.
+
+## Decoupled vs Coupled Partitioning
+
+| Aspect | Decoupled (default) | Coupled (deprecated) |
+|---|---|---|
+| Option | `decouple_partitioned_filters = true` | `decouple_partitioned_filters = false` |
+| Partition cutting | Independent, based on `keys_per_partition_` | Coordinated with index builder |
+| Target size accuracy | Each type hits its target size independently | Compromise between filter and index sizes |
+| Parallel compression | Compatible | Not compatible (sanitized to `parallel_threads = 1`) |
+| Status | Current default | Deprecated |

--- a/docs/components/filter/06_construction_pipeline.md
+++ b/docs/components/filter/06_construction_pipeline.md
@@ -1,0 +1,79 @@
+# Filter Construction Pipeline
+
+**Files:** `table/block_based/filter_policy.cc`, `table/block_based/filter_policy_internal.h`
+
+## Overview
+
+Filter construction accumulates key hashes during SST file creation and generates filter bits in a single `Finish()` call. The pipeline is shared between FastLocalBloom and Ribbon via the `XXPH3FilterBitsBuilder` base class.
+
+## Hash Accumulation
+
+### XXPH3FilterBitsBuilder
+
+All modern filter builders (FastLocalBloom and Ribbon) extend `XXPH3FilterBitsBuilder`, which uses XXH3 (via `GetSliceHash64()`) to hash keys to 64-bit values.
+
+**Hash storage:** Hashes are stored in a `std::deque<uint64_t>` (not `std::vector`) to avoid unnecessary copying during growth and minimize peak memory usage.
+
+**Thread-safe entry counting:** `entries_count` is a `RelaxedAtomic<size_t>` separate from `entries.size()`, allowing `EstimateEntriesAdded()` to be called safely from background threads during parallel compression.
+
+### Deduplication
+
+**AddKey(key):** Hashes the key and appends to the deque only if different from the last entry. Since keys arrive in sorted order, adjacent duplicates are the only duplicates that need elimination.
+
+**AddKeyAndAlt(key, alt):** Handles the common case of adding both a whole key and its prefix. Performs five-way deduplication across successive calls (matching the code comment's k/a notation where k=key, a=alt):
+- key_hash vs prev_key_hash (k3<>k2: adjacent key dedup)
+- alt_hash vs prev_alt_hash (a3<>a2: adjacent prefix dedup)
+- key_hash vs prev_alt_hash (k3<>a2: key matches previous prefix)
+- alt_hash vs prev_key_hash (a3<>k2: prefix matches previous key)
+- alt_hash vs key_hash (a2<>k2: key equals its own prefix)
+
+The alt is added first so that entries.back() always contains the most recent key hash for the primary dedup path. Note: AddKey() after AddKeyAndAlt() only deduplicates against the previous key hash, not the previous alt hash.
+
+## optimize_filters_for_memory
+
+When `BlockBasedTableOptions::optimize_filters_for_memory` is `true` (default), the filter builder adjusts filter sizes to minimize memory fragmentation using `malloc_usable_size`.
+
+### How It Works
+
+`AllocateMaybeRounding()` in `XXPH3FilterBitsBuilder`:
+
+Step 1 -- Compute the target filter size normally.
+Step 2 -- Check `aggregate_rounding_balance_` (a per-policy atomic counter tracking cumulative FP rate deviation).
+Step 3 -- If the balance is negative (previous filters were rounded down, contributing less FP rate than target), try smaller filter sizes (3/4, 13/16, 7/8, 15/16 of target) to find one that restores balance.
+Step 4 -- Allocate with the chosen size, then call `malloc_usable_size()` to discover the actual allocation size.
+Step 5 -- If the usable size exceeds the requested size (up to 4/3 ratio), expand the filter to use the extra space via `RoundDownUsableSpace()`.
+Step 6 -- Update `aggregate_rounding_balance_` with the FP rate difference.
+
+This approach saves ~10% memory on average by aligning filter sizes with allocator bucket boundaries, at the cost of ~1-2% more disk usage.
+
+**Requirement:** `format_version >= 5` (only FastLocalBloom and Ribbon support it). Only effective when `ROCKSDB_MALLOC_USABLE_SIZE` is defined (Linux with glibc).
+
+## Cache Reservation During Construction
+
+Filter construction memory can be charged to the block cache to prevent OOM during bulk loading:
+
+**Hash entry charging:** Every `kUint64tHashEntryCacheResBucketSize` hashes, a cache reservation is made via `CacheReservationManager`. The bucket size matches the dummy entry size for `CacheEntryRole::kFilterConstruction`.
+
+**Banding memory charging (Ribbon only):** Before allocating the banding structure, its estimated memory usage is charged. If this fails with `IsMemoryLimit()`, Ribbon falls back to Bloom.
+
+**Final filter charging:** After `AllocateMaybeRounding()`, the final filter buffer is charged to the cache.
+
+Cache charging is enabled when `BlockBasedTableOptions::block_cache` is set and `cache_usage_options.options_overrides[kFilterConstruction].charged == kEnabled`.
+
+## Corruption Detection
+
+When `BlockBasedTableOptions::detect_filter_construct_corruption` is `true` (default `false`):
+
+**During construction:** An XOR checksum of all added hashes is maintained in hash_entries_info_.xor_checksum. After populating the filter bits, MaybeVerifyHashEntriesChecksum() recomputes the checksum and compares. On mismatch, returns Status::Corruption.
+
+**Post-construction verification:** MaybePostVerify() creates a BuiltinFilterBitsReader from the completed filter and re-queries every stored hash. If any hash fails to match (false negative), returns Status::Corruption. For full filters, post-verification is invoked from the table builder's WriteMaybeCompressedBlock(), not from Finish(). For partitioned filters, post-verification is performed inside CutAFilterBlock() at partition-cut time.
+
+**Build failure on corruption:** When corruption is detected, the table build fails. WriteFilterBlock() checks the status from Finish() and stops on Status::Corruption. Post-verification failures in WriteMaybeCompressedBlock() also fail the table build. The result is that flush/compaction returns an error rather than silently installing a degraded filter.
+
+**Cost:** ~30% increase in construction time due to the verification pass. The hash entries are kept in memory until post-verification completes, doubling peak memory for the hash list.
+
+## Legacy Filter Construction
+
+`LegacyBloomBitsBuilder` uses 32-bit hashes (`BloomHash()` instead of `GetSliceHash64()`) and stores them in a `std::vector<uint32_t>`. It does not support `optimize_filters_for_memory` or cache reservation.
+
+The legacy builder also warns about excessive keys: if `num_entries >= 3 million` and the estimated FP rate exceeds 1.5x what the same bits/key would give at 65536 keys, it logs a warning suggesting upgrade to `format_version >= 5`.

--- a/docs/components/filter/07_storage_format.md
+++ b/docs/components/filter/07_storage_format.md
@@ -1,0 +1,104 @@
+# Filter Storage Format
+
+**Files:** `table/block_based/filter_policy.cc`, `table/block_based/block_based_table_builder.cc`, `table/block_based/block_based_table_reader.cc`
+
+## SST File Metaindex Entries
+
+Filters are stored as meta-blocks in the block-based table format. The metaindex block maps a string key to the filter's `BlockHandle`. The key prefix depends on the filter structure:
+
+| Filter Type | Metaindex Key | Points To |
+|---|---|---|
+| Full filter | `"fullfilter.<CompatibilityName()>"` | The single filter block |
+| Partitioned filter | `"partitionedfilter.<CompatibilityName()>"` | The top-level partition index block |
+| Obsolete block-based filter | `"filter.<CompatibilityName()>"` | Legacy per-block filter |
+
+For all built-in policies, `CompatibilityName()` is `"rocksdb.BuiltinBloomFilter"`, so the keys are:
+- `"fullfilter.rocksdb.BuiltinBloomFilter"`
+- `"partitionedfilter.rocksdb.BuiltinBloomFilter"`
+
+During table open, the reader tries these prefixes in order: fullfilter. first, then partitionedfilter., then the obsolete filter. for backward compatibility. It breaks on the first successful match.
+
+## Metadata Trailer Format
+
+Every built-in filter block has a 5-byte metadata trailer appended after the filter payload (separate from the standard block trailer with compression type and checksum).
+
+```
+[filter payload: N bytes][metadata: 5 bytes]
+
+Byte layout of metadata:
+  Byte 0: discriminator / num_probes
+  Bytes 1-4: type-specific metadata
+```
+
+### Discriminator Byte (Byte 0)
+
+The first metadata byte acts as a version discriminator:
+
+| Value | Meaning | Reader Used |
+|---|---|---|
+| 1-127 (positive) | Legacy Bloom `num_probes` | `LegacyBloomBitsReader` |
+| 0 | Zero probes (always FP) | `AlwaysTrueFilter` |
+| -1 (0xFF) | Newer Bloom implementations | `FastLocalBloomBitsReader` |
+| -2 (0xFE) | Ribbon implementations | `Standard128RibbonBitsReader` |
+| Other negative | Reserved (future use) | `AlwaysTrueFilter` (safe default) |
+
+This design ensures forward compatibility: unknown negative values degrade to always-true (no filtering, but correct results), giving users degraded performance until compaction rebuilds filters with a known type.
+
+### Legacy Bloom Trailer (byte 0 positive)
+
+```
+Byte 0: num_probes (1-127)
+Bytes 1-4: num_lines (uint32 little-endian) - number of cache lines
+```
+
+The filter payload size is `num_lines * CACHE_LINE_SIZE`. The reader determines `log2_cache_line_size` by checking if `num_lines * CACHE_LINE_SIZE == payload_len`. If not (filter from a platform with different cache line size), it finds the power-of-two block size that satisfies `num_lines * block_size == payload_len`.
+
+### FastLocalBloom Trailer (byte 0 = -1)
+
+```
+Byte 0: -1 (0xFF) - marker for newer Bloom
+Byte 1: sub-implementation (0 = FastLocalBloom, others reserved)
+Byte 2: block_and_probes
+  - Top 3 bits: log2(block_bytes) - 6 (0 = 64-byte blocks, 1 = 128-byte, etc.)
+  - Bottom 5 bits: num_probes (1-30; 0 and 31 reserved)
+Bytes 3-4: reserved (currently 0)
+```
+
+For the current implementation, byte 2's top 3 bits are always 0 (64-byte cache lines), and the bottom 5 bits contain `num_probes`.
+
+### Ribbon Trailer (byte 0 = -2)
+
+```
+Byte 0: -2 (0xFE) - marker for Ribbon
+Byte 1: seed (uint8, 0-255) - hash seed used during construction
+Bytes 2-4: num_blocks (24-bit little-endian) - number of 128-slot interleaved blocks
+```
+
+`num_blocks` must be >= 2. Values 0 and 1 are reserved/unsupported and cause the reader to fall back to `AlwaysTrueFilter`.
+
+## Reader Dispatch
+
+`BuiltinFilterPolicy::GetBuiltinFilterBitsReader()` reads the discriminator byte and dispatches:
+
+Step 1 -- Check total size. If `<= 5` bytes (metadata only), return `AlwaysFalseFilter` (empty filter).
+Step 2 -- Read byte 0 as `int8_t`.
+Step 3 -- If positive (1-127): decode Legacy Bloom metadata and return `LegacyBloomBitsReader`.
+Step 4 -- If negative: switch on value to select `GetBloomBitsReader()` (-1), `GetRibbonBitsReader()` (-2), or `AlwaysTrueFilter` (other).
+Step 5 -- If zero: return `AlwaysTrueFilter`.
+
+### Always-True and Always-False Filters
+
+- `AlwaysTrueFilter`: `MayMatch()` returns `true` for everything. Used for invalid/unknown filter formats and zero-probes case.
+- `AlwaysFalseFilter`: `MayMatch()` returns `false` for everything. Used for empty filters (no keys added). Represented by `Slice(nullptr, 0)`.
+
+A special 6-byte encoding (`"\0\0\0\0\0\0"`) is used for always-true filters. The zero discriminator byte triggers `AlwaysTrueFilter` in the reader.
+
+## Cross-Version Compatibility
+
+All built-in filter policies share `CompatibilityName() == "rocksdb.BuiltinBloomFilter"`. This means:
+
+- A `BloomFilterPolicy` can read Ribbon filters
+- A `RibbonFilterPolicy` can read Bloom filters
+- The actual reader selection happens via the trailer byte, not the policy configuration
+
+However, Ribbon filters are only readable by RocksDB >= 6.15.0. Older versions treat the unknown `-2` discriminator as `AlwaysTrueFilter`, resulting in degraded performance (no filtering) but correct results. Compaction on the newer version will rebuild filters.

--- a/docs/components/filter/08_memtable_bloom.md
+++ b/docs/components/filter/08_memtable_bloom.md
@@ -1,0 +1,96 @@
+# Memtable Bloom Filter (DynamicBloom)
+
+**Files:** util/dynamic_bloom.h, util/dynamic_bloom.cc, db/memtable.cc, include/rocksdb/advanced_options.h
+
+## Overview
+
+`DynamicBloom` is an in-memory-only Bloom filter used optionally in memtables to reduce unnecessary lookups. Unlike SST filters, it is never serialized to disk, supports concurrent writes via relaxed atomics, and uses a compact double-probe design optimized for speed over accuracy.
+
+## Configuration
+
+```
+Options options;
+options.memtable_prefix_bloom_size_ratio = 0.1;  // 10% of memtable size (default 0.0 = disabled)
+options.memtable_whole_key_filtering = true;      // Also add whole keys (default false)
+options.prefix_extractor.reset(NewFixedPrefixTransform(8));  // Required for prefix filtering
+```
+
+The bloom filter is allocated when a new memtable is created, sized as `memtable_prefix_bloom_size_ratio * write_buffer_size * 8` total bits.
+
+**Activation requirements:** At least one of the following must be true, in addition to memtable_prefix_bloom_size_ratio > 0:
+- prefix_extractor is set (enables prefix bloom)
+- memtable_whole_key_filtering is true (enables whole-key bloom)
+
+If neither is set, no DynamicBloom is allocated regardless of the size ratio setting.
+
+**Sanitization:** The ratio is sanitized to [0, 0.25] in SanitizeCfOptions(). Values above 0.25 are clamped, and negative values are zeroed.
+
+## Double-Probe Design
+
+`DynamicBloom` uses a unique double-probe optimization: two bit probes per 64-bit memory access. This trades ~10% FP rate increase for ~10% faster operations.
+
+### Hash Expansion
+
+A 32-bit hash (from `BloomHash()`) is expanded to 64 bits via multiplication by the 64-bit golden ratio:
+`h = 0x9e3779b97f4a7c13ULL * h32`
+
+### Probing
+
+For each of `kNumDoubleProbes` iterations (where `kNumDoubleProbes = num_probes / 2`):
+- Extract two 6-bit positions from the 64-bit hash: `h & 63` and `(h >> 6) & 63`
+- Build a 64-bit mask with exactly two bits set
+- Check (or set) both bits via a single 64-bit load/store
+
+Between iterations, the hash is remixed: `h = (h >> 12) | (h << 52)` (rotation by 12 bits).
+
+**Constraint:** `num_probes` must be even and <= 10. The default is 6 (3 double-probes).
+
+### Memory Layout
+
+The filter data is an array of `RelaxedAtomic<uint64_t>` words. The starting word for a key is determined by `FastRange32(h32, kLen)`, where `kLen` is the total number of 64-bit words. Subsequent probes use XOR offsetting: word index `start ^ i` for the i-th double-probe.
+
+This XOR-based offsetting provides effective cache locality (all probes within a small neighborhood) without explicitly targeting cache lines.
+
+## Concurrency
+
+### Concurrent Add
+
+`AddHashConcurrently()` uses `FetchOrRelaxed()` (atomic OR with relaxed memory ordering):
+
+```
+if ((mask & ptr->LoadRelaxed()) != mask) {
+    ptr->FetchOrRelaxed(mask);
+}
+```
+
+The check-before-CAS optimization avoids expensive atomic RMW operations when the bits are already set (common for hot keys/prefixes).
+
+### Memory Ordering
+
+Relaxed memory ordering is sufficient because the happens-before relationship between `Add` and `MayContain` is established externally through the memtable's sequence number visibility mechanism (access to `versions_->LastSequence()`). The atomic operations only need to prevent data races (undefined behavior), not establish ordering.
+
+### Query Thread Safety
+
+`MayContain()` and `MayContainHash()` use `LoadRelaxed()` and are safe to call concurrently with `Add`/`AddConcurrently`.
+
+## Batch Query (MultiGet)
+
+`MayContain(num_keys, keys, may_match)` optimizes MultiGet by separating hash computation and prefetching from probe checking:
+
+Step 1 -- For each key: compute hash, compute starting word offset via `FastRange32`, issue `PREFETCH` for the starting word.
+Step 2 -- For each key: call `DoubleProbe()` with the pre-computed hash and offset.
+
+This separation maximizes memory-level parallelism by overlapping prefetch latencies across keys.
+
+## Huge Page TLB Support
+
+`DynamicBloom` supports allocation on huge pages via the `huge_page_tlb_size` constructor parameter. When set to a non-zero value (e.g., 2MB for x86 huge pages), the allocator attempts to use huge page TLB for the bloom filter memory. This reduces TLB misses for large bloom filters.
+
+Huge pages must be pre-reserved on Linux:
+`sysctl -w vm.nr_hugepages=20`
+
+## FP Rate Characteristics
+
+The FP rate penalty for DynamicBloom vs. standard Bloom is roughly 1.12x, on top of the 1.15x penalty for a 512-bit cache-local Bloom. This gives approximately 1.29x total FP rate increase compared to an ideal Bloom filter.
+
+For 1% target FP rate, this means the actual FP rate is roughly 1.3%. The design assumes that the latency of a lookup triggered by a false positive should be less than ~100x the cost of a bloom filter operation for the tradeoff to be worthwhile.

--- a/docs/components/filter/09_prefix_filtering.md
+++ b/docs/components/filter/09_prefix_filtering.md
@@ -1,0 +1,101 @@
+# Prefix Filtering
+
+**Files:** table/block_based/full_filter_block.cc, table/block_based/block_based_table_reader.cc, table/block_based/filter_block_reader_common.cc, include/rocksdb/slice_transform.h
+
+## Overview
+
+Prefix filtering uses a `SliceTransform` to extract key prefixes and add them to the filter alongside (or instead of) whole keys. This enables filtering for range queries (`Seek`, `SeekForPrev`) that target a specific prefix, in addition to point queries (`Get`).
+
+## Configuration
+
+```
+Options options;
+options.prefix_extractor.reset(NewFixedPrefixTransform(8));  // Extract first 8 bytes
+
+BlockBasedTableOptions table_options;
+table_options.filter_policy.reset(NewBloomFilterPolicy(10.0));
+table_options.whole_key_filtering = true;   // Add both whole keys and prefixes (default)
+// table_options.whole_key_filtering = false;  // Add prefixes only
+```
+
+## What Gets Added to the Filter
+
+The addition logic in `FullFilterBlockBuilder::Add()`:
+
+| `whole_key_filtering` | `prefix_extractor` set | Key in domain | What's added |
+|---|---|---|---|
+| true | yes | yes | Both key and prefix via `AddKeyAndAlt(key, prefix)` |
+| true | yes | no | Key only via `AddKey(key)` |
+| true | no | N/A | Key only via `AddKey(key)` |
+| false | yes | yes | Prefix only via `AddKey(prefix)` |
+| false | yes | no | Nothing (key is not in the extractor's domain) |
+| false | no | N/A | Nothing added |
+
+## Query Path Dispatch
+
+### Point Query (Get)
+
+When `Get(key)` is called, the filter check in `FullFilterKeyMayMatch()` uses an if-else chain -- only one type of check is performed:
+
+Step 1 -- If `whole_key_filtering == true`: call `KeyMayMatch(key)`. This checks the whole key hash against the filter. **Prefix is NOT checked**, even if both whole keys and prefixes were added during construction.
+
+Step 2 -- Else if `whole_key_filtering == false` and `prefix_extractor` is compatible and key is in-domain: call `PrefixMayMatch(prefix)`. This checks the prefix hash.
+
+Step 3 -- If neither applies: no filter check, proceed to read the SST data blocks.
+
+Note: When `whole_key_filtering == true` and `prefix_extractor` is set, both whole keys and prefixes are added to the filter during construction (via `AddKeyAndAlt`), but during point queries, only the whole-key check is performed. The prefix entries are still useful for `Seek`/`SeekForPrev` operations.
+
+### Range Query (Seek/SeekForPrev)
+
+`Seek(target)` uses `PrefixMayMatch(prefix_of_target)` when `prefix_extractor` is configured and the target is in-domain. If the prefix is not in the filter, the entire SST file can be skipped.
+
+## Prefix Extractor Compatibility
+
+### The Problem
+
+Filters are built with a specific `prefix_extractor`. If the extractor changes between SST creation and read time, prefix filtering could produce false negatives (incorrectly skipping keys).
+
+### The Solution
+
+RocksDB preserves correctness when prefix_extractor changes, but the behavior differs between point lookups and iterator/seek operations:
+
+**Point queries (Get/MultiGet):** During table open, the current prefix_extractor is compared with the stored name. If incompatible, prefix filtering is disabled for point queries on that SST. Queries fall through without prefix filter checks until compaction rebuilds the filter.
+
+**Iterator/Seek queries:** The reader stores the SST-time prefix extractor (reconstructed from TableProperties::prefix_extractor_name) in table_prefix_extractor. When the current options extractor differs, PrefixMayMatch() uses the SST-local extractor for filter checks. The decision to apply the filter depends on RangeMayExist(), which checks whether the seek key and upper bound are compatible with the SST-local extractor. This means old SST filters can still be used for iterator prefix filtering even after the extractor changes, as long as the query bounds are compatible.
+
+Step 1 -- During SST file creation, the prefix extractor's name is stored in TableProperties::prefix_extractor_name.
+
+Step 2 -- During table open (BlockBasedTable::Open()), the current prefix_extractor is compared with the stored name, and the SST-time extractor is saved in table_prefix_extractor.
+
+Step 3 -- For point queries: if incompatible, prefix filtering is skipped. For iterator queries: the SST-local extractor may still be used if RangeMayExist() determines the query bounds are compatible.
+
+Step 4 -- Compaction rebuilds filters with the current extractor.
+
+This means changing `prefix_extractor` is safe (no data corruption or incorrect results) but degrades performance for existing SST files until they are compacted.
+
+### Compatible Changes
+
+Some extractor changes are recognized as compatible:
+- A `nullptr` current extractor disables prefix filtering for all SSTs
+- The same extractor name is always compatible
+
+### Practical Implications
+
+- Changing from `NewFixedPrefixTransform(8)` to `NewFixedPrefixTransform(4)` is safe but loses prefix filter benefit on older SSTs
+- Removing `prefix_extractor` entirely is safe but disables all prefix filtering
+- Adding a `prefix_extractor` where none existed before only benefits new SSTs
+
+## Whole-Key Filtering with prefix_extractor
+
+When `whole_key_filtering == true` and `prefix_extractor` is set, both whole keys and prefixes coexist in the same filter. This is the recommended configuration for workloads that use both point queries and prefix-based range queries.
+
+The `AddKeyAndAlt()` deduplication ensures that when a key equals its own prefix (e.g., the key is exactly the prefix length), only one hash is added. This prevents inflating the filter with duplicate entries.
+
+## Out-of-Domain Keys
+
+Keys that are not in the prefix extractor's domain (i.e., `prefix_extractor->InDomain(key)` returns false) get special treatment:
+
+- With `whole_key_filtering == true`: the whole key is still added and can be filtered
+- With `whole_key_filtering == false`: the key is not added to the filter at all, and queries for such keys bypass filtering entirely
+
+This is a common pitfall: if most keys are out-of-domain, `whole_key_filtering = false` effectively disables filtering for them.

--- a/docs/components/filter/10_caching_and_pinning.md
+++ b/docs/components/filter/10_caching_and_pinning.md
@@ -1,0 +1,116 @@
+# Filter Caching and Pinning
+
+**Files:** `table/block_based/full_filter_block.cc`, `table/block_based/partitioned_filter_block.cc`, `table/block_based/block_based_table_reader.cc`, `include/rocksdb/table.h`
+
+## Overview
+
+Filters are cached in the block cache to avoid repeated disk I/O. RocksDB provides multiple strategies for managing filter cache lifetime, from fully managed LRU eviction to explicit pinning that keeps filters in memory for the table's lifetime.
+
+## cache_index_and_filter_blocks
+
+BlockBasedTableOptions::cache_index_and_filter_blocks (default false) controls whether filters are stored in the block cache:
+
+- true -- Filters go through the block cache. Subject to LRU eviction, contributing to cache memory accounting.
+- false -- For unpartitioned full filters, the filter is loaded into the table reader's memory, pinned for the table's lifetime, and not managed by the block cache. For partitioned filters, individual filter partitions still use the block cache path when a block cache exists; only the top-level partition index follows the reader-memory path.
+
+**Important:** With cache_index_and_filter_blocks = false, unpartitioned filter memory is not bounded by the cache size. For 1000 SST files with 10MB filters each, this pins 10GB.
+
+## Pinning Options
+
+### MetadataCacheOptions (Modern)
+
+`BlockBasedTableOptions::metadata_cache_options` provides fine-grained control via `PinningTier`:
+
+| PinningTier | Meaning |
+|---|---|
+| kFallback | Use the deprecated boolean settings |
+| kNone | Never pin |
+| kFlushedAndSimilar | Pin for flushed files and similar (L0, plus some ingested and intra-L0 compaction outputs based on a size heuristic) |
+| kAll | Pin for all levels |
+
+Three independent fields:
+- `top_level_index_pinning` -- Top-level partition index for partitioned filters
+- `partition_pinning` -- Individual filter partitions
+- `unpartitioned_pinning` -- Full (non-partitioned) filters
+
+### Deprecated Boolean Options
+
+- `pin_l0_filter_and_index_blocks_in_cache` -- Pin filters for L0 SSTs
+- `pin_top_level_index_and_filter` -- Pin the top-level index of partitioned filters
+
+These are superseded by `MetadataCacheOptions` but still functional when `PinningTier::kFallback` is used.
+
+## Cache Priority
+
+`BlockBasedTableOptions::cache_index_and_filter_blocks_with_high_priority` (default `true`) controls the eviction priority of filter cache entries.
+
+Note: This only affects eviction **priority** (making filters less likely to be evicted than data blocks), not pinning. Filters with high priority can still be evicted if cache pressure is high enough. To prevent eviction entirely, use pinning.
+
+## Full Filter Caching
+
+### Cache Lookup
+
+`FullFilterBlockReader::MayMatch()` calls `GetOrReadFilterBlock()` which:
+
+Step 1 -- Check if the filter is already pinned in the reader (from `Create()` time).
+Step 2 -- If not pinned, look up in the block cache by cache key.
+Step 3 -- If cache miss, read from disk and insert into cache.
+Step 4 -- Return a `CachableEntry<ParsedFullFilterBlock>`.
+
+### Pinned Filters
+
+When `pin == true` during `FullFilterBlockReader::Create()`:
+- The `CachableEntry` is stored in the reader
+- The cache handle reference prevents eviction
+- On table close, the `CachableEntry` destructor releases the handle
+
+When `pin == false`:
+- The filter is read into cache during table open (if prefetch is enabled)
+- The cache handle is released immediately
+- The filter may be evicted and re-read later
+
+## Partitioned Filter Caching
+
+### Individual Partition Caching
+
+Each partition is cached as a separate entry in the block cache. This provides:
+- Granular eviction (only unused partitions are evicted)
+- Smaller individual cache entries (better cache utilization)
+- Partial pinning (pin only the top-level index, let partitions be managed by LRU)
+
+### CacheDependencies (Prefetching)
+
+During table open, `PartitionedFilterBlockReader::CacheDependencies()` can prefetch all partitions:
+
+Step 1 -- Load the top-level index.
+Step 2 -- Calculate the byte range for all partitions (first to last handle).
+Step 3 -- Issue a single `Prefetch()` for the entire range to batch the I/O.
+Step 4 -- Load each partition into the block cache via `MaybeReadBlockAndLoadToCache()`.
+Step 5 -- If pinning: store the `CachableEntry` in `filter_map_` (keyed by block offset).
+
+### filter_map_ (Pinned Partitions)
+
+Pinned partitions are stored in `PartitionedFilterBlockReader::filter_map_`, an `UnorderedMap<uint64_t, CachableEntry<ParsedFullFilterBlock>>`. During queries, the reader checks `filter_map_` first before going to the block cache.
+
+Some partitions may fail to pin (e.g., cache insertion failure). These are not stored in `filter_map_` and will be loaded from cache (or disk) on demand.
+
+## EraseFromCacheBeforeDestruction
+
+When a table is closed with `uncache_aggressiveness > 0`, `PartitionedFilterBlockReader::EraseFromCacheBeforeDestruction()` aggressively removes cached partitions:
+
+Step 1 -- Load the top-level index.
+Step 2 -- Iterate through index entries.
+Step 3 -- Erase each partition's cache entry using the cache key derived from its block handle.
+
+This is stronger than unpinning: it removes the entries entirely from the cache, freeing memory immediately. Without this, unpinned entries remain in the cache until LRU eviction.
+
+## Prefetching During Table Open
+
+The `prefetch` parameter in `FilterBlockReader::Create()` controls whether the filter is read into cache proactively during table open, or lazily on first query.
+
+Prefetching is beneficial when:
+- The table will likely be queried soon
+- Disk I/O during the open path is acceptable
+- Avoiding lazy load latency on the first query matters
+
+The tail prefetch buffer (`FilePrefetchBuffer`) is used to batch I/O for filters and indexes during table open.

--- a/docs/components/filter/11_monitoring_and_best_practices.md
+++ b/docs/components/filter/11_monitoring_and_best_practices.md
@@ -1,0 +1,117 @@
+# Monitoring and Best Practices
+
+**Files:** `include/rocksdb/statistics.h`, `include/rocksdb/perf_context.h`, `include/rocksdb/table.h`
+
+## Filter Statistics
+
+### Statistics Counters (DB-level)
+
+These counters in `include/rocksdb/statistics.h` track aggregate filter behavior across all SST files:
+
+| Counter | Meaning |
+|---|---|
+| `BLOOM_FILTER_USEFUL` | SST filter said "not present" -- avoided a disk read (true negative) |
+| `BLOOM_FILTER_FULL_POSITIVE` | Filter said "maybe present" for whole-key check (all positives: true + false) |
+| `BLOOM_FILTER_FULL_TRUE_POSITIVE` | Filter said "maybe present" AND key was actually found (true positive only) |
+| `BLOOM_FILTER_PREFIX_CHECKED` | Number of prefix filter checks performed |
+| `BLOOM_FILTER_PREFIX_USEFUL` | Prefix filter said "not present" -- avoided a read (true negative) |
+| `BLOOM_FILTER_PREFIX_TRUE_POSITIVE` | Prefix filter true positive |
+
+### PerfContext Counters (per-thread)
+
+These counters in `include/rocksdb/perf_context.h` track filter behavior for the current thread's operations:
+
+| Counter | Meaning |
+|---|---|
+| `bloom_sst_hit_count` | SST filter said "maybe present" |
+| `bloom_sst_miss_count` | SST filter said "definitely not present" |
+| `bloom_memtable_hit_count` | Memtable filter said "maybe present" |
+| `bloom_memtable_miss_count` | Memtable filter said "definitely not present" |
+
+### Computing Effective FP Rate
+
+**Whole-key point lookups:**
+
+```
+False Positives = BLOOM_FILTER_FULL_POSITIVE - BLOOM_FILTER_FULL_TRUE_POSITIVE
+Total Filter Checks = BLOOM_FILTER_USEFUL + BLOOM_FILTER_FULL_POSITIVE
+Actual FP Rate = False Positives / Total Filter Checks
+Filter Efficiency = BLOOM_FILTER_USEFUL / total_Get_calls
+```
+
+**Prefix point lookups:** Use BLOOM_FILTER_PREFIX_CHECKED, BLOOM_FILTER_PREFIX_USEFUL, and BLOOM_FILTER_PREFIX_TRUE_POSITIVE for the analogous calculation.
+
+**Iterator/seek filtering:** Uses separate NON_LAST_LEVEL_SEEK_FILTER_MATCH and NON_LAST_LEVEL_SEEK_FILTERED counters. These are not covered by the BLOOM_FILTER_* counters above.
+
+A high `Filter Efficiency` (close to 1.0) means filters are successfully avoiding most unnecessary disk reads. A high `Actual FP Rate` (much higher than theoretical) may indicate too few bits per key, hash collisions from too many keys per filter, or corrupted filters.
+
+## Choosing Bloom vs. Ribbon
+
+| Factor | Bloom | Ribbon |
+|---|---|---|
+| Space | Standard (10 bits/key for 1% FP) | ~30% smaller (7 bits/key for 1% FP) |
+| Construction CPU | Fast | 3-4x slower |
+| Construction memory | ~1x filter size | ~3x filter size (temporary) |
+| Query speed | Fast (AVX2 SIMD) | Comparable to Bloom |
+| Min version to read | Any | 6.15.0 |
+
+**Recommendation:** Use `NewRibbonFilterPolicy(10.0, 1)` for most workloads. This gives Bloom for L0/flushes (fast construction when it matters most) and Ribbon for L1+ (space savings on larger, longer-lived files).
+
+## Choosing Full vs. Partitioned Filters
+
+| Factor | Full | Partitioned |
+|---|---|---|
+| Memory per SST | Single block (all or nothing) | Granular (per-partition) |
+| Cache efficiency | One cache entry per SST | Multiple entries, LRU per partition |
+| Query latency | One cache lookup | Two lookups (index + partition) |
+| Best for | Small SSTs, high cache ratio | Large SSTs, limited cache |
+
+**Recommendation:** Use partitioned filters when SST files are large (> 64MB) or when the total filter size exceeds what can comfortably fit in the block cache.
+
+## Bits-per-Key Selection Guide
+
+| Bits/Key | Approx FP Rate | Use Case |
+|---|---|---|
+| 5 | ~10% | Very low memory, high disk bandwidth |
+| 7 | ~2% | Balanced |
+| 10 | ~1% | Recommended default |
+| 14 | ~0.1% | Premium on avoiding disk I/O |
+| 20 | ~0.01% | Extremely latency-sensitive |
+
+**Rule of thumb:** The cost of a false positive (one unnecessary disk read) should be roughly 100x the cost of a filter probe for the configured FP rate to be worthwhile. At 10 bits/key and 1% FP rate, you avoid 99% of unnecessary reads.
+
+## Common Pitfalls
+
+### 1. Changing prefix_extractor
+
+Changing `prefix_extractor` is safe but degrades performance on existing SSTs until compaction rebuilds filters. During the transition, prefix filters are skipped for incompatible SSTs (correctness preserved, filtering benefit lost).
+
+### 2. Disabling whole_key_filtering with point queries
+
+With `whole_key_filtering = false`, point queries can only use prefix filters for in-domain keys. Keys outside the prefix extractor's domain get no filter benefit at all. Keep `whole_key_filtering = true` for mixed workloads.
+
+### 3. Over-pinning filters
+
+Pinning all filters (`cache_index_and_filter_blocks = false` or aggressive pinning tiers) can exhaust memory. Calculate total filter memory: `num_sst_files * avg_filter_size`. Use `cache_index_and_filter_blocks = true` with LRU management, or use partitioned filters for granular control.
+
+### 4. Using format_version < 5
+
+Legacy Bloom with format_version < 5 uses 32-bit hashes. At 10 bits/key, the fingerprint FP rate becomes significant around ~40 million keys. A warning is logged at >= 3 million keys when estimated FP exceeds 1.5x expected. Upgrade to format_version >= 5 for 64-bit hashes and SIMD acceleration.
+
+### 5. Not setting filter_policy
+
+Without a `filter_policy`, every `Get()` on a non-existent key reads data blocks from every level. Set `filter_policy` for any workload with significant point query traffic.
+
+## Advanced Options
+
+### optimize_filters_for_memory
+
+Default `true`. Adjusts filter sizes to align with allocator buckets via `malloc_usable_size`, saving ~10% filter memory at the cost of ~1-2% more disk usage. Only effective with `format_version >= 5`.
+
+### detect_filter_construct_corruption
+
+Default `false`. Verifies filter construction integrity by re-querying all added keys after building the filter. Increases construction time by ~30%. Useful for detecting software bugs or hardware malfunctions during filter construction.
+
+### cache_index_and_filter_blocks_with_high_priority
+
+Default `true`. Makes filter cache entries less likely to be evicted than data blocks. Does not prevent eviction entirely -- use pinning for that.

--- a/docs/components/filter/index.md
+++ b/docs/components/filter/index.md
@@ -1,0 +1,43 @@
+# RocksDB Filter (Bloom/Ribbon) Subsystem
+
+## Overview
+
+Filters are probabilistic data structures that reduce unnecessary disk reads for non-existent keys. RocksDB supports Bloom and Ribbon filters at the SST level, and an optional DynamicBloom filter at the memtable level. Filters never produce false negatives -- if a filter says "not present," the key is guaranteed absent. False positive rates are configurable via bits-per-key.
+
+**Key source files:** `include/rocksdb/filter_policy.h`, `table/block_based/filter_policy.cc`, `table/block_based/filter_policy_internal.h`, `util/bloom_impl.h`, `util/ribbon_impl.h`, `util/dynamic_bloom.h`
+
+## Chapters
+
+| Chapter | File | Summary |
+|---------|------|---------|
+| 1. Filter Types and Selection | [01_types_and_selection.md](01_types_and_selection.md) | `FilterPolicy` API, `NewBloomFilterPolicy` vs `NewRibbonFilterPolicy`, `bloom_before_level` hybrid strategy, and format_version-dependent implementation selection. |
+| 2. FastLocalBloom Implementation | [02_fast_local_bloom.md](02_fast_local_bloom.md) | Cache-local Bloom filter with AVX2 SIMD queries, 64-byte cache line probing, hash expansion via golden ratio, and FP rate characteristics. |
+| 3. Ribbon Filter Implementation | [03_ribbon_filter.md](03_ribbon_filter.md) | Space-efficient 128-bit linear algebra filter, construction retry with 256 seeds, Bloom fallback conditions, and `desired_one_in_fp_rate` configuration. |
+| 4. Full Filter Blocks | [04_full_filter_blocks.md](04_full_filter_blocks.md) | Single-block filter construction and reading, key/prefix addition with deduplication, and MultiGet batch query optimization. |
+| 5. Partitioned Filter Blocks | [05_partitioned_filter_blocks.md](05_partitioned_filter_blocks.md) | Filter partitioning strategy, cross-boundary prefix insertion, decoupled vs coupled partitioning, and partition-level caching. |
+| 6. Filter Construction Pipeline | [06_construction_pipeline.md](06_construction_pipeline.md) | Hash accumulation in `XXPH3FilterBitsBuilder`, `optimize_filters_for_memory`, cache reservation during construction, and corruption detection. |
+| 7. Filter Storage Format | [07_storage_format.md](07_storage_format.md) | SST metaindex entries, 5-byte metadata trailer encoding, discriminator byte dispatch, and cross-version compatibility. |
+| 8. Memtable Bloom Filter | [08_memtable_bloom.md](08_memtable_bloom.md) | `DynamicBloom` double-probe design, concurrent-safe add with relaxed atomics, huge page TLB allocation, and configuration. |
+| 9. Prefix Filtering | [09_prefix_filtering.md](09_prefix_filtering.md) | `SliceTransform` integration, whole-key + prefix combined filtering, prefix extractor compatibility across SST files, and query path dispatch. |
+| 10. Filter Caching and Pinning | [10_caching_and_pinning.md](10_caching_and_pinning.md) | Block cache integration for full and partitioned filters, pinning strategies via `MetadataCacheOptions`, `EraseFromCacheBeforeDestruction`, and prefetching. |
+| 11. Monitoring and Best Practices | [11_monitoring_and_best_practices.md](11_monitoring_and_best_practices.md) | Statistics and PerfContext counters, FP rate calculation, bits-per-key selection guide, and common configuration pitfalls. |
+
+## Key Characteristics
+
+- **Two filter algorithms**: FastLocalBloom (fast, default for format_version >= 5) and Ribbon (30% smaller, 3-4x slower construction)
+- **Hybrid filter strategy**: `NewRibbonFilterPolicy` with `bloom_before_level` uses Bloom for upper levels and Ribbon for lower levels
+- **Full or partitioned**: Single-block filters for simplicity; partitioned filters for memory-efficient caching of large SSTs
+- **Prefix and whole-key filtering**: Both can be combined in a single filter via `AddKeyAndAlt` deduplication
+- **SIMD-accelerated queries**: AVX2 checks 8 Bloom probes in parallel per cache line
+- **Memtable filters optional**: `DynamicBloom` with concurrent-safe relaxed atomics, not serialized to disk
+- **Automatic corruption detection**: Optional `detect_filter_construct_corruption` verifies filter integrity post-construction
+- **Memory-optimized sizing**: `optimize_filters_for_memory` uses `malloc_usable_size` to minimize fragmentation waste
+- **Cache-charged construction**: Filter construction memory can be charged to the block cache
+
+## Key Invariants
+
+- Filters never produce false negatives; only false positives are possible
+- All built-in filter policies share `CompatibilityName() == "rocksdb.BuiltinBloomFilter"` and can read each other's filters
+- The metadata trailer discriminator byte (byte 0 of 5-byte trailer) determines the reader: positive = legacy Bloom, -1 = FastLocalBloom, -2 = Ribbon, 0 = always-true
+- Partitioned filter partitions must include prefixes from adjacent partitions for Seek/SeekForPrev correctness
+- FastLocalBloom filter payload must be aligned to 64 bytes (cache line size)

--- a/docs/components/snapshot/01_public_api.md
+++ b/docs/components/snapshot/01_public_api.md
@@ -1,0 +1,50 @@
+# Public API
+
+**Files:** `include/rocksdb/snapshot.h`, `include/rocksdb/db.h`, `db/snapshot_impl.cc`
+
+## Snapshot Abstract Class
+
+The `Snapshot` class in `include/rocksdb/snapshot.h` is the public interface for point-in-time database views. It provides three virtual methods:
+
+- `GetSequenceNumber()` -- returns the sequence number identifying this snapshot
+- `GetUnixTime()` -- returns the wall-clock time (seconds since epoch) when the snapshot was created
+- `GetTimestamp()` -- returns the user-defined timestamp associated with the snapshot
+
+The destructor is protected, preventing direct deletion. Snapshots must be released through `DB::ReleaseSnapshot()`.
+
+## Creating and Releasing Snapshots
+
+`DB::GetSnapshot()` in `include/rocksdb/db.h` creates a snapshot of the current database state. It returns a pointer to an immutable `Snapshot` object. The snapshot captures the last published sequence number at creation time.
+
+`DB::ReleaseSnapshot()` releases a previously acquired snapshot. After calling this, the caller must not use the snapshot pointer. Passing `nullptr` is safe (no-op).
+
+Important: GetSnapshot() returns nullptr when is_snapshot_supported_ is false. This is a DB-wide flag: if any live column family's memtable does not support snapshots, GetSnapshot() returns nullptr for the entire DB. The most common reason is inplace_update_support being enabled, but a custom MemTableRep can also disable snapshots by returning false from IsSnapshotSupported().
+
+Important: Snapshots are volatile -- they do not persist across DB restarts. A snapshot is an in-memory object tied to a sequence number. After closing and reopening the database, all previously acquired snapshots are invalid.
+
+## ManagedSnapshot RAII Wrapper
+
+`ManagedSnapshot` in `include/rocksdb/snapshot.h` provides automatic snapshot lifecycle management:
+
+- **Constructor** `ManagedSnapshot(DB* db)` -- acquires a new snapshot via `db->GetSnapshot()`
+- **Ownership constructor** `ManagedSnapshot(DB* db, const Snapshot* snapshot)` -- takes ownership of an existing snapshot
+- **Destructor** -- calls `db->ReleaseSnapshot(snapshot_)` if the snapshot is non-null
+- **Accessor** `snapshot()` -- returns the underlying `const Snapshot*`
+
+The implementation in `db/snapshot_impl.cc` is straightforward: the constructors store the DB pointer and snapshot pointer, and the destructor releases the snapshot.
+
+## ReadOptions::snapshot Usage
+
+To read from a specific snapshot, set `ReadOptions::snapshot` before calling `DB::Get()`, `DB::MultiGet()`, or `DB::NewIterator()`:
+
+- If `ReadOptions::snapshot` is set, the read sees the database as of the snapshot's sequence number
+- If `ReadOptions::snapshot` is null (default), the read sees the latest committed state
+
+**Workflow for snapshot-based reads:**
+
+1. Call `db->GetSnapshot()` to capture current state
+2. Set `read_options.snapshot = snapshot` for each read operation
+3. Perform reads -- all see a consistent view at the snapshot's point in time
+4. Call `db->ReleaseSnapshot(snapshot)` when done (or use `ManagedSnapshot` for automatic cleanup)
+
+Note: Using `ManagedSnapshot` is recommended over manual `GetSnapshot()`/`ReleaseSnapshot()` pairs to avoid resource leaks from forgotten releases.

--- a/docs/components/snapshot/02_data_structures.md
+++ b/docs/components/snapshot/02_data_structures.md
@@ -1,0 +1,73 @@
+# Data Structures
+
+**Files:** `db/snapshot_impl.h`, `include/rocksdb/snapshot.h`
+
+## SnapshotImpl
+
+`SnapshotImpl` in `db/snapshot_impl.h` extends the public `Snapshot` class with internal implementation details. Each instance represents a single snapshot in the database.
+
+### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `number_` | `SequenceNumber` | The snapshot's sequence number. Const after creation. |
+| `min_uncommitted_` | `SequenceNumber` | Smallest uncommitted sequence at snapshot time. Used by WritePrepared transactions to limit IsInSnapshot() queries. Defaults to kMinUnCommittedSeq (value 1; sequence 0 is always considered committed). May be set after creation by EnhanceSnapshot(). |
+| `prev_` | `SnapshotImpl*` | Previous node in the doubly-linked list. |
+| `next_` | `SnapshotImpl*` | Next node in the doubly-linked list. |
+| `list_` | `SnapshotList*` | Pointer to the owning list (used for sanity-check assertions). |
+| `unix_time_` | `int64_t` | Wall-clock time when the snapshot was created. |
+| `timestamp_` | `uint64_t` | User-defined timestamp. Defaults to `std::numeric_limits<uint64_t>::max()`. |
+| `is_write_conflict_boundary_` | `bool` | Whether this snapshot is used for transaction write-conflict checking. |
+
+## SnapshotList
+
+`SnapshotList` in `db/snapshot_impl.h` is a circular doubly-linked list that manages all active snapshots. It uses a dummy head node as the sentinel.
+
+### List Structure
+
+The list is organized as a circular doubly-linked list with a dummy head node (`list_`):
+
+- `list_.next_` points to the oldest snapshot (smallest sequence number)
+- `list_.prev_` points to the newest snapshot (largest sequence number)
+- The dummy head's `number_` is set to `0xFFFFFFFFL` as a debugging marker
+- When empty, both `list_.next_` and `list_.prev_` point to `&list_` (self-referential)
+
+### Operations
+
+**New()** -- Inserts a snapshot at the tail of the list. Sets all fields on the `SnapshotImpl`, links it before the dummy head (making it the newest), and increments the count. Returns the snapshot pointer.
+
+**Delete()** -- Unlinks a snapshot from the list by updating its neighbors' pointers. Decrements the count. Does NOT free the `SnapshotImpl` object -- that is the caller's responsibility.
+
+**GetAll()** -- Walks the list from oldest to newest, collecting sequence numbers into a vector. Skips duplicates (multiple snapshots can share the same sequence number). Also tracks the oldest write-conflict boundary snapshot for transaction support. Stops when reaching a snapshot with sequence number greater than `max_seq`.
+
+**Utility methods:**
+
+| Method | Returns |
+|--------|---------|
+| `empty()` | Whether the list has no snapshots |
+| `oldest()` | Pointer to the oldest snapshot (`list_.next_`) |
+| `newest()` | Pointer to the newest snapshot (`list_.prev_`) |
+| `GetNewest()` | Sequence number of the newest snapshot (0 if empty) |
+| `GetOldestSnapshotTime()` | Unix time of the oldest snapshot (0 if empty) |
+| `GetOldestSnapshotSequence()` | Sequence number of the oldest snapshot (0 if empty) |
+| `count()` | Number of active snapshots |
+
+## TimestampedSnapshotList
+
+`TimestampedSnapshotList` in `db/snapshot_impl.h` provides an alternative snapshot container indexed by user-defined timestamps. Unlike `SnapshotList`, it uses a `std::map<uint64_t, std::shared_ptr<const SnapshotImpl>>` for ordered timestamp-based lookup.
+
+### Operations
+
+**GetSnapshot(ts)** -- Looks up a snapshot by exact timestamp. If `ts` is `max uint64_t` and the map is non-empty, returns the most recent snapshot. Returns an empty `shared_ptr` if not found.
+
+**GetSnapshots(ts_lb, ts_ub)** -- Returns all snapshots with timestamps in the half-open range `[ts_lb, ts_ub)`.
+
+**AddSnapshot(snapshot)** -- Inserts a snapshot indexed by its timestamp via `try_emplace` (does not overwrite existing entries at the same timestamp).
+
+**ReleaseSnapshotsOlderThan(ts, snapshots_to_release)** -- Moves all snapshots with timestamps less than `ts` into the output container (an autovector<std::shared_ptr<const SnapshotImpl>>, not std::vector, to avoid heap allocation for small counts), then erases them from the map. The actual snapshot release (which requires DB mutex) happens outside this method by the caller.
+
+### Ownership Model
+
+Timestamped snapshots use `std::shared_ptr` for shared ownership. This allows multiple holders to reference the same snapshot. The `ReleaseSnapshotsOlderThan()` method deliberately moves snapshots to an output container rather than releasing them inline, because the actual release requires holding the DB mutex.
+
+Note: All operations on `TimestampedSnapshotList` must be protected by the DB mutex.

--- a/docs/components/snapshot/03_lifecycle.md
+++ b/docs/components/snapshot/03_lifecycle.md
@@ -1,0 +1,61 @@
+# Snapshot Lifecycle
+
+**Files:** `db/db_impl/db_impl.cc`, `db/db_impl/db_impl.h`, `db/snapshot_impl.h`
+
+## Creating a Snapshot
+
+`DBImpl::GetSnapshotImpl()` in `db/db_impl/db_impl.cc` is the internal implementation behind `DB::GetSnapshot()`. The workflow is:
+
+1. **Get wall-clock time** -- calls `clock->GetCurrentTime()` for the snapshot's `unix_time_` field
+2. **Allocate** -- creates a new `SnapshotImpl` on the heap
+3. **Acquire DB mutex** -- either locks (lock=true, the default for public API) or asserts already held (lock=false, used internally)
+4. **Check support** -- if is_snapshot_supported_ is false (because any column family's memtable does not support snapshots, most commonly due to inplace_update_support), unlocks the mutex, deletes the allocated object, and returns nullptr
+5. **Get sequence number** -- calls `GetLastPublishedSequence()` to get the snapshot's sequence number
+6. **Insert into list** -- calls `snapshots_.New(s, snapshot_seq, unix_time, is_write_conflict_boundary)` to link the snapshot into the doubly-linked list
+7. **Release DB mutex** -- if it was acquired in step 3
+
+### GetLastPublishedSequence vs LastSequence
+
+`GetLastPublishedSequence()` returns the last sequence number that has been made visible to readers. This may differ from `LastSequence()` (which includes sequences assigned but not yet published) when pipelined writes or WritePrepared transactions are in use. Using `GetLastPublishedSequence()` ensures the snapshot only sees data that is fully committed and visible.
+
+### GetSnapshotForWriteConflictBoundary
+
+`GetSnapshotForWriteConflictBoundary()` in `db/db_impl/db_impl.h` calls `GetSnapshotImpl(true)`, creating a snapshot with `is_write_conflict_boundary_` set to `true`. This tells the compaction system to preserve old key versions needed for transaction write-conflict detection.
+
+## Releasing a Snapshot
+
+`DBImpl::ReleaseSnapshot()` in `db/db_impl/db_impl.cc` releases a snapshot and potentially triggers compaction. The workflow is:
+
+1. **Null check** -- returns immediately if the snapshot pointer is nullptr
+2. **Cast** -- static-casts the public Snapshot* to SnapshotImpl*
+3. **Acquire DB mutex** -- via InstrumentedMutexLock
+4. **Remove from list** -- calls snapshots_.Delete(casted_s) to unlink from the doubly-linked list
+5. **Compute oldest snapshot** -- if the snapshot list is now empty, uses GetLastPublishedSequence(); otherwise uses snapshots_.oldest()->number_
+6. **Check DB-wide threshold** -- compares oldest_snapshot against bottommost_files_mark_threshold_. If the threshold is not crossed, skips the column family scan entirely
+7. **Check standalone range deletion threshold** -- separately compares oldest_snapshot against standalone_range_deletion_files_mark_threshold_ to schedule compaction for files with standalone range deletions
+8. **Update column families** -- iterates column families (skipping those with AllowIngestBehind() set) to call UpdateOldestSnapshot() on each, which may mark additional bottommost files for compaction
+9. **Enqueue compaction** -- calls EnqueuePendingCompaction() and MaybeScheduleFlushOrCompaction() for any column family that gained new compaction candidates
+10. **Release DB mutex**
+11. **Free memory** -- delete casted_s happens outside the mutex scope to minimize lock hold time
+
+### Post-Release Compaction Triggering
+
+When a snapshot is released, previously pinned key versions may become eligible for garbage collection. The release process first checks whether the new oldest snapshot sequence crosses the DB-wide bottommost_files_mark_threshold_. If the threshold is not crossed, the column family scan is skipped entirely (fast path). If it is crossed, ReleaseSnapshot() iterates column families (skipping those with allow_ingest_behind set) and calls UpdateOldestSnapshot() on each. Column families whose bottommost files become eligible are marked for compaction.
+
+A separate standalone_range_deletion_files_mark_threshold_ check handles files containing standalone range deletions. This can trigger compaction scheduling independently of the bottommost files path.
+
+The `bottommost_files_mark_threshold_` (see `VersionStorageInfo` in `db/version_set.h`) is defined as the minimum of the maximum nonzero sequence numbers across all unmarked bottommost files. When the oldest snapshot's sequence number exceeds this threshold, new bottommost files become eligible for compaction to zero out their sequence numbers.
+
+## Thread Safety
+
+- **List modifications** (create/delete) always require holding DB mutex
+- **Snapshot reads** (calling GetSequenceNumber(), GetUnixTime(), etc.) are thread-safe without any lock, because the public accessor fields (number_, unix_time_, timestamp_) are immutable after creation. Note: WritePrepared transactions may mutate min_uncommitted_ via EnhanceSnapshot() immediately after creation, but this happens before the snapshot is used by readers
+- The SnapshotImpl::number_ field is documented as "const after creation" in the source
+- Multiple threads can safely read from the same snapshot concurrently
+
+## Object Ownership
+
+- `GetSnapshot()` allocates a `SnapshotImpl` via `new` and returns a raw pointer
+- The caller owns the object and must call `ReleaseSnapshot()` to free it
+- `ReleaseSnapshot()` unlinks from the list under mutex, then `delete`s outside the mutex
+- `ManagedSnapshot` wraps this pattern with RAII, releasing in its destructor

--- a/docs/components/snapshot/04_reads.md
+++ b/docs/components/snapshot/04_reads.md
@@ -1,0 +1,88 @@
+# Snapshots and Reads
+
+**Files:** `db/db_impl/db_impl.cc`, `db/db_iter.cc`, `db/db_impl/db_impl.h`
+
+## Sequence Number Visibility
+
+When a read operation uses a snapshot, it only sees key versions with sequence numbers less than or equal to the snapshot's sequence number. This is the fundamental mechanism that provides point-in-time consistency.
+
+For a key with multiple versions at sequence numbers `s1 < s2 < s3`:
+- A snapshot at sequence `s2` sees the version at `s2` (the latest version <= `s2`)
+- A snapshot at sequence `s1` sees the version at `s1`
+- A read without a snapshot sees the version at `s3` (the latest)
+
+## Explicit vs. Implicit Snapshots
+
+### Explicit Snapshot
+
+When `ReadOptions::snapshot` is set, the read uses that snapshot's sequence number. The caller is responsible for ensuring the snapshot remains valid (not released) for the duration of the read.
+
+### Implicit Snapshot
+
+When `ReadOptions::snapshot` is null, RocksDB creates an implicit snapshot internally. In `DBImpl::NewIteratorImpl()`, if no explicit snapshot is provided, the sequence number is set to `versions_->LastSequence()`.
+
+Important: The implicit snapshot sequence is assigned AFTER referencing the SuperVersion. This ordering is critical -- if the snapshot were assigned first, a flush occurring between snapshot assignment and SuperVersion reference could compact away data for the snapshot, causing the reader to see neither the old data visible to the snapshot nor the newer data inserted afterward.
+
+### Iterator Consistency
+
+An iterator's view never changes during its lifetime, regardless of concurrent writes. Whether using an explicit or implicit snapshot:
+- The `DBIter` constructor receives the snapshot sequence number
+- All key filtering during `Seek()`, `Next()`, `Prev()` operations uses this fixed sequence number
+- New writes with higher sequence numbers are invisible to the iterator
+- The `IsVisible()` method in `DBIter` (see `db/db_iter.cc`) performs the core visibility check: `entry_sequence <= sequence_`. When a `ReadCallback` is present (for transactions), it delegates to `ReadCallback::IsVisible()` instead.
+
+### Skip Optimization
+
+When iterating through many versions of the same key written after the snapshot, `DBIter` counts skipped entries. If the count exceeds `max_skip_`, it performs a `Seek()` to the snapshot sequence number rather than continuing to scan linearly. This avoids O(n) scanning through post-snapshot writes.
+
+### Explicit vs. Implicit Snapshot Lifetime Differences
+
+An important distinction: explicit snapshots (from DB::GetSnapshot()) are tracked in the SnapshotList and prevent compaction from dropping entries visible to the snapshot. Implicit snapshots (when no snapshot is set in ReadOptions) are NOT tracked in the SnapshotList, so compaction may drop old key versions that would be visible only through implicit snapshots.
+
+However, iterators with implicit snapshots are still safe for reading. The pinned SuperVersion holds a reference to the Version, which prevents the underlying SST files from being deleted. The iterator always reads from its original file set regardless of concurrent compactions. The data is physically present in the files even if newer compactions logically dropped those versions.
+
+The practical difference: with explicit snapshots, old key versions are preserved across compactions (available to any reader using that snapshot). With implicit snapshots, old key versions may be dropped by compaction, but the specific iterator that pinned the SuperVersion can still read its original file set.
+
+### Iterator Auto-Refresh
+
+Explicit-snapshot iterators can opt into auto-refresh via ReadOptions::auto_refresh_iterator_with_snapshot. When enabled, the iterator periodically refreshes its SuperVersion to release old files while preserving the same snapshot sequence number for visibility. This is useful for long-running scans where holding obsolete files indefinitely is undesirable. Implicit-snapshot iterators do not support auto-refresh because they have no SnapshotList entry to anchor their visibility.
+
+### ForwardIterator Exception
+
+ForwardIterator (tailing iterators, enabled via ReadOptions::tailing) does NOT pin a fixed SuperVersion. It dynamically picks up new versions as they become available. This is an intentional exception to the general iterator snapshot safety described above -- tailing iterators sacrifice point-in-time consistency in exchange for seeing the latest data.
+
+## Point Lookup Flow
+
+`DBImpl::GetImpl()` handles point lookups (Get/MultiGet). The snapshot interaction is:
+
+1. **Pin SuperVersion** -- acquire a reference via `GetAndRefSuperVersion()` to the current SuperVersion (memtable + immutable memtables + SST files)
+2. **Determine sequence number** -- if `ReadOptions::snapshot` is set, extract the sequence number directly from the `SnapshotImpl`; otherwise call `GetLastPublishedSequence()`
+3. **Construct LookupKey** -- the sequence number is embedded into a `LookupKey` (see `db/lookup_key.h`) which packages the user key + sequence for memtable probing
+4. **Search memtable** -- look for the key in the active memtable, filtering by sequence number
+5. **Search immutable memtables** -- if not found, search immutable memtables
+6. **Search SST files** -- if not found, search SST files via the version's file set
+7. **Release SuperVersion** -- unpin after the read completes
+
+At each level, the sequence number acts as a filter: only entries with sequence <= snapshot sequence are considered.
+
+## Iterator Creation Flow
+
+`DBImpl::NewIteratorImpl()` creates iterators with snapshot support:
+
+1. **Pin SuperVersion** -- acquire a reference via `GetAndRefSuperVersion()`
+2. **Assign sequence number** -- if explicit snapshot, use its sequence; otherwise use `versions_->LastSequence()`
+3. **Create internal iterator** -- builds a `MergingIterator` across memtable, immutable memtables, and SST file iterators
+4. **Wrap with DBIter** -- creates a `DBIter` that applies sequence number filtering and handles merge operations
+
+The `DBIter` uses the snapshot sequence number throughout its lifetime to filter keys. The `FindNextUserEntryInternal()` and `FindValueForCurrentKey()` methods in `db/db_iter.cc` skip entries with sequence numbers above the snapshot's sequence.
+
+## SuperVersion and Snapshot Ordering
+
+The relationship between SuperVersion pinning and snapshot assignment is subtle but important:
+
+- **SuperVersion** pins a specific set of memtables and SST files
+- **Snapshot sequence** determines which entries within those files are visible
+- The SuperVersion must be pinned BEFORE the snapshot sequence is determined
+- This ensures all data up to the snapshot sequence exists in the pinned SuperVersion
+
+If this ordering were reversed, a concurrent flush could move data from memtable to an SST file that is not part of the SuperVersion, creating a gap in the reader's view.

--- a/docs/components/snapshot/05_compaction.md
+++ b/docs/components/snapshot/05_compaction.md
@@ -1,0 +1,101 @@
+# Snapshots and Compaction
+
+**Files:** `db/compaction/compaction_iterator.cc`, `db/compaction/compaction_job.cc`, `db/db_impl/db_impl_compaction_flush.cc`, `db/version_set.h`
+
+## Snapshot-Aware Garbage Collection
+
+Compaction's primary constraint from snapshots: for each user key, it must keep the latest version visible at each snapshot boundary, plus the latest version overall. Old versions that are not the latest visible version at any snapshot boundary can be safely deleted.
+
+Important: This snapshot-aware GC only applies to compaction styles that run through the CompactionIterator (Level, Universal). FIFO compaction ignores snapshots entirely -- it operates at file granularity, deleting or moving whole files without key-level filtering. The snapshot parameters (existing_snapshots, snapshot_checker) are explicitly unused in FIFOCompactionPicker::PickCompaction().
+
+### How Snapshots Reach the Compaction Iterator
+
+Before a compaction or flush job runs, `DBImpl::InitSnapshotContext()` gathers the snapshot state:
+
+1. Calls `snapshots_.GetAll()` to collect all active snapshot sequence numbers into a sorted vector
+2. Determines `earliest_write_conflict_snapshot` for transaction support
+3. If a `SnapshotChecker` is in use (WritePrepared/WriteUnprepared transactions), takes a temporary snapshot to ensure no data is missed
+4. Passes the snapshot vector, earliest snapshot, and snapshot checker to the `CompactionIterator`
+
+## findEarliestVisibleSnapshot
+
+`CompactionIterator::findEarliestVisibleSnapshot()` in `db/compaction/compaction_iterator.cc` uses binary search (`std::lower_bound`) to find the earliest snapshot in which a given sequence number is visible.
+
+Given a sequence number `in` and the sorted snapshot vector:
+- Finds the first snapshot `s` where `s >= in`
+- If found, returns `s` (this key version is visible starting from snapshot `s`)
+- If not found, returns `kMaxSequenceNumber` (visible only at the current tip)
+
+When a SnapshotChecker is present (for WritePrepared transactions), the search additionally verifies that the key is actually committed in the candidate snapshot by calling CheckInSnapshot(). If the key is not yet committed at a snapshot, the search continues to the next snapshot. This linear probing can degrade the per-key cost from O(log num_snapshots) toward O(num_snapshots) in the worst case with many released or uncommitted snapshots.
+
+## Key Version Retention Rules
+
+For each user key, the `CompactionIterator` tracks `current_user_key_snapshot_` -- the snapshot boundary that the current version belongs to. The retention decision:
+
+| Condition | Action |
+|-----------|--------|
+| Latest version for this user key | Always KEEP |
+| current_user_key_snapshot_ != last_snapshot (different snapshot boundary than previous version) | KEEP -- this is the first version visible to a new snapshot |
+| current_user_key_snapshot_ == last_snapshot (same snapshot boundary as previous version) | DROP -- shadowed by the previously kept version in the same boundary |
+
+The snapshot boundary for each version is determined by findEarliestVisibleSnapshot(), which uses DefinitelyInSnapshot() rather than a raw sequence comparison. This correctly handles WritePrepared transactions where a key's prepare sequence may be less than a snapshot's sequence without being visible to that snapshot.
+
+### Example
+
+With snapshots at sequence numbers [100, 150, 200] and key "foo" at sequences [250, 180, 120, 90, 80]:
+
+- foo@250: KEEP (latest version, visible at tip)
+- foo@180: KEEP (latest version visible to snapshot 200)
+- foo@120: KEEP (latest version visible to snapshot 150)
+- foo@90: KEEP (latest version visible to snapshot 100)
+- foo@80: DROP (in same snapshot boundary as foo@90, shadowed)
+
+## visible_at_tip_ Optimization
+
+When the snapshots vector is empty, visible_at_tip_ is set to true. In this case, current_user_key_snapshot_ is assigned earliest_snapshot_ directly without binary search, causing all versions except the first of each key to share the same snapshot boundary and thus get dropped. The earliest_snapshot_ value is a parameter passed by the caller (typically the last published sequence number when there are no snapshots), not automatically set to kMaxSequenceNumber.
+
+## preserve_seqno_after_
+
+The `preserve_seqno_after_` field controls the minimum sequence number above which sequence numbers must be preserved (not zeroed out) at the bottommost level. It is typically set to `earliest_snapshot_` but can be overridden by `preserve_seqno_min` for features like sequence-number-based tiered storage (see `preserve_internal_time_seconds` in `ColumnFamilyOptions`). The invariant is `preserve_seqno_after_ <= earliest_snapshot_`.
+
+At the bottommost level, when a key's sequence number is at or below `preserve_seqno_after_` and the key is definitively in the earliest snapshot (or older than all snapshots), the sequence number is zeroed out. This zeroing improves compression ratios and allows future compactions to discard tombstones.
+
+## Deletion Marker Handling
+
+Deletion markers (Delete, SingleDelete) interact with snapshots specially. A deletion marker can be dropped when ALL of the following conditions are met:
+
+1. The compaction is a real compaction (not a flush)
+2. allow_ingest_behind is false for the compaction
+3. The deletion's sequence number is definitively in the earliest snapshot (DefinitelyInSnapshot(seq, earliest_snapshot_) returns true)
+4. The key does not exist in any level beyond the compaction output level (verified via KeyNotExistsBeyondOutputLevel() in db/compaction/compaction.h)
+5. For kTypeDeletionWithTimestamp, the key's timestamp must also be older than full_history_ts_low_
+
+This logic applies at any compaction level, not just non-bottommost levels. If any condition fails, the deletion marker must be preserved because it is needed to shadow older versions that may still be visible to a snapshot or that exist in lower levels.
+
+At the bottommost level specifically, there is an additional code path that handles the case where a deletion marker may skip output even when the key might exist in the same level -- this uses a deferred check that verifies no subsequent Put for the same key appears in the same snapshot stripe.
+
+## Bottommost File Compaction Triggering
+
+When a snapshot is released, previously pinned data in bottommost SST files may become eligible for garbage collection. The mechanism uses `bottommost_files_mark_threshold_` in `VersionStorageInfo` (see `db/version_set.h`):
+
+1. **Threshold tracking** -- Each `VersionStorageInfo` maintains `bottommost_files_mark_threshold_`, defined as the minimum of the maximum nonzero sequence numbers across all unmarked bottommost files
+2. **On snapshot release** -- `DBImpl::ReleaseSnapshot()` calls `UpdateOldestSnapshot()` for each column family
+3. **Mark check** -- If the new oldest snapshot sequence exceeds the threshold, additional bottommost files are marked for compaction
+4. **Compaction scheduling** -- Marked files are enqueued via `EnqueuePendingCompaction()` and `MaybeScheduleFlushOrCompaction()`
+5. **Sequence zeroing** -- When these bottommost files are compacted, sequence numbers below the oldest snapshot can be zeroed out, reducing space amplification
+
+The `oldest_snapshot_seqnum_` field in `VersionStorageInfo` monotonically increases as snapshots are released. When no snapshots remain, it is set to the current sequence number (protected because a new snapshot could still reference it).
+
+## Space Amplification from Snapshots
+
+Each active snapshot potentially keeps one extra version of every key that was modified after the snapshot was taken. The space amplification impact:
+
+- **Without snapshots**: compaction keeps only the latest version of each key
+- **With k snapshots**: compaction keeps up to k+1 versions per key (one per snapshot boundary plus the tip)
+- **Long-lived snapshots**: the oldest snapshot has the largest impact because it prevents dropping the most old versions
+
+The space overhead is proportional to both the number of snapshots and the write rate between them.
+
+### Sequence Number Zeroing and Space Savings
+
+In a well-tuned LSM tree, the majority of data resides at the bottommost level. Without snapshots, compaction zeros out sequence numbers at the bottommost level, which significantly improves compression ratios. Each key stores 8 internal bytes (7 bytes for sequence number, 1 byte for type). Zeroing the sequence number makes these bytes highly compressible because all values become zero, substantially reducing space overhead compared to non-zeroed sequence numbers at non-bottommost levels. Active snapshots that span the bottommost level prevent this zeroing, causing measurable space amplification.

--- a/docs/components/snapshot/06_transactions.md
+++ b/docs/components/snapshot/06_transactions.md
@@ -1,0 +1,59 @@
+# Transaction Integration
+
+**Files:** `db/snapshot_impl.h`, `db/db_impl/db_impl.h`, `db/db_impl/db_impl_compaction_flush.cc`, `utilities/transactions/transaction_base.h`
+
+## Write-Conflict Boundary Snapshots
+
+When a transaction calls `SetSnapshot()`, RocksDB creates a snapshot with `is_write_conflict_boundary_` set to `true` via `GetSnapshotForWriteConflictBoundary()`. This flag tells the compaction system that old key versions visible to this snapshot must be preserved for write-conflict detection.
+
+### How Write-Conflict Boundaries Affect Compaction
+
+`SnapshotList::GetAll()` tracks the `oldest_write_conflict_snapshot` -- the sequence number of the oldest snapshot with `is_write_conflict_boundary_` set to `true`. This is passed to the compaction iterator as `earliest_write_conflict_snapshot`.
+
+The compaction iterator uses this to decide whether old versions of keys tracked by transactions need to be preserved. Without this, compaction could remove old versions that transactions need to detect conflicts.
+
+## SnapshotChecker
+
+`SnapshotChecker` is an interface used by WritePrepared and WriteUnprepared transaction implementations to determine whether a given sequence number is visible within a specific snapshot.
+
+### Why SnapshotChecker Is Needed
+
+In the standard (WriteCommitted) transaction policy, a key's sequence number directly indicates when it became visible. In WritePrepared and WriteUnprepared policies, a key is written to the memtable at prepare time but only becomes visible at commit time. The sequence number in the key is the prepare sequence, not the commit sequence. A `SnapshotChecker` maps from prepare sequence to commit order to determine actual visibility.
+
+### Impact on Compaction
+
+When a `SnapshotChecker` is present, `findEarliestVisibleSnapshot()` in `CompactionIterator` must verify each candidate snapshot by calling `CheckInSnapshot()`. A key may have a sequence number less than a snapshot's sequence but still not be visible to that snapshot if it was prepared but not yet committed at snapshot time.
+
+### InitSnapshotContext and Job Snapshots
+
+`DBImpl::InitSnapshotContext()` in `db/db_impl/db_impl_compaction_flush.cc` handles the snapshot checker's interaction with compaction:
+
+1. Retrieves the `SnapshotChecker` from `snapshot_checker_`
+2. If `use_custom_gc_` is set without a custom checker, uses `DisableGCSnapshotChecker` (which prevents any GC, treating all keys as uncommitted)
+3. If a checker exists, takes an additional snapshot via `GetSnapshotImpl(false, false)` to ensure the compaction sees all snapshots that might be affected by pending transactions
+4. This extra snapshot is wrapped in a `ManagedSnapshot` for automatic cleanup after the compaction job completes
+
+## min_uncommitted_ Field
+
+The `min_uncommitted_` field in `SnapshotImpl` (default `kMinUnCommittedSeq`) records the smallest uncommitted sequence number at the time the snapshot was created. WritePrepared transactions use this to optimize `IsInSnapshot()` queries:
+
+- If a sequence number is less than `min_uncommitted_`, it is guaranteed to be committed and visible in the snapshot
+- This avoids expensive commit table lookups for the common case where most data is committed
+
+## Transaction Snapshot Usage Patterns
+
+Transactions in `TransactionBaseImpl` (see `utilities/transactions/transaction_base.h`) manage snapshots through:
+
+| Method | Behavior |
+|--------|----------|
+| `SetSnapshot()` | Takes a snapshot immediately for conflict detection |
+| `SetSnapshotOnNextOperation()` | Defers snapshot creation until the next write (Put, PutEntity, Merge, Delete), GetForUpdate, or MultiGetForUpdate operation. For WriteCommitted transactions, Commit() also triggers deferred snapshot creation. Plain Get() does NOT trigger it. Optionally notifies via TransactionNotifier |
+| `ClearSnapshot()` | Releases the transaction's snapshot |
+| `GetSnapshot()` | Returns the current snapshot (may be `nullptr` if not set) |
+| `GetTimestampedSnapshot()` | Returns the snapshot as a `shared_ptr` for timestamped snapshot support |
+
+The snapshot_needed_ flag tracks whether SetSnapshotOnNextOperation() has been called. When true, the next operation triggers snapshot creation via the deferred path, and optionally calls TransactionNotifier::SnapshotCreated().
+
+## Monitoring
+
+WritePrepared transactions expose TXN_SNAPSHOT_MUTEX_OVERHEAD in include/rocksdb/statistics.h, which counts the number of times the snapshot mutex is acquired in the fast path. This is useful for diagnosing snapshot-related contention in WritePrepared transaction workloads.

--- a/docs/components/snapshot/07_timestamped_snapshots.md
+++ b/docs/components/snapshot/07_timestamped_snapshots.md
@@ -1,0 +1,79 @@
+# Timestamped Snapshots
+
+**Files:** `db/snapshot_impl.h`, `db/db_impl/db_impl.cc`, `include/rocksdb/utilities/transaction_db.h`, `include/rocksdb/utilities/transaction.h`
+
+## Overview
+
+Timestamped snapshots extend the standard snapshot mechanism by associating each snapshot with a user-defined timestamp (e.g., Hybrid Logical Clock). This enables lookup and range queries by timestamp rather than by sequence number. They are useful for applications that need to access database state at specific wall-clock times or logical timestamps, and critically, they allow consistent reads across multiple RocksDB instances by using the same timestamp on snapshots from different instances (which is impossible with raw sequence numbers since they are instance-local).
+
+Currently, this functionality is exposed through the RocksDB transactions layer (see `TransactionDB::CreateTimestampedSnapshot()` and `Transaction::CommitAndTryCreateSnapshot()`).
+
+## Application-Enforced Ordering Invariant
+
+Applications must ensure that any two timestamped snapshots satisfy: if `snapshot1.seq <= snapshot2.seq` then `snapshot1.ts <= snapshot2.ts`, and vice versa. In other words, timestamp ordering must be consistent with sequence number ordering. Violating this invariant breaks the cross-instance consistency guarantee.
+
+## TimestampedSnapshotList
+
+`TimestampedSnapshotList` in `db/snapshot_impl.h` stores snapshots in a `std::map<uint64_t, std::shared_ptr<const SnapshotImpl>>` ordered by timestamp. This provides O(log n) lookup, insertion, and range queries.
+
+### Differences from SnapshotList
+
+| Aspect | SnapshotList | TimestampedSnapshotList |
+|--------|-------------|------------------------|
+| Indexing | Sequence-number ordered linked list | Timestamp-ordered map |
+| Ownership | Raw pointer (caller owns) | `shared_ptr` (shared ownership) |
+| Lookup | Walk from oldest/newest | O(log n) by timestamp |
+| Primary use | Core snapshot GC mechanism | User-facing timestamp-based access |
+| Deduplication | Allows duplicate sequence numbers | `try_emplace` prevents duplicate timestamps |
+
+Note: Timestamped snapshots are also stored in the regular `SnapshotList` (for compaction GC purposes). The `TimestampedSnapshotList` provides the additional timestamp-based index.
+
+## API
+
+### Creating Timestamped Snapshots
+
+TransactionDB::CreateTimestampedSnapshot() creates a snapshot associated with a specific timestamp. This API requires that no active writes are in progress. The snapshot is added to both the regular SnapshotList (for GC tracking) and the TimestampedSnapshotList (for timestamp-based lookup). The implementation in DBImpl::CreateTimestampedSnapshotImpl() enforces several validation rules:
+
+- Timestamps must be monotonically non-decreasing: if the latest existing timestamped snapshot has a timestamp greater than the requested timestamp, the call returns `InvalidArgument`
+- If the latest snapshot has the same timestamp AND the same sequence number as the request, the existing snapshot is reused (returns a `shared_ptr` to it)
+- If the latest snapshot has the same timestamp but a DIFFERENT sequence number, the call returns `InvalidArgument` (same timestamp, different sequence is not allowed)
+
+Timestamped snapshots are always created with is_write_conflict_boundary_ = true, even for snapshots intended only for reads. This means timestamped snapshots can pin more history than ordinary read-only snapshots because compaction must preserve enough state for transaction conflict detection as well.
+
+They use shared_ptr for shared ownership, but the DB itself retains a shared_ptr in the TimestampedSnapshotList. Dropping the application's shared_ptr does NOT release the snapshot from the SnapshotList. The snapshot remains active until it is explicitly removed from the TimestampedSnapshotList via ReleaseTimestampedSnapshotsOlderThan(), or when the DB is torn down.
+
+### Additional Public APIs
+
+TransactionDB provides several additional APIs for working with timestamped snapshots:
+
+- GetLatestTimestampedSnapshot() -- returns the most recent timestamped snapshot
+- GetAllTimestampedSnapshots() -- returns all timestamped snapshots
+- GetTimestampedSnapshots(ts_lb, ts_ub) -- returns snapshots in the timestamp range [ts_lb, ts_ub)
+- ReleaseTimestampedSnapshotsOlderThan(ts) -- releases all timestamped snapshots with timestamps less than ts
+
+Transaction::CommitAndTryCreateSnapshot() commits the transaction and attempts to create a timestamped snapshot atomically. This is currently only supported for WriteCommitted transactions. Callers must check the returned snapshot pointer -- a transaction can commit successfully without producing a timestamped snapshot if another snapshot already exists at the same timestamp with a different sequence number.
+
+### Looking Up by Timestamp
+
+`TimestampedSnapshotList::GetSnapshot(ts)` supports two modes:
+
+- **Exact lookup**: returns the snapshot at exactly timestamp `ts`, or empty `shared_ptr` if none exists
+- **Latest lookup**: when `ts` is `std::numeric_limits<uint64_t>::max()`, returns the most recent timestamped snapshot (via `rbegin()`)
+
+### Range Queries
+
+`TimestampedSnapshotList::GetSnapshots(ts_lb, ts_ub)` returns all snapshots with timestamps in the half-open range `[ts_lb, ts_ub)`. Uses `lower_bound()` for efficient range scanning.
+
+### Bulk Release
+
+`TimestampedSnapshotList::ReleaseSnapshotsOlderThan(ts, snapshots_to_release)` releases all snapshots with timestamps less than `ts`:
+
+1. Finds the upper bound using `lower_bound(ts)`
+2. Moves all entries from `begin()` to the upper bound into `snapshots_to_release`
+3. Erases the moved entries from the map
+
+The snapshots are moved to the output container rather than released inline because the actual `SnapshotList::Delete()` call requires holding the DB mutex. The caller handles the actual release.
+
+## Thread Safety
+
+All operations on `TimestampedSnapshotList` must be protected by the DB mutex, as stated in the class documentation. The `shared_ptr` ownership model allows safe sharing of snapshot references across threads after the mutex is released, but the container operations themselves are not thread-safe.

--- a/docs/components/snapshot/08_monitoring_and_best_practices.md
+++ b/docs/components/snapshot/08_monitoring_and_best_practices.md
@@ -1,0 +1,98 @@
+# Monitoring and Best Practices
+
+**Files:** `db/internal_stats.cc`, `db/db_impl/db_impl.cc`, `include/rocksdb/db.h`
+
+## DB Properties for Snapshot Monitoring
+
+RocksDB exposes snapshot-related metrics through `DB::GetProperty()`:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `rocksdb.num-snapshots` | uint64 | Number of active snapshots in the `SnapshotList` |
+| `rocksdb.oldest-snapshot-time` | uint64 | Unix timestamp (seconds since epoch) of the oldest active snapshot. Returns 0 if no snapshots exist. |
+| `rocksdb.oldest-snapshot-sequence` | int64 | Sequence number of the oldest active snapshot. Returns 0 if no snapshots exist. |
+
+These properties read directly from the `SnapshotList` under the DB mutex.
+
+### PerfContext Counter
+
+PerfContext provides get_snapshot_time (in include/rocksdb/perf_context.h), which measures the total nanoseconds spent on acquiring snapshots. This is useful for profiling snapshot overhead in read-heavy workloads.
+
+### Using Properties for Diagnosis
+
+- **High `num-snapshots`**: May indicate snapshot leaks (forgotten `ReleaseSnapshot()` calls)
+- **Old `oldest-snapshot-time`**: A snapshot held for hours or days blocks GC across the entire database, causing space amplification
+- **Gap between `oldest-snapshot-sequence` and current sequence**: The larger the gap, the more old key versions are pinned. A large gap with high write throughput means significant space overhead.
+
+## Space Amplification Diagnosis
+
+### Symptoms
+
+- Disk usage grows unexpectedly even though the logical data size is stable
+- Compaction runs but does not reclaim expected space
+- `rocksdb.estimate-live-data-size` is much smaller than actual disk usage
+
+### Root Cause Analysis
+
+1. Check `rocksdb.num-snapshots` and `rocksdb.oldest-snapshot-time`
+2. If a snapshot is hours or days old, it is likely the cause
+3. Each active snapshot pins up to one additional version of every key modified after the snapshot was taken
+4. With k snapshots and n keys modified between snapshots, worst-case extra storage is O(k * n * average_value_size)
+
+### Mitigation Strategies
+
+- Release snapshots as soon as they are no longer needed
+- Use `ManagedSnapshot` for RAII-based lifecycle management to prevent leaks
+- Set application-level timeouts for snapshot-holding operations
+- Monitor `oldest-snapshot-time` and alert when snapshots exceed a configured age threshold
+- Consider using `DB::GetProperty("rocksdb.num-snapshots")` in health checks
+
+## Common Pitfalls
+
+### Forgotten Snapshot Release
+
+Acquiring a snapshot via `GetSnapshot()` without a corresponding `ReleaseSnapshot()` causes a resource leak. The snapshot remains in the `SnapshotList` indefinitely, preventing GC. Use `ManagedSnapshot` to avoid this.
+
+### Using Snapshot After Release
+
+Calling `ReleaseSnapshot()` frees the `SnapshotImpl` object. Any subsequent use of the pointer (e.g., setting it in `ReadOptions`) results in undefined behavior. Clear the pointer after release to prevent accidental reuse.
+
+### Long-Lived Snapshots in Production
+
+Snapshots held for extended periods (hours or days) block compaction across the entire database. Even if only a few keys are read through the snapshot, ALL keys modified after the snapshot are pinned. This is a common source of unexpected disk usage growth.
+
+### Snapshot with inplace_update_support
+
+Snapshot support is tracked at DB scope via is_snapshot_supported_. If any live column family's memtable does not support snapshots (most commonly because inplace_update_support is enabled, or because a custom MemTableRep returns false from IsSnapshotSupported()), GetSnapshot() returns nullptr for the entire DB. Applications must check for nullptr return values.
+
+## Performance Characteristics
+
+| Operation | Time Complexity | Lock Required |
+|-----------|----------------|---------------|
+| `GetSnapshot()` | O(1) | DB mutex |
+| `ReleaseSnapshot()` | O(num_column_families) worst case | DB mutex |
+| `SnapshotList::GetAll()` | O(num_snapshots) | DB mutex |
+| Reading with snapshot | O(1) additional cost | None |
+| Compaction GC decision per key | O(log num_snapshots) without SnapshotChecker; up to O(num_snapshots) with SnapshotChecker | None |
+
+### Memory Overhead
+
+- Per snapshot: one SnapshotImpl object containing pointers, sequence number, timestamps, and flags
+- Negligible for typical workloads with fewer than 1000 active snapshots
+- The indirect space cost (pinned old key versions on disk) dominates the direct memory cost
+
+### Impact on Write Throughput
+
+Snapshot consistency requires strict write ordering: a write is only visible to readers when all updates with smaller sequence numbers have been applied to the memtable. This ordering is necessary for snapshot reads (both explicit and implicit via iterators) to return consistent results. This is a deliberate design trade-off: RocksDB prioritizes read consistency over maximum write throughput. WritePrepared transactions provide an alternative path that reduces this overhead by using a commit table instead of strict sequence ordering.
+
+### Impact on Compaction Throughput
+
+Snapshots do not slow down compaction execution. The per-key cost is a binary search over the snapshot vector, which is O(log k) for k snapshots. However, snapshots increase the amount of data that compaction must preserve, which increases compaction I/O and output file sizes.
+
+### Scalability: Very High Snapshot Counts
+
+The `SnapshotList` is a linked list that cannot be binary-searched directly. Before each flush/compaction job, `SnapshotList::GetAll()` linearly scans the entire list and copies sequence numbers into a sorted vector. The compaction iterator then uses the vector for O(log n) binary search per key.
+
+This design works well for typical workloads, but when snapshot count reaches the hundreds of thousands, the linear scan during `GetAll()` can significantly slow down flush/compaction job setup, potentially causing write stalls. The vector copy is a space-time trade-off: it trades O(n) memory per compaction job for O(log n) per-key lookup instead of O(n) per-key linked list traversal.
+
+Applications that create many short-lived snapshots should monitor `rocksdb.num-snapshots` and ensure that snapshot release keeps pace with creation.

--- a/docs/components/snapshot/index.md
+++ b/docs/components/snapshot/index.md
@@ -1,0 +1,39 @@
+# RocksDB Snapshots
+
+## Overview
+
+A Snapshot represents a point-in-time view of the database. Snapshots enable consistent reads across multiple operations without blocking concurrent writes. They are implemented as a doubly-linked list of sequence numbers maintained under DB mutex protection. For compaction styles that run through the snapshot-aware CompactionIterator (Level, Universal), snapshots pin old key versions by preventing compaction from deleting data visible to any active snapshot. FIFO compaction does not honor snapshots because it operates at file granularity without key-level filtering.
+
+**Key source files:** `include/rocksdb/snapshot.h`, `db/snapshot_impl.h`, `db/snapshot_impl.cc`, `db/db_impl/db_impl.cc`
+
+## Chapters
+
+| Chapter | File | Summary |
+|---------|------|---------|
+| 1. Public API | [01_public_api.md](01_public_api.md) | `Snapshot` abstract class, `ManagedSnapshot` RAII wrapper, `DB::GetSnapshot()` / `DB::ReleaseSnapshot()`, and `ReadOptions::snapshot` usage. |
+| 2. Data Structures | [02_data_structures.md](02_data_structures.md) | `SnapshotImpl` fields, `SnapshotList` circular doubly-linked list, `GetAll()` for compaction, and `TimestampedSnapshotList` map. |
+| 3. Snapshot Lifecycle | [03_lifecycle.md](03_lifecycle.md) | `GetSnapshotImpl()` and `ReleaseSnapshot()` workflows, DB mutex requirements, sequence number assignment, and post-release compaction scheduling. |
+| 4. Snapshots and Reads | [04_reads.md](04_reads.md) | Sequence number visibility filtering, explicit vs. implicit snapshots, iterator snapshot semantics, and SuperVersion ordering. |
+| 5. Snapshots and Compaction | [05_compaction.md](05_compaction.md) | How snapshots prevent garbage collection, `findEarliestVisibleSnapshot()` binary search, `visible_at_tip_` optimization, and bottommost file compaction triggering. |
+| 6. Transaction Integration | [06_transactions.md](06_transactions.md) | Write-conflict boundary snapshots, `SnapshotChecker` for WritePrepared/WriteUnprepared transactions, and `min_uncommitted_` scope limiting. |
+| 7. Timestamped Snapshots | [07_timestamped_snapshots.md](07_timestamped_snapshots.md) | `TimestampedSnapshotList`, timestamp-indexed lookup, range queries, bulk release, and shared ownership model. |
+| 8. Monitoring and Best Practices | [08_monitoring_and_best_practices.md](08_monitoring_and_best_practices.md) | DB properties for snapshot monitoring, space amplification diagnosis, common pitfalls, and operational guidance. |
+
+## Key Characteristics
+
+- **Sequence-number based**: Each snapshot captures the database state at a specific monotonically increasing sequence number
+- **Immutable public interface**: Snapshot public accessors are read-only after creation, safe for concurrent access without synchronization. Internally, WritePrepared transactions may mutate min_uncommitted_ immediately after creation via EnhanceSnapshot()
+- **Doubly-linked list**: Snapshots are stored in a circular doubly-linked list ordered by ascending sequence number
+- **O(1) create/delete**: Insertion at tail and unlinking from list are constant-time operations
+- **DB mutex protected**: All list modifications require holding the DB mutex
+- **Pin old versions**: Active snapshots prevent compaction from deleting key versions visible to any snapshot (except FIFO compaction, which ignores snapshots)
+- **Implicit snapshots for iterators**: Iterators without an explicit snapshot use the latest sequence number at creation time
+- **Transaction support**: Write-conflict boundary snapshots and `SnapshotChecker` enable snapshot isolation in TransactionDB
+
+## Key Invariants
+
+- Snapshots in the list are ordered by ascending sequence number
+- All `SnapshotList` modifications must be protected by DB mutex
+- Snapshot public accessors are immutable after creation (number_ is const after SnapshotList::New()). WritePrepared transactions may set min_uncommitted_ after creation via EnhanceSnapshot() before the snapshot is used
+- For each user key, compaction keeps the latest version visible at each snapshot boundary plus the latest version overall
+- is_snapshot_supported_ is false when any column family's memtable does not support snapshots (either because inplace_update_support is enabled or because the MemTableRep returns false from IsSnapshotSupported()); GetSnapshot() returns nullptr

--- a/docs/components/transaction/01_types_and_models.md
+++ b/docs/components/transaction/01_types_and_models.md
@@ -1,0 +1,86 @@
+# Transaction Types and Models
+
+**Files:** `include/rocksdb/utilities/transaction.h`, `include/rocksdb/utilities/transaction_db.h`, `include/rocksdb/utilities/optimistic_transaction_db.h`, `utilities/transactions/transaction_base.h`, `utilities/transactions/pessimistic_transaction.h`, `utilities/transactions/optimistic_transaction.h`
+
+## Class Hierarchy
+
+The transaction subsystem has a layered class hierarchy:
+
+| Class | Role |
+|-------|------|
+| `Transaction` | Abstract public API (see `include/rocksdb/utilities/transaction.h`) |
+| `TransactionBaseImpl` | Base implementation with WriteBatchWithIndex, lock tracking, save points |
+| `PessimisticTransaction` | Adds lock acquisition, expiration, deadlock detection |
+| `WriteCommittedTxn` | Writes data at commit time (default) |
+| `WritePreparedTxn` | Writes data at prepare time |
+| `WriteUnpreparedTxn` | Writes data before prepare (extends `WritePreparedTxn`) |
+| `OptimisticTransaction` | Validation-based concurrency (no locks during execution) |
+
+The database wrappers follow a parallel hierarchy:
+
+| Class | Role |
+|-------|------|
+| `TransactionDB` | Abstract pessimistic transactional DB API |
+| `PessimisticTransactionDB` | Base for lock-based transactional DBs |
+| `WriteCommittedTxnDB` | Factory for `WriteCommittedTxn` |
+| `WritePreparedTxnDB` | Factory for `WritePreparedTxn`, owns CommitCache and PreparedHeap |
+| `WriteUnpreparedTxnDB` | Factory for `WriteUnpreparedTxn` (extends `WritePreparedTxnDB`) |
+| `OptimisticTransactionDB` | Abstract optimistic transactional DB API |
+| `OptimisticTransactionDBImpl` | Factory for `OptimisticTransaction` |
+
+## Pessimistic Transactions
+
+Pessimistic transactions acquire locks during execution to prevent conflicts. When a transaction calls `Put()`, `Delete()`, or `GetForUpdate()`, the lock is acquired immediately via the lock manager. If the lock is unavailable, the transaction blocks until it becomes available or a timeout is reached.
+
+**Opening a pessimistic transactional DB:**
+
+Step 1: Call `TransactionDB::Open()` with `Options`, `TransactionDBOptions`, and a DB path. Step 2: The write policy is selected via `TransactionDBOptions::write_policy` (default: `WRITE_COMMITTED`). Step 3: The lock manager is created based on `TransactionDBOptions::lock_mgr_handle` (default: point lock manager).
+
+**Key properties:**
+- Locks prevent conflicting concurrent writes
+- Blocking behavior when lock unavailable (configurable timeout)
+- Deadlock detection available (optional, per-transaction)
+- Three write policies: WriteCommitted, WritePrepared, WriteUnprepared
+- Supports two-phase commit for distributed transactions
+
+## Optimistic Transactions
+
+Optimistic transactions do not acquire locks during execution. Instead, they track which keys were written and validate at commit time that no conflicts occurred.
+
+**Opening an optimistic transactional DB:**
+
+Step 1: Call `OptimisticTransactionDB::Open()` with `Options`, optional `OptimisticTransactionDBOptions`, and a DB path. Step 2: The validation policy is selected via `OptimisticTransactionDBOptions::validate_policy` (default: `kValidateParallel`).
+
+**Key properties:**
+- No locks during execution -- lower per-operation overhead
+- Validation at commit checks for write-write conflicts using sequence number comparison
+- Returns `Status::Busy()` or `Status::TryAgain()` on conflict; caller must retry
+- Best for workloads with infrequent conflicts
+- Does NOT support `DeleteRange` (returns `Status::NotSupported()`)
+
+Note: `OptimisticTransactionDB::BeginTransaction()` takes `OptimisticTransactionOptions` (not `TransactionOptions`). This struct has `set_snapshot` and `cmp` fields only.
+
+## Choosing Between Models
+
+| Factor | Pessimistic | Optimistic |
+|--------|-------------|------------|
+| Lock overhead | Per-write lock acquisition | None during execution |
+| Conflict handling | Blocking (waits for lock) | Retry on conflict at commit |
+| Wasted work on conflict | Minimal (blocks early) | Full transaction wasted |
+| Memory overhead | Lock table per CF | Tracked keys for validation |
+| Best for | High-conflict workloads | Low-conflict workloads |
+| 2PC support | Yes | No (Prepare returns InvalidArgument) |
+| Range locks | Yes (with range lock manager) | No |
+| Write policies | WriteCommitted, WritePrepared, WriteUnprepared | N/A (always write-at-commit) |
+
+## Common Base: TransactionBaseImpl
+
+Both pessimistic and optimistic transactions share common infrastructure through `TransactionBaseImpl` (see `utilities/transactions/transaction_base.h`):
+
+- **WriteBatchWithIndex** (`write_batch_`): Buffers pending writes with an index for read-your-own-writes
+- **LockTracker** (`tracked_locks_`): Tracks acquired locks (pessimistic) or write intentions (optimistic)
+- **Save points** (`save_points_`): Stack of transaction state snapshots for partial rollback
+- **Snapshot** (`snapshot_`): Optional read snapshot for isolation
+- **Operation counters**: `num_puts_`, `num_deletes_`, `num_merges_`, `num_put_entities_`
+
+The `TryLock()` method is the key extension point: pessimistic transactions acquire real locks; optimistic transactions merely record the key for later validation.

--- a/docs/components/transaction/02_write_policies.md
+++ b/docs/components/transaction/02_write_policies.md
@@ -1,0 +1,85 @@
+# Write Policies
+
+**Files:** `utilities/transactions/pessimistic_transaction_db.h`, `utilities/transactions/pessimistic_transaction.cc`, `utilities/transactions/write_prepared_txn.h`, `utilities/transactions/write_unprepared_txn.h`, `include/rocksdb/utilities/transaction_db.h`
+
+## Overview
+
+The write policy determines when transaction data is written to the memtable. It is configured via `TransactionDBOptions::write_policy` (see `TxnDBWritePolicy` enum in `include/rocksdb/utilities/transaction_db.h`).
+
+| Policy | When data is written | Commit phase | Memory usage | Maturity |
+|--------|---------------------|--------------|--------------|----------|
+| `WRITE_COMMITTED` (default) | At commit time | Heavy (writes data) | Buffers all writes | Most mature |
+| `WRITE_PREPARED` | At prepare time | Light (writes marker) | Buffers all writes | Experimental |
+| `WRITE_UNPREPARED` | During execution | Light (writes marker) | Minimal (flushes to DB) | Experimental |
+
+## WriteCommitted
+
+`WriteCommittedTxnDB` and `WriteCommittedTxn` (see `utilities/transactions/pessimistic_transaction_db.h` and `utilities/transactions/pessimistic_transaction.h`).
+
+**Data flow:**
+
+Step 1: `Put("k1", "v1")` -- buffered in `WriteBatchWithIndex` in memory. Step 2: `Put("k2", "v2")` -- buffered in `WriteBatchWithIndex` in memory. Step 3: `Commit()` -- entire batch written to WAL and memtable atomically via `DBImpl::WriteImpl()`.
+
+**Advantages:**
+- Simplest implementation; uncommitted data never visible to other transactions
+- Supports all features including user-defined timestamps
+- Rollback is trivial (discard the in-memory batch)
+
+**Disadvantages:**
+- High memory usage for large transactions (all writes buffered)
+- Commit phase is heavyweight (all data written at once)
+- In 2PC with serial commits (e.g., MySQL), commit latency is a throughput bottleneck
+
+## WritePrepared
+
+`WritePreparedTxnDB` and `WritePreparedTxn` (see `utilities/transactions/write_prepared_txn_db.h` and `utilities/transactions/write_prepared_txn.h`).
+
+**Data flow:**
+
+Step 1: `Put("k1", "v1")` -- buffered in `WriteBatchWithIndex` in memory. Step 2: `Prepare()` -- batch written to WAL + memtable. Data tagged with `prepare_seq`. Added to `PreparedHeap`. Step 3: `Commit()` -- commit marker written to WAL only. Mapping `(prepare_seq -> commit_seq)` added to CommitCache. Removed from PreparedHeap.
+
+**Key difference from WriteCommitted:** The commit phase only writes a small marker to WAL and updates an in-memory commit map. It does NOT write data to memtable. This is the defining optimization.
+
+**Dual write queue optimization:** When `two_write_queues` is enabled in `DBOptions` (recommended for WritePrepared but not the default; `DBOptions::two_write_queues` defaults to `false`), prepare writes go through the main write queue (WAL + memtable) and commits go through a second queue (WAL only). This prevents commit writes from blocking behind prepare writes.
+
+**Visibility:** Data written at prepare time is in the memtable but not yet visible. Readers use `WritePreparedTxnDB::IsInSnapshot()` to check whether a value's `prepare_seq` has been committed before the reader's snapshot. See chapter 6 for the full algorithm.
+
+## WriteUnprepared
+
+`WriteUnpreparedTxnDB` and `WriteUnpreparedTxn` (see `utilities/transactions/write_unprepared_txn_db.h` and `utilities/transactions/write_unprepared_txn.h`).
+
+**Data flow:**
+
+Step 1: `Put()` -- if write batch size exceeds `write_batch_flush_threshold`, flush to DB with `kTypeBeginUnprepareXID` marker. Record sequence number in `unprep_seqs_`. Step 2: More `Put()` operations -- continue flushing when threshold exceeded. Step 3: `Prepare()` -- flush remaining batch with `kTypeBeginPersistedPrepareXID`. Step 4: `Commit()` -- write commit marker. Pre-release callback updates CommitCache for all entries in `unprep_seqs_`.
+
+**Key difference from WritePrepared:** Data is written to the DB incrementally BEFORE prepare, not at prepare time. This allows transactions of arbitrary size without memory constraints.
+
+**Configuration:** The flush threshold is controlled by `TransactionDBOptions::default_write_batch_flush_threshold` (DB-level default) or `TransactionOptions::write_batch_flush_threshold` (per-transaction override). Default is 0 (disabled).
+
+## WAL Markers
+
+Each write policy uses different WAL record type markers:
+
+| Marker | Used by | Purpose |
+|--------|---------|---------|
+| `kTypeBeginPrepareXID` | WriteCommitted | Start of prepared batch (non-persisted prepare) |
+| `kTypeBeginPersistedPrepareXID` | WritePrepared, WriteUnprepared | Start of prepared batch (persisted prepare) |
+| `kTypeBeginUnprepareXID` | WriteUnprepared | Start of unprepared batch (data flushed before prepare) |
+| `kTypeEndPrepareXID` | All (2PC) | End of prepared section, contains transaction name |
+| `kTypeCommitXID` | All (2PC) | Commit marker, contains transaction name |
+| `kTypeRollbackXID` | WritePrepared, WriteUnprepared | Rollback marker |
+
+Important: The WAL format differs between WriteCommitted and WritePrepared/WriteUnprepared. Switching write policies requires emptying the WAL first (flush the DB).
+
+## Write Policy Comparison
+
+| Aspect | WriteCommitted | WritePrepared | WriteUnprepared |
+|--------|---------------|---------------|-----------------|
+| Data in memtable | Only after commit | After prepare | During execution |
+| Commit cost | Heavy (data + WAL) | Light (WAL marker in common case) | Light (WAL marker in common case) |
+| Memory for writes | Unbounded | Unbounded | Bounded by flush threshold |
+| Rollback | Discard batch | Write compensating entries | Write compensating entries |
+| Visibility tracking | Not needed | CommitCache + PreparedHeap | CommitCache + PreparedHeap + unprep_seqs |
+| User-defined timestamps | Supported | Not supported | Not supported |
+| Read overhead | None | ~1% (IsInSnapshot check) | ~1% + read-your-own-writes overhead |
+| 2PC recovery | Replays from WAL | Rebuilds CommitCache | Rebuilds CommitCache + unprep_seqs |

--- a/docs/components/transaction/03_lock_management.md
+++ b/docs/components/transaction/03_lock_management.md
@@ -1,0 +1,90 @@
+# Lock Management
+
+**Files:** `utilities/transactions/lock/lock_manager.h`, `utilities/transactions/lock/lock_tracker.h`, `utilities/transactions/lock/point/point_lock_manager.h`, `utilities/transactions/lock/point/point_lock_manager.cc`, `utilities/transactions/lock/range/range_tree/range_tree_lock_manager.h`
+
+## Lock Manager Architecture
+
+The lock manager is an abstraction layer defined by the `LockManager` interface (see `utilities/transactions/lock/lock_manager.h`). It supports both point locks (individual keys) and range locks (key ranges).
+
+The lock manager is selected at `TransactionDB::Open()` time via `NewLockManager()`. Custom `lock_mgr_handle` takes highest precedence; otherwise RocksDB chooses between `PointLockManager` and `PerKeyPointLockManager`:
+- **Custom `lock_mgr_handle` provided:** Uses the provided lock manager unconditionally (e.g., `RangeTreeLockManager`)
+- **No custom handle, `use_per_key_point_lock_mgr = true`:** Creates a `PerKeyPointLockManager` (experimental)
+- **No custom handle, default:** Creates a `PointLockManager`
+
+The factory function `NewLockManager()` in `utilities/transactions/lock/lock_manager.cc` handles this selection.
+
+## Point Lock Manager
+
+The `PointLockManager` (see `utilities/transactions/lock/point/point_lock_manager.h`) uses a striped hash table design for scalable concurrent locking.
+
+**Data structure layout:**
+
+`PointLockManager` contains a map of `LockMap` per column family. Each `LockMap` is divided into `num_stripes` stripes. Each stripe (`LockMapStripe`) has its own mutex and a hash map from key to `LockInfo`. A key is assigned to a stripe via `Hash(key) % num_stripes`.
+
+**LockInfo** (defined in `utilities/transactions/lock/point/point_lock_manager.cc`) contains:
+- `exclusive`: whether the lock is exclusive
+- `txn_ids`: list of transaction IDs holding the lock (multiple for shared locks)
+- `expiration_time`: when the lock expires (microseconds)
+- `waiter_queue`: per-key waiter queue of `KeyLockWaiter` objects (lazily allocated; used only by `PerKeyPointLockManager`, not populated by the default `PointLockManager`)
+
+**Lock acquisition flow:**
+
+Step 1: Hash the key to determine the stripe. Step 2: Acquire the stripe mutex. Step 3: Look up the key in the stripe's map. Step 4: If lock is available (no conflicting holders), add transaction to holders and return OK. Step 5: If not available, check if the holder's lock has expired. If expired, steal it. Step 6: If still not available and deadlock detection is enabled, call `IncrementWaiters()` to check for cycles. Step 7: Wait on the stripe's condition variable with timeout. Step 8: When woken (by lock release or timeout), recheck availability.
+
+Note: The default `PointLockManager` waits on stripe-level condition variables. All waiters for keys in the same stripe share the same condition variable. The `PerKeyPointLockManager` uses per-key waiter queues instead (see below).
+
+**Lock types:**
+- **Shared (read) lock**: Granted if no exclusive lock is held. Multiple shared locks can coexist.
+- **Exclusive (write) lock**: Granted only if no other locks are held.
+- **Lock upgrade** (shared to exclusive): Supported in-place only when the upgrading transaction is the sole shared holder. Otherwise, the transaction blocks until other shared holders release. May deadlock if two transactions both hold shared locks and try to upgrade simultaneously.
+
+**Configuration** (in `TransactionDBOptions`):
+- `num_stripes` (default 16): Number of lock map stripes per column family. Higher values reduce contention but increase memory. A value of 0 is treated as 1.
+- `max_num_locks` (default -1, no limit): Maximum total locked keys per column family. Returns `Status::Aborted()` (check via `Status::IsLockLimit()`) when exceeded.
+- `transaction_lock_timeout` (default 1000ms): Default wait timeout for lock acquisition.
+- `default_lock_timeout` (default 1000ms): Timeout for non-transactional writes (DB::Put, etc.).
+
+**Thread-local cache optimization:** Lock map lookups are cached in thread-local storage (`lock_maps_cache_`) to avoid acquiring `lock_map_mutex_` on every lock operation.
+
+## Per-Key Point Lock Manager
+
+The `PerKeyPointLockManager` (see `utilities/transactions/lock/point/point_lock_manager.h`) is an experimental variant that provides per-key waiter queues instead of shared stripe condition variables. This eliminates the thundering herd problem where unrelated waiters are woken when a lock is released.
+
+**Key differences from default `PointLockManager`:**
+- Per-key `KeyLockWaiter` queues: each lock has a dedicated waiter queue (`std::list<KeyLockWaiter*>`) for transactions waiting on that specific key
+- Lock upgrade priority: upgrade waiters are inserted at the head of the waiter queue via `JoinWaitQueue(isUpgrade=true)`
+- Delayed deadlock detection: supports `deadlock_timeout_us` to wait briefly before performing deadlock detection (the default `PointLockManager` ignores `deadlock_timeout_us`)
+- Wake-up efficiency: `TryWakeUpNextWaiters` wakes consecutive shared-lock waiters until it hits an exclusive waiter, avoiding unnecessary wake-ups
+- Thread-local `KeyLockWaiter` optimization: reuses waiter objects via `ThreadLocalPtr` since a thread can only wait on one lock at a time
+
+## Range Lock Manager
+
+The `RangeTreeLockManager` (see `utilities/transactions/lock/range/range_tree/range_tree_lock_manager.h`) supports locking key ranges `[start, end]` using an interval tree from the ported TokuDB lock tree library.
+
+**Key features:**
+- Range locks prevent phantom reads for range queries
+- Lock escalation: when lock memory exceeds `SetMaxLockMemory()`, adjacent locks are merged into coarser ranges
+- Escalation barrier function (`SetEscalationBarrierFunc()`): prevents escalation across application-defined boundaries
+- Memory tracking via `Counters::current_lock_memory`
+
+**Using range locks:**
+
+Step 1: Create a range lock manager via `NewRangeLockManager()`. Step 2: Pass it to `TransactionDBOptions::lock_mgr_handle`. Step 3: Open the DB with `TransactionDB::Open()`. Step 4: Call `Transaction::GetRangeLock()` to acquire range locks.
+
+Note: `max_num_locks` applies only to the point lock manager. Range lock memory is controlled via `RangeLockManagerHandle::SetMaxLockMemory()`.
+
+## Lock Tracker
+
+The `LockTracker` interface (see `utilities/transactions/lock/lock_tracker.h`) is used by transactions to track their lock state. For pessimistic transactions, it tracks actually acquired locks. For optimistic transactions, it tracks lock intentions for commit-time validation.
+
+The `LockTrackerFactory` creates tracker instances. Each lock manager type provides its own factory (e.g., `PointLockTrackerFactory`).
+
+Key operations: `Track()` records a lock acquisition, `Untrack()` removes it, `Merge()` combines two trackers, `Subtract()` removes one tracker's entries from another.
+
+## Lock Expiration
+
+Transaction locks can expire based on `TransactionOptions::expiration` (point lock manager only):
+- When a lock's expiration time passes, other transactions can "steal" it via `TryStealingExpiredTransactionLocks()` in the point lock acquisition path
+- The expired transaction transitions to `LOCKS_STOLEN` state
+- Subsequent operations on the expired transaction return `Status::Expired()`, particularly on `Prepare()` and `Commit()`
+- See `PessimisticTransactionDB::TryStealingExpiredTransactionLocks()` in `utilities/transactions/pessimistic_transaction_db.h`

--- a/docs/components/transaction/04_deadlock_detection.md
+++ b/docs/components/transaction/04_deadlock_detection.md
@@ -1,0 +1,75 @@
+# Deadlock Detection
+
+**Files:** `utilities/transactions/lock/point/point_lock_manager.h`, `utilities/transactions/lock/point/point_lock_manager.cc`
+
+## Overview
+
+Deadlock detection identifies circular wait dependencies among transactions. It is implemented in the `PointLockManager` using a wait-for graph and BFS-based cycle detection. The `RangeTreeLockManager` also reports deadlocks through locktree callbacks, translating them into the same public `GetDeadlockInfoBuffer()` format.
+
+Deadlock detection is optional and configured per-transaction via `TransactionOptions::deadlock_detect` (default `false`). When enabled, the lock manager checks for cycles before blocking on a lock.
+
+## Wait-For Graph
+
+The wait-for graph is maintained using two data structures in `PointLockManager`:
+
+**`wait_txn_map_`** (`HashMap<TransactionID, TrackedTrxInfo>`): Maps each waiting transaction to a `TrackedTrxInfo` containing:
+- `m_neighbors`: the blocking transaction IDs
+- `m_cf_id`: column family of the contended key
+- `m_exclusive`: whether the requested lock is exclusive
+- `m_waiting_key`: the key being waited on
+
+**`rev_wait_txn_map_`** (`HashMap<TransactionID, int>`): Reverse mapping from each blocking transaction to the count of transactions waiting on it. Used for efficient cleanup.
+
+## Cycle Detection Algorithm
+
+When a transaction encounters a lock conflict and `deadlock_detect` is true, the lock manager calls `IncrementWaiters()`:
+
+Step 1: Add wait edges to `wait_txn_map_` (waiting txn -> blocking txn IDs). Step 2: Increment `rev_wait_txn_map_` counts for each blocking transaction. Step 3: Perform BFS from the waiting transaction following edges in `wait_txn_map_`, using a queue with head/tail indices. Step 4: If the BFS revisits the original waiting transaction, a cycle (deadlock) is detected. Step 5: If cycle found, record it in `DeadlockInfoBuffer`, call `DecrementWaiters()`, and return true.
+
+The BFS depth is bounded by `TransactionOptions::deadlock_detect_depth` (default 50) to prevent expensive searches in large wait-for graphs.
+
+## Deadlock Info Buffer
+
+The `DeadlockInfoBuffer` (see `utilities/transactions/lock/point/point_lock_manager.h`) is a circular buffer that stores recent deadlock incidents for debugging and monitoring.
+
+- Size controlled by `TransactionDBOptions::max_num_deadlocks` (default 5)
+- Each entry contains a `DeadlockPath` with the cycle of `DeadlockInfo` entries
+- Accessible via `TransactionDB::GetDeadlockInfoBuffer()`
+- Can be resized at runtime via `TransactionDB::SetDeadlockInfoBufferSize()`
+
+Each `DeadlockInfo` entry records:
+- `m_txn_id`: the transaction in the cycle
+- `m_cf_id`: column family of the contended key
+- `m_exclusive`: lock type requested
+- `m_waiting_key`: the key being waited on
+
+## Deadlock Timeout
+
+`TransactionOptions::deadlock_timeout_us` (default 500 microseconds) controls the delay before performing deadlock detection.
+
+Important: In the default `PointLockManager`, `deadlock_timeout_us` is ignored -- deadlock detection always runs immediately when `deadlock_detect` is true. The delayed detection behavior (wait briefly, then detect) is implemented only by `PerKeyPointLockManager`. This allows:
+- Setting to 0: immediate deadlock detection on every lock conflict
+- Setting higher: transaction waits briefly first, performing detection only if the lock is not released quickly
+
+The deadlock timeout is automatically capped at the lock timeout value: `deadlock_timeout_us_ = min(deadlock_timeout_us, lock_timeout_)`.
+
+## Lock Timeout vs. Deadlock Detection
+
+Both mechanisms can be enabled simultaneously:
+
+| Mechanism | Trigger | Result | Best for |
+|-----------|---------|--------|----------|
+| Lock timeout | Lock not acquired within timeout | `Status::TimedOut()` | Simple workloads |
+| Deadlock detection | Circular wait detected | `Status::Busy(SubCode::kDeadlock)` | Complex lock patterns |
+
+When both are enabled, deadlock detection fires first (faster detection), while lock timeout acts as a safety net for non-deadlock contention.
+
+## Internal Lock Ordering
+
+The point lock manager enforces an internal lock ordering to avoid deadlocking itself:
+
+1. `lock_map_mutex_` (protects `lock_maps_`)
+2. Stripe mutexes in ascending column family ID, then ascending stripe order
+3. `wait_txn_map_mutex_` (protects wait-for graph)
+
+Note: In the default `PointLockManager`, `IncrementWaiters()` is called while the stripe mutex is still held. The `wait_txn_map_mutex_` is acquired inside `IncrementWaiters()`, maintaining the lock ordering.

--- a/docs/components/transaction/05_two_phase_commit.md
+++ b/docs/components/transaction/05_two_phase_commit.md
@@ -1,0 +1,86 @@
+# Two-Phase Commit
+
+**Files:** `utilities/transactions/pessimistic_transaction.cc`, `utilities/transactions/pessimistic_transaction_db.cc`, `include/rocksdb/utilities/transaction.h`, `include/rocksdb/utilities/transaction_db.h`
+
+## Overview
+
+Two-phase commit (2PC) enables distributed transaction coordination across multiple RocksDB instances or with external systems. It separates the transaction lifecycle into a prepare phase (durability guarantee) and a commit phase (visibility).
+
+## Protocol
+
+**Phase 1: Prepare**
+
+Step 1: Validate that the transaction is in `STARTED` state. Step 2: If `skip_prepare` is false and the transaction has no name, return `Status::InvalidArgument()`. Step 3: Call `PrepareInternal()` which writes the transaction data to WAL with prepare markers. Step 4: Record the WAL log number containing the prepare section. Step 5: Transition state to `PREPARED`.
+
+**Phase 2: Commit**
+
+Step 1: If not yet prepared and `skip_prepare` is false, return `Status::TxnNotPrepared()`. Step 2: If not prepared and `skip_prepare` is true, call `CommitWithoutPrepareInternal()`. Step 3: Otherwise, call `CommitInternal()` which writes a commit marker to WAL. Step 4: Release all locks. Step 5: Transition state to `COMMITTED`.
+
+## WAL Record Layout
+
+For a 2PC transaction using WriteCommitted:
+
+```
+kTypeBeginPrepareXID
+  kTypePut(cf, key1, value1)
+  kTypeDelete(cf, key2)
+kTypeEndPrepareXID(txn_name)
+... other writes ...
+kTypeCommitXID(txn_name)
+```
+
+For WritePrepared/WriteUnprepared, `kTypeBeginPersistedPrepareXID` is used instead of `kTypeBeginPrepareXID`. The distinction matters during recovery: persisted prepares indicate that the data was applied to the memtable at prepare time.
+
+## Named Transactions
+
+2PC requires named transactions. The name serves as the transaction identifier (XID) that links prepare and commit records across crashes.
+
+Step 1: Create transaction via `BeginTransaction()`. Step 2: Set a unique name via `Transaction::SetName()`. Step 3: The name is registered in `PessimisticTransactionDB::transactions_` map. Step 4: After crash recovery, the transaction can be retrieved via `TransactionDB::GetTransactionByName()`.
+
+Important: `SetName()` returns `Status::InvalidArgument()` if the name is already in use, if the name is empty or exceeds 512 bytes, if the transaction has already been named, or if the transaction is not in `STARTED` state. Transaction names must be unique across all active transactions.
+
+## Crash Recovery
+
+Recovery of prepared transactions occurs during `TransactionDB::Open()` in `PessimisticTransactionDB::Initialize()` (see `utilities/transactions/pessimistic_transaction_db.cc`):
+
+Step 1: WAL replay identifies prepared transactions without corresponding commit records. Step 2: For each recovered prepared transaction, `BeginTransaction()` creates a new transaction object. Step 3: The transaction is rebuilt from the recovered write batch via `RebuildFromWriteBatch()`. Step 4: State is set to `PREPARED`. Step 5: The transaction is registered in the `transactions_` map.
+
+After recovery, the application is responsible for:
+- Calling `GetAllPreparedTransactions()` or `GetTransactionByName()` to find recovered transactions
+- Deciding whether to commit or rollback each one
+- Deleting the transaction object after resolution
+
+**Recovery with skip_concurrency_control:**
+
+Recovered transactions are recreated with `TransactionOptions::skip_concurrency_control = true` to avoid deadlocks during recovery when no other transactions are active. This skips lock acquisition during commit/rollback of recovered transactions.
+
+## Rollback in 2PC
+
+Rollback behavior depends on the write policy:
+
+**WriteCommitted:** Trivial -- discard the in-memory `WriteBatch`. No data was written to the memtable.
+
+**WritePrepared:** Data was already written to memtable at prepare time. Rollback writes compensating entries:
+
+Step 1: For each key in the prepared batch, read the pre-transaction value from the DB. Step 2: If a value exists, write a `Put()` with that value. If no value exists, write a `Delete()`. Step 3: The rollback batch and original prepared batch are both committed with the same `commit_seq`. Step 4: The original `prepare_seq` and the rollback batch's sequence number are both removed from `PreparedHeap`.
+
+**WriteUnprepared:** Similar to WritePrepared, but must also handle multiple flushed batches tracked in `unprep_seqs_`. Uses `WriteRollbackKeys()` to write compensating entries with a `ReadCallback` to see only committed data.
+
+## WAL Log Retention for 2PC
+
+With 2PC, WAL files must be retained longer than normal because a prepared transaction's data may span log files that would otherwise be eligible for deletion. The minimum log to retain is determined by three sources:
+
+1. **Column family log numbers**: the minimum `log_number_` across all column families
+2. **Prepared sections heap**: the minimum log number containing a prepared section in `PessimisticTransactionDB`
+3. **Memtable references**: the minimum prepare-section log referenced by all unflushed memtables (including immutable memtables)
+
+When a transaction commits, its log number is removed from the prepared sections heap. However, the memtable that absorbed the commit data now tracks that log number until the memtable is flushed to L0.
+
+## Configuration
+
+| Option | Location | Default | Description |
+|--------|----------|---------|-------------|
+| `skip_prepare` | `TransactionOptions` | `true` | If true, Commit() works without Prepare() |
+| `use_only_the_last_commit_time_batch_for_recovery` | `TransactionOptions` | `false` | Optimization for CommitTimeWriteBatch (WritePrepared/WriteUnprepared only) |
+| `rollback_deletion_type_callback` | `TransactionDBOptions` | none | Callback to choose Delete vs SingleDelete for rollback (WritePrepared/WriteUnprepared) |
+| `rollback_merge_operands` | `TransactionDBOptions` | false | When true, changes rollback behavior for merge operands (MyRocks-specific) |

--- a/docs/components/transaction/06_write_prepared_internals.md
+++ b/docs/components/transaction/06_write_prepared_internals.md
@@ -1,0 +1,113 @@
+# WritePrepared Internals
+
+**Files:** `utilities/transactions/write_prepared_txn_db.h`, `utilities/transactions/write_prepared_txn.h`, `utilities/transactions/write_prepared_txn.cc`
+
+## Overview
+
+WritePrepared transactions write data to the memtable at prepare time and only write a commit marker at commit time. This requires data structures to track which prepared entries have been committed and to determine visibility for concurrent readers.
+
+## CommitCache
+
+The CommitCache is the core data structure of WritePrepared. It is a fixed-size array of `std::atomic<CommitEntry64b>` indexed by `prepare_seq % COMMIT_CACHE_SIZE`.
+
+**Configuration:**
+- `COMMIT_CACHE_SIZE` = `2^wp_commit_cache_bits` (see `TransactionDBOptions`, private member `wp_commit_cache_bits`, default 23 = 8M entries, ~64MB; not user-configurable, internal testing parameter)
+- Each entry stores a `(prepare_seq, commit_seq)` pair encoded in 64 bits
+
+**Encoding (CommitEntry64b):**
+
+The 64-bit encoding exploits the array index to avoid storing redundant bits:
+- The lower `INDEX_BITS` (= `wp_commit_cache_bits`) of `prepare_seq` are implied by the array index
+- The upper `PREP_BITS` of `prepare_seq` are stored in the high bits of the 64-bit word
+- The delta `commit_seq - prepare_seq + 1` is stored in the low `COMMIT_BITS` (= `INDEX_BITS + PAD_BITS`)
+- `PAD_BITS` = 8 (upper bits of sequence number reserved for type tags)
+
+This lock-free encoding allows reads and writes to be simple atomic loads/stores, which on x86_64 compile to plain memory operations thanks to hardware cache coherency.
+
+**Eviction:** Each insertion overwrites the previous entry at that index. The `max_evicted_seq_` variable tracks the maximum sequence number that has been evicted. When `max_evicted_seq_` advances, maintenance operations run (see below).
+
+**Capacity estimation:** With 80K transactions/sec and 8M entries, an entry remains in cache for ~50 seconds. In practice, the gap between prepare and commit is sub-millisecond.
+
+## PreparedHeap
+
+The `PreparedHeap` (see inner class in `utilities/transactions/write_prepared_txn_db.h`) tracks all prepared-but-not-yet-committed sequence numbers.
+
+**Design:** A deque-based structure with an auxiliary min-heap for amortized O(1) erase:
+- `heap_`: deque of prepare sequence numbers (insertion order)
+- `erased_heap_`: min-heap of removed entries not yet at the front of `heap_`
+- `heap_top_`: atomic variable for lock-free read of the minimum
+
+**Operations:**
+- `push(v)`: appends to deque (must be called in ascending order, enforced by primary write queue)
+- `pop()`: removes from front; skips entries that appear in `erased_heap_`
+- `erase(v)`: if `v` is at the front, pops it; otherwise adds to `erased_heap_`
+- `top()`: returns `heap_top_` atomically (kMaxSequenceNumber if empty)
+
+**Invariant:** Entries are always added in ascending sequence order because `AddPrepared()` is called only from the primary write queue's `PreReleaseCallback`.
+
+## IsInSnapshot Algorithm
+
+`WritePreparedTxnDB::IsInSnapshot(prep_seq, snapshot_seq, min_uncommitted, snap_released)` determines whether a value tagged with `prep_seq` is visible at `snapshot_seq`.
+
+**Fast path:**
+
+Step 0: If `prep_seq == 0`, return true immediately (sequence number zeroed by compaction, meaning fully committed and visible to all). Step 1: If `snapshot_seq < prep_seq`, return false (written after snapshot). Step 2: If `prep_seq < min_uncommitted`, return true (known committed before any live transaction). Step 3: Check CommitCache at `prep_seq % COMMIT_CACHE_SIZE`. If found with matching `prep_seq`, return `commit_seq <= snapshot_seq`.
+
+**Slow path (cache miss):**
+
+Step 4: If `prep_seq > max_evicted_seq_`, the entry was never in the cache and is still in PreparedHeap (not committed), return false. Step 5: Check `delayed_prepared_` set (prepared entries that were moved from PreparedHeap when `max_evicted_seq_` advanced past them). If found and not in `delayed_prepared_commits_`, still uncommitted. Step 6: If `max_evicted_seq_ < snapshot_seq`, the commit must have happened before the snapshot, return true. Step 7: Check `old_commit_map_` for evicted entries that overlap with live snapshots.
+
+**Atomicity considerations:** The algorithm uses a do-while loop to handle the race between reading `max_evicted_seq_` and CommitCache. If `max_evicted_seq_` changes during the lookup, the loop retries.
+
+## Delayed Prepared
+
+When `max_evicted_seq_` advances past a `prepare_seq` still in `PreparedHeap`, the entry is moved to `delayed_prepared_` (a set protected by `prepared_mutex_`). This represents an abnormally long-running transaction.
+
+The commit of a delayed prepared entry involves four non-atomic steps:
+1. Update CommitCache
+2. Add to `delayed_prepared_commits_`
+3. Publish sequence number
+4. Remove from `delayed_prepared_`
+
+The `IsInSnapshot` algorithm handles this non-atomicity with a second CommitCache lookup after checking `delayed_prepared_`.
+
+## old_commit_map
+
+The `old_commit_map_` (`std::map<SequenceNumber, std::vector<uint64_t>>`) stores evicted commit entries that overlap with live snapshots:
+- Key: snapshot sequence number
+- Value: sorted vector of `prepare_seq` values that committed after that snapshot
+
+This is needed for long-running read-only transactions (e.g., backups) whose snapshots are older than `max_evicted_seq_`. If a snapshot is not found in `old_commit_map_`, it has been released, and `IsInSnapshot` sets `*snap_released = true`.
+
+**Garbage collection:** `old_commit_map_` entries are cleaned up when the corresponding snapshot is released, detected during the periodic snapshot list refresh when advancing `max_evicted_seq_`.
+
+## max_evicted_seq Advancement
+
+To reduce maintenance overhead, `max_evicted_seq_` is advanced by 1% of `COMMIT_CACHE_SIZE` at a time (rather than once per eviction). This amortizes the cost of:
+- Checking PreparedHeap top against the new max
+- Fetching live snapshot list (requires db mutex)
+- Updating `old_commit_map_`
+
+## Snapshot Cache
+
+The snapshot list is cached in a lock-free array of `std::atomic<uint64_t>` for efficient lookup during `IsInSnapshot`:
+- Size: `2^wp_snapshot_cache_bits` (default 7 = 128 entries)
+- Single writer updates sorted in ascending order
+- Concurrent readers scan from the end
+- Overflow beyond array size stored in a mutex-protected vector
+
+## Smallest Uncommitted Optimization
+
+The smallest uncommitted sequence number (`min_uncommitted`) is tracked and stored with each snapshot. When `prep_seq < min_uncommitted`, IsInSnapshot can immediately return true without consulting CommitCache, reducing CPU cache misses.
+
+Sources: `delayed_prepared_` minimum (if non-empty), otherwise `PreparedHeap::top()`.
+
+## Duplicate Key Handling
+
+WritePrepared assigns the same sequence number to all keys in a write batch. If the batch contains duplicate keys, the memtable rejects the second insertion (same sequence number for the same key). To handle this:
+
+Step 1: The write batch is divided into sub-batches, one after each duplicate key. Step 2: Each sub-batch gets a separate sequence number. Step 3: The memtable inserter advances the sequence number when the memtable returns false.
+
+When using the Transaction API, duplicate detection is done cheaply via `WriteBatchWithIndex`. When using `::CommitBatch` to write directly, the DB must iterate the batch to count sub-batches, which incurs overhead.
+
+Important: If a column family is dropped, the WAL must not contain entries belonging to that column family. Otherwise, recovery cannot determine duplicates without the column family's comparator.

--- a/docs/components/transaction/07_write_unprepared_internals.md
+++ b/docs/components/transaction/07_write_unprepared_internals.md
@@ -1,0 +1,86 @@
+# WriteUnprepared Internals
+
+**Files:** `utilities/transactions/write_unprepared_txn.h`, `utilities/transactions/write_unprepared_txn.cc`, `utilities/transactions/write_unprepared_txn_db.h`
+
+## Overview
+
+WriteUnprepared extends WritePrepared to support transactions that exceed memory limits by flushing data to the database incrementally during execution, before `Prepare()` is called. This is critical for very large transactions (e.g., bulk imports) that would otherwise exhaust memory.
+
+## Incremental Flushing
+
+Each write operation (`Put`, `Delete`, `Merge`, `SingleDelete`) calls `MaybeFlushWriteBatchToDB()` to check if the batch should be flushed:
+
+Step 1: Check if `write_batch_flush_threshold_` is set and the batch size exceeds it. Step 2: If threshold exceeded, call `FlushWriteBatchToDB(prepared=false)`. Step 3: The flush writes the batch to WAL with `kTypeBeginUnprepareXID` marker and applies to memtable. Step 4: Record the sequence number and sub-batch count in `unprep_seqs_`. Step 5: Clear the in-memory write batch for subsequent writes.
+
+**Configuration:**
+- `TransactionDBOptions::default_write_batch_flush_threshold` (default 0 = disabled)
+- `TransactionOptions::write_batch_flush_threshold` (per-transaction, -1 = use DB default)
+
+## unprep_seqs Tracking
+
+`unprep_seqs_` (`std::map<SequenceNumber, size_t>`) is the central data structure for tracking flushed batches:
+- Key: sequence number of the flushed batch
+- Value: number of sub-batches (for duplicate key handling)
+
+This map is used for:
+- Visibility tracking (read-your-own-writes)
+- Commit processing (all entries added to CommitCache)
+- Recovery (rebuilt from WAL)
+
+## Read-Your-Own-Writes
+
+WriteUnprepared transactions must be able to read their own uncommitted writes that have been flushed to the DB. This is handled by `WriteUnpreparedTxnReadCallback` (see `utilities/transactions/write_unprepared_txn.h`):
+
+**Visibility calculation:**
+- `max_visible_seq = max(snapshot_seq, max_unprep_seq)` where `max_unprep_seq` is the highest sequence in `unprep_seqs_`
+- For a key at sequence `seq`:
+  - If `seq` is in `unprep_seqs_` ranges: visible (own write)
+  - If `seq` is from another uncommitted transaction: not visible
+  - If `seq` is committed and `commit_seq <= snapshot_seq`: visible
+  - Otherwise: not visible
+
+Note: `max_visible_seq` is calculated once at iterator construction time. Writes added to the transaction during iteration may not be visible.
+
+## SavePoint Handling
+
+WriteUnprepared has the most complex savepoint implementation because savepoints may span both flushed (in DB) and unflushed (in memory) data. Three data structures work together:
+
+**`TransactionBaseImpl::save_points_`:** Tracks which keys were modified in each savepoint (shared with all transaction types).
+
+**`flushed_save_points_`** (`autovector<WriteUnpreparedTxn::SavePoint>`): Savepoints on already-flushed unprepared batches. Each entry contains:
+- `unprep_seqs_`: snapshot of the `unprep_seqs_` map at that savepoint
+- `snapshot_`: a `ManagedSnapshot` for reading pre-savepoint state during rollback
+
+**`unflushed_save_points_`** (`autovector<size_t>`): Savepoints on the current in-memory write batch. Records the write batch size at each savepoint.
+
+**Invariant:** `size(flushed_save_points_) + size(unflushed_save_points_) = size(save_points_)`
+
+**Rollback to savepoint:**
+
+Step 1: Rollback unflushed data (discard WriteBatch entries after the savepoint). Step 2: For flushed data, call `WriteRollbackKeys()` to write compensating entries using the savepoint's snapshot. Step 3: Restore `unprep_seqs_` and snapshot state from the `flushed_save_points_` entry.
+
+## Rollback
+
+Rolling back a WriteUnprepared transaction requires writing compensating entries for all flushed data:
+
+Step 1: For each key tracked in `tracked_locks_`, read the pre-transaction value using a ReadCallback. Step 2: If the key had a value before the transaction, write a `Put()` with that value. Step 3: If the key did not exist, write a `Delete()` (or `SingleDelete()` based on `rollback_deletion_type_callback`). Step 4: Commit the rollback batch with all `unprep_seqs_` entries.
+
+For untracked keys (written via `PutUntracked()` etc.), the `untracked_keys_` map tracks them separately for rollback.
+
+## Active Iterator Safety
+
+It is unsafe to flush a write batch while iterators created from the transaction are active. This is because the `WriteBatchWithIndex` delta iterator may point to invalidated memory after a flush. The `active_iterators_` vector tracks all active iterators, and flushing is deferred while any are alive.
+
+## Prepare Phase
+
+When `Prepare()` is called on a WriteUnprepared transaction:
+
+Step 1: Flush the remaining in-memory write batch (if any) with `kTypeBeginPersistedPrepareXID` marker. Step 2: Write `kTypeEndPrepareXID` marker.
+
+At this point, all data is in the DB (both previously flushed unprepared batches and the final prepared batch).
+
+## Recovery
+
+Recovery of WriteUnprepared transactions (in `WriteUnpreparedTxnDB::RollbackRecoveredTransaction()`):
+
+Step 1: WAL replay identifies unprepared batches (`kTypeBeginUnprepareXID`) and prepared batches. Step 2: If no commit record found, the transaction is either recreated as a prepared transaction or rolled back. Step 3: `unprep_seqs_` is rebuilt from the WAL entries. Step 4: Recovered transactions with only unprepared data (no prepare) are automatically rolled back.

--- a/docs/components/transaction/08_snapshot_and_conflicts.md
+++ b/docs/components/transaction/08_snapshot_and_conflicts.md
@@ -1,0 +1,95 @@
+# Snapshot and Conflict Detection
+
+**Files:** `utilities/transactions/transaction_base.cc`, `utilities/transactions/pessimistic_transaction.cc`, `utilities/transactions/transaction_util.h`, `utilities/transactions/transaction_util.cc`
+
+## Snapshot Isolation
+
+Transactions can optionally use snapshots to provide a consistent read view of the database.
+
+### Setting Snapshots
+
+**`SetSnapshot()`:** Captures the current sequence number immediately. This sets the baseline for conflict checking (ValidateSnapshot), but does NOT change what `Get()` returns. To control read visibility, set `ReadOptions::snapshot`.
+
+**`SetSnapshotOnNextOperation()`:** Delays snapshot creation until the next write or `GetForUpdate()` operation. Regular `Get()` does NOT trigger snapshot creation. This reduces snapshot holding time.
+
+**`TransactionOptions::set_snapshot = true`:** Equivalent to calling `SetSnapshot()` at transaction creation time.
+
+**WritePrepared difference:** `SetSnapshot()` in WritePrepared transactions calls `GetSnapshotForWriteConflictBoundary()` instead of the standard snapshot. When `two_write_queues` is enabled, this uses the `LastPublishedSequence` (which accounts for out-of-order sequence number publishing) rather than the latest memtable sequence.
+
+### Snapshot Lifecycle
+
+Snapshots are ref-counted via `std::shared_ptr<const Snapshot>`. The snapshot is:
+- Created by `SetSnapshot()` or lazily by `SetSnapshotOnNextOperation()`
+- Cleared by `ClearSnapshot()` or when the transaction is destroyed
+- Used for both reads AND conflict validation
+
+## Conflict Detection: Pessimistic Transactions
+
+### ValidateSnapshot
+
+When a pessimistic transaction performs a write or `GetForUpdate()`, `ValidateSnapshot()` checks that the key has not been modified since the snapshot was taken:
+
+Step 1: Get the snapshot sequence number from `snapshot_->GetSequenceNumber()`. Step 2: If the key was already tracked at or before the snapshot sequence, no conflict possible (skip). Step 3: Call `TransactionUtil::CheckKeyForConflicts()` which uses `GetLatestSequenceForKey()` to find the most recent write to the key. Step 4: If a write exists with sequence > `snap_seq`, return `Status::Busy()` (conflict). Step 5: Update `tracked_at_seq` to `snap_seq` to avoid re-validation.
+
+### CheckKeyForConflicts
+
+`TransactionUtil::CheckKeyForConflicts()` (see `utilities/transactions/transaction_util.h`) is the low-level conflict check:
+
+Step 1: Acquire a `SuperVersion` reference for the column family. Step 2: Call `CheckKey()` which looks up the key's latest sequence number. Step 3: Compare against `snap_seq`:
+- `seq < min_uncommitted`: no conflict (committed before any live transaction)
+- `seq > snap_seq`: potential conflict
+- `min_uncommitted <= seq <= snap_seq`: use `snap_checker` (ReadCallback) to determine
+
+The `cache_only` parameter controls whether SST files are consulted. When true, only memtables are checked (faster but may miss conflicts).
+
+### User-Defined Timestamp Validation
+
+For WriteCommitted transactions with user-defined timestamps enabled (`TransactionDBOptions::enable_udt_validation = true`):
+
+Step 1: `SetReadTimestampForValidation()` records the timestamp for conflict checks. Step 2: `SetCommitTimestamp()` sets the timestamp for the commit. Step 3: During validation, both sequence number AND timestamp are checked. A conflict is detected if a write with a timestamp greater than the read timestamp exists.
+
+Note: WritePrepared and WriteUnprepared do NOT support user-defined timestamps.
+
+## Conflict Detection: Optimistic Transactions
+
+Optimistic transactions defer all conflict checking to commit time.
+
+### Commit-Time Validation
+
+`OptimisticTransaction::CheckTransactionForConflicts()` validates at commit:
+
+Step 1: For each tracked key, call `TransactionUtil::CheckKeysForConflicts()`. Step 2: This iterates over all column families in the `LockTracker` and checks each key. Step 3: If any key was modified since it was first tracked, return `Status::Busy()`.
+
+The validation is performed inside a `WriteCallback` (`OptimisticTransactionCallback`), which is invoked during `DBImpl::WriteImpl()`. This ensures validation happens atomically with the write. Note: this callback path applies to serial validation only. For parallel validation, locking and validation happen before entering the write group (see chapter 9).
+
+### Validation Policies
+
+Two validation policies are available (see `OccValidationPolicy` in `include/rocksdb/utilities/optimistic_transaction_db.h`):
+
+**`kValidateSerial` (0):** Validation happens after entering the write group (single-threaded). Simple but may cause high mutex contention.
+
+**`kValidateParallel` (1, default):** Validation happens before entering the write group using per-key bucket locks. Each key is locked in a consistent order to avoid deadlock. This reduces write group contention.
+
+For parallel validation, the bucket lock pool is configurable:
+- `OptimisticTransactionDBOptions::occ_lock_buckets` (default 2^20 = ~1M buckets)
+- `OptimisticTransactionDBOptions::shared_lock_buckets` allows sharing buckets across DB instances
+
+## Compaction Correctness for Conflict Detection
+
+Transaction conflict detection relies on SST file history to check whether keys were modified after a transaction's snapshot. This imposes correctness invariants on the compaction layer:
+
+1. **Record preservation**: Compaction must not remove a key's last record visible to a live snapshot. At least one record for each key must be preserved in every live snapshot's view.
+2. **Sequence number zeroing**: Sequence numbers may only be zeroed out when no earlier snapshots exist.
+3. **Compaction filters**: `CompactionFilter::Filter()` is safe because compaction converts filtered keys to deletes processed through the standard path. However, `CompactionFilter::FilterMergeOperand()` may be unsafe with transactions -- consult its documentation before use.
+
+These invariants are enforced in `CompactionIterator` (see `db/compaction/compaction_iterator.cc`).
+
+## Error Codes for Conflicts
+
+| Status | Meaning | Action |
+|--------|---------|--------|
+| `Status::Busy()` | Write-write conflict (optimistic) or general lock contention (pessimistic) | Retry transaction |
+| `Status::Busy(SubCode::kDeadlock)` | Deadlock detected (pessimistic) | Retry transaction |
+| `Status::TimedOut()` | Lock acquisition timed out (pessimistic) | Retry or increase timeout |
+| `Status::TryAgain()` | Memtable history insufficient for validation | Increase `max_write_buffer_size_to_maintain` |
+| `Status::Aborted()` / `IsLockLimit()` | Lock count exceeded `max_num_locks` | Reduce transaction size or increase limit |

--- a/docs/components/transaction/09_optimistic_internals.md
+++ b/docs/components/transaction/09_optimistic_internals.md
@@ -1,0 +1,55 @@
+# Optimistic Transaction Internals
+
+**Files:** `utilities/transactions/optimistic_transaction.h`, `utilities/transactions/optimistic_transaction.cc`, `utilities/transactions/optimistic_transaction_db_impl.h`, `include/rocksdb/utilities/optimistic_transaction_db.h`
+
+## Overview
+
+Optimistic transactions avoid acquiring locks during execution. Instead, they track which keys are written and validate at commit time that no concurrent transaction has modified those keys. This eliminates lock overhead but requires retry logic when conflicts are detected.
+
+## Transaction Lifecycle
+
+**TryLock (no-op):** When `OptimisticTransaction::TryLock()` is called during `Put()` or `GetForUpdate()`, it merely records the key and its current sequence number in the `LockTracker`. No actual lock is acquired.
+
+**Commit:** Calls either `CommitWithSerialValidate()` or `CommitWithParallelValidate()` depending on the validation policy.
+
+**Rollback:** Simply clears the in-memory write batch and tracked keys. No locks to release.
+
+**Prepare:** Returns `Status::InvalidArgument()`. Optimistic transactions do not support 2PC.
+
+## Validation Policies
+
+### Serial Validation (kValidateSerial)
+
+Step 1: Transaction submits its write batch to `DBImpl::WriteImpl()` with an `OptimisticTransactionCallback`. Step 2: Inside the write group (holding the write mutex), the callback calls `CheckTransactionForConflicts()`. Step 3: For each tracked key, `TransactionUtil::CheckKeysForConflicts()` checks if the key was modified since it was tracked. Step 4: If any conflict found, returns `Status::Busy()` and the write is aborted.
+
+**Advantage:** Simple, correct. **Disadvantage:** Validation is serialized in the write group. Under high write concurrency, this creates a bottleneck.
+
+### Parallel Validation (kValidateParallel, default)
+
+Step 1: Before entering the write group, hash all keys to bucket indices, deduplicate the bucket set, and acquire bucket locks in ascending order. Step 2: Validate all keys for conflicts (can happen in parallel with other transactions' validations). Step 3: If validation passes, enter the write group and commit. Step 4: Release bucket locks after commit.
+
+**OCC Lock Buckets:**
+
+The bucket lock pool (`OccLockBuckets`) provides striped mutex locks. Keys are mapped to buckets via hashing. The implementation is in `OptimisticTransactionDBImpl` (see `utilities/transactions/optimistic_transaction_db_impl.h`).
+
+Configuration:
+- `OptimisticTransactionDBOptions::occ_lock_buckets` (default 2^20): number of buckets (minimum clamped to 16)
+- `OptimisticTransactionDBOptions::shared_lock_buckets`: shared bucket pool across DB instances (optional)
+- Cache alignment via `MakeSharedOccLockBuckets(count, cache_aligned)` (default: not cache-aligned)
+
+## Conflict Check Implementation
+
+`OptimisticTransaction::CheckTransactionForConflicts()` delegates to `TransactionUtil::CheckKeysForConflicts()`:
+
+Step 1: Iterate over all column families in the `LockTracker`. Step 2: For each key, call `CheckKey()` to find the latest sequence number for that key. Step 3: If the latest sequence > the sequence at which the key was first tracked, a conflict is detected. Step 4: Return `Status::Busy()` on first conflict found.
+
+Important: The check uses `cache_only = true` initially, which only checks memtables. If the key is not found in memtables but was tracked at a sequence older than the earliest memtable sequence, a full SST check is needed. If memtable history is insufficient, returns `Status::TryAgain()`.
+
+## Limitations
+
+- No support for 2PC (`Prepare()` returns `InvalidArgument`)
+- No support for `DeleteRange` (returns `Status::NotSupported()`)
+- No deadlock detection (no locks to deadlock on)
+- No lock timeout (no locks to time out on)
+- No range locks
+- All writes must go through the transaction API; direct writes to the underlying DB bypass conflict detection

--- a/docs/components/transaction/10_api_and_lifecycle.md
+++ b/docs/components/transaction/10_api_and_lifecycle.md
@@ -1,0 +1,112 @@
+# Transaction API and Lifecycle
+
+**Files:** `include/rocksdb/utilities/transaction.h`, `include/rocksdb/utilities/transaction_db.h`, `utilities/transactions/transaction_base.h`, `utilities/transactions/transaction_base.cc`
+
+## Transaction States
+
+The `Transaction::TransactionState` enum (see `include/rocksdb/utilities/transaction.h`) defines the lifecycle:
+
+| State | Value | Description |
+|-------|-------|-------------|
+| `STARTED` | 0 | Initial state after `BeginTransaction()` |
+| `AWAITING_PREPARE` | 1 | `Prepare()` called, waiting for completion |
+| `PREPARED` | 2 | Prepare succeeded, ready for commit |
+| `AWAITING_COMMIT` | 3 | `Commit()` called, waiting for completion |
+| `COMMITTED` | 4 | Transaction committed successfully |
+| `AWAITING_ROLLBACK` | 5 | `Rollback()` called, waiting for completion |
+| `ROLLEDBACK` | 6 | Transaction rolled back |
+| `LOCKS_STOLEN` | 7 | Transaction expired, locks released |
+
+## Creating Transactions
+
+**Pessimistic:**
+
+`TransactionDB::BeginTransaction()` creates a new transaction or reuses an existing one:
+- `old_txn` parameter: if non-null, reuses the transaction handle (optimization to avoid allocations)
+- `TransactionOptions::set_snapshot`: calls `SetSnapshot()` at creation
+- `TransactionOptions::expiration`: auto-expire timeout in milliseconds (default -1 = no expiration)
+- `TransactionOptions::deadlock_detect`: enable deadlock detection (default false)
+- `TransactionOptions::lock_timeout`: per-transaction lock timeout in ms (default -1 = use DB default)
+
+**Optimistic:**
+
+`OptimisticTransactionDB::BeginTransaction()` creates a new transaction:
+- Takes `OptimisticTransactionOptions` (not `TransactionOptions`)
+- `OptimisticTransactionOptions::set_snapshot`: calls `SetSnapshot()` at creation
+- `OptimisticTransactionOptions::cmp`: comparator for WriteBatchWithIndex (default: `BytewiseComparator()`)
+
+## Read Operations
+
+### Get
+
+`Transaction::Get()` reads from both the transaction's write batch and the DB:
+
+Step 1: Check the `WriteBatchWithIndex` for the key. Step 2: If found in the batch, return that value. Step 3: If not found, read from the DB using the read options snapshot. Step 4: No locks acquired. Snapshot isolation applies if a snapshot is set.
+
+Note: If `read_options.snapshot` is set, it controls what is read from the DB. But `SetSnapshot()` on the transaction does NOT affect what `Get()` reads. `Get()` always reads the latest committed value unless `read_options.snapshot` is explicitly set.
+
+### GetForUpdate
+
+`Transaction::GetForUpdate()` reads the key AND acquires a lock:
+
+Step 1: Call `TryLock()` to acquire the lock (pessimistic) or record the key (optimistic). Step 2: If `do_validate` is true and a snapshot is set, call `ValidateSnapshot()` to check for conflicts. Step 3: Read the value (same as `Get()`).
+
+Parameters:
+- `exclusive` (default true): exclusive lock or shared lock
+- `do_validate` (default true): whether to check for snapshot conflicts
+- If `value` is nullptr, acquires the lock but does not read data
+
+### GetRangeLock
+
+`Transaction::GetRangeLock()` acquires a range lock (pessimistic with range lock manager only). Returns `Status::NotSupported()` by default.
+
+## Write Operations
+
+All write operations (`Put`, `Delete`, `SingleDelete`, `Merge`, `PutEntity`) follow the same pattern:
+
+Step 1: Call `TryLock()` on the key. Step 2: If lock acquired (or tracked), add the operation to `WriteBatchWithIndex`. Step 3: Update operation counters.
+
+**Untracked writes** (`PutUntracked`, `DeleteUntracked`, etc.): Skip conflict checking (`do_validate=false`). For pessimistic transactions, locks are still acquired for write ordering but no snapshot validation occurs. For optimistic transactions, the key is not tracked for commit-time validation.
+
+**`assume_tracked` parameter:** When true, skips `TryLock()` entirely, assuming the key was already locked. Must only be used when the key was previously tracked in the same savepoint, with the same exclusivity, at a lower sequence number.
+
+## SavePoints
+
+SavePoints provide partial rollback within a transaction:
+
+**`SetSavePoint()`:** Captures current state:
+- WriteBatch position
+- Lock tracker state (new locks since savepoint tracked separately)
+- Snapshot and operation counters
+
+**`RollbackToSavePoint()`:** Restores captured state:
+- Truncates WriteBatch to savepoint position
+- Releases locks acquired after savepoint
+- Restores snapshot and counters
+
+**`PopSavePoint()`:** Removes the most recent savepoint without rolling back. Merges savepoint's tracked locks into the parent.
+
+SavePoints are LIFO. Rolling back to an earlier savepoint implicitly rolls back all later ones.
+
+## Iterators
+
+`Transaction::GetIterator()` returns an iterator that merges the transaction's pending writes with the DB contents:
+
+- Uses `WriteBatchWithIndex::NewIteratorWithBase()` to create a merge iterator
+- Pending writes in the batch take precedence over DB values
+- The iterator is valid until `Commit()`, `Rollback()`, or `RollbackToSavePoint()`
+- For WritePrepared/WriteUnprepared, snapshot handling uses `LastPublishedSequence`
+
+`Transaction::GetCoalescingIterator()` and `GetAttributeGroupIterator()` provide multi-column-family iteration with the same merge semantics. Note: WritePrepared and WriteUnprepared transactions return `Status::NotSupported()` for these APIs; they are only available for WriteCommitted and optimistic transactions.
+
+## Indexing Control
+
+`DisableIndexing()` / `EnableIndexing()` control whether subsequent writes are indexed in the `WriteBatchWithIndex`:
+- When disabled, writes go directly to the underlying `WriteBatch` without indexing
+- Results of `Get()`, `GetForUpdate()`, or `GetIterator()` for keys written after `DisableIndexing()` are undefined
+- Useful for performance when the caller does not need to read back its own writes
+- Default: enabled
+
+## CollapseKey
+
+`Transaction::CollapseKey()` (pessimistic only) collapses merge chains for a key. This is an on-demand optimization to reduce read amplification without waiting for compaction.

--- a/docs/components/transaction/11_advanced_features.md
+++ b/docs/components/transaction/11_advanced_features.md
@@ -1,0 +1,89 @@
+# Advanced Features
+
+**Files:** `utilities/transactions/pessimistic_transaction.cc`, `utilities/transactions/pessimistic_transaction_db.cc`, `include/rocksdb/utilities/transaction_db.h`, `include/rocksdb/utilities/transaction.h`
+
+## Large Transaction Commit Bypass
+
+For WriteCommitted transactions with many operations, the standard commit path (writing the entire batch through the write group) can be slow. The commit bypass optimization ingests the transaction as an immutable memtable instead.
+
+**Configuration** (in `TransactionOptions`):
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `commit_bypass_memtable` | false | If true, always bypass memtable write on commit |
+| `large_txn_commit_optimize_threshold` | 0 (disabled) | Bypass when operation count >= this threshold |
+| `large_txn_commit_optimize_byte_threshold` | 0 (disabled) | Bypass when write batch size >= this threshold |
+
+**Requirements:**
+- WriteCommitted policy only
+- Transaction must call `Prepare()` before `Commit()`
+- `Merge()` and `PutEntity()` operations are not supported (the underlying `WBWIMemTable` can handle merges, but the transaction-level bypass path rejects them)
+- All updates must be indexed (i.e., written through Transaction APIs, not directly to the underlying WriteBatch)
+- The WBWI operation count must match the WriteBatch count
+
+**Side effects:**
+- The transaction is ingested as an immutable memtable, triggering a memtable switch for each affected column family
+- Rapid ingestion of many bypass transactions may cause write stalls due to too many immutable memtables
+- Since WBWI tracks only the most recent update per key, a `Put` followed by `SingleDelete` on the same key results in a standalone `SingleDelete`
+
+## CommitTimeWriteBatch
+
+`Transaction::GetCommitTimeWriteBatch()` returns a secondary write batch that is committed atomically with the transaction but bypasses concurrency control.
+
+**Use case:** Writing metadata that should be committed with the transaction but does not need conflict checking (e.g., commit timestamps, bookkeeping data).
+
+**WritePrepared/WriteUnprepared restriction:** Can only be used when `TransactionOptions::use_only_the_last_commit_time_batch_for_recovery` is true. This tells RocksDB the CommitTimeWriteBatch represents the latest application state and can be written only to WAL (not memtable), with the last copy kept in memory for SST flush. When using this optimization, the CommitTimeWriteBatch must have no duplicate keys.
+
+## Timestamped Snapshots
+
+`TransactionDB::CreateTimestampedSnapshot()` creates a snapshot associated with an application-provided timestamp:
+
+Step 1: Application provides a `TxnTimestamp` value. Step 2: A DB snapshot is created and associated with the timestamp. Step 3: The snapshot is stored in an internal map for later retrieval.
+
+**Retrieval:**
+- `GetTimestampedSnapshot(ts)`: get snapshot for exact timestamp
+- `GetLatestTimestampedSnapshot()`: get the most recent timestamped snapshot
+- `GetTimestampedSnapshots(ts_lb, ts_ub)`: get snapshots in timestamp range `[ts_lb, ts_ub)` (half-open: upper bound is exclusive)
+
+**Cleanup:** `ReleaseTimestampedSnapshotsOlderThan(ts)` releases all timestamped snapshots with timestamp <= ts.
+
+**CommitAndTryCreateSnapshot:** `Transaction::CommitAndTryCreateSnapshot()` atomically commits the transaction and creates a timestamped snapshot. The snapshot captures the database state after all writes by the transaction are visible. Currently only supported by WriteCommitted transactions.
+
+## Transaction Expiration
+
+Transactions can be configured to auto-expire:
+
+Step 1: Set `TransactionOptions::expiration` (milliseconds). Step 2: The expiration time is `start_time + expiration * 1000` (microseconds). Step 3: When another transaction encounters an expired lock, it can steal the lock via `TryStealingExpiredTransactionLocks()`. Step 4: The expired transaction's state transitions to `LOCKS_STOLEN`. Step 5: All subsequent operations on the expired transaction return `Status::Expired()`.
+
+Note: Expired transactions are tracked in `PessimisticTransactionDB::expirable_transactions_map_`.
+
+## Secondary Indices
+
+`TransactionDBOptions::secondary_indices` (experimental) allows registering secondary index implementations. These are automatically maintained when WriteCommitted transactions modify primary keys. Secondary index support is injected via `SecondaryIndexMixin<WriteCommittedTxn>` in `WriteCommittedTxnDB::BeginTransaction()` and is not available for other write policies.
+
+The `SecondaryIndex` interface enables the transaction system to automatically update secondary index entries during transactional writes, ensuring atomicity between primary and secondary data.
+
+## Skip Concurrency Control
+
+`TransactionOptions::skip_concurrency_control` and `TransactionDBOptions::skip_concurrency_control` allow bypassing lock acquisition:
+
+**Per-transaction:** When true, the transaction skips all lock acquisition. Useful for:
+- Recovery of prepared transactions (when no other transactions are active)
+- Application-guaranteed non-conflicting writes
+
+**DB-level:** When true on `TransactionDBOptions`, direct `TransactionDB::Write()` calls bypass concurrency control (no internal transaction created, writes go straight to `db_impl_->Write()`). This does NOT affect the default for transactions created via `BeginTransaction()`. Can be used with `DBOptions::unordered_write` when TransactionDB is used purely for write ordering.
+
+**`TransactionDBWriteOptimizations`:** Per-write optimizations for `TransactionDB::Write()`:
+- `skip_concurrency_control`: skip lock acquisition for this batch
+- `skip_duplicate_key_check`: skip duplicate key detection (WritePrepared/WriteUnprepared)
+
+## User-Defined Timestamps
+
+WriteCommitted transactions support user-defined timestamps for conflict validation:
+
+Step 1: `Transaction::SetReadTimestampForValidation(ts)` sets the read timestamp. Step 2: `Transaction::SetCommitTimestamp(ts)` sets the commit timestamp. Step 3: During conflict validation, both sequence number and timestamp are checked. Step 4: A conflict is detected if a write with timestamp greater than the read timestamp exists.
+
+**Limitations:**
+- Only WriteCommitted supports user-defined timestamps
+- `TransactionDBOptions::enable_udt_validation` (default true) controls whether timestamp-based validation is enabled
+- The commit bypass memtable optimization is not compatible with user-defined timestamps

--- a/docs/components/transaction/12_performance_and_best_practices.md
+++ b/docs/components/transaction/12_performance_and_best_practices.md
@@ -1,0 +1,128 @@
+# Performance and Best Practices
+
+**Files:** `include/rocksdb/utilities/transaction_db.h`, `include/rocksdb/utilities/optimistic_transaction_db.h`, `include/rocksdb/utilities/transaction.h`
+
+## Write Policy Selection
+
+| Workload | Recommended Policy | Reason |
+|----------|-------------------|--------|
+| General purpose | WriteCommitted | Simplest, most mature, supports all features |
+| Low-latency 2PC commits | WritePrepared | Common-case commit writes WAL marker only; prepare does the heavy lifting. If a commit-time batch is present, commit may also write data. |
+| Very large transactions (GBs) | WriteUnprepared | Flushes data incrementally; no memory bottleneck |
+| Needs user-defined timestamps | WriteCommitted | Only policy that supports UDT |
+
+**WritePrepared benchmarks** (from original design, via MyRocks):
+- Insert throughput: +68%
+- Update-with-index throughput: +61%, latency: -28%
+- Read-write throughput: +6%
+- Read-only throughput: -1.2% (due to IsInSnapshot overhead)
+
+## Optimistic vs. Pessimistic
+
+| Factor | Threshold | Recommendation |
+|--------|-----------|----------------|
+| Conflict rate < 10% | Low conflict | Optimistic likely faster (no lock overhead) |
+| Conflict rate > 50% | High conflict | Pessimistic likely faster (no wasted work) |
+| 10-50% | Medium conflict | Benchmark both |
+
+For optimistic transactions, prefer `kValidateParallel` (default) over `kValidateSerial` to reduce write group contention.
+
+## Lock Manager Tuning
+
+### Point Lock Manager
+
+| Option | Default | Tuning |
+|--------|---------|--------|
+| `num_stripes` | 16 | Increase to 64+ for high concurrency; decrease to 4-8 if memory-constrained |
+| `max_num_locks` | -1 (unlimited) | Set positive to prevent lock table memory exhaustion |
+| `transaction_lock_timeout` | 1000ms | Increase for long-running transactions; decrease for fast-fail behavior |
+| `default_lock_timeout` | 1000ms | Timeout for non-transactional writes through TransactionDB |
+
+### Range Lock Manager
+
+- `SetMaxLockMemory()`: control total memory for range locks
+- `SetEscalationBarrierFunc()`: prevent lock escalation across application boundaries
+- Range locks are useful when application performs range scans and needs phantom read prevention
+
+## Deadlock Handling
+
+| Approach | When to use |
+|----------|-------------|
+| Lock timeout only | Simple workloads with rare contention |
+| Deadlock detection | Complex lock patterns, multi-key transactions |
+| Both enabled | Maximum safety: detection catches cycles quickly, timeout is safety net |
+
+Tuning `deadlock_timeout_us`:
+- Set to 0 for immediate detection when deadlocks are frequent
+- Set to a value slightly longer than typical transaction duration when deadlocks are rare
+
+## Common Pitfalls
+
+**1. Lost update (use GetForUpdate):**
+
+Incorrect: `Get()` followed by `Put()` based on the read value. Another transaction may modify the key between the read and write.
+
+Correct: `GetForUpdate()` acquires a lock during the read, preventing concurrent modifications.
+
+**2. Snapshot not set:**
+
+Without calling `SetSnapshot()`, each `Get()` reads the latest committed value. This can lead to inconsistent reads within a transaction if other transactions commit between reads.
+
+**3. Deadlock from inconsistent lock ordering:**
+
+When multiple transactions lock keys in different orders (e.g., T1 locks A then B, T2 locks B then A), deadlock occurs. Solutions: consistent lock ordering, enable `deadlock_detect`, or use lock timeouts.
+
+**4. Memory exhaustion with large WriteCommitted transactions:**
+
+WriteCommitted buffers all writes in memory until commit. For very large transactions, either:
+- Switch to WriteUnprepared (flushes data incrementally)
+- Use the commit bypass memtable optimization (WriteCommitted with `commit_bypass_memtable`)
+- Set `max_write_batch_size` to limit transaction size
+
+**5. Non-transactional writes bypassing locks:**
+
+Direct calls to `DB::Put()` through a `TransactionDB` internally create a transaction via `BeginInternalTransaction()` and use `CommitBatch()`, which sorts keys before locking to avoid deadlocks with concurrent `Write()` calls. These internal transactions do not participate in snapshot isolation. For full isolation, use `TransactionDB::Write()` with `TransactionDBWriteOptimizations` or create a transaction.
+
+**6. DeleteRange incompatibility:**
+
+`DeleteRange()` support depends on the DB type and write policy:
+
+| DB Type | Direct API | Via `TransactionDB::Write()` |
+|---------|-----------|------------------------------|
+| `OptimisticTransactionDB` | Not supported | Not supported (rejected even in `WriteBatch`) |
+| `TransactionDB` (WriteCommitted) | Not supported | Supported with `skip_concurrency_control = true` |
+| `TransactionDB` (WritePrepared/WriteUnprepared) | Not supported | Supported with `skip_concurrency_control = true` AND `skip_duplicate_key_check = true` |
+
+## db_bench Transaction Benchmarks
+
+Transaction throughput can be measured using `db_bench`:
+
+```
+# Pessimistic transactions
+./db_bench --benchmarks=randomtransaction --transaction_db
+
+# Optimistic transactions
+./db_bench --benchmarks=randomtransaction --optimistic_transaction_db
+```
+
+Key `db_bench` options for transactions:
+- `--transaction_db`: use `TransactionDB`
+- `--optimistic_transaction_db`: use `OptimisticTransactionDB`
+- `--transaction_lock_timeout`: lock timeout in ms
+- `--transaction_sets`: number of key groups per transaction
+- `--transaction_set_snapshot`: set snapshot at transaction start
+
+## WritePrepared/WriteUnprepared Tuning
+
+| Option | Default | Notes |
+|--------|---------|-------|
+| `wp_commit_cache_bits` (private) | 23 (8M entries) | Larger = more memory, longer before eviction |
+| `wp_snapshot_cache_bits` (private) | 7 (128 entries) | Increase if many concurrent snapshots |
+| `two_write_queues` (`DBOptions`) | false | Recommended true for WritePrepared/WriteUnprepared |
+| `default_write_batch_flush_threshold` | 0 (disabled) | WriteUnprepared: set to limit in-memory batch size |
+
+Note: `wp_commit_cache_bits` and `wp_snapshot_cache_bits` are private members of `TransactionDBOptions` (not user-configurable in production; used primarily for testing).
+
+## WAL Compatibility
+
+Important: The WAL format differs between WriteCommitted and WritePrepared/WriteUnprepared. Switching write policies requires flushing the DB first to empty the WAL. The SST file format is compatible across all policies.

--- a/docs/components/transaction/index.md
+++ b/docs/components/transaction/index.md
@@ -1,0 +1,46 @@
+# RocksDB Transactions
+
+## Overview
+
+RocksDB provides ACID-compliant transactions with two concurrency control models -- pessimistic (lock-based) and optimistic (validation-based) -- and three write policies for pessimistic transactions: WriteCommitted, WritePrepared, and WriteUnprepared. The transaction subsystem supports two-phase commit (2PC), snapshot isolation, deadlock detection, point and range locking, and large-transaction optimizations.
+
+**Key source files:** `include/rocksdb/utilities/transaction.h`, `include/rocksdb/utilities/transaction_db.h`, `include/rocksdb/utilities/optimistic_transaction_db.h`, `utilities/transactions/pessimistic_transaction.{h,cc}`, `utilities/transactions/write_prepared_txn_db.h`
+
+## Chapters
+
+| Chapter | File | Summary |
+|---------|------|---------|
+| 1. Transaction Types and Models | [01_types_and_models.md](01_types_and_models.md) | Pessimistic vs. optimistic concurrency control, class hierarchy, and when to use each model. |
+| 2. Write Policies | [02_write_policies.md](02_write_policies.md) | WriteCommitted, WritePrepared, and WriteUnprepared policies: data flow, WAL markers, and tradeoffs. |
+| 3. Lock Management | [03_lock_management.md](03_lock_management.md) | Point lock manager with striped hash table, range lock manager with interval trees, lock escalation, and lock expiration. |
+| 4. Deadlock Detection | [04_deadlock_detection.md](04_deadlock_detection.md) | Wait-for graph construction, BFS-based cycle detection, deadlock info buffer, and timeout interaction. |
+| 5. Two-Phase Commit | [05_two_phase_commit.md](05_two_phase_commit.md) | 2PC protocol, WAL record types, named transactions, and crash recovery of prepared transactions. |
+| 6. WritePrepared Internals | [06_write_prepared_internals.md](06_write_prepared_internals.md) | CommitCache encoding, PreparedHeap, IsInSnapshot algorithm, old_commit_map, dual write queues, and snapshot list. |
+| 7. WriteUnprepared Internals | [07_write_unprepared_internals.md](07_write_unprepared_internals.md) | Incremental flushing, unprep_seqs tracking, savepoint handling, read-your-own-writes, and rollback. |
+| 8. Snapshot and Conflict Detection | [08_snapshot_and_conflicts.md](08_snapshot_and_conflicts.md) | Snapshot isolation, ValidateSnapshot, conflict detection for pessimistic and optimistic transactions, and user-defined timestamps. |
+| 9. Optimistic Transaction Internals | [09_optimistic_internals.md](09_optimistic_internals.md) | Serial vs. parallel validation, OCC lock buckets, commit-time conflict checking, and WriteBatch callback. |
+| 10. Transaction API and Lifecycle | [10_api_and_lifecycle.md](10_api_and_lifecycle.md) | Transaction states, core operations (Get/Put/GetForUpdate), save points, iterators, and untracked writes. |
+| 11. Advanced Features | [11_advanced_features.md](11_advanced_features.md) | Large transaction commit bypass, secondary indices, timestamped snapshots, transaction expiration, and CommitTimeWriteBatch. |
+| 12. Performance and Best Practices | [12_performance_and_best_practices.md](12_performance_and_best_practices.md) | Configuration tuning, write policy selection, lock striping, common pitfalls, and db_bench transaction benchmarks. |
+
+## Key Characteristics
+
+- **Two concurrency models**: Pessimistic (lock-based, `TransactionDB`) and optimistic (validation-based, `OptimisticTransactionDB`)
+- **Three write policies**: WriteCommitted (default, simplest), WritePrepared (low-latency commit), WriteUnprepared (large transactions)
+- **Point and range locking**: Striped hash table for point locks, interval tree for range locks with lock escalation
+- **Deadlock detection**: BFS-based cycle detection with configurable depth and timeout
+- **Two-phase commit**: Named transactions, WAL-persisted prepare, crash recovery of prepared transactions
+- **Snapshot isolation**: Per-transaction snapshots, lazy snapshot via `SetSnapshotOnNextOperation()`
+- **Dual write queues**: WritePrepared/WriteUnprepared use a second write queue for commits to avoid blocking prepare writes
+- **Large transaction optimization**: Commit bypass memtable ingests transaction as immutable memtable for fast commit of large write batches
+
+## Key Constraints
+
+- Transactions are NOT thread-safe; each must be accessed by a single thread at a time
+- Prepared transactions MUST be committed or rolled back, even after crash recovery
+- `GetForUpdate()` is required for read-modify-write atomicity; plain `Get()` does not acquire locks
+
+## Key Invariants
+
+- For WritePrepared: `prepare_seq < commit_seq` always holds; CommitCache is updated before the commit sequence is published
+- Lock ordering within the point lock manager: `lock_map_mutex_` > stripe mutexes (ascending CF, ascending stripe) > `wait_txn_map_mutex_`


### PR DESCRIPTION
## transaction/ (12 chapters)
Pessimistic/Optimistic/WritePrepared/WriteUnprepared transactions, 2PC, lock management (PointLockManager, PerKeyPointLockManager), deadlock detection (BFS), snapshot isolation, conflict detection.

## filter/ (11 chapters)
Bloom filter, Ribbon filter, partitioned filters, prefix bloom, memtable bloom, filter caching, filter construction.

## snapshot/ (8 chapters)
Snapshot implementation, sequence numbers, compaction interaction, transaction integration, timestamped snapshots.

Part 6 of 11 in the RocksDB AI documentation series.