### PR TITLE
Fix SupportedOps to verify per-thread io_uring before advertising kAsyncIO (#14514)

### DIFF
--- a/env/env_test.cc
+++ b/env/env_test.cc
@@ -1700,6 +1700,61 @@ TEST_F(EnvPosixTest, MultiReadIOUringError2) {
   SyncPoint::GetInstance()->DisableProcessing();
   SyncPoint::GetInstance()->ClearAllCallBacks();
 }
+TEST_F(EnvPosixTest, SupportedOpsNoAsyncIOOnIOUringInitFailure) {
+  // Verify that SupportedOps does not advertise kAsyncIO when CreateIOUring
+  // fails on the calling thread.
+  auto fs = FileSystem::Default();
+  int64_t supported_ops = 0;
+
+  // Check baseline on the current thread.
+  fs->SupportedOps(supported_ops);
+  bool baseline_has_async =
+      (supported_ops & (1 << FSSupportedOps::kAsyncIO)) != 0;
+
+  if (!baseline_has_async) {
+    // Platform doesn't support io_uring at all, nothing to test.
+    return;
+  }
+
+  // Simulate CreateIOUring failure by nullifying the returned pointer.
+  // Count how many times CreateIOUring is invoked to verify caching.
+  int create_count = 0;
+  SyncPoint::GetInstance()->SetCallBack(
+      "PosixFileSystem::SupportedOps:CreateIOUring", [&](void* arg) {
+        ++create_count;
+        auto* iu_ptr = static_cast<struct io_uring**>(arg);
+        if (*iu_ptr != nullptr) {
+          DeleteIOUring(*iu_ptr);
+          *iu_ptr = nullptr;
+        }
+      });
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  // Run SupportedOps on a new thread so the thread-local io_uring is
+  // uninitialized and CreateIOUring (+ our sync point) will be invoked.
+  // Call it twice on the same thread: the second call must NOT retry
+  // CreateIOUring (the failure should be cached).
+  int64_t thread_supported_ops = 0;
+  int64_t thread_supported_ops2 = 0;
+  std::thread t([&]() {
+    fs->SupportedOps(thread_supported_ops);
+    // Second call on the same thread — cached failure, no retry.
+    fs->SupportedOps(thread_supported_ops2);
+  });
+  t.join();
+
+  ASSERT_EQ(thread_supported_ops & (1 << FSSupportedOps::kAsyncIO), 0);
+  // kFSPrefetch should still be set.
+  ASSERT_NE(thread_supported_ops & (1 << FSSupportedOps::kFSPrefetch), 0);
+  // Second call should also lack kAsyncIO.
+  ASSERT_EQ(thread_supported_ops2 & (1 << FSSupportedOps::kAsyncIO), 0);
+  ASSERT_NE(thread_supported_ops2 & (1 << FSSupportedOps::kFSPrefetch), 0);
+  // CreateIOUring must have been called exactly once — not retried.
+  ASSERT_EQ(create_count, 1);
+
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+}
 #endif  // ROCKSDB_IOURING_PRESENT
 
 // Only works in linux platforms

--- a/env/fs_posix.cc
+++ b/env/fs_posix.cc
@@ -1275,8 +1275,31 @@ class PosixFileSystem : public FileSystem {
     supported_ops = 0;
 #if defined(ROCKSDB_IOURING_PRESENT)
     if (IsIOUringEnabled() && thread_local_async_read_io_urings_) {
-      // Underlying FS supports async_io
-      supported_ops |= (1 << FSSupportedOps::kAsyncIO);
+      // Eagerly initialize the thread-local io_uring instance to verify that
+      // io_uring actually works on the calling thread before advertising
+      // kAsyncIO support. CreateIOUring() can fail per-thread even when the
+      // constructor's one-time probe on the main thread succeeded (e.g. due to
+      // kernel resource limits or flag incompatibilities).
+      static thread_local bool io_uring_init_attempted = false;
+      struct io_uring* iu = static_cast<struct io_uring*>(
+          thread_local_async_read_io_urings_->Get());
+      if (iu == nullptr && !io_uring_init_attempted) {
+        iu = CreateIOUring();
+        TEST_SYNC_POINT_CALLBACK("PosixFileSystem::SupportedOps:CreateIOUring",
+                                 &iu);
+        if (iu != nullptr) {
+          thread_local_async_read_io_urings_->Reset(iu);
+        } else {
+          fprintf(stdout,
+                  "SupportedOps: failed to init io_uring, disabling async IO "
+                  "support on thread %lu\n",
+                  static_cast<unsigned long>(pthread_self()));
+        }
+        io_uring_init_attempted = true;
+      }
+      if (iu != nullptr) {
+        supported_ops |= (1 << FSSupportedOps::kAsyncIO);
+      }
     }
 #endif
     supported_ops |= (1 << FSSupportedOps::kFSPrefetch);


### PR DESCRIPTION
Summary:

SupportedOps previously checked only that the ThreadLocalPtr container existed (non-null), which was set during construction based on a one-time probe on the main thread. However, CreateIOUring() can fail on other threads due to kernel resource limits or flag incompatibilities, causing ReadAsync to hit "failed to init io_uring" at runtime.

Now SupportedOps eagerly initializes the thread-local io_uring instance via Get() + CreateIOUring() and only advertises kAsyncIO if it succeeds. Also logs to stderr (with thread id) when io_uring init fails, and adds a TEST_SYNC_POINT_CALLBACK for testing simulated CreateIOUring failures.

Reviewed By: mszeszko-meta, xingbowang

Differential Revision: D98409140
