### PR TITLE
Add regression tests and diagnostic logging for trie UDI post-seek seqno correction

### DIFF
--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -2418,6 +2418,144 @@ class NonBatchedOpsStressTest : public StressTest {
     }
   }
 
+  // Dumps diagnostic information on iterator verification failure.
+  // Logs expected-state details, iterator config, and replays the
+  // scan with fresh iterators (standard vs trie, direct vs coalescing)
+  // to aid triage.
+  void DumpIteratorVerificationFailure(
+      Iterator* iter, ColumnFamilyHandle* cfh, uint64_t curr, std::size_t index,
+      int64_t lb, int64_t ub, uint32_t value_base_from_db, bool must_not_exist,
+      bool in_expected_value_base_range,
+      const ExpectedValue& pre_read_expected_value,
+      const ExpectedValue& post_read_expected_value, const ReadOptions& ro,
+      int64_t mid, int64_t step,
+      const std::vector<int>& rand_column_families) const {
+    fprintf(stderr,
+            "Iterator verification details: curr=%llu, index=%zu, "
+            "range=[%lld, %lld), value_base_from_db=%u, "
+            "must_not_exist=%d, in_expected_value_base_range=%d\n",
+            static_cast<unsigned long long>(curr), index,
+            static_cast<long long>(lb), static_cast<long long>(ub),
+            static_cast<unsigned>(value_base_from_db),
+            static_cast<int>(must_not_exist),
+            static_cast<int>(in_expected_value_base_range));
+    fprintf(stderr,
+            "Expected state (pre): raw=0x%08x, value_base=%u, "
+            "final_value_base=%u, del_counter=%u, final_del_counter=%u, "
+            "deleted=%d, pending_write=%d, pending_delete=%d\n",
+            static_cast<unsigned>(pre_read_expected_value.Read()),
+            static_cast<unsigned>(pre_read_expected_value.GetValueBase()),
+            static_cast<unsigned>(pre_read_expected_value.GetFinalValueBase()),
+            static_cast<unsigned>(pre_read_expected_value.GetDelCounter()),
+            static_cast<unsigned>(pre_read_expected_value.GetFinalDelCounter()),
+            static_cast<int>(pre_read_expected_value.IsDeleted()),
+            static_cast<int>(pre_read_expected_value.PendingWrite()),
+            static_cast<int>(pre_read_expected_value.PendingDelete()));
+    fprintf(
+        stderr,
+        "Expected state (post): raw=0x%08x, value_base=%u, "
+        "final_value_base=%u, del_counter=%u, final_del_counter=%u, "
+        "deleted=%d, pending_write=%d, pending_delete=%d\n",
+        static_cast<unsigned>(post_read_expected_value.Read()),
+        static_cast<unsigned>(post_read_expected_value.GetValueBase()),
+        static_cast<unsigned>(post_read_expected_value.GetFinalValueBase()),
+        static_cast<unsigned>(post_read_expected_value.GetDelCounter()),
+        static_cast<unsigned>(post_read_expected_value.GetFinalDelCounter()),
+        static_cast<int>(post_read_expected_value.IsDeleted()),
+        static_cast<int>(post_read_expected_value.PendingWrite()),
+        static_cast<int>(post_read_expected_value.PendingDelete()));
+    fprintf(stderr,
+            "Iterator config: allow_unprepared_value=%d, "
+            "auto_refresh_iterator_with_snapshot=%d, has_snapshot=%d, "
+            "use_multi_cf_iterator=%d, using_udi=%d, use_trie_index=%d\n",
+            static_cast<int>(ro.allow_unprepared_value),
+            static_cast<int>(ro.auto_refresh_iterator_with_snapshot),
+            static_cast<int>(ro.snapshot != nullptr),
+            static_cast<int>(FLAGS_use_multi_cf_iterator),
+            static_cast<int>(ro.table_index_factory != nullptr),
+            static_cast<int>(FLAGS_use_trie_index));
+    fprintf(stderr, "Iterator value: %s\n",
+            iter->value().ToString(true).c_str());
+
+    const std::string failure_key = iter->key().ToString();
+    const std::string replay_key = Key(mid);
+
+    auto make_debug_iter =
+        [&](const ReadOptions& debug_ro,
+            bool use_multi_cf_iter) -> std::unique_ptr<Iterator> {
+      if (use_multi_cf_iter) {
+        std::vector<ColumnFamilyHandle*> cfhs;
+        cfhs.reserve(rand_column_families.size());
+        for (auto cf_index : rand_column_families) {
+          cfhs.emplace_back(column_families_[cf_index]);
+        }
+        return db_->NewCoalescingIterator(debug_ro, cfhs);
+      }
+      return std::unique_ptr<Iterator>(db_->NewIterator(debug_ro, cfh));
+    };
+
+    auto dump_debug_iter = [&](const char* label, const ReadOptions& debug_ro,
+                               bool use_multi_cf_iter, bool replay_from_mid) {
+      auto debug_iter = make_debug_iter(debug_ro, use_multi_cf_iter);
+      if (replay_from_mid) {
+        debug_iter->Seek(replay_key);
+        for (int64_t s = 0; s < step && debug_iter->Valid(); ++s) {
+          debug_iter->Next();
+        }
+      } else {
+        debug_iter->Seek(failure_key);
+      }
+
+      if (debug_iter->Valid() && debug_ro.allow_unprepared_value) {
+        if (!debug_iter->PrepareValue()) {
+          assert(!debug_iter->Valid());
+        }
+      }
+
+      std::string sv_number;
+      Status prop_s = debug_iter->GetProperty(
+          "rocksdb.iterator.super-version-number", &sv_number);
+      fprintf(stderr, "%s (%s): valid=%d, status=%s, sv=%s, key=%s, value=%s\n",
+              label, replay_from_mid ? "replay_from_mid" : "seek_failure_key",
+              static_cast<int>(debug_iter->Valid()),
+              debug_iter->status().ToString().c_str(),
+              prop_s.ok() ? sv_number.c_str() : prop_s.ToString().c_str(),
+              debug_iter->Valid() ? debug_iter->key().ToString(true).c_str()
+                                  : "(invalid)",
+              (debug_iter->Valid() &&
+               (!debug_ro.allow_unprepared_value || debug_iter->status().ok()))
+                  ? debug_iter->value().ToString(true).c_str()
+                  : "(n/a)");
+    };
+
+    ReadOptions standard_ro = ro;
+    standard_ro.table_index_factory = nullptr;
+    dump_debug_iter("Debug standard direct", standard_ro,
+                    /*use_multi_cf_iter=*/false,
+                    /*replay_from_mid=*/false);
+    dump_debug_iter("Debug trie direct", ro, /*use_multi_cf_iter=*/false,
+                    /*replay_from_mid=*/false);
+    dump_debug_iter("Debug standard direct", standard_ro,
+                    /*use_multi_cf_iter=*/false,
+                    /*replay_from_mid=*/true);
+    dump_debug_iter("Debug trie direct", ro, /*use_multi_cf_iter=*/false,
+                    /*replay_from_mid=*/true);
+    if (FLAGS_use_multi_cf_iterator) {
+      dump_debug_iter("Debug standard coalescing", standard_ro,
+                      /*use_multi_cf_iter=*/true,
+                      /*replay_from_mid=*/false);
+      dump_debug_iter("Debug trie coalescing", ro,
+                      /*use_multi_cf_iter=*/true,
+                      /*replay_from_mid=*/false);
+      dump_debug_iter("Debug standard coalescing", standard_ro,
+                      /*use_multi_cf_iter=*/true,
+                      /*replay_from_mid=*/true);
+      dump_debug_iter("Debug trie coalescing", ro,
+                      /*use_multi_cf_iter=*/true,
+                      /*replay_from_mid=*/true);
+    }
+  }
+
   // Given a key K, this creates an iterator which scans the range
   // [K, K + FLAGS_num_iterations) forward and backward.
   // Then does a random sequence of Next/Prev operations.
@@ -2863,11 +3001,13 @@ class NonBatchedOpsStressTest : public StressTest {
             pre_read_expected_values[index];
         const ExpectedValue post_read_expected_value =
             post_read_expected_values[index];
-        if (ExpectedValueHelper::MustHaveNotExisted(pre_read_expected_value,
-                                                    post_read_expected_value) ||
-            !ExpectedValueHelper::InExpectedValueBaseRange(
+        const bool must_not_exist = ExpectedValueHelper::MustHaveNotExisted(
+            pre_read_expected_value, post_read_expected_value);
+        const bool in_expected_value_base_range =
+            ExpectedValueHelper::InExpectedValueBaseRange(
                 value_base_from_db, pre_read_expected_value,
-                post_read_expected_value)) {
+                post_read_expected_value);
+        if (must_not_exist || !in_expected_value_base_range) {
           // Fail fast to preserve the DB state.
           thread->shared->SetVerificationFailure();
           fprintf(stderr,
@@ -2876,6 +3016,11 @@ class NonBatchedOpsStressTest : public StressTest {
                   iter->key().ToString(true).c_str());
           fprintf(stderr, "Column family: %s, op_logs: %s\n",
                   cfh->GetName().c_str(), op_logs.c_str());
+          DumpIteratorVerificationFailure(
+              iter.get(), cfh, curr, index, lb, ub, value_base_from_db,
+              must_not_exist, in_expected_value_base_range,
+              pre_read_expected_value, post_read_expected_value, ro, mid, i,
+              rand_column_families);
           thread->stats.AddErrors(1);
           break;
         }

--- a/utilities/trie_index/trie_index_db_test.cc
+++ b/utilities/trie_index/trie_index_db_test.cc
@@ -20,8 +20,10 @@
 
 #include "port/port.h"
 #include "rocksdb/db.h"
+#include "rocksdb/experimental.h"
 #include "rocksdb/options.h"
 #include "rocksdb/slice.h"
+#include "rocksdb/slice_transform.h"
 #include "rocksdb/sst_file_writer.h"
 #include "rocksdb/status.h"
 #include "rocksdb/table.h"
@@ -31,6 +33,7 @@
 #include "rocksdb/write_batch.h"
 #include "test_util/testharness.h"
 #include "test_util/testutil.h"
+#include "util/coding.h"
 #include "util/compression.h"
 #include "util/random.h"
 #include "utilities/merge_operators.h"
@@ -49,6 +52,94 @@ static std::string MakeKeyBody(int k) {
     val >>= 8;
   }
   return key_body;
+}
+
+static void AppendBigEndian64(uint64_t val, std::string* key) {
+  PutFixed64(key, val);
+  char* int_data = &((*key)[key->size() - sizeof(uint64_t)]);
+  for (size_t i = 0; i < sizeof(uint64_t) / 2; ++i) {
+    std::swap(int_data[i], int_data[sizeof(uint64_t) - 1 - i]);
+  }
+}
+
+// Matches db_stress's default key generation for:
+//   max_key_len=3, key_len_percent_dist=1,30,69, key_window_scale_factor=10
+static std::string MakeStressKey(int64_t val) {
+  static constexpr uint64_t kWindow = 1000;
+  static constexpr uint64_t kWeights[] = {10, 300, 690};
+  static constexpr size_t kNumWeights = 3;
+
+  uint64_t window_idx = static_cast<uint64_t>(val) / kWindow;
+  uint64_t offset = static_cast<uint64_t>(val) % kWindow;
+  std::string key;
+  key.reserve(3 * sizeof(uint64_t));
+
+  for (size_t level = 0; level < kNumWeights; ++level) {
+    const uint64_t weight = kWeights[level];
+    uint64_t pfx = (level == 0) ? window_idx * weight : 0;
+    pfx += offset >= weight ? weight - 1 : offset;
+    AppendBigEndian64(pfx, &key);
+    if (offset < weight) {
+      if (offset < weight - 1 && level + 1 < kNumWeights) {
+        key.append(static_cast<size_t>(offset & 0x7), 'x');
+      }
+      break;
+    }
+    offset -= weight;
+  }
+
+  return key;
+}
+
+static std::string MakePaddedValue(int version, int key_num) {
+  std::string value =
+      "value_v" + std::to_string(version) + "_k" + std::to_string(key_num);
+  value.append(128, static_cast<char>('a' + (version % 26)));
+  return value;
+}
+
+class StressLikeVariableWidthExtractor
+    : public experimental::KeySegmentsExtractor {
+ public:
+  const char* Name() const override { return "StressLikeVariableWidth"; }
+
+  std::string GetId() const override { return Name(); }
+
+  void Extract(const Slice& key_or_bound, KeyKind /*kind*/,
+               Result* result) const override {
+    const uint32_t len = static_cast<uint32_t>(key_or_bound.size());
+    bool prev_non_zero = false;
+    for (uint32_t i = 0; i < len; ++i) {
+      if ((prev_non_zero && key_or_bound[i] == 0) || i + 1 == len) {
+        result->segment_ends.push_back(i + 1);
+      }
+      prev_non_zero = key_or_bound[i] != 0;
+    }
+  }
+};
+
+static std::shared_ptr<experimental::SstQueryFilterConfigsManager::Factory>
+MakeStressLikeSqfcFactory() {
+  using experimental::MakeSharedBytewiseMinMaxSQFC;
+  using experimental::SelectKeySegment;
+  using experimental::SstQueryFilterConfigs;
+  using experimental::SstQueryFilterConfigsManager;
+
+  auto extractor = std::make_shared<StressLikeVariableWidthExtractor>();
+  auto filter0 = MakeSharedBytewiseMinMaxSQFC(SelectKeySegment(0));
+  auto filter2 = MakeSharedBytewiseMinMaxSQFC(SelectKeySegment(2));
+
+  SstQueryFilterConfigs configs{{filter0, filter2}, extractor};
+  SstQueryFilterConfigsManager::Data data = {{1, {{"foo", configs}}}};
+
+  std::shared_ptr<SstQueryFilterConfigsManager> manager;
+  EXPECT_OK(SstQueryFilterConfigsManager::MakeShared(data, &manager));
+  EXPECT_TRUE(manager);
+
+  std::shared_ptr<SstQueryFilterConfigsManager::Factory> factory;
+  EXPECT_OK(manager->MakeSharedFactory("foo", 1, &factory));
+  EXPECT_TRUE(factory);
+  return factory;
 }
 
 class TrieIndexDBTest : public testing::Test {
@@ -1277,6 +1368,295 @@ TEST_F(TrieIndexDBTest, SameUserKeyManyVersionsSeekCorrectness) {
   for (auto* snap : snaps) {
     db_->ReleaseSnapshot(snap);
   }
+}
+
+TEST_F(TrieIndexDBTest, AutoRefreshSnapshotNextAcrossSameUserKeyBoundaries) {
+  options_.create_if_missing = true;
+  options_.disable_auto_compactions = true;
+
+  BlockBasedTableOptions table_options;
+  table_options.user_defined_index_factory = trie_factory_;
+  table_options.block_size = 64;
+  table_options.separate_key_value_in_data_block = true;
+  options_.table_factory.reset(NewBlockBasedTableFactory(table_options));
+  last_options_ = options_;
+  ASSERT_OK(DB::Open(options_, dbname_, &db_));
+
+  const std::vector<std::string> keys = {"key_aaa", "key_mmm", "key_zzz"};
+  constexpr int kVersionsPerKey = 12;
+  std::vector<const Snapshot*> snaps;
+
+  for (int v = 0; v < kVersionsPerKey; ++v) {
+    for (const auto& key : keys) {
+      std::string value =
+          key + "_v" + std::to_string(v) + "_padding_to_force_more_data_blocks";
+      ASSERT_OK(db_->Put(WriteOptions(), key, value));
+    }
+    snaps.push_back(db_->GetSnapshot());
+  }
+
+  ASSERT_OK(db_->Flush(FlushOptions()));
+
+  const Snapshot* snap = snaps.back();
+  const std::string expected_mmm = "key_mmm_v" +
+                                   std::to_string(kVersionsPerKey - 1) +
+                                   "_padding_to_force_more_data_blocks";
+
+  ReadOptions std_ro;
+  std_ro.snapshot = snap;
+  std_ro.auto_refresh_iterator_with_snapshot = true;
+  std_ro.allow_unprepared_value = true;
+
+  ReadOptions trie_ro = std_ro;
+  trie_ro.table_index_factory = trie_factory_.get();
+
+  std::unique_ptr<Iterator> std_iter(db_->NewIterator(std_ro));
+  std::unique_ptr<Iterator> trie_iter(db_->NewIterator(trie_ro));
+
+  std_iter->Seek("key_aaa");
+  trie_iter->Seek("key_aaa");
+  ASSERT_TRUE(std_iter->Valid());
+  ASSERT_TRUE(trie_iter->Valid());
+  ASSERT_EQ(std_iter->key().ToString(), "key_aaa");
+  ASSERT_EQ(trie_iter->key().ToString(), "key_aaa");
+  ASSERT_TRUE(std_iter->PrepareValue());
+  ASSERT_TRUE(trie_iter->PrepareValue());
+
+  std::string std_sv_before;
+  std::string trie_sv_before;
+  ASSERT_OK(std_iter->GetProperty("rocksdb.iterator.super-version-number",
+                                  &std_sv_before));
+  ASSERT_OK(trie_iter->GetProperty("rocksdb.iterator.super-version-number",
+                                   &trie_sv_before));
+
+  // Bump SuperVersion after the iterators are already positioned so the next
+  // Next() must reconcile against the held snapshot.
+  for (int i = 0; i < 100; ++i) {
+    ASSERT_OK(db_->Put(WriteOptions(), "key_after_" + std::to_string(i),
+                       "value_after_" + std::to_string(i)));
+  }
+  ASSERT_OK(db_->Flush(FlushOptions()));
+
+  std_iter->Next();
+  trie_iter->Next();
+  ASSERT_TRUE(std_iter->Valid());
+  ASSERT_TRUE(trie_iter->Valid());
+  ASSERT_EQ(std_iter->key().ToString(), "key_mmm");
+  ASSERT_EQ(trie_iter->key().ToString(), "key_mmm");
+  ASSERT_TRUE(std_iter->PrepareValue());
+  ASSERT_TRUE(trie_iter->PrepareValue());
+  ASSERT_EQ(std_iter->value().ToString(), expected_mmm);
+  ASSERT_EQ(trie_iter->value().ToString(), expected_mmm);
+
+  std::string std_sv_after;
+  std::string trie_sv_after;
+  ASSERT_OK(std_iter->GetProperty("rocksdb.iterator.super-version-number",
+                                  &std_sv_after));
+  ASSERT_OK(trie_iter->GetProperty("rocksdb.iterator.super-version-number",
+                                   &trie_sv_after));
+  ASSERT_LT(std::stoull(std_sv_before), std::stoull(std_sv_after));
+  ASSERT_LT(std::stoull(trie_sv_before), std::stoull(trie_sv_after));
+
+  for (auto* held : snaps) {
+    db_->ReleaseSnapshot(held);
+  }
+}
+
+TEST_F(TrieIndexDBTest,
+       AutoRefreshSnapshotNextAfterCompactionAcrossSameUserKeyBoundaries) {
+  options_.create_if_missing = true;
+  options_.disable_auto_compactions = true;
+
+  BlockBasedTableOptions table_options;
+  table_options.user_defined_index_factory = trie_factory_;
+  table_options.block_size = 64;
+  table_options.separate_key_value_in_data_block = true;
+  options_.table_factory.reset(NewBlockBasedTableFactory(table_options));
+  last_options_ = options_;
+  ASSERT_OK(DB::Open(options_, dbname_, &db_));
+
+  const std::vector<std::string> keys = {"key_aaa", "key_mmm", "key_zzz"};
+  constexpr int kVersionsPerKey = 12;
+  std::vector<const Snapshot*> snaps;
+
+  for (int v = 0; v < kVersionsPerKey; ++v) {
+    for (const auto& key : keys) {
+      std::string value =
+          key + "_v" + std::to_string(v) + "_padding_to_force_more_data_blocks";
+      ASSERT_OK(db_->Put(WriteOptions(), key, value));
+    }
+    snaps.push_back(db_->GetSnapshot());
+  }
+
+  ASSERT_OK(db_->Flush(FlushOptions()));
+
+  const Snapshot* snap = snaps.back();
+  const std::string expected_mmm = "key_mmm_v" +
+                                   std::to_string(kVersionsPerKey - 1) +
+                                   "_padding_to_force_more_data_blocks";
+
+  ReadOptions std_ro;
+  std_ro.snapshot = snap;
+  std_ro.auto_refresh_iterator_with_snapshot = true;
+  std_ro.allow_unprepared_value = true;
+
+  ReadOptions trie_ro = std_ro;
+  trie_ro.table_index_factory = trie_factory_.get();
+
+  std::unique_ptr<Iterator> std_iter(db_->NewIterator(std_ro));
+  std::unique_ptr<Iterator> trie_iter(db_->NewIterator(trie_ro));
+
+  std_iter->Seek("key_aaa");
+  trie_iter->Seek("key_aaa");
+  ASSERT_TRUE(std_iter->Valid());
+  ASSERT_TRUE(trie_iter->Valid());
+  ASSERT_TRUE(std_iter->PrepareValue());
+  ASSERT_TRUE(trie_iter->PrepareValue());
+
+  std::string std_sv_before;
+  std::string trie_sv_before;
+  ASSERT_OK(std_iter->GetProperty("rocksdb.iterator.super-version-number",
+                                  &std_sv_before));
+  ASSERT_OK(trie_iter->GetProperty("rocksdb.iterator.super-version-number",
+                                   &trie_sv_before));
+
+  // Rewrite the SST containing the multi-version keys while the iterators are
+  // open. The held snapshot keeps all versions live across compaction.
+  ASSERT_OK(db_->CompactRange(CompactRangeOptions(), nullptr, nullptr));
+
+  std_iter->Next();
+  trie_iter->Next();
+  ASSERT_TRUE(std_iter->Valid());
+  ASSERT_TRUE(trie_iter->Valid());
+  ASSERT_EQ(std_iter->key().ToString(), "key_mmm");
+  ASSERT_EQ(trie_iter->key().ToString(), "key_mmm");
+  ASSERT_TRUE(std_iter->PrepareValue());
+  ASSERT_TRUE(trie_iter->PrepareValue());
+  ASSERT_EQ(std_iter->value().ToString(), expected_mmm);
+  ASSERT_EQ(trie_iter->value().ToString(), expected_mmm);
+
+  std::string std_sv_after;
+  std::string trie_sv_after;
+  ASSERT_OK(std_iter->GetProperty("rocksdb.iterator.super-version-number",
+                                  &std_sv_after));
+  ASSERT_OK(trie_iter->GetProperty("rocksdb.iterator.super-version-number",
+                                   &trie_sv_after));
+  ASSERT_LT(std::stoull(std_sv_before), std::stoull(std_sv_after));
+  ASSERT_LT(std::stoull(trie_sv_before), std::stoull(trie_sv_after));
+
+  for (auto* held : snaps) {
+    db_->ReleaseSnapshot(held);
+  }
+}
+
+TEST_F(TrieIndexDBTest,
+       AutoRefreshSnapshotStressLikeSingleCfCoalescingIterator) {
+  auto sqfc_factory = MakeStressLikeSqfcFactory();
+
+  options_.create_if_missing = true;
+  options_.disable_auto_compactions = true;
+  options_.prefix_extractor.reset(NewFixedPrefixTransform(5));
+  options_.table_properties_collector_factories.emplace_back(sqfc_factory);
+
+  BlockBasedTableOptions table_options;
+  table_options.user_defined_index_factory = trie_factory_;
+  table_options.block_size = 128;
+  table_options.separate_key_value_in_data_block = true;
+  options_.table_factory.reset(NewBlockBasedTableFactory(table_options));
+  last_options_ = options_;
+  ASSERT_OK(DB::Open(options_, dbname_, &db_));
+
+  constexpr int kRangeStart = 36745;
+  constexpr int kRangeEnd = 36755;
+  constexpr int kFillerStart = kRangeStart - 40;
+  constexpr int kFillerEnd = kRangeEnd + 40;
+  constexpr int kFinalVersion = 8;
+
+  FlushOptions flush_opts;
+  flush_opts.wait = true;
+
+  for (int version = 0; version <= kFinalVersion; ++version) {
+    for (int key_num = kFillerStart; key_num < kFillerEnd; ++key_num) {
+      ASSERT_OK(db_->Put(WriteOptions(), MakeStressKey(key_num),
+                         MakePaddedValue(version, key_num)));
+    }
+    ASSERT_OK(db_->Flush(flush_opts));
+  }
+
+  const Snapshot* snap = db_->GetSnapshot();
+  const std::string lb = MakeStressKey(kRangeStart);
+  const std::string ub = MakeStressKey(kRangeEnd);
+
+  auto expected_value = [&](int key_num) {
+    return MakePaddedValue(kFinalVersion, key_num);
+  };
+
+  auto make_iter = [&](bool use_trie, bool use_coalescing) {
+    ReadOptions ro;
+    ro.snapshot = snap;
+    ro.allow_unprepared_value = true;
+    ro.auto_refresh_iterator_with_snapshot = true;
+    ro.table_filter = sqfc_factory->GetTableFilterForRangeQuery(lb, ub);
+    if (use_trie) {
+      ro.table_index_factory = trie_factory_.get();
+    }
+    if (use_coalescing) {
+      return db_->NewCoalescingIterator(ro, {db_->DefaultColumnFamily()});
+    }
+    return std::unique_ptr<Iterator>(db_->NewIterator(ro));
+  };
+
+  auto assert_iter_state = [&](const char* label, Iterator* iter, int key_num) {
+    SCOPED_TRACE(label);
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_EQ(iter->key().ToString(), MakeStressKey(key_num));
+    ASSERT_TRUE(iter->PrepareValue());
+    ASSERT_EQ(iter->value().ToString(), expected_value(key_num));
+  };
+
+  auto std_iter = make_iter(/*use_trie=*/false, /*use_coalescing=*/false);
+  auto trie_iter = make_iter(/*use_trie=*/true, /*use_coalescing=*/false);
+  auto std_coalescing = make_iter(/*use_trie=*/false, /*use_coalescing=*/true);
+  auto trie_coalescing = make_iter(/*use_trie=*/true, /*use_coalescing=*/true);
+
+  const std::string seek_key = MakeStressKey(kRangeStart);
+  std_iter->Seek(seek_key);
+  trie_iter->Seek(seek_key);
+  std_coalescing->Seek(seek_key);
+  trie_coalescing->Seek(seek_key);
+
+  assert_iter_state("standard iterator before refresh", std_iter.get(),
+                    kRangeStart);
+  assert_iter_state("trie iterator before refresh", trie_iter.get(),
+                    kRangeStart);
+  assert_iter_state("standard coalescing iterator before refresh",
+                    std_coalescing.get(), kRangeStart);
+  assert_iter_state("trie coalescing iterator before refresh",
+                    trie_coalescing.get(), kRangeStart);
+
+  for (int i = 0; i < 100; ++i) {
+    const int key_num = 90000 + i;
+    ASSERT_OK(db_->Put(WriteOptions(), MakeStressKey(key_num),
+                       MakePaddedValue(100 + i, key_num)));
+  }
+  ASSERT_OK(db_->Flush(flush_opts));
+
+  for (int key_num = kRangeStart + 1; key_num < kRangeEnd; ++key_num) {
+    std_iter->Next();
+    trie_iter->Next();
+    std_coalescing->Next();
+    trie_coalescing->Next();
+
+    assert_iter_state("standard iterator after refresh", std_iter.get(),
+                      key_num);
+    assert_iter_state("trie iterator after refresh", trie_iter.get(), key_num);
+    assert_iter_state("standard coalescing iterator after refresh",
+                      std_coalescing.get(), key_num);
+    assert_iter_state("trie coalescing iterator after refresh",
+                      trie_coalescing.get(), key_num);
+  }
+
+  db_->ReleaseSnapshot(snap);
 }
 
 // ============================================================================

--- a/utilities/trie_index/trie_index_test.cc
+++ b/utilities/trie_index/trie_index_test.cc
@@ -3846,6 +3846,26 @@ TEST_F(TrieIndexFactoryTest, SeekWithZeroSeqOnSameKeyBlocks) {
       AssertSeekOffset(ctx.iter.get(), Slice("key"), 0, 2000u));
 }
 
+TEST_F(TrieIndexFactoryTest, ZeroSeqMustNotSkipLeafForSmallerUserKey) {
+  // Regression test for DBIter's forward-scan reseek path.
+  //
+  // Block 0 ends with user key "m" and block 1 starts with the same user key,
+  // so the trie stores separator "m" with non-zero seqno metadata on block 0.
+  // However, a seek target for a *smaller* user key "l"|0 must still land on
+  // block 0, because block 0 can contain keys in ("l", "m"].
+  //
+  // Current buggy behavior applies seqno-based post-seek correction whenever
+  // target_seq < leaf_seqno, even if target user key < separator user key. In
+  // that case it incorrectly advances to block 1.
+  auto ctx = BuildTrieAndGetIterator({
+      {"m", "m", 0, 1000, 300, 200},
+      {"y", "zzz", 1000, 1000, 100, 1},
+      {"zzz", "", 2000, 1000, 1, 0},
+  });
+
+  ASSERT_NO_FATAL_FAILURE(AssertSeekOffset(ctx.iter.get(), Slice("l"), 0, 0u));
+}
+
 TEST_F(TrieIndexFactoryTest, NextTransitionOverflowToOverflow) {
   // Test Next() transitioning from one overflow run to the next trie leaf
   // that also has an overflow run.


### PR DESCRIPTION
## Summary

Adds regression tests and failure-diagnostic tooling for the trie UDI post-seek seqno correction bug (T258590238). The core fix itself already landed in #14466.

## What's in this PR

### Regression tests

- `TrieIndexFactoryTest.ZeroSeqMustNotSkipLeafForSmallerUserKey` — minimal unit test proving the original bug; exercises the seqno-based block advancement with a smaller user key that should NOT trigger advancement
- `TrieIndexDBTest.AutoRefreshSnapshotNextAcrossSameUserKeyBoundaries` — DB-level test for snapshot-refresh iteration across same-user-key block boundaries
- `TrieIndexDBTest.AutoRefreshSnapshotNextAfterCompactionAcrossSameUserKeyBoundaries` — same scenario after compaction reshapes SST layout
- `TrieIndexDBTest.AutoRefreshSnapshotStressLikeSingleCfCoalescingIterator` — stress-like test exercising snapshot-refresh + coalescing-iterator interaction

### Diagnostic logging in db_stress

Extracts the iterator verification failure dump into a `DumpIteratorVerificationFailure()` helper in `NonBatchedOpsStressTest`. On verification failure, logs:
- Expected-state window (pre/post read values, raw state, pending flags)
- Iterator config (UDI, trie, snapshot, multi-CF)
- Replay comparison: creates fresh iterators with standard vs trie index, direct vs coalescing, seek-to-failure-key vs replay-from-mid — making it possible to identify which index/iterator combination diverges

This logging was instrumental in triaging the original bug and will help with future trie UDI stress failures.

## Tests

All existing trie index tests pass. New tests listed above all pass.