### PR TITLE
Minimize WAL and and tracer gap 

### DIFF
--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -1734,6 +1734,10 @@ Status DBImpl::WriteImplWALOnly(
     }
   }
   if (status.ok()) {
+    // Write trace  after WAL right. This ensures the replayer does not replay a
+    // record that has not been recorded in the DB. However, it is not a full
+    // solution as a crash may still happen before the trace write and after the
+    // WAL write. TODO: Atomically write WAL and trace.
     MaybeTraceWriteGroupForPreservedWriteOrder(write_group);
   }
   PERF_TIMER_START(write_pre_and_post_process_time);


### PR DESCRIPTION
## Summary
https://github.com/facebook/rocksdb/pull/14575 addresses an existing issue where trace record before WAL lead to inconsistent expected state. 

However, placing the trace record after the WAL is still problematic because. The trace may not have all the records in the WAL, resulting in `Error restoring historical expected values -> Trace ended before replaying all expected write ops` on recovery. 

This change minimizes the gap to reduce stress test failures, but it is still not a full solution. It is however still better than previously writing the trace before the WAL because the error is much more obvious when writing the trace after WAL. 

## Test Plan

Existing CI passes.