### PR TITLE
Fix null sqe crash in ReadAsync when io_uring submission queue is full (#14521)

### DIFF
--- a/env/env_test.cc
+++ b/env/env_test.cc
@@ -3728,6 +3728,71 @@ TEST_F(TestAsyncRead, InterleavingIOUringOperations) {
 #endif
 }
 
+// Test that ReadAsync returns IOStatus::Busy when io_uring_get_sqe returns
+// null (submission queue full), rather than crashing on a null SQE dereference.
+// Uses SyncPoint injection to simulate the null SQE since io_uring_submit is
+// called per-request, making it difficult to naturally saturate the SQ.
+TEST_F(TestAsyncRead, ReadAsyncQueueFull) {
+#if defined(ROCKSDB_IOURING_PRESENT)
+  std::shared_ptr<FileSystem> fs = env_->GetFileSystem();
+  std::string fname = test::PerThreadDBPath(env_, "testfile_queuefull");
+
+  constexpr size_t kSectorSize = 4096;
+
+  // 1. Create a test file.
+  {
+    std::unique_ptr<FSWritableFile> wfile;
+    ASSERT_OK(
+        fs->NewWritableFile(fname, FileOptions(), &wfile, nullptr /*dbg*/));
+    auto data = NewAligned(kSectorSize * 8, 'x');
+    Slice slice(data.get(), kSectorSize);
+    ASSERT_OK(wfile->Append(slice, IOOptions(), nullptr));
+    ASSERT_OK(wfile->Close(IOOptions(), nullptr));
+  }
+
+  // 2. Open the file and verify ReadAsync handles null SQE gracefully.
+  {
+    std::unique_ptr<FSRandomAccessFile> file;
+    ASSERT_OK(fs->NewRandomAccessFile(fname, FileOptions(), &file, nullptr));
+
+    // Force io_uring_get_sqe to appear to return null via SyncPoint.
+    SyncPoint::GetInstance()->SetCallBack(
+        "PosixRandomAccessFile::ReadAsync:io_uring_get_sqe",
+        [](void* arg) { *static_cast<io_uring_sqe**>(arg) = nullptr; });
+    SyncPoint::GetInstance()->EnableProcessing();
+
+    IOOptions opts;
+    auto scratch = NewAligned(kSectorSize, 0);
+    FSReadRequest req;
+    req.offset = 0;
+    req.len = kSectorSize;
+    req.scratch = scratch.get();
+
+    void* io_handle = nullptr;
+    IOHandleDeleter del_fn = nullptr;
+    std::function<void(FSReadRequest&, void*)> callback =
+        [](FSReadRequest& /*req*/, void* /*cb_arg*/) {};
+
+    IOStatus s = file->ReadAsync(req, opts, callback, nullptr, &io_handle,
+                                 &del_fn, nullptr);
+
+    if (s.IsNotSupported()) {
+      fprintf(stderr, "Skipping test - io_uring not supported: %s\n",
+              s.ToString().c_str());
+    } else {
+      ASSERT_TRUE(s.IsBusy()) << s.ToString();
+      ASSERT_EQ(io_handle, nullptr);
+      ASSERT_EQ(del_fn, nullptr);
+    }
+
+    SyncPoint::GetInstance()->DisableProcessing();
+    SyncPoint::GetInstance()->ClearAllCallBacks();
+  }
+#else
+  fprintf(stderr, "Skipping test - ROCKSDB_IOURING_PRESENT not defined\n");
+#endif
+}
+
 // Helper function to run AbortIO test with parameterized read requests.
 // Each request is specified as {offset, length}.
 // use_direct_io: if true, opens the file with O_DIRECT to bypass page cache.

--- a/env/io_posix.cc
+++ b/env/io_posix.cc
@@ -1099,6 +1099,9 @@ IOStatus PosixRandomAccessFile::ReadAsync(
     return IOStatus::NotSupported("ReadAsync: failed to init io_uring");
   }
 
+  *io_handle = nullptr;
+  *del_fn = nullptr;
+
   // Allocate io_handle.
   IOHandleDeleter deletefn = [](void* args) -> void {
     delete (static_cast<Posix_IOHandle*>(args));
@@ -1112,12 +1115,19 @@ IOStatus PosixRandomAccessFile::ReadAsync(
   posix_handle->iov.iov_base = req.scratch;
   posix_handle->iov.iov_len = req.len;
 
-  *io_handle = static_cast<void*>(posix_handle);
-  *del_fn = deletefn;
-
   // Step 3: io_uring_sqe_set_data
   struct io_uring_sqe* sqe;
   sqe = io_uring_get_sqe(iu);
+  TEST_SYNC_POINT_CALLBACK("PosixRandomAccessFile::ReadAsync:io_uring_get_sqe",
+                           &sqe);
+  if (sqe == nullptr) {
+    // Submission queue is full, so outstanding completions have not been
+    // reaped yet. Submission never succeeded, so clean up the local handle and
+    // return Busy without publishing io_handle/del_fn to the caller.
+    delete posix_handle;
+    return IOStatus::Busy(
+        "PosixRandomAccessFile::ReadAsync: io_uring submission queue is full");
+  }
 
   io_uring_prep_readv(sqe, fd_, /*sqe->addr=*/&posix_handle->iov,
                       /*sqe->len=*/1, /*sqe->offset=*/posix_handle->offset);
@@ -1146,6 +1156,7 @@ IOStatus PosixRandomAccessFile::ReadAsync(
     }
   } while (ret < 1);
   if (ret <= 0) {
+    delete posix_handle;
     return IOStatus::IOError(
         "PosixRandomAccessFile::ReadAsync: io_uring_submit() returned " +
         std::to_string(ret));
@@ -1156,6 +1167,8 @@ IOStatus PosixRandomAccessFile::ReadAsync(
             "io_uring_submit() returned = %zd\n",
             ret);
   }
+  *io_handle = static_cast<void*>(posix_handle);
+  *del_fn = deletefn;
   return IOStatus::OK();
 #else
   (void)req;


### PR DESCRIPTION
Summary:

ReadAsync calls io_uring_get_sqe() without checking for nullptr. When the
io_uring submission queue is full (outstanding completions not yet reaped),
io_uring_get_sqe returns NULL and the subsequent io_uring_prep_readv
dereferences it, causing a segfault.

MultiRead already handles this correctly by using io_uring_sq_space_left()
to cap submissions. ReadAsync submits exactly one SQE per call so a simple
null check with error return is sufficient.

On null sqe, clean up the already-allocated Posix_IOHandle and return
IOStatus::Busy so the caller can retry after reaping completions.

The io_uring queue depth is kIoUringDepth (256), and each thread gets its
own io_uring instance via thread-local storage. In practice the SQ rarely
fills because ReadAsync calls io_uring_submit() after each io_uring_get_sqe(),
immediately flushing the SQE to the kernel. The null SQE would only occur
under unusual kernel backpressure where the kernel cannot consume from the
SQ ring fast enough.

IOStatus::Busy was chosen (over IOError) because this is a transient
condition. The caller has two options:
1. Call Poll() to reap outstanding completions from the CQ, then retry
   ReadAsync. This mirrors how MultiRead handles queue pressure internally
   by capping submissions and reaping between batches.
2. Fall back to synchronous Read(). Existing callers (FilePrefetchBuffer,
   IODispatcher) already have synchronous fallback paths for non-OK
   ReadAsync status, so IOStatus::Busy naturally triggers that fallback
   without additional code changes. Given the rarity of this condition,
   the synchronous fallback is pragmatic and avoids adding retry complexity.

Also adds a TEST_SYNC_POINT_CALLBACK on io_uring_get_sqe to enable test
injection, and a new ReadAsyncQueueFull unit test that uses SyncPoint to
force a null SQE and verifies the Busy return, handle cleanup, and no crash.

Differential Revision: D98533853


