### PR TITLE
skip stats if setup-ccache did not run or failed

### DIFF
--- a/.github/actions/teardown-ccache/action.yml
+++ b/.github/actions/teardown-ccache/action.yml
@@ -5,7 +5,11 @@ runs:
   steps:
     - name: Trim and print ccache stats
       run: |
+        if [ -z "$CCACHE_DIR" ]; then
+          echo "teardown-ccache: CCACHE_DIR not set, skipping (setup-ccache may not have run)"
+          exit 0
+        fi
         .github/scripts/ccache-trim.sh || true
-        ccache -s
+        ccache -s || echo "teardown-ccache: ccache not found, skipping stats"
       if: always()
       shell: bash


### PR DESCRIPTION
`teardown-ccache` runs with if: always(), but in folly jobs `setup-folly` precedes `setup-ccache`. When `setup-folly` fails, `setup-ccache` is skipped, so `CCACHE_DIR` is unset and ccache is not on `PATH`. This is exactly what happened [here](https://github.com/facebook/rocksdb/actions/runs/23660261947/job/68928337162). Fix guards `teardown-ccache` to exit gracefully when `CCACHE_DIR` is unset, and tolerate missing ccache binary for stats.   