### PR TITLE
Fix unused parameter warning in ExtractUncompressedSize

### DIFF
--- a/util/compression.cc
+++ b/util/compression.cc
@@ -1538,7 +1538,7 @@ class BuiltinDecompressorV2SnappyOnly final : public BuiltinDecompressorV2 {
     return "BuiltinDecompressorV2SnappyOnly";
   }
 
-  Status ExtractUncompressedSize(Args& args) override {
+  Status ExtractUncompressedSize([[maybe_unused]] Args& args) override {
     assert(args.compression_type == kSnappyCompression);
 #ifdef SNAPPY
     size_t uncompressed_length = 0;


### PR DESCRIPTION
- Fix #14309


## Problem

When `SNAPPY` is not defined, `ExtractUncompressedSize` in `BuiltinDecompressorV2SnappyOnly` does not use the `args` parameter, causing a `-Werror=unused-parameter` compilation error:

```
  CC       util/compression.o
util/compression.cc: In member function ‘virtual rocksdb::Status rocksdb::{anonymous}::BuiltinDecompressorV2SnappyOnly::ExtractUncompressedSize(rocksdb::Decompressor::Args&)’:
util/compression.cc:1541:40: error: unused parameter ‘args’ [-Werror=unused-parameter]
 1541 |   Status ExtractUncompressedSize(Args& args) override {
      |                                  ~~~~~~^~~~
cc1plus: all warnings being treated as errors
make: *** [Makefile:2590: util/compression.o] Error 1
```

## Fix

Add `[[maybe_unused]]` to the `args` parameter to suppress the warning when `SNAPPY` is not defined.
