### PR TITLE
Store UniqueIdVerifier file in expected_values_dir on local filesystem

### DIFF
--- a/db_stress_tool/db_stress_listener.cc
+++ b/db_stress_tool/db_stress_listener.cc
@@ -15,10 +15,8 @@ namespace ROCKSDB_NAMESPACE {
 
 #ifdef GFLAGS
 
-// TODO: consider using expected_values_dir instead, but this is more
-// convenient for now.
-UniqueIdVerifier::UniqueIdVerifier(const std::string& db_name, Env* env)
-    : path_(db_name + "/.unique_ids") {
+UniqueIdVerifier::UniqueIdVerifier(const std::string& dir)
+    : path_(dir + "/.unique_ids") {
   // We expect such a small number of files generated during this test
   // (thousands?), checking full 192-bit IDs for uniqueness is a very
   // weak check. For a stronger check, we pick a specific 64-bit
@@ -27,12 +25,15 @@ UniqueIdVerifier::UniqueIdVerifier(const std::string& db_name, Env* env)
   // very good probability for the quantities in this test.
   offset_ = Random::GetTLSInstance()->Uniform(17);  // 0 to 16
 
-  const std::shared_ptr<FileSystem> fs = env->GetFileSystem();
+  // Always use local (default) filesystem for this bookkeeping file,
+  // even when DB is on a remote/warm filesystem, to avoid issues with
+  // weaker durability guarantees on remote filesystems.
+  const std::shared_ptr<FileSystem> fs = Env::Default()->GetFileSystem();
   IOOptions opts;
 
-  Status st = fs->CreateDirIfMissing(db_name, opts, nullptr);
+  Status st = fs->CreateDirIfMissing(dir, opts, nullptr);
   if (!st.ok()) {
-    fprintf(stderr, "Failed to create directory %s: %s\n", db_name.c_str(),
+    fprintf(stderr, "Failed to create directory %s: %s\n", dir.c_str(),
             st.ToString().c_str());
     exit(1);
   }

--- a/db_stress_tool/db_stress_listener.h
+++ b/db_stress_tool/db_stress_listener.h
@@ -31,7 +31,7 @@ namespace ROCKSDB_NAMESPACE {
 // Verify across process executions that all seen IDs are unique
 class UniqueIdVerifier {
  public:
-  explicit UniqueIdVerifier(const std::string& db_name, Env* env);
+  explicit UniqueIdVerifier(const std::string& dir);
   ~UniqueIdVerifier();
 
   void Verify(const std::string& id);
@@ -41,7 +41,7 @@ class UniqueIdVerifier {
 
  private:
   std::mutex mutex_;
-  // IDs persisted to a hidden file inside DB dir
+  // IDs persisted to a hidden file inside expected_values_dir (or DB dir)
   std::string path_;
   std::unique_ptr<WritableFileWriter> data_file_writer_;
   // Starting byte for which 8 bytes to check in memory within 24 byte ID
@@ -55,12 +55,14 @@ class DbStressListener : public EventListener {
   DbStressListener(const std::string& db_name,
                    const std::vector<DbPath>& db_paths,
                    const std::vector<ColumnFamilyDescriptor>& column_families,
-                   Env* env, SharedState* shared)
+                   SharedState* shared)
       : db_name_(db_name),
         db_paths_(db_paths),
         column_families_(column_families),
         num_pending_file_creations_(0),
-        unique_ids_(db_name, env),
+        unique_ids_(FLAGS_expected_values_dir.empty()
+                        ? db_name
+                        : FLAGS_expected_values_dir),
         shared_(shared) {}
 
   const char* Name() const override { return kClassName(); }

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -3837,9 +3837,8 @@ void StressTest::Open(SharedState* shared, bool reopen) {
     }
 
     options_.listeners.clear();
-    options_.listeners.emplace_back(
-        new DbStressListener(FLAGS_db, options_.db_paths, cf_descriptors,
-                             db_stress_listener_env, shared));
+    options_.listeners.emplace_back(new DbStressListener(
+        FLAGS_db, options_.db_paths, cf_descriptors, shared));
     RegisterAdditionalListeners();
 
     // If this is for DB reopen,  error injection may have been enabled.


### PR DESCRIPTION
Summary:
The warm_storage_crash_test was failing because UniqueIdVerifier stored its .unique_ids bookkeeping file in the DB directory, which lives on warm storage. After a crash, warm storage's weaker durability guarantees could cause flushed-but-not-synced data to be lost, making the file appear shorter on a second open within the same constructor. This caused CopyFile to return Corruption and trigger assert(false).

Move the file to expected_values_dir (which is always on local filesystem) and always use Env::Default() for file operations, so that POSIX flush semantics are sufficient for read consistency without needing Sync.

Test Plan:
Full local run of `make blackbox_crash_test`

Tasks: T254541253