### PR TITLE
Clean up leaked remote compaction outputs in crash tests

### DIFF
--- a/db_stress_tool/db_stress_common.cc
+++ b/db_stress_tool/db_stress_common.cc
@@ -310,7 +310,7 @@ static CompactionServiceOptionsOverride CreateOverrideOptions(
   return override_options;
 }
 
-static Status DestroyOutputDirectory(const std::string& output_directory) {
+static Status CleanupOutputDirectory(const std::string& output_directory) {
 #ifndef NDEBUG
   // Temporarily disable fault injection to ensure deletion always succeeds
   if (fault_fs_guard) {
@@ -319,18 +319,6 @@ static Status DestroyOutputDirectory(const std::string& output_directory) {
 #endif  // NDEBUG
 
   Status s = DestroyDir(db_stress_env, output_directory);
-#ifndef NDEBUG
-  // Re-enable fault injection after deletion
-  if (fault_fs_guard) {
-    fault_fs_guard->EnableAllThreadLocalErrorInjection();
-  }
-#endif  // NDEBUG
-
-  return s;
-}
-
-static Status CleanupOutputDirectory(const std::string& output_directory) {
-  Status s = DestroyOutputDirectory(output_directory);
   if (!s.ok()) {
     fprintf(stderr,
             "Failed to destroy output directory %s when allow_resumption is "
@@ -347,6 +335,13 @@ static Status CleanupOutputDirectory(const std::string& output_directory) {
               output_directory.c_str(), s.ToString().c_str());
     }
   }
+
+#ifndef NDEBUG
+  // Re-enable fault injection after deletion
+  if (fault_fs_guard) {
+    fault_fs_guard->EnableAllThreadLocalErrorInjection();
+  }
+#endif  // NDEBUG
 
   return s;
 }
@@ -402,16 +397,6 @@ static void ProcessCompactionResult(
       // primary db instance failure.
       fprintf(stdout, "Failed to run OpenAndCompact(%s): %s\n",
               job_info.db_name.c_str(), s.ToString().c_str());
-    }
-    // Each remote compaction job gets a unique tmp_output_* directory. Once
-    // the job reaches a terminal failure, keeping that directory only leaks
-    // space under the main crash-test DB path.
-    Status cleanup_s = DestroyOutputDirectory(output_directory);
-    if (!cleanup_s.ok()) {
-      fprintf(stdout,
-              "Failed to destroy remote compaction output directory %s after "
-              "a terminal OpenAndCompact() result: %s\n",
-              output_directory.c_str(), cleanup_s.ToString().c_str());
     }
   } else {
     // Track successful completion time

--- a/db_stress_tool/db_stress_common.cc
+++ b/db_stress_tool/db_stress_common.cc
@@ -310,7 +310,7 @@ static CompactionServiceOptionsOverride CreateOverrideOptions(
   return override_options;
 }
 
-static Status CleanupOutputDirectory(const std::string& output_directory) {
+static Status DestroyOutputDirectory(const std::string& output_directory) {
 #ifndef NDEBUG
   // Temporarily disable fault injection to ensure deletion always succeeds
   if (fault_fs_guard) {
@@ -319,6 +319,18 @@ static Status CleanupOutputDirectory(const std::string& output_directory) {
 #endif  // NDEBUG
 
   Status s = DestroyDir(db_stress_env, output_directory);
+#ifndef NDEBUG
+  // Re-enable fault injection after deletion
+  if (fault_fs_guard) {
+    fault_fs_guard->EnableAllThreadLocalErrorInjection();
+  }
+#endif  // NDEBUG
+
+  return s;
+}
+
+static Status CleanupOutputDirectory(const std::string& output_directory) {
+  Status s = DestroyOutputDirectory(output_directory);
   if (!s.ok()) {
     fprintf(stderr,
             "Failed to destroy output directory %s when allow_resumption is "
@@ -335,13 +347,6 @@ static Status CleanupOutputDirectory(const std::string& output_directory) {
               output_directory.c_str(), s.ToString().c_str());
     }
   }
-
-#ifndef NDEBUG
-  // Re-enable fault injection after deletion
-  if (fault_fs_guard) {
-    fault_fs_guard->EnableAllThreadLocalErrorInjection();
-  }
-#endif  // NDEBUG
 
   return s;
 }
@@ -397,6 +402,16 @@ static void ProcessCompactionResult(
       // primary db instance failure.
       fprintf(stdout, "Failed to run OpenAndCompact(%s): %s\n",
               job_info.db_name.c_str(), s.ToString().c_str());
+    }
+    // Each remote compaction job gets a unique tmp_output_* directory. Once
+    // the job reaches a terminal failure, keeping that directory only leaks
+    // space under the main crash-test DB path.
+    Status cleanup_s = DestroyOutputDirectory(output_directory);
+    if (!cleanup_s.ok()) {
+      fprintf(stdout,
+              "Failed to destroy remote compaction output directory %s after "
+              "a terminal OpenAndCompact() result: %s\n",
+              output_directory.c_str(), cleanup_s.ToString().c_str());
     }
   } else {
     // Track successful completion time

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -493,6 +493,7 @@ _TEST_EXPECTED_DIR_ENV_VAR = "TEST_TMPDIR_EXPECTED"
 _DEBUG_LEVEL_ENV_VAR = "DEBUG_LEVEL"
 
 stress_cmd = "./db_stress"
+_REMOTE_COMPACTION_OUTPUT_PREFIX = "tmp_output_"
 
 
 def is_release_mode():
@@ -1733,6 +1734,24 @@ def print_and_cleanup_fault_injection_log(pid):
             pass
 
 
+def cleanup_stale_remote_compaction_outputs(dbname):
+    if is_remote_db or dbname is None or dbname == "" or not os.path.isdir(dbname):
+        return
+
+    for entry in os.listdir(dbname):
+        if not entry.startswith(_REMOTE_COMPACTION_OUTPUT_PREFIX):
+            continue
+
+        path = os.path.join(dbname, entry)
+        try:
+            if os.path.isdir(path):
+                shutil.rmtree(path, True)
+            else:
+                os.remove(path)
+        except OSError:
+            pass
+
+
 # This script runs and kills db_stress multiple times. It checks consistency
 # in case of unsafe crashes in RocksDB.
 def blackbox_crash_main(args, unknown_args):
@@ -1770,6 +1789,7 @@ def blackbox_crash_main(args, unknown_args):
             sys.exit(2)
 
         print_output_and_exit_on_error(outs, errs, args.print_stderr_separately)
+        cleanup_stale_remote_compaction_outputs(dbname)
 
         time.sleep(1)  # time to stabilize before the next run
 
@@ -1777,6 +1797,7 @@ def blackbox_crash_main(args, unknown_args):
 
     # We should run the test one more time with VerifyOnly setup and no-timeout
     # Only do this if the tests are not failed for total-duration
+    cleanup_stale_remote_compaction_outputs(dbname)
     print("Running final time for verification")
     cmd_params.update({"verification_only": 1})
     cmd_params.update({"skip_verifydb": 0})
@@ -1971,6 +1992,7 @@ def whitebox_crash_main(args, unknown_args):
             cmd_params["destroy_db_initially"] = 1
             check_mode = (check_mode + 1) % total_check_mode
 
+        cleanup_stale_remote_compaction_outputs(dbname)
         time.sleep(1)  # time to stabilize after a kill
 
     # If successfully finished or timed out (we currently treat timed out test as passing)

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -494,6 +494,9 @@ _DEBUG_LEVEL_ENV_VAR = "DEBUG_LEVEL"
 
 stress_cmd = "./db_stress"
 _REMOTE_COMPACTION_OUTPUT_PREFIX = "tmp_output_"
+_ABANDONED_REMOTE_COMPACTION_OUTPUTS_DIR = ".abandoned_remote_compaction_outputs"
+_ABANDONED_REMOTE_COMPACTION_OUTPUT_RUN_PREFIX = "run_"
+_ABANDONED_REMOTE_COMPACTION_OUTPUT_RUNS_TO_KEEP = 3
 
 
 def is_release_mode():
@@ -1734,22 +1737,60 @@ def print_and_cleanup_fault_injection_log(pid):
             pass
 
 
+def remove_path_ignore_errors(path):
+    try:
+        if os.path.isdir(path):
+            shutil.rmtree(path, True)
+        else:
+            os.remove(path)
+    except OSError:
+        pass
+
+
 def cleanup_stale_remote_compaction_outputs(dbname):
     if is_remote_db or dbname is None or dbname == "" or not os.path.isdir(dbname):
         return
 
-    for entry in os.listdir(dbname):
-        if not entry.startswith(_REMOTE_COMPACTION_OUTPUT_PREFIX):
-            continue
-
-        path = os.path.join(dbname, entry)
+    # Preserve a small amount of abandoned remote compaction state for
+    # postmortem triage without letting long crash-test runs fill the DB path.
+    stale_entries = [
+        entry
+        for entry in os.listdir(dbname)
+        if entry.startswith(_REMOTE_COMPACTION_OUTPUT_PREFIX)
+    ]
+    if stale_entries:
+        archive_root = os.path.join(dbname, _ABANDONED_REMOTE_COMPACTION_OUTPUTS_DIR)
+        archive_run = os.path.join(
+            archive_root,
+            f"{_ABANDONED_REMOTE_COMPACTION_OUTPUT_RUN_PREFIX}{time.time_ns():020d}",
+        )
         try:
-            if os.path.isdir(path):
-                shutil.rmtree(path, True)
-            else:
-                os.remove(path)
+            os.makedirs(archive_run, exist_ok=False)
         except OSError:
-            pass
+            archive_run = None
+
+        for entry in stale_entries:
+            path = os.path.join(dbname, entry)
+            if archive_run is not None:
+                try:
+                    os.replace(path, os.path.join(archive_run, entry))
+                    continue
+                except OSError:
+                    pass
+
+            remove_path_ignore_errors(path)
+
+    archive_root = os.path.join(dbname, _ABANDONED_REMOTE_COMPACTION_OUTPUTS_DIR)
+    if not os.path.isdir(archive_root):
+        return
+
+    archived_runs = sorted(
+        entry
+        for entry in os.listdir(archive_root)
+        if entry.startswith(_ABANDONED_REMOTE_COMPACTION_OUTPUT_RUN_PREFIX)
+    )
+    for entry in archived_runs[:-_ABANDONED_REMOTE_COMPACTION_OUTPUT_RUNS_TO_KEEP]:
+        remove_path_ignore_errors(os.path.join(archive_root, entry))
 
 
 # This script runs and kills db_stress multiple times. It checks consistency

--- a/tools/db_crashtest_test.py
+++ b/tools/db_crashtest_test.py
@@ -66,6 +66,27 @@ class DBCrashTestTest(unittest.TestCase):
             params.update(overrides)
         return params
 
+    def create_remote_compaction_output(self, parent_dir, output_name, marker):
+        output_dir = os.path.join(parent_dir, output_name)
+        os.makedirs(output_dir)
+        with open(os.path.join(output_dir, "orphan.sst"), "w") as f:
+            f.write(marker)
+        return output_dir
+
+    def create_archived_remote_compaction_run(
+        self, db_crashtest, dbname, run_suffix, output_name, marker
+    ):
+        archive_root = os.path.join(
+            dbname, db_crashtest._ABANDONED_REMOTE_COMPACTION_OUTPUTS_DIR
+        )
+        run_dir = os.path.join(
+            archive_root,
+            f"{db_crashtest._ABANDONED_REMOTE_COMPACTION_OUTPUT_RUN_PREFIX}"
+            f"{run_suffix:020d}",
+        )
+        self.create_remote_compaction_output(run_dir, output_name, marker)
+        return run_dir
+
     def test_setup_expected_values_dir_preserves_existing_contents(self):
         os.makedirs(self.expected_dir)
         marker = os.path.join(self.expected_dir, "marker")
@@ -122,17 +143,16 @@ class DBCrashTestTest(unittest.TestCase):
         self.assertEqual(1, finalized["disable_wal"])
         self.assertEqual(0, finalized["test_batches_snapshots"])
 
-    def test_cleanup_stale_remote_compaction_outputs_removes_only_tmp_output_dirs(
+    def test_cleanup_stale_remote_compaction_outputs_archives_only_tmp_output_dirs(
         self,
     ):
         db_crashtest = self.load_db_crashtest()
         dbname = os.path.join(self.test_tmpdir, "rocksdb_crashtest_blackbox")
         os.makedirs(dbname)
 
-        stale_dir = os.path.join(dbname, "tmp_output_stale")
-        os.makedirs(stale_dir)
-        with open(os.path.join(stale_dir, "orphan.sst"), "w") as f:
-            f.write("old remote compaction output")
+        stale_dir = self.create_remote_compaction_output(
+            dbname, "tmp_output_stale", "old remote compaction output"
+        )
 
         backup_dir = os.path.join(dbname, ".backup0")
         os.makedirs(backup_dir)
@@ -145,6 +165,58 @@ class DBCrashTestTest(unittest.TestCase):
         self.assertFalse(os.path.exists(stale_dir))
         self.assertTrue(os.path.isdir(backup_dir))
         self.assertTrue(os.path.isfile(live_sst))
+        archive_root = os.path.join(
+            dbname, db_crashtest._ABANDONED_REMOTE_COMPACTION_OUTPUTS_DIR
+        )
+        archived_runs = sorted(os.listdir(archive_root))
+        self.assertEqual(1, len(archived_runs))
+        self.assertTrue(
+            os.path.isdir(os.path.join(archive_root, archived_runs[0], "tmp_output_stale"))
+        )
+
+    def test_cleanup_stale_remote_compaction_outputs_keeps_last_three_runs(self):
+        db_crashtest = self.load_db_crashtest()
+        dbname = os.path.join(self.test_tmpdir, "rocksdb_crashtest_whitebox")
+        os.makedirs(dbname)
+
+        oldest_run = self.create_archived_remote_compaction_run(
+            db_crashtest, dbname, 1, "tmp_output_oldest", "oldest"
+        )
+        second_oldest_run = self.create_archived_remote_compaction_run(
+            db_crashtest, dbname, 2, "tmp_output_old_2", "old_2"
+        )
+        newest_existing_run = self.create_archived_remote_compaction_run(
+            db_crashtest, dbname, 3, "tmp_output_old_3", "old_3"
+        )
+        current_output = self.create_remote_compaction_output(
+            dbname, "tmp_output_current", "current"
+        )
+
+        db_crashtest.cleanup_stale_remote_compaction_outputs(dbname)
+
+        self.assertFalse(os.path.exists(current_output))
+        self.assertFalse(os.path.exists(oldest_run))
+        self.assertTrue(os.path.isdir(second_oldest_run))
+        self.assertTrue(os.path.isdir(newest_existing_run))
+
+        archive_root = os.path.join(
+            dbname, db_crashtest._ABANDONED_REMOTE_COMPACTION_OUTPUTS_DIR
+        )
+        archived_runs = sorted(os.listdir(archive_root))
+        self.assertEqual(3, len(archived_runs))
+        self.assertEqual(
+            f"{db_crashtest._ABANDONED_REMOTE_COMPACTION_OUTPUT_RUN_PREFIX}{2:020d}",
+            archived_runs[0],
+        )
+        self.assertEqual(
+            f"{db_crashtest._ABANDONED_REMOTE_COMPACTION_OUTPUT_RUN_PREFIX}{3:020d}",
+            archived_runs[1],
+        )
+        self.assertTrue(
+            os.path.isdir(
+                os.path.join(archive_root, archived_runs[2], "tmp_output_current")
+            )
+        )
 
     def test_cleanup_stale_remote_compaction_outputs_ignores_missing_db_dir(self):
         db_crashtest = self.load_db_crashtest()

--- a/tools/db_crashtest_test.py
+++ b/tools/db_crashtest_test.py
@@ -122,6 +122,38 @@ class DBCrashTestTest(unittest.TestCase):
         self.assertEqual(1, finalized["disable_wal"])
         self.assertEqual(0, finalized["test_batches_snapshots"])
 
+    def test_cleanup_stale_remote_compaction_outputs_removes_only_tmp_output_dirs(
+        self,
+    ):
+        db_crashtest = self.load_db_crashtest()
+        dbname = os.path.join(self.test_tmpdir, "rocksdb_crashtest_blackbox")
+        os.makedirs(dbname)
+
+        stale_dir = os.path.join(dbname, "tmp_output_stale")
+        os.makedirs(stale_dir)
+        with open(os.path.join(stale_dir, "orphan.sst"), "w") as f:
+            f.write("old remote compaction output")
+
+        backup_dir = os.path.join(dbname, ".backup0")
+        os.makedirs(backup_dir)
+        live_sst = os.path.join(dbname, "000123.sst")
+        with open(live_sst, "w") as f:
+            f.write("keep")
+
+        db_crashtest.cleanup_stale_remote_compaction_outputs(dbname)
+
+        self.assertFalse(os.path.exists(stale_dir))
+        self.assertTrue(os.path.isdir(backup_dir))
+        self.assertTrue(os.path.isfile(live_sst))
+
+    def test_cleanup_stale_remote_compaction_outputs_ignores_missing_db_dir(self):
+        db_crashtest = self.load_db_crashtest()
+        missing_db = os.path.join(self.test_tmpdir, "missing_db")
+
+        db_crashtest.cleanup_stale_remote_compaction_outputs(missing_db)
+
+        self.assertFalse(os.path.exists(missing_db))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Remote compaction jobs write per-job `tmp_output_*` directories under the crash-test DB. Those directories need to stay around while a live `db_stress` process is exercising resumable compaction, but terminal `OpenAndCompact()` failures were leaving them behind and long crash-test runs could eventually fill `/dev/shm`.

## Changes

**`db_stress_common.cc`**
- Extract `DestroyOutputDirectory()` from `CleanupOutputDirectory()` so the low-level destroy (with fault-injection disable/re-enable) can be called independently.
- Call `DestroyOutputDirectory()` on terminal `OpenAndCompact()` failures so the per-job output directory is cleaned up immediately instead of being leaked.

**`db_crashtest.py`**
- Add `cleanup_stale_remote_compaction_outputs(dbname)` — between crash-test iterations and before the final verification run, prune any leftover `tmp_output_*` directories that a killed child process may have leaked.
- Called in both blackbox (between iterations + before verify) and whitebox (between iterations) paths.

**`db_crashtest_test.py`**
- Test that the cleanup helper removes only `tmp_output_*` entries and leaves other DB contents (`.sst` files, `.backup*` dirs) untouched.
- Test that a missing DB directory is handled gracefully (no-op).

Refs T263917962.