### PR TITLE
Add SortedRunBuilder: use RocksDB as an external… (#14499)

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -331,6 +331,7 @@ cpp_library_wrapper(name="rocksdb_lib", srcs=[
         "utilities/secondary_index/simple_secondary_index.cc",
         "utilities/simulator_cache/cache_simulator.cc",
         "utilities/simulator_cache/sim_cache.cc",
+        "utilities/sorted_run_builder/sorted_run_builder.cc",
         "utilities/table_properties_collectors/compact_for_tiering_collector.cc",
         "utilities/table_properties_collectors/compact_on_deletion_collector.cc",
         "utilities/trace/file_trace_reader_writer.cc",
@@ -5528,6 +5529,12 @@ cpp_unittest_wrapper(name="slice_test",
 
 cpp_unittest_wrapper(name="slice_transform_test",
             srcs=["util/slice_transform_test.cc"],
+            deps=[":rocksdb_test_lib"],
+            extra_compiler_flags=[])
+
+
+cpp_unittest_wrapper(name="sorted_run_builder_test",
+            srcs=["utilities/sorted_run_builder/sorted_run_builder_test.cc"],
             deps=[":rocksdb_test_lib"],
             extra_compiler_flags=[])
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -967,6 +967,7 @@ set(SOURCES
         utilities/cassandra/merge_operator.cc
         utilities/checkpoint/checkpoint_impl.cc
         utilities/compaction_filters.cc
+        utilities/sorted_run_builder/sorted_run_builder.cc
         utilities/compaction_filters/remove_emptyvalue_compactionfilter.cc
         utilities/counted_fs.cc
         utilities/debug.cc
@@ -1555,6 +1556,7 @@ if(WITH_TESTS)
         utilities/cassandra/cassandra_row_merge_test.cc
         utilities/cassandra/cassandra_serialize_test.cc
         utilities/checkpoint/checkpoint_test.cc
+        utilities/sorted_run_builder/sorted_run_builder_test.cc
         utilities/env_timed_test.cc
         utilities/fault_injection_fs_test.cc
         utilities/memory/memory_test.cc

--- a/Makefile
+++ b/Makefile
@@ -645,6 +645,7 @@ TESTS_PLATFORM_DEPENDENT := \
 	dynamic_bloom_test \
 	c_test \
 	checkpoint_test \
+	sorted_run_builder_test \
 	crc32c_test \
 	coding_test \
 	inlineskiplist_test \
@@ -1601,6 +1602,9 @@ backup_engine_test: $(OBJ_DIR)/utilities/backup/backup_engine_test.o $(TEST_LIBR
 	$(AM_LINK)
 
 checkpoint_test: $(OBJ_DIR)/utilities/checkpoint/checkpoint_test.o $(TEST_LIBRARY) $(LIBRARY)
+	$(AM_LINK)
+
+sorted_run_builder_test: $(OBJ_DIR)/utilities/sorted_run_builder/sorted_run_builder_test.o $(TEST_LIBRARY) $(LIBRARY)
 	$(AM_LINK)
 
 cache_simulator_test: $(OBJ_DIR)/utilities/simulator_cache/cache_simulator_test.o $(TEST_LIBRARY) $(LIBRARY)

--- a/include/rocksdb/utilities/sorted_run_builder.h
+++ b/include/rocksdb/utilities/sorted_run_builder.h
@@ -1,0 +1,144 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "rocksdb/options.h"
+#include "rocksdb/slice.h"
+#include "rocksdb/status.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+class Comparator;
+class Iterator;
+class WriteBatch;
+
+struct SortedRunBuilderOptions {
+  // Directory for temporary DB storage. Required.
+  std::string temp_dir;
+
+  // Comparator for key ordering. Default: BytewiseComparator.
+  const Comparator* comparator = nullptr;
+
+  // Target SST file size for output files.
+  // Default: 64MB (same as default target_file_size_base).
+  uint64_t target_file_size_bytes = 64 * 1024 * 1024;
+
+  // Compression type for output SST files.
+  // Default: kNoCompression (always available). Set to kSnappyCompression,
+  // kZSTD, etc. if the desired library is linked with your binary.
+  CompressionType compression = kNoCompression;
+
+  // Max number of background compaction threads.
+  // Higher = faster sort for large datasets.
+  int max_compaction_threads = 4;
+
+  // Memory budget for memtables (write_buffer_size).
+  // Controls how much data is sorted in-memory before flushing.
+  size_t write_buffer_size = 64 * 1024 * 1024;
+
+  // Max number of write buffers (memtables) before stalling writes.
+  int max_write_buffer_number = 4;
+
+  // Block-based table options for output files (optional).
+  // Caller can set block_size, filter_policy, etc.
+  std::shared_ptr<TableFactory> table_factory = nullptr;
+
+  // If true, keep the temporary DB after Finish() so files can be
+  // linked/moved rather than copied. Caller must call Cleanup() explicitly.
+  bool keep_temp_db = false;
+};
+
+// SortedRunBuilder is a utility that uses RocksDB internally to sort
+// arbitrary key-value data and produce sorted SST files. This allows
+// callers to use RocksDB as an external sort engine without managing
+// a DB instance directly.
+//
+// Usage:
+//   SortedRunBuilderOptions opts;
+//   opts.temp_dir = "/tmp/sort_work";
+//   std::unique_ptr<SortedRunBuilder> builder;
+//   SortedRunBuilder::Create(opts, &builder);
+//
+//   builder->Add("zebra", "v1");
+//   builder->Add("apple", "v2");
+//   builder->Finish();
+//
+//   // Get sorted SST files suitable for IngestExternalFile
+//   auto files = builder->GetOutputFiles();
+//
+// The output SST files have seqno=0 and can be ingested into another
+// DB via IngestExternalFile. Required ingestion settings:
+//   ingest_opts.allow_db_generated_files = true;
+//   ingest_opts.snapshot_consistency = false;
+//   ingest_opts.allow_blocking_flush = false;
+//
+// Thread safety: Add() and AddBatch() are thread-safe. All other methods
+// must not be called concurrently with any other method.
+class SortedRunBuilder {
+ public:
+  static Status Create(const SortedRunBuilderOptions& options,
+                       std::unique_ptr<SortedRunBuilder>* result);
+
+  virtual ~SortedRunBuilder();
+
+  // Add a key-value pair. Keys can be added in ANY order.
+  // Thread-safe: multiple threads may call Add() concurrently.
+  virtual Status Add(const Slice& key, const Slice& value) = 0;
+
+  // Add a batch of key-value pairs for efficiency. Only Put operations
+  // are expected; Delete/Merge in the batch will be written but may
+  // produce unexpected results after compaction.
+  // Thread-safe: multiple threads may call AddBatch() concurrently.
+  virtual Status AddBatch(WriteBatch* batch) = 0;
+
+  // Finalize: flush remaining memtables, run compaction to produce
+  // sorted SST files with seqno=0.
+  //
+  // After Finish():
+  // - GetOutputFiles() returns paths to sorted, non-overlapping SST files
+  // - These files can be ingested via IngestExternalFile (see class
+  //   comment for required ingestion settings)
+  // - NewIterator() can be used to read sorted output
+  virtual Status Finish() = 0;
+
+  // Get paths to the sorted output SST files.
+  // Only valid after Finish() succeeds.
+  virtual const std::vector<std::string>& GetOutputFiles() const = 0;
+
+  // Get total number of unique entries.
+  // Before Finish(): approximate count of Add()/AddBatch() calls (may
+  //   overcount if duplicate keys were added).
+  // After Finish(): exact number of entries in the output SST files
+  //   (duplicates resolved).
+  virtual uint64_t GetNumEntries() const = 0;
+
+  // Get total data size.
+  // Before Finish(): approximate (Add() tracks raw key+value sizes,
+  //   AddBatch() tracks serialized batch data size; may overcount
+  //   due to duplicate keys).
+  // After Finish(): total size of the output SST files on disk.
+  virtual uint64_t GetDataSize() const = 0;
+
+  // Create an iterator over all sorted output.
+  // Only valid after Finish() succeeds.
+  // Caller owns the returned iterator.
+  virtual Iterator* NewIterator(const ReadOptions& options) = 0;
+
+  // Clean up temporary DB and files.
+  // Called automatically by destructor unless keep_temp_db=true.
+  // WARNING: if keep_temp_db=true, caller MUST call Cleanup() explicitly
+  // to avoid leaking temporary files.
+  virtual Status Cleanup() = 0;
+
+ protected:
+  SortedRunBuilder() = default;
+};
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/src.mk
+++ b/src.mk
@@ -284,6 +284,7 @@ LIB_SOURCES =                                                   \
   utilities/cassandra/merge_operator.cc                         \
   utilities/checkpoint/checkpoint_impl.cc                       \
   utilities/compaction_filters.cc                               \
+  utilities/sorted_run_builder/sorted_run_builder.cc            \
   utilities/compaction_filters/remove_emptyvalue_compactionfilter.cc    \
   utilities/convenience/info_log_finder.cc                      \
   utilities/counted_fs.cc                                       \
@@ -648,6 +649,7 @@ TEST_MAIN_SOURCES =                                                     \
   utilities/cassandra/cassandra_row_merge_test.cc                       \
   utilities/cassandra/cassandra_serialize_test.cc                       \
   utilities/checkpoint/checkpoint_test.cc                               \
+  utilities/sorted_run_builder/sorted_run_builder_test.cc               \
   utilities/env_timed_test.cc                                           \
   utilities/fault_injection_fs_test.cc                                  \
   utilities/memory/memory_test.cc                                       \

--- a/utilities/sorted_run_builder/sorted_run_builder.cc
+++ b/utilities/sorted_run_builder/sorted_run_builder.cc
@@ -1,0 +1,242 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include "rocksdb/utilities/sorted_run_builder.h"
+
+#include <atomic>
+
+#include "file/filename.h"
+#include "rocksdb/comparator.h"
+#include "rocksdb/db.h"
+#include "rocksdb/memtablerep.h"
+#include "rocksdb/table.h"
+#include "rocksdb/write_batch.h"
+#include "util/atomic.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+class SortedRunBuilderImpl : public SortedRunBuilder {
+ public:
+  explicit SortedRunBuilderImpl(const SortedRunBuilderOptions& options)
+      : options_(options),
+        finished_(false),
+        cleaned_up_(false),
+        num_entries_(0),
+        data_size_(0) {}
+
+  SortedRunBuilderImpl(const SortedRunBuilderImpl&) = delete;
+  SortedRunBuilderImpl& operator=(const SortedRunBuilderImpl&) = delete;
+  SortedRunBuilderImpl(SortedRunBuilderImpl&&) = delete;
+  SortedRunBuilderImpl& operator=(SortedRunBuilderImpl&&) = delete;
+
+  ~SortedRunBuilderImpl() override {
+    if (!cleaned_up_ && !options_.keep_temp_db) {
+      CleanupInternal().PermitUncheckedError();
+    }
+  }
+
+  Status Open() {
+    Options db_options;
+
+    // Use VectorRepFactory: accepts unsorted writes, sorts on flush
+    db_options.memtable_factory = std::make_shared<VectorRepFactory>();
+    db_options.allow_concurrent_memtable_write = false;
+
+    // Universal compaction for merging all L0 files
+    db_options.compaction_style = kCompactionStyleUniversal;
+
+    // Disable auto compaction — we compact manually at the end
+    db_options.disable_auto_compactions = true;
+
+    // Memory budget
+    db_options.write_buffer_size = options_.write_buffer_size;
+    db_options.max_write_buffer_number = options_.max_write_buffer_number;
+
+    // Output file size
+    db_options.target_file_size_base = options_.target_file_size_bytes;
+
+    // Compression
+    db_options.compression = options_.compression;
+
+    // Compaction threads and subcompactions
+    db_options.max_background_jobs = options_.max_compaction_threads;
+    db_options.max_subcompactions =
+        static_cast<uint32_t>(options_.max_compaction_threads);
+
+    // Comparator
+    if (options_.comparator != nullptr) {
+      db_options.comparator = options_.comparator;
+    }
+
+    // Table factory
+    if (options_.table_factory != nullptr) {
+      db_options.table_factory = options_.table_factory;
+    }
+
+    // WAL is not needed — resumability comes from flushed SSTs
+    db_options.manual_wal_flush = true;
+    db_options.wal_bytes_per_sync = 0;
+
+    // Create the DB directory; fail if stale data exists
+    db_options.create_if_missing = true;
+    db_options.error_if_exists = true;
+
+    // Optimize for bulk-load workload
+    db_options.max_open_files = -1;
+    db_options.info_log_level = HEADER_LEVEL;
+    db_options.stats_dump_period_sec = 0;
+    db_options.avoid_unnecessary_blocking_io = true;
+
+    return DB::Open(db_options, options_.temp_dir, &db_);
+  }
+
+  Status Add(const Slice& key, const Slice& value) override {
+    if (finished_) {
+      return Status::InvalidArgument("Cannot Add() after Finish()");
+    }
+    WriteOptions wo;
+    wo.disableWAL = true;
+    Status s = db_->Put(wo, key, value);
+    if (s.ok()) {
+      num_entries_.FetchAddRelaxed(1);
+      data_size_.FetchAddRelaxed(key.size() + value.size());
+    }
+    return s;
+  }
+
+  Status AddBatch(WriteBatch* batch) override {
+    if (finished_) {
+      return Status::InvalidArgument("Cannot AddBatch() after Finish()");
+    }
+    WriteOptions wo;
+    wo.disableWAL = true;
+    Status s = db_->Write(wo, batch);
+    if (s.ok()) {
+      num_entries_.FetchAddRelaxed(batch->Count());
+      data_size_.FetchAddRelaxed(batch->GetDataSize());
+    }
+    return s;
+  }
+
+  Status Finish() override {
+    if (finished_) {
+      return Status::InvalidArgument("Finish() already called");
+    }
+
+    // Flush all memtables
+    FlushOptions flush_opts;
+    flush_opts.wait = true;
+    Status s = db_->Flush(flush_opts);
+
+    // Compact everything to produce sorted, non-overlapping SST files
+    // with seqno=0
+    if (s.ok()) {
+      CompactRangeOptions cro;
+      cro.bottommost_level_compaction =
+          BottommostLevelCompaction::kForceOptimized;
+      cro.max_subcompactions =
+          static_cast<uint32_t>(options_.max_compaction_threads);
+      s = db_->CompactRange(cro, nullptr, nullptr);
+    }
+
+    // Collect output file paths and accurate post-compaction stats
+    if (s.ok()) {
+      ColumnFamilyMetaData cf_meta;
+      db_->GetColumnFamilyMetaData(&cf_meta);
+      output_files_.clear();
+      uint64_t total_entries = 0;
+      uint64_t total_size = 0;
+      for (const auto& level_meta : cf_meta.levels) {
+        for (const auto& file_meta : level_meta.files) {
+          output_files_.push_back(file_meta.directory + kFilePathSeparator +
+                                  file_meta.relative_filename);
+          total_entries += file_meta.num_entries;
+          total_size += file_meta.size;
+        }
+      }
+      num_entries_.StoreRelaxed(total_entries);
+      data_size_.StoreRelaxed(total_size);
+
+      finished_ = true;
+    }
+    return s;
+  }
+
+  const std::vector<std::string>& GetOutputFiles() const override {
+    return output_files_;
+  }
+
+  uint64_t GetNumEntries() const override { return num_entries_.LoadRelaxed(); }
+
+  uint64_t GetDataSize() const override { return data_size_.LoadRelaxed(); }
+
+  Iterator* NewIterator(const ReadOptions& options) override {
+    if (!finished_) {
+      return NewErrorIterator(
+          Status::InvalidArgument("Must call Finish() before NewIterator()"));
+    }
+    return db_->NewIterator(options);
+  }
+
+  Status Cleanup() override { return CleanupInternal(); }
+
+ private:
+  Status CleanupInternal() {
+    if (cleaned_up_) {
+      return Status::OK();
+    }
+    cleaned_up_ = true;
+
+    Status s;
+    if (db_) {
+      const std::string& db_path = options_.temp_dir;
+      Options db_options;
+      if (options_.comparator != nullptr) {
+        db_options.comparator = options_.comparator;
+      }
+      db_.reset();  // Close the DB
+      s = DestroyDB(db_path, db_options);
+    }
+    return s;
+  }
+
+  SortedRunBuilderOptions options_;
+  std::unique_ptr<DB> db_;
+  std::atomic<bool> finished_;
+  std::atomic<bool> cleaned_up_;
+  RelaxedAtomic<uint64_t> num_entries_;
+  RelaxedAtomic<uint64_t> data_size_;
+  std::vector<std::string> output_files_;
+};
+
+SortedRunBuilder::~SortedRunBuilder() = default;
+
+Status SortedRunBuilder::Create(const SortedRunBuilderOptions& options,
+                                std::unique_ptr<SortedRunBuilder>* result) {
+  if (options.temp_dir.empty()) {
+    return Status::InvalidArgument("temp_dir must not be empty");
+  }
+  if (options.max_compaction_threads <= 0) {
+    return Status::InvalidArgument("max_compaction_threads must be positive");
+  }
+  if (options.write_buffer_size == 0) {
+    return Status::InvalidArgument("write_buffer_size must be non-zero");
+  }
+  if (options.max_write_buffer_number < 2) {
+    return Status::InvalidArgument("max_write_buffer_number must be >= 2");
+  }
+  if (options.target_file_size_bytes == 0) {
+    return Status::InvalidArgument("target_file_size_bytes must be non-zero");
+  }
+
+  auto builder = std::make_unique<SortedRunBuilderImpl>(options);
+  Status s = builder->Open();
+  if (s.ok()) {
+    *result = std::move(builder);
+  }
+  return s;
+}
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/utilities/sorted_run_builder/sorted_run_builder_test.cc
+++ b/utilities/sorted_run_builder/sorted_run_builder_test.cc
@@ -1,0 +1,562 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include "rocksdb/utilities/sorted_run_builder.h"
+
+#include <algorithm>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "port/stack_trace.h"
+#include "rocksdb/comparator.h"
+#include "rocksdb/db.h"
+#include "rocksdb/options.h"
+#include "test_util/testharness.h"
+#include "test_util/testutil.h"
+#include "util/random.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+class SortedRunBuilderTest : public testing::Test {
+ protected:
+  std::string temp_dir_;
+  std::string db_dir_;
+
+  void SetUp() override {
+    temp_dir_ = test::PerThreadDBPath("sorted_run_builder_test_tmp");
+    db_dir_ = test::PerThreadDBPath("sorted_run_builder_test_db");
+    ASSERT_OK(DestroyDB(temp_dir_, Options()));
+    ASSERT_OK(DestroyDB(db_dir_, Options()));
+  }
+
+  void TearDown() override {
+    EXPECT_OK(DestroyDB(temp_dir_, Options()));
+    EXPECT_OK(DestroyDB(db_dir_, Options()));
+  }
+
+  std::string Key(int i) {
+    char buf[32];
+    snprintf(buf, sizeof(buf), "key%08d", i);
+    return std::string(buf);
+  }
+
+  std::string Value(int i) {
+    char buf[64];
+    snprintf(buf, sizeof(buf), "value%08d", i);
+    return std::string(buf);
+  }
+};
+
+TEST_F(SortedRunBuilderTest, BasicSortCorrectness) {
+  SortedRunBuilderOptions opts;
+  opts.temp_dir = temp_dir_;
+  opts.write_buffer_size = 4 * 1024;  // small to trigger flushes
+  opts.target_file_size_bytes = 4 * 1024;
+
+  std::unique_ptr<SortedRunBuilder> builder;
+  ASSERT_OK(SortedRunBuilder::Create(opts, &builder));
+
+  // Add keys in reverse order
+  const int kNumKeys = 100;
+  for (int i = kNumKeys - 1; i >= 0; i--) {
+    ASSERT_OK(builder->Add(Key(i), Value(i)));
+  }
+
+  ASSERT_OK(builder->Finish());
+
+  // Verify output files exist
+  auto files = builder->GetOutputFiles();
+  ASSERT_GT(files.size(), 0);
+
+  // Verify sorted iteration
+  ReadOptions ro;
+  std::unique_ptr<Iterator> iter(builder->NewIterator(ro));
+  iter->SeekToFirst();
+  int count = 0;
+  std::string prev_key;
+  while (iter->Valid()) {
+    std::string key = iter->key().ToString();
+    std::string val = iter->value().ToString();
+    ASSERT_EQ(key, Key(count));
+    ASSERT_EQ(val, Value(count));
+    if (!prev_key.empty()) {
+      ASSERT_LT(prev_key, key);
+    }
+    prev_key = key;
+    count++;
+    iter->Next();
+  }
+  ASSERT_OK(iter->status());
+  ASSERT_EQ(count, kNumKeys);
+}
+
+TEST_F(SortedRunBuilderTest, EmptyBuilder) {
+  SortedRunBuilderOptions opts;
+  opts.temp_dir = temp_dir_;
+
+  std::unique_ptr<SortedRunBuilder> builder;
+  ASSERT_OK(SortedRunBuilder::Create(opts, &builder));
+
+  ASSERT_OK(builder->Finish());
+
+  auto files = builder->GetOutputFiles();
+  ASSERT_EQ(files.size(), 0);
+  ASSERT_EQ(builder->GetNumEntries(), 0);
+}
+
+TEST_F(SortedRunBuilderTest, WriteBatchPath) {
+  SortedRunBuilderOptions opts;
+  opts.temp_dir = temp_dir_;
+
+  std::unique_ptr<SortedRunBuilder> builder;
+  ASSERT_OK(SortedRunBuilder::Create(opts, &builder));
+
+  // Add via WriteBatch
+  WriteBatch batch;
+  for (int i = 50; i >= 0; i--) {
+    ASSERT_OK(batch.Put(Key(i), Value(i)));
+  }
+  ASSERT_OK(builder->AddBatch(&batch));
+
+  WriteBatch batch2;
+  for (int i = 100; i > 50; i--) {
+    ASSERT_OK(batch2.Put(Key(i), Value(i)));
+  }
+  ASSERT_OK(builder->AddBatch(&batch2));
+
+  ASSERT_OK(builder->Finish());
+
+  // Verify sorted output
+  ReadOptions ro;
+  std::unique_ptr<Iterator> iter(builder->NewIterator(ro));
+  iter->SeekToFirst();
+  int count = 0;
+  while (iter->Valid()) {
+    ASSERT_EQ(iter->key().ToString(), Key(count));
+    count++;
+    iter->Next();
+  }
+  ASSERT_OK(iter->status());
+  ASSERT_EQ(count, 101);
+}
+
+TEST_F(SortedRunBuilderTest, ConcurrentWrites) {
+  SortedRunBuilderOptions opts;
+  opts.temp_dir = temp_dir_;
+  opts.write_buffer_size = 4 * 1024;
+
+  std::unique_ptr<SortedRunBuilder> builder;
+  ASSERT_OK(SortedRunBuilder::Create(opts, &builder));
+
+  const int kNumThreads = 4;
+  const int kKeysPerThread = 250;
+  std::vector<std::thread> threads;
+  threads.reserve(kNumThreads);
+
+  for (int t = 0; t < kNumThreads; t++) {
+    threads.emplace_back([&, t]() {
+      for (int i = 0; i < kKeysPerThread; i++) {
+        int key_idx = t * kKeysPerThread + i;
+        EXPECT_OK(builder->Add(Key(key_idx), Value(key_idx)));
+      }
+    });
+  }
+
+  for (auto& t : threads) {
+    t.join();
+  }
+
+  ASSERT_OK(builder->Finish());
+
+  // Verify all keys present and sorted
+  ReadOptions ro;
+  std::unique_ptr<Iterator> iter(builder->NewIterator(ro));
+  iter->SeekToFirst();
+  int count = 0;
+  std::string prev_key;
+  while (iter->Valid()) {
+    std::string key = iter->key().ToString();
+    if (!prev_key.empty()) {
+      ASSERT_LT(prev_key, key);
+    }
+    prev_key = key;
+    count++;
+    iter->Next();
+  }
+  ASSERT_OK(iter->status());
+  ASSERT_EQ(count, kNumThreads * kKeysPerThread);
+}
+
+TEST_F(SortedRunBuilderTest, IngestIntoTargetDB) {
+  // Sort data using SortedRunBuilder
+  SortedRunBuilderOptions opts;
+  opts.temp_dir = temp_dir_;
+  opts.write_buffer_size = 4 * 1024;
+  opts.target_file_size_bytes = 4 * 1024;
+
+  std::unique_ptr<SortedRunBuilder> builder;
+  ASSERT_OK(SortedRunBuilder::Create(opts, &builder));
+
+  const int kNumKeys = 200;
+  for (int i = kNumKeys - 1; i >= 0; i--) {
+    ASSERT_OK(builder->Add(Key(i), Value(i)));
+  }
+
+  ASSERT_OK(builder->Finish());
+  auto files = builder->GetOutputFiles();
+  ASSERT_GT(files.size(), 0);
+
+  // Open a target DB and ingest the sorted files
+  Options db_opts;
+  db_opts.create_if_missing = true;
+  std::unique_ptr<DB> db;
+  ASSERT_OK(DB::Open(db_opts, db_dir_, &db));
+
+  IngestExternalFileOptions ingest_opts;
+  ingest_opts.allow_db_generated_files = true;
+  ingest_opts.snapshot_consistency = false;
+  ingest_opts.allow_blocking_flush = false;
+  ASSERT_OK(db->IngestExternalFile(files, ingest_opts));
+
+  // Verify data in target DB
+  ReadOptions ro;
+  std::unique_ptr<Iterator> iter(db->NewIterator(ro));
+  iter->SeekToFirst();
+  int count = 0;
+  while (iter->Valid()) {
+    ASSERT_EQ(iter->key().ToString(), Key(count));
+    ASSERT_EQ(iter->value().ToString(), Value(count));
+    count++;
+    iter->Next();
+  }
+  ASSERT_OK(iter->status());
+  ASSERT_EQ(count, kNumKeys);
+}
+
+TEST_F(SortedRunBuilderTest, LargeRandomDataset) {
+  SortedRunBuilderOptions opts;
+  opts.temp_dir = temp_dir_;
+  opts.write_buffer_size = 64 * 1024;
+  opts.target_file_size_bytes = 64 * 1024;
+
+  std::unique_ptr<SortedRunBuilder> builder;
+  ASSERT_OK(SortedRunBuilder::Create(opts, &builder));
+
+  // Generate random keys
+  const int kNumKeys = 10000;
+  std::vector<std::string> keys;
+  keys.reserve(kNumKeys);
+  for (int i = 0; i < kNumKeys; i++) {
+    keys.push_back(Key(i));
+  }
+
+  // Shuffle and insert
+  RandomShuffle(keys.begin(), keys.end(), 42);
+  for (const auto& key : keys) {
+    ASSERT_OK(builder->Add(key, "val_" + key));
+  }
+
+  ASSERT_OK(builder->Finish());
+
+  // Sort keys for comparison
+  std::sort(keys.begin(), keys.end());
+
+  // Verify output matches sorted order
+  ReadOptions ro;
+  std::unique_ptr<Iterator> iter(builder->NewIterator(ro));
+  iter->SeekToFirst();
+  int idx = 0;
+  while (iter->Valid()) {
+    ASSERT_EQ(iter->key().ToString(), keys[idx]);
+    idx++;
+    iter->Next();
+  }
+  ASSERT_OK(iter->status());
+  ASSERT_EQ(idx, kNumKeys);
+}
+
+TEST_F(SortedRunBuilderTest, NumEntriesAndDataSize) {
+  SortedRunBuilderOptions opts;
+  opts.temp_dir = temp_dir_;
+
+  std::unique_ptr<SortedRunBuilder> builder;
+  ASSERT_OK(SortedRunBuilder::Create(opts, &builder));
+
+  ASSERT_EQ(builder->GetNumEntries(), 0);
+  ASSERT_EQ(builder->GetDataSize(), 0);
+
+  ASSERT_OK(builder->Add("key1", "value1"));
+  ASSERT_OK(builder->Add("key2", "value2"));
+
+  // Before Finish(), counts reflect all Add() calls
+  ASSERT_EQ(builder->GetNumEntries(), 2);
+  ASSERT_GT(builder->GetDataSize(), 0);
+
+  ASSERT_OK(builder->Finish());
+
+  // After Finish(), stats come from SST metadata (exact, post-dedup)
+  ASSERT_EQ(builder->GetNumEntries(), 2);
+  ASSERT_GT(builder->GetDataSize(), 0);
+}
+
+TEST_F(SortedRunBuilderTest, NumEntriesAfterDedup) {
+  SortedRunBuilderOptions opts;
+  opts.temp_dir = temp_dir_;
+
+  std::unique_ptr<SortedRunBuilder> builder;
+  ASSERT_OK(SortedRunBuilder::Create(opts, &builder));
+
+  // Add duplicate keys — pre-Finish count includes duplicates
+  ASSERT_OK(builder->Add("key1", "old_value"));
+  ASSERT_OK(builder->Add("key1", "new_value"));
+  ASSERT_OK(builder->Add("key2", "value2"));
+  ASSERT_EQ(builder->GetNumEntries(), 3);
+
+  ASSERT_OK(builder->Finish());
+
+  // After Finish(), duplicates are resolved — only 2 unique keys remain
+  ASSERT_EQ(builder->GetNumEntries(), 2);
+}
+
+TEST_F(SortedRunBuilderTest, ErrorAddAfterFinish) {
+  SortedRunBuilderOptions opts;
+  opts.temp_dir = temp_dir_;
+
+  std::unique_ptr<SortedRunBuilder> builder;
+  ASSERT_OK(SortedRunBuilder::Create(opts, &builder));
+
+  ASSERT_OK(builder->Add("key1", "value1"));
+  ASSERT_OK(builder->Finish());
+
+  // Add after Finish should fail
+  Status s = builder->Add("key2", "value2");
+  ASSERT_TRUE(s.IsInvalidArgument());
+
+  // AddBatch after Finish should fail
+  WriteBatch batch;
+  ASSERT_OK(batch.Put("key3", "value3"));
+  s = builder->AddBatch(&batch);
+  ASSERT_TRUE(s.IsInvalidArgument());
+
+  // Double Finish should fail
+  s = builder->Finish();
+  ASSERT_TRUE(s.IsInvalidArgument());
+}
+
+TEST_F(SortedRunBuilderTest, ErrorIteratorBeforeFinish) {
+  SortedRunBuilderOptions opts;
+  opts.temp_dir = temp_dir_;
+
+  std::unique_ptr<SortedRunBuilder> builder;
+  ASSERT_OK(SortedRunBuilder::Create(opts, &builder));
+
+  ASSERT_OK(builder->Add("key1", "value1"));
+
+  ReadOptions ro;
+  std::unique_ptr<Iterator> iter(builder->NewIterator(ro));
+  // Iterator should report error
+  ASSERT_TRUE(!iter->Valid());
+  ASSERT_TRUE(iter->status().IsInvalidArgument());
+}
+
+TEST_F(SortedRunBuilderTest, ErrorEmptyTempDir) {
+  SortedRunBuilderOptions opts;
+  // temp_dir left empty
+
+  std::unique_ptr<SortedRunBuilder> builder;
+  Status s = SortedRunBuilder::Create(opts, &builder);
+  ASSERT_TRUE(s.IsInvalidArgument());
+}
+
+TEST_F(SortedRunBuilderTest, CleanupRemovesFiles) {
+  SortedRunBuilderOptions opts;
+  opts.temp_dir = temp_dir_;
+  opts.keep_temp_db = true;  // Keep so we can test explicit Cleanup()
+
+  std::unique_ptr<SortedRunBuilder> builder;
+  ASSERT_OK(SortedRunBuilder::Create(opts, &builder));
+
+  ASSERT_OK(builder->Add("key1", "value1"));
+  ASSERT_OK(builder->Finish());
+
+  auto files = builder->GetOutputFiles();
+  ASSERT_GT(files.size(), 0);
+
+  // Cleanup should remove the temp DB
+  ASSERT_OK(builder->Cleanup());
+
+  // Verify directory is cleaned up (DestroyDB removes all DB files)
+  Env* env = Env::Default();
+  std::vector<std::string> children;
+  // After DestroyDB, the directory should be empty or not exist
+  Status s = env->GetChildren(temp_dir_, &children);
+  if (s.ok()) {
+    // Filter out . and ..
+    int real_files = 0;
+    for (const auto& child : children) {
+      if (child != "." && child != "..") {
+        real_files++;
+      }
+    }
+    ASSERT_EQ(real_files, 0);
+  }
+}
+
+TEST_F(SortedRunBuilderTest, DuplicateKeys) {
+  SortedRunBuilderOptions opts;
+  opts.temp_dir = temp_dir_;
+
+  std::unique_ptr<SortedRunBuilder> builder;
+  ASSERT_OK(SortedRunBuilder::Create(opts, &builder));
+
+  // Add duplicate keys — later value should win (RocksDB semantics)
+  ASSERT_OK(builder->Add("key1", "old_value"));
+  ASSERT_OK(builder->Add("key1", "new_value"));
+  ASSERT_OK(builder->Add("key2", "value2"));
+
+  ASSERT_OK(builder->Finish());
+
+  ReadOptions ro;
+  std::unique_ptr<Iterator> iter(builder->NewIterator(ro));
+  iter->SeekToFirst();
+
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ(iter->key().ToString(), "key1");
+  ASSERT_EQ(iter->value().ToString(), "new_value");
+
+  iter->Next();
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ(iter->key().ToString(), "key2");
+  ASSERT_EQ(iter->value().ToString(), "value2");
+
+  iter->Next();
+  ASSERT_FALSE(iter->Valid());
+  ASSERT_OK(iter->status());
+}
+
+TEST_F(SortedRunBuilderTest, CustomComparator) {
+  SortedRunBuilderOptions opts;
+  opts.temp_dir = temp_dir_;
+  opts.comparator = ReverseBytewiseComparator();
+
+  std::unique_ptr<SortedRunBuilder> builder;
+  ASSERT_OK(SortedRunBuilder::Create(opts, &builder));
+
+  ASSERT_OK(builder->Add("apple", "v1"));
+  ASSERT_OK(builder->Add("zebra", "v2"));
+  ASSERT_OK(builder->Add("mango", "v3"));
+
+  ASSERT_OK(builder->Finish());
+
+  // Reverse comparator: zebra > mango > apple
+  ReadOptions ro;
+  std::unique_ptr<Iterator> iter(builder->NewIterator(ro));
+  iter->SeekToFirst();
+
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ(iter->key().ToString(), "zebra");
+  iter->Next();
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ(iter->key().ToString(), "mango");
+  iter->Next();
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ(iter->key().ToString(), "apple");
+  iter->Next();
+  ASSERT_FALSE(iter->Valid());
+  ASSERT_OK(iter->status());
+}
+
+TEST_F(SortedRunBuilderTest, SeekAndPrev) {
+  SortedRunBuilderOptions opts;
+  opts.temp_dir = temp_dir_;
+
+  std::unique_ptr<SortedRunBuilder> builder;
+  ASSERT_OK(SortedRunBuilder::Create(opts, &builder));
+
+  for (int i = 0; i < 10; i++) {
+    ASSERT_OK(builder->Add(Key(i), Value(i)));
+  }
+  ASSERT_OK(builder->Finish());
+
+  ReadOptions ro;
+  std::unique_ptr<Iterator> iter(builder->NewIterator(ro));
+
+  // Seek to middle
+  iter->Seek(Key(5));
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ(iter->key().ToString(), Key(5));
+
+  // Prev
+  iter->Prev();
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ(iter->key().ToString(), Key(4));
+
+  // SeekToLast
+  iter->SeekToLast();
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ(iter->key().ToString(), Key(9));
+  ASSERT_OK(iter->status());
+}
+
+TEST_F(SortedRunBuilderTest, DestructionWithoutFinish) {
+  // Verify no crash/leak when builder is destroyed without calling Finish()
+  SortedRunBuilderOptions opts;
+  opts.temp_dir = temp_dir_;
+
+  {
+    std::unique_ptr<SortedRunBuilder> builder;
+    ASSERT_OK(SortedRunBuilder::Create(opts, &builder));
+    ASSERT_OK(builder->Add("key1", "value1"));
+    // Intentionally not calling Finish() — destructor should clean up
+  }
+
+  // Verify temp dir is cleaned up
+  Env* env = Env::Default();
+  std::vector<std::string> children;
+  Status s = env->GetChildren(temp_dir_, &children);
+  if (s.ok()) {
+    int real_files = 0;
+    for (const auto& child : children) {
+      if (child != "." && child != "..") {
+        real_files++;
+      }
+    }
+    ASSERT_EQ(real_files, 0);
+  }
+}
+
+TEST_F(SortedRunBuilderTest, InvalidOptions) {
+  std::unique_ptr<SortedRunBuilder> builder;
+
+  // max_compaction_threads <= 0
+  SortedRunBuilderOptions opts;
+  opts.temp_dir = temp_dir_;
+  opts.max_compaction_threads = 0;
+  ASSERT_TRUE(SortedRunBuilder::Create(opts, &builder).IsInvalidArgument());
+
+  // write_buffer_size == 0
+  opts.max_compaction_threads = 4;
+  opts.write_buffer_size = 0;
+  ASSERT_TRUE(SortedRunBuilder::Create(opts, &builder).IsInvalidArgument());
+
+  // max_write_buffer_number < 2
+  opts.write_buffer_size = 64 * 1024 * 1024;
+  opts.max_write_buffer_number = 1;
+  ASSERT_TRUE(SortedRunBuilder::Create(opts, &builder).IsInvalidArgument());
+
+  // target_file_size_bytes == 0
+  opts.max_write_buffer_number = 4;
+  opts.target_file_size_bytes = 0;
+  ASSERT_TRUE(SortedRunBuilder::Create(opts, &builder).IsInvalidArgument());
+}
+
+}  // namespace ROCKSDB_NAMESPACE
+
+int main(int argc, char** argv) {
+  ROCKSDB_NAMESPACE::port::InstallStackTraceHandler();
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Summary:
CONTEXT: MyRocks and other third-party users currently need to understand deep RocksDB internals to sort unsorted data into SST files. The existing pattern requires: opening a full DB instance, configuring VectorRepFactory with universal compaction, disabling auto-compaction, writing unsorted data, manually triggering CompactRange with kForceOptimized, collecting output via GetColumnFamilyMetaData, and finally ingesting via IngestExternalFile with allow_db_generated_files. This is error-prone and requires ~30 lines of RocksDB configuration knowledge.

WHAT: This adds a new utility class, SortedRunBuilder, that wraps all of the above into a simple Create/Add/Finish API. Callers feed in unsorted key-value pairs (in any order, from any number of threads) and receive sorted SST files with seqno=0 ready for ingestion -- or can iterate sorted output directly.

The name SortedRunBuilder was chosen over alternatives like UnsortedSstFileWriter because this utility targets a broad audience: anyone wanting to use RocksDB as an external sort engine, not just users migrating from SstFileWriter. That said, this explicitly removes the sorted-input requirement that SstFileWriter enforces -- callers no longer need to pre-sort their data before writing SST files.

KEY DESIGN DECISIONS:
- Zero changes to core RocksDB internals. This is a pure utility layer that exclusively calls existing public APIs:
  * DB::Open(), DB::Put(), DB::Write(), DB::Flush(), DB::CompactRange(), DB::GetColumnFamilyMetaData(), DB::NewIterator(), DestroyDB()
  * VectorRepFactory (sort-on-flush memtable)
  * BottommostLevelCompaction::kForceOptimized (zero seqnos)
- No modifications to: compaction logic, memtable implementation, SST file format, ingestion logic, or DB open/close paths
- All new code lives in utilities/sorted_run_builder/ and the public header include/rocksdb/utilities/sorted_run_builder.h
- Build file changes are limited to registering the new source/test files

API SURFACE:
  SortedRunBuilderOptions opts; opts.temp_dir = "/tmp/sort_work"; std::unique_ptr<SortedRunBuilder> builder; SortedRunBuilder::Create(opts, &builder);
  builder->Add(key, value);   // any order, thread-safe
  builder->AddBatch(&batch);  // WriteBatch for throughput
  builder->Finish();           // flush + compact + collect
  builder->GetOutputFiles();   // sorted SSTs for ingestion
  builder->NewIterator(ro);    // iterate sorted output

FILES CHANGED:
  New: include/rocksdb/utilities/sorted_run_builder.h (public header) New: utilities/sorted_run_builder/sorted_run_builder.cc (implementation) New: utilities/sorted_run_builder/sorted_run_builder_test.cc (12 tests) New: docs/plans/sorted_run_builder_plan.md (design plan) New: docs/plans/sorted_run_builder_usage_guide.md (usage guide) Modified: src.mk, CMakeLists.txt, Makefile (register new files only)


Test Plan:
$ make clean && make -j$(nproc) sorted_run_builder_test $ ./sorted_run_builder_test [==========] Running 12 tests from 1 test case. [  PASSED  ] 12 tests. (688 ms total)

  Tests cover: basic sort correctness, empty builder, WriteBatch path, concurrent multi-threaded writes, ingestion into a target DB, large random dataset (10K keys), entry/size counters, error cases (Add after Finish, iterator before Finish, empty temp_dir), cleanup verification, and duplicate key handling.

Reviewed By: xingbowang

Differential Revision: D98935972

Pulled By: dannyhchen


