### PR TITLE
Fix memory accounting leak in IODispatcher ReadIndex() (#14569)

### DIFF
--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -455,6 +455,7 @@ DECLARE_uint32(ingest_wbwi_one_in);
 DECLARE_bool(universal_reduce_file_locking);
 DECLARE_bool(use_multiscan);
 DECLARE_bool(multiscan_use_async_io);
+DECLARE_uint64(multiscan_max_prefetch_memory_bytes);
 
 // Compaction deletion trigger declarations for stress testing
 DECLARE_bool(enable_compaction_on_deletion_trigger);

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -1661,4 +1661,10 @@ DEFINE_bool(use_multiscan, false,
 DEFINE_bool(multiscan_use_async_io, false,
             "If set, enable async_io for MultiScan operations.");
 
+DEFINE_uint64(multiscan_max_prefetch_memory_bytes, 0,
+              "If non-zero, sets the max_prefetch_memory_bytes on the "
+              "IODispatcher used for MultiScan. This limits the total memory "
+              "used for prefetching data blocks across all concurrent "
+              "MultiScan ReadSets.");
+
 #endif  // GFLAGS

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -29,6 +29,7 @@
 #include "options/options_parser.h"
 #include "rocksdb/convenience.h"
 #include "rocksdb/filter_policy.h"
+#include "rocksdb/io_dispatcher.h"
 #include "rocksdb/secondary_cache.h"
 #include "rocksdb/sst_file_manager.h"
 #include "rocksdb/table_properties.h"
@@ -1715,6 +1716,14 @@ Status StressTest::TestMultiScan(ThreadState* thread,
       FLAGS_multiscan_use_async_io &&
       CheckFSFeatureSupport(options_.env->GetFileSystem().get(),
                             FSSupportedOps::kAsyncIO);
+  std::shared_ptr<IODispatcher> io_dispatcher;
+  if (FLAGS_multiscan_max_prefetch_memory_bytes > 0) {
+    IODispatcherOptions io_opts;
+    io_opts.max_prefetch_memory_bytes =
+        FLAGS_multiscan_max_prefetch_memory_bytes;
+    io_dispatcher.reset(NewIODispatcher(io_opts));
+    scan_opts.io_dispatcher = io_dispatcher;
+  }
   start_key_strs.reserve(num_scans);
   end_key_strs.reserve(num_scans);
 

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -1437,6 +1437,9 @@ def finalize_and_sanitize(src_params):
         # LevelIterator multiscan currently relies on num_entries and num_range_deletions,
         # which are not updated if skip_stats_update_on_db_open is true
         dest_params["skip_stats_update_on_db_open"] = 0
+        dest_params["multiscan_max_prefetch_memory_bytes"] = random.choice(
+            [0, 0, 64 * 1024, 256 * 1024]
+        )
 
     # open_files_async requires skip_stats_update_on_db_open to avoid
     # synchronous I/O in UpdateAccumulatedStats during DB open

--- a/unreleased_history/bug_fixes/io_dispatcher_memory_leak.md
+++ b/unreleased_history/bug_fixes/io_dispatcher_memory_leak.md
@@ -1,0 +1,1 @@
+Fix a memory accounting leak in IODispatcher where ReadIndex() moved block values out of ReadSet without releasing the associated prefetch memory, causing subsequent prefetches to be blocked when max_prefetch_memory_bytes was set.

--- a/util/io_dispatcher_imp.cc
+++ b/util/io_dispatcher_imp.cc
@@ -168,6 +168,15 @@ Status ReadSet::ReadIndex(size_t block_index, CachableEntry<Block>* out) {
   // SubmitJob)
   if (pinned_blocks_[block_index].GetValue()) {
     *out = std::move(pinned_blocks_[block_index]);
+    // Release memory accounting for prefetched blocks. After moving the value
+    // out, ReleaseBlock() and the destructor check pinned_blocks_.GetValue()
+    // which will be null, so they won't release memory again.
+    if (block_index < block_sizes_.size() && block_sizes_[block_index] > 0) {
+      if (auto dispatcher_data = dispatcher_data_.lock()) {
+        dispatcher_data->ReleaseMemory(block_sizes_[block_index]);
+      }
+      block_sizes_[block_index] = 0;
+    }
     // Note: Statistics for this block were already counted during SubmitJob
     // (either as cache hit or sync read)
     return Status::OK();
@@ -190,6 +199,14 @@ Status ReadSet::ReadIndex(size_t block_index, CachableEntry<Block>* out) {
       // After polling, the block should be in pinned_blocks_
       if (pinned_blocks_[block_index].GetValue()) {
         *out = std::move(pinned_blocks_[block_index]);
+        // Release memory accounting (same as case 1 above)
+        if (block_index < block_sizes_.size() &&
+            block_sizes_[block_index] > 0) {
+          if (auto dispatcher_data = dispatcher_data_.lock()) {
+            dispatcher_data->ReleaseMemory(block_sizes_[block_index]);
+          }
+          block_sizes_[block_index] = 0;
+        }
         return Status::OK();
       }
 
@@ -197,8 +214,12 @@ Status ReadSet::ReadIndex(size_t block_index, CachableEntry<Block>* out) {
     }
   }
 
-  // Case 3: Block needs synchronous read
-  // If this block was pending prefetch, remove it since we're reading it now
+  // Case 3: Block needs synchronous read (pending or never-dispatched blocks).
+  // No ReleaseMemory() needed here because blocks reaching this path never had
+  // TryAcquireMemory() called — they were either pending prefetch or skipped
+  // during SubmitJob. block_sizes_[block_index] may be > 0 (set during
+  // SubmitJob for all uncached blocks) but that does not imply memory was
+  // acquired.
   RemoveFromPending(block_index);
 
   Status s = SyncRead(block_index);

--- a/util/io_dispatcher_test.cc
+++ b/util/io_dispatcher_test.cc
@@ -1791,6 +1791,125 @@ TEST_F(IODispatcherTest, CoalescedGroupsSplitByMemoryBudget) {
   }
 }
 
+// Regression tests for a bug where ReadIndex moved values out of
+// pinned_blocks_ via std::move, but neither ReleaseBlock() nor the destructor
+// released memory accounting because they checked pinned_blocks_.GetValue()
+// which was null after the move.
+// Tests run with both sync and async IO modes to cover Case 1 and Case 2
+// in ReadIndex().
+TEST_F(IODispatcherTest, MemoryReleasedAfterReadIndexThenReleaseBlock) {
+  for (bool async : {false, true}) {
+    // Skip async if io_uring not available
+    if (async && !kIOUringPresent) {
+      continue;
+    }
+    SCOPED_TRACE("async_io=" + std::to_string(async));
+
+    auto stats = CreateDBStatistics();
+    IODispatcherOptions opts;
+    opts.max_prefetch_memory_bytes = 100 * 1024;  // 100KB
+    opts.statistics = stats.get();
+    std::unique_ptr<IODispatcher> dispatcher(NewIODispatcher(opts));
+
+    std::unique_ptr<BlockBasedTable> table;
+    std::vector<BlockHandle> block_handles;
+    Status s = CreateAndOpenSST(20, &table, &block_handles);
+    ASSERT_OK(s);
+    ASSERT_GT(block_handles.size(), 0);
+
+    auto job = std::make_shared<IOJob>();
+    job->block_handles = block_handles;
+    job->table = table.get();
+    job->job_options.read_options.async_io = async;
+
+    std::shared_ptr<ReadSet> read_set;
+    s = dispatcher->SubmitJob(job, &read_set);
+    ASSERT_OK(s);
+    ASSERT_NE(read_set, nullptr);
+
+    // Some memory should have been granted for prefetch
+    ASSERT_GT(stats->getTickerCount(PREFETCH_MEMORY_BYTES_GRANTED), 0);
+
+    // Read all blocks — ReadIndex moves values out of pinned_blocks_.
+    // This also triggers TryDispatchPendingPrefetches as memory is released,
+    // which acquires more memory for pending groups. So granted grows during
+    // this loop.
+    for (size_t i = 0; i < block_handles.size(); ++i) {
+      CachableEntry<Block> block;
+      ASSERT_OK(read_set->ReadIndex(i, &block));
+      ASSERT_NE(block.GetValue(), nullptr);
+    }
+
+    // Release all blocks — should be a no-op for memory accounting since
+    // ReadIndex already released memory when moving values out
+    for (size_t i = 0; i < block_handles.size(); ++i) {
+      read_set->ReleaseBlock(i);
+    }
+
+    // Read both counters after all operations complete, since
+    // TryDispatchPendingPrefetches during ReadIndex may have granted additional
+    // memory for pending groups
+    uint64_t granted = stats->getTickerCount(PREFETCH_MEMORY_BYTES_GRANTED);
+    uint64_t released = stats->getTickerCount(PREFETCH_MEMORY_BYTES_RELEASED);
+    // With the bug, released < granted because ReleaseBlock skips
+    // ReleaseMemory when pinned_blocks_ value was already moved out
+    EXPECT_EQ(released, granted);
+  }
+}
+
+// Test that ReadSet destructor releases memory for blocks that were read
+// via ReadIndex but never explicitly released via ReleaseBlock.
+TEST_F(IODispatcherTest, DestructorReleasesMemoryAfterReadIndex) {
+  for (bool async : {false, true}) {
+    // Skip async if io_uring not available
+    if (async && !kIOUringPresent) {
+      continue;
+    }
+    SCOPED_TRACE("async_io=" + std::to_string(async));
+
+    auto stats = CreateDBStatistics();
+    IODispatcherOptions opts;
+    opts.max_prefetch_memory_bytes = 100 * 1024;  // 100KB
+    opts.statistics = stats.get();
+    std::unique_ptr<IODispatcher> dispatcher(NewIODispatcher(opts));
+
+    std::unique_ptr<BlockBasedTable> table;
+    std::vector<BlockHandle> block_handles;
+    Status s = CreateAndOpenSST(20, &table, &block_handles);
+    ASSERT_OK(s);
+    ASSERT_GT(block_handles.size(), 0);
+
+    {
+      auto job = std::make_shared<IOJob>();
+      job->block_handles = block_handles;
+      job->table = table.get();
+      job->job_options.read_options.async_io = async;
+
+      std::shared_ptr<ReadSet> read_set;
+      s = dispatcher->SubmitJob(job, &read_set);
+      ASSERT_OK(s);
+      ASSERT_NE(read_set, nullptr);
+
+      uint64_t granted = stats->getTickerCount(PREFETCH_MEMORY_BYTES_GRANTED);
+      ASSERT_GT(granted, 0);
+
+      // Read all blocks via ReadIndex (moves values out of pinned_blocks_)
+      // but do NOT call ReleaseBlock — let the destructor handle cleanup
+      for (size_t i = 0; i < block_handles.size(); ++i) {
+        CachableEntry<Block> block;
+        ASSERT_OK(read_set->ReadIndex(i, &block));
+      }
+      // read_set goes out of scope — destructor should release all memory
+    }
+
+    uint64_t granted = stats->getTickerCount(PREFETCH_MEMORY_BYTES_GRANTED);
+    uint64_t released = stats->getTickerCount(PREFETCH_MEMORY_BYTES_RELEASED);
+    // Destructor should release memory for all prefetched blocks,
+    // even those whose values were moved out by ReadIndex
+    EXPECT_EQ(released, granted);
+  }
+}
+
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Summary:

ReadSet::ReadIndex() moves block values out of pinned_blocks_ via std::move,
but never releases the associated prefetch memory accounting. This causes
ReleaseBlock() and the destructor to skip ReleaseMemory() since they check
pinned_blocks_.GetValue() which returns null after the move. Over time, the
memory budget is exhausted and no further prefetches can be dispatched when
max_prefetch_memory_bytes is set. The bug was introduced in https://github.com/facebook/rocksdb/pull/14401.

The fix releases memory accounting in ReadIndex() when moving values out
(both for Case 1: block already available, and Case 2: after async IO
polling), and zeros block_sizes_ to prevent double-release.

Also adds multiscan_max_prefetch_memory_bytes option to db_stress/crashtest
for stress testing this code path.

Reviewed By: hx235

Differential Revision: D99488961


