### PR TITLE
Fix NULL persisted_seqno_ in AnonExpectedState (#14523)

### DIFF
--- a/db_stress_tool/expected_state.cc
+++ b/db_stress_tool/expected_state.cc
@@ -211,6 +211,8 @@ Status AnonExpectedState::Open(bool /* create */) {
       new std::atomic<uint32_t>[GetValuesLen() /
                                 sizeof(std::atomic<uint32_t>)]);
   values_ = &values_allocation_[0];
+  persisted_seqno_allocation_.reset(new std::atomic<SequenceNumber>(0));
+  persisted_seqno_ = persisted_seqno_allocation_.get();
   Reset();
   return Status::OK();
 }

--- a/db_stress_tool/expected_state.h
+++ b/db_stress_tool/expected_state.h
@@ -193,6 +193,7 @@ class AnonExpectedState : public ExpectedState {
 
  private:
   std::unique_ptr<std::atomic<uint32_t>[]> values_allocation_;
+  std::unique_ptr<std::atomic<SequenceNumber>> persisted_seqno_allocation_;
 };
 
 // An `ExpectedStateManager` manages data about the expected state of the


### PR DESCRIPTION
Summary:

AnonExpectedState::Open() never initialized the base class
persisted_seqno_ pointer, leaving it as nullptr. Any call to
SetPersistedSeqno() or GetPersistedSeqno() on an AnonExpectedState
(used when expected_values_dir is empty) would dereference a null
pointer. Fix by allocating and assigning it in Open(), matching
FileExpectedState's pattern.

Differential Revision: D98556119
