### PR TITLE
Skip AllocateTest block-count checks on btrfs

### DIFF
--- a/env/env_test.cc
+++ b/env/env_test.cc
@@ -1260,8 +1260,7 @@ TEST_P(EnvPosixTestWithParam, AllocateTest) {
     if (statfs(fname.c_str(), &fs_stat) == 0 &&
         fs_stat.f_type ==
             static_cast<decltype(fs_stat.f_type)>(BTRFS_SUPER_MAGIC)) {
-      fprintf(stderr,
-              "Skipping preallocation block count checks on btrfs\n");
+      fprintf(stderr, "Skipping preallocation block count checks on btrfs\n");
       skip_block_checks = true;
     }
 #endif


### PR DESCRIPTION
Summary:
btrfs accepts fallocate without error but uses copy-on-write, so preallocated extents are not reflected in st_blocks. This caused AllocateTest to fail spuriously on btrfs filesystems. Detect btrfs via statfs and skip only the block-count assertions, keeping the rest of the test (write, flush, close, size checks) intact.

Test Plan:
env_test AllocateTest passes on btrfs (skips with message) and would still enforce preallocation checks on ext4.