### PR TITLE
Fix Range Tombstone Entry Accounting Bug

### DIFF
--- a/db/range_tombstone_fragmenter.cc
+++ b/db/range_tombstone_fragmenter.cc
@@ -76,6 +76,7 @@ FragmentedRangeTombstoneList::FragmentedRangeTombstoneList(
       values.emplace_back(value.data(), value.size());
     }
   }
+  num_unfragmented_tombstones_ = keys.size();
   if (pad_min_ts_for_end) {
     total_tombstone_payload_bytes_ += num_unfragmented_tombstones_ * ts_sz;
   }

--- a/db/range_tombstone_fragmenter_test.cc
+++ b/db/range_tombstone_fragmenter_test.cc
@@ -546,6 +546,23 @@ TEST_F(RangeTombstoneFragmenterTest, SeekOutOfBounds) {
                     {{"", {}, true /* out of range */}, {"z", {"l", "n", 4}}});
 }
 
+TEST_F(RangeTombstoneFragmenterTest, CountsAllTombstonesWhenInputNeedsSorting) {
+  std::vector<std::string> keys;
+  std::vector<std::string> values;
+  for (const auto& tombstone : std::vector<RangeTombstone>{
+           {"c", "e", 10}, {"a", "d", 8}, {"b", "f", 6}, {"d", "g", 4}}) {
+    auto key_and_value = tombstone.Serialize();
+    keys.emplace_back(key_and_value.first.Encode().ToString());
+    values.emplace_back(key_and_value.second.ToString());
+  }
+
+  auto unsorted_iter = std::make_unique<VectorIterator>(keys, values, nullptr);
+  FragmentedRangeTombstoneList fragment_list(std::move(unsorted_iter),
+                                             bytewise_icmp);
+
+  ASSERT_EQ(fragment_list.num_unfragmented_tombstones(), 4);
+}
+
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
## Summary:
Crash test T263619547 exposed a flush input accounting bug in
`FragmentedRangeTombstoneList`.

When the constructor sees that the incoming range tombstones are not sorted, it
falls back to rereading all tombstones into `keys`/`values` and sorting them via
`VectorIterator` before fragmentation. However, `num_unfragmented_tombstones_`
was left with the partial count from the aborted first pass. In timestamp
stripping flushes, this stale count could make flush verification report
`Expected X entries in memtables, but read Y` even though all tombstones were
still processed.

Fix the slow path by resetting `num_unfragmented_tombstones_` from
`keys.size()` after the second pass. Add a regression test that feeds unsorted
range tombstones into the fragmenter and verifies the full tombstone count is
preserved.

## Test Plan:
- New unit test that fails without the fix. 
