### PR TITLE
Add explicit Close() call in WriteStringToFile (#14566)

### DIFF
--- a/env/env_test.cc
+++ b/env/env_test.cc
@@ -4278,6 +4278,70 @@ TEST_F(TestIOActivity, IOActivityToString) {
   ASSERT_EQ(Env::IOActivityToString(Env::IOActivity::kUnknown), "Unknown");
 }
 
+TEST_F(EnvTest, WriteStringToFileClosesFile) {
+  auto counted_fs = std::make_shared<CountedFileSystem>(FileSystem::Default());
+  std::string fname = test::PerThreadDBPath("write_string_close_test");
+
+  // Write a file using WriteStringToFile
+  ASSERT_OK(WriteStringToFile(counted_fs.get(), "hello world", fname,
+                              /*should_sync=*/false));
+
+  // Verify Close() was called (closes counter should be > 0)
+  ASSERT_GT(counted_fs->counters()->closes.load(), 0);
+
+  // Verify the content was written correctly
+  std::string result;
+  ASSERT_OK(ReadFileToString(counted_fs.get(), fname, &result));
+  ASSERT_EQ(result, "hello world");
+
+  // Clean up
+  ASSERT_OK(counted_fs->DeleteFile(fname, IOOptions(), nullptr));
+}
+
+// Writable file wrapper that injects a Close() failure.
+// Uses FSWritableFileOwnerWrapper to properly take ownership of the wrapped
+// file.
+class CloseFailWritableFile : public FSWritableFileOwnerWrapper {
+ public:
+  explicit CloseFailWritableFile(std::unique_ptr<FSWritableFile>&& target)
+      : FSWritableFileOwnerWrapper(std::move(target)) {}
+  IOStatus Close(const IOOptions& /*options*/,
+                 IODebugContext* /*dbg*/) override {
+    return IOStatus::IOError("injected close failure");
+  }
+};
+
+// FileSystem wrapper that wraps writable files with CloseFailWritableFile.
+class CloseFailFS : public FileSystemWrapper {
+ public:
+  explicit CloseFailFS(const std::shared_ptr<FileSystem>& base)
+      : FileSystemWrapper(base) {}
+  const char* Name() const override { return "CloseFailFS"; }
+  IOStatus NewWritableFile(const std::string& fname,
+                           const FileOptions& file_opts,
+                           std::unique_ptr<FSWritableFile>* result,
+                           IODebugContext* dbg) override {
+    IOStatus s = target()->NewWritableFile(fname, file_opts, result, dbg);
+    if (s.ok()) {
+      result->reset(new CloseFailWritableFile(std::move(*result)));
+    }
+    return s;
+  }
+};
+
+TEST_F(EnvTest, WriteStringToFileCloseFailureDeletesFile) {
+  auto close_fail_fs = std::make_shared<CloseFailFS>(FileSystem::Default());
+  std::string fname = test::PerThreadDBPath("write_string_close_fail_test");
+
+  auto s = WriteStringToFile(close_fail_fs.get(), "hello world", fname,
+                             /*should_sync=*/false);
+  ASSERT_NOK(s);
+
+  // The file should have been deleted on failure
+  auto exists = FileSystem::Default()->FileExists(fname, IOOptions(), nullptr);
+  ASSERT_TRUE(exists.IsNotFound()) << exists.ToString();
+}
+
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {

--- a/env/file_system.cc
+++ b/env/file_system.cc
@@ -192,6 +192,13 @@ IOStatus WriteStringToFile(FileSystem* fs, const Slice& data,
   if (s.ok() && should_sync) {
     s = file->Sync(io_options, nullptr);
   }
+  // Explicitly close the file rather than relying on the unique_ptr destructor.
+  // The destructor may silently swallow write errors that occur during close
+  // (e.g., flushing buffered data), so we close here to detect and propagate
+  // such errors.
+  if (s.ok()) {
+    s = file->Close(io_options, nullptr);
+  }
   if (!s.ok()) {
     fs->DeleteFile(fname, io_options, nullptr);
   }


### PR DESCRIPTION
Summary:

**What**: Adds an explicit `file->Close()` call in `WriteStringToFile()` before
the function returns, instead of relying on the `unique_ptr` destructor to close
the file.

**How**: In `file_system.cc`, after the optional `Sync()` and before the
error-cleanup path, calls `file->Close()`. If `Close()` fails, the file is
deleted just like any other write failure. Adds two unit tests in `env_test.cc`:
- `WriteStringToFileClosesFile`: uses `CountedFileSystem` to verify `Close()` is
  called and content is written correctly.
- `WriteStringToFileCloseFailureDeletesFile`: uses a custom `CloseFailFS`
  wrapper to inject a `Close()` failure and verify the file is deleted on error.

**Why**: The previous implementation never called `Close()` explicitly — it
relied on the `unique_ptr` destructor which may silently swallow write errors
that occur during close (e.g., flushing buffered data). Explicit `Close()`
ensures such errors are detected and propagated to the caller.

Reviewed By: archang19

Differential Revision: D99462173


