### PR TITLE
Update version to 11.3.0 and add 11.1.fb to format compat

### DIFF
--- a/include/rocksdb/version.h
+++ b/include/rocksdb/version.h
@@ -12,7 +12,7 @@
 // NOTE: in 'main' development branch, this should be the *next*
 // minor or major version number planned for release.
 #define ROCKSDB_MAJOR 11
-#define ROCKSDB_MINOR 2
+#define ROCKSDB_MINOR 3
 #define ROCKSDB_PATCH 0
 
 // Make it easy to do conditional compilation based on version checks, i.e.

--- a/tools/check_format_compatible.sh
+++ b/tools/check_format_compatible.sh
@@ -304,6 +304,7 @@ force_no_fbcode()
   # to patch old branches for changes to available FB compilers.
   sed -i -e 's|-d /mnt/gvfs/third-party|"$ROCKSDB_FORCE_FBCODE"|' build_tools/build_detect_platform
   # Fix a build issue affecting at least 4.2.fb
+  11.1.fb
   if [ -e include/rocksdb/delete_scheduler.h ]; then
     sed -i -e 's|pragma once|pragma once\n#include <memory>|' include/rocksdb/delete_scheduler.h
   fi


### PR DESCRIPTION
## Summary
- Bump version.h from 11.2.0 to 11.3.0
- Add `11.1.fb` to `check_format_compatible.sh`

## Remaining manual steps
- [ ] Cherry-pick HISTORY.md update from release branch
- [ ] Update folly hash in Makefile to latest

Part of 11.1 release workflow.