### PR TITLE
Add atomic_flush to CreateBackupOptions (#14511)

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -2460,11 +2460,19 @@ Status StressTest::TestBackupRestore(
       // lock and wait on a background operation (flush).
       create_opts.flush_before_backup = true;
     }
+    if (FLAGS_atomic_flush) {
+      // When atomic flush is enabled for the DB, use it for backup too.
+      // This ensures cross-CF consistency without needing WAL files.
+      // flush_before_backup must be true for atomic_flush to take effect.
+      create_opts.flush_before_backup = true;
+      create_opts.atomic_flush = true;
+    }
     create_opts.decrease_background_thread_cpu_priority = thread->rand.OneIn(2);
     create_opts.background_thread_cpu_priority = static_cast<CpuPriority>(
         thread->rand.Next() % (static_cast<int>(CpuPriority::kHigh) + 1));
     create_backup_opt_oss << "flush_before_backup: "
                           << create_opts.flush_before_backup
+                          << ", atomic_flush: " << create_opts.atomic_flush
                           << ", decrease_background_thread_cpu_priority: "
                           << create_opts.decrease_background_thread_cpu_priority
                           << ", background_thread_cpu_priority: "

--- a/include/rocksdb/utilities/backup_engine.h
+++ b/include/rocksdb/utilities/backup_engine.h
@@ -346,6 +346,15 @@ struct CreateBackupOptions {
   // so you can decrease to priorities lower than kNormal.
   bool decrease_background_thread_cpu_priority = false;
   CpuPriority background_thread_cpu_priority = CpuPriority::kNormal;
+
+  // If true, use atomic flush to flush all column families atomically
+  // before creating the backup. This ensures cross-CF consistency without
+  // needing WAL files. When combined with
+  // BackupEngineOptions::backup_log_files=false, this allows skipping WAL
+  // backup safely for multi-CF databases.
+  // Only takes effect when flush_before_backup is also true.
+  // Default: false
+  bool atomic_flush = false;
 };
 
 struct RestoreOptions {

--- a/utilities/backup/backup_engine.cc
+++ b/utilities/backup/backup_engine.cc
@@ -1601,7 +1601,7 @@ IOStatus BackupEngineImpl::CreateNewBackupWithMetadata(
         } /* create_file_cb */,
         &sequence_number,
         options.flush_before_backup ? 0 : std::numeric_limits<uint64_t>::max(),
-        compare_checksum));
+        compare_checksum, options.atomic_flush));
     if (io_s.ok()) {
       new_backup->SetSequenceNumber(sequence_number);
     }

--- a/utilities/checkpoint/checkpoint_impl.cc
+++ b/utilities/checkpoint/checkpoint_impl.cc
@@ -230,12 +230,13 @@ Status CheckpointImpl::CreateCustomCheckpoint(
                          FileType type)>
         create_file_cb,
     uint64_t* sequence_number, uint64_t log_size_for_flush,
-    bool get_live_table_checksum) {
+    bool get_live_table_checksum, bool atomic_flush) {
   *sequence_number = db_->GetLatestSequenceNumber();
 
   LiveFilesStorageInfoOptions opts;
   opts.include_checksum_info = get_live_table_checksum;
   opts.wal_size_for_flush = log_size_for_flush;
+  opts.atomic_flush = atomic_flush;
 
   std::vector<LiveFileStorageInfo> infos;
   {

--- a/utilities/checkpoint/checkpoint_impl.h
+++ b/utilities/checkpoint/checkpoint_impl.h
@@ -41,7 +41,7 @@ class CheckpointImpl : public Checkpoint {
                            const std::string& contents, FileType type)>
           create_file_cb,
       uint64_t* sequence_number, uint64_t log_size_for_flush,
-      bool get_live_table_checksum = false);
+      bool get_live_table_checksum = false, bool atomic_flush = false);
 
  private:
   Status CleanStagingDirectory(const std::string& path, Logger* info_log);

--- a/utilities/checkpoint/checkpoint_test.cc
+++ b/utilities/checkpoint/checkpoint_test.cc
@@ -27,6 +27,7 @@
 #include "rocksdb/metadata.h"
 #include "rocksdb/rocksdb_namespace.h"
 #include "rocksdb/sst_file_manager.h"
+#include "rocksdb/utilities/backup_engine.h"
 #include "rocksdb/utilities/transaction_db.h"
 #include "test_util/sync_point.h"
 #include "test_util/testharness.h"
@@ -1334,6 +1335,93 @@ TEST_F(CheckpointTest, MixedAtomicThenNonAtomicFlushInQueue) {
   ASSERT_EQ("v1_2", Get(1, "k1_2"));
   ASSERT_EQ("v2", Get(2, "k2"));
 }
+TEST_F(CheckpointTest, BackupWithAtomicFlushSkipsWAL) {
+  // Test that BackupEngine with atomic_flush=true and backup_log_files=false
+  // creates a valid, restorable backup for a multi-CF database.
+  Options options = CurrentOptions();
+  options.create_if_missing = true;
+  CreateAndReopenWithCF({"cf1", "cf2"}, options);
+
+  // Write data to all column families (default, cf1, cf2)
+  ASSERT_OK(Put(0, "key0", "val0"));
+  ASSERT_OK(Put(1, "key1", "val1"));
+  ASSERT_OK(Put(2, "key2", "val2"));
+
+  // Set up backup engine with backup_log_files=false
+  std::string backup_dir = test::PerThreadDBPath(env_, "backup_atomic_flush");
+  std::string restore_dir = test::PerThreadDBPath(env_, "restore_atomic_flush");
+  ASSERT_OK(DestroyDB(restore_dir, options));
+  test::DeleteDir(env_, backup_dir);
+
+  BackupEngineOptions backup_options(backup_dir);
+  backup_options.backup_log_files = false;
+  backup_options.destroy_old_data = true;
+
+  BackupEngine* backup_engine_ptr;
+  ASSERT_OK(BackupEngine::Open(env_, backup_options, &backup_engine_ptr));
+  std::unique_ptr<BackupEngine> backup_engine(backup_engine_ptr);
+
+  // Verify that the atomic flush sync point is triggered
+  bool atomic_flush_triggered = false;
+  SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::AtomicFlushMemTables:AfterScheduleFlush",
+      [&](void* /*arg*/) { atomic_flush_triggered = true; });
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  // Create backup with atomic_flush=true, flush_before_backup=true
+  CreateBackupOptions create_options;
+  create_options.flush_before_backup = true;
+  create_options.atomic_flush = true;
+  ASSERT_OK(backup_engine->CreateNewBackup(create_options, db_.get()));
+
+  ASSERT_TRUE(atomic_flush_triggered);
+
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+
+  // Verify no WAL files in the backup
+  BackupInfo backup_info;
+  ASSERT_OK(backup_engine->GetLatestBackupInfo(&backup_info,
+                                               /*include_file_details=*/true));
+  for (const auto& file : backup_info.file_details) {
+    // WAL files have names like 000001.log
+    ASSERT_TRUE(file.relative_filename.find(".log") == std::string::npos)
+        << "Found WAL file in backup: " << file.relative_filename;
+  }
+
+  // Close the original DB and restore from backup
+  Close();
+
+  ASSERT_OK(backup_engine->RestoreDBFromLatestBackup(restore_dir, restore_dir));
+
+  // Open the restored DB and verify data
+  std::vector<ColumnFamilyDescriptor> cf_descs;
+  cf_descs.emplace_back(kDefaultColumnFamilyName, ColumnFamilyOptions(options));
+  cf_descs.emplace_back("cf1", ColumnFamilyOptions(options));
+  cf_descs.emplace_back("cf2", ColumnFamilyOptions(options));
+
+  std::unique_ptr<DB> restored_db;
+  std::vector<ColumnFamilyHandle*> restored_handles;
+  ASSERT_OK(DB::Open(DBOptions(options), restore_dir, cf_descs,
+                     &restored_handles, &restored_db));
+
+  ReadOptions ropts;
+  std::string value;
+  ASSERT_OK(restored_db->Get(ropts, restored_handles[0], "key0", &value));
+  ASSERT_EQ("val0", value);
+  ASSERT_OK(restored_db->Get(ropts, restored_handles[1], "key1", &value));
+  ASSERT_EQ("val1", value);
+  ASSERT_OK(restored_db->Get(ropts, restored_handles[2], "key2", &value));
+  ASSERT_EQ("val2", value);
+
+  for (auto* h : restored_handles) {
+    delete h;
+  }
+  restored_db.reset();
+  ASSERT_OK(DestroyDB(restore_dir, options));
+  test::DeleteDir(env_, backup_dir);
+}
+
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Summary:

Add `atomic_flush` option to `CreateBackupOptions` that plumbs through
`CheckpointImpl::CreateCustomCheckpoint` to `LiveFilesStorageInfoOptions`.

When `flush_before_backup=true` and `atomic_flush=true`, the backup engine
atomically flushes all column families before creating the backup. This
ensures cross-CF consistency without needing WAL files. Combined with
`BackupEngineOptions::backup_log_files=false`, this allows safely skipping
WAL backup for multi-CF databases, reducing backup size and complexity.

Changes:
- `backup_engine.h`: Add `bool atomic_flush = false` to `CreateBackupOptions`
- `checkpoint_impl.h/.cc`: Add `bool atomic_flush` parameter to
  `CreateCustomCheckpoint`, plumb to `LiveFilesStorageInfoOptions::atomic_flush`
- `backup_engine.cc`: Pass `options.atomic_flush` through to
  `CreateCustomCheckpoint`
- `checkpoint_test.cc`: Add `BackupWithAtomicFlushSkipsWAL` test verifying
  backup with atomic flush + no WAL creates a valid restorable multi-CF backup

Reviewed By: xingbowang

Differential Revision: D98208696


