### PR TITLE
Trace writes only after successful write

### DIFF
--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1649,6 +1649,10 @@ class DBImpl : public DB {
       PreReleaseCallback* pre_release_callback, const AssignOrder assign_order,
       const PublishLastSeq publish_last_seq, const bool disable_memtable);
 
+  void MaybeTraceWriteGroupForPreservedWriteOrder(
+      const WriteThread::WriteGroup& write_group,
+      WriteBatchWithIndex* wbwi = nullptr, bool ingest_wbwi_for_commit = true);
+
   // write cached_recoverable_state_ to memtable if it is not empty
   // The writer must be the leader in write_thread_ and holding mutex_
   Status WriteRecoverableState();

--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -1015,26 +1015,6 @@ Status DBImpl::WriteImpl(const WriteOptions& write_options,
         }
       }
     }
-    // TODO: this use of operator bool on `tracer_` can avoid unnecessary lock
-    // grabs but does not seem thread-safe.
-    if (tracer_) {
-      InstrumentedMutexLock lock(&trace_mutex_);
-      if (tracer_ && tracer_->IsWriteOrderPreserved()) {
-        for (auto* writer : write_group) {
-          if (writer->CallbackFailed()) {
-            continue;
-          }
-          // TODO: maybe handle the tracing status?
-          if (wbwi && !ingest_wbwi_for_commit) {
-            // for transaction write, tracer only needs the commit marker which
-            // is in writer->batch
-            tracer_->Write(wbwi->GetWriteBatch()).PermitUncheckedError();
-          } else {
-            tracer_->Write(writer->trace_batch).PermitUncheckedError();
-          }
-        }
-      }
-    }
     // Note about seq_per_batch_: either disableWAL is set for the entire write
     // group or not. In either case we inc seq for each write batch with no
     // failed callback. This means that there could be a batch with
@@ -1275,6 +1255,26 @@ Status DBImpl::WriteImpl(const WriteOptions& write_options,
       // Note: if we are to resume after non-OK statuses we need to revisit how
       // we react to non-OK statuses here.
       if (w.status.ok()) {  // Don't publish a partial batch write
+        // TODO: this use of operator bool on `tracer_` can avoid unnecessary
+        // lock grabs but does not seem thread-safe.
+        if (tracer_) {
+          InstrumentedMutexLock lock(&trace_mutex_);
+          if (tracer_ && tracer_->IsWriteOrderPreserved()) {
+            for (auto* writer : write_group) {
+              if (writer->CallbackFailed()) {
+                continue;
+              }
+              // TODO: maybe handle the tracing status?
+              if (wbwi && !ingest_wbwi_for_commit) {
+                // For transaction write, tracer only needs the commit marker
+                // which is in writer->batch.
+                tracer_->Write(wbwi->GetWriteBatch()).PermitUncheckedError();
+              } else {
+                tracer_->Write(writer->trace_batch).PermitUncheckedError();
+              }
+            }
+          }
+        }
         versions_->SetLastSequence(last_sequence);
       }
     }
@@ -1345,22 +1345,6 @@ Status DBImpl::PipelinedWriteImpl(const WriteOptions& write_options,
                 total_byte_size, WriteBatchInternal::ByteSize(writer->batch));
             next_sequence += count;
             total_count += count;
-          }
-        }
-      }
-      // TODO: this use of operator bool on `tracer_` can avoid unnecessary lock
-      // grabs but does not seem thread-safe.
-      if (tracer_) {
-        InstrumentedMutexLock lock(&trace_mutex_);
-        if (tracer_ != nullptr && tracer_->IsWriteOrderPreserved()) {
-          for (auto* writer : wal_write_group) {
-            if (writer->CallbackFailed()) {
-              // When optimisitc txn conflict checking fails, we should
-              // not record to trace.
-              continue;
-            }
-            // TODO: maybe handle the tracing status?
-            tracer_->Write(writer->trace_batch).PermitUncheckedError();
           }
         }
       }
@@ -1448,6 +1432,20 @@ Status DBImpl::PipelinedWriteImpl(const WriteOptions& write_options,
           seq_per_batch_, batch_per_txn_);
       if (memtable_write_group.status
               .ok()) {  // Don't publish a partial batch write
+        // TODO: this use of operator bool on `tracer_` can avoid unnecessary
+        // lock grabs but does not seem thread-safe.
+        if (tracer_) {
+          InstrumentedMutexLock lock(&trace_mutex_);
+          if (tracer_ != nullptr && tracer_->IsWriteOrderPreserved()) {
+            for (auto* writer : memtable_write_group) {
+              if (writer->CallbackFailed()) {
+                continue;
+              }
+              // TODO: maybe handle the tracing status?
+              tracer_->Write(writer->trace_batch).PermitUncheckedError();
+            }
+          }
+        }
         versions_->SetLastSequence(memtable_write_group.last_sequence);
       } else {
         HandleMemTableInsertFailure(memtable_write_group.status);
@@ -1481,6 +1479,20 @@ Status DBImpl::PipelinedWriteImpl(const WriteOptions& write_options,
 
     if (write_thread_.CompleteParallelMemTableWriter(&w)) {
       if (w.status.ok()) {  // Don't publish a partial batch write
+        // TODO: this use of operator bool on `tracer_` can avoid unnecessary
+        // lock grabs but does not seem thread-safe.
+        if (tracer_) {
+          InstrumentedMutexLock lock(&trace_mutex_);
+          if (tracer_ != nullptr && tracer_->IsWriteOrderPreserved()) {
+            for (auto* writer : *w.write_group) {
+              if (writer->CallbackFailed()) {
+                continue;
+              }
+              // TODO: maybe handle the tracing status?
+              tracer_->Write(writer->trace_batch).PermitUncheckedError();
+            }
+          }
+        }
         versions_->SetLastSequence(w.write_group->last_sequence);
       } else {
         HandleMemTableInsertFailure(w.status);
@@ -1635,20 +1647,6 @@ Status DBImpl::WriteImplWALOnly(
 
   // Note: no need to update last_batch_group_size_ here since the batch writes
   // to WAL only
-  // TODO: this use of operator bool on `tracer_` can avoid unnecessary lock
-  // grabs but does not seem thread-safe.
-  if (tracer_) {
-    InstrumentedMutexLock lock(&trace_mutex_);
-    if (tracer_ != nullptr && tracer_->IsWriteOrderPreserved()) {
-      for (auto* writer : write_group) {
-        if (writer->CallbackFailed()) {
-          continue;
-        }
-        // TODO: maybe handle the tracing status?
-        tracer_->Write(writer->trace_batch).PermitUncheckedError();
-      }
-    }
-  }
 
   const bool concurrent_update = true;
   // Update stats while we are an exclusive group leader, so we know
@@ -1746,6 +1744,22 @@ Status DBImpl::WriteImplWALOnly(
         if (!ws.ok()) {
           status = ws;
           break;
+        }
+      }
+    }
+  }
+  if (status.ok()) {
+    // TODO: this use of operator bool on `tracer_` can avoid unnecessary lock
+    // grabs but does not seem thread-safe.
+    if (tracer_) {
+      InstrumentedMutexLock lock(&trace_mutex_);
+      if (tracer_ != nullptr && tracer_->IsWriteOrderPreserved()) {
+        for (auto* writer : write_group) {
+          if (writer->CallbackFailed()) {
+            continue;
+          }
+          // TODO: maybe handle the tracing status?
+          tracer_->Write(writer->trace_batch).PermitUncheckedError();
         }
       }
     }

--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -621,6 +621,35 @@ Status DBImpl::SyncBlobDirectWriteManagers(
   return Status::OK();
 }
 
+void DBImpl::MaybeTraceWriteGroupForPreservedWriteOrder(
+    const WriteThread::WriteGroup& write_group, WriteBatchWithIndex* wbwi,
+    bool ingest_wbwi_for_commit) {
+  // TODO: this use of operator bool on `tracer_` can avoid unnecessary lock
+  // grabs but does not seem thread-safe.
+  if (tracer_) {
+    InstrumentedMutexLock lock(&trace_mutex_);
+    if (tracer_ != nullptr && tracer_->IsWriteOrderPreserved()) {
+      WriteBatch* wbwi_trace_batch = nullptr;
+      if (wbwi != nullptr && !ingest_wbwi_for_commit) {
+        // For transaction write, preserved-order tracing only needs the
+        // logical commit marker once, so trace the WBWI batch instead of the
+        // commit-time batch stored in each writer.
+        wbwi_trace_batch = wbwi->GetWriteBatch();
+      }
+      for (auto* writer : write_group) {
+        if (writer->CallbackFailed()) {
+          continue;
+        }
+        WriteBatch* trace_batch = wbwi_trace_batch != nullptr
+                                      ? wbwi_trace_batch
+                                      : writer->trace_batch;
+        // TODO: maybe handle the tracing status?
+        tracer_->Write(trace_batch).PermitUncheckedError();
+      }
+    }
+  }
+}
+
 Status DBImpl::WriteImpl(const WriteOptions& write_options,
                          WriteBatch* my_batch, WriteCallback* callback,
                          UserWriteCallback* user_write_cb, uint64_t* wal_used,
@@ -1255,26 +1284,8 @@ Status DBImpl::WriteImpl(const WriteOptions& write_options,
       // Note: if we are to resume after non-OK statuses we need to revisit how
       // we react to non-OK statuses here.
       if (w.status.ok()) {  // Don't publish a partial batch write
-        // TODO: this use of operator bool on `tracer_` can avoid unnecessary
-        // lock grabs but does not seem thread-safe.
-        if (tracer_) {
-          InstrumentedMutexLock lock(&trace_mutex_);
-          if (tracer_ && tracer_->IsWriteOrderPreserved()) {
-            for (auto* writer : write_group) {
-              if (writer->CallbackFailed()) {
-                continue;
-              }
-              // TODO: maybe handle the tracing status?
-              if (wbwi && !ingest_wbwi_for_commit) {
-                // For transaction write, tracer only needs the commit marker
-                // which is in writer->batch.
-                tracer_->Write(wbwi->GetWriteBatch()).PermitUncheckedError();
-              } else {
-                tracer_->Write(writer->trace_batch).PermitUncheckedError();
-              }
-            }
-          }
-        }
+        MaybeTraceWriteGroupForPreservedWriteOrder(write_group, wbwi.get(),
+                                                   ingest_wbwi_for_commit);
         versions_->SetLastSequence(last_sequence);
       }
     }
@@ -1432,20 +1443,7 @@ Status DBImpl::PipelinedWriteImpl(const WriteOptions& write_options,
           seq_per_batch_, batch_per_txn_);
       if (memtable_write_group.status
               .ok()) {  // Don't publish a partial batch write
-        // TODO: this use of operator bool on `tracer_` can avoid unnecessary
-        // lock grabs but does not seem thread-safe.
-        if (tracer_) {
-          InstrumentedMutexLock lock(&trace_mutex_);
-          if (tracer_ != nullptr && tracer_->IsWriteOrderPreserved()) {
-            for (auto* writer : memtable_write_group) {
-              if (writer->CallbackFailed()) {
-                continue;
-              }
-              // TODO: maybe handle the tracing status?
-              tracer_->Write(writer->trace_batch).PermitUncheckedError();
-            }
-          }
-        }
+        MaybeTraceWriteGroupForPreservedWriteOrder(memtable_write_group);
         versions_->SetLastSequence(memtable_write_group.last_sequence);
       } else {
         HandleMemTableInsertFailure(memtable_write_group.status);
@@ -1479,20 +1477,7 @@ Status DBImpl::PipelinedWriteImpl(const WriteOptions& write_options,
 
     if (write_thread_.CompleteParallelMemTableWriter(&w)) {
       if (w.status.ok()) {  // Don't publish a partial batch write
-        // TODO: this use of operator bool on `tracer_` can avoid unnecessary
-        // lock grabs but does not seem thread-safe.
-        if (tracer_) {
-          InstrumentedMutexLock lock(&trace_mutex_);
-          if (tracer_ != nullptr && tracer_->IsWriteOrderPreserved()) {
-            for (auto* writer : *w.write_group) {
-              if (writer->CallbackFailed()) {
-                continue;
-              }
-              // TODO: maybe handle the tracing status?
-              tracer_->Write(writer->trace_batch).PermitUncheckedError();
-            }
-          }
-        }
+        MaybeTraceWriteGroupForPreservedWriteOrder(*w.write_group);
         versions_->SetLastSequence(w.write_group->last_sequence);
       } else {
         HandleMemTableInsertFailure(w.status);
@@ -1749,20 +1734,7 @@ Status DBImpl::WriteImplWALOnly(
     }
   }
   if (status.ok()) {
-    // TODO: this use of operator bool on `tracer_` can avoid unnecessary lock
-    // grabs but does not seem thread-safe.
-    if (tracer_) {
-      InstrumentedMutexLock lock(&trace_mutex_);
-      if (tracer_ != nullptr && tracer_->IsWriteOrderPreserved()) {
-        for (auto* writer : write_group) {
-          if (writer->CallbackFailed()) {
-            continue;
-          }
-          // TODO: maybe handle the tracing status?
-          tracer_->Write(writer->trace_batch).PermitUncheckedError();
-        }
-      }
-    }
+    MaybeTraceWriteGroupForPreservedWriteOrder(write_group);
   }
   if (publish_last_seq == kDoPublishLastSeq) {
     versions_->SetLastSequence(last_sequence + seq_inc);

--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -4172,6 +4172,72 @@ TEST_F(DBTest2, TraceAndManualReplay) {
   ASSERT_OK(DestroyDB(dbname2, options));
 }
 
+TEST_F(DBTest2, TracePreserveWriteOrderSkipsFailedWrite) {
+  for (bool enable_pipelined_write : {false, true}) {
+    SCOPED_TRACE("enable_pipelined_write=" +
+                 std::to_string(enable_pipelined_write));
+
+    Options options = CurrentOptions();
+    options.enable_pipelined_write = enable_pipelined_write;
+    std::unique_ptr<FaultInjectionTestEnv> fault_env(
+        new FaultInjectionTestEnv(env_));
+    options.env = fault_env.get();
+    DestroyAndReopen(options);
+
+    TraceOptions trace_opts;
+    trace_opts.preserve_write_order = true;
+    const std::string trace_filename = dbname_ +
+                                       "/rocksdb.trace_failed_write." +
+                                       std::to_string(enable_pipelined_write);
+
+    std::unique_ptr<TraceWriter> trace_writer;
+    ASSERT_OK(
+        NewFileTraceWriter(env_, EnvOptions(), trace_filename, &trace_writer));
+    ASSERT_OK(db_->StartTrace(trace_opts, std::move(trace_writer)));
+
+    ASSERT_OK(Put("good", "1"));
+
+    fault_env->SetFilesystemActive(false);
+    ASSERT_NOK(Put("bad", "2"));
+    fault_env->SetFilesystemActive(true);
+
+    ASSERT_OK(db_->EndTrace());
+    Close();
+
+    options.env = env_;
+    Reopen(options);
+    ASSERT_EQ("1", Get("good"));
+    ASSERT_EQ("NOT_FOUND", Get("bad"));
+    Close();
+
+    const std::string replay_dbname = test::PerThreadDBPath(
+        env_, "/db_replay_failed." + std::to_string(enable_pipelined_write));
+    ASSERT_OK(DestroyDB(replay_dbname, options));
+
+    options.create_if_missing = true;
+    std::unique_ptr<DB> replay_db;
+    ASSERT_OK(DB::Open(options, replay_dbname, &replay_db));
+
+    std::unique_ptr<TraceReader> trace_reader;
+    ASSERT_OK(
+        NewFileTraceReader(env_, EnvOptions(), trace_filename, &trace_reader));
+    std::unique_ptr<Replayer> replayer;
+    ASSERT_OK(replay_db->NewDefaultReplayer({replay_db->DefaultColumnFamily()},
+                                            std::move(trace_reader),
+                                            &replayer));
+    ASSERT_OK(replayer->Prepare());
+    ASSERT_OK(replayer->Replay(ReplayOptions(), nullptr));
+
+    std::string value;
+    ASSERT_OK(replay_db->Get(ReadOptions(), "good", &value));
+    ASSERT_EQ("1", value);
+    ASSERT_TRUE(replay_db->Get(ReadOptions(), "bad", &value).IsNotFound());
+
+    replay_db.reset();
+    ASSERT_OK(DestroyDB(replay_dbname, options));
+  }
+}
+
 TEST_F(DBTest2, TraceWithLimit) {
   Options options = CurrentOptions();
   options.merge_operator = MergeOperators::CreatePutOperator();


### PR DESCRIPTION
## Summary

Fix trace ordering for `preserve_write_order` mode to only record writes that actually succeeded.

Previously, when `preserve_write_order = true`, trace records were emitted **before** confirming the write succeeded — at a point where the write could still fail (e.g., WAL I/O error). This meant the trace could contain records for writes that never actually committed to the DB. When `db_stress` crash testing replays the trace to reconstruct expected state, these phantom records cause the expected state to diverge from reality, leading to false verification failures.

This fix moves the `preserve_write_order` tracing to happen **after** the write is confirmed successful (after memtable insert, right before `SetLastSequence`), in all three write paths: `WriteImpl`, `PipelinedWriteImpl`, and `WriteImplWALOnly`.
default and pipelined write modes. Replays the trace into a fresh DB and confirms only the successful write is present.

## Test Plan
- New unit test: `TracePreserveWriteOrderSkipsFailedWrite` in `db/db_test2.cc`
  - Tests both `enable_pipelined_write = false` and `true`
  - Uses `FaultInjectionTestEnv` to force a write failure
  - Verifies the failed write is absent from both the original DB and the replayed trace
