### PR TITLE
Improve Claude review reliability

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -71,20 +71,31 @@ jobs:
             if (prs && prs.length > 0) {
               prNumber = prs[0].number;
             } else {
-              const { data: pulls } = await github.rest.pulls.list({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                state: 'open',
-                sort: 'updated',
-                direction: 'desc',
-                per_page: 30
-              });
-              const match = pulls.find(p => p.head.sha === headSha);
-              if (match) prNumber = match.number;
+              // PR may not be registered yet if push and PR creation raced.
+              // Retry up to 5 times with 10s delay.
+              for (let attempt = 0; attempt < 5; attempt++) {
+                if (attempt > 0) {
+                  core.info(`PR not found for SHA ${headSha}, retrying in 10s (attempt ${attempt + 1}/5)...`);
+                  await new Promise(r => setTimeout(r, 10000));
+                }
+                const { data: pulls } = await github.rest.pulls.list({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  state: 'open',
+                  sort: 'updated',
+                  direction: 'desc',
+                  per_page: 100
+                });
+                const match = pulls.find(p => p.head.sha === headSha);
+                if (match) {
+                  prNumber = match.number;
+                  break;
+                }
+              }
             }
 
             if (!prNumber) {
-              core.setFailed(`Could not find PR for SHA ${headSha}`);
+              core.setFailed(`Could not find PR for SHA ${headSha} after retries`);
               return;
             }
 


### PR DESCRIPTION
## Problems

**(1) Claude review times out on large PRs**
The `claude-code-base-action` defaults to `timeout_minutes=10`. Large PRs (e.g. #14499) get killed with exit code 124 after 600 seconds mid-review.

**(2) Exported PRs never get reviewed**
PRs exported from Meta's internal pipeline (e.g. #14515) trigger CI within milliseconds of PR creation. The `workflow_run` payload has `pull_requests=[]`, and the SHA-based fallback also misses because GitHub hasn't registered the PR yet — so Claude review never fires.

## Fixes

- Set `timeout_minutes: "60"` on both auto-review and manual-review `Run Claude` steps
- Retry the SHA→PR lookup up to 5 times with a 10s delay, giving GitHub up to ~50s to register the PR. Also bumped `per_page` from 30 to 100.