### PR TITLE
Fix correctness bugs in WritePreparedTxnDB snapshot visibility in two_write_queues mode (#14544)

### DIFF
--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -12,6 +12,7 @@
 
 #include "db/db_impl/db_impl.h"
 #include "db/dbformat.h"
+#include "db/version_set.h"
 #include "port/port.h"
 #include "port/stack_trace.h"
 #include "rocksdb/db.h"
@@ -338,6 +339,33 @@ class WritePreparedTxnDBMock : public WritePreparedTxnDB {
     snapshots_ = snapshots;
   }
   void TakeSnapshot(SequenceNumber seq) { snapshots_.push_back(seq); }
+  bool UpdateSnapshotsForTest(const std::vector<SequenceNumber>& snapshots,
+                              SequenceNumber version) {
+    return UpdateSnapshots(snapshots, version);
+  }
+  void CheckAgainstSnapshotsForTest(const CommitEntry& entry) {
+    CheckAgainstSnapshots(entry);
+  }
+  void ClearOldCommitMapForTest() {
+    WriteLock wl(&old_commit_map_mutex_);
+    old_commit_map_.clear();
+    old_commit_map_empty_.store(true, std::memory_order_release);
+  }
+  bool OldCommitMapHasEntryForTest(SequenceNumber snapshot_seq,
+                                   SequenceNumber prep_seq) {
+    ReadLock rl(&old_commit_map_mutex_);
+    auto it = old_commit_map_.find(snapshot_seq);
+    if (it == old_commit_map_.end()) {
+      return false;
+    }
+    return std::binary_search(it->second.begin(), it->second.end(), prep_seq);
+  }
+  void SetMaxEvictedSeqForTest(SequenceNumber seq) {
+    max_evicted_seq_.store(seq, std::memory_order_release);
+  }
+  SequenceNumber SnapshotsVersionForTest() const {
+    return snapshots_version_.load(std::memory_order_acquire);
+  }
 
  protected:
   const std::vector<SequenceNumber> GetSnapshotListFromDB(
@@ -368,6 +396,9 @@ class WritePreparedTransactionTestBase : public TransactionTestBase {
   }
   void UpdateTransactionDBOptions(size_t snapshot_cache_bits) {
     txn_db_options.wp_snapshot_cache_bits = snapshot_cache_bits;
+  }
+  SequenceNumber SmallestUnCommittedSeqForTest(WritePreparedTxnDB* txn_db) {
+    return txn_db->SmallestUnCommittedSeq();
   }
   // If expect_update is set, check if it actually updated old_commit_map_. If
   // it did not and yet suggested not to check the next snapshot, do the
@@ -1668,6 +1699,85 @@ TEST_P(WritePreparedTransactionTest, SmallestUnCommittedSeq) {
   }
 }
 #endif  // !defined(ROCKSDB_VALGRIND_RUN) || defined(ROCKSDB_FULL_VALGRIND_RUN)
+
+// Recreate the two_write_queues window where LastSequence is ahead of
+// LastPublishedSequence. A snapshot taken in this state must still treat the
+// first unpublished sequence as invisible.
+TEST_P(WritePreparedTransactionTest,
+       SnapshotRejectsUnpublishedSequenceWhenLastSequenceIsAhead) {
+  if (!options.two_write_queues) {
+    return;
+  }
+
+  ASSERT_OK(ReOpen());
+  auto* wp_db = dynamic_cast<WritePreparedTxnDB*>(db);
+  ASSERT_NE(wp_db, nullptr);
+  auto* db_impl = static_cast_with_check<DBImpl>(db->GetRootDB());
+  auto* versions = db_impl->GetVersionSet();
+  ASSERT_NE(versions, nullptr);
+
+  const SequenceNumber published_seq = db_impl->GetLastPublishedSequence();
+  const SequenceNumber first_unpublished_seq = published_seq + 1;
+  const SequenceNumber latest_seq = published_seq + 2;
+  versions->SetLastAllocatedSequence(latest_seq);
+  versions->SetLastSequence(latest_seq);
+
+  ASSERT_EQ(published_seq, db_impl->GetLastPublishedSequence());
+  ASSERT_EQ(latest_seq, db_impl->GetLatestSequenceNumber());
+  ASSERT_EQ(first_unpublished_seq, SmallestUnCommittedSeqForTest(wp_db));
+
+  const auto* snap = db->GetSnapshot();
+  const auto* snap_impl = static_cast<const SnapshotImpl*>(snap);
+  ASSERT_EQ(published_seq, snap_impl->GetSequenceNumber());
+  ASSERT_EQ(first_unpublished_seq, snap_impl->min_uncommitted_);
+
+  WritePreparedTxnReadCallback callback(
+      wp_db, snap_impl->GetSequenceNumber(), snap_impl->min_uncommitted_,
+      kBackedByDBSnapshot);
+  ASSERT_FALSE(callback.IsVisible(first_unpublished_seq));
+  ASSERT_FALSE(callback.IsVisible(latest_seq));
+
+  db->ReleaseSnapshot(snap);
+
+  db_impl->SetLastPublishedSequence(latest_seq);
+}
+
+// Simulate the concurrent max-advance race where an older UpdateSnapshots()
+// call runs after a newer one. A stale update must not discard a still-live
+// snapshot, otherwise later commit-cache evictions can become visible to that
+// snapshot and break snapshot consistency checks like MySQLStyleTransactionTest.
+TEST_P(WritePreparedTransactionTest, StaleSnapshotUpdateKeepsLiveSnapshot) {
+  const size_t snapshot_cache_bits = 1;
+  const size_t commit_cache_bits = 0;
+  DBImpl* mock_db = new DBImpl(options, dbname);
+  UpdateTransactionDBOptions(snapshot_cache_bits, commit_cache_bits);
+  std::unique_ptr<WritePreparedTxnDBMock> wp_db(
+      new WritePreparedTxnDBMock(mock_db, txn_db_options));
+
+  const std::vector<SequenceNumber> complete_snapshots = {10, 20};
+  const std::vector<SequenceNumber> stale_snapshots = {10};
+  const SequenceNumber complete_version = 30;
+  const SequenceNumber stale_version = 15;
+  const CommitEntry evicted(/*prep_seq=*/15, /*commit_seq=*/25);
+
+  ASSERT_TRUE(
+      wp_db->UpdateSnapshotsForTest(complete_snapshots, complete_version));
+  ASSERT_EQ(complete_version, wp_db->SnapshotsVersionForTest());
+  ASSERT_FALSE(wp_db->UpdateSnapshotsForTest(stale_snapshots, stale_version));
+  ASSERT_EQ(complete_version, wp_db->SnapshotsVersionForTest());
+
+  wp_db->ClearOldCommitMapForTest();
+  wp_db->CheckAgainstSnapshotsForTest(evicted);
+  ASSERT_FALSE(wp_db->OldCommitMapHasEntryForTest(10, evicted.prep_seq));
+  ASSERT_TRUE(wp_db->OldCommitMapHasEntryForTest(20, evicted.prep_seq));
+
+  wp_db->SetMaxEvictedSeqForTest(evicted.commit_seq);
+  bool snap_released = false;
+  ASSERT_FALSE(
+      wp_db->IsInSnapshot(evicted.prep_seq, 20, kMinUnCommittedSeq,
+                          &snap_released));
+  ASSERT_FALSE(snap_released);
+}
 
 TEST_P(SeqAdvanceConcurrentTest, SeqAdvanceConcurrent) {
   // Given the sequential run of txns, with this timeout we should never see a

--- a/utilities/transactions/write_prepared_txn_db.cc
+++ b/utilities/transactions/write_prepared_txn_db.cc
@@ -729,15 +729,16 @@ void WritePreparedTxnDB::AdvanceMaxEvictedSeq(const SequenceNumber& prev_max,
   SequenceNumber new_snapshots_version = new_max;
   std::vector<SequenceNumber> snapshots;
   bool update_snapshots = false;
-  if (new_snapshots_version > snapshots_version_) {
+  if (new_snapshots_version >
+      snapshots_version_.load(std::memory_order_acquire)) {
     // This is to avoid updating the snapshots_ if it already updated
     // with a more recent version by a concurrent thread
     update_snapshots = true;
     // We only care about snapshots lower then max
     snapshots = GetSnapshotListFromDB(new_max);
   }
-  if (update_snapshots) {
-    UpdateSnapshots(snapshots, new_snapshots_version);
+  if (update_snapshots &&
+      UpdateSnapshots(snapshots, new_snapshots_version)) {
     if (!snapshots.empty()) {
       WriteLock wl(&old_commit_map_mutex_);
       for (auto snap : snapshots) {
@@ -911,7 +912,7 @@ void WritePreparedTxnDB::CleanupReleasedSnapshots(
   }
 }
 
-void WritePreparedTxnDB::UpdateSnapshots(
+bool WritePreparedTxnDB::UpdateSnapshots(
     const std::vector<SequenceNumber>& snapshots,
     const SequenceNumber& version) {
   ROCKS_LOG_DETAILS(info_log_, "UpdateSnapshots with version %" PRIu64,
@@ -923,7 +924,12 @@ void WritePreparedTxnDB::UpdateSnapshots(
 #endif
   ROCKS_LOG_DETAILS(info_log_, "snapshots_mutex_ overhead");
   WriteLock wl(&snapshots_mutex_);
-  snapshots_version_ = version;
+  if (version <= snapshots_version_.load(std::memory_order_relaxed)) {
+    TEST_SYNC_POINT("WritePreparedTxnDB::UpdateSnapshots:p:end");
+    TEST_SYNC_POINT("WritePreparedTxnDB::UpdateSnapshots:s:end");
+    return false;
+  }
+  snapshots_version_.store(version, std::memory_order_release);
   // We update the list concurrently with the readers.
   // Both new and old lists are sorted and the new list is subset of the
   // previous list plus some new items. Thus if a snapshot repeats in
@@ -967,6 +973,7 @@ void WritePreparedTxnDB::UpdateSnapshots(
 
   TEST_SYNC_POINT("WritePreparedTxnDB::UpdateSnapshots:p:end");
   TEST_SYNC_POINT("WritePreparedTxnDB::UpdateSnapshots:s:end");
+  return true;
 }
 
 void WritePreparedTxnDB::CheckAgainstSnapshots(const CommitEntry& evicted) {

--- a/utilities/transactions/write_prepared_txn_db.h
+++ b/utilities/transactions/write_prepared_txn_db.h
@@ -671,11 +671,16 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
     // order: first read prepared_txns_ and then delayed_prepared_.
 
     // This must be called before calling ::top. This is because the concurrent
-    // thread would call ::RemovePrepared before updating
-    // GetLatestSequenceNumber(). Reading then in opposite order here guarantees
-    // that the ::top that we read would be lower the ::top if we had otherwise
-    // update/read them atomically.
-    auto next_prepare = db_impl_->GetLatestSequenceNumber() + 1;
+    // thread would call ::RemovePrepared before updating the published
+    // sequence. Reading then in opposite order here guarantees that the ::top
+    // that we read would be lower the ::top if we had otherwise update/read
+    // them atomically.
+    // Note: We use GetLastPublishedSequence() instead of
+    // GetLatestSequenceNumber() because GetSnapshotImpl() uses
+    // GetLastPublishedSequence() for the snapshot's sequence number. With
+    // two_write_queues, LastSequence can be ahead of LastPublishedSequence,
+    // which would cause min_uncommitted to exceed snapshot->number_ + 1.
+    auto next_prepare = db_impl_->GetLastPublishedSequence() + 1;
     auto min_prepare = prepared_txns_.top();
     // Since we update the prepare_heap always from the main write queue via
     // PreReleaseCallback, the prepared_txns_.top() indicates the smallest
@@ -691,8 +696,8 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
     }
     bool empty = min_prepare == kMaxSequenceNumber;
     if (empty) {
-      // Since GetLatestSequenceNumber is updated
-      // after prepared_txns_ are, the value of GetLatestSequenceNumber would
+      // Since the last published sequence is updated
+      // after prepared_txns_ are, the value of GetLastPublishedSequence would
       // reflect any uncommitted data that is not added to prepared_txns_ yet.
       // Otherwise, if there is no concurrent txn, this value simply reflects
       // that latest value in the memtable.
@@ -722,7 +727,7 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
   // The concurrent invocations of this function is equivalent to a serial
   // invocation in which the last invocation is the one with the largest
   // version value.
-  void UpdateSnapshots(const std::vector<SequenceNumber>& snapshots,
+  bool UpdateSnapshots(const std::vector<SequenceNumber>& snapshots,
                        const SequenceNumber& version);
   // Check the new list of new snapshots against the old one to see  if any of
   // the snapshots are released and to do the cleanup for the released snapshot.
@@ -772,7 +777,7 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
   std::vector<SequenceNumber> snapshots_all_;
   // The version of the latest list of snapshots. This can be used to avoid
   // rewriting a list that is concurrently updated with a more recent version.
-  SequenceNumber snapshots_version_ = 0;
+  std::atomic<SequenceNumber> snapshots_version_ = {0};
 
   // A heap of prepared transactions. Thread-safety is provided with
   // prepared_mutex_.


### PR DESCRIPTION
Summary:

This change fixes two related but distinct correctness issues in `WritePreparedTxnDB` snapshot visibility under `two_write_queues`.

The first issue is a snapshot-boundary bug in `SmallestUnCommittedSeq()`. Its fallback path used `GetLatestSequenceNumber()` + 1, while snapshots themselves are taken at `GetLastPublishedSequence()`. Under `two_write_queues`, `LastSequence` can be ahead of `LastPublishedSequence`, so the computed `min_uncommitted` could advance beyond the snapshot’s published boundary. That breaks the intended invariant `min_uncommitted <= snapshot_seq + 1` and can incorrectly classify unpublished memtable sequence numbers as definitely visible through the `seq` < `min_uncommitted` fast path. The fix is to derive that fallback from `GetLastPublishedSequence()` + 1, matching the sequence source used for snapshots.

The second issue is a concurrent snapshot-bookkeeping bug in the snapshot list used to preserve evicted commit-cache entries. `AdvanceMaxEvictedSeq()` decided whether to refresh snapshots by comparing against `snapshots_version_` before taking `snapshots_mutex_`, and `UpdateSnapshots()` then unconditionally overwrote the cached snapshot state once it acquired the lock. This allowed an older, lower-version update to run after a newer one and replace a newer snapshot list with a stale one. When that happened, `CheckAgainstSnapshots()` could stop preserving overlap for a still-live snapshot, so after commit-cache eviction `IsInSnapshot()` could treat a post-snapshot commit as committed-for-all. This is the shared snapshot/eviction path behind the intermittent `MySQLStyleTransactionTest.TransactionStressTest failures`, including both /12 (`WRITE_PREPARED`) and /26 (`WRITE_UNPREPARED`). The fix is to make `snapshots_version_` atomic and re-check the version under `snapshots_mutex_`, so stale updates are ignored and only the newest snapshot state is installed.

These two bugs are not the same bug, but they affect the same snapshot visibility subsystem and can produce the same class of corruption symptom: a held snapshot observing transactions inconsistently across keys. Fixing only one is not sufficient.

This affects both `WRITE_PREPARED` and `WRITE_UNPREPARED` because `WriteUnpreparedTxnDB` inherits the same `WritePreparedTxnDB` snapshot and commit-cache eviction machinery, and snapshot reads in both modes eventually rely on the same `IsInSnapshot()` visibility logic.

Reviewed By: hx235, xingbowang

Differential Revision: D98353495


