### PR TITLE
Export header to add log data on a transaction

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -3056,6 +3056,7 @@ class H : public WriteBatch::Handler {
       (*log_data_)(state_, blob.data(), blob.size());
     }
   }
+  Status MarkNoop(bool /* empty_batch */) override { return Status::OK(); }
 };
 
 class HCF : public WriteBatch::Handler {
@@ -3089,6 +3090,7 @@ class HCF : public WriteBatch::Handler {
       (*log_data_)(state_, blob.data(), blob.size());
     }
   }
+  Status MarkNoop(bool /* empty_batch */) override { return Status::OK(); }
 };
 
 void rocksdb_writebatch_iterate(rocksdb_writebatch_t* b, void* state,
@@ -8302,6 +8304,11 @@ void rocksdb_transaction_delete_cf(
     rocksdb_transaction_t* txn, rocksdb_column_family_handle_t* column_family,
     const char* key, size_t klen, char** errptr) {
   SaveError(errptr, txn->rep->Delete(column_family->rep, Slice(key, klen)));
+}
+
+void rocksdb_transaction_put_log_data(rocksdb_transaction_t* txn,
+                                      const char* blob, size_t len) {
+  txn->rep->PutLogData(Slice(blob, len));
 }
 
 // Delete a key outside a transaction

--- a/db/c_test.c
+++ b/db/c_test.c
@@ -205,6 +205,27 @@ static void CheckDel(void* ptr, const char* k, size_t klen) {
   (*state)++;
 }
 
+static void NopPut(void* ptr, const char* k, size_t klen, const char* v,
+                   size_t vlen) {
+  (void)ptr;
+  (void)k;
+  (void)klen;
+  (void)v;
+  (void)vlen;
+}
+
+static void NopDel(void* ptr, const char* k, size_t klen) {
+  (void)ptr;
+  (void)k;
+  (void)klen;
+}
+
+static void CheckLogData(void* ptr, const char* blob, size_t blen) {
+  CheckEqual("log_blob", blob, blen);
+  int* found = (int*)ptr;
+  *found = 1;
+}
+
 // Callback from rocksdb_writebatch_iterate_cf()
 static void CheckPutCF(void* ptr, uint32_t cfid, const char* k, size_t klen,
                        const char* v, size_t vlen) {
@@ -3858,9 +3879,34 @@ int main(int argc, char** argv) {
       CheckMultiGetValues(3, vals, vals_sizes, errs, expected);
     }
 
+    rocksdb_transaction_put_log_data(txn, "log_blob", 8);
+    // record sequence number before commit so we can scan the WAL after
+    rocksdb_t* base_db_ld = rocksdb_transactiondb_get_base_db(txn_db);
+    uint64_t seq_before = rocksdb_get_latest_sequence_number(base_db_ld);
+
     // commit
     rocksdb_transaction_commit(txn, &err);
     CheckNoError(err);
+
+    // verify log data was written to WAL by scanning batches since seq_before
+    {
+      rocksdb_wal_iterator_t* wal_iter =
+          rocksdb_get_updates_since(base_db_ld, seq_before, NULL, &err);
+      CheckNoError(err);
+      int log_found = 0;
+      for (; rocksdb_wal_iter_valid(wal_iter) && !log_found;
+           rocksdb_wal_iter_next(wal_iter)) {
+        uint64_t seq;
+        rocksdb_writebatch_t* wal_wb =
+            rocksdb_wal_iter_get_batch(wal_iter, &seq);
+        rocksdb_writebatch_iterate_ld(wal_wb, &log_found, NopPut, NopDel,
+                                      CheckLogData);
+        rocksdb_writebatch_destroy(wal_wb);
+      }
+      CheckCondition(log_found == 1);
+      rocksdb_wal_iter_destroy(wal_iter);
+    }
+    rocksdb_transactiondb_close_base_db(base_db_ld);
 
     // read from outside transaction, after commit
     CheckTxnDBGet(txn_db, roptions, "foo", "hello");

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -3303,6 +3303,9 @@ extern ROCKSDB_LIBRARY_API void rocksdb_transaction_delete_cf(
     rocksdb_transaction_t* txn, rocksdb_column_family_handle_t* column_family,
     const char* key, size_t klen, char** errptr);
 
+extern ROCKSDB_LIBRARY_API void rocksdb_transaction_put_log_data(
+    rocksdb_transaction_t* txn, const char* blob, size_t len);
+
 extern ROCKSDB_LIBRARY_API void rocksdb_transactiondb_delete(
     rocksdb_transactiondb_t* txn_db, const rocksdb_writeoptions_t* options,
     const char* key, size_t klen, char** errptr);


### PR DESCRIPTION
Transactions in rockdb supported adding log data using the `put_log_data` api, but this was not exported for other language bindings. Exported this binding allows other languages like rust, go, etc add log data on an transaction