### PR TITLE
Fix crash_test_with_ts failure: disable use_trie_index with timestamps (#14502)

### DIFF
--- a/db_stress_tool/db_stress_tool.cc
+++ b/db_stress_tool/db_stress_tool.cc
@@ -245,6 +245,16 @@ int db_stress_tool(int argc, char** argv) {
     exit(1);
   }
 
+  // TrieIndexFactory requires plain BytewiseComparator, but timestamps use
+  // BytewiseComparator.u64ts.
+  if (FLAGS_use_trie_index && FLAGS_user_timestamp_size > 0) {
+    fprintf(stderr,
+            "Error: use_trie_index is incompatible with user-defined "
+            "timestamps. TrieIndexFactory requires BytewiseComparator "
+            "but timestamps use BytewiseComparator.u64ts.\n");
+    exit(1);
+  }
+
   if (FLAGS_read_only) {
     if (FLAGS_writepercent != 0 || FLAGS_delpercent != 0 ||
         FLAGS_delrangepercent != 0) {

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -722,6 +722,9 @@ ts_params = {
     "use_put_entity_one_in": 0,
     # TimedPut is not compatible with user-defined timestamps yet.
     "use_timed_put_one_in": 0,
+    # TrieIndexFactory requires plain BytewiseComparator, but timestamps use
+    # BytewiseComparator.u64ts.
+    "use_trie_index": 0,
     # when test_best_efforts_recovery == true, disable_wal becomes 0.
     # TODO: Re-enable this once we fix WAL + Remote Compaction in Stress Test
     "remote_compaction_worker_threads": 0,
@@ -1129,6 +1132,8 @@ def finalize_and_sanitize(src_params):
         # Interpolation search requires BytewiseComparator but user-defined
         # timestamps use BytewiseComparatorWithU64TsWrapper.
         dest_params["index_block_search_type"] = 0
+        # TrieIndexFactory requires BytewiseComparator.
+        dest_params["use_trie_index"] = 0
     if (
         dest_params.get("enable_compaction_filter", 0) == 1
         or dest_params.get("inplace_update_support", 0) == 1


### PR DESCRIPTION
Summary:

The asan_crash_test_with_ts randomly selected use_trie_index=1 alongside
user_timestamp_size=8. TrieIndexFactory requires plain BytewiseComparator,
but user-defined timestamps wrap it as BytewiseComparator.u64ts, causing
Status::NotSupported errors during flush/compaction.

Fix:
1. Add use_trie_index=0 to ts_params in db_crashtest.py to prevent the
   incompatible combination (matches existing pattern for other features).
2. Add early validation in db_stress_tool.cc to reject this combination
   with a clear error message (defense in depth).

Differential Revision: D97592648


