### PR TITLE
Support UDI as primary index

### DIFF
--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -184,6 +184,7 @@ DECLARE_int32(data_block_index_type);
 DECLARE_int32(index_block_search_type);
 DECLARE_double(uniform_cv_threshold);
 DECLARE_bool(use_trie_index);
+DECLARE_bool(use_udi_as_primary_index);
 DECLARE_bool(test_backward_scan);
 DECLARE_string(db);
 DECLARE_string(secondaries_base);

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -675,9 +675,9 @@ DEFINE_bool(use_trie_index, false,
 
 DEFINE_bool(use_udi_as_primary_index, false,
             "When use_trie_index is enabled, use the UDI as the primary "
-            "index. The standard binary search index is not populated -- "
-            "all reads automatically go through the UDI. When false, the "
-            "UDI is a secondary index and reads require "
+            "index. All reads automatically go through the UDI (both "
+            "the standard index and UDI are always built). When false, "
+            "the UDI is a secondary index and reads require "
             "ReadOptions::table_index_factory to be set.");
 
 DEFINE_bool(test_backward_scan, true,

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -669,7 +669,16 @@ DEFINE_double(uniform_cv_threshold,
 DEFINE_bool(use_trie_index, false,
             "Use trie-based user defined index (UDI) for SST files. "
             "Compatible with all operation types (Put, Delete, Merge, etc.) "
-            "and all iteration directions (forward and reverse).");
+            "and all iteration directions (forward and reverse). "
+            "Combined with use_udi_as_primary_index to control whether the "
+            "UDI is the primary or secondary index.");
+
+DEFINE_bool(use_udi_as_primary_index, false,
+            "When use_trie_index is enabled, use the UDI as the primary "
+            "index. The standard binary search index is not populated -- "
+            "all reads automatically go through the UDI. When false, the "
+            "UDI is a secondary index and reads require "
+            "ReadOptions::table_index_factory to be set.");
 
 DEFINE_bool(test_backward_scan, true,
             "Test backward iteration (Prev, SeekForPrev) in stress tests.");

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -4408,12 +4408,15 @@ void InitializeOptionsFromFlags(
     block_based_options.user_defined_index_factory = udi_factory;
     if (FLAGS_use_udi_as_primary_index) {
       block_based_options.use_udi_as_primary_index = true;
-      // Write fault injection can corrupt the UDI meta block during SST
-      // creation. A corrupted UDI block causes the reader to fail to
-      // create the UDI iterator, and in primary mode all reads route
-      // through the UDI. This can cause compaction to read zero keys
-      // from the affected SST, triggering a false positive in the
-      // compaction record count verification.
+    }
+    // Write fault injection can corrupt the UDI meta block during SST
+    // creation. A corrupted UDI block causes the reader to fail to
+    // create the UDI iterator, and all reads route through the UDI in
+    // primary mode. This can cause compaction to read zero keys from
+    // the affected SST, triggering a false positive in the compaction
+    // record count verification. Only disable when fault injection is
+    // active (write_fault_one_in or metadata_write_fault_one_in).
+    if (FLAGS_write_fault_one_in > 0 || FLAGS_metadata_write_fault_one_in > 0) {
       options.compaction_verify_record_count = false;
     }
   }

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -4408,6 +4408,16 @@ void InitializeOptionsFromFlags(
     block_based_options.user_defined_index_factory = udi_factory;
     if (FLAGS_use_udi_as_primary_index) {
       block_based_options.use_udi_as_primary_index = true;
+      // The trie index uses user-key-only separators while the standard
+      // index uses full internal key separators (with seqno trailer). During
+      // subcompacted compaction, the per-subcompaction seek target can land
+      // past the trie's last separator for SSTs whose data is entirely in
+      // another subcompaction's range. The trie correctly returns "past end"
+      // for these SSTs (the data IS processed by the other subcompaction),
+      // but the compaction record count verification sees a mismatch
+      // because it expects ALL input SSTs' records to be processed. This
+      // is a verification false positive, not data loss.
+      options.compaction_verify_record_count = false;
     }
   }
   options.table_factory.reset(NewBlockBasedTableFactory(block_based_options));

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -4410,13 +4410,14 @@ void InitializeOptionsFromFlags(
       block_based_options.use_udi_as_primary_index = true;
     }
     // Write fault injection can corrupt the UDI meta block during SST
-    // creation. A corrupted UDI block causes the reader to fail to
-    // create the UDI iterator, and all reads route through the UDI in
-    // primary mode. This can cause compaction to read zero keys from
-    // the affected SST, triggering a false positive in the compaction
-    // record count verification. Only disable when fault injection is
-    // active (write_fault_one_in or metadata_write_fault_one_in).
-    if (FLAGS_write_fault_one_in > 0 || FLAGS_metadata_write_fault_one_in > 0) {
+    // creation. In primary mode all reads route through the UDI, so a
+    // corrupted UDI block causes the reader to fail, making compaction
+    // read zero keys from the affected SST and triggering a false
+    // positive in record count verification. In secondary mode this is
+    // not an issue because reads fall back to the standard index.
+    if (FLAGS_use_udi_as_primary_index &&
+        (FLAGS_write_fault_one_in > 0 ||
+         FLAGS_metadata_write_fault_one_in > 0)) {
       options.compaction_verify_record_count = false;
     }
   }

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -4408,15 +4408,11 @@ void InitializeOptionsFromFlags(
     block_based_options.user_defined_index_factory = udi_factory;
     if (FLAGS_use_udi_as_primary_index) {
       block_based_options.use_udi_as_primary_index = true;
-      // The trie index uses user-key-only separators while the standard
-      // index uses full internal key separators (with seqno trailer). During
-      // subcompacted compaction, the per-subcompaction seek target can land
-      // past the trie's last separator for SSTs whose data is entirely in
-      // another subcompaction's range. The trie correctly returns "past end"
-      // for these SSTs (the data IS processed by the other subcompaction),
-      // but the compaction record count verification sees a mismatch
-      // because it expects ALL input SSTs' records to be processed. This
-      // is a verification false positive, not data loss.
+      // Write fault injection can corrupt the UDI meta block during SST
+      // creation. In primary mode there is no standard index to fall back
+      // to, so a corrupted UDI can cause compaction to read zero keys
+      // from the affected SST, triggering a false positive in the
+      // compaction record count verification.
       options.compaction_verify_record_count = false;
     }
   }

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -4409,8 +4409,9 @@ void InitializeOptionsFromFlags(
     if (FLAGS_use_udi_as_primary_index) {
       block_based_options.use_udi_as_primary_index = true;
       // Write fault injection can corrupt the UDI meta block during SST
-      // creation. In primary mode there is no standard index to fall back
-      // to, so a corrupted UDI can cause compaction to read zero keys
+      // creation. A corrupted UDI block causes the reader to fail to
+      // create the UDI iterator, and in primary mode all reads route
+      // through the UDI. This can cause compaction to read zero keys
       // from the affected SST, triggering a false positive in the
       // compaction record count verification.
       options.compaction_verify_record_count = false;

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -1002,10 +1002,9 @@ void StressTest::OperateDb(ThreadState* thread) {
   read_opts.allow_unprepared_value = FLAGS_allow_unprepared_value;
   read_opts.auto_refresh_iterator_with_snapshot =
       FLAGS_auto_refresh_iterator_with_snapshot;
-  if (FLAGS_use_trie_index && udi_factory_) {
+  if (FLAGS_use_trie_index && !FLAGS_use_udi_as_primary_index && udi_factory_) {
     read_opts.table_index_factory = udi_factory_.get();
   }
-
   WriteOptions write_opts;
   if (FLAGS_rate_limit_auto_wal_flush) {
     write_opts.rate_limiter_priority = Env::IO_USER;
@@ -4407,6 +4406,9 @@ void InitializeOptionsFromFlags(
       fLU64::FLAGS_super_block_alignment_space_overhead_ratio;
   if (udi_factory) {
     block_based_options.user_defined_index_factory = udi_factory;
+    if (FLAGS_use_udi_as_primary_index) {
+      block_based_options.use_udi_as_primary_index = true;
+    }
   }
   options.table_factory.reset(NewBlockBasedTableFactory(block_based_options));
   options.db_write_buffer_size = FLAGS_db_write_buffer_size;

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -2304,9 +2304,15 @@ struct ReadOptions {
   // block based table index. The table_factory used for the column family
   // must support building/reading this index.
   //
-  // All iterator operations are supported: forward scans (SeekToFirst, Seek,
-  // Next), reverse scans (SeekToLast, SeekForPrev, Prev), and point lookups
-  // (Get). Leave this null to use the native block-based table index.
+  // The UDI framework supports all iterator operations: forward scans
+  // (SeekToFirst, Seek, Next), reverse scans (SeekToLast, SeekForPrev, Prev),
+  // and point lookups (Get). Concrete UDI implementations may impose their
+  // own restrictions -- check the specific implementation's documentation.
+  //
+  // When BlockBasedTableOptions::use_udi_as_primary_index is true, this field
+  // does not need to be set -- all reads automatically use the UDI. This field
+  // is only needed when the UDI is a secondary index and you want to
+  // explicitly select it for reads.
   const UserDefinedIndexFactory* table_index_factory = nullptr;
 
   // *** END options only relevant to iterators or scans ***

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -2310,9 +2310,11 @@ struct ReadOptions {
   // own restrictions -- check the specific implementation's documentation.
   //
   // When BlockBasedTableOptions::use_udi_as_primary_index is true, this field
-  // does not need to be set -- all reads automatically use the UDI. This field
-  // is only needed when the UDI is a secondary index and you want to
-  // explicitly select it for reads.
+  // does not need to be set -- all reads automatically use the UDI. If set
+  // while use_udi_as_primary_index is true, the UDI from
+  // BlockBasedTableOptions takes precedence. This field is only needed when
+  // the UDI is a secondary index and you want to explicitly select it for
+  // reads.
   const UserDefinedIndexFactory* table_index_factory = nullptr;
 
   // *** END options only relevant to iterators or scans ***

--- a/include/rocksdb/table.h
+++ b/include/rocksdb/table.h
@@ -540,17 +540,19 @@ struct BlockBasedTableOptions {
   // EXPERIMENTAL
   //
   // When true and user_defined_index_factory is set, the UDI becomes the
-  // primary index. The standard binary search index is not populated with
-  // real entries -- only a minimal stub is written to satisfy the SST footer
-  // format.
-  // This saves CPU during SST creation and space in every SST file.
+  // primary index for reads. All reads (including internal operations like
+  // compaction and VerifyChecksum) automatically route through the UDI
+  // without needing ReadOptions::table_index_factory.
+  //
+  // Both the standard binary search index and the UDI are always fully
+  // built. The standard index serves as a safety fallback (e.g., for
+  // backup/restore or rollback to a non-UDI configuration). A future
+  // refactor will extract the index abstraction to allow skipping the
+  // standard index build when the UDI is primary.
   //
   // When the UDI is primary:
   // - All reads automatically use the UDI (ReadOptions::table_index_factory
   //   does not need to be set)
-  // - The standard index block contains only a stub -- it cannot be used for
-  //   reads. SST files written with this option can only be read by RocksDB
-  //   versions that support UDI-primary mode
   // - Partitioned index (kTwoLevelIndexSearch) and partitioned filters are
   //   incompatible with this option
   // - fail_if_no_udi_on_open is automatically enforced to prevent silent
@@ -560,35 +562,26 @@ struct BlockBasedTableOptions {
   //
   // 1. Deploy with user_defined_index_factory set but
   //    use_udi_as_primary_index=false (secondary mode). New SSTs are written
-  //    with both indexes. Reads still use the standard index by default. This
-  //    is zero-risk -- rollback by removing user_defined_index_factory.
+  //    with both indexes. Reads use the standard index by default.
   //
   // 2. Validate reads through the UDI by setting
-  //    ReadOptions::table_index_factory on a subset of reads. Compare results
-  //    against the standard index to build confidence.
+  //    ReadOptions::table_index_factory on a subset of reads.
   //
-  // 3. Compact the entire DB to rewrite all pre-existing SSTs (from before
-  //    step 1) into SSTs with both indexes. All SSTs must have a UDI block
-  //    before proceeding -- use_udi_as_primary_index will refuse to open
-  //    SSTs without one.
+  // 3. Compact the entire DB to rewrite all pre-existing SSTs with both
+  //    indexes. All SSTs must have a UDI block before proceeding.
   //
-  // 4. Enable use_udi_as_primary_index=true. New SSTs use UDI only. Old SSTs
-  //    (from step 1/3) still have both indexes and are read through the UDI
-  //    automatically.
+  // 4. Enable use_udi_as_primary_index=true. All reads use the UDI.
   //
-  // Rollback from step 4: you must compact the entire DB with
-  // use_udi_as_primary_index=false to rewrite all SSTs with both indexes
-  // before removing user_defined_index_factory. Without this, SSTs written
-  // in primary mode have a stub standard index and cannot be read without
-  // UDI support.
+  // Rollback: set use_udi_as_primary_index=false. Since the standard index
+  // is always fully populated, SSTs are immediately readable without the
+  // UDI. No compaction is required.
   //
   // Backup/restore: the user_defined_index_factory is a shared_ptr that
   // cannot survive Options serialization (e.g., GetStringFromDBOptions).
-  // Tools or code paths that reconstruct Options from strings will lose
-  // the factory. In secondary mode this is safe (the standard index is
-  // fully populated). In primary mode, the restored DB cannot read
-  // primary-mode SSTs. Ensure the factory is explicitly set when opening
-  // a restored DB.
+  // Since the standard index is always fully populated, a restored DB can
+  // be opened and read without the factory (reads fall back to the standard
+  // index). Set the factory when opening the restored DB to resume using
+  // the UDI.
   //
   // Default: false (UDI is built alongside the standard index as a secondary)
   bool use_udi_as_primary_index = false;
@@ -597,6 +590,8 @@ struct BlockBasedTableOptions {
   //
   // Return an error Status if a user_defined_index_factory is configured,
   // but there's no corresponding UDI block in the SST file being opened.
+  // When use_udi_as_primary_index is true, this check is automatically
+  // enforced (a missing UDI block is always an error in primary mode).
   bool fail_if_no_udi_on_open = false;
 
   // If true, place whole keys in the filter (not just prefixes).

--- a/include/rocksdb/table.h
+++ b/include/rocksdb/table.h
@@ -574,7 +574,12 @@ struct BlockBasedTableOptions {
   //
   // Rollback: set use_udi_as_primary_index=false. Since the standard index
   // is always fully populated, SSTs are immediately readable without the
-  // UDI. No compaction is required.
+  // UDI. No compaction is required. Note: SSTs written in primary mode
+  // retain the udi_is_primary_index table property, so reads on those
+  // SSTs will continue routing through the UDI as long as
+  // user_defined_index_factory is set. To fully revert to standard-
+  // index-only reads, also remove user_defined_index_factory and compact
+  // to rewrite all SSTs.
   //
   // Backup/restore: the user_defined_index_factory is a shared_ptr that
   // cannot survive Options serialization (e.g., GetStringFromDBOptions).

--- a/include/rocksdb/table.h
+++ b/include/rocksdb/table.h
@@ -539,6 +539,54 @@ struct BlockBasedTableOptions {
 
   // EXPERIMENTAL
   //
+  // When true and user_defined_index_factory is set, the UDI becomes the
+  // primary index. The standard binary search index is not populated with
+  // real entries -- only a minimal stub is written to satisfy the SST footer
+  // format.
+  // This saves CPU during SST creation and space in every SST file.
+  //
+  // When the UDI is primary:
+  // - All reads automatically use the UDI (ReadOptions::table_index_factory
+  //   does not need to be set)
+  // - The standard index block contains only a stub -- it cannot be used for
+  //   reads. SST files written with this option can only be read by RocksDB
+  //   versions that support UDI-primary mode
+  // - Partitioned index (kTwoLevelIndexSearch) and partitioned filters are
+  //   incompatible with this option
+  // - fail_if_no_udi_on_open is automatically enforced to prevent silent
+  //   data loss if these SSTs are opened without UDI support
+  //
+  // Recommended migration path:
+  //
+  // 1. Deploy with user_defined_index_factory set but
+  //    use_udi_as_primary_index=false (secondary mode). New SSTs are written
+  //    with both indexes. Reads still use the standard index by default. This
+  //    is zero-risk -- rollback by removing user_defined_index_factory.
+  //
+  // 2. Validate reads through the UDI by setting
+  //    ReadOptions::table_index_factory on a subset of reads. Compare results
+  //    against the standard index to build confidence.
+  //
+  // 3. Compact the entire DB to rewrite all pre-existing SSTs (from before
+  //    step 1) into SSTs with both indexes. All SSTs must have a UDI block
+  //    before proceeding -- use_udi_as_primary_index will refuse to open
+  //    SSTs without one.
+  //
+  // 4. Enable use_udi_as_primary_index=true. New SSTs use UDI only. Old SSTs
+  //    (from step 1/3) still have both indexes and are read through the UDI
+  //    automatically.
+  //
+  // Rollback from step 4: you must compact the entire DB with
+  // use_udi_as_primary_index=false to rewrite all SSTs with both indexes
+  // before removing user_defined_index_factory. Without this, SSTs written
+  // in primary mode have a stub standard index and cannot be read without
+  // UDI support.
+  //
+  // Default: false (UDI is built alongside the standard index as a secondary)
+  bool use_udi_as_primary_index = false;
+
+  // EXPERIMENTAL
+  //
   // Return an error Status if a user_defined_index_factory is configured,
   // but there's no corresponding UDI block in the SST file being opened.
   bool fail_if_no_udi_on_open = false;

--- a/include/rocksdb/table.h
+++ b/include/rocksdb/table.h
@@ -573,13 +573,9 @@ struct BlockBasedTableOptions {
   // 4. Enable use_udi_as_primary_index=true. All reads use the UDI.
   //
   // Rollback: set use_udi_as_primary_index=false. Since the standard index
-  // is always fully populated, SSTs are immediately readable without the
-  // UDI. No compaction is required. Note: SSTs written in primary mode
-  // retain the udi_is_primary_index table property, so reads on those
-  // SSTs will continue routing through the UDI as long as
-  // user_defined_index_factory is set. To fully revert to standard-
-  // index-only reads, also remove user_defined_index_factory and compact
-  // to rewrite all SSTs.
+  // is always fully populated, SSTs are immediately readable through the
+  // standard index. No compaction is required. All reads immediately
+  // revert to the standard index path.
   //
   // Backup/restore: the user_defined_index_factory is a shared_ptr that
   // cannot survive Options serialization (e.g., GetStringFromDBOptions).

--- a/include/rocksdb/table.h
+++ b/include/rocksdb/table.h
@@ -582,6 +582,14 @@ struct BlockBasedTableOptions {
   // in primary mode have a stub standard index and cannot be read without
   // UDI support.
   //
+  // Backup/restore: the user_defined_index_factory is a shared_ptr that
+  // cannot survive Options serialization (e.g., GetStringFromDBOptions).
+  // Tools or code paths that reconstruct Options from strings will lose
+  // the factory. In secondary mode this is safe (the standard index is
+  // fully populated). In primary mode, the restored DB cannot read
+  // primary-mode SSTs. Ensure the factory is explicitly set when opening
+  // a restored DB.
+  //
   // Default: false (UDI is built alongside the standard index as a secondary)
   bool use_udi_as_primary_index = false;
 

--- a/include/rocksdb/table_properties.h
+++ b/include/rocksdb/table_properties.h
@@ -239,7 +239,8 @@ struct TableProperties {
   uint64_t index_key_is_user_key = 0;
   // Whether delta encoding is used to encode the index values.
   uint64_t index_value_is_delta_encoded = 0;
-  // Whether the UDI is the primary index (standard index is a stub).
+  // Whether the UDI is the primary index for reads. The standard index is
+  // still fully populated alongside the UDI.
   uint64_t udi_is_primary_index = 0;
   // the size of filter block.
   uint64_t filter_size = 0;

--- a/include/rocksdb/table_properties.h
+++ b/include/rocksdb/table_properties.h
@@ -46,6 +46,7 @@ struct TablePropertiesNames {
   static const std::string kTopLevelIndexSize;
   static const std::string kIndexKeyIsUserKey;
   static const std::string kIndexValueIsDeltaEncoded;
+  static const std::string kUDIIsPrimaryIndex;
   static const std::string kFilterSize;
   static const std::string kRawKeySize;
   static const std::string kRawValueSize;
@@ -238,6 +239,8 @@ struct TableProperties {
   uint64_t index_key_is_user_key = 0;
   // Whether delta encoding is used to encode the index values.
   uint64_t index_value_is_delta_encoded = 0;
+  // Whether the UDI is the primary index (standard index is a stub).
+  uint64_t udi_is_primary_index = 0;
   // the size of filter block.
   uint64_t filter_size = 0;
   // total raw (uncompressed, undelineated) key size

--- a/include/rocksdb/user_defined_index.h
+++ b/include/rocksdb/user_defined_index.h
@@ -127,6 +127,15 @@ class UserDefinedIndexBuilder {
   // The memory backing the contents should not be freed until this builder
   // object is destructed.
   virtual Status Finish(Slice* index_contents) = 0;
+
+  // Returns an estimate of the current serialized index size in bytes.
+  // Used for compaction file size estimation when the UDI is the primary
+  // index (no standard index builder to delegate to).
+  //
+  // The default implementation returns 0. Concrete implementations should
+  // override this to provide a meaningful estimate for optimal compaction
+  // file sizing.
+  virtual uint64_t EstimatedSize() const { return 0; }
 };
 
 // The interface for iterating the user defined index. This will be

--- a/include/rocksdb/user_defined_index.h
+++ b/include/rocksdb/user_defined_index.h
@@ -129,13 +129,9 @@ class UserDefinedIndexBuilder {
   virtual Status Finish(Slice* index_contents) = 0;
 
   // Returns an estimate of the current serialized index size in bytes.
-  // Used for compaction file size estimation when the UDI is the primary
-  // index (no standard index builder to delegate to).
-  //
-  // The default implementation returns 0. Concrete implementations should
-  // override this to provide a meaningful estimate for optimal compaction
-  // file sizing.
-  virtual uint64_t EstimatedSize() const { return 0; }
+  // Used for compaction file size estimation when use_udi_as_primary_index
+  // is true (no standard index builder to delegate to).
+  virtual uint64_t EstimatedSize() const = 0;
 };
 
 // The interface for iterating the user defined index. This will be

--- a/include/rocksdb/user_defined_index.h
+++ b/include/rocksdb/user_defined_index.h
@@ -129,8 +129,6 @@ class UserDefinedIndexBuilder {
   virtual Status Finish(Slice* index_contents) = 0;
 
   // Returns an estimate of the current serialized index size in bytes.
-  // Used for compaction file size estimation when use_udi_as_primary_index
-  // is true (no standard index builder to delegate to).
   virtual uint64_t EstimatedSize() const = 0;
 };
 

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -208,6 +208,7 @@ TEST_F(OptionsSettableTest, BlockBasedTableOptionsAllFieldsSettable) {
       "initial_auto_readahead_size=0;"
       "num_file_reads_for_auto_readahead=0;"
       "fail_if_no_udi_on_open=true;"
+      "use_udi_as_primary_index=true;"
       "separate_key_value_in_data_block=true;"
       "uniform_cv_threshold=0.2",
       new_bbto));
@@ -296,7 +297,8 @@ TEST_F(OptionsSettableTest, TablePropertiesAllFieldsSettable) {
       "external_sst_file_global_seqno_offset=0;num_merge_operands=0;index_key_"
       "is_user_key=0;key_largest_seqno=18446744073709551615;key_smallest_seqno="
       "18;data_block_restart_interval=16;index_block_restart_interval=1;"
-      "separate_key_value_in_data_block=0;num_uniform_blocks=0;",
+      "separate_key_value_in_data_block=0;num_uniform_blocks=0;"
+      "udi_is_primary_index=0;",
       new_tp));
 
   // All bytes are set from the parse

--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -1301,8 +1301,7 @@ struct BlockBasedTableBuilder::Rep {
             index_builder = std::make_unique<UserDefinedIndexBuilderWrapper>(
                 std::string(table_options.user_defined_index_factory->Name()),
                 std::move(index_builder), std::move(user_defined_index_builder),
-                &internal_comparator, ts_sz, persist_user_defined_timestamps,
-                table_options.use_udi_as_primary_index);
+                &internal_comparator, ts_sz, persist_user_defined_timestamps);
           }
         }
       }
@@ -2507,12 +2506,11 @@ void BlockBasedTableBuilder::WritePropertiesBlock(
     if (rep_->table_options.use_udi_as_primary_index &&
         rep_->table_options.user_defined_index_factory != nullptr) {
       rep_->props.udi_is_primary_index = 1;
-      // The standard index is a stub -- these properties don't apply.
-      rep_->props.index_value_is_delta_encoded = 0;
-    } else {
-      rep_->props.index_value_is_delta_encoded =
-          rep_->use_delta_encoding_for_index_values;
     }
+    // The standard index is always fully populated (even in primary mode),
+    // so delta encoding applies normally.
+    rep_->props.index_value_is_delta_encoded =
+        rep_->use_delta_encoding_for_index_values;
     if (rep_->sampled_input_data_bytes.LoadRelaxed() > 0) {
       rep_->props.slow_compression_estimated_data_size = static_cast<uint64_t>(
           static_cast<double>(

--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -1265,12 +1265,29 @@ struct BlockBasedTableBuilder::Rep {
 
     // If user_defined_index_factory is provided, wrap the index builder with
     // UserDefinedIndexWrapper
+    if (table_options.use_udi_as_primary_index &&
+        table_options.user_defined_index_factory == nullptr) {
+      SetStatus(Status::InvalidArgument(
+          "use_udi_as_primary_index requires user_defined_index_factory to "
+          "be set"));
+    }
     if (table_options.user_defined_index_factory != nullptr) {
       if (tbo.moptions.compression_opts.parallel_threads > 1 ||
           tbo.moptions.bottommost_compression_opts.parallel_threads > 1) {
         SetStatus(
             Status::InvalidArgument("user_defined_index_factory not supported "
                                     "with parallel compression"));
+      } else if (table_options.use_udi_as_primary_index &&
+                 table_options.index_type ==
+                     BlockBasedTableOptions::kTwoLevelIndexSearch) {
+        SetStatus(Status::InvalidArgument(
+            "use_udi_as_primary_index is incompatible with partitioned index "
+            "(kTwoLevelIndexSearch)"));
+      } else if (table_options.use_udi_as_primary_index &&
+                 table_options.partition_filters) {
+        SetStatus(Status::InvalidArgument(
+            "use_udi_as_primary_index is incompatible with partitioned "
+            "filters"));
       } else {
         std::unique_ptr<UserDefinedIndexBuilder> user_defined_index_builder;
         UserDefinedIndexOption udi_options;
@@ -1284,7 +1301,8 @@ struct BlockBasedTableBuilder::Rep {
             index_builder = std::make_unique<UserDefinedIndexBuilderWrapper>(
                 std::string(table_options.user_defined_index_factory->Name()),
                 std::move(index_builder), std::move(user_defined_index_builder),
-                &internal_comparator, ts_sz, persist_user_defined_timestamps);
+                &internal_comparator, ts_sz, persist_user_defined_timestamps,
+                table_options.use_udi_as_primary_index);
           }
         }
       }
@@ -2486,8 +2504,15 @@ void BlockBasedTableBuilder::WritePropertiesBlock(
     }
     rep_->props.index_key_is_user_key =
         !rep_->index_builder->separator_is_key_plus_seq();
-    rep_->props.index_value_is_delta_encoded =
-        rep_->use_delta_encoding_for_index_values;
+    if (rep_->table_options.use_udi_as_primary_index &&
+        rep_->table_options.user_defined_index_factory != nullptr) {
+      rep_->props.udi_is_primary_index = 1;
+      // The standard index is a stub -- these properties don't apply.
+      rep_->props.index_value_is_delta_encoded = 0;
+    } else {
+      rep_->props.index_value_is_delta_encoded =
+          rep_->use_delta_encoding_for_index_values;
+    }
     if (rep_->sampled_input_data_bytes.LoadRelaxed() > 0) {
       rep_->props.slow_compression_estimated_data_size = static_cast<uint64_t>(
           static_cast<double>(

--- a/table/block_based/block_based_table_factory.cc
+++ b/table/block_based/block_based_table_factory.cc
@@ -760,11 +760,35 @@ Status BlockBasedTableFactory::ValidateOptions(
         "data_block_hash_table_util_ratio should be greater than 0 when "
         "data_block_index_type is set to kDataBlockBinaryAndHash");
   }
-  if (table_options_.user_defined_index_factory &&
-      (cf_opts.compression_opts.parallel_threads > 1 ||
-       cf_opts.bottommost_compression_opts.parallel_threads > 1)) {
+  if (table_options_.user_defined_index_factory) {
+    if (cf_opts.compression_opts.parallel_threads > 1 ||
+        cf_opts.bottommost_compression_opts.parallel_threads > 1) {
+      return Status::InvalidArgument(
+          "user_defined_index_factory not supported with parallel compression");
+    }
+    if (table_options_.use_udi_as_primary_index) {
+      if (!table_options_.user_defined_index_factory) {
+        return Status::InvalidArgument(
+            "use_udi_as_primary_index requires user_defined_index_factory");
+      }
+      if (table_options_.index_type ==
+          BlockBasedTableOptions::kTwoLevelIndexSearch) {
+        return Status::InvalidArgument(
+            "use_udi_as_primary_index is incompatible with partitioned index "
+            "(kTwoLevelIndexSearch). Primary UDI skips the standard index "
+            "builder, but partitioned index requires it for partition "
+            "boundaries.");
+      }
+      if (table_options_.partition_filters) {
+        return Status::InvalidArgument(
+            "use_udi_as_primary_index is incompatible with partitioned "
+            "filters. Partitioned filters require the standard "
+            "PartitionedIndexBuilder for partition boundaries.");
+      }
+    }
+  } else if (table_options_.use_udi_as_primary_index) {
     return Status::InvalidArgument(
-        "user_defined_index_factory not supported with parallel compression");
+        "use_udi_as_primary_index requires user_defined_index_factory");
   }
   if (db_opts.unordered_write && cf_opts.max_successive_merges > 0) {
     // TODO(myabandeh): support it

--- a/table/block_based/block_based_table_factory.cc
+++ b/table/block_based/block_based_table_factory.cc
@@ -767,23 +767,18 @@ Status BlockBasedTableFactory::ValidateOptions(
           "user_defined_index_factory not supported with parallel compression");
     }
     if (table_options_.use_udi_as_primary_index) {
-      if (!table_options_.user_defined_index_factory) {
-        return Status::InvalidArgument(
-            "use_udi_as_primary_index requires user_defined_index_factory");
-      }
       if (table_options_.index_type ==
           BlockBasedTableOptions::kTwoLevelIndexSearch) {
         return Status::InvalidArgument(
             "use_udi_as_primary_index is incompatible with partitioned index "
-            "(kTwoLevelIndexSearch). Primary UDI skips the standard index "
-            "builder, but partitioned index requires it for partition "
-            "boundaries.");
+            "(kTwoLevelIndexSearch). The UDI wrapper currently only supports "
+            "flat (single-level) index builders.");
       }
       if (table_options_.partition_filters) {
         return Status::InvalidArgument(
             "use_udi_as_primary_index is incompatible with partitioned "
-            "filters. Partitioned filters require the standard "
-            "PartitionedIndexBuilder for partition boundaries.");
+            "filters. The UDI wrapper does not support the partitioned "
+            "index/filter layout.");
       }
     }
   } else if (table_options_.use_udi_as_primary_index) {

--- a/table/block_based/block_based_table_factory.cc
+++ b/table/block_based/block_based_table_factory.cc
@@ -430,6 +430,9 @@ static struct BlockBasedTableTypeInfo {
         {"fail_if_no_udi_on_open",
          {offsetof(struct BlockBasedTableOptions, fail_if_no_udi_on_open),
           OptionType::kBoolean, OptionVerificationType::kNormal}},
+        {"use_udi_as_primary_index",
+         {offsetof(struct BlockBasedTableOptions, use_udi_as_primary_index),
+          OptionType::kBoolean, OptionVerificationType::kNormal}},
     };
   }
 } block_based_table_type_info;
@@ -938,6 +941,9 @@ std::string BlockBasedTableFactory::GetPrintableOptions() const {
            table_options_.user_defined_index_factory == nullptr
                ? "nullptr"
                : table_options_.user_defined_index_factory->Name());
+  ret.append(buffer);
+  snprintf(buffer, kBufferSize, "  use_udi_as_primary_index: %d\n",
+           table_options_.use_udi_as_primary_index);
   ret.append(buffer);
   snprintf(buffer, kBufferSize, "  fail_if_no_udi_on_open: %d\n",
            table_options_.fail_if_no_udi_on_open);

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -1366,16 +1366,15 @@ Status BlockBasedTable::PrefetchIndexAndFilterBlocks(
             udi_option, rep_->udi_block.GetValue()->data, udi_reader);
         if (s.ok()) {
           if (udi_reader) {
-            // Determine primary UDI mode: use UDI for all reads if the SST
-            // was built with UDI-primary or the config says primary. This
-            // enables reading old dual-index SSTs through the UDI too.
-            bool udi_is_primary =
-                (rep_->table_properties &&
-                 rep_->table_properties->udi_is_primary_index != 0) ||
-                table_options.use_udi_as_primary_index;
+            // Primary UDI mode is purely config-driven. The
+            // udi_is_primary_index table property is informational only
+            // (for diagnostics / sst_dump) and does not affect routing.
+            // This keeps rollback simple: setting
+            // use_udi_as_primary_index=false immediately reverts all SSTs
+            // to standard-index reads without needing compaction.
             index_reader = std::make_unique<UserDefinedIndexReaderWrapper>(
                 udi_name, std::move(index_reader), std::move(udi_reader),
-                udi_is_primary);
+                table_options.use_udi_as_primary_index);
           } else {
             s = Status::Corruption("Failed to create UDI reader for " +
                                    udi_name + " in file " +

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -1316,7 +1316,9 @@ Status BlockBasedTable::PrefetchIndexAndFilterBlocks(
     std::string udi_name(table_options.user_defined_index_factory->Name());
     BlockHandle udi_block_handle;
 
-    // Should we use FindOptionalMetaBlock here?
+    // Use FindMetaBlock (not FindOptionalMetaBlock) so we get a non-OK status
+    // when the block is missing, allowing the fail_if_no_udi_on_open logic
+    // below to decide whether to error or warn.
     s = FindMetaBlock(meta_iter, kUserDefinedIndexPrefix + udi_name,
                       &udi_block_handle);
     if (!s.ok()) {
@@ -1325,16 +1327,16 @@ Status BlockBasedTable::PrefetchIndexAndFilterBlocks(
       if (table_options.fail_if_no_udi_on_open ||
           table_options.use_udi_as_primary_index) {
         ROCKS_LOG_ERROR(rep_->ioptions.logger,
-                        "Failed to find the the UDI block %s in file %s; %s",
+                        "Failed to find the UDI block %s in file %s; %s",
                         udi_name.c_str(), rep_->file->file_name().c_str(),
                         s.ToString().c_str());
-        // MAke the status more informative
+        // Make the status more informative
         s = Status::Corruption(s.ToString(), rep_->file->file_name());
         return s;
       } else {
         // Emit a warning, but ignore the error status
         ROCKS_LOG_WARN(rep_->ioptions.logger,
-                       "Failed to find the the UDI block %s in file %s; %s",
+                       "Failed to find the UDI block %s in file %s; %s",
                        udi_name.c_str(), rep_->file->file_name().c_str(),
                        s.ToString().c_str());
         s = Status::OK();
@@ -1364,20 +1366,16 @@ Status BlockBasedTable::PrefetchIndexAndFilterBlocks(
             udi_option, rep_->udi_block.GetValue()->data, udi_reader);
         if (s.ok()) {
           if (udi_reader) {
-            // Determine primary UDI mode:
-            // - udi_written_as_primary: SST was built with UDI-primary (stub
-            //   standard index). Affects CacheDependencies/EraseFromCache.
-            // - udi_use_as_primary: Use UDI for reads by default. True if
-            //   the SST was written as primary OR the config says primary
-            //   (enables reading old dual-index SSTs through the UDI too).
-            bool udi_written_as_primary =
+            // Determine primary UDI mode: use UDI for all reads if the SST
+            // was built with UDI-primary or the config says primary. This
+            // enables reading old dual-index SSTs through the UDI too.
+            bool udi_is_primary =
                 (rep_->table_properties &&
-                 rep_->table_properties->udi_is_primary_index != 0);
-            bool udi_is_primary = udi_written_as_primary ||
-                                  table_options.use_udi_as_primary_index;
+                 rep_->table_properties->udi_is_primary_index != 0) ||
+                table_options.use_udi_as_primary_index;
             index_reader = std::make_unique<UserDefinedIndexReaderWrapper>(
                 udi_name, std::move(index_reader), std::move(udi_reader),
-                udi_is_primary, udi_written_as_primary);
+                udi_is_primary);
           } else {
             s = Status::Corruption("Failed to create UDI reader for " +
                                    udi_name + " in file " +

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -1322,7 +1322,8 @@ Status BlockBasedTable::PrefetchIndexAndFilterBlocks(
     if (!s.ok()) {
       RecordTick(rep_->ioptions.statistics.get(),
                  SST_USER_DEFINED_INDEX_LOAD_FAIL_COUNT);
-      if (table_options.fail_if_no_udi_on_open) {
+      if (table_options.fail_if_no_udi_on_open ||
+          table_options.use_udi_as_primary_index) {
         ROCKS_LOG_ERROR(rep_->ioptions.logger,
                         "Failed to find the the UDI block %s in file %s; %s",
                         udi_name.c_str(), rep_->file->file_name().c_str(),
@@ -1363,8 +1364,20 @@ Status BlockBasedTable::PrefetchIndexAndFilterBlocks(
             udi_option, rep_->udi_block.GetValue()->data, udi_reader);
         if (s.ok()) {
           if (udi_reader) {
+            // Determine primary UDI mode:
+            // - udi_written_as_primary: SST was built with UDI-primary (stub
+            //   standard index). Affects CacheDependencies/EraseFromCache.
+            // - udi_use_as_primary: Use UDI for reads by default. True if
+            //   the SST was written as primary OR the config says primary
+            //   (enables reading old dual-index SSTs through the UDI too).
+            bool udi_written_as_primary =
+                (rep_->table_properties &&
+                 rep_->table_properties->udi_is_primary_index != 0);
+            bool udi_is_primary = udi_written_as_primary ||
+                                  table_options.use_udi_as_primary_index;
             index_reader = std::make_unique<UserDefinedIndexReaderWrapper>(
-                udi_name, std::move(index_reader), std::move(udi_reader));
+                udi_name, std::move(index_reader), std::move(udi_reader),
+                udi_is_primary, udi_written_as_primary);
           } else {
             s = Status::Corruption("Failed to create UDI reader for " +
                                    udi_name + " in file " +

--- a/table/block_based/user_defined_index_wrapper.h
+++ b/table/block_based/user_defined_index_wrapper.h
@@ -31,11 +31,12 @@ class UserDefinedIndexBuilderWrapper : public IndexBuilder {
       std::unique_ptr<IndexBuilder> internal_index_builder,
       std::unique_ptr<UserDefinedIndexBuilder> user_defined_index_builder,
       const InternalKeyComparator* comparator, size_t ts_sz,
-      bool persist_user_defined_timestamps)
+      bool persist_user_defined_timestamps, bool udi_is_primary = false)
       : IndexBuilder(comparator, ts_sz, persist_user_defined_timestamps),
         name_(name),
         internal_index_builder_(std::move(internal_index_builder)),
-        user_defined_index_builder_(std::move(user_defined_index_builder)) {}
+        user_defined_index_builder_(std::move(user_defined_index_builder)),
+        udi_is_primary_(udi_is_primary) {}
 
   ~UserDefinedIndexBuilderWrapper() override = default;
 
@@ -80,6 +81,12 @@ class UserDefinedIndexBuilderWrapper : public IndexBuilder {
           first_key_in_next_block ? &pkey_first.user_key : nullptr, handle,
           separator_scratch, ctx);
     }
+    // When UDI is primary, skip the standard index builder -- only the UDI
+    // index is populated. Return an empty Slice since the standard separator
+    // is not computed.
+    if (udi_is_primary_) {
+      return Slice();
+    }
     return internal_index_builder_->AddIndexEntry(
         last_key_in_current_block, first_key_in_next_block, block_handle,
         separator_scratch, skip_delta_encoding);
@@ -112,11 +119,13 @@ class UserDefinedIndexBuilderWrapper : public IndexBuilder {
 
   void OnKeyAdded(const Slice& key,
                   const std::optional<Slice>& value) override {
-    // Always forward to internal index builder first. It relies on receiving
+    // When UDI is secondary, forward to the internal builder which needs
     // OnKeyAdded for every key to maintain state (e.g.,
-    // current_block_first_internal_key_) needed by AddIndexEntry, which is
-    // always forwarded regardless of UDI status.
-    internal_index_builder_->OnKeyAdded(key, value);
+    // current_block_first_internal_key_). When UDI is primary, skip it --
+    // the internal builder is not populated.
+    if (!udi_is_primary_) {
+      internal_index_builder_->OnKeyAdded(key, value);
+    }
 
     ParsedInternalKey pkey;
     if (status_.ok()) {
@@ -172,24 +181,39 @@ class UserDefinedIndexBuilderWrapper : public IndexBuilder {
       udi_finished_ = true;
     }
 
-    // Finish the internal index builder
+    // Finish the internal index builder. When UDI is primary, the internal
+    // builder was never populated (no AddIndexEntry/OnKeyAdded calls), so it
+    // produces a minimal stub index block. This stub satisfies the SST footer
+    // format requirement for an index block handle.
     status_ = internal_index_builder_->Finish(index_blocks,
                                               last_partition_block_handle);
     if (!status_.ok()) {
       return status_;
     }
 
-    index_size_ = internal_index_builder_->IndexSize();
+    if (udi_is_primary_) {
+      // Use the UDI's serialized size as the index size.
+      index_size_ = user_defined_index_builder_->EstimatedSize();
+    } else {
+      index_size_ = internal_index_builder_->IndexSize();
+    }
     return status_;
   }
 
   size_t IndexSize() const override { return index_size_; }
 
   uint64_t CurrentIndexSizeEstimate() const override {
+    if (udi_is_primary_) {
+      return user_defined_index_builder_->EstimatedSize();
+    }
     return internal_index_builder_->CurrentIndexSizeEstimate();
   }
 
   bool separator_is_key_plus_seq() override {
+    if (udi_is_primary_) {
+      // UDI always uses user keys (no internal key trailer).
+      return false;
+    }
     return internal_index_builder_->separator_is_key_plus_seq();
   }
 
@@ -223,6 +247,7 @@ class UserDefinedIndexBuilderWrapper : public IndexBuilder {
   std::unique_ptr<UserDefinedIndexBuilder> user_defined_index_builder_;
   Status status_;
   bool udi_finished_ = false;
+  bool udi_is_primary_ = false;
 };
 
 class UserDefinedIndexIteratorWrapper
@@ -356,49 +381,78 @@ class UserDefinedIndexIteratorWrapper
 
 class UserDefinedIndexReaderWrapper : public BlockBasedTable::IndexReader {
  public:
+  // @udi_is_primary: use UDI for all reads (default dispatch).
+  // @udi_written_as_primary: SST was built with UDI-primary (stub standard
+  //   index). When true, CacheDependencies/EraseFromCache skip the standard
+  //   reader. When false (old SSTs with both indexes), the standard reader
+  //   still holds cache entries that need cleanup.
   UserDefinedIndexReaderWrapper(
       const std::string& name,
       std::unique_ptr<BlockBasedTable::IndexReader>&& reader,
-      std::unique_ptr<UserDefinedIndexReader>&& udi_reader)
+      std::unique_ptr<UserDefinedIndexReader>&& udi_reader,
+      bool udi_is_primary = false, bool udi_written_as_primary = false)
       : name_(name),
         reader_(std::move(reader)),
-        udi_reader_(std::move(udi_reader)) {}
+        udi_reader_(std::move(udi_reader)),
+        udi_is_primary_(udi_is_primary),
+        udi_written_as_primary_(udi_written_as_primary) {}
 
   InternalIteratorBase<IndexValue>* NewIterator(
       const ReadOptions& read_options, bool disable_prefix_seek,
       IndexBlockIter* iter, GetContext* get_context,
       BlockCacheLookupContext* lookup_context) override {
-    if (!read_options.table_index_factory) {
-      return reader_->NewIterator(read_options, disable_prefix_seek, iter,
-                                  get_context, lookup_context);
+    // Determine whether to use the UDI for this read:
+    // 1. UDI is primary -- always use it (no standard index to fall back to)
+    // 2. ReadOptions::table_index_factory is set -- use it (explicit request)
+    // 3. Neither -- fall through to the standard index
+    bool use_udi = udi_is_primary_;
+    if (!use_udi && read_options.table_index_factory) {
+      if (name_ == read_options.table_index_factory->Name()) {
+        use_udi = true;
+      } else {
+        return NewErrorInternalIterator<IndexValue>(Status::InvalidArgument(
+            "Bad index name: " +
+            std::string(read_options.table_index_factory->Name()) +
+            ". Only supported UDI is " + name_));
+      }
     }
-    if (name_ != read_options.table_index_factory->Name()) {
-      return NewErrorInternalIterator<IndexValue>(Status::InvalidArgument(
-          "Bad index name: " +
-          std::string(read_options.table_index_factory->Name()) +
-          ". Only supported UDI is " + name_));
+
+    if (use_udi) {
+      std::unique_ptr<UserDefinedIndexIterator> udi_iter =
+          udi_reader_->NewIterator(read_options);
+      if (udi_iter) {
+        return new UserDefinedIndexIteratorWrapper(std::move(udi_iter));
+      }
+      return NewErrorInternalIterator<IndexValue>(
+          Status::NotFound("Could not create UDI iterator"));
     }
-    std::unique_ptr<UserDefinedIndexIterator> udi_iter =
-        udi_reader_->NewIterator(read_options);
-    if (udi_iter) {
-      return new UserDefinedIndexIteratorWrapper(std::move(udi_iter));
-    }
-    return NewErrorInternalIterator<IndexValue>(
-        Status::NotFound("Could not create UDI iterator"));
+
+    return reader_->NewIterator(read_options, disable_prefix_seek, iter,
+                                get_context, lookup_context);
   }
 
   Status CacheDependencies(const ReadOptions& ro, bool pin,
                            FilePrefetchBuffer* tail_prefetch_buffer) override {
+    if (udi_written_as_primary_) {
+      // SST was built with UDI-primary -- the standard index is a stub with
+      // no partitions to cache. The UDI block is already pinned.
+      return Status::OK();
+    }
     return reader_->CacheDependencies(ro, pin, tail_prefetch_buffer);
   }
 
   size_t ApproximateMemoryUsage() const override {
-    return reader_->ApproximateMemoryUsage() +
-           udi_reader_->ApproximateMemoryUsage();
+    size_t usage = udi_reader_->ApproximateMemoryUsage();
+    // Always include the standard reader's memory -- it's allocated regardless
+    // of primary mode (it holds the stub or full index block).
+    usage += reader_->ApproximateMemoryUsage();
+    return usage;
   }
 
   void EraseFromCacheBeforeDestruction(
       uint32_t uncache_aggressiveness) override {
+    // Always clean up the standard reader's cache entries. Even for
+    // UDI-primary SSTs, the stub index block may be cached.
     reader_->EraseFromCacheBeforeDestruction(uncache_aggressiveness);
   }
 
@@ -406,5 +460,7 @@ class UserDefinedIndexReaderWrapper : public BlockBasedTable::IndexReader {
   std::string name_;
   std::unique_ptr<BlockBasedTable::IndexReader> reader_;
   std::unique_ptr<UserDefinedIndexReader> udi_reader_;
+  bool udi_is_primary_ = false;
+  bool udi_written_as_primary_ = false;
 };
 }  // namespace ROCKSDB_NAMESPACE

--- a/table/block_based/user_defined_index_wrapper.h
+++ b/table/block_based/user_defined_index_wrapper.h
@@ -7,7 +7,6 @@
 
 #include <memory>
 #include <string>
-#include <unordered_map>
 
 #include "db/seqno_to_time_mapping.h"
 #include "rocksdb/slice.h"
@@ -15,15 +14,14 @@
 #include "rocksdb/user_defined_index.h"
 #include "table/block_based/block_based_table_reader.h"
 #include "table/block_based/block_type.h"
-#include "table/block_based/cachable_entry.h"
 #include "table/block_based/index_builder.h"
 
 namespace ROCKSDB_NAMESPACE {
 
-// UserDefinedIndexWrapper wraps around the existing index types in block based
-// table, and supports plugging in an additional user defined index. The wrapper
-// class forwards calls to both the wrapped internal index, and a user defined
-// index builder.
+// UserDefinedIndexBuilderWrapper wraps around the existing index types in block
+// based table, and supports plugging in an additional user defined index. The
+// wrapper class forwards calls to both the wrapped internal index, and a user
+// defined index builder.
 class UserDefinedIndexBuilderWrapper : public IndexBuilder {
  public:
   UserDefinedIndexBuilderWrapper(
@@ -31,12 +29,11 @@ class UserDefinedIndexBuilderWrapper : public IndexBuilder {
       std::unique_ptr<IndexBuilder> internal_index_builder,
       std::unique_ptr<UserDefinedIndexBuilder> user_defined_index_builder,
       const InternalKeyComparator* comparator, size_t ts_sz,
-      bool persist_user_defined_timestamps, bool udi_is_primary)
+      bool persist_user_defined_timestamps)
       : IndexBuilder(comparator, ts_sz, persist_user_defined_timestamps),
         name_(name),
         internal_index_builder_(std::move(internal_index_builder)),
-        user_defined_index_builder_(std::move(user_defined_index_builder)),
-        udi_is_primary_(udi_is_primary) {}
+        user_defined_index_builder_(std::move(user_defined_index_builder)) {}
 
   ~UserDefinedIndexBuilderWrapper() override = default;
 
@@ -81,12 +78,15 @@ class UserDefinedIndexBuilderWrapper : public IndexBuilder {
           first_key_in_next_block ? &pkey_first.user_key : nullptr, handle,
           separator_scratch, ctx);
     }
-    // When UDI is primary, skip the standard index builder -- only the UDI
-    // index is populated. Return an empty Slice since the standard separator
-    // is not computed.
-    if (udi_is_primary_) {
-      return Slice();
-    }
+    // Always forward to the standard index builder, even in primary mode.
+    // The standard index is fully populated alongside the UDI. In primary
+    // mode the UDI handles all reads, but the standard index serves as a
+    // safety fallback (e.g., backup/restore, rollback to non-UDI config)
+    // and its presence is required for correct internal RocksDB behavior.
+    // The write-path cost is the standard index block in the SST (~1-2%
+    // of SST size). Skipping the standard index is deferred to a future
+    // refactor that extracts the index abstraction to put the binary
+    // index and UDI at the same level (see PR #14547 discussion).
     return internal_index_builder_->AddIndexEntry(
         last_key_in_current_block, first_key_in_next_block, block_handle,
         separator_scratch, skip_delta_encoding);
@@ -119,13 +119,10 @@ class UserDefinedIndexBuilderWrapper : public IndexBuilder {
 
   void OnKeyAdded(const Slice& key,
                   const std::optional<Slice>& value) override {
-    // When UDI is secondary, forward to the internal builder which needs
-    // OnKeyAdded for every key to maintain state (e.g.,
-    // current_block_first_internal_key_). When UDI is primary, skip it --
-    // the internal builder is not populated.
-    if (!udi_is_primary_) {
-      internal_index_builder_->OnKeyAdded(key, value);
-    }
+    // Always forward to the internal builder which needs OnKeyAdded for
+    // every key to maintain state (e.g., current_block_first_internal_key_).
+    // The standard index is always fully populated, even in primary mode.
+    internal_index_builder_->OnKeyAdded(key, value);
 
     ParsedInternalKey pkey;
     if (status_.ok()) {
@@ -181,39 +178,25 @@ class UserDefinedIndexBuilderWrapper : public IndexBuilder {
       udi_finished_ = true;
     }
 
-    // Finish the internal index builder. When UDI is primary, the internal
-    // builder was never populated (no AddIndexEntry/OnKeyAdded calls), so it
-    // produces a minimal stub index block. This stub satisfies the SST footer
-    // format requirement for an index block handle.
+    // Finish the internal index builder. The standard index is always fully
+    // populated (even in primary mode), producing a real index block.
     status_ = internal_index_builder_->Finish(index_blocks,
                                               last_partition_block_handle);
     if (!status_.ok()) {
       return status_;
     }
 
-    if (udi_is_primary_) {
-      // Use the UDI's serialized size as the index size.
-      index_size_ = user_defined_index_builder_->EstimatedSize();
-    } else {
-      index_size_ = internal_index_builder_->IndexSize();
-    }
+    index_size_ = internal_index_builder_->IndexSize();
     return status_;
   }
 
   size_t IndexSize() const override { return index_size_; }
 
   uint64_t CurrentIndexSizeEstimate() const override {
-    if (udi_is_primary_) {
-      return user_defined_index_builder_->EstimatedSize();
-    }
     return internal_index_builder_->CurrentIndexSizeEstimate();
   }
 
   bool separator_is_key_plus_seq() override {
-    if (udi_is_primary_) {
-      // UDI always uses user keys (no internal key trailer).
-      return false;
-    }
     return internal_index_builder_->separator_is_key_plus_seq();
   }
 
@@ -247,7 +230,6 @@ class UserDefinedIndexBuilderWrapper : public IndexBuilder {
   std::unique_ptr<UserDefinedIndexBuilder> user_defined_index_builder_;
   Status status_;
   bool udi_finished_ = false;
-  bool udi_is_primary_ = false;
 };
 
 class UserDefinedIndexIteratorWrapper
@@ -381,28 +363,25 @@ class UserDefinedIndexIteratorWrapper
 
 class UserDefinedIndexReaderWrapper : public BlockBasedTable::IndexReader {
  public:
-  // @udi_is_primary: use UDI for all reads (default dispatch).
-  // @udi_written_as_primary: SST was built with UDI-primary (stub standard
-  //   index). When true, CacheDependencies/EraseFromCache skip the standard
-  //   reader. When false (old SSTs with both indexes), the standard reader
-  //   still holds cache entries that need cleanup.
+  // @udi_is_primary: use UDI for all reads (default dispatch), including
+  //   internal operations like compaction and VerifyChecksum that don't
+  //   set ReadOptions::table_index_factory.
   UserDefinedIndexReaderWrapper(
       const std::string& name,
       std::unique_ptr<BlockBasedTable::IndexReader>&& reader,
-      std::unique_ptr<UserDefinedIndexReader>&& udi_reader, bool udi_is_primary,
-      bool udi_written_as_primary)
+      std::unique_ptr<UserDefinedIndexReader>&& udi_reader, bool udi_is_primary)
       : name_(name),
         reader_(std::move(reader)),
         udi_reader_(std::move(udi_reader)),
-        udi_is_primary_(udi_is_primary),
-        udi_written_as_primary_(udi_written_as_primary) {}
+        udi_is_primary_(udi_is_primary) {}
 
   InternalIteratorBase<IndexValue>* NewIterator(
       const ReadOptions& read_options, bool disable_prefix_seek,
       IndexBlockIter* iter, GetContext* get_context,
       BlockCacheLookupContext* lookup_context) override {
     // Determine whether to use the UDI for this read:
-    // 1. UDI is primary -- always use it (no standard index to fall back to)
+    // 1. UDI is primary -- always use it (standard index is present in the
+    //    SST but not used for reads in this mode)
     // 2. ReadOptions::table_index_factory is set -- use it (explicit request)
     // 3. Neither -- fall through to the standard index
     bool use_udi = udi_is_primary_;
@@ -433,34 +412,25 @@ class UserDefinedIndexReaderWrapper : public BlockBasedTable::IndexReader {
 
   Status CacheDependencies(const ReadOptions& ro, bool pin,
                            FilePrefetchBuffer* tail_prefetch_buffer) override {
-    if (udi_written_as_primary_) {
-      // SST was built with UDI-primary -- the standard index is a stub with
-      // no partitions to cache. The UDI block is already pinned.
-      return Status::OK();
-    }
+    // The standard index is always fully populated, even in primary mode.
     return reader_->CacheDependencies(ro, pin, tail_prefetch_buffer);
   }
 
   size_t ApproximateMemoryUsage() const override {
     size_t usage = udi_reader_->ApproximateMemoryUsage();
-    // Always include the standard reader's memory -- it's allocated regardless
-    // of primary mode (it holds the stub or full index block).
     usage += reader_->ApproximateMemoryUsage();
     return usage;
   }
 
   void EraseFromCacheBeforeDestruction(
       uint32_t uncache_aggressiveness) override {
-    // Always clean up the standard reader's cache entries. Even for
-    // UDI-primary SSTs, the stub index block may be cached.
     reader_->EraseFromCacheBeforeDestruction(uncache_aggressiveness);
   }
 
  private:
-  std::string name_;
+  const std::string name_;
   std::unique_ptr<BlockBasedTable::IndexReader> reader_;
   std::unique_ptr<UserDefinedIndexReader> udi_reader_;
-  bool udi_is_primary_ = false;
-  bool udi_written_as_primary_ = false;
+  const bool udi_is_primary_;
 };
 }  // namespace ROCKSDB_NAMESPACE

--- a/table/block_based/user_defined_index_wrapper.h
+++ b/table/block_based/user_defined_index_wrapper.h
@@ -31,7 +31,7 @@ class UserDefinedIndexBuilderWrapper : public IndexBuilder {
       std::unique_ptr<IndexBuilder> internal_index_builder,
       std::unique_ptr<UserDefinedIndexBuilder> user_defined_index_builder,
       const InternalKeyComparator* comparator, size_t ts_sz,
-      bool persist_user_defined_timestamps, bool udi_is_primary = false)
+      bool persist_user_defined_timestamps, bool udi_is_primary)
       : IndexBuilder(comparator, ts_sz, persist_user_defined_timestamps),
         name_(name),
         internal_index_builder_(std::move(internal_index_builder)),
@@ -389,8 +389,8 @@ class UserDefinedIndexReaderWrapper : public BlockBasedTable::IndexReader {
   UserDefinedIndexReaderWrapper(
       const std::string& name,
       std::unique_ptr<BlockBasedTable::IndexReader>&& reader,
-      std::unique_ptr<UserDefinedIndexReader>&& udi_reader,
-      bool udi_is_primary = false, bool udi_written_as_primary = false)
+      std::unique_ptr<UserDefinedIndexReader>&& udi_reader, bool udi_is_primary,
+      bool udi_written_as_primary)
       : name_(name),
         reader_(std::move(reader)),
         udi_reader_(std::move(udi_reader)),

--- a/table/block_based/user_defined_index_wrapper.h
+++ b/table/block_based/user_defined_index_wrapper.h
@@ -193,7 +193,10 @@ class UserDefinedIndexBuilderWrapper : public IndexBuilder {
   size_t IndexSize() const override { return index_size_; }
 
   uint64_t CurrentIndexSizeEstimate() const override {
-    return internal_index_builder_->CurrentIndexSizeEstimate();
+    // Include both the standard index and UDI sizes for accurate
+    // compaction file sizing.
+    return internal_index_builder_->CurrentIndexSizeEstimate() +
+           user_defined_index_builder_->EstimatedSize();
   }
 
   bool separator_is_key_plus_seq() override {

--- a/table/block_based/user_defined_index_wrapper.h
+++ b/table/block_based/user_defined_index_wrapper.h
@@ -193,10 +193,14 @@ class UserDefinedIndexBuilderWrapper : public IndexBuilder {
   size_t IndexSize() const override { return index_size_; }
 
   uint64_t CurrentIndexSizeEstimate() const override {
-    // Include both the standard index and UDI sizes for accurate
-    // compaction file sizing.
-    return internal_index_builder_->CurrentIndexSizeEstimate() +
-           user_defined_index_builder_->EstimatedSize();
+    // Only includes the standard index size. The UDI meta block size is
+    // not included because EstimatedSize() reads non-atomic fields that
+    // are written by AddIndexEntry, which would be a data race if
+    // parallel compression were enabled. The conservative tail-size
+    // estimates in BlockBasedTableBuilder (properties + meta-index)
+    // provide a rough buffer. A more accurate estimate would require
+    // making EstimatedSize() thread-safe.
+    return internal_index_builder_->CurrentIndexSizeEstimate();
   }
 
   bool separator_is_key_plus_seq() override {
@@ -406,7 +410,7 @@ class UserDefinedIndexReaderWrapper : public BlockBasedTable::IndexReader {
         return new UserDefinedIndexIteratorWrapper(std::move(udi_iter));
       }
       return NewErrorInternalIterator<IndexValue>(
-          Status::NotFound("Could not create UDI iterator"));
+          Status::Corruption("Could not create UDI iterator"));
     }
 
     return reader_->NewIterator(read_options, disable_prefix_seek, iter,

--- a/table/meta_blocks.cc
+++ b/table/meta_blocks.cc
@@ -91,6 +91,9 @@ void PropertyBlockBuilder::AddTableProperty(const TableProperties& props) {
   Add(TablePropertiesNames::kIndexKeyIsUserKey, props.index_key_is_user_key);
   Add(TablePropertiesNames::kIndexValueIsDeltaEncoded,
       props.index_value_is_delta_encoded);
+  if (props.udi_is_primary_index != 0) {
+    Add(TablePropertiesNames::kUDIIsPrimaryIndex, props.udi_is_primary_index);
+  }
   Add(TablePropertiesNames::kNumEntries, props.num_entries);
   Add(TablePropertiesNames::kNumFilterEntries, props.num_filter_entries);
   Add(TablePropertiesNames::kDeletedKeys, props.num_deletions);
@@ -286,6 +289,8 @@ Status ParsePropertiesBlock(
        &new_table_properties->index_key_is_user_key},
       {TablePropertiesNames::kIndexValueIsDeltaEncoded,
        &new_table_properties->index_value_is_delta_encoded},
+      {TablePropertiesNames::kUDIIsPrimaryIndex,
+       &new_table_properties->udi_is_primary_index},
       {TablePropertiesNames::kFilterSize, &new_table_properties->filter_size},
       {TablePropertiesNames::kRawKeySize, &new_table_properties->raw_key_size},
       {TablePropertiesNames::kRawValueSize,

--- a/table/table_properties.cc
+++ b/table/table_properties.cc
@@ -278,6 +278,8 @@ const std::string TablePropertiesNames::kIndexKeyIsUserKey =
     "rocksdb.index.key.is.user.key";
 const std::string TablePropertiesNames::kIndexValueIsDeltaEncoded =
     "rocksdb.index.value.is.delta.encoded";
+const std::string TablePropertiesNames::kUDIIsPrimaryIndex =
+    "rocksdb.udi.is.primary.index";
 const std::string TablePropertiesNames::kFilterSize = "rocksdb.filter.size";
 const std::string TablePropertiesNames::kRawKeySize = "rocksdb.raw.key.size";
 const std::string TablePropertiesNames::kRawValueSize =
@@ -371,6 +373,10 @@ static std::unordered_map<std::string, OptionTypeInfo>
           OptionTypeFlags::kNone}},
         {"index_value_is_delta_encoded",
          {offsetof(struct TableProperties, index_value_is_delta_encoded),
+          OptionType::kUInt64T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"udi_is_primary_index",
+         {offsetof(struct TableProperties, udi_is_primary_index),
           OptionType::kUInt64T, OptionVerificationType::kNormal,
           OptionTypeFlags::kNone}},
         {"filter_size",

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -7976,6 +7976,8 @@ class UserDefinedIndexTestBase : public BlockBasedTableTestBase {
 
       int GetEntriesAdded() const { return entries_added_; }
 
+      uint64_t EstimatedSize() const override { return 0; }
+
       // When true, skip the EXPECT_EQ(key.size(), 5) checks, allowing
       // variable-length keys (e.g., from DB flush/compaction).
       bool skip_key_size_check_ = false;

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -250,10 +250,8 @@ default_params = {
      "use_trie_index": random.choice([0, 0, 0, 0, 0, 0, 0, 1]),
      # use_udi_as_primary_index must be the same across invocations (like
      # use_trie_index) so that SSTs written in primary mode can be read on
-     # reopen. A lambda would re-randomize per invocation, potentially
-     # causing open failures when a primary-mode SST is opened without the
-     # primary flag.
-     "use_udi_as_primary_index": random.choice([0, 1]),
+     # reopen.
+     "use_udi_as_primary_index": random.choice([0, 0, 0, 1]),
     # use_put_entity_one_in has to be the same across invocations for verification to work, hence no lambda
     "use_put_entity_one_in": random.choice([0] * 7 + [1, 5, 10]),
     "use_attribute_group": lambda: random.randint(0, 1),

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -245,10 +245,15 @@ default_params = {
     "uncache_aggressiveness": lambda: int(math.pow(10, 4.0 * random.random()) - 1.0),
     "use_full_merge_v1": lambda: random.randint(0, 1),
     "use_merge": lambda: random.randint(0, 1),
-    # use_trie_index must be the same across invocations so that all SSTs
-    # in a DB are opened with matching table options.
-    # Temporarily disabled due to trie UDI stress test failures.
-    "use_trie_index": 0,
+     # use_trie_index must be the same across invocations so that all SSTs
+     # in a DB are opened with matching table options.
+     "use_trie_index": random.choice([0, 0, 0, 0, 0, 0, 0, 1]),
+     # use_udi_as_primary_index must be the same across invocations (like
+     # use_trie_index) so that SSTs written in primary mode can be read on
+     # reopen. A lambda would re-randomize per invocation, potentially
+     # causing open failures when a primary-mode SST is opened without the
+     # primary flag.
+     "use_udi_as_primary_index": random.choice([0, 1]),
     # use_put_entity_one_in has to be the same across invocations for verification to work, hence no lambda
     "use_put_entity_one_in": random.choice([0] * 7 + [1, 5, 10]),
     "use_attribute_group": lambda: random.randint(0, 1),
@@ -1057,6 +1062,9 @@ def finalize_and_sanitize(src_params):
         dest_params["mmap_read"] = 0
         # Parallel compression is incompatible with UDI
         dest_params["compression_parallel_threads"] = 1
+    else:
+        # use_udi_as_primary_index requires use_trie_index
+        dest_params["use_udi_as_primary_index"] = 0
 
     # Multi-key operations are not currently compatible with transactions or
     # timestamp.

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -1066,15 +1066,10 @@ def finalize_and_sanitize(src_params):
             # filters are not compatible with the UDI wrapper layout.
             dest_params["index_type"] = random.choice([0, 0, 3])
             dest_params["partition_filters"] = 0
-            # Backup/restore verification opens the restored DB by
-            # serializing the current Options to a string and parsing it
-            # back (PrepareOptionsForRestoredDB). The user_defined_index_factory
-            # is a shared_ptr that cannot survive this round-trip -- the
-            # restored DB opens without UDI support. In secondary mode this
-            # In primary mode, backup serializes Options to strings,
-            # losing the user_defined_index_factory (shared_ptr). The
-            # restored DB opens without UDI support and cannot route
-            # reads through the trie.
+            # Backup/restore serializes Options to strings, losing the
+            # user_defined_index_factory (shared_ptr). The restored DB
+            # opens without UDI support and cannot route reads through
+            # the trie in primary mode.
             dest_params["backup_one_in"] = 0
             # Secondary DB opens SSTs with default Options (not a copy of
             # the primary's), losing the UDI factory. Without the factory,

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -1062,6 +1062,28 @@ def finalize_and_sanitize(src_params):
         dest_params["mmap_read"] = 0
         # Parallel compression is incompatible with UDI
         dest_params["compression_parallel_threads"] = 1
+        if dest_params.get("use_udi_as_primary_index") == 1:
+            # Primary UDI skips the standard index builder (only a stub is
+            # written). Partitioned index (kTwoLevelIndexSearch) and
+            # partitioned filters require the standard PartitionedIndexBuilder
+            # to provide partition boundaries, which doesn't work with an
+            # empty stub. These combinations are rejected at builder creation
+            # time with InvalidArgument.
+            dest_params["index_type"] = random.choice([0, 0, 3])
+            dest_params["partition_filters"] = 0
+            # Backup/restore verification opens the restored DB by
+            # serializing the current Options to a string and parsing it
+            # back (PrepareOptionsForRestoredDB). The user_defined_index_factory
+            # is a shared_ptr that cannot survive this round-trip -- the
+            # restored DB opens without UDI support. In secondary mode this
+            # is fine (reads fall through to the fully populated standard
+            # index). In primary mode the standard index is a stub with zero
+            # entries, so every read returns nothing.
+            dest_params["backup_one_in"] = 0
+            # Secondary DB opens SSTs with default Options (not a copy of
+            # the primary's options), losing the UDI factory. Reads through
+            # the stub standard index return nothing.
+            dest_params["test_secondary"] = 0
     else:
         # use_udi_as_primary_index requires use_trie_index
         dest_params["use_udi_as_primary_index"] = 0

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -245,13 +245,13 @@ default_params = {
     "uncache_aggressiveness": lambda: int(math.pow(10, 4.0 * random.random()) - 1.0),
     "use_full_merge_v1": lambda: random.randint(0, 1),
     "use_merge": lambda: random.randint(0, 1),
-     # use_trie_index must be the same across invocations so that all SSTs
-     # in a DB are opened with matching table options.
-     "use_trie_index": random.choice([0, 0, 0, 0, 0, 0, 0, 1]),
-     # use_udi_as_primary_index must be the same across invocations (like
-     # use_trie_index) so that SSTs written in primary mode can be read on
-     # reopen.
-     "use_udi_as_primary_index": random.choice([0, 0, 0, 1]),
+    # use_trie_index must be the same across invocations so that all SSTs
+    # in a DB are opened with matching table options.
+    "use_trie_index": random.choice([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
+    # use_udi_as_primary_index must be the same across invocations (like
+    # use_trie_index) so that SSTs written in primary mode can be read on
+    # reopen.
+    "use_udi_as_primary_index": random.choice([0, 0, 0, 1]),
     # use_put_entity_one_in has to be the same across invocations for verification to work, hence no lambda
     "use_put_entity_one_in": random.choice([0] * 7 + [1, 5, 10]),
     "use_attribute_group": lambda: random.randint(0, 1),
@@ -1061,12 +1061,9 @@ def finalize_and_sanitize(src_params):
         # Parallel compression is incompatible with UDI
         dest_params["compression_parallel_threads"] = 1
         if dest_params.get("use_udi_as_primary_index") == 1:
-            # Primary UDI skips the standard index builder (only a stub is
-            # written). Partitioned index (kTwoLevelIndexSearch) and
-            # partitioned filters require the standard PartitionedIndexBuilder
-            # to provide partition boundaries, which doesn't work with an
-            # empty stub. These combinations are rejected at builder creation
-            # time with InvalidArgument.
+            # Primary UDI mode: the standard index is still fully populated,
+            # but partitioned index (kTwoLevelIndexSearch) and partitioned
+            # filters are not compatible with the UDI wrapper layout.
             dest_params["index_type"] = random.choice([0, 0, 3])
             dest_params["partition_filters"] = 0
             # Backup/restore verification opens the restored DB by
@@ -1074,13 +1071,14 @@ def finalize_and_sanitize(src_params):
             # back (PrepareOptionsForRestoredDB). The user_defined_index_factory
             # is a shared_ptr that cannot survive this round-trip -- the
             # restored DB opens without UDI support. In secondary mode this
-            # is fine (reads fall through to the fully populated standard
-            # index). In primary mode the standard index is a stub with zero
-            # entries, so every read returns nothing.
+            # In primary mode, backup serializes Options to strings,
+            # losing the user_defined_index_factory (shared_ptr). The
+            # restored DB opens without UDI support and cannot route
+            # reads through the trie.
             dest_params["backup_one_in"] = 0
             # Secondary DB opens SSTs with default Options (not a copy of
-            # the primary's options), losing the UDI factory. Reads through
-            # the stub standard index return nothing.
+            # the primary's), losing the UDI factory. Without the factory,
+            # reads cannot be routed through the trie.
             dest_params["test_secondary"] = 0
     else:
         # use_udi_as_primary_index requires use_trie_index

--- a/utilities/trie_index/louds_trie.h
+++ b/utilities/trie_index/louds_trie.h
@@ -384,11 +384,11 @@ class LoudsTrie {
   // separator maps to multiple blocks.
   //
   // leaf_seqnos_[i]: seqno for the i-th leaf (BFS order).
-  //   For non-boundary leaves: stores
-  //   PackSequenceAndType(kMaxSequenceNumber, kValueTypeForSeek) -- the same
-  //   tag the standard index uses for non-boundary separators.
-  //   For boundary leaves: stores the actual tag
-  //   ((sequence_number << 8) | value_type).
+  //   For non-boundary leaves: stores 0 (sentinel meaning "no seqno
+  //   correction needed"), matching the standard index's user-key-only
+  //   comparison mode.
+  //   For same-user-key boundary and last-block leaves: stores the actual
+  //   tag ((sequence_number << 8) | value_type).
   //
   // leaf_block_counts_[i]: how many consecutive blocks share this separator.
   //   1 = no overflow (the common case). >1 = same-user-key run.

--- a/utilities/trie_index/trie_index_db_test.cc
+++ b/utilities/trie_index/trie_index_db_test.cc
@@ -2520,21 +2520,8 @@ TEST_P(TrieIndexDBTest, PrefixIterationWithDeletesAndMerges) {
             std::make_pair(std::string("aaa05"), std::string("v5,,m2")));
   ASSERT_EQ(std_result[3].first, "aaa06");
 
-  auto ReversePrefixScan = [&](const ReadOptions& ro) {
-    std::vector<std::string> result;
-    std::unique_ptr<Iterator> iter(db_->NewIterator(ro));
-    for (iter->SeekForPrev("aaa\xff"); iter->Valid(); iter->Prev()) {
-      if (iter->key().ToString().substr(0, 3) != "aaa") {
-        break;
-      }
-      result.push_back(iter->key().ToString());
-    }
-    EXPECT_OK(iter->status());
-    return result;
-  };
-
-  auto std_rev = ReversePrefixScan(StandardIndexReadOptions());
-  auto trie_rev = ReversePrefixScan(TrieIndexReadOptions());
+  auto std_rev = ReversePrefixScanKeys(StandardIndexReadOptions(), "aaa");
+  auto trie_rev = ReversePrefixScanKeys(TrieIndexReadOptions(), "aaa");
   ASSERT_EQ(std_rev, trie_rev);
   ASSERT_EQ(std_rev.size(), 4u);
 }
@@ -2561,23 +2548,10 @@ TEST_P(TrieIndexDBTest, PrefixIterationAfterCompaction) {
   ASSERT_OK(db_->Flush(FlushOptions()));
   ASSERT_OK(db_->CompactRange(CompactRangeOptions(), nullptr, nullptr));
 
-  auto PrefixScan = [&](const ReadOptions& ro, const std::string& prefix) {
-    std::vector<std::string> keys;
-    std::unique_ptr<Iterator> iter(db_->NewIterator(ro));
-    for (iter->Seek(prefix); iter->Valid(); iter->Next()) {
-      if (iter->key().ToString().substr(0, 3) != prefix) {
-        break;
-      }
-      keys.push_back(iter->key().ToString());
-    }
-    EXPECT_OK(iter->status());
-    return keys;
-  };
-
   for (const char* pfx : {"aaa", "bbb", "ccc"}) {
     SCOPED_TRACE(pfx);
-    ASSERT_EQ(PrefixScan(StandardIndexReadOptions(), pfx),
-              PrefixScan(TrieIndexReadOptions(), pfx));
+    ASSERT_EQ(PrefixScanKeys(StandardIndexReadOptions(), pfx),
+              PrefixScanKeys(TrieIndexReadOptions(), pfx));
   }
 }
 
@@ -2717,39 +2691,13 @@ TEST_P(TrieIndexDBTest, PrefixIterationWithDeleteRange) {
                              "aaa0005", "aaa0015"));
   ASSERT_OK(db_->Flush(FlushOptions()));
 
-  auto PrefixScan = [&](const ReadOptions& ro) {
-    std::vector<std::string> keys;
-    std::unique_ptr<Iterator> iter(db_->NewIterator(ro));
-    for (iter->Seek("aaa"); iter->Valid(); iter->Next()) {
-      if (iter->key().ToString().substr(0, 3) != "aaa") {
-        break;
-      }
-      keys.push_back(iter->key().ToString());
-    }
-    EXPECT_OK(iter->status());
-    return keys;
-  };
-
-  auto std_keys = PrefixScan(StandardIndexReadOptions());
-  auto trie_keys = PrefixScan(TrieIndexReadOptions());
+  auto std_keys = PrefixScanKeys(StandardIndexReadOptions(), "aaa");
+  auto trie_keys = PrefixScanKeys(TrieIndexReadOptions(), "aaa");
   ASSERT_EQ(std_keys, trie_keys);
   ASSERT_EQ(std_keys.size(), 10u);
 
-  auto ReversePrefixScan = [&](const ReadOptions& ro) {
-    std::vector<std::string> keys;
-    std::unique_ptr<Iterator> iter(db_->NewIterator(ro));
-    for (iter->SeekForPrev("aaa\xff"); iter->Valid(); iter->Prev()) {
-      if (iter->key().ToString().substr(0, 3) != "aaa") {
-        break;
-      }
-      keys.push_back(iter->key().ToString());
-    }
-    EXPECT_OK(iter->status());
-    return keys;
-  };
-
-  ASSERT_EQ(ReversePrefixScan(StandardIndexReadOptions()),
-            ReversePrefixScan(TrieIndexReadOptions()));
+  ASSERT_EQ(ReversePrefixScanKeys(StandardIndexReadOptions(), "aaa"),
+            ReversePrefixScanKeys(TrieIndexReadOptions(), "aaa"));
 }
 
 TEST_P(TrieIndexDBTest, PrefixIterationMemtablePlusSST) {
@@ -2785,21 +2733,8 @@ TEST_P(TrieIndexDBTest, PrefixIterationMemtablePlusSST) {
   ASSERT_EQ(std_result, trie_result);
   ASSERT_EQ(std_result.size(), 5u);
 
-  auto ReversePrefixScan = [&](const ReadOptions& ro) {
-    std::vector<std::string> result;
-    std::unique_ptr<Iterator> iter(db_->NewIterator(ro));
-    for (iter->SeekForPrev("aaa\xff"); iter->Valid(); iter->Prev()) {
-      if (iter->key().ToString().substr(0, 3) != "aaa") {
-        break;
-      }
-      result.push_back(iter->key().ToString());
-    }
-    EXPECT_OK(iter->status());
-    return result;
-  };
-
-  ASSERT_EQ(ReversePrefixScan(StandardIndexReadOptions()),
-            ReversePrefixScan(TrieIndexReadOptions()));
+  ASSERT_EQ(ReversePrefixScanKeys(StandardIndexReadOptions(), "aaa"),
+            ReversePrefixScanKeys(TrieIndexReadOptions(), "aaa"));
 }
 
 // ---------------------------------------------------------------------------
@@ -4060,13 +3995,7 @@ TEST_P(TrieIndexDBTest, ForwardThenReverseDirection) {
   // Interleave forward and reverse iteration to test direction switching.
   ASSERT_OK(OpenDB(/*block_size=*/64));
 
-  for (int i = 0; i < 50; i++) {
-    char key[16];
-    char val[16];
-    snprintf(key, sizeof(key), "key_%04d", i);
-    snprintf(val, sizeof(val), "val_%04d", i);
-    ASSERT_OK(db_->Put(WriteOptions(), key, val));
-  }
+  WriteSequentialKeys(0, 50);
   ASSERT_OK(db_->Flush(FlushOptions()));
 
   for (const auto& ro : {StandardIndexReadOptions(), TrieIndexReadOptions()}) {
@@ -4277,13 +4206,7 @@ TEST_P(TrieIndexDBTest, PrimaryUDIBackwardCompatibility) {
   // indexes, new config says "use UDI as primary for all reads."
   ASSERT_OK(OpenDBSecondary(/*block_size=*/128));
 
-  for (int i = 0; i < 50; i++) {
-    char key[16];
-    char val[16];
-    snprintf(key, sizeof(key), "key_%04d", i);
-    snprintf(val, sizeof(val), "val_%04d", i);
-    ASSERT_OK(db_->Put(WriteOptions(), key, val));
-  }
+  WriteSequentialKeys(0, 50);
   ASSERT_OK(db_->Flush(FlushOptions()));
 
   // Verify via trie (secondary mode -- explicit ReadOptions).
@@ -4322,26 +4245,14 @@ TEST_P(TrieIndexDBTest, MigrationFullPath) {
 
   // Step 1: Start without UDI. Write some data.
   ASSERT_OK(OpenDBWithoutUDI(/*block_size=*/128));
-  for (int i = 0; i < 30; i++) {
-    char key[16];
-    char val[16];
-    snprintf(key, sizeof(key), "key_%04d", i);
-    snprintf(val, sizeof(val), "val_%04d", i);
-    ASSERT_OK(db_->Put(WriteOptions(), key, val));
-  }
+  WriteSequentialKeys(0, 30);
   ASSERT_OK(db_->Flush(FlushOptions()));
   ASSERT_OK(db_->Close());
   db_.reset();
 
   // Step 2: Enable UDI as secondary. Write more data.
   ASSERT_OK(OpenDBSecondary(/*block_size=*/128));
-  for (int i = 30; i < 50; i++) {
-    char key[16];
-    char val[16];
-    snprintf(key, sizeof(key), "key_%04d", i);
-    snprintf(val, sizeof(val), "val_%04d", i);
-    ASSERT_OK(db_->Put(WriteOptions(), key, val));
-  }
+  WriteSequentialKeys(30, 50);
   ASSERT_OK(db_->Flush(FlushOptions()));
 
   // Verify reads work through both indexes for the new SST.
@@ -4414,13 +4325,7 @@ TEST_P(TrieIndexDBTest, RollbackFromPrimaryToSecondary) {
 
   // Start in primary mode. Write data.
   ASSERT_OK(OpenDBPrimary(/*block_size=*/128));
-  for (int i = 0; i < 30; i++) {
-    char key[16];
-    char val[16];
-    snprintf(key, sizeof(key), "key_%04d", i);
-    snprintf(val, sizeof(val), "val_%04d", i);
-    ASSERT_OK(db_->Put(WriteOptions(), key, val));
-  }
+  WriteSequentialKeys(0, 30);
   ASSERT_OK(db_->Flush(FlushOptions()));
 
   // Verify data is readable in primary mode.

--- a/utilities/trie_index/trie_index_db_test.cc
+++ b/utilities/trie_index/trie_index_db_test.cc
@@ -4412,6 +4412,60 @@ TEST_P(TrieIndexDBTest, RollbackFromPrimaryWithoutCompactFails) {
   // If open failed, that's also acceptable -- the SST is unusable without UDI.
 }
 
+TEST_P(TrieIndexDBTest, PrimaryModeTableProperties) {
+  // Verifies primary-mode-specific behavior: the udi_is_primary_index table
+  // property is set, and SSTs are readable in secondary mode (the standard
+  // index is a valid stub).
+  if (!IsPrimaryMode()) {
+    ROCKSDB_GTEST_SKIP("Only applicable in primary mode");
+    return;
+  }
+  ASSERT_OK(OpenDB());
+
+  ASSERT_OK(db_->Put(WriteOptions(), "key1", "val1"));
+  ASSERT_OK(db_->Put(WriteOptions(), "key2", "val2"));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+
+  // Verify the table property is set.
+  TablePropertiesCollection props;
+  ASSERT_OK(db_->GetPropertiesOfAllTables(&props));
+  ASSERT_FALSE(props.empty());
+  for (const auto& p : props) {
+    ASSERT_EQ(p.second->udi_is_primary_index, 1u);
+    // Standard index should report user-key-only (since we set
+    // separator_is_key_plus_seq()=false for primary).
+    ASSERT_EQ(p.second->index_key_is_user_key, 1u);
+  }
+
+  // Reads work with default ReadOptions (no table_index_factory needed).
+  ReadOptions ro;
+  std::string value;
+  ASSERT_OK(db_->Get(ro, "key1", &value));
+  ASSERT_EQ(value, "val1");
+}
+
+TEST_P(TrieIndexDBTest, EstimatedSizeNonZero) {
+  // Verifies that TrieIndexBuilder::EstimatedSize() returns non-zero after
+  // adding entries, ensuring compaction file sizing works.
+  if (!IsPrimaryMode()) {
+    ROCKSDB_GTEST_SKIP("Only applicable in primary mode");
+    return;
+  }
+  ASSERT_OK(OpenDB(/*block_size=*/128));
+
+  // Write enough data to produce multiple blocks.
+  WriteSequentialKeys(0, 200);
+  ASSERT_OK(db_->Flush(FlushOptions()));
+
+  // Check that the SST's index size is non-zero in table properties.
+  TablePropertiesCollection props;
+  ASSERT_OK(db_->GetPropertiesOfAllTables(&props));
+  ASSERT_FALSE(props.empty());
+  for (const auto& p : props) {
+    ASSERT_GT(p.second->index_size, 0u);
+  }
+}
+
 // Run all parameterized tests in both UDI modes:
 // - Secondary (false): UDI is secondary, reads require table_index_factory
 // - Primary (true): UDI is primary, all reads use the trie by default

--- a/utilities/trie_index/trie_index_db_test.cc
+++ b/utilities/trie_index/trie_index_db_test.cc
@@ -4466,6 +4466,273 @@ TEST_P(TrieIndexDBTest, EstimatedSizeNonZero) {
   }
 }
 
+// ============================================================================
+// Issue #14561 DB-level reproducer: NonBoundary separator seek regression
+// ============================================================================
+
+TEST_P(TrieIndexDBTest, NonBoundarySeparatorSeekRegression) {
+  // DB-level reproducer for GitHub issue #14561. When FindShortestSeparator
+  // cannot shorten the separator (e.g., "acc" -> "acd" stays "acc") and
+  // seqno encoding is active from an earlier same-user-key boundary, the
+  // post-seek correction must not advance past the correct block.
+  ASSERT_OK(OpenDB(/*block_size=*/64));
+
+  // Write a same-user-key pair to trigger seqno encoding.
+  ASSERT_OK(db_->Put(WriteOptions(), "aaa", std::string(100, 'a')));
+  ManagedSnapshot snap_for_encoding(db_.get());
+  ASSERT_OK(db_->Put(WriteOptions(), "aaa", std::string(100, 'A')));
+
+  // Write keys where shortening fails: "acc" -> "acd" stays "acc".
+  ASSERT_OK(db_->Put(WriteOptions(), "acc", std::string(100, 'c')));
+  ASSERT_OK(db_->Put(WriteOptions(), "acd", std::string(100, 'd')));
+  ManagedSnapshot read_snap(db_.get());
+  ASSERT_OK(db_->Flush(FlushOptions()));
+
+  // Seek for "acc" should find "acc" through both indexes.
+  for (auto base_ro : {StandardIndexReadOptions(), TrieIndexReadOptions()}) {
+    SCOPED_TRACE(base_ro.table_index_factory ? "trie" : "standard");
+    base_ro.snapshot = read_snap.snapshot();
+    std::unique_ptr<Iterator> iter(db_->NewIterator(base_ro));
+    iter->Seek("acc");
+    ASSERT_TRUE(iter->Valid()) << "Seek(acc) should be valid";
+    ASSERT_EQ(iter->key().ToString(), "acc");
+    ASSERT_OK(iter->status());
+  }
+
+  // Also verify point Get works.
+  for (auto base_ro : {StandardIndexReadOptions(), TrieIndexReadOptions()}) {
+    SCOPED_TRACE(base_ro.table_index_factory ? "trie" : "standard");
+    base_ro.snapshot = read_snap.snapshot();
+    std::string value;
+    ASSERT_OK(db_->Get(base_ro, "acc", &value));
+    ASSERT_EQ(value, std::string(100, 'c'));
+  }
+}
+
+// ============================================================================
+// Multi-CF iterator with trie index
+// ============================================================================
+
+TEST_P(TrieIndexDBTest, MultiCFCoalescingIterator) {
+  // Exercises the trie index through NewCoalescingIterator with multiple
+  // distinct column families. This covers the trie + use_multi_cf_iterator
+  // gap identified in issue #14560.
+  options_.merge_operator = MergeOperators::CreateStringAppendOperator();
+  options_.disable_auto_compactions = true;
+  options_.create_if_missing = true;
+  BlockBasedTableOptions table_options;
+  table_options.user_defined_index_factory = trie_factory_;
+  table_options.use_udi_as_primary_index = IsPrimaryMode();
+  options_.table_factory.reset(NewBlockBasedTableFactory(table_options));
+  last_options_ = options_;
+  ASSERT_OK(DB::Open(options_, dbname_, &db_));
+
+  // Create two additional CFs.
+  ColumnFamilyHandle* cf1 = nullptr;
+  ColumnFamilyHandle* cf2 = nullptr;
+  ASSERT_OK(db_->CreateColumnFamily(options_, "cf_one", &cf1));
+  ASSERT_OK(db_->CreateColumnFamily(options_, "cf_two", &cf2));
+
+  // Write different keys to each CF (with some overlap in key space).
+  for (int i = 0; i < 20; i++) {
+    char key[16];
+    snprintf(key, sizeof(key), "key_%04d", i);
+    ASSERT_OK(db_->Put(WriteOptions(), key, "default_" + std::to_string(i)));
+    ASSERT_OK(db_->Put(WriteOptions(), cf1, key, "cf1_" + std::to_string(i)));
+    ASSERT_OK(db_->Put(WriteOptions(), cf2, key, "cf2_" + std::to_string(i)));
+  }
+
+  // Flush all CFs.
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  ASSERT_OK(db_->Flush(FlushOptions(), cf1));
+  ASSERT_OK(db_->Flush(FlushOptions(), cf2));
+
+  // Create coalescing iterator across all CFs.
+  ReadOptions ro = TrieIndexReadOptions();
+  std::vector<ColumnFamilyHandle*> cfhs = {db_->DefaultColumnFamily(), cf1,
+                                           cf2};
+  std::unique_ptr<Iterator> coal_iter = db_->NewCoalescingIterator(ro, cfhs);
+  ASSERT_NE(coal_iter, nullptr);
+
+  // Forward scan: should see all 20 keys.
+  coal_iter->SeekToFirst();
+  int count = 0;
+  std::string prev_key;
+  while (coal_iter->Valid()) {
+    std::string key = coal_iter->key().ToString();
+    if (!prev_key.empty()) {
+      ASSERT_GT(key, prev_key) << "Keys must be in order";
+    }
+    prev_key = key;
+    count++;
+    coal_iter->Next();
+  }
+  ASSERT_OK(coal_iter->status());
+  ASSERT_EQ(count, 20);
+
+  // Reverse scan.
+  coal_iter->SeekToLast();
+  count = 0;
+  prev_key.clear();
+  while (coal_iter->Valid()) {
+    std::string key = coal_iter->key().ToString();
+    if (!prev_key.empty()) {
+      ASSERT_LT(key, prev_key) << "Reverse keys must be in order";
+    }
+    prev_key = key;
+    count++;
+    coal_iter->Prev();
+  }
+  ASSERT_OK(coal_iter->status());
+  ASSERT_EQ(count, 20);
+
+  // Seek to specific key.
+  coal_iter->Seek("key_0010");
+  ASSERT_TRUE(coal_iter->Valid());
+  ASSERT_EQ(coal_iter->key().ToString(), "key_0010");
+  ASSERT_OK(coal_iter->status());
+
+  delete cf1;
+  delete cf2;
+}
+
+// ============================================================================
+// GetEntity with explicit snapshot comparison
+// ============================================================================
+
+TEST_P(TrieIndexDBTest, GetEntityWithExplicitSnapshotComparison) {
+  // Compares GetEntity results between standard and trie indexes using an
+  // explicit snapshot. This covers the gap identified in issue #14562.
+  ASSERT_OK(OpenDB(/*block_size=*/128));
+
+  // Write PutEntity and regular Put.
+  WideColumns columns{
+      {kDefaultWideColumnName, "default_val_v1"},
+      {"col_a", "val_a_v1"},
+  };
+  ASSERT_OK(db_->PutEntity(WriteOptions(), db_->DefaultColumnFamily(),
+                           "entity_key", columns));
+  ASSERT_OK(db_->Put(WriteOptions(), "regular_key", "regular_val_v1"));
+
+  // Take an explicit snapshot.
+  const Snapshot* snap = db_->GetSnapshot();
+  ASSERT_NE(snap, nullptr);
+
+  // Overwrite both keys.
+  WideColumns columns_v2{
+      {kDefaultWideColumnName, "default_val_v2"},
+      {"col_a", "val_a_v2"},
+      {"col_b", "val_b_v2"},
+  };
+  ASSERT_OK(db_->PutEntity(WriteOptions(), db_->DefaultColumnFamily(),
+                           "entity_key", columns_v2));
+  ASSERT_OK(db_->Put(WriteOptions(), "regular_key", "regular_val_v2"));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+
+  // Read at snapshot through both indexes — should see v1 data.
+  for (auto base_ro : {StandardIndexReadOptions(), TrieIndexReadOptions()}) {
+    SCOPED_TRACE(base_ro.table_index_factory ? "trie" : "standard");
+    base_ro.snapshot = snap;
+
+    // GetEntity on PutEntity key at snapshot.
+    PinnableWideColumns result;
+    ASSERT_OK(db_->GetEntity(base_ro, db_->DefaultColumnFamily(), "entity_key",
+                             &result));
+    ASSERT_EQ(result.columns().size(), 2u);
+    ASSERT_EQ(result.columns()[0].value(), "default_val_v1");
+    ASSERT_EQ(result.columns()[1].value(), "val_a_v1");
+
+    // GetEntity on regular Put key at snapshot.
+    PinnableWideColumns result2;
+    ASSERT_OK(db_->GetEntity(base_ro, db_->DefaultColumnFamily(), "regular_key",
+                             &result2));
+    ASSERT_EQ(result2.columns().size(), 1u);
+    ASSERT_EQ(result2.columns()[0].value(), "regular_val_v1");
+
+    // GetEntity on nonexistent key.
+    PinnableWideColumns result3;
+    ASSERT_TRUE(db_->GetEntity(base_ro, db_->DefaultColumnFamily(),
+                               "no_such_key", &result3)
+                    .IsNotFound());
+  }
+
+  // Read without snapshot — should see v2 data.
+  for (auto base_ro : {StandardIndexReadOptions(), TrieIndexReadOptions()}) {
+    SCOPED_TRACE(base_ro.table_index_factory ? "trie" : "standard");
+
+    PinnableWideColumns result;
+    ASSERT_OK(db_->GetEntity(base_ro, db_->DefaultColumnFamily(), "entity_key",
+                             &result));
+    ASSERT_EQ(result.columns().size(), 3u);
+    ASSERT_EQ(result.columns()[0].value(), "default_val_v2");
+    ASSERT_EQ(result.columns()[1].value(), "val_a_v2");
+    ASSERT_EQ(result.columns()[2].value(), "val_b_v2");
+  }
+
+  db_->ReleaseSnapshot(snap);
+}
+
+// ============================================================================
+// Same-user-key across blocks with Prev (reverse iteration through overflow)
+// ============================================================================
+
+TEST_P(TrieIndexDBTest, ReverseIterationAcrossSameUserKeyBlocks) {
+  // Verifies that reverse iteration correctly traverses through same-user-key
+  // blocks (overflow runs). This exercises the PrevAndGetResult overflow
+  // decrement path at the DB level.
+  ASSERT_OK(OpenDB(/*block_size=*/64));
+
+  // Write multiple versions of the same key to force them across blocks.
+  std::vector<const Snapshot*> snapshots;
+  for (int i = 0; i < 8; i++) {
+    ASSERT_OK(
+        db_->Put(WriteOptions(), "same_key", "value_v" + std::to_string(i)));
+    snapshots.push_back(db_->GetSnapshot());
+  }
+  // Write surrounding keys.
+  ASSERT_OK(db_->Put(WriteOptions(), "aaa", "before"));
+  ASSERT_OK(db_->Put(WriteOptions(), "zzz", "after"));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+
+  // Forward scan at latest snapshot should see: aaa, same_key(v7), zzz.
+  std::vector<std::string> expected = {"aaa", "same_key", "zzz"};
+  VerifyScanBothIndexes(expected);
+
+  // At an older snapshot, same_key should have the older value.
+  for (auto base_ro : {StandardIndexReadOptions(), TrieIndexReadOptions()}) {
+    SCOPED_TRACE(base_ro.table_index_factory ? "trie" : "standard");
+    base_ro.snapshot = snapshots[3];
+    std::string value;
+    ASSERT_OK(db_->Get(base_ro, "same_key", &value));
+    ASSERT_EQ(value, "value_v3");
+  }
+
+  // Reverse scan through trie should produce zzz, same_key, aaa.
+  for (auto base_ro : {StandardIndexReadOptions(), TrieIndexReadOptions()}) {
+    SCOPED_TRACE(base_ro.table_index_factory ? "trie" : "standard");
+    std::unique_ptr<Iterator> iter(db_->NewIterator(base_ro));
+    iter->SeekToLast();
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_EQ(iter->key().ToString(), "zzz");
+
+    iter->Prev();
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_EQ(iter->key().ToString(), "same_key");
+
+    iter->Prev();
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_EQ(iter->key().ToString(), "aaa");
+
+    iter->Prev();
+    ASSERT_FALSE(iter->Valid());
+    ASSERT_OK(iter->status());
+  }
+
+  for (auto* snap : snapshots) {
+    db_->ReleaseSnapshot(snap);
+  }
+}
+
 // Run all parameterized tests in both UDI modes:
 // - Secondary (false): UDI is secondary, reads require table_index_factory
 // - Primary (true): UDI is primary, all reads use the trie by default

--- a/utilities/trie_index/trie_index_db_test.cc
+++ b/utilities/trie_index/trie_index_db_test.cc
@@ -4333,14 +4333,16 @@ TEST_P(TrieIndexDBTest, RollbackFromPrimaryToSecondary) {
   db_.reset();
 
   // Rollback step 1: Reopen as secondary (with UDI factory still set).
-  // The primary-mode SSTs are readable because udi_written_as_primary=true
-  // in the table property causes the reader to use the trie automatically.
+  // Primary UDI routing is purely config-driven, so reopening as secondary
+  // immediately reverts all reads to the standard index path. The trie is
+  // still accessible via explicit ReadOptions::table_index_factory.
   ASSERT_OK(OpenDBSecondary(/*block_size=*/128));
 
   // Verify the primary-mode SST is readable through both paths.
+  // Explicit trie read:
   ASSERT_OK(db_->Get(TrieIndexReadOptions(), "key_0015", &value));
   ASSERT_EQ(value, "val_0015");
-  // Default ReadOptions also works because udi_is_primary_=true for this SST.
+  // Standard index read (default ReadOptions, no table_index_factory):
   ASSERT_OK(db_->Get(ReadOptions(), "key_0015", &value));
   ASSERT_EQ(value, "val_0015");
 
@@ -4407,8 +4409,8 @@ TEST_P(TrieIndexDBTest, RollbackFromPrimaryWithoutCompactSucceeds) {
 
 TEST_P(TrieIndexDBTest, PrimaryModeTableProperties) {
   // Verifies primary-mode-specific behavior: the udi_is_primary_index table
-  // property is set, the standard index is fully populated (not a stub),
-  // and reads work without setting ReadOptions::table_index_factory.
+  // property is set (informational, does not affect read routing), and
+  // reads work without setting ReadOptions::table_index_factory.
   if (!IsPrimaryMode()) {
     ROCKSDB_GTEST_SKIP("Only applicable in primary mode");
     return;
@@ -4419,7 +4421,7 @@ TEST_P(TrieIndexDBTest, PrimaryModeTableProperties) {
   ASSERT_OK(db_->Put(WriteOptions(), "key2", "val2"));
   ASSERT_OK(db_->Flush(FlushOptions()));
 
-  // Verify the table property is set.
+  // Verify the informational table property is set.
   TablePropertiesCollection props;
   ASSERT_OK(db_->GetPropertiesOfAllTables(&props));
   ASSERT_FALSE(props.empty());

--- a/utilities/trie_index/trie_index_db_test.cc
+++ b/utilities/trie_index/trie_index_db_test.cc
@@ -146,8 +146,12 @@ MakeStressLikeSqfcFactory() {
   return factory;
 }
 
-class TrieIndexDBTest : public testing::Test {
+// Parameterized on UDI mode: false = secondary, true = primary.
+// All tests run in both modes to ensure full coverage.
+class TrieIndexDBTest : public testing::TestWithParam<bool> {
  protected:
+  bool IsPrimaryMode() const { return GetParam(); }
+
   void SetUp() override {
     trie_factory_ = std::make_shared<TrieIndexFactory>();
     dbname_ = test::PerThreadDBPath("trie_index_db_test");
@@ -162,13 +166,26 @@ class TrieIndexDBTest : public testing::Test {
     EXPECT_OK(DestroyDB(dbname_, last_options_));
   }
 
-  // Opens a DB with the trie UDI factory configured. Caller should set
-  // options_ fields before calling this. An optional block_size overrides
-  // the default to force more data blocks in the SST.
+  // Opens a DB using the parameterized UDI mode.
   Status OpenDB(int block_size = 0) {
+    return OpenDBImpl(block_size, IsPrimaryMode());
+  }
+
+  // Explicitly opens as primary -- used by the backward compatibility test.
+  Status OpenDBPrimary(int block_size = 0) {
+    return OpenDBImpl(block_size, /*udi_primary=*/true);
+  }
+
+  // Explicitly opens as secondary -- used by the backward compatibility test.
+  Status OpenDBSecondary(int block_size = 0) {
+    return OpenDBImpl(block_size, /*udi_primary=*/false);
+  }
+
+  Status OpenDBImpl(int block_size, bool udi_primary) {
     options_.create_if_missing = true;
     BlockBasedTableOptions table_options;
     table_options.user_defined_index_factory = trie_factory_;
+    table_options.use_udi_as_primary_index = udi_primary;
     if (block_size > 0) {
       table_options.block_size = block_size;
     }
@@ -177,14 +194,20 @@ class TrieIndexDBTest : public testing::Test {
     return DB::Open(options_, dbname_, &db_);
   }
 
-  // Returns a ReadOptions that routes reads through the standard binary
-  // search index (the default when table_index_factory is null).
+  // Returns a ReadOptions for the standard index. In secondary mode, this
+  // is a bare ReadOptions (no table_index_factory). In primary mode, this
+  // also returns a bare ReadOptions -- which routes through the trie anyway,
+  // making the dual-index comparison a trie-vs-trie sanity check.
   ReadOptions StandardIndexReadOptions() const { return ReadOptions(); }
 
-  // Returns a ReadOptions that routes reads through the trie UDI index.
+  // Returns a ReadOptions that routes reads through the trie. In primary
+  // mode, a bare ReadOptions already uses the trie, so table_index_factory
+  // is not set. In secondary mode, table_index_factory is set explicitly.
   ReadOptions TrieIndexReadOptions() const {
     ReadOptions ro;
-    ro.table_index_factory = trie_factory_.get();
+    if (!IsPrimaryMode()) {
+      ro.table_index_factory = trie_factory_.get();
+    }
     return ro;
   }
 
@@ -534,6 +557,49 @@ class TrieIndexDBTest : public testing::Test {
     }
   }
 
+  // Writes sequential keys "key_NNNN" with values "val_NNNN" for i in
+  // [start, end).
+  void WriteSequentialKeys(int start, int end) {
+    for (int i = start; i < end; i++) {
+      char key[16];
+      char val[16];
+      snprintf(key, sizeof(key), "key_%04d", i);
+      snprintf(val, sizeof(val), "val_%04d", i);
+      ASSERT_OK(db_->Put(WriteOptions(), key, val));
+    }
+  }
+
+  // Forward prefix scan: collect all keys with the given prefix.
+  std::vector<std::string> PrefixScanKeys(const ReadOptions& ro,
+                                          const std::string& prefix) {
+    std::vector<std::string> keys;
+    std::unique_ptr<Iterator> iter(db_->NewIterator(ro));
+    for (iter->Seek(prefix); iter->Valid(); iter->Next()) {
+      if (iter->key().ToString().substr(0, prefix.size()) != prefix) {
+        break;
+      }
+      keys.push_back(iter->key().ToString());
+    }
+    EXPECT_OK(iter->status());
+    return keys;
+  }
+
+  // Reverse prefix scan: collect all keys with the given prefix via
+  // SeekForPrev from prefix + "\xff".
+  std::vector<std::string> ReversePrefixScanKeys(const ReadOptions& ro,
+                                                 const std::string& prefix) {
+    std::vector<std::string> keys;
+    std::unique_ptr<Iterator> iter(db_->NewIterator(ro));
+    for (iter->SeekForPrev(prefix + "\xff"); iter->Valid(); iter->Prev()) {
+      if (iter->key().ToString().substr(0, prefix.size()) != prefix) {
+        break;
+      }
+      keys.push_back(iter->key().ToString());
+    }
+    EXPECT_OK(iter->status());
+    return keys;
+  }
+
   std::shared_ptr<TrieIndexFactory> trie_factory_;
   std::string dbname_;
   Options options_;
@@ -545,7 +611,7 @@ class TrieIndexDBTest : public testing::Test {
 // Flush tests
 // ============================================================================
 
-TEST_F(TrieIndexDBTest, FlushWithAllOperationTypes) {
+TEST_P(TrieIndexDBTest, FlushWithAllOperationTypes) {
   // Write every supported operation type via the DB API, flush, and verify
   // reads return correct results through both the standard binary search index
   // and the trie UDI. This exercises the full path from memtable through
@@ -559,7 +625,7 @@ TEST_F(TrieIndexDBTest, FlushWithAllOperationTypes) {
   ASSERT_OK(db_->Put(WriteOptions(), "key_01_put", "val_put"));
   // kTypeMerge
   ASSERT_OK(db_->Merge(WriteOptions(), "key_02_merge", "val_merge"));
-  // kTypeDeletion (bare tombstone — no prior value for this key)
+  // kTypeDeletion (bare tombstone -- no prior value for this key)
   ASSERT_OK(db_->Delete(WriteOptions(), "key_03_del"));
   // kTypeSingleDeletion (preceded by a Put; both cancel out with no snapshot)
   ASSERT_OK(db_->Put(WriteOptions(), "key_04_sdel", "val_sdel"));
@@ -574,12 +640,12 @@ TEST_F(TrieIndexDBTest, FlushWithAllOperationTypes) {
   ASSERT_OK(db_->Flush(FlushOptions()));
 
   // Scan via both indexes. Expected visible keys after flush:
-  //   key_01_put    — Put (visible)
-  //   key_02_merge  — Merge single operand (visible)
-  //   key_03_del    — bare Delete tombstone (hidden by DBIter)
-  //   key_04_sdel   — Put + SingleDelete cancel out (hidden)
-  //   key_05_entity — PutEntity (visible)
-  //   key_06_put    — Put (visible)
+  //   key_01_put    -- Put (visible)
+  //   key_02_merge  -- Merge single operand (visible)
+  //   key_03_del    -- bare Delete tombstone (hidden by DBIter)
+  //   key_04_sdel   -- Put + SingleDelete cancel out (hidden)
+  //   key_05_entity -- PutEntity (visible)
+  //   key_06_put    -- Put (visible)
   {
     std::vector<std::string> expected = {"key_01_put", "key_02_merge",
                                          "key_05_entity", "key_06_put"};
@@ -596,7 +662,7 @@ TEST_F(TrieIndexDBTest, FlushWithAllOperationTypes) {
   ASSERT_NO_FATAL_FAILURE(VerifyGetBothIndexes("key_06_put", "val_put2"));
 }
 
-TEST_F(TrieIndexDBTest, TimedPutFlush) {
+TEST_P(TrieIndexDBTest, TimedPutFlush) {
   // TimedPut produces kTypeValuePreferredSeqno entries during flush when
   // preclude_last_level_data_seconds > 0. The UDI wrapper strips the packed
   // preferred seqno suffix via ParsePackedValueForValue() before forwarding
@@ -628,12 +694,12 @@ TEST_F(TrieIndexDBTest, TimedPutFlush) {
 
   ASSERT_OK(db_->Flush(FlushOptions()));
 
-  // Point lookups via both indexes — the packed seqno must be transparent.
+  // Point lookups via both indexes -- the packed seqno must be transparent.
   ASSERT_NO_FATAL_FAILURE(VerifyGetBothIndexes("key_01_put", "val_put"));
   ASSERT_NO_FATAL_FAILURE(VerifyGetBothIndexes("key_02_timed", "val_timed"));
   ASSERT_NO_FATAL_FAILURE(VerifyGetBothIndexes("key_03_merge", "val_merge"));
 
-  // Scan via both indexes — all three keys visible in order.
+  // Scan via both indexes -- all three keys visible in order.
   {
     std::vector<std::pair<std::string, std::string>> expected = {
         {"key_01_put", "val_put"},
@@ -647,7 +713,7 @@ TEST_F(TrieIndexDBTest, TimedPutFlush) {
 // Compaction tests
 // ============================================================================
 
-TEST_F(TrieIndexDBTest, CompactionWithMixedOpsAndSnapshots) {
+TEST_P(TrieIndexDBTest, CompactionWithMixedOpsAndSnapshots) {
   // Multiple flushes followed by compaction with a snapshot held. The snapshot
   // forces compaction to preserve multiple versions of the same user key,
   // exercising the UDI builder's handling of duplicate user keys with different
@@ -698,7 +764,7 @@ TEST_F(TrieIndexDBTest, CompactionWithMixedOpsAndSnapshots) {
   db_->ReleaseSnapshot(snap);
 }
 
-TEST_F(TrieIndexDBTest, CompactionWithAllOperationTypes) {
+TEST_P(TrieIndexDBTest, CompactionWithAllOperationTypes) {
   // Exercises all operation types (Put, Delete, Merge, SingleDelete, PutEntity)
   // across two flushes with a snapshot, then compacts. Verified through both
   // indexes. This ensures the UDI builder handles the full range of value types
@@ -768,7 +834,7 @@ TEST_F(TrieIndexDBTest, CompactionWithAllOperationTypes) {
   db_->ReleaseSnapshot(snap);
 }
 
-TEST_F(TrieIndexDBTest, TimedPutCompaction) {
+TEST_P(TrieIndexDBTest, TimedPutCompaction) {
   // Verifies that kTypeValuePreferredSeqno entries survive compaction and the
   // UDI builder correctly strips the packed seqno during compaction output.
   // Verified through both indexes.
@@ -822,7 +888,7 @@ TEST_F(TrieIndexDBTest, TimedPutCompaction) {
   db_->ReleaseSnapshot(snap);
 }
 
-TEST_F(TrieIndexDBTest, CrossFlushSingleDelete) {
+TEST_P(TrieIndexDBTest, CrossFlushSingleDelete) {
   // Verifies that a SingleDelete in a later SST correctly cancels a Put from
   // an earlier SST after compaction with the trie UDI active. Verified through
   // both indexes.
@@ -860,7 +926,7 @@ TEST_F(TrieIndexDBTest, CrossFlushSingleDelete) {
 // Iteration tests
 // ============================================================================
 
-TEST_F(TrieIndexDBTest, ReverseIteration) {
+TEST_P(TrieIndexDBTest, ReverseIteration) {
   // Verifies that reverse iteration (SeekToLast, Prev, SeekForPrev) works
   // correctly with mixed operation types through BOTH the standard binary
   // search index and the trie UDI index.
@@ -907,7 +973,7 @@ TEST_F(TrieIndexDBTest, ReverseIteration) {
   ASSERT_NO_FATAL_FAILURE(
       VerifySeekForPrevBothIndexes("key_04", "key_04", "v4"));
 
-  // SeekForPrev to a deleted key — should land on key_02.
+  // SeekForPrev to a deleted key -- should land on key_02.
   ASSERT_NO_FATAL_FAILURE(
       VerifySeekForPrevBothIndexes("key_03", "key_02", "m1"));
 
@@ -915,10 +981,10 @@ TEST_F(TrieIndexDBTest, ReverseIteration) {
   ASSERT_NO_FATAL_FAILURE(
       VerifySeekForPrevBothIndexes("key_04_5", "key_04", "v4"));
 
-  // SeekForPrev before all keys — should be invalid.
+  // SeekForPrev before all keys -- should be invalid.
   ASSERT_NO_FATAL_FAILURE(VerifySeekForPrevNotFoundBothIndexes("key_00"));
 
-  // Prev from a Seek position in the middle of the range — both indexes.
+  // Prev from a Seek position in the middle of the range -- both indexes.
   for (const auto& ro : {StandardIndexReadOptions(), TrieIndexReadOptions()}) {
     SCOPED_TRACE(ro.table_index_factory ? "trie index" : "standard index");
     std::unique_ptr<Iterator> iter(db_->NewIterator(ro));
@@ -948,7 +1014,7 @@ TEST_F(TrieIndexDBTest, ReverseIteration) {
 // DeleteRange test
 // ============================================================================
 
-TEST_F(TrieIndexDBTest, DeleteRangeWithTrieUDI) {
+TEST_P(TrieIndexDBTest, DeleteRangeWithTrieUDI) {
   // Verifies that DeleteRange (kTypeRangeDeletion) works correctly alongside
   // the trie UDI. Range deletions go to a separate range_del_block (not
   // through OnKeyAdded), but we verify that reads correctly filter out
@@ -965,7 +1031,7 @@ TEST_F(TrieIndexDBTest, DeleteRangeWithTrieUDI) {
     ASSERT_OK(db_->Put(WriteOptions(), key_buf, val_buf));
   }
 
-  // DeleteRange [key_04, key_08) — deletes key_04 through key_07.
+  // DeleteRange [key_04, key_08) -- deletes key_04 through key_07.
   ASSERT_OK(db_->DeleteRange(WriteOptions(), db_->DefaultColumnFamily(),
                              "key_04", "key_08"));
 
@@ -991,7 +1057,7 @@ TEST_F(TrieIndexDBTest, DeleteRangeWithTrieUDI) {
 // DB reopen test
 // ============================================================================
 
-TEST_F(TrieIndexDBTest, ReopenWithMixedOperationTypes) {
+TEST_P(TrieIndexDBTest, ReopenWithMixedOperationTypes) {
   // Writes all operation types, flushes, closes the DB, reopens, and verifies
   // all data reads correctly from cold SST files through both indexes. This
   // exercises the read path on a freshly opened DB where no memtable data
@@ -1038,7 +1104,7 @@ TEST_F(TrieIndexDBTest, ReopenWithMixedOperationTypes) {
 // Ingest external file test
 // ============================================================================
 
-TEST_F(TrieIndexDBTest, IngestExternalFileWithTrieUDI) {
+TEST_P(TrieIndexDBTest, IngestExternalFileWithTrieUDI) {
   // Creates an SST with SstFileWriter using the trie UDI, then ingests it
   // into a live DB that also has trie UDI configured. Verifies that both the
   // existing DB data and the ingested data are correctly readable through both
@@ -1074,11 +1140,11 @@ TEST_F(TrieIndexDBTest, IngestExternalFileWithTrieUDI) {
   IngestExternalFileOptions ingest_opts;
   ASSERT_OK(db_->IngestExternalFile({sst_path}, ingest_opts));
 
-  // Point lookups via both indexes — combined DB + ingested data.
+  // Point lookups via both indexes -- combined DB + ingested data.
   ASSERT_NO_FATAL_FAILURE(VerifyGetBothIndexes("key_01", "db_val1"));
   ASSERT_NO_FATAL_FAILURE(VerifyGetBothIndexes("key_02", "ingest_val2"));
   ASSERT_NO_FATAL_FAILURE(VerifyGetBothIndexes("key_03", "ingest_merge3"));
-  // key_04: ingested Delete tombstone, no prior value — NotFound.
+  // key_04: ingested Delete tombstone, no prior value -- NotFound.
   ASSERT_NO_FATAL_FAILURE(VerifyGetNotFoundBothIndexes("key_04"));
   ASSERT_NO_FATAL_FAILURE(VerifyGetBothIndexes("key_05", "db_val5"));
   ASSERT_NO_FATAL_FAILURE(VerifyGetBothIndexes("key_06", "ingest_val6"));
@@ -1095,7 +1161,7 @@ TEST_F(TrieIndexDBTest, IngestExternalFileWithTrieUDI) {
 // WriteBatch test
 // ============================================================================
 
-TEST_F(TrieIndexDBTest, WriteBatchWithMixedOperations) {
+TEST_P(TrieIndexDBTest, WriteBatchWithMixedOperations) {
   // Verifies that a single WriteBatch containing multiple operation types
   // (Put, Delete, Merge, SingleDelete, PutEntity) works correctly with the
   // trie UDI. Verified through both indexes. Real-world workloads typically
@@ -1113,7 +1179,7 @@ TEST_F(TrieIndexDBTest, WriteBatchWithMixedOperations) {
   ASSERT_OK(wb.Put(db_->DefaultColumnFamily(), "key_01_put", "batch_put"));
   ASSERT_OK(wb.Delete(db_->DefaultColumnFamily(), "key_02_del"));
   ASSERT_OK(wb.Merge(db_->DefaultColumnFamily(), "key_03_merge", "batch_m"));
-  // Put + SingleDelete within the same batch — they cancel out.
+  // Put + SingleDelete within the same batch -- they cancel out.
   ASSERT_OK(wb.Put(db_->DefaultColumnFamily(), "key_04_sd", "sd_target"));
   ASSERT_OK(wb.SingleDelete(db_->DefaultColumnFamily(), "key_04_sd"));
   ASSERT_OK(wb.PutEntity(db_->DefaultColumnFamily(), "key_05_entity",
@@ -1144,7 +1210,7 @@ TEST_F(TrieIndexDBTest, WriteBatchWithMixedOperations) {
 // Large-scale test
 // ============================================================================
 
-TEST_F(TrieIndexDBTest, LargeMixedOperationsAcrossBlocks) {
+TEST_P(TrieIndexDBTest, LargeMixedOperationsAcrossBlocks) {
   // Large-scale test with many keys of different operation types and a small
   // block size. This stresses block boundary handling in the trie UDI across
   // Put, Delete, Merge, SingleDelete, and PutEntity entries. Verified through
@@ -1178,7 +1244,7 @@ TEST_F(TrieIndexDBTest, LargeMixedOperationsAcrossBlocks) {
       expected_visible.push_back(key);
     } else if (type <= 5) {
       ASSERT_OK(db_->Delete(WriteOptions(), key));
-      // Bare tombstone — not visible.
+      // Bare tombstone -- not visible.
     } else if (type <= 7) {
       char val_buf[32];
       snprintf(val_buf, sizeof(val_buf), "merge_%06d", i);
@@ -1187,7 +1253,7 @@ TEST_F(TrieIndexDBTest, LargeMixedOperationsAcrossBlocks) {
     } else if (type == 8) {
       ASSERT_OK(db_->Put(WriteOptions(), key, "to_be_deleted"));
       ASSERT_OK(db_->SingleDelete(WriteOptions(), key));
-      // Put + SingleDelete cancel — not visible.
+      // Put + SingleDelete cancel -- not visible.
     } else {
       ASSERT_OK(db_->PutEntity(WriteOptions(), db_->DefaultColumnFamily(), key,
                                WideColumns{{"", "entity_val"}}));
@@ -1197,7 +1263,7 @@ TEST_F(TrieIndexDBTest, LargeMixedOperationsAcrossBlocks) {
 
   ASSERT_OK(db_->Flush(FlushOptions()));
 
-  // Scan via both indexes — verify exactly the expected visible keys.
+  // Scan via both indexes -- verify exactly the expected visible keys.
   ASSERT_NO_FATAL_FAILURE(VerifyScanBothIndexes(expected_visible));
 
   // Spot-check: Seek to every 10th visible key via both indexes.
@@ -1217,7 +1283,7 @@ TEST_F(TrieIndexDBTest, LargeMixedOperationsAcrossBlocks) {
 // Seqno side-table tests (same user key spanning data block boundaries)
 // ============================================================================
 
-TEST_F(TrieIndexDBTest, SameUserKeyAcrossBlockBoundaries) {
+TEST_P(TrieIndexDBTest, SameUserKeyAcrossBlockBoundaries) {
   // Forces the same user key to appear in multiple data blocks by writing many
   // versions with snapshots held to prevent garbage collection, using a tiny
   // block_size. This exercises the trie's seqno side-table: the trie stores
@@ -1266,7 +1332,7 @@ TEST_F(TrieIndexDBTest, SameUserKeyAcrossBlockBoundaries) {
     ASSERT_NO_FATAL_FAILURE(VerifyScanBothIndexes(snaps[i], expected));
   }
 
-  // Seek to the key through the trie index with each snapshot — the trie's
+  // Seek to the key through the trie index with each snapshot -- the trie's
   // post-seek correction must advance through overflow blocks to find the
   // correct version for each seqno.
   for (int i = 0; i < kNumVersions; i++) {
@@ -1281,7 +1347,7 @@ TEST_F(TrieIndexDBTest, SameUserKeyAcrossBlockBoundaries) {
   }
 }
 
-TEST_F(TrieIndexDBTest, SameUserKeyPutThenDeleteAcrossBlocks) {
+TEST_P(TrieIndexDBTest, SameUserKeyPutThenDeleteAcrossBlocks) {
   // Same user key with a Put followed by a Delete, where both entries land in
   // different data blocks. A snapshot pins the Put version. After compaction,
   // the current view shows NotFound while the snapshot view shows the Put.
@@ -1323,7 +1389,7 @@ TEST_F(TrieIndexDBTest, SameUserKeyPutThenDeleteAcrossBlocks) {
   db_->ReleaseSnapshot(snap);
 }
 
-TEST_F(TrieIndexDBTest, SameUserKeyManyVersionsSeekCorrectness) {
+TEST_P(TrieIndexDBTest, SameUserKeyManyVersionsSeekCorrectness) {
   // Writes many versions of three different keys (with snapshots), using a
   // tiny block_size to force same-user-key block boundaries. Verifies that
   // Seek + Get through the trie index returns the correct version for each
@@ -1374,7 +1440,7 @@ TEST_F(TrieIndexDBTest, SameUserKeyManyVersionsSeekCorrectness) {
   }
 }
 
-TEST_F(TrieIndexDBTest,
+TEST_P(TrieIndexDBTest,
        AutoPrefixBoundsSnapshotIteratorMatchesStandardIndexWithHiddenVersions) {
   options_.compression = kNoCompression;
   options_.disable_auto_compactions = true;
@@ -1447,7 +1513,7 @@ TEST_F(TrieIndexDBTest,
   db_->ReleaseSnapshot(snapshot);
 }
 
-TEST_F(TrieIndexDBTest, AutoRefreshSnapshotNextAcrossSameUserKeyBoundaries) {
+TEST_P(TrieIndexDBTest, AutoRefreshSnapshotNextAcrossSameUserKeyBoundaries) {
   options_.create_if_missing = true;
   options_.disable_auto_compactions = true;
 
@@ -1539,7 +1605,7 @@ TEST_F(TrieIndexDBTest, AutoRefreshSnapshotNextAcrossSameUserKeyBoundaries) {
   }
 }
 
-TEST_F(TrieIndexDBTest,
+TEST_P(TrieIndexDBTest,
        AutoRefreshSnapshotNextAfterCompactionAcrossSameUserKeyBoundaries) {
   options_.create_if_missing = true;
   options_.disable_auto_compactions = true;
@@ -1626,7 +1692,7 @@ TEST_F(TrieIndexDBTest,
   }
 }
 
-TEST_F(TrieIndexDBTest,
+TEST_P(TrieIndexDBTest,
        AutoRefreshSnapshotStressLikeSingleCfCoalescingIterator) {
   auto sqfc_factory = MakeStressLikeSqfcFactory();
 
@@ -1740,7 +1806,7 @@ TEST_F(TrieIndexDBTest,
 // MultiGet test
 // ============================================================================
 
-TEST_F(TrieIndexDBTest, MultiGetWithTrieUDI) {
+TEST_P(TrieIndexDBTest, MultiGetWithTrieUDI) {
   // Verifies that the batched MultiGet API works correctly with the trie UDI.
   // MultiGet is a separate code path from single Get and uses batched block
   // lookups, so it needs dedicated testing.
@@ -1789,7 +1855,7 @@ TEST_F(TrieIndexDBTest, MultiGetWithTrieUDI) {
 // WAL replay / crash recovery test
 // ============================================================================
 
-TEST_F(TrieIndexDBTest, WALReplayRecovery) {
+TEST_P(TrieIndexDBTest, WALReplayRecovery) {
   // Writes data without flushing, then closes and reopens the DB. The data
   // must be recovered from the WAL and then flushed. This tests that the trie
   // UDI builder handles entries replayed from the WAL correctly.
@@ -1798,14 +1864,14 @@ TEST_F(TrieIndexDBTest, WALReplayRecovery) {
   // WAL is enabled by default (WriteOptions::disableWAL = false).
   ASSERT_OK(OpenDB());
 
-  // Write data — do NOT flush. Data lives only in the WAL + memtable.
+  // Write data -- do NOT flush. Data lives only in the WAL + memtable.
   ASSERT_OK(db_->Put(WriteOptions(), "wal_key_01", "wal_val_01"));
   ASSERT_OK(db_->Merge(WriteOptions(), "wal_key_02", "wal_merge"));
   ASSERT_OK(db_->Put(WriteOptions(), "wal_key_03", "wal_val_03"));
   ASSERT_OK(db_->Delete(WriteOptions(), "wal_key_03"));
   ASSERT_OK(db_->Put(WriteOptions(), "wal_key_04", "wal_val_04"));
 
-  // Close and reopen — triggers WAL replay.
+  // Close and reopen -- triggers WAL replay.
   ASSERT_OK(db_->Close());
   db_.reset();
   ASSERT_OK(OpenDB());
@@ -1834,7 +1900,7 @@ TEST_F(TrieIndexDBTest, WALReplayRecovery) {
 // Multiple column families test
 // ============================================================================
 
-TEST_F(TrieIndexDBTest, MultipleColumnFamilies) {
+TEST_P(TrieIndexDBTest, MultipleColumnFamilies) {
   // Opens a DB with multiple column families, each using the trie UDI. Writes
   // different data to each CF, flushes, and verifies reads through both indexes
   // for each CF. This tests that the UDI builder/reader are correctly isolated
@@ -1975,7 +2041,7 @@ TEST_F(TrieIndexDBTest, MultipleColumnFamilies) {
 //
 // We run with both the standard index and the trie index and compare.
 // ---------------------------------------------------------------------------
-TEST_F(TrieIndexDBTest, BatchedPrefixScan) {
+TEST_P(TrieIndexDBTest, BatchedPrefixScan) {
   // Small block size to force many data blocks (and thus many trie entries).
   ASSERT_OK(OpenDB(/*block_size=*/256));
 
@@ -2021,7 +2087,7 @@ TEST_F(TrieIndexDBTest, BatchedPrefixScan) {
 
 // Same as above but with multiple flushes, compaction, and a DB reopen
 // in between to simulate the crash-recovery path.
-TEST_F(TrieIndexDBTest, BatchedPrefixScanAfterReopen) {
+TEST_P(TrieIndexDBTest, BatchedPrefixScanAfterReopen) {
   ASSERT_OK(OpenDB(/*block_size=*/256));
 
   const int kNumBatches = 100;
@@ -2069,7 +2135,7 @@ TEST_F(TrieIndexDBTest, BatchedPrefixScanAfterReopen) {
 
 // Test with overwrites: multiple writes to the same key body, ensuring
 // the latest value is consistent across all prefixes.
-TEST_F(TrieIndexDBTest, BatchedPrefixScanWithOverwrites) {
+TEST_P(TrieIndexDBTest, BatchedPrefixScanWithOverwrites) {
   ASSERT_OK(OpenDB(/*block_size=*/256));
 
   const int kNumKeys = 50;
@@ -2116,7 +2182,7 @@ TEST_F(TrieIndexDBTest, BatchedPrefixScanWithOverwrites) {
 // Stress-like test: write + delete + rewrite many keys, flush between rounds,
 // then verify prefix scan consistency. Simulates the crash test pattern that
 // triggered failures.
-TEST_F(TrieIndexDBTest, BatchedPrefixScanStressLike) {
+TEST_P(TrieIndexDBTest, BatchedPrefixScanStressLike) {
   ASSERT_OK(OpenDB(/*block_size=*/4096));
 
   const int kMaxKey = 10000;
@@ -2174,7 +2240,7 @@ TEST_F(TrieIndexDBTest, BatchedPrefixScanStressLike) {
   }
 }
 
-TEST_F(TrieIndexDBTest, PrefixIterationWithTrieIndex) {
+TEST_P(TrieIndexDBTest, PrefixIterationWithTrieIndex) {
   // Verifies that prefix iteration (total_order_seek=false with a prefix
   // extractor) returns identical results through the trie and standard indexes.
   options_.prefix_extractor.reset(NewFixedPrefixTransform(4));
@@ -2273,7 +2339,7 @@ TEST_F(TrieIndexDBTest, PrefixIterationWithTrieIndex) {
   }
 }
 
-TEST_F(TrieIndexDBTest, PrefixIterationWithUpperBound) {
+TEST_P(TrieIndexDBTest, PrefixIterationWithUpperBound) {
   options_.prefix_extractor.reset(NewFixedPrefixTransform(4));
   options_.disable_auto_compactions = true;
   ASSERT_OK(OpenDB(/*block_size=*/128));
@@ -2337,7 +2403,7 @@ TEST_F(TrieIndexDBTest, PrefixIterationWithUpperBound) {
   }
 }
 
-TEST_F(TrieIndexDBTest, PrefixIterationDirectionSwitchStress) {
+TEST_P(TrieIndexDBTest, PrefixIterationDirectionSwitchStress) {
   options_.prefix_extractor.reset(NewFixedPrefixTransform(3));
   options_.disable_auto_compactions = true;
   ASSERT_OK(OpenDB(/*block_size=*/64));
@@ -2409,7 +2475,7 @@ TEST_F(TrieIndexDBTest, PrefixIterationDirectionSwitchStress) {
   }
 }
 
-TEST_F(TrieIndexDBTest, PrefixIterationWithDeletesAndMerges) {
+TEST_P(TrieIndexDBTest, PrefixIterationWithDeletesAndMerges) {
   options_.prefix_extractor.reset(NewFixedPrefixTransform(3));
   options_.merge_operator = MergeOperators::CreateStringAppendOperator();
   options_.disable_auto_compactions = true;
@@ -2473,7 +2539,7 @@ TEST_F(TrieIndexDBTest, PrefixIterationWithDeletesAndMerges) {
   ASSERT_EQ(std_rev.size(), 4u);
 }
 
-TEST_F(TrieIndexDBTest, PrefixIterationAfterCompaction) {
+TEST_P(TrieIndexDBTest, PrefixIterationAfterCompaction) {
   options_.prefix_extractor.reset(NewFixedPrefixTransform(3));
   ASSERT_OK(OpenDB(/*block_size=*/128));
 
@@ -2515,7 +2581,7 @@ TEST_F(TrieIndexDBTest, PrefixIterationAfterCompaction) {
   }
 }
 
-TEST_F(TrieIndexDBTest, PrefixIterationWithSnapshots) {
+TEST_P(TrieIndexDBTest, PrefixIterationWithSnapshots) {
   options_.prefix_extractor.reset(NewFixedPrefixTransform(3));
   options_.disable_auto_compactions = true;
   ASSERT_OK(OpenDB(/*block_size=*/128));
@@ -2564,7 +2630,7 @@ TEST_F(TrieIndexDBTest, PrefixIterationWithSnapshots) {
   db_->ReleaseSnapshot(snap2);
 }
 
-TEST_F(TrieIndexDBTest, PrefixIterationEmptyPrefix) {
+TEST_P(TrieIndexDBTest, PrefixIterationEmptyPrefix) {
   options_.prefix_extractor.reset(NewFixedPrefixTransform(3));
   ASSERT_OK(OpenDB());
 
@@ -2588,7 +2654,7 @@ TEST_F(TrieIndexDBTest, PrefixIterationEmptyPrefix) {
   }
 }
 
-TEST_F(TrieIndexDBTest, PrefixIterationWithLowerBound) {
+TEST_P(TrieIndexDBTest, PrefixIterationWithLowerBound) {
   options_.prefix_extractor.reset(NewFixedPrefixTransform(3));
   options_.disable_auto_compactions = true;
   ASSERT_OK(OpenDB(/*block_size=*/128));
@@ -2633,7 +2699,7 @@ TEST_F(TrieIndexDBTest, PrefixIterationWithLowerBound) {
   }
 }
 
-TEST_F(TrieIndexDBTest, PrefixIterationWithDeleteRange) {
+TEST_P(TrieIndexDBTest, PrefixIterationWithDeleteRange) {
   options_.prefix_extractor.reset(NewFixedPrefixTransform(3));
   options_.disable_auto_compactions = true;
   ASSERT_OK(OpenDB(/*block_size=*/128));
@@ -2686,7 +2752,7 @@ TEST_F(TrieIndexDBTest, PrefixIterationWithDeleteRange) {
             ReversePrefixScan(TrieIndexReadOptions()));
 }
 
-TEST_F(TrieIndexDBTest, PrefixIterationMemtablePlusSST) {
+TEST_P(TrieIndexDBTest, PrefixIterationMemtablePlusSST) {
   options_.prefix_extractor.reset(NewFixedPrefixTransform(3));
   options_.disable_auto_compactions = true;
   ASSERT_OK(OpenDB(/*block_size=*/128));
@@ -2749,10 +2815,10 @@ TEST_F(TrieIndexDBTest, PrefixIterationMemtablePlusSST) {
 // iterators to desynchronize.
 //
 // The standard ShortenedIndexBuilder (with default kShortenSeparators mode)
-// does NOT call FindShortSuccessor on the last block — it uses the last key
+// does NOT call FindShortSuccessor on the last block -- it uses the last key
 // as-is. The fix makes the trie builder match this behavior.
 // ---------------------------------------------------------------------------
-TEST_F(TrieIndexDBTest, LastBlockSeparatorNotShortened) {
+TEST_P(TrieIndexDBTest, LastBlockSeparatorNotShortened) {
   // Use a small block size so each key lands in its own block.
   ASSERT_OK(OpenDB(/*block_size=*/32));
 
@@ -2799,7 +2865,7 @@ TEST_F(TrieIndexDBTest, LastBlockSeparatorNotShortened) {
 
 // Variant: tests that when deletes remove the last key, seeking past the last
 // remaining key correctly returns "not found" with both indexes.
-TEST_F(TrieIndexDBTest, LastBlockSeparatorWithDeletes) {
+TEST_P(TrieIndexDBTest, LastBlockSeparatorWithDeletes) {
   ASSERT_OK(OpenDB(/*block_size=*/32));
 
   // Write and flush initial data.
@@ -2818,7 +2884,7 @@ TEST_F(TrieIndexDBTest, LastBlockSeparatorWithDeletes) {
     SCOPED_TRACE(ro.table_index_factory ? "trie index" : "standard index");
     std::unique_ptr<Iterator> iter(db_->NewIterator(ro));
 
-    // Seek to the deleted key — should skip it and land on nothing (it was
+    // Seek to the deleted key -- should skip it and land on nothing (it was
     // the last key).
     iter->Seek(std::string("9\xff\xff", 3));
     ASSERT_TRUE(!iter->Valid())
@@ -2826,7 +2892,7 @@ TEST_F(TrieIndexDBTest, LastBlockSeparatorWithDeletes) {
         << iter->key().ToString(true);
     ASSERT_OK(iter->status());
 
-    // Seek to a key between "5bbb" and the deleted key — should find "5bbb"
+    // Seek to a key between "5bbb" and the deleted key -- should find "5bbb"
     // or nothing depending on order. Actually, "6" > "5bbb" and "6" <
     // "9\xff\xff", so seeking "6" should find nothing since there's no key
     // >= "6" that's still alive.
@@ -2857,7 +2923,7 @@ TEST_F(TrieIndexDBTest, LastBlockSeparatorWithDeletes) {
 
 // Single-entry SST: the trie has exactly one leaf. Validates that Seek,
 // SeekToFirst, Next, and Get all work with a one-block, one-key SST.
-TEST_F(TrieIndexDBTest, SingleEntrySST) {
+TEST_P(TrieIndexDBTest, SingleEntrySST) {
   ASSERT_OK(OpenDB());
   ASSERT_OK(db_->Put(WriteOptions(), "only_key", "only_val"));
   ASSERT_OK(db_->Flush(FlushOptions()));
@@ -2874,10 +2940,10 @@ TEST_F(TrieIndexDBTest, SingleEntrySST) {
   ASSERT_NO_FATAL_FAILURE(
       VerifySeekBothIndexes("only_key", "only_key", "only_val"));
 
-  // Seek before the key — should land on it.
+  // Seek before the key -- should land on it.
   ASSERT_NO_FATAL_FAILURE(VerifySeekBothIndexes("a", "only_key", "only_val"));
 
-  // Seek past the key — should be invalid.
+  // Seek past the key -- should be invalid.
   for (const auto& ro : {StandardIndexReadOptions(), TrieIndexReadOptions()}) {
     SCOPED_TRACE(ro.table_index_factory ? "trie index" : "standard index");
     std::unique_ptr<Iterator> iter(db_->NewIterator(ro));
@@ -2889,14 +2955,14 @@ TEST_F(TrieIndexDBTest, SingleEntrySST) {
 
 // Deletion-only SST: flush a Put, then flush a Delete for that key so the
 // second SST contains only a tombstone. After compaction, the key is gone.
-TEST_F(TrieIndexDBTest, DeletionOnlySST) {
+TEST_P(TrieIndexDBTest, DeletionOnlySST) {
   ASSERT_OK(OpenDB());
 
   // Flush 1: a real Put.
   ASSERT_OK(db_->Put(WriteOptions(), "del_target", "val"));
   ASSERT_OK(db_->Flush(FlushOptions()));
 
-  // Flush 2: only a Delete — this creates an SST whose only entry is a
+  // Flush 2: only a Delete -- this creates an SST whose only entry is a
   // tombstone (the trie still builds an index for the block containing it).
   ASSERT_OK(db_->Delete(WriteOptions(), "del_target"));
   ASSERT_OK(db_->Flush(FlushOptions()));
@@ -2917,7 +2983,7 @@ TEST_F(TrieIndexDBTest, DeletionOnlySST) {
 // land in the same SST, possibly spanning multiple blocks. Validates that
 // the trie's same-key-run handling (seqno-based separators) works at the
 // DB level through both indexes.
-TEST_F(TrieIndexDBTest, AllSameKeySST) {
+TEST_P(TrieIndexDBTest, AllSameKeySST) {
   options_.disable_auto_compactions = true;
   // Small block size to force multiple blocks for the same user key.
   ASSERT_OK(OpenDB(/*block_size=*/32));
@@ -2949,7 +3015,7 @@ TEST_F(TrieIndexDBTest, AllSameKeySST) {
         VerifyScanBothIndexes(snaps[i], {{"same_key", expected}}));
   }
 
-  // Seek with earliest snapshot — should find the earliest version.
+  // Seek with earliest snapshot -- should find the earliest version.
   ASSERT_NO_FATAL_FAILURE(
       VerifySeekBothIndexes(snaps[0], "same_key", "same_key", "val_0"));
 
@@ -2960,7 +3026,7 @@ TEST_F(TrieIndexDBTest, AllSameKeySST) {
 
 // Operations on a completely empty DB: nothing should crash, and after
 // creating + deleting all data, the DB should correctly return nothing.
-TEST_F(TrieIndexDBTest, EmptyDBOperations) {
+TEST_P(TrieIndexDBTest, EmptyDBOperations) {
   ASSERT_OK(OpenDB());
 
   // Get / Seek / SeekToFirst on empty memtable (no SSTs yet).
@@ -2996,7 +3062,7 @@ TEST_F(TrieIndexDBTest, EmptyDBOperations) {
 
 // Focused seek-pattern tests: before all data, between blocks, exact match,
 // after all data, and empty-key seek.
-TEST_F(TrieIndexDBTest, SeekEdgeCases) {
+TEST_P(TrieIndexDBTest, SeekEdgeCases) {
   ASSERT_OK(OpenDB(/*block_size=*/64));
 
   // Write keys with deliberate gaps.
@@ -3047,7 +3113,7 @@ TEST_F(TrieIndexDBTest, SeekEdgeCases) {
 }
 
 // PutEntity + GetEntity through the trie index read path.
-TEST_F(TrieIndexDBTest, GetEntityWithTrieUDI) {
+TEST_P(TrieIndexDBTest, GetEntityWithTrieUDI) {
   ASSERT_OK(OpenDB());
 
   // PutEntity with wide columns.
@@ -3095,7 +3161,7 @@ TEST_F(TrieIndexDBTest, GetEntityWithTrieUDI) {
 
 // Multiple overlapping L0 SSTs: the level iterator must coordinate trie
 // iterators across multiple SST files with overlapping key ranges.
-TEST_F(TrieIndexDBTest, OverlappingL0SSTs) {
+TEST_P(TrieIndexDBTest, OverlappingL0SSTs) {
   options_.disable_auto_compactions = true;
   ASSERT_OK(OpenDB(/*block_size=*/128));
 
@@ -3151,7 +3217,7 @@ TEST_F(TrieIndexDBTest, OverlappingL0SSTs) {
 }
 
 // CompactRange with a sub-range: only part of the key space is compacted.
-TEST_F(TrieIndexDBTest, CompactRangeSubset) {
+TEST_P(TrieIndexDBTest, CompactRangeSubset) {
   options_.disable_auto_compactions = true;
   ASSERT_OK(OpenDB(/*block_size=*/128));
 
@@ -3180,7 +3246,7 @@ TEST_F(TrieIndexDBTest, CompactRangeSubset) {
 }
 
 // Write keys, delete all of them, compact. The DB should be empty.
-TEST_F(TrieIndexDBTest, AllKeysDeletedCompaction) {
+TEST_P(TrieIndexDBTest, AllKeysDeletedCompaction) {
   ASSERT_OK(OpenDB());
 
   for (int i = 0; i < 20; i++) {
@@ -3214,7 +3280,7 @@ TEST_F(TrieIndexDBTest, AllKeysDeletedCompaction) {
 
 // Keys with special byte values: 0x00, 0xFF, embedded nulls, very short keys.
 // These exercise trie byte-traversal edge cases.
-TEST_F(TrieIndexDBTest, BinaryKeyEdgeCases) {
+TEST_P(TrieIndexDBTest, BinaryKeyEdgeCases) {
   ASSERT_OK(OpenDB(/*block_size=*/64));
 
   // All keys in sorted order (BytewiseComparator).
@@ -3266,7 +3332,7 @@ TEST_F(TrieIndexDBTest, BinaryKeyEdgeCases) {
 }
 
 // Puts with empty string values.
-TEST_F(TrieIndexDBTest, EmptyValuePuts) {
+TEST_P(TrieIndexDBTest, EmptyValuePuts) {
   ASSERT_OK(OpenDB());
 
   ASSERT_OK(db_->Put(WriteOptions(), "key1", ""));
@@ -3285,7 +3351,7 @@ TEST_F(TrieIndexDBTest, EmptyValuePuts) {
 
 // Zlib compression: data blocks are compressed, UDI block is not.
 // Verifies that reads through the trie index work with compressed data.
-TEST_F(TrieIndexDBTest, CompressionZlib) {
+TEST_P(TrieIndexDBTest, CompressionZlib) {
   if (!Zlib_Supported()) {
     ROCKSDB_GTEST_SKIP("Zlib not linked");
     return;
@@ -3318,7 +3384,7 @@ TEST_F(TrieIndexDBTest, CompressionZlib) {
 
 // Iterator stability: an iterator pinned to a snapshot should not see data
 // written after the iterator was created, even after flush.
-TEST_F(TrieIndexDBTest, IteratorStabilityDuringFlush) {
+TEST_P(TrieIndexDBTest, IteratorStabilityDuringFlush) {
   ASSERT_OK(OpenDB());
 
   ASSERT_OK(db_->Put(WriteOptions(), "key1", "v1"));
@@ -3360,7 +3426,7 @@ TEST_F(TrieIndexDBTest, IteratorStabilityDuringFlush) {
 
 // iterate_upper_bound without prefix scan: the iterator should stop at the
 // upper bound.
-TEST_F(TrieIndexDBTest, IteratorUpperBound) {
+TEST_P(TrieIndexDBTest, IteratorUpperBound) {
   ASSERT_OK(OpenDB(/*block_size=*/64));
 
   for (const auto& k : {"aa", "bb", "cc", "dd", "ee", "ff"}) {
@@ -3412,7 +3478,7 @@ TEST_F(TrieIndexDBTest, IteratorUpperBound) {
 
 // Combined snapshot + upper_bound: iterator sees the snapshot's view of data,
 // bounded by iterate_upper_bound.
-TEST_F(TrieIndexDBTest, IteratorSnapshotAndUpperBound) {
+TEST_P(TrieIndexDBTest, IteratorSnapshotAndUpperBound) {
   ASSERT_OK(OpenDB());
 
   ASSERT_OK(db_->Put(WriteOptions(), "key_a", "old_a"));
@@ -3453,7 +3519,7 @@ TEST_F(TrieIndexDBTest, IteratorSnapshotAndUpperBound) {
 }
 
 // VerifyChecksum goes through SeekToFirst+Next on the index iterator.
-TEST_F(TrieIndexDBTest, VerifyChecksumWithTrieUDI) {
+TEST_P(TrieIndexDBTest, VerifyChecksumWithTrieUDI) {
   ASSERT_OK(OpenDB(/*block_size=*/128));
 
   for (int i = 0; i < 50; i++) {
@@ -3472,7 +3538,7 @@ TEST_F(TrieIndexDBTest, VerifyChecksumWithTrieUDI) {
 
 // Many small SSTs from frequent flushes: exercises trie iteration across
 // many L0 files without compaction.
-TEST_F(TrieIndexDBTest, ManySmallSSTs) {
+TEST_P(TrieIndexDBTest, ManySmallSSTs) {
   options_.disable_auto_compactions = true;
   ASSERT_OK(OpenDB());
 
@@ -3507,7 +3573,7 @@ TEST_F(TrieIndexDBTest, ManySmallSSTs) {
 }
 
 // Merge values accumulate across multiple compaction rounds.
-TEST_F(TrieIndexDBTest, MergeAcrossMultipleCompactions) {
+TEST_P(TrieIndexDBTest, MergeAcrossMultipleCompactions) {
   options_.merge_operator = MergeOperators::CreateStringAppendOperator();
   ASSERT_OK(OpenDB());
 
@@ -3536,7 +3602,14 @@ TEST_F(TrieIndexDBTest, MergeAcrossMultipleCompactions) {
 
 // Graceful degradation: reopen a DB that was written with UDI, but without
 // the UDI factory configured. Reads should fall back to the standard index.
-TEST_F(TrieIndexDBTest, ReopenWithoutTrieUDI) {
+TEST_P(TrieIndexDBTest, ReopenWithoutTrieUDI) {
+  // In primary mode, the standard index is a stub -- reopening without UDI
+  // is expected to fail because there's no usable index. This test is only
+  // meaningful in secondary mode where both indexes are populated.
+  if (IsPrimaryMode()) {
+    ROCKSDB_GTEST_SKIP("Not applicable in primary mode");
+    return;
+  }
   ASSERT_OK(OpenDB());
 
   ASSERT_OK(db_->Put(WriteOptions(), "key_a", "val_a"));
@@ -3564,7 +3637,14 @@ TEST_F(TrieIndexDBTest, ReopenWithoutTrieUDI) {
 
 // Mixed SSTs: some written with UDI, some without. Both should be readable
 // through both index paths.
-TEST_F(TrieIndexDBTest, MixedSSTsWithAndWithoutUDI) {
+TEST_P(TrieIndexDBTest, MixedSSTsWithAndWithoutUDI) {
+  // This test mixes SSTs with and without UDI by reopening without UDI.
+  // In primary mode, the standard index is a stub, so SSTs written in
+  // primary mode can't be read without UDI. Only meaningful in secondary.
+  if (IsPrimaryMode()) {
+    ROCKSDB_GTEST_SKIP("Not applicable in primary mode");
+    return;
+  }
   options_.disable_auto_compactions = true;
 
   // Phase 1: Write with UDI → SST1 has UDI + standard index.
@@ -3604,10 +3684,11 @@ TEST_F(TrieIndexDBTest, MixedSSTsWithAndWithoutUDI) {
 }
 
 // TransactionDB commit: Put + Delete inside a transaction, then commit.
-TEST_F(TrieIndexDBTest, TransactionCommit) {
+TEST_P(TrieIndexDBTest, TransactionCommit) {
   options_.create_if_missing = true;
   BlockBasedTableOptions table_options;
   table_options.user_defined_index_factory = trie_factory_;
+  table_options.use_udi_as_primary_index = IsPrimaryMode();
   options_.table_factory.reset(NewBlockBasedTableFactory(table_options));
   last_options_ = options_;
 
@@ -3637,10 +3718,11 @@ TEST_F(TrieIndexDBTest, TransactionCommit) {
 // TransactionDB rollback: writes should be discarded. Rollback writes DELETE
 // entries to WAL. Verifies the UDI builder correctly handles DELETE entries
 // replayed from the WAL during recovery.
-TEST_F(TrieIndexDBTest, TransactionRollback) {
+TEST_P(TrieIndexDBTest, TransactionRollback) {
   options_.create_if_missing = true;
   BlockBasedTableOptions table_options;
   table_options.user_defined_index_factory = trie_factory_;
+  table_options.use_udi_as_primary_index = IsPrimaryMode();
   options_.table_factory.reset(NewBlockBasedTableFactory(table_options));
   last_options_ = options_;
 
@@ -3675,7 +3757,7 @@ TEST_F(TrieIndexDBTest, TransactionRollback) {
 // total_order_seek with prefix_extractor: a common stress-test configuration.
 // With total_order_seek=true, SeekToFirst and full forward scan should work
 // correctly even when a prefix extractor is configured.
-TEST_F(TrieIndexDBTest, TotalOrderSeekWithPrefixExtractor) {
+TEST_P(TrieIndexDBTest, TotalOrderSeekWithPrefixExtractor) {
   options_.prefix_extractor.reset(NewFixedPrefixTransform(3));
   ASSERT_OK(OpenDB(/*block_size=*/128));
 
@@ -3733,7 +3815,7 @@ TEST_F(TrieIndexDBTest, TotalOrderSeekWithPrefixExtractor) {
 // 5. Snapshot before large DeleteRange, verify snapshot preserves state
 // 6. Re-insert into deleted ranges, compact, and re-verify
 // ============================================================================
-TEST_F(TrieIndexDBTest, MultiLevelDeleteRangeRandomized) {
+TEST_P(TrieIndexDBTest, MultiLevelDeleteRangeRandomized) {
   uint32_t seed = static_cast<uint32_t>(
       std::chrono::system_clock::now().time_since_epoch().count());
   SCOPED_TRACE("seed=" + std::to_string(seed));
@@ -3847,11 +3929,11 @@ TEST_F(TrieIndexDBTest, MultiLevelDeleteRangeRandomized) {
   ASSERT_OK(db_->Flush(FlushOptions()));
   ASSERT_NO_FATAL_FAILURE(verify_scan_consistency());
 
-  // Phase 5: Full compaction — all range tombstones should be resolved.
+  // Phase 5: Full compaction -- all range tombstones should be resolved.
   ASSERT_OK(db_->CompactRange(CompactRangeOptions(), nullptr, nullptr));
   ASSERT_NO_FATAL_FAILURE(verify_scan_consistency());
 
-  // Phase 6: Point lookups for a sample of keys — both indexes must agree.
+  // Phase 6: Point lookups for a sample of keys -- both indexes must agree.
   for (int i = 0; i < kMaxKey; i += 7) {
     std::string key = format_key(i);
     std::string std_val;
@@ -3869,8 +3951,8 @@ TEST_F(TrieIndexDBTest, MultiLevelDeleteRangeRandomized) {
 // Reverse iteration / direction switching tests
 // ============================================================================
 
-TEST_F(TrieIndexDBTest, ScanAfterCompactionWithDeletes) {
-  // Forward and reverse scans after compaction with deletions — verifies that
+TEST_P(TrieIndexDBTest, ScanAfterCompactionWithDeletes) {
+  // Forward and reverse scans after compaction with deletions -- verifies that
   // both scan directions produce correct results on compacted SSTs through
   // both indexes.
   options_.merge_operator = MergeOperators::CreateStringAppendOperator();
@@ -3906,7 +3988,7 @@ TEST_F(TrieIndexDBTest, ScanAfterCompactionWithDeletes) {
   ASSERT_NO_FATAL_FAILURE(VerifyScanBothIndexes(expected));
 }
 
-TEST_F(TrieIndexDBTest, ScanLargeDatasetAcrossBlocks) {
+TEST_P(TrieIndexDBTest, ScanLargeDatasetAcrossBlocks) {
   // Forward and reverse scans on a larger dataset spanning many blocks.
   ASSERT_OK(OpenDB(/*block_size=*/128));
 
@@ -3925,8 +4007,8 @@ TEST_F(TrieIndexDBTest, ScanLargeDatasetAcrossBlocks) {
   ASSERT_NO_FATAL_FAILURE(VerifyScanBothIndexes(expected));
 }
 
-TEST_F(TrieIndexDBTest, SeekForPrevAfterCompaction) {
-  // SeekForPrev on a compacted dataset — verifies boundary correctness.
+TEST_P(TrieIndexDBTest, SeekForPrevAfterCompaction) {
+  // SeekForPrev on a compacted dataset -- verifies boundary correctness.
   ASSERT_OK(OpenDB(/*block_size=*/128));
 
   for (int i = 0; i < 100; i += 2) {
@@ -3939,7 +4021,7 @@ TEST_F(TrieIndexDBTest, SeekForPrevAfterCompaction) {
   ASSERT_OK(db_->Flush(FlushOptions()));
   ASSERT_OK(db_->CompactRange(CompactRangeOptions(), nullptr, nullptr));
 
-  // SeekForPrev to odd keys (not present) — should land on the previous even.
+  // SeekForPrev to odd keys (not present) -- should land on the previous even.
   for (int i = 1; i < 100; i += 2) {
     char target[16];
     char expected_key[16];
@@ -3952,7 +4034,7 @@ TEST_F(TrieIndexDBTest, SeekForPrevAfterCompaction) {
   }
 }
 
-TEST_F(TrieIndexDBTest, PrevAfterSeekToFirstBothIndexes) {
+TEST_P(TrieIndexDBTest, PrevAfterSeekToFirstBothIndexes) {
   // Prev immediately after SeekToFirst should invalidate the iterator.
   ASSERT_OK(OpenDB());
 
@@ -3974,7 +4056,7 @@ TEST_F(TrieIndexDBTest, PrevAfterSeekToFirstBothIndexes) {
   }
 }
 
-TEST_F(TrieIndexDBTest, ForwardThenReverseDirection) {
+TEST_P(TrieIndexDBTest, ForwardThenReverseDirection) {
   // Interleave forward and reverse iteration to test direction switching.
   ASSERT_OK(OpenDB(/*block_size=*/64));
 
@@ -4026,7 +4108,7 @@ TEST_F(TrieIndexDBTest, ForwardThenReverseDirection) {
   }
 }
 
-TEST_F(TrieIndexDBTest, SeekToLastSingleEntry) {
+TEST_P(TrieIndexDBTest, SeekToLastSingleEntry) {
   // SeekToLast on a single-entry SST.
   ASSERT_OK(OpenDB());
 
@@ -4047,7 +4129,7 @@ TEST_F(TrieIndexDBTest, SeekToLastSingleEntry) {
   }
 }
 
-TEST_F(TrieIndexDBTest, ScanWithSnapshots) {
+TEST_P(TrieIndexDBTest, ScanWithSnapshots) {
   // Forward and reverse scans at different snapshot points must produce
   // consistent results through both indexes.
   ASSERT_OK(OpenDB());
@@ -4079,7 +4161,7 @@ TEST_F(TrieIndexDBTest, ScanWithSnapshots) {
   db_->ReleaseSnapshot(snap1);
 }
 
-TEST_F(TrieIndexDBTest, SeekForPrevVariableLengthKeys) {
+TEST_P(TrieIndexDBTest, SeekForPrevVariableLengthKeys) {
   // Verifies SeekForPrev with variable-length keys that mimic
   // the stress test's key format: 8-byte big-endian key number followed by
   // optional padding bytes (0x78 = 'x'). Variable lengths exercise the
@@ -4133,7 +4215,7 @@ TEST_F(TrieIndexDBTest, SeekForPrevVariableLengthKeys) {
   }
   ASSERT_OK(db_->Flush(FlushOptions()));
 
-  // SeekForPrev for every key — trie must match standard index.
+  // SeekForPrev for every key -- trie must match standard index.
   for (const auto& key : keys) {
     std::string std_result, trie_result;
     {
@@ -4182,6 +4264,254 @@ TEST_F(TrieIndexDBTest, SeekForPrevVariableLengthKeys) {
         << "SeekForPrev(" << target << ") diverged";
   }
 }
+
+// ============================================================================
+// Primary UDI backward compatibility test -- uses explicit mode, not
+// parameterized, because it tests the upgrade path from secondary to primary.
+// ============================================================================
+
+TEST_P(TrieIndexDBTest, PrimaryUDIBackwardCompatibility) {
+  // Verifies that SSTs written with UDI as secondary (both indexes present)
+  // can be read correctly when the DB is reopened with
+  // use_udi_as_primary_index. This is the upgrade path: old SSTs have both
+  // indexes, new config says "use UDI as primary for all reads."
+  ASSERT_OK(OpenDBSecondary(/*block_size=*/128));
+
+  for (int i = 0; i < 50; i++) {
+    char key[16];
+    char val[16];
+    snprintf(key, sizeof(key), "key_%04d", i);
+    snprintf(val, sizeof(val), "val_%04d", i);
+    ASSERT_OK(db_->Put(WriteOptions(), key, val));
+  }
+  ASSERT_OK(db_->Flush(FlushOptions()));
+
+  // Verify via trie (secondary mode -- explicit ReadOptions).
+  auto trie_keys = ScanAllKeys(TrieIndexReadOptions());
+  ASSERT_EQ(trie_keys.size(), 50u);
+
+  // Close and reopen with primary UDI config.
+  EXPECT_OK(db_->Close());
+  db_.reset();
+  ASSERT_OK(OpenDBPrimary(/*block_size=*/128));
+
+  // Now all reads automatically use UDI -- no ReadOptions::table_index_factory.
+  ReadOptions ro;
+  std::vector<std::string> keys;
+  std::unique_ptr<Iterator> iter(db_->NewIterator(ro));
+  for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
+    keys.push_back(iter->key().ToString());
+  }
+  ASSERT_OK(iter->status());
+  ASSERT_EQ(keys, trie_keys);
+
+  // Point lookups also work.
+  std::string value;
+  ASSERT_OK(db_->Get(ro, "key_0025", &value));
+  ASSERT_EQ(value, "val_0025");
+}
+
+// ============================================================================
+// Migration path and rollback tests
+// ============================================================================
+
+TEST_P(TrieIndexDBTest, MigrationFullPath) {
+  // Tests the complete recommended migration path:
+  // Step 1: No UDI → Step 2: UDI secondary → Step 3: Compact all SSTs →
+  // Step 4: UDI primary
+
+  // Step 1: Start without UDI. Write some data.
+  ASSERT_OK(OpenDBWithoutUDI(/*block_size=*/128));
+  for (int i = 0; i < 30; i++) {
+    char key[16];
+    char val[16];
+    snprintf(key, sizeof(key), "key_%04d", i);
+    snprintf(val, sizeof(val), "val_%04d", i);
+    ASSERT_OK(db_->Put(WriteOptions(), key, val));
+  }
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  ASSERT_OK(db_->Close());
+  db_.reset();
+
+  // Step 2: Enable UDI as secondary. Write more data.
+  ASSERT_OK(OpenDBSecondary(/*block_size=*/128));
+  for (int i = 30; i < 50; i++) {
+    char key[16];
+    char val[16];
+    snprintf(key, sizeof(key), "key_%04d", i);
+    snprintf(val, sizeof(val), "val_%04d", i);
+    ASSERT_OK(db_->Put(WriteOptions(), key, val));
+  }
+  ASSERT_OK(db_->Flush(FlushOptions()));
+
+  // Verify reads work through both indexes for the new SST.
+  std::string value;
+  ASSERT_OK(db_->Get(TrieIndexReadOptions(), "key_0035", &value));
+  ASSERT_EQ(value, "val_0035");
+  // Old SST (no UDI) readable through standard index.
+  ASSERT_OK(db_->Get(ReadOptions(), "key_0010", &value));
+  ASSERT_EQ(value, "val_0010");
+
+  // Step 3: Compact everything to rewrite all SSTs with UDI.
+  // Use bottommost_level_compaction to ensure ALL SSTs are rewritten.
+  CompactRangeOptions cro;
+  cro.bottommost_level_compaction = BottommostLevelCompaction::kForce;
+  ASSERT_OK(db_->CompactRange(cro, nullptr, nullptr));
+
+  // After compaction, all data is in SSTs with both indexes.
+  auto all_keys = ScanAllKeys(TrieIndexReadOptions());
+  ASSERT_EQ(all_keys.size(), 50u);
+
+  // Reopen in secondary mode to ensure the MANIFEST is clean -- old SST
+  // files from step 1 (without UDI) are fully purged.
+  ASSERT_OK(db_->Close());
+  db_.reset();
+  ASSERT_OK(OpenDBSecondary(/*block_size=*/128));
+  ASSERT_EQ(ScanAllKeys(TrieIndexReadOptions()).size(), 50u);
+  ASSERT_OK(db_->Close());
+  db_.reset();
+
+  // Step 4: Enable UDI as primary.
+  ASSERT_OK(OpenDBPrimary(/*block_size=*/128));
+
+  // All reads go through UDI automatically -- no table_index_factory needed.
+  ReadOptions ro;
+  std::vector<std::string> keys;
+  std::unique_ptr<Iterator> iter(db_->NewIterator(ro));
+  for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
+    keys.push_back(iter->key().ToString());
+  }
+  ASSERT_OK(iter->status());
+  ASSERT_EQ(keys, all_keys);
+
+  // Point lookups from all original data.
+  ASSERT_OK(db_->Get(ro, "key_0000", &value));
+  ASSERT_EQ(value, "val_0000");
+  ASSERT_OK(db_->Get(ro, "key_0049", &value));
+  ASSERT_EQ(value, "val_0049");
+}
+
+TEST_P(TrieIndexDBTest, MigrationPrimaryRejectsPreUDISSTs) {
+  // Verifies that enabling use_udi_as_primary_index on a DB with SSTs
+  // that have no UDI block fails at open time (not silently).
+  options_.disable_auto_compactions = true;
+
+  // Write SSTs without UDI.
+  ASSERT_OK(OpenDBWithoutUDI(/*block_size=*/128));
+  ASSERT_OK(db_->Put(WriteOptions(), "key_a", "val_a"));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  ASSERT_OK(db_->Close());
+  db_.reset();
+
+  // Try to open with UDI as primary -- should fail because the SST has no
+  // UDI block.
+  Status s = OpenDBPrimary(/*block_size=*/128);
+  ASSERT_TRUE(s.IsCorruption()) << s.ToString();
+}
+
+TEST_P(TrieIndexDBTest, RollbackFromPrimaryToSecondary) {
+  // Tests the rollback path: primary → compact with secondary → remove UDI.
+
+  // Start in primary mode. Write data.
+  ASSERT_OK(OpenDBPrimary(/*block_size=*/128));
+  for (int i = 0; i < 30; i++) {
+    char key[16];
+    char val[16];
+    snprintf(key, sizeof(key), "key_%04d", i);
+    snprintf(val, sizeof(val), "val_%04d", i);
+    ASSERT_OK(db_->Put(WriteOptions(), key, val));
+  }
+  ASSERT_OK(db_->Flush(FlushOptions()));
+
+  // Verify data is readable in primary mode.
+  ReadOptions ro;
+  std::string value;
+  ASSERT_OK(db_->Get(ro, "key_0015", &value));
+  ASSERT_EQ(value, "val_0015");
+  ASSERT_OK(db_->Close());
+  db_.reset();
+
+  // Rollback step 1: Reopen as secondary (with UDI factory still set).
+  // The primary-mode SSTs are readable because udi_written_as_primary=true
+  // in the table property causes the reader to use the trie automatically.
+  ASSERT_OK(OpenDBSecondary(/*block_size=*/128));
+
+  // Verify the primary-mode SST is readable through both paths.
+  ASSERT_OK(db_->Get(TrieIndexReadOptions(), "key_0015", &value));
+  ASSERT_EQ(value, "val_0015");
+  // Default ReadOptions also works because udi_is_primary_=true for this SST.
+  ASSERT_OK(db_->Get(ReadOptions(), "key_0015", &value));
+  ASSERT_EQ(value, "val_0015");
+
+  // Full scan to verify all data is accessible.
+  auto all_keys = ScanAllKeys(ReadOptions());
+  ASSERT_EQ(all_keys.size(), 30u);
+
+  // Rollback step 2: Compact to rewrite all SSTs with both indexes.
+  CompactRangeOptions cro;
+  cro.bottommost_level_compaction = BottommostLevelCompaction::kForce;
+  ASSERT_OK(db_->CompactRange(cro, nullptr, nullptr));
+
+  // Verify data is readable through trie after compaction.
+  ASSERT_OK(db_->Get(TrieIndexReadOptions(), "key_0015", &value));
+  ASSERT_EQ(value, "val_0015");
+
+  // Reopen to ensure old SSTs are fully purged and only the compacted
+  // output (with both indexes) remains.
+  ASSERT_OK(db_->Close());
+  db_.reset();
+  ASSERT_OK(OpenDBSecondary(/*block_size=*/128));
+
+  // Now all SSTs were written by secondary mode -- standard index works.
+  ASSERT_OK(db_->Get(ReadOptions(), "key_0015", &value));
+  ASSERT_EQ(value, "val_0015");
+  ASSERT_EQ(ScanAllKeys(ReadOptions()), all_keys);
+  ASSERT_OK(db_->Close());
+  db_.reset();
+
+  // Rollback step 3: Remove UDI entirely. SSTs have both indexes so
+  // the standard index works.
+  ASSERT_OK(OpenDBWithoutUDI(/*block_size=*/128));
+  ASSERT_OK(db_->Get(ReadOptions(), "key_0015", &value));
+  ASSERT_EQ(value, "val_0015");
+  ASSERT_EQ(ScanAllKeys(ReadOptions()), all_keys);
+}
+
+TEST_P(TrieIndexDBTest, RollbackFromPrimaryWithoutCompactFails) {
+  // Verifies that removing UDI from primary-mode SSTs WITHOUT compacting
+  // first fails (the stub standard index has no entries).
+  options_.disable_auto_compactions = true;
+
+  // Write SSTs in primary mode.
+  ASSERT_OK(OpenDBPrimary(/*block_size=*/128));
+  ASSERT_OK(db_->Put(WriteOptions(), "key_a", "val_a"));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  ASSERT_OK(db_->Close());
+  db_.reset();
+
+  // Try to open without UDI -- the SST has a stub standard index.
+  // The open itself may succeed (the stub is valid), but reads return nothing.
+  Status s = OpenDBWithoutUDI(/*block_size=*/128);
+  if (s.ok()) {
+    // DB opened, but reads through the stub index find nothing.
+    std::string value;
+    Status get_s = db_->Get(ReadOptions(), "key_a", &value);
+    ASSERT_TRUE(get_s.IsNotFound()) << get_s.ToString();
+
+    // Scan returns nothing -- data is effectively lost.
+    std::unique_ptr<Iterator> iter(db_->NewIterator(ReadOptions()));
+    iter->SeekToFirst();
+    ASSERT_FALSE(iter->Valid());
+    ASSERT_OK(iter->status());
+  }
+  // If open failed, that's also acceptable -- the SST is unusable without UDI.
+}
+
+// Run all parameterized tests in both UDI modes:
+// - Secondary (false): UDI is secondary, reads require table_index_factory
+// - Primary (true): UDI is primary, all reads use the trie by default
+INSTANTIATE_TEST_CASE_P(SecondaryAndPrimaryUDI, TrieIndexDBTest,
+                        ::testing::Bool());
 
 }  // namespace trie_index
 }  // namespace ROCKSDB_NAMESPACE

--- a/utilities/trie_index/trie_index_db_test.cc
+++ b/utilities/trie_index/trie_index_db_test.cc
@@ -1291,9 +1291,10 @@ TEST_P(TrieIndexDBTest, SameUserKeyAcrossBlockBoundaries) {
   // overflow block count so that Seek() can find the correct data block for
   // each version.
   //
-  // Without the seqno side-table fix (PR #14412), reads through the trie index
-  // would return incorrect data when multiple versions of the same key span
-  // different data blocks.
+  // Without the seqno side-table, reads through the trie index return
+  // incorrect data when multiple versions of the same key span different
+  // data blocks, because the trie cannot distinguish which block contains
+  // which version.
   options_.disable_auto_compactions = true;
   // Tiny block_size (64 bytes) forces each version of the key into its own
   // data block, creating same-user-key block boundaries that the trie must
@@ -2738,20 +2739,13 @@ TEST_P(TrieIndexDBTest, PrefixIterationMemtablePlusSST) {
 }
 
 // ---------------------------------------------------------------------------
-// Regression test for the FindShortSuccessor last-block bug.
-//
-// Before the fix, TrieIndexBuilder::AddIndexEntry called
-// FindShortSuccessor() on the last block's separator key, producing a
-// shorter key that covered a wider range than the actual data. For example,
-// if the last key's user key was "9\xff\xff", FindShortSuccessor would
-// produce ":" (0x3A), making the trie claim it covers keys up to ":". A
-// seek for "9\xff\xff\x01" (between the real last key and ":") would find a
-// block via the trie but not via the standard index, causing prefix scan
-// iterators to desynchronize.
-//
-// The standard ShortenedIndexBuilder (with default kShortenSeparators mode)
-// does NOT call FindShortSuccessor on the last block -- it uses the last key
-// as-is. The fix makes the trie builder match this behavior.
+// Verifies that the trie builder does NOT call FindShortSuccessor() on the
+// last block's separator key. FindShortSuccessor would produce a shorter
+// key covering a wider range than the actual data. For example, if the
+// last key's user key is "9\xff\xff", FindShortSuccessor produces ":"
+// (0x3A), making the trie claim it covers keys up to ":". A seek for
+// "9\xff\xff\x01" would then find a block via the trie but not via the
+// standard index, causing iterators to desynchronize.
 // ---------------------------------------------------------------------------
 TEST_P(TrieIndexDBTest, LastBlockSeparatorNotShortened) {
   // Use a small block size so each key lands in its own block.
@@ -2766,9 +2760,9 @@ TEST_P(TrieIndexDBTest, LastBlockSeparatorNotShortened) {
   ASSERT_OK(db_->Flush(FlushOptions()));
 
   // The key "9\xff\xff\x01" is lexicographically after "9\xff\xff" but
-  // before ":" (0x3A). With the old bug, the trie would return a valid
-  // block for this key. With the fix, both indexes correctly say "not
-  // found".
+  // before ":" (0x3A). If FindShortSuccessor were applied, the trie would
+  // return a valid block for this key. Both indexes must correctly say
+  // "not found".
   std::string seek_target = std::string("9\xff\xff\x01", 4);
 
   for (const auto& ro : {StandardIndexReadOptions(), TrieIndexReadOptions()}) {
@@ -3538,9 +3532,10 @@ TEST_P(TrieIndexDBTest, MergeAcrossMultipleCompactions) {
 // Graceful degradation: reopen a DB that was written with UDI, but without
 // the UDI factory configured. Reads should fall back to the standard index.
 TEST_P(TrieIndexDBTest, ReopenWithoutTrieUDI) {
-  // In primary mode, the standard index is a stub -- reopening without UDI
-  // is expected to fail because there's no usable index. This test is only
-  // meaningful in secondary mode where both indexes are populated.
+  // In primary mode, reopening without UDI still works because the standard
+  // index is always fully populated. This test validates the secondary-mode
+  // behavior where the UDI block is optional and reads fall back to the
+  // standard index.
   if (IsPrimaryMode()) {
     ROCKSDB_GTEST_SKIP("Not applicable in primary mode");
     return;
@@ -3574,8 +3569,9 @@ TEST_P(TrieIndexDBTest, ReopenWithoutTrieUDI) {
 // through both index paths.
 TEST_P(TrieIndexDBTest, MixedSSTsWithAndWithoutUDI) {
   // This test mixes SSTs with and without UDI by reopening without UDI.
-  // In primary mode, the standard index is a stub, so SSTs written in
-  // primary mode can't be read without UDI. Only meaningful in secondary.
+  // In primary mode, SSTs can still be read without UDI (the standard
+  // index is always fully populated). This test validates the secondary-
+  // mode mixed-SST fallback path.
   if (IsPrimaryMode()) {
     ROCKSDB_GTEST_SKIP("Not applicable in primary mode");
     return;
@@ -4382,9 +4378,10 @@ TEST_P(TrieIndexDBTest, RollbackFromPrimaryToSecondary) {
   ASSERT_EQ(ScanAllKeys(ReadOptions()), all_keys);
 }
 
-TEST_P(TrieIndexDBTest, RollbackFromPrimaryWithoutCompactFails) {
+TEST_P(TrieIndexDBTest, RollbackFromPrimaryWithoutCompactSucceeds) {
   // Verifies that removing UDI from primary-mode SSTs WITHOUT compacting
-  // first fails (the stub standard index has no entries).
+  // first still works. The standard index is always fully populated (even
+  // in primary mode), so reads fall back to the standard index correctly.
   options_.disable_auto_compactions = true;
 
   // Write SSTs in primary mode.
@@ -4394,28 +4391,24 @@ TEST_P(TrieIndexDBTest, RollbackFromPrimaryWithoutCompactFails) {
   ASSERT_OK(db_->Close());
   db_.reset();
 
-  // Try to open without UDI -- the SST has a stub standard index.
-  // The open itself may succeed (the stub is valid), but reads return nothing.
-  Status s = OpenDBWithoutUDI(/*block_size=*/128);
-  if (s.ok()) {
-    // DB opened, but reads through the stub index find nothing.
-    std::string value;
-    Status get_s = db_->Get(ReadOptions(), "key_a", &value);
-    ASSERT_TRUE(get_s.IsNotFound()) << get_s.ToString();
+  // Open without UDI -- reads fall back to the standard index.
+  ASSERT_OK(OpenDBWithoutUDI(/*block_size=*/128));
+  std::string value;
+  ASSERT_OK(db_->Get(ReadOptions(), "key_a", &value));
+  ASSERT_EQ(value, "val_a");
 
-    // Scan returns nothing -- data is effectively lost.
-    std::unique_ptr<Iterator> iter(db_->NewIterator(ReadOptions()));
-    iter->SeekToFirst();
-    ASSERT_FALSE(iter->Valid());
-    ASSERT_OK(iter->status());
-  }
-  // If open failed, that's also acceptable -- the SST is unusable without UDI.
+  // Scan also works.
+  std::unique_ptr<Iterator> iter(db_->NewIterator(ReadOptions()));
+  iter->SeekToFirst();
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ(iter->key().ToString(), "key_a");
+  ASSERT_OK(iter->status());
 }
 
 TEST_P(TrieIndexDBTest, PrimaryModeTableProperties) {
   // Verifies primary-mode-specific behavior: the udi_is_primary_index table
-  // property is set, and SSTs are readable in secondary mode (the standard
-  // index is a valid stub).
+  // property is set, the standard index is fully populated (not a stub),
+  // and reads work without setting ReadOptions::table_index_factory.
   if (!IsPrimaryMode()) {
     ROCKSDB_GTEST_SKIP("Only applicable in primary mode");
     return;
@@ -4432,9 +4425,6 @@ TEST_P(TrieIndexDBTest, PrimaryModeTableProperties) {
   ASSERT_FALSE(props.empty());
   for (const auto& p : props) {
     ASSERT_EQ(p.second->udi_is_primary_index, 1u);
-    // Standard index should report user-key-only (since we set
-    // separator_is_key_plus_seq()=false for primary).
-    ASSERT_EQ(p.second->index_key_is_user_key, 1u);
   }
 
   // Reads work with default ReadOptions (no table_index_factory needed).
@@ -4447,10 +4437,6 @@ TEST_P(TrieIndexDBTest, PrimaryModeTableProperties) {
 TEST_P(TrieIndexDBTest, EstimatedSizeNonZero) {
   // Verifies that TrieIndexBuilder::EstimatedSize() returns non-zero after
   // adding entries, ensuring compaction file sizing works.
-  if (!IsPrimaryMode()) {
-    ROCKSDB_GTEST_SKIP("Only applicable in primary mode");
-    return;
-  }
   ASSERT_OK(OpenDB(/*block_size=*/128));
 
   // Write enough data to produce multiple blocks.
@@ -4467,10 +4453,10 @@ TEST_P(TrieIndexDBTest, EstimatedSizeNonZero) {
 }
 
 // ============================================================================
-// Issue #14561 DB-level reproducer: NonBoundary separator seek regression
+// Issue #14561 DB-level reproducer: non-boundary separator seek correctness
 // ============================================================================
 
-TEST_P(TrieIndexDBTest, NonBoundarySeparatorSeekRegression) {
+TEST_P(TrieIndexDBTest, NonBoundarySeparatorSeekCorrectness) {
   // DB-level reproducer for GitHub issue #14561. When FindShortestSeparator
   // cannot shorten the separator (e.g., "acc" -> "acd" stays "acc") and
   // seqno encoding is active from an earlier same-user-key boundary, the

--- a/utilities/trie_index/trie_index_factory.cc
+++ b/utilities/trie_index/trie_index_factory.cc
@@ -16,13 +16,6 @@
 namespace ROCKSDB_NAMESPACE {
 namespace trie_index {
 
-// Tag used for non-boundary separators (between blocks with different user
-// keys). This is the same tag the standard index uses:
-// the smallest possible internal key for a given user key.
-static uint64_t NonBoundaryTag() {
-  return PackSequenceAndType(kMaxSequenceNumber, kValueTypeForSeek);
-}
-
 // ============================================================================
 // TrieIndexBuilder
 // ============================================================================
@@ -123,19 +116,29 @@ Slice TrieIndexBuilder::AddIndexEntry(const Slice& last_key_in_current_block,
 
   BufferedEntry entry;
   entry.separator_key = separator.ToString();
-  // For same-user-key boundaries, use the actual seqno of the last key.
-  // For different-user-key boundaries, use the maximum tag as a
-  // non-boundary tag meaning "use the same comparison semantics as the
-  // standard index's InternalKeyComparator".
   if (same_user_key) {
+    // Same-user-key boundary: store the real tag for correct block
+    // selection within the overflow run.
+    entry.tag = last_key_tag;
+  } else if (first_key_in_next_block == nullptr) {
+    // Last block: store the real tag. The standard index stores the full
+    // internal key (user key + seqno) as the last block's separator. The
+    // real tag ensures the post-seek correction correctly handles seeks
+    // where the target user key matches but the seqno differs.
     entry.tag = last_key_tag;
   } else {
-    // Not a same-user-key boundary. Use a sentinel value that ensures
-    // Use the same tag the standard index uses for non-boundary
-    // separators: kMaxSequenceNumber | kValueTypeForSeek. This ensures the
-    // trie's post-seek comparison exactly matches the standard index's
-    // InternalKeyComparator behavior.
-    entry.tag = NonBoundaryTag();
+    // Non-boundary separator between blocks with different user keys.
+    // Store 0 (sentinel meaning "no seqno correction needed"). When the
+    // standard index has index_key_is_user_key=true, it compares user keys
+    // only and always stays on equal user keys. The trie matches this by
+    // ensuring target_tag < 0 is always false.
+    entry.tag = 0;
+  }
+
+  // Seqno encoding must always be enabled so the post-seek correction
+  // handles the last block correctly. The overhead is 8 bytes per leaf.
+  if (!must_use_separator_with_seq_) {
+    must_use_separator_with_seq_ = true;
   }
   entry.handle = handle;
   total_separator_bytes_ += entry.separator_key.size();
@@ -171,11 +174,10 @@ Status TrieIndexBuilder::Finish(Slice* index_contents) {
     // goes into the trie (as the primary block). The remaining blocks in the
     // run are stored as overflow blocks in the side-table.
     //
-    // For non-boundary separators (different user keys), the tag
-    // is PackSequenceAndType(kMaxSequenceNumber, kValueTypeForSeek) -- the
-    // same tag the standard index uses. This is stored directly in the
-    // seqno side-table, ensuring the post-seek correction correctly matches
-    // the standard index's InternalKeyComparator behavior.
+    // For non-boundary separators (different user keys), the tag is 0
+    // (sentinel meaning "no seqno correction needed"), matching the standard
+    // index's user-key-only comparison mode. For the last block, the real
+    // tag is stored to match the standard index's full internal key behavior.
     size_t i = 0;
     while (i < buffered_entries_.size()) {
       const auto& entry = buffered_entries_[i];
@@ -189,11 +191,10 @@ Status TrieIndexBuilder::Finish(Slice* index_contents) {
       }
       uint32_t block_count = static_cast<uint32_t>(run_end - run_start);
 
-      // For non-boundary separators (between blocks with different user keys),
-      // store the same tag the standard index uses:
-      // PackSequenceAndType(kMaxSequenceNumber, kValueTypeForSeek). This
-      // makes the trie's post-seek comparison exactly match the standard
-      // index's InternalKeyComparator behavior.
+      // Non-boundary entries have tag=0 (sentinel meaning "no seqno
+      // correction needed"). Same-user-key boundary and last-block entries
+      // have real tags. The trie builder stores these directly in the seqno
+      // side-table.
       //
       // For boundary separators (same user key), store the actual packed
       // tag for correct seqno-based block selection.
@@ -209,7 +210,8 @@ Status TrieIndexBuilder::Finish(Slice* index_contents) {
       // The tag may be 0 when bottommost compaction zeroes all sequence
       // numbers -- this is valid; see AddOverflowBlock comment.
       for (size_t j = run_start + 1; j < run_end; j++) {
-        assert(buffered_entries_[j].tag != NonBoundaryTag());
+        assert(buffered_entries_[j].tag !=
+               PackSequenceAndType(kMaxSequenceNumber, kValueTypeForSeek));
         trie_builder_.AddOverflowBlock(buffered_entries_[j].handle,
                                        buffered_entries_[j].tag);
       }
@@ -385,11 +387,14 @@ Status TrieIndexIterator::SeekAndGetResult(const Slice& target,
   // within a run of same-key blocks is correct. If target_packed < leaf_packed,
   // advance through overflow blocks.
   //
-  // For non-boundary separators: leaf_seqno stores the same tag
-  // the standard index uses for these separators:
-  // PackSequenceAndType(kMaxSequenceNumber, kValueTypeForSeek). The comparison
-  // target_packed < leaf_seqno determines whether to advance, exactly matching
-  // the standard index's InternalKeyComparator behavior.
+  // For non-boundary separators: leaf_seqno is 0. The comparison
+  // target_tag < 0 is always false, so no advancement occurs. This matches
+  // the standard index's index_key_is_user_key=true mode where equal user
+  // keys always match without seqno comparison.
+  //
+  // For the last block: leaf_seqno stores the real tag of the last key.
+  // This matches the standard index which stores the full internal key
+  // as the last block's separator.
   if (has_seqno_encoding_ && iter_.Valid()) {
     uint64_t leaf_idx = iter_.LeafIndex();
     uint64_t leaf_seqno = trie_->GetLeafSeqno(leaf_idx);

--- a/utilities/trie_index/trie_index_factory.cc
+++ b/utilities/trie_index/trie_index_factory.cc
@@ -138,6 +138,7 @@ Slice TrieIndexBuilder::AddIndexEntry(const Slice& last_key_in_current_block,
     entry.tag = NonBoundaryTag();
   }
   entry.handle = handle;
+  total_separator_bytes_ += entry.separator_key.size();
   buffered_entries_.push_back(std::move(entry));
 
   return separator;
@@ -239,6 +240,14 @@ Status TrieIndexBuilder::Finish(Slice* index_contents) {
 // ============================================================================
 // TrieIndexIterator
 // ============================================================================
+
+uint64_t TrieIndexBuilder::EstimatedSize() const {
+  // Estimate the serialized trie size from the running counters. A LOUDS trie
+  // uses ~2.5 bits per node plus the label data, rank/select tables, and block
+  // handle arrays. For a rough estimate:
+  // ~3 bytes per unique key byte + 16 bytes per entry for handles/metadata.
+  return total_separator_bytes_ * 3 + buffered_entries_.size() * 16;
+}
 
 TrieIndexIterator::TrieIndexIterator(const LoudsTrie* trie,
                                      const Comparator* comparator,

--- a/utilities/trie_index/trie_index_factory.cc
+++ b/utilities/trie_index/trie_index_factory.cc
@@ -57,9 +57,6 @@ Slice TrieIndexBuilder::AddIndexEntry(const Slice& last_key_in_current_block,
     // impossible to distinguish the two blocks. Set the sticky flag so that
     // at Finish() time, ALL separators will include encoded seqnos.
     // This mirrors ShortenedIndexBuilder::must_use_separator_with_seq_.
-    if (!must_use_separator_with_seq_ && same_user_key) {
-      must_use_separator_with_seq_ = true;
-    }
 
     // Edge case: FindShortestSeparator may fail to shorten the key even when
     // the user keys are different. Example: FindShortestSeparator("abc","abd")
@@ -72,9 +69,6 @@ Slice TrieIndexBuilder::AddIndexEntry(const Slice& last_key_in_current_block,
     if (!same_user_key && !buffered_entries_.empty() &&
         buffered_entries_.back().separator_key == *separator_scratch) {
       same_user_key = true;
-      if (!must_use_separator_with_seq_) {
-        must_use_separator_with_seq_ = true;
-      }
     }
   } else {
     // Last block: use the last key itself as the separator, NOT a shortened
@@ -101,9 +95,6 @@ Slice TrieIndexBuilder::AddIndexEntry(const Slice& last_key_in_current_block,
         comparator_->Compare(buffered_entries_.back().separator_key,
                              separator) == 0) {
       same_user_key = true;
-      if (!must_use_separator_with_seq_) {
-        must_use_separator_with_seq_ = true;
-      }
     }
   }
 
@@ -137,9 +128,7 @@ Slice TrieIndexBuilder::AddIndexEntry(const Slice& last_key_in_current_block,
 
   // Seqno encoding must always be enabled so the post-seek correction
   // handles the last block correctly. The overhead is 8 bytes per leaf.
-  if (!must_use_separator_with_seq_) {
-    must_use_separator_with_seq_ = true;
-  }
+  must_use_separator_with_seq_ = true;
   entry.handle = handle;
   total_separator_bytes_ += entry.separator_key.size();
   buffered_entries_.push_back(std::move(entry));
@@ -159,12 +148,10 @@ Status TrieIndexBuilder::Finish(Slice* index_contents) {
   }
   finished_ = true;
 
-  // Use seqno side-table when any same-user-key block boundary was detected.
-  // The must_use_separator_with_seq_ flag is set in AddIndexEntry() whenever
-  // the comparator finds two identical user keys at a block boundary. This
-  // always implies duplicate separators exist (since
-  // FindShortestSeparator("foo", "foo") = "foo"), so no separate scan is
-  // needed.
+  // Seqno encoding is unconditionally enabled: must_use_separator_with_seq_
+  // is always set to true at the end of AddIndexEntry(), so use_seqno
+  // is always true when at least one entry was added. The else branch below
+  // is only reachable for an empty trie (zero entries).
   bool use_seqno = must_use_separator_with_seq_;
   trie_builder_.SetHasSeqnoEncoding(use_seqno);
 
@@ -219,11 +206,11 @@ Status TrieIndexBuilder::Finish(Slice* index_contents) {
       i = run_end;
     }
   } else {
-    // Common case: no same-user-key boundaries, add separators directly.
-    // Zero overhead — no seqno data stored.
-    for (const auto& entry : buffered_entries_) {
-      trie_builder_.AddKey(Slice(entry.separator_key), entry.handle);
-    }
+    // Only reachable when no entries were added (empty trie).
+    // must_use_separator_with_seq_ is unconditionally set to true in
+    // AddIndexEntry(), so this branch cannot be reached when there is at
+    // least one entry.
+    assert(buffered_entries_.empty());
   }
 
   // Release buffered entries — no longer needed after feeding to the trie.
@@ -388,7 +375,7 @@ Status TrieIndexIterator::SeekAndGetResult(const Slice& target,
   // advance through overflow blocks.
   //
   // For non-boundary separators: leaf_seqno is 0. The comparison
-  // target_tag < 0 is always false, so no advancement occurs. This matches
+  // target_packed < 0 is always false, so no advancement occurs. This matches
   // the standard index's index_key_is_user_key=true mode where equal user
   // keys always match without seqno comparison.
   //

--- a/utilities/trie_index/trie_index_factory.h
+++ b/utilities/trie_index/trie_index_factory.h
@@ -108,12 +108,10 @@ class TrieIndexBuilder final : public UserDefinedIndexBuilder {
 
   // Buffered separator entries: (separator_key, tag, handle).
   // The separator_key is the user-key-only separator computed by
-  // FindShortestSeparator. The seqno field stores a packed internal key
-  // tag ((sequence_number << 8) | value_type):
-  //   - For same-user-key boundaries: the tag of last_key
-  //   - For different-user-key boundaries:
-  //     PackSequenceAndType(kMaxSequenceNumber, kValueTypeForSeek) --
-  //     the same tag the standard index uses for these separators
+  // FindShortestSeparator. The tag field stores:
+  //   - For same-user-key boundaries: the real tag of last_key
+  //   - For the last block: the real tag of last_key
+  //   - For intermediate non-boundary entries: 0 (sentinel)
   struct BufferedEntry {
     std::string separator_key;
     uint64_t tag{};

--- a/utilities/trie_index/trie_index_factory.h
+++ b/utilities/trie_index/trie_index_factory.h
@@ -79,6 +79,9 @@ class TrieIndexBuilder final : public UserDefinedIndexBuilder {
   // Finalize the trie and return the serialized index data.
   Status Finish(Slice* index_contents) override;
 
+  // Returns an estimate of the current serialized index size.
+  uint64_t EstimatedSize() const override;
+
  private:
   const Comparator* comparator_;
   LoudsTrieBuilder trie_builder_;
@@ -117,6 +120,8 @@ class TrieIndexBuilder final : public UserDefinedIndexBuilder {
     TrieBlockHandle handle;
   };
   std::vector<BufferedEntry> buffered_entries_;
+  // Running total of separator key bytes for O(1) EstimatedSize().
+  uint64_t total_separator_bytes_ = 0;
 };
 
 // ============================================================================

--- a/utilities/trie_index/trie_index_factory.h
+++ b/utilities/trie_index/trie_index_factory.h
@@ -87,23 +87,21 @@ class TrieIndexBuilder final : public UserDefinedIndexBuilder {
   LoudsTrieBuilder trie_builder_;
   bool finished_;
 
-  // --- Sequence number handling for same-user-key boundaries ---
+  // --- Sequence number handling ---
   //
-  // When the same user key spans a data block boundary (e.g., "foo"|seq=100
-  // ends block N, "foo"|seq=50 starts block N+1), the trie's
-  // FindShortestSeparator("foo", "foo") returns "foo" — which cannot
-  // distinguish the two blocks. To handle this, we use the same all-or-nothing
-  // strategy as ShortenedIndexBuilder::must_use_separator_with_seq_:
+  // Seqno encoding is always enabled: AddIndexEntry() unconditionally sets
+  // must_use_separator_with_seq_ to true (the unconditional set at the end of
+  // AddIndexEntry()). This means the 8-byte-per-leaf seqno side-table overhead
+  // is always incurred. The flag exists so that Finish() can check it to decide
+  // whether to serialize the seqno side-table (true path) or emit a plain
+  // trie without seqno data (false/else path, only reachable for an empty
+  // trie with zero entries).
   //
-  // - Common case: all separators are user-key-only (zero overhead).
-  // - Rare case (any same-user-key boundary detected): ALL separators include
-  //   an 8-byte encoded seqno suffix. This decision is made at Finish() time.
+  // We buffer all separator entries during building, then at Finish() feed
+  // them to the trie with seqno side-table metadata.
   //
-  // We buffer all separator entries during building, then at Finish() either
-  // feed them to the trie as-is (common case) or re-encode them with seqnos.
-  //
-  // True if any same-user-key block boundary was detected during building.
-  // Once set, never cleared (sticky flag, same as internal index).
+  // Always set to true in AddIndexEntry() — seqno encoding is
+  // unconditionally enabled. The 8-byte per-leaf overhead is always incurred.
   bool must_use_separator_with_seq_;
 
   // Buffered separator entries: (separator_key, tag, handle).

--- a/utilities/trie_index/trie_index_test.cc
+++ b/utilities/trie_index/trie_index_test.cc
@@ -2617,7 +2617,8 @@ TEST_F(TrieIndexFactoryTest, IteratorNoBounds) {
 }
 
 TEST_F(TrieIndexFactoryTest, UpperBoundDoesNotDropValidBlocks) {
-  // Regression test for Finding 1: the trie stores separator keys (upper
+  // Validates that CheckBounds uses the previous separator (not the current
+  // one) as the reference key. The trie stores separator keys (upper
   // bounds on block contents), NOT first-in-block keys. CheckBounds must
   // use the previous separator (or seek target) as the reference key, not
   // the current separator, to avoid prematurely rejecting blocks that
@@ -2686,7 +2687,7 @@ TEST_F(TrieIndexFactoryTest, UpperBoundDoesNotDropValidBlocks) {
 }
 
 TEST_F(TrieIndexFactoryTest, MultiScanBoundsAdvanceCorrectly) {
-  // Regression test for Finding 2: current_scan_idx_ must advance when
+  // Validates that current_scan_idx_ advances correctly when
   // the seek target is past the current scan's limit. Otherwise all
   // bounds checks evaluate against scan 0's limit.
   UserDefinedIndexOption option;
@@ -3017,9 +3018,9 @@ TEST_F(TrieIndexFactoryTest, NullComparator) {
   Slice index_contents;
   ASSERT_OK(builder->Finish(&index_contents));
 
-  // NewReader with nullptr comparator should also default to
-  // BytewiseComparator. Without the fix, this would store a null comparator
-  // in the reader and crash on Seek when CheckBounds dereferences it.
+  // NewReader with nullptr comparator must default to BytewiseComparator.
+  // Storing a null comparator would cause a crash on Seek when CheckBounds
+  // dereferences it.
   std::unique_ptr<UserDefinedIndexReader> reader;
   ASSERT_OK(factory_->NewReader(option, index_contents, reader));
   ASSERT_NE(reader, nullptr);
@@ -3855,16 +3856,18 @@ TEST_F(TrieIndexFactoryTest, SeekWithZeroSeqOnSameKeyBlocks) {
 }
 
 TEST_F(TrieIndexFactoryTest, ZeroSeqMustNotSkipLeafForSmallerUserKey) {
-  // Regression test for DBIter's forward-scan reseek path.
+  // Validates correctness of DBIter's forward-scan reseek path.
   //
   // Block 0 ends with user key "m" and block 1 starts with the same user key,
   // so the trie stores separator "m" with non-zero seqno metadata on block 0.
   // However, a seek target for a *smaller* user key "l"|0 must still land on
   // block 0, because block 0 can contain keys in ("l", "m"].
   //
-  // Current buggy behavior applies seqno-based post-seek correction whenever
-  // target_seq < leaf_seqno, even if target user key < separator user key. In
-  // that case it incorrectly advances to block 1.
+  // Verifies that seqno-based post-seek correction is NOT applied when the
+  // target user key is strictly less than the separator user key. The seqno
+  // comparison is only meaningful when user keys are equal. If the target
+  // user key "l" < separator "m", the seek must stay on block 0 regardless
+  // of seqno, because block 0 can contain keys up to "m".
   auto ctx = BuildTrieAndGetIterator({
       {"m", "m", 0, 1000, 300, 200},
       {"y", "zzz", 1000, 1000, 100, 1},
@@ -4087,7 +4090,7 @@ TEST_F(TrieIndexFactoryTest, SeqnoEncodingReSeekAfterOverflow) {
 }
 
 TEST_F(TrieIndexFactoryTest, AllFfLastKeyWithSameKeyBoundary) {
-  // Regression test: all-0xFF last key with same-user-key boundary preceding
+  // Validates that an all-0xFF last key with same-user-key boundary preceding
   // it. The last block uses "\xff\xff" as its separator (no shortening), which
   // matches the previous entry's separator. AddIndexEntry detects the collision
   // and correctly treats it as a same-user-key continuation.
@@ -4446,21 +4449,11 @@ TEST_F(TrieIndexSSTTest, SmallSST) {
   ASSERT_EQ(count, 3);
 }
 
-// Regression test for a historical crash in
-// UserDefinedIndexBuilderWrapper::OnKeyAdded(). Originally, the UDI wrapper
-// rejected non-Put key types (e.g., Delete) by setting its internal status_
-// to non-OK and stopping OnKeyAdded() forwarding to the wrapped internal index
-// builder. However, AddIndexEntry() was always forwarded unconditionally.
-// This asymmetry caused the internal ShortenedIndexBuilder's
-// current_block_first_internal_key_ to remain empty, hitting an assertion
-// in GetFirstInternalKey() during the buffered-block replay in
-// MaybeEnterUnbuffered(). That bug was fixed by ensuring the internal builder
-// always receives OnKeyAdded() regardless of UDI-specific errors.
-//
-// Since then, the UDI wrapper has been updated to support all operation types
-// (Put, Delete, Merge, SingleDelete, etc.), so Finish() now succeeds. This
-// test remains valuable as a regression guard for the compression dictionary
-// buffered-mode code path with mixed key types.
+// Validates that mixed key types (Put, Delete, Merge, SingleDelete) work
+// correctly with the compression dictionary buffered-mode code path. The
+// UDI wrapper forwards OnKeyAdded() to the internal ShortenedIndexBuilder
+// for all value types, ensuring current_block_first_internal_key_ is always
+// populated before the buffered-block replay in MaybeEnterUnbuffered().
 TEST_F(TrieIndexSSTTest, MixedKeyTypesWithCompressionDict) {
   const auto& dict_compressions = GetSupportedDictCompressions();
   if (dict_compressions.empty()) {
@@ -5061,9 +5054,9 @@ TEST_F(TrieIndexFactoryTest, WrapperNextAndGetResultReturnsInternalKey) {
   ASSERT_TRUE(valid);
   ASSERT_OK(wrapper.status());
 
-  // result.key must also be an internal key, not a raw user key.
-  // Before the fix, result.key would be "b" (1 byte, raw user key).
-  // After the fix, result.key is "b" + 8-byte internal key suffix.
+  // result.key must be an internal key ("b" + 8-byte suffix), not a raw
+  // user key ("b" alone). Returning a raw user key would cause the
+  // BlockBasedTableIterator to misinterpret the key format.
   ASSERT_EQ(result.key.size(), 1u + 8u)
       << "NextAndGetResult key must be internal key (user_key + 8-byte "
          "footer), got size "
@@ -5090,10 +5083,10 @@ TEST_F(TrieIndexFactoryTest, WrapperNextAndGetResultReturnsInternalKey) {
   EXPECT_FALSE(valid);
 }
 
-// Regression test: overflow blocks must be BFS-reordered alongside primary
-// handles. Without BFS reordering, when separator keys have different lengths
-// (causing BFS leaf order to differ from key-sorted order), the overflow_base_
-// prefix sum maps overflow blocks to the wrong leaves.
+// Verifies that overflow blocks are BFS-reordered alongside primary handles.
+// If overflow blocks were stored in key-sorted order instead of BFS order,
+// the overflow_base_ prefix sum would map overflow blocks to the wrong
+// leaves when separator keys have different lengths.
 //
 // Key design:
 //   Trie entries: "ab"(bc=2), "ac"(bc=1), "b"(bc=2), "c"(bc=1), "e"(bc=1)
@@ -5276,8 +5269,9 @@ TEST_F(TrieIndexFactoryTest, OverflowBfsReordering) {
   // "b" overflow: Seek("b", 200) → offset=400
   // Primary seqno=300, 200<300 → advance to overflow. Overflow seqno=200,
   // 200>=200 → match.
-  // WITHOUT THE FIX: overflow[0] would be ab's data {offset=100,seqno=400},
-  // and 200<400 would fail to match, incorrectly advancing to "c".
+  // If overflow blocks were NOT BFS-reordered, overflow[0] would contain
+  // ab's data {offset=100,seqno=400}, and 200<400 would fail to match,
+  // incorrectly advancing to "c".
   ASSERT_OK(iter->SeekAndGetResult(Slice("b"), &result, SeekCtx(200)));
   EXPECT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
   EXPECT_EQ(result.key.ToString(), "b")
@@ -5369,8 +5363,8 @@ TEST_F(TrieIndexFactoryTest, LastBlockSeekWithRealSeqno) {
   // stays on this block (matching the standard index which stores the full
   // internal key for the last block's separator).
   //
-  // Without this fix, the last block stored NonBoundaryTag() which caused
-  // seeks with real seqnos to incorrectly advance past the last block.
+  // The last block stores the real tag of its last key (not a sentinel),
+  // so seeks with real seqnos correctly stay on this block.
   auto ctx = BuildTrieAndGetIterator({
       {"apple", "cherry", 0, 1000, 100, 50},
       {"cherry", "", 1000, 1000, 50, 0},
@@ -5450,9 +5444,11 @@ TEST_F(TrieIndexFactoryTest, NonBoundarySeparatorSeekWhenShorteningFails) {
   // The separator "acc" has tag=0 (non-boundary sentinel), so
   // target_packed < 0 is always false → no advancement occurs.
   //
-  // Before the fix (NonBoundaryTag = kMaxSequenceNumber), the comparison
-  // target_packed < kMaxSequenceNumber was always true for real seqnos,
-  // causing incorrect advancement past block 1.
+  // Non-boundary separators use tag=0 (sentinel). For unsigned uint64_t,
+  // target_packed < 0 is always false, so no advancement occurs. This
+  // matches the standard index's user-key-only comparison semantics.
+  // If the sentinel were kMaxSequenceNumber instead, target_packed < kMax
+  // would be true for all real seqnos, causing incorrect advancement.
   ASSERT_NO_FATAL_FAILURE(
       AssertSeekOffset(ctx.iter.get(), Slice("acc"), kMaxSequenceNumber, 1000));
   ASSERT_NO_FATAL_FAILURE(

--- a/utilities/trie_index/trie_index_test.cc
+++ b/utilities/trie_index/trie_index_test.cc
@@ -2427,7 +2427,8 @@ class TrieIndexFactoryTest : public testing::Test {
       const std::vector<uint64_t>& expected_offsets) {
     ASSERT_FALSE(expected_offsets.empty());
     IterateResult result;
-    ASSERT_OK(iter->SeekAndGetResult(first_key, &result, {kMaxSequenceNumber}));
+    ASSERT_OK(iter->SeekAndGetResult(first_key, &result,
+                                     SeekCtx(kMaxSequenceNumber)));
     ASSERT_EQ(iter->value().offset, expected_offsets[0]);
     for (size_t i = 1; i < expected_offsets.size(); i++) {
       ASSERT_OK(iter->NextAndGetResult(&result));
@@ -2464,7 +2465,7 @@ TEST_F(TrieIndexFactoryTest, BasicBuildAndRead) {
     Slice next_slice(first_keys[i]);
     const Slice* next = (i < last_keys.size() - 1) ? &next_slice : nullptr;
     builder->AddIndexEntry(Slice(last_keys[i]), next, handle, &scratch,
-                           EntryCtx(0, 0));
+                           EntryCtx(100, 100));
   }
 
   // Finish building.
@@ -2485,8 +2486,8 @@ TEST_F(TrieIndexFactoryTest, BasicBuildAndRead) {
 
   // Seek to "banana" — should find the separator for the second block.
   IterateResult result;
-  ASSERT_OK(
-      iter->SeekAndGetResult(Slice("banana"), &result, {kMaxSequenceNumber}));
+  ASSERT_OK(iter->SeekAndGetResult(Slice("banana"), &result,
+                                   SeekCtx(kMaxSequenceNumber)));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
 }
 
@@ -2547,10 +2548,10 @@ TEST_F(TrieIndexFactoryTest, IteratorBoundsChecking) {
       snprintf(next_buf, sizeof(next_buf), "key_%02d", i + 1);
       Slice next(next_buf);
       udi_builder->AddIndexEntry(Slice(sep), &next, handle, &scratch,
-                                 EntryCtx(0, 0));
+                                 EntryCtx(100, 100));
     } else {
       udi_builder->AddIndexEntry(Slice(sep), nullptr, handle, &scratch,
-                                 EntryCtx(0, 0));
+                                 EntryCtx(100, 100));
     }
   }
 
@@ -2569,8 +2570,8 @@ TEST_F(TrieIndexFactoryTest, IteratorBoundsChecking) {
 
   // Seek to first key — should be in bound.
   IterateResult result;
-  ASSERT_OK(
-      iter->SeekAndGetResult(Slice("key_00"), &result, {kMaxSequenceNumber}));
+  ASSERT_OK(iter->SeekAndGetResult(Slice("key_00"), &result,
+                                   SeekCtx(kMaxSequenceNumber)));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
 
   // Next — should be in bound (key_01 < key_01z).
@@ -2597,7 +2598,7 @@ TEST_F(TrieIndexFactoryTest, IteratorNoBounds) {
   UserDefinedIndexBuilder::BlockHandle handle{0, 500};
   std::string scratch;
   udi_builder->AddIndexEntry(Slice("key"), nullptr, handle, &scratch,
-                             EntryCtx(0, 0));
+                             EntryCtx(100, 100));
 
   Slice index_contents;
   ASSERT_OK(udi_builder->Finish(&index_contents));
@@ -2610,8 +2611,8 @@ TEST_F(TrieIndexFactoryTest, IteratorNoBounds) {
 
   // No Prepare() call — bounds should be kInbound.
   IterateResult result;
-  ASSERT_OK(
-      iter->SeekAndGetResult(Slice("key"), &result, {kMaxSequenceNumber}));
+  ASSERT_OK(iter->SeekAndGetResult(Slice("key"), &result,
+                                   SeekCtx(kMaxSequenceNumber)));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
 }
 
@@ -2633,7 +2634,7 @@ TEST_F(TrieIndexFactoryTest, UpperBoundDoesNotDropValidBlocks) {
     std::string scratch;
     Slice next("c");
     udi_builder->AddIndexEntry(Slice("az"), &next, handle, &scratch,
-                               EntryCtx(0, 0));
+                               EntryCtx(100, 100));
   }
   // Block 1: last="cz", next_first="e" → separator ≈ "d"
   {
@@ -2641,14 +2642,14 @@ TEST_F(TrieIndexFactoryTest, UpperBoundDoesNotDropValidBlocks) {
     std::string scratch;
     Slice next("e");
     udi_builder->AddIndexEntry(Slice("cz"), &next, handle, &scratch,
-                               EntryCtx(0, 0));
+                               EntryCtx(100, 100));
   }
   // Block 2: last="ez", no next → separator ≈ "f"
   {
     UserDefinedIndexBuilder::BlockHandle handle{2000, 1000};
     std::string scratch;
     udi_builder->AddIndexEntry(Slice("ez"), nullptr, handle, &scratch,
-                               EntryCtx(0, 0));
+                               EntryCtx(100, 100));
   }
 
   Slice index_contents;
@@ -2666,7 +2667,8 @@ TEST_F(TrieIndexFactoryTest, UpperBoundDoesNotDropValidBlocks) {
 
   IterateResult result;
   // Seek("a") → lands on block 0 (separator "b"). target "a" < "d" → kInbound.
-  ASSERT_OK(iter->SeekAndGetResult(Slice("a"), &result, {kMaxSequenceNumber}));
+  ASSERT_OK(
+      iter->SeekAndGetResult(Slice("a"), &result, SeekCtx(kMaxSequenceNumber)));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
   ASSERT_EQ(iter->value().offset, 0u);
 
@@ -2736,7 +2738,8 @@ TEST_F(TrieIndexFactoryTest, MultiScanBoundsAdvanceCorrectly) {
 
   // --- Scan 0 ---
   // Seek("a") → block 0 (separator "b"). target "a" < limit "c" → kInbound.
-  ASSERT_OK(iter->SeekAndGetResult(Slice("a"), &result, {kMaxSequenceNumber}));
+  ASSERT_OK(
+      iter->SeekAndGetResult(Slice("a"), &result, SeekCtx(kMaxSequenceNumber)));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
   ASSERT_EQ(iter->value().offset, 0u);
 
@@ -2753,7 +2756,8 @@ TEST_F(TrieIndexFactoryTest, MultiScanBoundsAdvanceCorrectly) {
   // Seek("e") should advance current_scan_idx_ to 1 (target "e" >= scan 0
   // limit "c"), then check against scan 1's limit "g".
   // Lands on block 2 (separator "f"). target "e" < "g" → kInbound.
-  ASSERT_OK(iter->SeekAndGetResult(Slice("e"), &result, {kMaxSequenceNumber}));
+  ASSERT_OK(
+      iter->SeekAndGetResult(Slice("e"), &result, SeekCtx(kMaxSequenceNumber)));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
   ASSERT_EQ(iter->value().offset, 2000u);
 
@@ -2858,8 +2862,8 @@ TEST_F(TrieIndexFactoryTest, EmptyTrieIterator) {
   ASSERT_NE(iter, nullptr);
 
   IterateResult result;
-  ASSERT_OK(
-      iter->SeekAndGetResult(Slice("anything"), &result, {kMaxSequenceNumber}));
+  ASSERT_OK(iter->SeekAndGetResult(Slice("anything"), &result,
+                                   SeekCtx(kMaxSequenceNumber)));
   // kUnknown: no leaf has a key >= target, so the target is past all blocks
   // in this SST. We return kUnknown (not kOutOfBound) because exhausting
   // this SST says nothing about the upper bound — the next SST on the level
@@ -2879,8 +2883,8 @@ TEST_F(TrieIndexFactoryTest, PrepareWithZeroScans) {
   ctx.iter->Prepare(nullptr, 0);
 
   IterateResult result;
-  ASSERT_OK(
-      ctx.iter->SeekAndGetResult(Slice("a"), &result, {kMaxSequenceNumber}));
+  ASSERT_OK(ctx.iter->SeekAndGetResult(Slice("a"), &result,
+                                       SeekCtx(kMaxSequenceNumber)));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
 }
 
@@ -2897,8 +2901,8 @@ TEST_F(TrieIndexFactoryTest, RePrepareResetsScanState) {
   ctx.iter->Prepare(&scan1, 1);
 
   IterateResult result;
-  ASSERT_OK(
-      ctx.iter->SeekAndGetResult(Slice("a"), &result, {kMaxSequenceNumber}));
+  ASSERT_OK(ctx.iter->SeekAndGetResult(Slice("a"), &result,
+                                       SeekCtx(kMaxSequenceNumber)));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
 
   // Re-prepare with a broader limit "f".
@@ -2906,8 +2910,8 @@ TEST_F(TrieIndexFactoryTest, RePrepareResetsScanState) {
   ctx.iter->Prepare(&scan2, 1);
 
   // Should be able to seek to "d" and get inbound with the new limit.
-  ASSERT_OK(
-      ctx.iter->SeekAndGetResult(Slice("d"), &result, {kMaxSequenceNumber}));
+  ASSERT_OK(ctx.iter->SeekAndGetResult(Slice("d"), &result,
+                                       SeekCtx(kMaxSequenceNumber)));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
 }
 
@@ -2925,8 +2929,8 @@ TEST_F(TrieIndexFactoryTest, ScanWithNoLimit) {
 
   // All seeks should be inbound with no limit.
   IterateResult result;
-  ASSERT_OK(
-      ctx.iter->SeekAndGetResult(Slice("a"), &result, {kMaxSequenceNumber}));
+  ASSERT_OK(ctx.iter->SeekAndGetResult(Slice("a"), &result,
+                                       SeekCtx(kMaxSequenceNumber)));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
 
   ASSERT_OK(ctx.iter->NextAndGetResult(&result));
@@ -2977,7 +2981,7 @@ TEST_F(TrieIndexFactoryTest, OnKeyAddedNoOp) {
   UserDefinedIndexBuilder::BlockHandle handle{0, 500};
   std::string scratch;
   builder->AddIndexEntry(Slice("key5"), nullptr, handle, &scratch,
-                         EntryCtx(0, 0));
+                         EntryCtx(100, 100));
 
   Slice index_contents;
   ASSERT_OK(builder->Finish(&index_contents));
@@ -3002,11 +3006,12 @@ TEST_F(TrieIndexFactoryTest, NullComparator) {
   {
     UserDefinedIndexBuilder::BlockHandle h{0, 100};
     Slice next("b");
-    builder->AddIndexEntry(Slice("a"), &next, h, &scratch, EntryCtx(0, 0));
+    builder->AddIndexEntry(Slice("a"), &next, h, &scratch, EntryCtx(100, 100));
   }
   {
     UserDefinedIndexBuilder::BlockHandle h{100, 100};
-    builder->AddIndexEntry(Slice("b"), nullptr, h, &scratch, EntryCtx(0, 0));
+    builder->AddIndexEntry(Slice("b"), nullptr, h, &scratch,
+                           EntryCtx(100, 100));
   }
 
   Slice index_contents;
@@ -3023,11 +3028,13 @@ TEST_F(TrieIndexFactoryTest, NullComparator) {
   ReadOptions ro;
   auto iter = reader->NewIterator(ro);
   IterateResult result;
-  ASSERT_OK(iter->SeekAndGetResult(Slice("a"), &result, SeekCtx(0)));
+  ASSERT_OK(
+      iter->SeekAndGetResult(Slice("a"), &result, SeekCtx(kMaxSequenceNumber)));
   EXPECT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
   EXPECT_EQ(iter->value().offset, 0u);
 
-  ASSERT_OK(iter->SeekAndGetResult(Slice("b"), &result, SeekCtx(0)));
+  ASSERT_OK(
+      iter->SeekAndGetResult(Slice("b"), &result, SeekCtx(kMaxSequenceNumber)));
   EXPECT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
   EXPECT_EQ(iter->value().offset, 100u);
 }
@@ -3047,13 +3054,13 @@ TEST_F(TrieIndexFactoryTest, SeekSucceedsButTargetPastLimit) {
 
   // Seek to "c" — target == limit, so CheckBounds returns kOutOfBound.
   IterateResult result;
-  ASSERT_OK(
-      ctx.iter->SeekAndGetResult(Slice("c"), &result, {kMaxSequenceNumber}));
+  ASSERT_OK(ctx.iter->SeekAndGetResult(Slice("c"), &result,
+                                       SeekCtx(kMaxSequenceNumber)));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kOutOfBound);
 
   // Seek to "d" — target > limit, also kOutOfBound.
-  ASSERT_OK(
-      ctx.iter->SeekAndGetResult(Slice("d"), &result, {kMaxSequenceNumber}));
+  ASSERT_OK(ctx.iter->SeekAndGetResult(Slice("d"), &result,
+                                       SeekCtx(kMaxSequenceNumber)));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kOutOfBound);
 }
 
@@ -3120,9 +3127,9 @@ TEST_F(TrieIndexFactoryTest, SameUserKeyBoundaryTriggersSeqnoEncoding) {
       AssertFullForwardScan(ctx.iter.get(), Slice("foo"), {0, 1000, 2000}));
 }
 
-TEST_F(TrieIndexFactoryTest, DistinctUserKeysNoSeqnoOverhead) {
-  // When all user keys are distinct (the common case), the trie should NOT
-  // use seqno encoding. This verifies zero overhead for the normal case.
+TEST_F(TrieIndexFactoryTest, DistinctUserKeysSeekWithMaxSeqno) {
+  // Seqno encoding is always active. Verify that seeking with
+  // kMaxSequenceNumber correctly finds each block.
   auto ctx = BuildTrieAndGetIterator({
       {"apple", "cherry", 0, 1000, 100, 50},
       {"cherry", "elderberry", 1000, 1000, 50, 1},
@@ -3379,8 +3386,8 @@ TEST_F(TrieIndexFactoryTest, LargeOverflowRun) {
   IterateResult result;
 
   // Seek "key"|kMax → Block 0.
-  ASSERT_OK(
-      iter->SeekAndGetResult(Slice("key"), &result, {kMaxSequenceNumber}));
+  ASSERT_OK(iter->SeekAndGetResult(Slice("key"), &result,
+                                   SeekCtx(kMaxSequenceNumber)));
   ASSERT_EQ(iter->value().offset, 0u);
 
   // Seek "key"|1100 → leaf_seqno=1200, 1100<1200 → advance.
@@ -3407,8 +3414,8 @@ TEST_F(TrieIndexFactoryTest, LargeOverflowRun) {
   ASSERT_EQ(iter->value().offset, 11000u);
 
   // Full forward scan: blocks 0..10 ("key" run) → 11 ("l") → 12 ("zzz").
-  ASSERT_OK(
-      iter->SeekAndGetResult(Slice("key"), &result, {kMaxSequenceNumber}));
+  ASSERT_OK(iter->SeekAndGetResult(Slice("key"), &result,
+                                   SeekCtx(kMaxSequenceNumber)));
   ASSERT_EQ(iter->value().offset, 0u);
   for (int i = 1; i <= kNumKeyBlocks; i++) {
     ASSERT_OK(iter->NextAndGetResult(&result));
@@ -3515,8 +3522,8 @@ TEST_F(TrieIndexFactoryTest, MixedSameKeyRuns) {
   // Trie structure: "aaa"(run=2) → "b" → "mmm"(run=1) → "n" → "zzz"
   //
   // Seek "aaa"|kMax → Block 0.
-  ASSERT_OK(
-      iter->SeekAndGetResult(Slice("aaa"), &result, {kMaxSequenceNumber}));
+  ASSERT_OK(iter->SeekAndGetResult(Slice("aaa"), &result,
+                                   SeekCtx(kMaxSequenceNumber)));
   ASSERT_EQ(iter->value().offset, 0u);
 
   // Seek "aaa"|250 → leaf_seqno=300, 250<300 → advance.
@@ -3530,8 +3537,8 @@ TEST_F(TrieIndexFactoryTest, MixedSameKeyRuns) {
   ASSERT_EQ(iter->value().offset, 2000u);
 
   // Seek "mmm"|kMax → Block 3 (the "mmm" trie leaf).
-  ASSERT_OK(
-      iter->SeekAndGetResult(Slice("mmm"), &result, {kMaxSequenceNumber}));
+  ASSERT_OK(iter->SeekAndGetResult(Slice("mmm"), &result,
+                                   SeekCtx(kMaxSequenceNumber)));
   ASSERT_EQ(iter->value().offset, 3000u);
 
   // Seek "mmm"|45 → leaf_seqno=60, 45<60 → advance.
@@ -3543,8 +3550,8 @@ TEST_F(TrieIndexFactoryTest, MixedSameKeyRuns) {
   ASSERT_EQ(iter->value().offset, 4000u);
 
   // Full forward scan: 0 → 1 → 2 → 3 → 4 → 5.
-  ASSERT_OK(
-      iter->SeekAndGetResult(Slice("aaa"), &result, {kMaxSequenceNumber}));
+  ASSERT_OK(iter->SeekAndGetResult(Slice("aaa"), &result,
+                                   SeekCtx(kMaxSequenceNumber)));
   ASSERT_EQ(iter->value().offset, 0u);
 
   uint64_t expected_offsets[] = {0, 1000, 2000, 3000, 4000, 5000};
@@ -3584,8 +3591,8 @@ TEST_F(TrieIndexFactoryTest, AdjacentSameKeyRuns) {
 
   // Full scan: "aaa" (block 0) → "b" (block 1) → "bbb" (block 2) → "bbb"
   // overflow (block 3).
-  ASSERT_OK(
-      ctx.iter->SeekAndGetResult(Slice("aaa"), &result, {kMaxSequenceNumber}));
+  ASSERT_OK(ctx.iter->SeekAndGetResult(Slice("aaa"), &result,
+                                       SeekCtx(kMaxSequenceNumber)));
   ASSERT_EQ(ctx.iter->value().offset, 0u);
   ASSERT_EQ(result.key.ToString(), "aaa");
 
@@ -3658,7 +3665,8 @@ TEST_F(TrieIndexFactoryTest, SeekNonExistentKeyWithSeqnoEncoding) {
 
   // Seek "|" (past all keys, "|" > "zzz") → kUnknown.
   IterateResult result;
-  ASSERT_OK(iter->SeekAndGetResult(Slice("|"), &result, {kMaxSequenceNumber}));
+  ASSERT_OK(
+      iter->SeekAndGetResult(Slice("|"), &result, SeekCtx(kMaxSequenceNumber)));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kUnknown);
 }
 
@@ -3675,8 +3683,8 @@ TEST_F(TrieIndexFactoryTest, SeqnoEncodingPastEndAndNextPastEnd) {
   IterateResult result;
 
   // Seek past all keys → kUnknown (exhaustion doesn't imply upper bound).
-  ASSERT_OK(
-      iter->SeekAndGetResult(Slice("zzz"), &result, {kMaxSequenceNumber}));
+  ASSERT_OK(iter->SeekAndGetResult(Slice("zzz"), &result,
+                                   SeekCtx(kMaxSequenceNumber)));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kUnknown);
 
   // Seek "key"|5 → seqno=10 on primary, 5<10 → overflow seqno=5, 5>=5 →
@@ -3758,9 +3766,9 @@ TEST_F(TrieIndexFactoryTest, SeqnoEncodingOutOfBoundWithOverflow) {
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kOutOfBound);
 }
 
-TEST_F(TrieIndexFactoryTest, SeqnoEncodingZeroOverhead) {
-  // Verify that when all user keys are distinct, the serialized trie with
-  // seqno parameters is identical in size to a trie built without them.
+TEST_F(TrieIndexFactoryTest, SeqnoEncodingConsistentSize) {
+  // Verify that tries built with different seqno contexts produce the
+  // same serialized size (seqno encoding is always on).
   UserDefinedIndexOption option;
   option.comparator = BytewiseComparator();
 
@@ -3939,8 +3947,8 @@ TEST_F(TrieIndexFactoryTest, NextTransitionOverflowToOverflow) {
   IterateResult result;
 
   // Full forward scan.
-  ASSERT_OK(
-      iter->SeekAndGetResult(Slice("aaa"), &result, {kMaxSequenceNumber}));
+  ASSERT_OK(iter->SeekAndGetResult(Slice("aaa"), &result,
+                                   SeekCtx(kMaxSequenceNumber)));
   ASSERT_EQ(iter->value().offset, 0u);
   ASSERT_EQ(result.key.ToString(), "aaa");
 
@@ -5007,16 +5015,17 @@ TEST_F(TrieIndexFactoryTest, WrapperNextAndGetResultReturnsInternalKey) {
   {
     UserDefinedIndexBuilder::BlockHandle h{0, 100};
     Slice next("b");
-    builder->AddIndexEntry(Slice("a"), &next, h, &scratch, EntryCtx(0, 0));
+    builder->AddIndexEntry(Slice("a"), &next, h, &scratch, EntryCtx(100, 100));
   }
   {
     UserDefinedIndexBuilder::BlockHandle h{100, 100};
     Slice next("c");
-    builder->AddIndexEntry(Slice("b"), &next, h, &scratch, EntryCtx(0, 0));
+    builder->AddIndexEntry(Slice("b"), &next, h, &scratch, EntryCtx(100, 100));
   }
   {
     UserDefinedIndexBuilder::BlockHandle h{200, 100};
-    builder->AddIndexEntry(Slice("c"), nullptr, h, &scratch, EntryCtx(0, 0));
+    builder->AddIndexEntry(Slice("c"), nullptr, h, &scratch,
+                           EntryCtx(100, 100));
   }
 
   Slice index_contents;
@@ -5032,7 +5041,7 @@ TEST_F(TrieIndexFactoryTest, WrapperNextAndGetResultReturnsInternalKey) {
 
   // Seek to "a" — constructs an internal key from user key "a".
   InternalKey seek_ikey;
-  seek_ikey.Set(Slice("a"), 0, ValueType::kTypeValue);
+  seek_ikey.Set(Slice("a"), kMaxSequenceNumber, kValueTypeForSeek);
   wrapper.Seek(Slice(*seek_ikey.const_rep()));
   ASSERT_TRUE(wrapper.Valid());
   ASSERT_OK(wrapper.status());
@@ -5138,7 +5147,7 @@ TEST_F(TrieIndexFactoryTest, OverflowBfsReordering) {
     UserDefinedIndexBuilder::BlockHandle h{200, 100};
     Slice next("b");
     sep = builder->AddIndexEntry(Slice("abc"), &next, h, &scratch,
-                                 EntryCtx(0, 0));
+                                 EntryCtx(100, 100));
     ASSERT_EQ(scratch, "ac") << "Block 2 separator";
   }
   // Block 3: last="b", next="b" (same-key boundary)
@@ -5166,8 +5175,8 @@ TEST_F(TrieIndexFactoryTest, OverflowBfsReordering) {
   {
     UserDefinedIndexBuilder::BlockHandle h{500, 100};
     Slice next("d");
-    sep =
-        builder->AddIndexEntry(Slice("ba"), &next, h, &scratch, EntryCtx(0, 0));
+    sep = builder->AddIndexEntry(Slice("ba"), &next, h, &scratch,
+                                 EntryCtx(100, 100));
     ASSERT_EQ(scratch, "c") << "Block 5 separator";
   }
   // Block 6: last="d", next=null (last block, no successor shortening)
@@ -5175,7 +5184,7 @@ TEST_F(TrieIndexFactoryTest, OverflowBfsReordering) {
   {
     UserDefinedIndexBuilder::BlockHandle h{600, 100};
     sep = builder->AddIndexEntry(Slice("d"), nullptr, h, &scratch,
-                                 EntryCtx(0, 0));
+                                 EntryCtx(100, 100));
   }
 
   // After Finish(), trie entries (key-sorted):
@@ -5238,7 +5247,8 @@ TEST_F(TrieIndexFactoryTest, OverflowBfsReordering) {
   // --- Seek-based tests: verify overflow data is correctly associated ---
 
   // "ab" primary: Seek("ab", kMax) → offset=0
-  ASSERT_OK(iter->SeekAndGetResult(Slice("ab"), &result, {kMaxSequenceNumber}));
+  ASSERT_OK(iter->SeekAndGetResult(Slice("ab"), &result,
+                                   SeekCtx(kMaxSequenceNumber)));
   EXPECT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
   EXPECT_EQ(iter->value().offset, 0u) << "Seek(ab,kMax): ab primary";
 
@@ -5258,7 +5268,8 @@ TEST_F(TrieIndexFactoryTest, OverflowBfsReordering) {
   EXPECT_EQ(iter->value().offset, 200u) << "Seek(ab,50): expected ac (200)";
 
   // "b" primary: Seek("b", kMax) → offset=300
-  ASSERT_OK(iter->SeekAndGetResult(Slice("b"), &result, {kMaxSequenceNumber}));
+  ASSERT_OK(
+      iter->SeekAndGetResult(Slice("b"), &result, SeekCtx(kMaxSequenceNumber)));
   EXPECT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
   EXPECT_EQ(iter->value().offset, 300u) << "Seek(b,kMax): b primary";
 
@@ -5349,6 +5360,72 @@ TEST_F(TrieIndexFactoryTest, SeekToLastAndPrevWithPrefixKeys) {
   }
   std::vector<std::string> expected_rev(fwd_keys.rbegin(), fwd_keys.rend());
   ASSERT_EQ(rev_keys, expected_rev);
+}
+
+TEST_F(TrieIndexFactoryTest, LastBlockSeekWithRealSeqno) {
+  // Verifies that seeking with a real seqno (not kMaxSequenceNumber) on the
+  // last block's separator correctly finds the block. The last block stores
+  // the real tag of the last key, so a seek with any seqno <= that tag
+  // stays on this block (matching the standard index which stores the full
+  // internal key for the last block's separator).
+  //
+  // Without this fix, the last block stored NonBoundaryTag() which caused
+  // seeks with real seqnos to incorrectly advance past the last block.
+  auto ctx = BuildTrieAndGetIterator({
+      {"apple", "cherry", 0, 1000, 100, 50},
+      {"cherry", "", 1000, 1000, 50, 0},
+  });
+
+  // Seek "cherry" with kMaxSequenceNumber — should find block at offset 1000.
+  ASSERT_NO_FATAL_FAILURE(AssertSeekOffset(ctx.iter.get(), Slice("cherry"),
+                                           kMaxSequenceNumber, 1000));
+
+  // Seek "cherry" with a real seqno (200) — the last block's separator has
+  // seqno=50. In internal key order, 200 > 50 means target is SMALLER (higher
+  // seqno = smaller key). So target <= separator → should stay on this block.
+  ASSERT_NO_FATAL_FAILURE(
+      AssertSeekOffset(ctx.iter.get(), Slice("cherry"), 200, 1000));
+
+  // Seek "cherry" with seqno=50 (equal to separator) — should stay.
+  ASSERT_NO_FATAL_FAILURE(
+      AssertSeekOffset(ctx.iter.get(), Slice("cherry"), 50, 1000));
+
+  // Seek "cherry" with seqno=10 (less than separator seqno=50) — target is
+  // LARGER in internal key order. target > separator → should advance past.
+  // But this is the last block — no next block → past end.
+  IterateResult result;
+  ASSERT_OK(ctx.iter->SeekAndGetResult(Slice("cherry"), &result, SeekCtx(10)));
+  ASSERT_EQ(result.bound_check_result, IterBoundCheck::kUnknown);
+}
+
+TEST_F(TrieIndexFactoryTest, IntermediateNonBoundarySeparatorNoAdvance) {
+  // Verifies that seeking with any seqno on an intermediate non-boundary
+  // separator does NOT advance past it. Intermediate non-boundary separators
+  // store tag=0 (sentinel), making target_tag < 0 always false → stays.
+  // This matches the standard index's index_key_is_user_key=true mode where
+  // equal user keys always match without seqno comparison.
+  auto ctx = BuildTrieAndGetIterator({
+      {"apple", "cherry", 0, 1000, 100, 50},
+      {"cherry", "elderberry", 1000, 1000, 50, 1},
+      {"elderberry", "", 2000, 1000, 1, 0},
+  });
+
+  // FindShortestSeparator("apple", "cherry") = "b" (shortened).
+  // Seeking for "apple" should find block 0 regardless of seqno.
+  ASSERT_NO_FATAL_FAILURE(
+      AssertSeekOffset(ctx.iter.get(), Slice("apple"), kMaxSequenceNumber, 0));
+  ASSERT_NO_FATAL_FAILURE(
+      AssertSeekOffset(ctx.iter.get(), Slice("apple"), 1, 0));
+  ASSERT_NO_FATAL_FAILURE(
+      AssertSeekOffset(ctx.iter.get(), Slice("apple"), 0, 0));
+
+  // Seeking for "cherry" should find block 1 regardless of seqno.
+  // The separator between block 0 and 1 is a shortened key (non-boundary).
+  // "cherry" matches block 1's separator — should stay with any seqno.
+  ASSERT_NO_FATAL_FAILURE(AssertSeekOffset(ctx.iter.get(), Slice("cherry"),
+                                           kMaxSequenceNumber, 1000));
+  ASSERT_NO_FATAL_FAILURE(
+      AssertSeekOffset(ctx.iter.get(), Slice("cherry"), 1, 1000));
 }
 
 }  // namespace trie_index

--- a/utilities/trie_index/trie_index_test.cc
+++ b/utilities/trie_index/trie_index_test.cc
@@ -5428,6 +5428,268 @@ TEST_F(TrieIndexFactoryTest, IntermediateNonBoundarySeparatorNoAdvance) {
       AssertSeekOffset(ctx.iter.get(), Slice("cherry"), 1, 1000));
 }
 
+TEST_F(TrieIndexFactoryTest, NonBoundarySeparatorSeekWhenShorteningFails) {
+  // Reproducer for GitHub issue #14561: when FindShortestSeparator cannot
+  // shorten the separator (e.g., "acc" -> "acd" stays "acc"), the trie lands
+  // on separator "acc" with tag=0 (non-boundary sentinel). The post-seek
+  // correction must NOT advance past it regardless of the target seqno.
+  //
+  // Seqno encoding is always active (must_use_separator_with_seq_=true).
+  // The key arrangement:
+  //   Block 0: separator = FindShortestSeparator("aaa","acc") = "ab"
+  //   Block 1: separator = FindShortestSeparator("acc","acd") = "acc"
+  //            (shortening fails because 'c'+1='d' is not < 'd')
+  //   Block 2: last block, separator = "acd", real tag
+  auto ctx = BuildTrieAndGetIterator({
+      {"aaa", "acc", 0, 1000, 100, 50},
+      {"acc", "acd", 1000, 1000, 50, 40},
+      {"acd", "", 2000, 1000, 40, 0},
+  });
+
+  // Seek for "acc" with any seqno should find block 1 at offset 1000.
+  // The separator "acc" has tag=0 (non-boundary sentinel), so
+  // target_packed < 0 is always false → no advancement occurs.
+  //
+  // Before the fix (NonBoundaryTag = kMaxSequenceNumber), the comparison
+  // target_packed < kMaxSequenceNumber was always true for real seqnos,
+  // causing incorrect advancement past block 1.
+  ASSERT_NO_FATAL_FAILURE(
+      AssertSeekOffset(ctx.iter.get(), Slice("acc"), kMaxSequenceNumber, 1000));
+  ASSERT_NO_FATAL_FAILURE(
+      AssertSeekOffset(ctx.iter.get(), Slice("acc"), 50, 1000));
+  ASSERT_NO_FATAL_FAILURE(
+      AssertSeekOffset(ctx.iter.get(), Slice("acc"), 1, 1000));
+  ASSERT_NO_FATAL_FAILURE(
+      AssertSeekOffset(ctx.iter.get(), Slice("acc"), 0, 1000));
+
+  // Full forward scan verifies all blocks are reachable.
+  AssertFullForwardScan(ctx.iter.get(), Slice("aaa"), {0, 1000, 2000});
+}
+
+TEST_F(TrieIndexFactoryTest, PrevWithinOverflowRun) {
+  // Exercises PrevAndGetResult when positioned mid-overflow: the fast path
+  // that decrements overflow_run_index_ without calling iter_.Prev().
+  auto ctx = BuildTrieAndGetIterator({
+      // Block 0-2: "key" spans 3 blocks (overflow run).
+      {"key", "key", 0, 1000, 300, 200},
+      {"key", "key", 1000, 1000, 200, 100},
+      {"key", "zzz", 2000, 1000, 100, 50},
+      // Block 3: "zzz" last block.
+      {"zzz", "", 3000, 1000, 50, 0},
+  });
+
+  IterateResult result;
+
+  // Seek to "key"|100 — should land on the last block in the "key" overflow
+  // run (offset 2000) since seqno=100 matches that block's tag.
+  ASSERT_OK(ctx.iter->SeekAndGetResult(Slice("key"), &result, SeekCtx(100)));
+  ASSERT_EQ(ctx.iter->value().offset, 2000u);
+
+  // Prev should go back to the middle of the overflow run (offset 1000).
+  ASSERT_OK(ctx.iter->PrevAndGetResult(&result));
+  ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
+  ASSERT_EQ(ctx.iter->value().offset, 1000u);
+
+  // Prev again: first block of the run (offset 0).
+  ASSERT_OK(ctx.iter->PrevAndGetResult(&result));
+  ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
+  ASSERT_EQ(ctx.iter->value().offset, 0u);
+
+  // Prev again: past the beginning.
+  ASSERT_OK(ctx.iter->PrevAndGetResult(&result));
+  ASSERT_NE(result.bound_check_result, IterBoundCheck::kInbound);
+}
+
+TEST_F(TrieIndexFactoryTest, SeekToLastWithOverflowRun) {
+  // SeekToLast on a trie where the last leaf has block_count > 1 should
+  // position at the last overflow block.
+  auto ctx = BuildTrieAndGetIterator({
+      // Block 0: "aaa" standalone.
+      {"aaa", "zzz", 0, 1000, 100, 50},
+      // Block 1-3: "zzz" spans 3 blocks (overflow run) — this is the last leaf.
+      {"zzz", "zzz", 1000, 1000, 50, 30},
+      {"zzz", "zzz", 2000, 1000, 30, 10},
+      {"zzz", "", 3000, 1000, 10, 0},
+  });
+
+  IterateResult result;
+
+  // SeekToLast should land on the last overflow block (offset 3000).
+  ASSERT_OK(ctx.iter->SeekToLastAndGetResult(&result));
+  ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
+  ASSERT_EQ(result.key.ToString(), "zzz");
+  ASSERT_EQ(ctx.iter->value().offset, 3000u);
+
+  // Prev within overflow: offset 2000.
+  ASSERT_OK(ctx.iter->PrevAndGetResult(&result));
+  ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
+  ASSERT_EQ(ctx.iter->value().offset, 2000u);
+
+  // Prev within overflow: offset 1000.
+  ASSERT_OK(ctx.iter->PrevAndGetResult(&result));
+  ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
+  ASSERT_EQ(ctx.iter->value().offset, 1000u);
+
+  // Prev to previous trie leaf: "aaa" at offset 0.
+  ASSERT_OK(ctx.iter->PrevAndGetResult(&result));
+  ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
+  ASSERT_EQ(ctx.iter->value().offset, 0u);
+
+  // Prev past beginning.
+  ASSERT_OK(ctx.iter->PrevAndGetResult(&result));
+  ASSERT_NE(result.bound_check_result, IterBoundCheck::kInbound);
+}
+
+TEST_F(TrieIndexFactoryTest, PrevLandsOnLeafWithOverflow) {
+  // Prev from a standalone leaf should land on a previous leaf that has an
+  // overflow run, positioning at the last block in that run.
+  auto ctx = BuildTrieAndGetIterator({
+      // Block 0-1: "aaa" spans 2 blocks.
+      {"aaa", "aaa", 0, 1000, 200, 100},
+      {"aaa", "mmm", 1000, 1000, 100, 50},
+      // Block 2: "mmm" standalone.
+      {"mmm", "zzz", 2000, 1000, 50, 10},
+      // Block 3: "zzz" standalone.
+      {"zzz", "", 3000, 1000, 10, 0},
+  });
+
+  IterateResult result;
+
+  // Seek to "zzz" (offset 3000).
+  ASSERT_NO_FATAL_FAILURE(
+      AssertSeekOffset(ctx.iter.get(), Slice("zzz"), kMaxSequenceNumber, 3000));
+
+  // Prev to "mmm" (offset 2000).
+  ASSERT_OK(ctx.iter->PrevAndGetResult(&result));
+  ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
+  ASSERT_EQ(ctx.iter->value().offset, 2000u);
+
+  // Prev to "aaa" — should land on the LAST block in the overflow run
+  // (offset 1000), not the primary block (offset 0).
+  ASSERT_OK(ctx.iter->PrevAndGetResult(&result));
+  ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
+  ASSERT_EQ(ctx.iter->value().offset, 1000u);
+
+  // Prev within "aaa" overflow: offset 0.
+  ASSERT_OK(ctx.iter->PrevAndGetResult(&result));
+  ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
+  ASSERT_EQ(ctx.iter->value().offset, 0u);
+
+  // Prev past beginning.
+  ASSERT_OK(ctx.iter->PrevAndGetResult(&result));
+  ASSERT_NE(result.bound_check_result, IterBoundCheck::kInbound);
+}
+
+TEST_F(TrieIndexFactoryTest, SeekToFirstOnEmptyTrie) {
+  // SeekToFirstAndGetResult on an empty trie should return kUnknown.
+  UserDefinedIndexOption option;
+  option.comparator = BytewiseComparator();
+  std::unique_ptr<UserDefinedIndexBuilder> builder;
+  ASSERT_OK(factory_->NewBuilder(option, builder));
+  Slice index_contents;
+  ASSERT_OK(builder->Finish(&index_contents));
+  std::unique_ptr<UserDefinedIndexReader> reader;
+  ASSERT_OK(factory_->NewReader(option, index_contents, reader));
+  ReadOptions ro;
+  auto iter = reader->NewIterator(ro);
+
+  IterateResult result;
+  ASSERT_OK(iter->SeekToFirstAndGetResult(&result));
+  ASSERT_EQ(result.bound_check_result, IterBoundCheck::kUnknown);
+}
+
+TEST_F(TrieIndexFactoryTest, SeekToLastOnEmptyTrie) {
+  // SeekToLastAndGetResult on an empty trie should return kUnknown.
+  UserDefinedIndexOption option;
+  option.comparator = BytewiseComparator();
+  std::unique_ptr<UserDefinedIndexBuilder> builder;
+  ASSERT_OK(factory_->NewBuilder(option, builder));
+  Slice index_contents;
+  ASSERT_OK(builder->Finish(&index_contents));
+  std::unique_ptr<UserDefinedIndexReader> reader;
+  ASSERT_OK(factory_->NewReader(option, index_contents, reader));
+  ReadOptions ro;
+  auto iter = reader->NewIterator(ro);
+
+  IterateResult result;
+  ASSERT_OK(iter->SeekToLastAndGetResult(&result));
+  ASSERT_EQ(result.bound_check_result, IterBoundCheck::kUnknown);
+}
+
+TEST_F(TrieIndexFactoryTest, OverflowExhaustionThenForwardScanThroughOverflow) {
+  // When SeekAndGetResult exhausts an overflow run and advances to the next
+  // trie leaf, verify that subsequent Next() calls correctly traverse through
+  // any later overflow runs.
+  //
+  // Layout:
+  //   Blocks 0-1: "key" same-key run (2 blocks)
+  //   Block 2: separator "l" (shortened "key"->"zzz"), standalone
+  //   Blocks 3-4: "zzz" same-key run (2 blocks)
+  auto ctx = BuildTrieAndGetIterator({
+      {"key", "key", 0, 1000, 300, 200},
+      {"key", "key", 1000, 1000, 200, 100},
+      {"key", "zzz", 2000, 1000, 100, 50},
+      {"zzz", "zzz", 3000, 1000, 50, 30},
+      {"zzz", "", 4000, 1000, 30, 0},
+  });
+
+  IterateResult result;
+
+  // Seek "key"|1 — seqno=1 is below all overflow tags in the "key" run
+  // (300, 200), so it exhausts the run and advances to the next leaf.
+  // FindShortestSeparator("key", "zzz") = "l", so the next leaf is "l".
+  ASSERT_OK(ctx.iter->SeekAndGetResult(Slice("key"), &result, SeekCtx(1)));
+  ASSERT_EQ(result.key.ToString(), "l");
+  ASSERT_EQ(ctx.iter->value().offset, 2000u);
+
+  // Next advances to "zzz" primary (offset 3000).
+  ASSERT_OK(ctx.iter->NextAndGetResult(&result));
+  ASSERT_EQ(result.key.ToString(), "zzz");
+  ASSERT_EQ(ctx.iter->value().offset, 3000u);
+
+  // Next advances through "zzz" overflow (offset 4000).
+  ASSERT_OK(ctx.iter->NextAndGetResult(&result));
+  ASSERT_EQ(ctx.iter->value().offset, 4000u);
+
+  // Next past end.
+  ASSERT_OK(ctx.iter->NextAndGetResult(&result));
+  ASSERT_EQ(result.bound_check_result, IterBoundCheck::kUnknown);
+}
+
+TEST_F(TrieIndexFactoryTest, AllScansExhaustedThenSeek) {
+  // After all scan ranges are exhausted (current_scan_idx_ >= size), any
+  // subsequent seek should return kOutOfBound.
+  auto ctx = BuildTrieAndGetIterator({
+      {"az", "c", 0, 500, 0, 0},
+      {"cz", "e", 1000, 500, 0, 0},
+      {"ez", "", 2000, 500, 0, 0},
+  });
+
+  // Two non-overlapping scan ranges: [a,b) and [c,d).
+  ScanOptions scans[2] = {
+      ScanOptions(Slice("a"), Slice("b")),
+      ScanOptions(Slice("c"), Slice("d")),
+  };
+  ctx.iter->Prepare(scans, 2);
+
+  IterateResult result;
+
+  // Seek "a" — within first scan range, kInbound.
+  ASSERT_OK(ctx.iter->SeekAndGetResult(Slice("a"), &result,
+                                       SeekCtx(kMaxSequenceNumber)));
+  ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
+
+  // Seek "c" — advances to second scan range, kInbound.
+  ASSERT_OK(ctx.iter->SeekAndGetResult(Slice("c"), &result,
+                                       SeekCtx(kMaxSequenceNumber)));
+  ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
+
+  // Seek "e" — past both scan ranges, kOutOfBound.
+  ASSERT_OK(ctx.iter->SeekAndGetResult(Slice("e"), &result,
+                                       SeekCtx(kMaxSequenceNumber)));
+  ASSERT_EQ(result.bound_check_result, IterBoundCheck::kOutOfBound);
+}
+
 }  // namespace trie_index
 }  // namespace ROCKSDB_NAMESPACE
 


### PR DESCRIPTION
Add `use_udi_as_primary_index` option to `BlockBasedTableOptions`. When
enabled, the UDI becomes the primary index — all reads (including
internal operations like compaction and VerifyChecksum) automatically
route through the UDI without needing `ReadOptions::table_index_factory`.

Both the standard binary search index and the UDI are always fully
built. The standard index serves as a safety fallback (e.g., for
backup/restore or rollback to a non-UDI configuration). A future
refactor will extract the index abstraction to allow skipping the
standard index build when the UDI is primary (see discussion below).

## Write path

- `UserDefinedIndexBuilderWrapper` always forwards `AddIndexEntry` and
  `OnKeyAdded` to both the internal standard builder and the UDI builder
- New `udi_is_primary_index` table property marks primary-mode SSTs
- Validates incompatible options at `DB::Open` and builder creation:
  partitioned index, partitioned filters, missing
  `user_defined_index_factory`

## Read path

- `UserDefinedIndexReaderWrapper` defaults to UDI when `udi_is_primary_`,
  even when `ReadOptions::table_index_factory` is null — this handles
  the 15+ internal call sites that don't set `table_index_factory`
- `use_udi_as_primary_index` automatically enforces `fail_if_no_udi_on_open`
  to prevent silent data loss if SSTs are opened without UDI support

## Rollback

Since the standard index is always fully populated, rollback from
primary mode is straightforward: set `use_udi_as_primary_index=false`.
No compaction required — SSTs written in primary mode are immediately
readable through the standard index.

## Public API

- `BlockBasedTableOptions::use_udi_as_primary_index` (default: false)
- `UserDefinedIndexBuilder::EstimatedSize()` — pure virtual, O(1) via
  running counter in the trie implementation

## Bug fixes (issues #14560, #14561, #14562)

Fixed trie index correctness bugs that caused crash test failures:

- **Always-on seqno encoding**: `must_use_separator_with_seq_` is now
  unconditionally true. Non-boundary separators store tag=0 (sentinel),
  same-user-key boundaries store the real tag, and the last block stores
  its real last-key tag. This fixes the `NonBoundaryTag` bug where
  non-boundary separators with `kMaxSequenceNumber` caused the post-seek
  correction to incorrectly advance past the correct block.
- **Standard index always built in primary mode**: An empty (stub)
  standard index block caused behavioral divergence in
  `BlockBasedTableIterator` under concurrent flush/compaction, leading to
  `test_batches_snapshots` prefix scan inconsistencies.

## Stress test

- `use_udi_as_primary_index` flag randomized by `db_crashtest.py`
- Both primary and secondary UDI modes exercised in crash tests
- Trie index probability halved (~6%) per reviewer request
- Re-enables trie crash tests (disabled by #14559)

## Tests

- Parameterized `TrieIndexDBTest` on UDI mode (secondary vs primary)
- New factory-level tests: non-boundary separator seek, Prev within
  overflow, SeekToLast with overflow, empty trie, overflow exhaustion,
  all-scans-exhausted
- New DB-level tests: multi-CF coalescing iterator, GetEntity with
  explicit snapshot, reverse iteration across same-user-key blocks,
  non-boundary separator seek correctness, rollback from primary