### PR TITLE
Fix range deletion crash test errors

### DIFF
--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -92,8 +92,7 @@ DBIter::DBIter(Env* _env, const ReadOptions& read_options,
       expose_blob_index_(expose_blob_index),
       allow_unprepared_value_(read_options.allow_unprepared_value),
       is_blob_(false),
-      arena_mode_(arena_mode),
-      range_tomb_max_seq_(0) {
+      arena_mode_(arena_mode) {
   RecordTick(statistics_, NO_ITERATOR_CREATED);
   if (pin_thru_lifetime_) {
     pinned_iters_mgr_.StartPinning();
@@ -502,7 +501,7 @@ bool DBIter::FindNextUserEntryInternal(bool skipping_saved_key) {
               // a new run outside the prefix.
               if (min_tombstones_for_range_conversion_ > 0 &&
                   PrefixCheck(user_key_without_ts)) {
-                TrackContiguousTombstone(ikey_.user_key, ikey_.sequence,
+                TrackContiguousTombstone(ikey_.user_key,
                                          /*always_update_first_key=*/false);
               }
             }
@@ -936,8 +935,10 @@ void DBIter::PrevInternal() {
     if (!PrefixCheck(saved_key_without_ts)) {
       // Insert any pending tombstone run before leaving the seek prefix.
       // Only insert if end_key (previous live key) is within the seek prefix.
-      FlushPendingTombstoneRun(range_tomb_end_key_.GetUserKey(),
-                               /*check_prefix_match=*/true);
+      if (range_tomb_end_key_.Size() > 0) {
+        FlushPendingTombstoneRun(range_tomb_end_key_.GetUserKey(),
+                                 /*check_prefix_match=*/true);
+      }
       if (prefix_same_as_start_) {
         valid_ = false;
         return;
@@ -953,8 +954,10 @@ void DBIter::PrevInternal() {
             saved_key_.GetUserKey(), /*a_has_ts=*/true, *iterate_lower_bound_,
             /*b_has_ts=*/false) < 0) {
       // We've iterated earlier than the user-specified lower bound.
-      FlushPendingTombstoneRun(range_tomb_end_key_.GetUserKey(),
-                               /*check_prefix_match=*/true);
+      if (range_tomb_end_key_.Size() > 0) {
+        FlushPendingTombstoneRun(range_tomb_end_key_.GetUserKey(),
+                                 /*check_prefix_match=*/true);
+      }
       valid_ = false;
       return;
     }
@@ -972,11 +975,10 @@ void DBIter::PrevInternal() {
     // visible entry is found, so reading ikey_.sequence without this guard
     // would use a stale value.
     if (min_tombstones_for_range_conversion_ > 0 &&
-        range_tomb_end_key_.GetUserKey().size() > 0 &&
-        timestamp_lb_ == nullptr) {
+        range_tomb_end_key_.Size() > 0 && timestamp_lb_ == nullptr) {
       if (!valid_ && found_visible && PrefixCheck(saved_key_without_ts)) {
         // Key was deleted and is within the seek prefix — track it.
-        TrackContiguousTombstone(saved_key_.GetUserKey(), ikey_.sequence,
+        TrackContiguousTombstone(saved_key_.GetUserKey(),
                                  /*always_update_first_key=*/true);
       } else if (valid_) {
         // Live key breaks the run.
@@ -1001,8 +1003,10 @@ void DBIter::PrevInternal() {
     }
   }
 
-  FlushPendingTombstoneRun(range_tomb_end_key_.GetUserKey(),
-                           /*check_prefix_match=*/true);
+  if (range_tomb_end_key_.Size() > 0) {
+    FlushPendingTombstoneRun(range_tomb_end_key_.GetUserKey(),
+                             /*check_prefix_match=*/true);
+  }
 
   // We haven't found any key - iterator is not valid
   valid_ = false;
@@ -1595,15 +1599,10 @@ bool DBIter::FindUserKeyBeforeSavedKey() {
   return true;
 }
 
-void DBIter::TrackContiguousTombstone(const Slice& user_key, SequenceNumber seq,
+void DBIter::TrackContiguousTombstone(const Slice& user_key,
                                       bool always_update_first_key) {
   if (always_update_first_key || contiguous_tombstone_count_ == 0) {
     range_tomb_first_key_.SetUserKey(user_key, true /* copy */);
-  }
-  if (contiguous_tombstone_count_ == 0) {
-    range_tomb_max_seq_ = seq;
-  } else {
-    range_tomb_max_seq_ = std::max(range_tomb_max_seq_, seq);
   }
   contiguous_tombstone_count_++;
 }
@@ -1641,8 +1640,6 @@ void DBIter::MaybeInsertRangeTombstone(const Slice& end_key) {
   assert(user_comparator_.Compare(range_tomb_first_key_.GetUserKey(),
                                   end_key) <= 0);
 
-  assert(range_tomb_max_seq_ <= sequence_);
-
   auto earliest_seq = active_mem_->GetEarliestSequenceNumber();
   // Skip if the iterator's snapshot predates the memtable. Otherwise entries
   // added with seqno between sequence_ and earliest_seq will be unintentionally
@@ -1652,17 +1649,11 @@ void DBIter::MaybeInsertRangeTombstone(const Slice& end_key) {
     return;
   }
 
-  // Bump the insertion seq to preserve the memtable's earliest_seqno_
-  // invariant. Safe because the guard above guarantees sequence_ >=
-  // earliest_seq.
-  SequenceNumber insert_seq = std::max(range_tomb_max_seq_, earliest_seq);
+  // Insert at the read sequence so the synthesized tombstone is visible only
+  // to readers that could already observe the deletion run.
+  SequenceNumber insert_seq = sequence_;
 
-  // Skip if any tombstone in the run might be uncommitted, OR if the
-  // bumped insert_seq could shadow prepared-but-uncommitted writes.
-  // With write-prepared/write-unprepared transactions, a prepared entry's
-  // seqno can fall between range_tomb_max_seq_ and insert_seq (which is
-  // bumped to earliest_seq).  The range tombstone at insert_seq would
-  // shadow such entries after they commit.
+  // Skip if the insertion seq could shadow prepared-but-uncommitted writes.
   if (read_callback_ != nullptr &&
       insert_seq >= read_callback_->min_uncommitted()) {
     RecordTick(statistics_, READ_PATH_RANGE_TOMBSTONES_DISCARDED);
@@ -2118,6 +2109,10 @@ void DBIter::SeekToLast() {
   MarkMemtableForFlushForAvgTrigger();
   ClearSavedValue();
   is_key_seqnum_zero_ = false;
+
+  // Clear stale saved_key_ so PrevInternal()'s Swap does not pollute
+  // range_tomb_end_key_ with a key from a previous seek operation.
+  saved_key_.Clear();
 
   {
     PERF_TIMER_GUARD(seek_internal_seek_time);

--- a/db/db_iter.h
+++ b/db/db_iter.h
@@ -420,7 +420,7 @@ class DBIter final : public Iterator {
   // In forward iteration, first_key is set only for the first tombstone
   // (always_update_first_key=false). In reverse, keys arrive in decreasing
   // order so first_key is updated every time (always_update_first_key=true).
-  void TrackContiguousTombstone(const Slice& user_key, SequenceNumber seq,
+  void TrackContiguousTombstone(const Slice& user_key,
                                 bool always_update_first_key);
 
   // If a contiguous tombstone run is pending, insert a range tombstone
@@ -436,7 +436,6 @@ class DBIter final : public Iterator {
   void MaybeInsertRangeTombstone(const Slice& end_key);
   void ResetContiguousTombstoneTracking() {
     contiguous_tombstone_count_ = 0;
-    range_tomb_max_seq_ = 0;
   }
   void ResetRangeTombEndKey() { range_tomb_end_key_.Clear(); }
 
@@ -592,7 +591,6 @@ class DBIter final : public Iterator {
   bool is_blob_;
   bool arena_mode_;
 
-  SequenceNumber range_tomb_max_seq_;
   IterKey range_tomb_first_key_;
   IterKey range_tomb_end_key_;
 };

--- a/db/db_iterator_test.cc
+++ b/db/db_iterator_test.cc
@@ -6809,12 +6809,11 @@ TEST_P(ReadPathRangeTombstoneTest, LowerBoundTruncatesReverse) {
   }
 }
 
-// Regression test: FindValueForCurrentKeyUsingSeek must set ikey_ to the entry
-// found by the seek. A stale (too-low) sequence feeds into range_tomb_max_seq_
-// and becomes the range tombstone's insertion seq. A reader whose snapshot
-// falls between the stale seq and the real deletion seq would see the range
-// tombstone but not the point delete, incorrectly hiding live data.
-TEST_P(ReadPathRangeTombstoneTest, ReseekStaleIkey) {
+// Regression test: a delete run discovered through the reseek path must be
+// materialized at the reader's sequence so older snapshots keep seeing the
+// pre-delete values.
+TEST_P(ReadPathRangeTombstoneTest,
+       ReseekDiscoveredDeleteRunPreservesOlderSnapshots) {
   Options options = CurrentOptions();
   options.min_tombstones_for_range_conversion = 2;
   // Low skip threshold forces FindValueForCurrentKeyUsingSeek for keys with
@@ -6848,19 +6847,16 @@ TEST_P(ReadPathRangeTombstoneTest, ReseekStaleIkey) {
   ASSERT_OK(Delete("b"));
   ASSERT_OK(Delete("c"));
 
-  // Iterate at the latest sequence. Both b and c hit the reseek path.
-  // This inserts a range tombstone [b, d). Without the fix, the tombstone's
-  // insertion seq would be based on stale intermediate Put seqs (~5-9) instead
-  // of the actual deletion seqs (11-12).
+  // Iterate at the latest sequence. Both b and c hit the reseek path and
+  // synthesize a range tombstone [b, d) for later readers at the same seq.
   inserted_ranges_.clear();
   VerifyIteration({"a", "d"});
 
   ASSERT_EQ(inserted_ranges_.size(), 1);
   AssertRange(0, "b", "d");
 
-  // Read with the earlier snapshot. The point deletes (seq 11-12) are NOT
-  // visible, so b and c must be live. But a range tombstone inserted at a
-  // stale seq <= 10 WOULD be visible and would incorrectly cover the Puts.
+  // Read with the earlier snapshot. The point deletes (seq 11-12) are not
+  // visible, so b and c must remain live after the latest iterator ran.
   ReadOptions ro;
   ro.snapshot = snap;
   VerifyIteration({"a", "b", "c", "d"}, ro);
@@ -6868,11 +6864,8 @@ TEST_P(ReadPathRangeTombstoneTest, ReseekStaleIkey) {
   db_->ReleaseSnapshot(snap);
 }
 
-// Regression test: when the forward scan sets ikey_ to a visible entry's
-// seqno, and then Prev() encounters keys that were written entirely AFTER
-// the snapshot (no visible entries at all), FindValueForCurrentKey breaks
-// early without updating ikey_.  The reverse tombstone tracking then uses
-// the stale ikey_.sequence, which can exceed sequence_.
+// Regression test: keys written entirely after the snapshot do not break a
+// tombstone run discovered by reverse iteration.
 TEST_P(ReadPathRangeTombstoneTest, InvisibleKeysDontBreakTombstoneRun) {
   Options options = CurrentOptions();
   options.min_tombstones_for_range_conversion = 2;
@@ -6908,6 +6901,131 @@ TEST_P(ReadPathRangeTombstoneTest, InvisibleKeysDontBreakTombstoneRun) {
   // 2 tombstones (b, d) ≥ threshold → range [b, f).
   ASSERT_EQ(inserted_ranges_.size(), 1);
   AssertRange(0, "b", "f");
+
+  db_->ReleaseSnapshot(snap);
+}
+
+// Regression test: SeekToLast() after Seek() must clear stale saved_key_ to
+// avoid corrupting range tombstone tracking bounds.
+TEST_P(ReadPathRangeTombstoneTest, SeekToLastStaleSavedKey) {
+  if (Forward()) {
+    return;
+  }
+
+  Options options = CurrentOptions();
+  options.min_tombstones_for_range_conversion = 2;
+  options.statistics = CreateDBStatistics();
+  DestroyAndReopen(options);
+
+  for (char c = 'a'; c <= 'z'; c++) {
+    ASSERT_OK(Put(std::string(1, c), std::string("v") + c));
+  }
+  ASSERT_OK(Flush());
+
+  ASSERT_OK(Delete("x"));
+  ASSERT_OK(Delete("y"));
+
+  auto iter = std::unique_ptr<Iterator>(db_->NewIterator(ReadOptions()));
+
+  // Seek populates saved_key_ with "a".
+  iter->Seek("a");
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ("a", iter->key().ToString());
+
+  // SeekToLast must not carry the stale saved_key_ into range tombstone bounds.
+  iter->SeekToLast();
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_OK(iter->status());
+  ASSERT_EQ("z", iter->key().ToString());
+
+  // Reverse iteration skips deleted x and y.
+  iter->Prev();
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_OK(iter->status());
+  ASSERT_EQ("w", iter->key().ToString());
+}
+
+TEST_P(ReadPathRangeTombstoneTest, SeekToLastTombstones) {
+  if (Forward()) {
+    ROCKSDB_GTEST_SKIP("SeekToLast tombstone materialization is reverse-only.");
+  }
+
+  Options options = CurrentOptions();
+  options.min_tombstones_for_range_conversion = 2;
+  options.statistics = CreateDBStatistics();
+  DestroyAndReopen(options);
+
+  for (char c = 'a'; c <= 'z'; c++) {
+    ASSERT_OK(Put(std::string(1, c), std::string("v") + c));
+  }
+  ASSERT_OK(Flush());
+
+  ASSERT_OK(Delete("x"));
+  ASSERT_OK(Delete("y"));
+  auto iter = std::unique_ptr<Iterator>(db_->NewIterator(ReadOptions()));
+  inserted_ranges_.clear();
+
+  iter->Seek("a");
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ("a", iter->key().ToString());
+
+  iter->SeekToLast();
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_OK(iter->status());
+  ASSERT_EQ("z", iter->key().ToString());
+  ASSERT_EQ(inserted_ranges_.size(), 0u);
+
+  // Reverse iteration skips deleted x and y.
+  iter->Prev();
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_OK(iter->status());
+  ASSERT_EQ("w", iter->key().ToString());
+  ASSERT_EQ(inserted_ranges_.size(), 1u);
+  AssertRange(0, "x", "z");
+}
+
+// Regression test for a crash-test pattern where the interior between two
+// point tombstones is hidden by a later DeleteRange. A latest iterator may
+// still synthesize a redundant range tombstone, but an older snapshot must
+// continue to see the pre-DeleteRange live key after iteration.
+TEST_P(ReadPathRangeTombstoneTest,
+       RangeDeletedInteriorPreservesOlderSnapshots) {
+  Options options = CurrentOptions();
+  options.min_tombstones_for_range_conversion = 2;
+  options.statistics = CreateDBStatistics();
+  DestroyAndReopen(options);
+
+  for (char c = 'a'; c <= 'n'; ++c) {
+    ASSERT_OK(Put(std::string(1, c), std::string("v") + c));
+  }
+  ASSERT_OK(Flush());
+
+  // Point tombstones at the boundaries of the future range-deleted interior.
+  ASSERT_OK(Delete("b"));
+  ASSERT_OK(Delete("m"));
+
+  const Snapshot* snap = db_->GetSnapshot();
+  ReadOptions snap_ro;
+  snap_ro.snapshot = snap;
+  std::string snap_value;
+  ASSERT_OK(db_->Get(snap_ro, "c", &snap_value));
+  ASSERT_EQ(snap_value, "vc");
+
+  // Latest readers now see c-l deleted by range tombstone, but the older
+  // snapshot above must still see them live.
+  ASSERT_OK(
+      db_->DeleteRange(WriteOptions(), db_->DefaultColumnFamily(), "c", "m"));
+
+  inserted_ranges_.clear();
+  VerifyIteration({"a", "n"});
+
+  // Materialize the redundant tombstone at the latest read sequence only.
+  ASSERT_EQ(inserted_ranges_.size(), 1);
+  AssertRange(0, "b", "n");
+
+  snap_value.clear();
+  ASSERT_OK(db_->Get(snap_ro, "c", &snap_value));
+  ASSERT_EQ(snap_value, "vc");
 
   db_->ReleaseSnapshot(snap);
 }

--- a/tools/trace_analyzer_tool.cc
+++ b/tools/trace_analyzer_tool.cc
@@ -1586,6 +1586,13 @@ Status TraceAnalyzer::PutCF(uint32_t column_family_id, const Slice& key,
                               column_family_id, key, value.size());
 }
 
+Status TraceAnalyzer::TimedPutCF(uint32_t column_family_id, const Slice& key,
+                                 const Slice& value,
+                                 uint64_t /*write_unix_time*/) {
+  return OutputAnalysisResult(TraceOperationType::kPut, write_batch_ts_,
+                              column_family_id, key, value.size());
+}
+
 Status TraceAnalyzer::PutEntityCF(uint32_t column_family_id, const Slice& key,
                                   const Slice& value) {
   return OutputAnalysisResult(TraceOperationType::kPutEntity, write_batch_ts_,
@@ -1633,14 +1640,21 @@ Status TraceAnalyzer::OutputAnalysisResult(TraceOperationType op_type,
   Status s;
 
   if (FLAGS_convert_to_human_readable_trace && trace_sequence_f_) {
-    // DeleteRane only writes the begin_key.
-    size_t cnt =
-        op_type == TraceOperationType::kRangeDelete ? 1 : cf_ids.size();
-    for (size_t i = 0; i < cnt; i++) {
-      s = WriteTraceSequence(op_type, cf_ids[i], keys[i], value_sizes[i],
-                             timestamp);
+    if (op_type == TraceOperationType::kRangeDelete) {
+      assert(cf_ids.size() == 2);
+      assert(keys.size() == 2);
+      s = WriteRangeDeleteTraceSequence(cf_ids[0], keys[0], keys[1], timestamp);
       if (!s.ok()) {
         return Status::Corruption("Failed to write the trace sequence to file");
+      }
+    } else {
+      for (size_t i = 0; i < cf_ids.size(); i++) {
+        s = WriteTraceSequence(op_type, cf_ids[i], keys[i], value_sizes[i],
+                               timestamp);
+        if (!s.ok()) {
+          return Status::Corruption(
+              "Failed to write the trace sequence to file");
+        }
       }
     }
   }
@@ -1864,6 +1878,28 @@ Status TraceAnalyzer::WriteTraceSequence(const uint32_t& type,
   std::string printout(buffer_);
   if (!FLAGS_no_key) {
     printout = hex_key + " " + printout;
+  }
+  return trace_sequence_f_->Append(printout);
+}
+
+Status TraceAnalyzer::WriteRangeDeleteTraceSequence(const uint32_t& cf_id,
+                                                    const Slice& begin_key,
+                                                    const Slice& end_key,
+                                                    const uint64_t ts) {
+  int ret;
+  ret = snprintf(buffer_, sizeof(buffer_), "%u %u %zu %" PRIu64 "\n",
+                 TraceOperationType::kRangeDelete, cf_id,
+                 static_cast<size_t>(0), ts);
+  if (ret < 0) {
+    return Status::IOError("failed to format the output");
+  }
+  std::string printout(buffer_);
+  if (!FLAGS_no_key) {
+    const std::string begin_hex =
+        ROCKSDB_NAMESPACE::LDBCommand::StringToHex(begin_key.ToString());
+    const std::string end_hex =
+        ROCKSDB_NAMESPACE::LDBCommand::StringToHex(end_key.ToString());
+    printout = begin_hex + " " + end_hex + " " + printout;
   }
   return trace_sequence_f_->Append(printout);
 }

--- a/tools/trace_analyzer_tool.h
+++ b/tools/trace_analyzer_tool.h
@@ -201,6 +201,10 @@ class TraceAnalyzer : private TraceRecord::Handler,
   Status PutCF(uint32_t column_family_id, const Slice& key,
                const Slice& value) override;
 
+  using WriteBatch::Handler::TimedPutCF;
+  Status TimedPutCF(uint32_t column_family_id, const Slice& key,
+                    const Slice& value, uint64_t write_unix_time) override;
+
   using WriteBatch::Handler::PutEntityCF;
   Status PutEntityCF(uint32_t column_family_id, const Slice& key,
                      const Slice& value) override;
@@ -317,6 +321,9 @@ class TraceAnalyzer : private TraceRecord::Handler,
   Status WriteTraceSequence(const uint32_t& type, const uint32_t& cf_id,
                             const Slice& key, const size_t value_size,
                             const uint64_t ts);
+  Status WriteRangeDeleteTraceSequence(const uint32_t& cf_id,
+                                       const Slice& begin_key,
+                                       const Slice& end_key, const uint64_t ts);
   Status MakeStatisticKeyStatsOrPrefix(TraceStats& stats);
   Status MakeStatisticCorrelation(TraceStats& stats, StatsUnit& unit);
   Status MakeStatisticQPS();

--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -4085,9 +4085,11 @@ TEST_P(WritePreparedTransactionTest, WC_WP_WALForwardIncompatibility) {
   CrossCompatibilityTest(WRITE_PREPARED, WRITE_COMMITTED, !empty_wal);
 }
 
-// Range tombstone insertion uses max_tombstone_seq to safely gate insertion:
-// only insert if max_tombstone_seq < min_uncommitted (all prepared entries
-// have seqno above the tombstone's seqno).
+// With insert_seq = read iterator seqno, insertion depends on the latest
+// published read seq. In one-write-queue mode, the latest read seq reaches the
+// prepared seq, so insertion is blocked. In two-write-queues mode, the latest
+// published seq can still lag the prepared seq, so insertion remains safe and
+// is allowed.
 TEST_P(WritePreparedTransactionTest, RangeTombstoneInsertionWithWritePrepared) {
   for (bool forward : {true, false}) {
     SCOPED_TRACE(forward ? "forward" : "reverse");
@@ -4124,8 +4126,9 @@ TEST_P(WritePreparedTransactionTest, RangeTombstoneInsertionWithWritePrepared) {
     ASSERT_OK(txn->Put("z", "txn_val"));
     ASSERT_OK(txn->Prepare());
 
-    // Pre-commit: tombstones have max_seq < prepare_seq == min_uncommitted,
-    // so range tombstone IS safely inserted.
+    // Pre-commit: one-write-queue mode publishes the prepare seq to readers,
+    // so insertion must be discarded. Two-write-queues mode can still expose
+    // an older published seq to readers, so insertion remains safe.
     {
       ReadOptions read_opts;
       std::unique_ptr<Iterator> iter(db->NewIterator(read_opts));
@@ -4136,14 +4139,17 @@ TEST_P(WritePreparedTransactionTest, RangeTombstoneInsertionWithWritePrepared) {
         for (iter->SeekToLast(); iter->Valid(); iter->Prev()) {
         }
       }
-      ASSERT_OK(iter->status());
+      EXPECT_OK(iter->status());
     }
-    ASSERT_EQ(
+    const size_t expected_insertions = options.two_write_queues ? 1u : 0u;
+    EXPECT_EQ(
         options.statistics->getTickerCount(READ_PATH_RANGE_TOMBSTONES_INSERTED),
-        1u);
-    ASSERT_EQ(inserted_ranges.size(), 1);
-    ASSERT_EQ(inserted_ranges[0].first, "c");
-    ASSERT_EQ(inserted_ranges[0].second, "h");
+        expected_insertions);
+    EXPECT_EQ(inserted_ranges.size(), expected_insertions);
+    if (options.two_write_queues) {
+      EXPECT_EQ(inserted_ranges[0].first, "c");
+      EXPECT_EQ(inserted_ranges[0].second, "h");
+    }
 
     SyncPoint::GetInstance()->DisableProcessing();
     SyncPoint::GetInstance()->ClearAllCallBacks();
@@ -4180,8 +4186,8 @@ TEST_P(WritePreparedTransactionTest,
       ASSERT_OK(db->Delete(WriteOptions(), std::string(1, c)));
     }
 
-    // Pre-commit: tombstone max_seq >= prepare_seq == min_uncommitted,
-    // so range tombstone is NOT inserted.
+    // Pre-commit: a prepared transaction is still outstanding, so the
+    // synthesized range tombstone must be discarded.
     {
       ReadOptions read_opts;
       std::unique_ptr<Iterator> iter(db->NewIterator(read_opts));

--- a/utilities/transactions/write_unprepared_transaction_test.cc
+++ b/utilities/transactions/write_unprepared_transaction_test.cc
@@ -748,14 +748,16 @@ std::vector<std::string> VerifyIterator(Iterator* iter, bool forward) {
 // Multiple unprepared batches write to the memtable with different seqno
 // ranges tracked in unprep_seqs. Committed tombstones (c-g) exist, and the
 // transaction's own Delete("h") extends the run with an uncommitted entry.
-// Since range_tomb_max_seq_ >= min_uncommitted, insertion is blocked for the
-// entire run. Verifies data correctness after commit.
+// Write-unprepared iterators widen their visible seqno to include own
+// unprepared writes, so synthesizing a range tombstone for a run containing
+// one of those deletes would insert it at a seqno that can cover uncommitted
+// entries. Verify insertion is blocked and data remains correct after commit.
 TEST_P(WriteUnpreparedTransactionTest, RangeTombstoneMultipleBatchesAndCommit) {
   // Test two scenarios:
   // 1) Txn Delete extends the END of a committed tombstone run.
   // 2) Txn Delete in the MIDDLE of a committed tombstone run.
-  // Both should block insertion because range_tomb_max_seq_ >=
-  // min_uncommitted.
+  // Both should block insertion because the visible seqno is widened by the
+  // transaction's own unprepared writes.
   for (bool middle_tombstone : {false, true}) {
     SCOPED_TRACE(middle_tombstone ? "middle tombstone" : "end tombstone");
     for (bool forward : {true, false}) {
@@ -803,8 +805,9 @@ TEST_P(WriteUnpreparedTransactionTest, RangeTombstoneMultipleBatchesAndCommit) {
       ASSERT_OK(txn->Put("i", "txn_i"));
       ASSERT_OK(txn->Put("z", "txn_z"));
 
-      // The txn Delete (whether at "e" or "h") has seqno >= min_uncommitted.
-      // It contaminates the run's range_tomb_max_seq_, blocking insertion.
+      // The txn Delete (whether at "e" or "h") is an own unprepared write.
+      // The iterator exposes it by widening its visible seqno, so a synthesized
+      // tombstone for the whole run must be discarded.
       {
         ReadOptions ro;
         std::unique_ptr<Iterator> iter(txn->GetIterator(ro));
@@ -841,8 +844,10 @@ TEST_P(WriteUnpreparedTransactionTest, RangeTombstoneMultipleBatchesAndCommit) {
 // WriteUnprepared computes max_visible_seq as max(max_unprepared_seqno,
 // snapshot_seq). With a snapshot taken before deletions and multiple unprepared
 // batches after, the iterator's visible range extends beyond the snapshot to
-// include both committed deletes and own writes. Since all tombstone seqnos
-// are < min_uncommitted, insertion is allowed with correct boundaries [c, h).
+// include both committed deletes and own writes. The committed deletes are
+// still visible to the iterator, but a synthesized range tombstone must be
+// discarded because it would be inserted at the widened visible seqno rather
+// than the original snapshot seqno.
 TEST_P(WriteUnpreparedTransactionTest,
        RangeTombstoneCalcMaxVisibleSeqExtendedVisibility) {
   for (bool forward : {true, false}) {
@@ -896,14 +901,16 @@ TEST_P(WriteUnpreparedTransactionTest,
                 (std::vector<std::string>{"a", "b", "h", "i", "j", "x", "y"}));
       ASSERT_OK(iter->status());
     }
-    // Committed tombstones c-g have seqno < min_uncommitted, so insertion
-    // is allowed.
+    // The committed tombstones are visible to the iterator, but insertion is
+    // discarded because the iterator's visible seqno was widened by its own
+    // unprepared writes.
     ASSERT_EQ(
         options.statistics->getTickerCount(READ_PATH_RANGE_TOMBSTONES_INSERTED),
-        1u);
-    ASSERT_EQ(inserted_ranges.size(), 1);
-    ASSERT_EQ(inserted_ranges[0].first, "c");
-    ASSERT_EQ(inserted_ranges[0].second, "h");
+        0u);
+    ASSERT_EQ(options.statistics->getTickerCount(
+                  READ_PATH_RANGE_TOMBSTONES_DISCARDED),
+              1u);
+    ASSERT_EQ(inserted_ranges.size(), 0);
 
     SyncPoint::GetInstance()->DisableProcessing();
     SyncPoint::GetInstance()->ClearAllCallBacks();
@@ -914,10 +921,9 @@ TEST_P(WriteUnpreparedTransactionTest,
 
 // The transaction issues its own uncommitted contiguous Deletes (j-n) forming
 // a tombstone run visible to its iterator, alongside committed tombstones
-// (c-g). Committed tombstones are inserted with correct boundaries [c, h)
-// (seqno < min_uncommitted). Uncommitted tombstones are skipped (seqno >=
-// min_uncommitted). After rollback, own Deletes and Puts are undone while
-// committed deletes remain.
+// (c-g). Because the iterator's visible seqno is widened to include those own
+// writes, both candidate synthesized tombstones are discarded. After rollback,
+// own Deletes and Puts are undone while committed deletes remain.
 TEST_P(WriteUnpreparedTransactionTest, RangeTombstoneOwnDeletionsAndRollback) {
   for (bool forward : {true, false}) {
     SCOPED_TRACE(forward ? "forward" : "reverse");
@@ -972,17 +978,15 @@ TEST_P(WriteUnpreparedTransactionTest, RangeTombstoneOwnDeletionsAndRollback) {
                 (std::vector<std::string>{"a", "b", "h", "i", "o", "p"}));
       ASSERT_OK(iter->status());
     }
-    // Committed tombstones c-g are inserted (seqno < min_uncommitted).
-    // Uncommitted tombstones j-n are skipped (seqno >= min_uncommitted).
+    // Both visible tombstone runs are discarded because the iterator's visible
+    // seqno includes the transaction's own unprepared writes.
     ASSERT_EQ(
         options.statistics->getTickerCount(READ_PATH_RANGE_TOMBSTONES_INSERTED),
-        1u);
+        0u);
     ASSERT_EQ(options.statistics->getTickerCount(
                   READ_PATH_RANGE_TOMBSTONES_DISCARDED),
-              1u);
-    ASSERT_EQ(inserted_ranges.size(), 1);
-    ASSERT_EQ(inserted_ranges[0].first, "c");
-    ASSERT_EQ(inserted_ranges[0].second, "h");
+              2u);
+    ASSERT_EQ(inserted_ranges.size(), 0);
 
     SyncPoint::GetInstance()->DisableProcessing();
     SyncPoint::GetInstance()->ClearAllCallBacks();


### PR DESCRIPTION
## Summary

Fix two bugs in read-path range tombstone conversion (`min_tombstones_for_range_conversion`):

1. **SeekToLast stale saved_key_**: `SeekToLast()` did not clear `saved_key_` before calling `PrevInternal()`. A stale key from a prior `Seek()` would be swapped into `range_tomb_end_key_`, corrupting the tombstone tracking bounds and triggering an assertion failure when `range_tomb_first_key_ > end_key`.

2. **Tombstone inserted at wrong sequence**: The current behavior uses the "max" seqno of the tombstones as the insertion seqno. This is not correct because it does not take into account the seqno range deletions seen throughout the iteration. Unfortunately, range deletions are not visible to the db_iter as the are filtered at the merging iterator level. A future refactor may try to expose this, but currently the simplest solution is to just use the iterator seqno. 

- Other: Tracer improvements; TimedPut and Range Deletion can be human readable

## Test Plan

- Unit tests for both bugs that fail without the fix. 
- Manually launched SC runs to verify no more crash test issues from range tombstones