### PR TITLE
Log errno and thread ID on CreateIOUring failure (#14520)

### DIFF
--- a/env/io_posix.cc
+++ b/env/io_posix.cc
@@ -1096,7 +1096,6 @@ IOStatus PosixRandomAccessFile::ReadAsync(
 
   // Init failed, platform doesn't support io_uring.
   if (iu == nullptr) {
-    fprintf(stderr, "failed to init io_uring\n");
     return IOStatus::NotSupported("ReadAsync: failed to init io_uring");
   }
 

--- a/env/io_posix.h
+++ b/env/io_posix.h
@@ -10,7 +10,12 @@
 #include <errno.h>
 #if defined(ROCKSDB_IOURING_PRESENT)
 #include <liburing.h>
+#include <pthread.h>
 #include <sys/uio.h>
+
+#include <cstdio>
+
+#include "util/string_util.h"
 
 // Compatibility defines for io_uring flags that may not be present in older
 // kernel headers. These values are fixed and won't change, so it's safe to
@@ -341,6 +346,9 @@ inline struct io_uring* CreateIOUring() {
   flags |= IORING_SETUP_DEFER_TASKRUN;
   int ret = io_uring_queue_init(kIoUringDepth, new_io_uring, flags);
   if (ret) {
+    fprintf(stderr, "CreateIOUring failed: %s (errno=%d), thread=%lu\n",
+            errnoStr(-ret).c_str(), -ret,
+            static_cast<unsigned long>(pthread_self()));
     delete new_io_uring;
     new_io_uring = nullptr;
   }


### PR DESCRIPTION
Summary:

CreateIOUring() silently returns nullptr on failure, discarding the errno
from io_uring_queue_init. This makes it impossible to diagnose why
io_uring initialization fails on specific threads (e.g. ENOMEM from
memlock limits, EINVAL from unsupported flags, EMFILE from fd exhaustion).

Add a fprintf(stderr, ...) that logs strerror, errno, and pthread thread
ID when io_uring_queue_init fails, so failures are diagnosable from logs
without needing to reproduce.

Reviewed By: xingbowang

Differential Revision: D98526792


