### PR TITLE
Fix warm_storage_crash_test SyncWAL NotSupported failure

### DIFF
--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -7492,6 +7492,38 @@ TEST_F(DBTest, UnsupportedManualSync) {
   ASSERT_TRUE(s.IsNotSupported());
 }
 
+TEST_F(DBTest, SyncWALNotSupportedFallbackToFlushWAL) {
+  // Simulates the warm_storage_crash_test scenario where the WAL
+  // implementation does not support IsSyncThreadSafe(), causing SyncWAL() to
+  // return NotSupported. The stress test's reopen logic should fall back to
+  // FlushWAL(sync=false) and data should still be available after reopen.
+  DestroyAndReopen(CurrentOptions());
+
+  // Write some data
+  ASSERT_OK(Put("key1", "value1"));
+  ASSERT_OK(Put("key2", "value2"));
+
+  // Make SyncWAL() unsupported (as in Warm Storage WAL)
+  env_->is_wal_sync_thread_safe_.store(false);
+
+  // SyncWAL() should fail with NotSupported
+  Status s = db_->SyncWAL();
+  ASSERT_TRUE(s.IsNotSupported());
+
+  // FlushWAL(sync=false) should succeed as fallback
+  s = db_->FlushWAL(/*sync=*/false);
+  ASSERT_OK(s);
+
+  // Restore sync thread safety before reopen (reopen creates new WAL files
+  // and the test env needs to work normally for recovery)
+  env_->is_wal_sync_thread_safe_.store(true);
+
+  // Reopen should succeed and data should be available
+  Reopen(CurrentOptions());
+  ASSERT_EQ("value1", Get("key1"));
+  ASSERT_EQ("value2", Get("key2"));
+}
+
 INSTANTIATE_TEST_CASE_P(DBTestWithParam, DBTestWithParam,
                         ::testing::Combine(::testing::Values(1, 4),
                                            ::testing::Bool()));

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -4131,6 +4131,13 @@ void StressTest::Reopen(ThreadState* thread) {
     } else {
       s = db_->SyncWAL();
     }
+    if (s.IsNotSupported()) {
+      // Some WAL implementations (e.g., Warm Storage) do not support
+      // SyncWAL()/FlushWAL(sync=true) because their WritableFile is not
+      // sync-thread-safe. Fall back to FlushWAL(sync=false) to flush the
+      // internal buffer; persistence is handled by the WAL implementation.
+      s = db_->FlushWAL(/*sync=*/false);
+    }
     if (!s.ok()) {
       fprintf(stderr,
               "Error persisting WAL data which is needed before reopening the "


### PR DESCRIPTION
Summary:
The warm_storage_crash_test fails during reopen because the Warm
Storage WAL implementation does not support IsSyncThreadSafe(), causing
SyncWAL() to return NotSupported. The stress test's reopen logic treated
this as a fatal error and called exit(1).

Fix: When SyncWAL() or FlushWAL(sync=true) returns NotSupported, fall back
to FlushWAL(sync=false) to flush the internal buffer. Persistence is handled
by the Warm Storage WAL implementation itself.

Differential Revision: D98425496


