### PR TITLE
Fix MultiScanIndexIterator crash on reseek after exhaustion (#14581)

### DIFF
--- a/table/block_based/block_based_table_reader_test.cc
+++ b/table/block_based/block_based_table_reader_test.cc
@@ -1624,6 +1624,76 @@ TEST_P(BlockBasedTableReaderMultiScanTest, MultiScanUnpinPreviousBlocks) {
   }
 }
 
+// Regression test for assertion failure when re-seeking to an already-exhausted
+// scan range. This can happen when MergingIterator re-seeks a child iterator
+// after all scan ranges have been consumed (e.g., due to range tombstone
+// adjustments in other levels). The bug was that SeekToBlockIdx() set
+// valid_=true without bounds checking, while cur_idx_ was past
+// block_handles_.size().
+TEST_P(BlockBasedTableReaderMultiScanTest, MultiScanReseekAfterExhaustion) {
+  std::vector<std::pair<std::string, std::string>> kv =
+      BlockBasedTableReaderBaseTest::GenerateKVMap(
+          10 /* num_block */, true /* mixed_with_human_readable_string_value */,
+          comparator_->timestamp_size(), same_key_diff_ts_, comparator_);
+  std::string table_name = "BlockBasedTableReaderTest_ReseekAfterExhaustion" +
+                           CompressionTypeToString(compression_type_);
+  ImmutableOptions ioptions(options_);
+  CreateTable(table_name, ioptions, compression_type_, kv,
+              compression_parallel_threads_, compression_dict_bytes_);
+
+  std::unique_ptr<BlockBasedTable> table;
+  FileOptions foptions;
+  foptions.use_direct_reads = use_direct_reads_;
+  InternalKeyComparator comparator(options_.comparator);
+  NewBlockBasedTableReader(foptions, ioptions, comparator, table_name, &table,
+                           true /* bool prefetch_index_and_filter_in_cache */,
+                           nullptr /* status */, persist_udt_);
+
+  ReadOptions read_opts;
+  std::unique_ptr<InternalIterator> iter;
+  iter.reset(table->NewIterator(
+      read_opts, options_.prefix_extractor.get(), /*arena=*/nullptr,
+      /*skip_filters=*/false, TableReaderCaller::kUncategorized));
+
+  // Set up two scan ranges covering blocks 0-4 and 5-9
+  MultiScanArgs scan_options(BytewiseComparator());
+  scan_options.insert(ExtractUserKey(kv[0].first),
+                      ExtractUserKey(kv[5 * kEntriesPerBlock - 1].first));
+  scan_options.insert(ExtractUserKey(kv[5 * kEntriesPerBlock].first),
+                      ExtractUserKey(kv[10 * kEntriesPerBlock - 1].first));
+
+  iter->Prepare(&scan_options);
+
+  // Seek to range 1 and iterate through all blocks
+  iter->Seek(kv[0].first);
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_OK(iter->status());
+  while (iter->Valid()) {
+    iter->Next();
+  }
+
+  // Re-seek to the first range's start key after range 1 is exhausted.
+  // The forward-only check in MultiScanIndexIterator rejects this seek,
+  // so the iterator remains in the scan_range_exhausted state (valid but
+  // out-of-bound, signaling the caller to seek to the next range).
+  iter->Seek(kv[0].first);
+
+  // Seek to range 2 and iterate through all blocks
+  iter->Seek(kv[5 * kEntriesPerBlock].first);
+  while (iter->Valid()) {
+    iter->Next();
+  }
+  // Now all scan ranges are fully exhausted.
+
+  // Re-seek to the last range's start key. This simulates what happens when
+  // MergingIterator re-seeks a child due to range tombstone key adjustment.
+  // Before the fix, this would trigger:
+  //   assert(cur_idx_ < block_handles_.size()) in value()
+  // because SeekToBlockIdx set valid_=true with cur_idx_ past bounds.
+  iter->Seek(kv[5 * kEntriesPerBlock].first);
+  ASSERT_FALSE(iter->Valid());
+}
+
 // Test that fs_prefetch_support flag is correctly initialized during table
 // construction based on filesystem capabilities
 TEST_P(BlockBasedTableReaderTest, FSPrefetchSupportInitializedCorrectly) {

--- a/table/block_based/multi_scan_index_iterator.cc
+++ b/table/block_based/multi_scan_index_iterator.cc
@@ -143,6 +143,12 @@ void MultiScanIndexIterator::Seek(const Slice& target) {
     // max_sequential_skip_in_iterations can trigger a reseek on the start
     // key of a scan range, even though we're already past cur_scan_start_idx
     size_t block_idx = std::max(cur_scan_start_idx, cur_idx_);
+    if (block_idx >= cur_scan_end_idx) {
+      // cur_idx_ has advanced past this range's blocks (e.g., due to a
+      // reseek after all ranges were exhausted). Treat as exhausted.
+      SetExhausted();
+      return;
+    }
     SeekToBlockIdx(block_idx);
   }
 }


### PR DESCRIPTION
Summary:

In `MultiScanIndexIterator::Seek()` Case 3, when re-entering a scan range
after all ranges were exhausted, `block_idx = std::max(cur_scan_start_idx,
cur_idx_)` could produce an out-of-bounds value because `cur_idx_` was left
at `block_handles_.size()` from previous exhaustion. `SeekToBlockIdx()`
unconditionally set `valid_ = true` without checking bounds, causing the
subsequent `value()` call to hit the assertion
`cur_idx_ < block_handles_.size()`.

Added bounds check before `SeekToBlockIdx()` in Case 3 to correctly report
exhaustion instead of crashing.

Reviewed By: joshkang97

Differential Revision: D99604049
