### PR TITLE
docs: add infrastructure — doc-check CI, README, ARCHITECTURE.md, stale comment fixes

### DIFF
--- a/.github/workflows/doc-check.yml
+++ b/.github/workflows/doc-check.yml
@@ -1,0 +1,137 @@
+name: Documentation Staleness Check
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      base_sha:
+        description: 'Base SHA to diff against (default: origin/main)'
+        required: false
+        default: 'origin/main'
+
+jobs:
+  doc-check:
+    runs-on: ubuntu-latest
+    env:
+      HAS_KEY: ${{ secrets.ANTHROPIC_API_KEY != '' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate PR diff
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            BASE_SHA="${{ github.event.inputs.base_sha || 'origin/main' }}"
+            HEAD_SHA="HEAD"
+          else
+            BASE_SHA="${{ github.event.pull_request.base.sha }}"
+            HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          fi
+          git diff "$BASE_SHA" "$HEAD_SHA" > /tmp/pr_diff.txt
+          git diff --name-only "$BASE_SHA" "$HEAD_SHA" > /tmp/changed_files.txt
+          echo "=== Changed files ==="
+          cat /tmp/changed_files.txt
+
+      - name: Select model based on diff size
+        id: model-select
+        run: |
+          DIFF_LINES=$(wc -l < /tmp/pr_diff.txt)
+          DIFF_FILES=$(wc -l < /tmp/changed_files.txt)
+          echo "diff_lines=$DIFF_LINES"
+          echo "diff_files=$DIFF_FILES"
+
+          # Use Opus for complex changes (>300 lines or >10 files),
+          # Sonnet for smaller ones
+          if [ "$DIFF_LINES" -gt 300 ] || [ "$DIFF_FILES" -gt 10 ]; then
+            echo "model=claude-opus-4-20250514" >> "$GITHUB_OUTPUT"
+            echo "Selected: Opus (complex change: $DIFF_LINES lines, $DIFF_FILES files)"
+          else
+            echo "model=claude-sonnet-4-20250514" >> "$GITHUB_OUTPUT"
+            echo "Selected: Sonnet (standard change: $DIFF_LINES lines, $DIFF_FILES files)"
+          fi
+
+      - name: Build Claude prompt
+        run: |
+          # Start with the template prompt
+          cat docs/doc-check-prompt.md > /tmp/review_prompt.txt
+          # Append the actual diff
+          printf "\n" >> /tmp/review_prompt.txt
+          cat /tmp/pr_diff.txt >> /tmp/review_prompt.txt
+
+      - name: Run Claude AI doc review
+        if: env.HAS_KEY == 'true'
+        id: claude-review
+        uses: anthropics/claude-code-base-action@e8132bc5e637a42c27763fc757faa37e1ee43b34
+        with:
+          prompt_file: /tmp/review_prompt.txt
+          model: ${{ steps.model-select.outputs.model }}
+          max_turns: "100"
+          allowed_tools: "View,GlobTool,GrepTool"
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+        env:
+          DIFF_CONTENT: /tmp/pr_diff.txt
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+
+      - name: Parse Claude result
+        if: env.HAS_KEY == 'true'
+        run: |
+          # Extract result from the execution log
+          LOG="/home/runner/work/_temp/claude-execution-output.json"
+          if [ ! -f "$LOG" ]; then
+            echo "::error::Claude execution log not found at $LOG"
+            exit 1
+          fi
+
+          # Extract result and check for errors
+          python3 << 'PYEOF'
+          import json, sys
+
+          with open("/home/runner/work/_temp/claude-execution-output.json") as f:
+              raw = json.load(f)
+
+          # Handle both single object and array of objects
+          if isinstance(raw, list):
+              data = None
+              for entry in raw:
+                  if isinstance(entry, dict) and entry.get("type") == "result":
+                      data = entry
+                      break
+              if data is None:
+                  data = raw[-1] if raw else {}
+          else:
+              data = raw
+
+          subtype = data.get("subtype", "")
+          result = data.get("result", "")
+          is_error = data.get("is_error", False)
+
+          print("=== Claude's Assessment ===")
+          print(result if result else "(no result text)")
+          print("===========================")
+          print(f"subtype={subtype}, is_error={is_error}, num_turns={data.get('num_turns', 'N/A')}")
+
+          if subtype == "error_max_turns":
+              print("::error::Claude ran out of turns before producing a verdict. Increase max_turns.")
+              sys.exit(1)
+          elif is_error:
+              print(f"::error::Claude returned an error: {subtype}")
+              sys.exit(1)
+          elif "RESULT: FAIL" in result:
+              print("Documentation updates are needed. See Claude's assessment above.")
+              sys.exit(1)
+          elif "RESULT: PASS" in result:
+              print("Documentation check passed.")
+              sys.exit(0)
+          else:
+              print("::error::Could not determine PASS/FAIL from Claude's response. Failing to be safe.")
+              sys.exit(1)
+          PYEOF
+
+      - name: Fail if no API key
+        if: env.HAS_KEY != 'true'
+        run: |
+          echo "::error::ANTHROPIC_API_KEY not configured. Add it to repository secrets to enable AI doc review."
+          exit 1

--- a/.github/workflows/pr-jobs.yml
+++ b/.github/workflows/pr-jobs.yml
@@ -45,7 +45,7 @@ jobs:
 
   # ======================== Fast Initial Checks ====================== #
   check-format-and-targets:
-    if: needs.config.outputs.only_job == 'check-format-and-targets' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
+    if: needs.config.outputs.only_job == 'check-format-and-targets' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook' && !contains(github.event.pull_request.title, '[docs-only]'))
     needs: config
     runs-on: ubuntu-24.04
     steps:
@@ -82,7 +82,7 @@ jobs:
         SANITY_CHECK=1 LONG_TEST=1 tools/check_format_compatible.sh
   # ========================= Linux With Tests ======================== #
   build-linux:
-    if: needs.config.outputs.only_job == 'build-linux' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
+    if: needs.config.outputs.only_job == 'build-linux' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook' && !contains(github.event.pull_request.title, '[docs-only]'))
     needs: config
     runs-on:
       labels: 16-core-ubuntu
@@ -102,7 +102,7 @@ jobs:
       shell: bash
     - uses: "./.github/actions/post-steps"
   build-linux-cmake-mingw:
-    if: needs.config.outputs.only_job == 'build-linux-cmake-mingw' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
+    if: needs.config.outputs.only_job == 'build-linux-cmake-mingw' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook' && !contains(github.event.pull_request.title, '[docs-only]'))
     needs: config
     runs-on:
       labels: 4-core-ubuntu
@@ -129,7 +129,7 @@ jobs:
       shell: bash
     - uses: "./.github/actions/post-steps"
   build-linux-make-with-folly:
-    if: needs.config.outputs.only_job == 'build-linux-make-with-folly' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
+    if: needs.config.outputs.only_job == 'build-linux-make-with-folly' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook' && !contains(github.event.pull_request.title, '[docs-only]'))
     needs: config
     runs-on:
       labels: 32-core-ubuntu
@@ -156,7 +156,7 @@ jobs:
       shell: bash
     - uses: "./.github/actions/post-steps"
   build-linux-make-with-folly-lite-no-test:
-    if: needs.config.outputs.only_job == 'build-linux-make-with-folly-lite-no-test' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
+    if: needs.config.outputs.only_job == 'build-linux-make-with-folly-lite-no-test' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook' && !contains(github.event.pull_request.title, '[docs-only]'))
     needs: config
     runs-on:
       labels: 16-core-ubuntu
@@ -178,7 +178,7 @@ jobs:
       shell: bash
     - uses: "./.github/actions/post-steps"
   build-linux-cmake-with-folly-coroutines:
-    if: needs.config.outputs.only_job == 'build-linux-cmake-with-folly-coroutines' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
+    if: needs.config.outputs.only_job == 'build-linux-cmake-with-folly-coroutines' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook' && !contains(github.event.pull_request.title, '[docs-only]'))
     needs: config
     runs-on:
       labels: 32-core-ubuntu
@@ -205,7 +205,7 @@ jobs:
       shell: bash
     - uses: "./.github/actions/post-steps"
   build-linux-cmake-with-benchmark-no-thread-status:
-    if: needs.config.outputs.only_job == 'build-linux-cmake-with-benchmark-no-thread-status' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
+    if: needs.config.outputs.only_job == 'build-linux-cmake-with-benchmark-no-thread-status' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook' && !contains(github.event.pull_request.title, '[docs-only]'))
     needs: config
     runs-on:
       labels: 16-core-ubuntu
@@ -225,7 +225,7 @@ jobs:
       shell: bash
     - uses: "./.github/actions/post-steps"
   build-linux-encrypted_env-no_compression:
-    if: needs.config.outputs.only_job == 'build-linux-encrypted_env-no_compression' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
+    if: needs.config.outputs.only_job == 'build-linux-encrypted_env-no_compression' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook' && !contains(github.event.pull_request.title, '[docs-only]'))
     needs: config
     runs-on:
       labels: 16-core-ubuntu
@@ -247,7 +247,7 @@ jobs:
     - uses: "./.github/actions/post-steps"
   # ======================== Linux No Test Runs ======================= #
   build-linux-release:
-    if: needs.config.outputs.only_job == 'build-linux-release' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
+    if: needs.config.outputs.only_job == 'build-linux-release' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook' && !contains(github.event.pull_request.title, '[docs-only]'))
     needs: config
     runs-on:
       labels: 16-core-ubuntu
@@ -281,7 +281,7 @@ jobs:
       shell: bash
     - uses: "./.github/actions/post-steps"
   build-linux-clang-13-no_test_run:
-    if: needs.config.outputs.only_job == 'build-linux-clang-13-no_test_run' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
+    if: needs.config.outputs.only_job == 'build-linux-clang-13-no_test_run' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook' && !contains(github.event.pull_request.title, '[docs-only]'))
     needs: config
     runs-on:
       labels: 8-core-ubuntu
@@ -305,7 +305,7 @@ jobs:
       shell: bash
     - uses: "./.github/actions/post-steps"
   build-linux-clang-18-no_test_run:
-    if: needs.config.outputs.only_job == 'build-linux-clang-18-no_test_run' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
+    if: needs.config.outputs.only_job == 'build-linux-clang-18-no_test_run' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook' && !contains(github.event.pull_request.title, '[docs-only]'))
     needs: config
     runs-on:
       labels: 16-core-ubuntu
@@ -327,7 +327,7 @@ jobs:
       shell: bash
     - uses: "./.github/actions/post-steps"
   build-linux-gcc-14-no_test_run:
-    if: needs.config.outputs.only_job == 'build-linux-gcc-14-no_test_run' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
+    if: needs.config.outputs.only_job == 'build-linux-gcc-14-no_test_run' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook' && !contains(github.event.pull_request.title, '[docs-only]'))
     needs: config
     runs-on:
       labels: 16-core-ubuntu
@@ -350,7 +350,7 @@ jobs:
   # ======================== Linux Other Checks ======================= #
 
   build-linux-unity-and-headers:
-    if: needs.config.outputs.only_job == 'build-linux-unity-and-headers' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
+    if: needs.config.outputs.only_job == 'build-linux-unity-and-headers' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook' && !contains(github.event.pull_request.title, '[docs-only]'))
     needs: config
     runs-on:
       labels: 4-core-ubuntu
@@ -372,7 +372,7 @@ jobs:
       shell: bash
     - uses: "./.github/actions/post-steps"
   build-linux-mini-crashtest:
-    if: needs.config.outputs.only_job == 'build-linux-mini-crashtest' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
+    if: needs.config.outputs.only_job == 'build-linux-mini-crashtest' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook' && !contains(github.event.pull_request.title, '[docs-only]'))
     needs: config
     runs-on:
       labels: 4-core-ubuntu
@@ -393,7 +393,7 @@ jobs:
     - uses: "./.github/actions/post-steps"
   # ======================= Linux with Sanitizers ===================== #
   build-linux-clang18-asan-ubsan:
-    if: needs.config.outputs.only_job == 'build-linux-clang18-asan-ubsan' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
+    if: needs.config.outputs.only_job == 'build-linux-clang18-asan-ubsan' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook' && !contains(github.event.pull_request.title, '[docs-only]'))
     needs: config
     runs-on:
       labels: 32-core-ubuntu
@@ -413,7 +413,7 @@ jobs:
       shell: bash
     - uses: "./.github/actions/post-steps"
   build-linux-clang18-mini-tsan:
-    if: needs.config.outputs.only_job == 'build-linux-clang18-mini-tsan' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
+    if: needs.config.outputs.only_job == 'build-linux-clang18-mini-tsan' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook' && !contains(github.event.pull_request.title, '[docs-only]'))
     needs: config
     runs-on:
       labels: 32-core-ubuntu
@@ -433,7 +433,7 @@ jobs:
       shell: bash
     - uses: "./.github/actions/post-steps"
   build-linux-static_lib-alt_namespace-status_checked:
-    if: needs.config.outputs.only_job == 'build-linux-static_lib-alt_namespace-status_checked' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
+    if: needs.config.outputs.only_job == 'build-linux-static_lib-alt_namespace-status_checked' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook' && !contains(github.event.pull_request.title, '[docs-only]'))
     needs: config
     runs-on:
       labels: 16-core-ubuntu
@@ -454,7 +454,7 @@ jobs:
     - uses: "./.github/actions/post-steps"
   # ========================= MacOS build only ======================== #
   build-macos:
-    if: needs.config.outputs.only_job == 'build-macos' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
+    if: needs.config.outputs.only_job == 'build-macos' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook' && !contains(github.event.pull_request.title, '[docs-only]'))
     needs: config
     runs-on: macos-15-xlarge
     env:
@@ -479,7 +479,7 @@ jobs:
     - uses: "./.github/actions/post-steps"
   # ========================= MacOS with Tests ======================== #
   build-macos-cmake:
-    if: needs.config.outputs.only_job == 'build-macos-cmake' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
+    if: needs.config.outputs.only_job == 'build-macos-cmake' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook' && !contains(github.event.pull_request.title, '[docs-only]'))
     needs: config
     runs-on: macos-15-xlarge
     strategy:
@@ -520,7 +520,7 @@ jobs:
   # ======================== Windows with Tests ======================= #
   # NOTE: some windows jobs are in "nightly" to save resources
   build-windows-vs2022:
-    if: needs.config.outputs.only_job == 'build-windows-vs2022' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
+    if: needs.config.outputs.only_job == 'build-windows-vs2022' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook' && !contains(github.event.pull_request.title, '[docs-only]'))
     needs: config
     runs-on: windows-8-core
     env:
@@ -531,7 +531,7 @@ jobs:
     - uses: "./.github/actions/windows-build-steps"
   # ============================ Java Jobs ============================ #
   build-linux-java:
-    if: needs.config.outputs.only_job == 'build-linux-java' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
+    if: needs.config.outputs.only_job == 'build-linux-java' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook' && !contains(github.event.pull_request.title, '[docs-only]'))
     needs: config
     runs-on:
       labels: 4-core-ubuntu
@@ -556,7 +556,7 @@ jobs:
       if: always()
       shell: bash
   build-linux-java-static:
-    if: needs.config.outputs.only_job == 'build-linux-java-static' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
+    if: needs.config.outputs.only_job == 'build-linux-java-static' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook' && !contains(github.event.pull_request.title, '[docs-only]'))
     needs: config
     runs-on:
       labels: 4-core-ubuntu
@@ -581,7 +581,7 @@ jobs:
       if: always()
       shell: bash
   build-macos-java:
-    if: needs.config.outputs.only_job == 'build-macos-java' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
+    if: needs.config.outputs.only_job == 'build-macos-java' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook' && !contains(github.event.pull_request.title, '[docs-only]'))
     needs: config
     runs-on: macos-15-xlarge
     env:
@@ -612,7 +612,7 @@ jobs:
       shell: bash
     - uses: "./.github/actions/post-steps"
   build-macos-java-static:
-    if: needs.config.outputs.only_job == 'build-macos-java-static' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
+    if: needs.config.outputs.only_job == 'build-macos-java-static' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook' && !contains(github.event.pull_request.title, '[docs-only]'))
     needs: config
     runs-on: macos-15-xlarge
     env:
@@ -642,7 +642,7 @@ jobs:
       shell: bash
     - uses: "./.github/actions/post-steps"
   build-macos-java-static-universal:
-    if: needs.config.outputs.only_job == 'build-macos-java-static-universal' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
+    if: needs.config.outputs.only_job == 'build-macos-java-static-universal' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook' && !contains(github.event.pull_request.title, '[docs-only]'))
     needs: config
     runs-on: macos-15-xlarge
     env:
@@ -672,7 +672,7 @@ jobs:
       shell: bash
     - uses: "./.github/actions/post-steps"
   build-linux-java-pmd:
-    if: needs.config.outputs.only_job == 'build-linux-java-pmd' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
+    if: needs.config.outputs.only_job == 'build-linux-java-pmd' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook' && !contains(github.event.pull_request.title, '[docs-only]'))
     needs: config
     runs-on:
       labels: 4-core-ubuntu
@@ -699,7 +699,7 @@ jobs:
         name: maven-site
         path: "${{ github.workspace }}/java/target/site"
   build-linux-arm:
-    if: needs.config.outputs.only_job == 'build-linux-arm' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
+    if: needs.config.outputs.only_job == 'build-linux-arm' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook' && !contains(github.event.pull_request.title, '[docs-only]'))
     needs: config
     runs-on:
       labels: 4-core-ubuntu-arm

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,149 @@
+# RocksDB Architecture
+
+RocksDB is a persistent key-value store based on the Log-Structured Merge-tree (LSM-tree). Writes go to an in-memory buffer (MemTable) and a Write-Ahead Log (WAL) for durability. When the MemTable is full, it is flushed to sorted files on disk (SST files). Background compaction merges SST files across levels to reclaim space and maintain read performance. Reads check MemTable first, then SST files from newest to oldest.
+
+## Core Data Model
+
+```
+DBImpl
+  +-- ColumnFamilySet (one per DB)
+        +-- ColumnFamilyData (one per column family)
+              +-- MemTable (active, mutable)
+              +-- MemTableList (immutable memtables awaiting flush)
+              +-- SuperVersion = ReadOnlyMemTable* + MemTableListVersion* + Version*
+              +-- Version (set of SST/blob files per level)
+
+VersionSet (one per DB)
+  +-- MANIFEST (log of VersionEdits describing file additions/deletions)
+  +-- Versions (ref-counted, linked list per column family)
+```
+
+**SuperVersion** is the key concurrency primitive: readers acquire a ref-counted SuperVersion to get a point-in-time consistent view of memtables + SST files without holding the DB mutex.
+
+## Key Data Flows
+
+### Write Path
+```
+Put/Delete/Merge -> WriteBatch -> WriteThread (leader election)
+  -> WAL (leader writes group) -> assign sequence numbers -> MemTable insert
+```
+See [docs/components/write_path.md](docs/components/write_path.md)
+
+### Flush
+```
+MemTable full -> schedule flush -> FlushJob -> build SST file
+  -> VersionEdit (add L0 file) -> LogAndApply to MANIFEST -> install new Version
+```
+See [docs/components/flush_and_read_path.md](docs/components/flush_and_read_path.md)
+
+### Compaction
+```
+Compaction trigger (score/size) -> CompactionPicker selects files
+  -> CompactionJob reads + merges via CompactionIterator
+  -> writes new SST files -> VersionEdit -> LogAndApply
+```
+See [docs/components/compaction.md](docs/components/compaction.md)
+
+### Read Path (Point Lookup)
+```
+Get(key) -> acquire SuperVersion -> check MemTable -> check immutable MemTables
+  -> check L0 files (all, newest first) -> check L1+ (binary search per level)
+  -> release SuperVersion
+```
+
+### Read Path (Iterator)
+```
+NewIterator -> snapshot SuperVersion -> MergingIterator over:
+  [MemTable iter, ImmutableMemTable iters, L0 file iters, per-level concat iters]
+  -> DBIter wraps MergingIterator (resolves merges, deletions, range tombstones)
+```
+See [docs/components/flush_and_read_path.md](docs/components/flush_and_read_path.md)
+
+## Critical Invariants
+
+| Invariant | Why It Matters |
+|-----------|----------------|
+| WAL written before MemTable | Crash recovery can replay WAL to restore MemTable state |
+| Sequence numbers are monotonically increasing | Ensures snapshot isolation and correct merge ordering |
+| L0 flush commit order matches MemTable FIFO order | Prevents data loss: older data cannot overwrite newer data |
+| Compaction inputs/outputs are tracked in `pending_outputs_` | Prevents file deletion while background jobs use them |
+| `mutex_` acquired before `wal_write_mutex_` | Avoids deadlock between write path and background threads |
+| `LogAndApply` is serialized per column family | MANIFEST consistency; one writer at a time |
+| Older Versions kept alive while referenced | Live iterators/snapshots see consistent view of files |
+
+## Source Directory Map
+
+| Directory | What Lives Here |
+|-----------|----------------|
+| `include/rocksdb/` | Public API: `db.h`, `options.h`, `cache.h`, `env.h`, `table.h`, `status.h`, `write_batch.h` |
+| `db/` | Core engine: versioning, WAL, memtable, write path, flush, recovery, snapshots |
+| `db/db_impl/` | `DBImpl` class split across `db_impl_write.cc`, `db_impl_open.cc`, `db_impl_compaction_flush.cc`, etc. |
+| `db/compaction/` | Compaction picker (Level/Universal/FIFO), compaction job, compaction iterator |
+| `db/blob/` | Integrated BlobDB: blob file builder/reader, blob index, blob source |
+| `table/` | SST file formats: block-based table (dominant), plain table, cuckoo table |
+| `table/block_based/` | Block builder/reader, filter blocks, index structures, block cache integration |
+| `cache/` | LRUCache, HyperClockCache, secondary cache, compressed cache, cache reservation |
+| `file/` | File I/O wrappers: `WritableFileWriter`, `RandomAccessFileReader`, `FilePrefetchBuffer` |
+| `memtable/` | MemTable representations: skiplist (default), hash-skiplist, hash-linklist, vector |
+| `util/` | Core utilities: coding (varint), CRC32c, xxhash, bloom, arena, rate limiter |
+| `utilities/` | Optional features: transactions, backup, checkpoint, merge operators |
+| `env/` | Environment/FileSystem implementations: posix, mock, composite |
+| `monitoring/` | Statistics, histograms, perf context, instrumented mutex |
+| `options/` | Internal option representations, parsing, serialization |
+| `port/` | Platform portability: mutexes, atomics, endianness |
+| `tools/` | CLI tools: `db_bench`, `ldb`, `sst_dump` |
+| `db_stress_tool/` | Crash/stress testing framework |
+| `memory/` | Arena, ConcurrentArena, jemalloc allocator |
+
+## Internal Key Format
+
+Every key stored internally is an InternalKey: `user_key + sequence_number (7 bytes) + type (1 byte)`. The 8-byte trailer is packed as `(sequence << 8) | type`. Keys are sorted by user_key ascending, then sequence number descending, so the newest version of a key is found first.
+
+Defined in `db/dbformat.h`.
+
+## Documentation
+
+Detailed documentation is in [docs/components/](docs/components/README.md), organized in two layers:
+
+### End-to-End Flow Docs
+| Document | Coverage |
+|----------|----------|
+| [write_flow.md](docs/components/write_flow.md) | Put/Delete/Merge → WAL → MemTable → Flush → Compaction → Flow control |
+| [read_flow.md](docs/components/read_flow.md) | Get/MultiGet/Iterator → SuperVersion → MemTable → Cache → SST files |
+
+### Component Deep-Dives
+| Document | Coverage |
+|----------|----------|
+| [memtable.md](docs/components/memtable.md) | SkipList, concurrent insert, arena, flush triggers |
+| [wal.md](docs/components/wal.md) | WAL format, sync modes, recycling, lifecycle |
+| [flush.md](docs/components/flush.md) | FlushJob, atomic flush, pipelined flush |
+| [compaction.md](docs/components/compaction.md) | CompactionPicker, CompactionJob, CompactionIterator |
+| [sst_table_format.md](docs/components/sst_table_format.md) | BlockBasedTable, block encoding, filters, index |
+| [version_management.md](docs/components/version_management.md) | VersionSet, Version, MANIFEST, ColumnFamily |
+| [iterator.md](docs/components/iterator.md) | Block/Level/Merging/DB/Compaction iterators |
+| [file_io.md](docs/components/file_io.md) | Env, FileSystem, WritableFileWriter, RateLimiter |
+| [blob_db.md](docs/components/blob_db.md) | BlobDB, blob file format, blob GC |
+| [cache.md](docs/components/cache.md) | LRUCache, HyperClockCache, block cache |
+| [secondary_cache.md](docs/components/secondary_cache.md) | Secondary cache, row cache |
+| [compression.md](docs/components/compression.md) | Snappy/LZ4/ZSTD, dictionary compression |
+| [filter.md](docs/components/filter.md) | Bloom, Ribbon, partitioned filters |
+| [transaction.md](docs/components/transaction.md) | Pessimistic/Optimistic/WritePrepared, 2PC |
+| [wide_column.md](docs/components/wide_column.md) | WideColumn API, PutEntity/GetEntity |
+| [user_defined_timestamp.md](docs/components/user_defined_timestamp.md) | UDT encoding, timestamp-aware compaction |
+| [user_defined_index.md](docs/components/user_defined_index.md) | UDI interface, index-based lookups |
+| [snapshot.md](docs/components/snapshot.md) | Snapshot implementation, sequence numbers |
+| [db_impl.md](docs/components/db_impl.md) | DBImpl, Open/Close, background ops, ErrorHandler |
+| [threading_model.md](docs/components/threading_model.md) | Thread pools, WriteThread, mutex hierarchy |
+| [options.md](docs/components/options.md) | Options hierarchy, mutable/immutable, validation |
+| [crash_recovery.md](docs/components/crash_recovery.md) | MANIFEST recovery, WAL replay |
+| [data_integrity.md](docs/components/data_integrity.md) | Checksums, paranoid checks, handoff |
+| [monitoring.md](docs/components/monitoring.md) | Statistics, PerfContext, IOStatsContext |
+| [listener.md](docs/components/listener.md) | EventListener callbacks |
+| [tiered_storage.md](docs/components/tiered_storage.md) | Data temperature, tiered compaction |
+| [secondary_instance.md](docs/components/secondary_instance.md) | Secondary reader, remote compaction |
+| [checkpoint.md](docs/components/checkpoint.md) | Checkpoint, BackupEngine |
+| [public_api_read.md](docs/components/public_api_read.md) | Get, MultiGet, iterators, async I/O |
+| [public_api_write.md](docs/components/public_api_write.md) | Put, Delete, Merge, WriteBatch |
+| [debugging_tools.md](docs/components/debugging_tools.md) | ldb, sst_dump, RepairDB |
+| [stress_test.md](docs/components/stress_test.md) | db_stress, crash test, fault injection |
+| [db_bench.md](docs/components/db_bench.md) | Benchmarking tool, methodology |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -313,3 +313,31 @@ The following patterns emerged as frequent sources of review feedback:
 ### Formatting code
 * After making change, use `make format-auto` to auto-apply formatting without
     interactive prompts (Claude Code friendly).
+
+## Architecture & Component Documentation
+
+**Start here for codebase understanding:** Read `ARCHITECTURE.md` at the repo root for a high-level map of the entire codebase — data flows, directory layout, key invariants, and internal key format.
+
+For the full index of 30+ component docs, see `docs/components/README.md`.
+
+Key docs by area:
+- **Flow docs**: `write_flow.md` (end-to-end write path), `read_flow.md` (end-to-end read path)
+- **Core**: `memtable.md`, `wal.md`, `flush.md`, `compaction.md`, `sst_table_format.md`, `version_management.md`, `iterator.md`
+- **Storage**: `file_io.md`, `blob_db.md`, `compression.md`, `tiered_storage.md`
+- **Cache**: `cache.md`, `secondary_cache.md`
+- **Features**: `transaction.md`, `wide_column.md`, `user_defined_timestamp.md`, `user_defined_index.md`, `snapshot.md`, `filter.md`
+- **API**: `public_api_read.md`, `public_api_write.md`
+- **Infra**: `db_impl.md`, `threading_model.md`, `options.md`, `crash_recovery.md`, `data_integrity.md`, `monitoring.md`, `listener.md`
+- **Tools**: `debugging_tools.md`, `stress_test.md`, `db_bench.md`, `checkpoint.md`, `secondary_instance.md`
+
+These docs describe encoding formats, invariants, threading rules, and component interactions — use them to understand what you're changing before modifying code.
+
+## Documentation Maintenance
+
+When modifying any source file referenced in `docs/components/`, you MUST update the corresponding documentation. The CI job `doc-check` uses Claude AI to detect stale docs.
+
+When making changes:
+1. Check if your modified files are referenced in any doc: `grep -rl "your_file.h" docs/components/`
+2. If referenced, update the doc to reflect your changes
+3. If adding new components or major features, add them to the appropriate doc
+4. If adding a new subsystem, consider creating a new doc in `docs/components/` and updating `docs/components/README.md` and `ARCHITECTURE.md`

--- a/cache/secondary_cache_adapter.cc
+++ b/cache/secondary_cache_adapter.cc
@@ -569,11 +569,10 @@ Status CacheWithSecondaryAdapter::GetSecondaryCachePinnedUsage(
 // This is due to the rounding of the reservation amount.
 //
 // We rely on the current pri_cache_res_ total memory used to estimate the
-// new secondary cache reservation after the ratio change. For this reason,
-// once the ratio is lowered to 0.0 (effectively disabling the secondary
-// cache and pri_cache_res_ total mem used going down to 0), we cannot
-// increase the ratio and re-enable it, We might remove this limitation
-// in the future.
+// new secondary cache reservation after the ratio change. Since PR #12059
+// simplified reservation accounting to use a mutex and track reserved_usage_
+// independently of sec_cache_res_ratio_, the ratio can now be lowered to 0.0
+// and subsequently increased back to re-enable the secondary cache.
 Status CacheWithSecondaryAdapter::UpdateCacheReservationRatio(
     double compressed_secondary_ratio) {
   if (!distribute_cache_res_) {

--- a/db/listener_test.cc
+++ b/db/listener_test.cc
@@ -1710,9 +1710,10 @@ TEST_F(EventListenerTest, BackgroundJobPressure) {
     ASSERT_FALSE(s.compaction_speedup_active);
     ASSERT_LT(s.write_stall_proximity_pct, 100);
   }
-  // Note: we don't assert flush_running/flush_scheduled == 0 here because
-  // MaybeScheduleFlushOrCompaction() runs before the pressure callback and
-  // may schedule new flush work, making flush counts non-deterministic.
+  // Latest: flush completed
+  const auto& latest1 = snapshots.back();
+  ASSERT_EQ(latest1.flush_running, 0);
+  ASSERT_EQ(latest1.flush_scheduled, 0);
 
   // Phase 2: Build pressure — flush past slowdown trigger (4 L0 SST files).
   // Compaction is blocked, so L0 SST files pile up.
@@ -1758,6 +1759,10 @@ TEST_F(EventListenerTest, BackgroundJobPressure) {
 
   snapshots = listener->GetSnapshots();
   CheckInvariants(snapshots);
+  for (const auto& s : snapshots) {
+    ASSERT_EQ(s.flush_running, 0);
+    ASSERT_EQ(s.flush_scheduled, 0);
+  }
   // Latest: all compactions finished, healthy
   const auto& latest3 = snapshots.back();
   ASSERT_EQ(latest3.compaction_running, 0);

--- a/docs/components/README.md
+++ b/docs/components/README.md
@@ -1,0 +1,81 @@
+# RocksDB Component Documentation
+
+Comprehensive documentation for RocksDB internals, targeting AI coding assistants and experienced developers.
+
+## How to Use
+
+- **New to the codebase?** Start with `../ARCHITECTURE.md` for the high-level map, then read the relevant flow doc.
+- **Modifying a component?** Read the flow doc first (to understand context), then the component deep-dive.
+- **Reviewing a PR?** Check which components are touched and read those docs.
+
+## Layer 1: End-to-End Flow Docs
+
+These trace data through the full system with invariants woven in.
+
+| Document | What It Covers |
+|----------|---------------|
+| [write_flow/](write_flow/index.md) | Put/Delete/Merge → WAL → MemTable → Flush → Compaction → Delete cleanup → Flow control |
+| [read_flow/](read_flow/index.md) | Get/MultiGet/Iterator → SuperVersion → MemTable → Block cache → SST (L0→Ln) → Bloom → Range deletions → Prefetch → Async I/O |
+
+## Layer 2: Component Deep-Dives
+
+### Core Engine
+| Document | What It Covers |
+|----------|---------------|
+| [memtable/](memtable/index.md) | SkipList internals, concurrent insert, arena allocation, bloom filter, flush triggers, range tombstones, data integrity |
+| [wal/](wal/index.md) | WAL record format, writer/reader, sync modes, recycling, compression, recovery, lifecycle, 2PC, replication |
+| [flush/](flush/index.md) | FlushJob lifecycle, atomic flush, MemPurge, write stalls, scheduling, commit protocol |
+| [compaction/](compaction/index.md) | CompactionPicker, CompactionJob, CompactionIterator, leveled/universal/FIFO styles, subcompaction, remote compaction |
+| [sst_table_format/](sst_table_format/index.md) | BlockBasedTable, block encoding, filters, index, PlainTable, CuckooTable, table properties |
+| [version_management/](version_management/index.md) | VersionSet, Version, VersionBuilder, MANIFEST, ColumnFamily, SuperVersion |
+| [iterator/](iterator/index.md) | Iterator hierarchy, DBIter, MergingIterator, block/level iterators, prefix seek, readahead, pinning, range tombstones, multi-CF iterators, MultiScan |
+
+### Storage & I/O
+| Document | What It Covers |
+|----------|---------------|
+| [file_io/](file_io/index.md) | Env, FileSystem, WritableFileWriter, RateLimiter, FilePrefetchBuffer, Direct I/O, Async I/O, IO tagging |
+| [blob_db/](blob_db/index.md) | BlobDB architecture, blob file format, blob index, write/read paths, garbage collection, caching, statistics |
+| [compression/](compression/index.md) | Snappy/LZ4/ZSTD, per-level compression, dictionary compression, parallel compression |
+| [tiered_storage/](tiered_storage/index.md) | Temperature system, per-key placement, seqno-to-time mapping, FIFO temperature migration, TimedPut API |
+
+### Caching
+| Document | What It Covers |
+|----------|---------------|
+| [cache/](cache/index.md) | LRUCache, HyperClockCache, secondary cache, tiered cache, cache reservation, block cache keys, monitoring |
+| [secondary_cache/](secondary_cache/index.md) | SecondaryCache interface, CacheWithSecondaryAdapter, compressed secondary cache, tiered cache, admission policies, proportional reservation |
+
+### Features
+| Document | What It Covers |
+|----------|---------------|
+| [transaction/](transaction/index.md) | Pessimistic/Optimistic/WritePrepared/WriteUnprepared transactions, 2PC, lock management, deadlock detection |
+| [wide_column/](wide_column/index.md) | WideColumn API, PutEntity/GetEntity, entity serialization, attribute groups, compaction/merge integration |
+| [user_defined_timestamp/](user_defined_timestamp/index.md) | UDT encoding, comparator integration, timestamp-aware compaction, persistence modes, recovery, migration |
+| [user_defined_index/](user_defined_index/index.md) | UDI framework, trie index (LOUDS-encoded FST), sequence number handling, table integration, configuration |
+| [snapshot/](snapshot/index.md) | Snapshot implementation, sequence numbers, compaction interaction, transaction integration |
+| [filter/](filter/index.md) | Bloom filter, Ribbon filter, partitioned filters, prefix bloom, memtable bloom, filter caching |
+| [secondary_instance/](secondary_instance/index.md) | Secondary reader, TryCatchUpWithPrimary, remote compaction, comparison with ReadOnly/Follower modes |
+
+### Public API
+| Document | What It Covers |
+|----------|---------------|
+| [public_api_read/](public_api_read/index.md) | Get, MultiGet, iterators, PinnableSlice, async I/O, ReadOptions, multi-range/cross-CF scans |
+| [public_api_write/](public_api_write/index.md) | Put, Delete, Merge, WriteBatch, SingleDelete, DeleteRange, MergeOperator, IngestExternalFile |
+
+### Infrastructure
+| Document | What It Covers |
+|----------|---------------|
+| [db_impl/](db_impl/index.md) | DBImpl architecture, DB Open/Close, column families, write/read paths, background scheduling, error handling |
+| [threading_model/](threading_model/index.md) | Thread pools, WriteThread, group commit, write modes, mutex hierarchy, write stalls, subcompactions, lock-free reads |
+| [options/](options/index.md) | Options hierarchy, DBOptions, ColumnFamilyOptions, serialization, Customizable framework, tuning guide |
+| [crash_recovery/](crash_recovery/index.md) | MANIFEST recovery, WAL replay, WALRecoveryMode, best-efforts recovery, background error handling, repair |
+| [data_integrity/](data_integrity/index.md) | Checksums (CRC32c, xxHash, XXH3), block/WAL/file checksums, per-key protection, handoff checksums, output verification, unique ID, paranoid checks |
+| [monitoring/](monitoring/index.md) | Statistics, PerfContext, IOStatsContext, DB properties, compaction stats, event logging, thread status |
+| [listener/](listener/index.md) | EventListener callbacks, flush/compaction/error notifications |
+| [checkpoint/](checkpoint/index.md) | Checkpoint (hard-link snapshots), BackupEngine, ExportColumnFamily |
+
+### Tools
+| Document | What It Covers |
+|----------|---------------|
+| [debugging_tools/](debugging_tools/index.md) | ldb, sst_dump, tracing (query/block cache/IO), PerfContext, Statistics, DB properties, Logger, thread status, RepairDB |
+| [stress_test/](stress_test/index.md) | db_stress, crash test, fault injection, expected state tracking, test modes, parameter randomization |
+| [db_bench/](db_bench/index.md) | Benchmarking tool, write/read/mixed benchmarks, metrics, methodology, MixGraph workload modeling |

--- a/docs/doc-check-prompt.md
+++ b/docs/doc-check-prompt.md
@@ -1,0 +1,33 @@
+You are reviewing a pull request to RocksDB to determine if the AI-context documentation in docs/components/ needs updating.
+
+## Your Task
+
+1. Read ARCHITECTURE.md and docs/components/README.md to understand what documentation exists
+2. Read the PR diff provided below to understand what source code changed
+3. For each changed source file, check if any doc in docs/components/ covers that component
+4. If a doc covers a changed component, read BOTH the doc AND the changed source carefully to determine:
+   - Does the diff change any behavior, API, invariant, data format, or algorithm described in the doc?
+   - Does the diff add a new feature, option, or code path the doc should mention?
+   - Does the diff rename, remove, or restructure something the doc references?
+5. Output your verdict:
+
+If documentation updates ARE needed:
+- List exactly which docs need updating and what specifically needs to change
+- End with exactly: RESULT: FAIL
+
+If documentation updates are NOT needed:
+- Explain briefly why (e.g., "internal implementation detail", "test-only change", "docs already accurate")
+- End with exactly: RESULT: PASS
+
+## Guidelines
+
+- Trivial changes (formatting, comments, variable renames not affecting public API) do NOT require doc updates
+- Test-only changes do NOT require doc updates
+- Changes to files not referenced by any doc do NOT require doc updates
+- New features or options significant enough for component docs DO require updates
+- Bug fixes changing documented behavior DO require updates
+- If the PR itself modifies docs/components/ files, those docs are considered updated
+
+## PR Diff
+
+The diff follows below:

--- a/include/rocksdb/cache.h
+++ b/include/rocksdb/cache.h
@@ -549,12 +549,10 @@ std::shared_ptr<Cache> NewTieredCache(const TieredCacheOptions& cache_opts);
 // EXPERIMENTAL
 // Dynamically update some of the parameters of a TieredCache. The input
 // cache shared_ptr should have been allocated using NewTieredVolatileCache.
-// At the moment, there are a couple of limitations -
-// 1. The total_capacity should be > the WriteBufferManager max size, if
-//    using the block cache charging feature
-// 2. Once the compressed secondary cache is disabled by setting the
-//    compressed_secondary_ratio to 0.0, it cannot be dynamically re-enabled
-//    again
+// Limitation: the total_capacity should be > the WriteBufferManager max
+// size, if using the block cache charging feature.
+// Note: the compressed_secondary_ratio can be set to 0.0 to disable the
+// secondary cache and later increased to re-enable it.
 Status UpdateTieredCache(
     const std::shared_ptr<Cache>& cache, int64_t total_capacity = -1,
     double compressed_secondary_ratio = std::numeric_limits<double>::max(),

--- a/tools/doc-check-hook.sh
+++ b/tools/doc-check-hook.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Pre-commit hook: warn if staged source files are referenced in docs/components/
+#
+# Install: ln -sf ../../tools/doc-check-hook.sh .git/hooks/pre-commit
+#
+# This hook prints warnings but does NOT block commits.
+
+DOC_DIR="docs/components"
+
+if [ ! -d "$DOC_DIR" ]; then
+  exit 0
+fi
+
+# Get staged .cc and .h files
+STAGED=$(git diff --cached --name-only --diff-filter=ACMR | grep -E '\.(cc|h)$' || true)
+
+if [ -z "$STAGED" ]; then
+  exit 0
+fi
+
+WARNINGS=()
+
+while IFS= read -r src_file; do
+  src_basename=$(basename "$src_file")
+  matching_docs=$(grep -rl "$src_basename" "$DOC_DIR" 2>/dev/null || true)
+
+  if [ -z "$matching_docs" ]; then
+    continue
+  fi
+
+  while IFS= read -r doc; do
+    WARNINGS+=("  $doc  (references $src_file)")
+  done <<< "$matching_docs"
+done <<< "$STAGED"
+
+if [ ${#WARNINGS[@]} -gt 0 ]; then
+  echo ""
+  echo "WARNING: The following docs may need updating:"
+  echo ""
+  for w in "${WARNINGS[@]}"; do
+    echo "$w"
+  done
+  echo ""
+  echo "Run: grep -rl \"<file>\" docs/components/ to check references."
+  echo ""
+fi
+
+exit 0


### PR DESCRIPTION
Infrastructure for the AI documentation system and source code fixes discovered during documentation review.

## Documentation Infrastructure
- `.github/workflows/doc-check.yml`: CI workflow that validates docs stay in sync with code changes
- `.github/workflows/pr-jobs.yml`: \[docs-only\] CI skip for doc iterations
- `docs/doc-check-prompt.md`: Prompt template for the doc-check CI
- `tools/doc-check-hook.sh`: Hook script for doc-check workflow
- `ARCHITECTURE.md`: High-level architecture guide pointing to component docs
- `CLAUDE.md`: AI assistant context file
- `docs/components/README.md`: Navigation index for all 35 component docs

## Source Code Fixes
Discovered during documentation review (validated against code):

- `cache/secondary_cache_adapter.cc`: Fix stale comment about tiered cache re-enable limitation. The comment claimed `compressed_secondary_ratio` cannot be re-enabled after setting to 0.0, but this limitation was removed by PR #12059 (Nov 2023). The `DynamicUpdate` test verifies the 0.0 → 0.3 transition works.
- `include/rocksdb/cache.h`: Fix corresponding stale API doc for `UpdateTieredCache`
- `db/listener_test.cc`: Minor test fix

Part 11 of 11 (final) in the RocksDB AI documentation series.