### PR TITLE
Fix LLD linker detection in Makefile for C++ exceptions (Fixes RISC-V builds)

### DIFF
--- a/build_tools/build_detect_platform
+++ b/build_tools/build_detect_platform
@@ -154,7 +154,10 @@ PLATFORM_SHARED_VERSIONED=true
 # Set ROCKSDB_NO_FAST_LINKER=1 to disable this auto-detection.
 if [ -z "$ROCKSDB_NO_FAST_LINKER" ] && [ "$TARGET_OS" = "Linux" ]; then
     if $CXX -fuse-ld=lld -L/usr/local/lib -x c++ - -o /dev/null 2>/dev/null <<EOF
-int main() { return 0; }
+int main() {
+    try { throw 1; } catch (...) { return 1; }
+    return 0;
+}
 EOF
     then
         PLATFORM_LDFLAGS="$PLATFORM_LDFLAGS -fuse-ld=lld"


### PR DESCRIPTION
### Summary
This is the Makefile/script equivalent of the CMake fix for the LLD linker detection. It ensures that `build_detect_platform` does not falsely enable LLD on systems where it cannot link C++ exception tables (specifically on RISC-V with older LLD versions).

### The Problem
The current script checks if LLD is usable by compiling a trivial program: `int main() { return 0; }`.
This check is too simple because it does not generate a `.gcc_except_table` section. 

On RISC-V, modern compilers use `R_RISCV_SET_ULEB128` relocations for C++ exceptions. Older LLD versions do not support these relocations. Because the trivial `main()` test passes successfully, the script adds `-fuse-ld=lld` to `PLATFORM_LDFLAGS`. Later, when compiling actual RocksDB code (which heavily uses exceptions), the build crashes with `unknown relocation (60)`.
```
/usr/bin/ar: creating librocksdb.a
  CCLD     db_repl_stress
  CCLD     db_sanity_test
  CCLD     write_stress
  CCLD     rocksdb_dump
  CCLD     rocksdb_undump
ld.lld: error: ./librocksdb.a(cache_helpers.o):(.gcc_except_table+0x3): unknown relocation (60) against symbol .LLSDACSE8331
ld.lld: error: ./librocksdb.a(cache_helpers.o):(.gcc_except_table+0x3): unknown relocation (61) against symbol .LLSDACSB8331
ld.lld: error: ./librocksdb.a(cache_helpers.o):(.gcc_except_table+0x4): unknown relocation (60) against symbol .LEHB0
```

### The Solution
Updated the dummy C++ code in `build_tools/build_detect_platform` to include a `try { throw 1; } catch (...) {}` block. 

This forces the compiler to generate the exception handling sections during the detection phase. If the installed LLD cannot link these sections, the test fails, and the script safely ignores LLD, falling back to the default GNU linker.