### PR TITLE
Fast file open: retrieve, persist, and pass file open metadata (#14596)

### DIFF
--- a/db/builder.cc
+++ b/db/builder.cc
@@ -87,7 +87,7 @@ Status BuildTable(
     Env::WriteLifeTimeHint write_hint, const std::string* full_history_ts_low,
     BlobFileCompletionCallback* blob_callback, Version* version,
     uint64_t* memtable_payload_bytes, uint64_t* memtable_garbage_bytes,
-    InternalStats::CompactionStats* flush_stats) {
+    InternalStats::CompactionStats* flush_stats, bool fast_sst_open) {
   assert((tboptions.column_family_id ==
           TablePropertiesCollectorFactory::Context::kUnknownColumnFamily) ==
          tboptions.column_family_name.empty());
@@ -457,6 +457,8 @@ Status BuildTable(
       // here because this is a special case after we finish the table building.
       // No matter whether use_direct_io_for_flush_and_compaction is true,
       // the goal is to cache it here for further user reads.
+      std::string* file_open_metadata_ptr =
+          fast_sst_open ? &meta->file_open_metadata : nullptr;
       std::unique_ptr<InternalIterator> it(table_cache->NewIterator(
           tboptions.read_options, file_options, tboptions.internal_comparator,
           *meta, nullptr /* range_del_agg */, mutable_cf_options, nullptr,
@@ -467,7 +469,10 @@ Status BuildTable(
           MaxFileSizeForL0MetaPin(mutable_cf_options),
           /*smallest_compaction_key=*/nullptr,
           /*largest_compaction_key*/ nullptr,
-          /*allow_unprepared_value*/ false));
+          /*allow_unprepared_value*/ false,
+          /*range_del_read_seqno=*/nullptr,
+          /*range_del_iter=*/nullptr,
+          /*maybe_pin_table_handle=*/false, file_open_metadata_ptr));
       s = it->status();
       if (s.ok() && paranoid_file_checks) {
         OutputValidator file_validator(tboptions.internal_comparator,

--- a/db/builder.h
+++ b/db/builder.h
@@ -79,6 +79,7 @@ Status BuildTable(
     BlobFileCompletionCallback* blob_callback = nullptr,
     Version* version = nullptr, uint64_t* memtable_payload_bytes = nullptr,
     uint64_t* memtable_garbage_bytes = nullptr,
-    InternalStats::CompactionStats* flush_stats = nullptr);
+    InternalStats::CompactionStats* flush_stats = nullptr,
+    bool fast_sst_open = false);
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -58,6 +58,7 @@
 #include "table/table_builder.h"
 #include "table/unique_id_impl.h"
 #include "test_util/sync_point.h"
+#include "util/hash_containers.h"
 #include "util/stop_watch.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -898,6 +899,10 @@ Status CompactionJob::VerifyOutputFiles() {
   }
 
   auto verify_table = [&](SubcompactionState& subcompaction_state) {
+    // Collect file open metadata during verification when fast_sst_open
+    // is enabled, keyed by file number.
+    UnorderedMap<uint64_t, std::string> file_open_metadata_map;
+
     for (const auto& output_file : subcompaction_state.GetOutputs()) {
       // Verify that the table is usable
       // We set for_compaction to false and don't
@@ -915,6 +920,10 @@ Status CompactionJob::VerifyOutputFiles() {
       TableReader* table_reader_ptr = table_reader_guard.get();
       verification_read_options.rate_limiter_priority =
           GetRateLimiterPriority();
+      std::string file_open_metadata;
+      std::string* file_open_metadata_ptr =
+          mutable_db_options_copy_.fast_sst_open ? &file_open_metadata
+                                                 : nullptr;
       InternalIterator* iter = cfd->table_cache()->NewIterator(
           verification_read_options, file_options_, cfd->internal_comparator(),
           output_file.meta,
@@ -927,7 +936,10 @@ Status CompactionJob::VerifyOutputFiles() {
           MaxFileSizeForL0MetaPin(compact_->compaction->mutable_cf_options()),
           /*smallest_compaction_key=*/nullptr,
           /*largest_compaction_key=*/nullptr,
-          /*allow_unprepared_value=*/false);
+          /*allow_unprepared_value=*/false,
+          /*range_del_read_seqno=*/nullptr,
+          /*range_del_iter=*/nullptr,
+          /*maybe_pin_table_handle=*/false, file_open_metadata_ptr);
       auto s = iter->status();
       if (s.ok()) {
         // Check for remote/local compaction and verify_output_flags flags
@@ -1002,6 +1014,27 @@ Status CompactionJob::VerifyOutputFiles() {
         subcompaction_state.status = s;
         break;
       }
+
+      if (!file_open_metadata.empty()) {
+        file_open_metadata_map[output_file.meta.fd.GetNumber()] =
+            std::move(file_open_metadata);
+      }
+    }
+
+    // Apply collected file open metadata to mutable outputs
+    if (!file_open_metadata_map.empty()) {
+      auto apply_metadata =
+          [&file_open_metadata_map](
+              std::vector<CompactionOutputs::Output>& outputs) {
+            for (auto& output : outputs) {
+              auto it = file_open_metadata_map.find(output.meta.fd.GetNumber());
+              if (it != file_open_metadata_map.end()) {
+                output.meta.file_open_metadata = std::move(it->second);
+              }
+            }
+          };
+      apply_metadata(subcompaction_state.GetMutableCompactionOutputs());
+      apply_metadata(subcompaction_state.GetMutableProximalOutputs());
     }
   };
   for (size_t i = 1; i < compact_->sub_compact_states.size(); i++) {

--- a/db/compaction/compaction_outputs.h
+++ b/db/compaction/compaction_outputs.h
@@ -60,6 +60,7 @@ class CompactionOutputs {
   }
 
   const std::vector<Output>& GetOutputs() const { return outputs_; }
+  std::vector<Output>& GetMutableOutputs() { return outputs_; }
 
   // Set new table builder for the current output
   void NewBuilder(const TableBuilderOptions& tboptions);

--- a/db/compaction/subcompaction_state.h
+++ b/db/compaction/subcompaction_state.h
@@ -81,6 +81,15 @@ class SubcompactionState {
   // it returns both the last level outputs and proximal level outputs.
   OutputIterator GetOutputs() const;
 
+  // Get mutable access to outputs for post-processing (e.g., retrieving
+  // file open metadata).
+  std::vector<CompactionOutputs::Output>& GetMutableCompactionOutputs() {
+    return compaction_outputs_.GetMutableOutputs();
+  }
+  std::vector<CompactionOutputs::Output>& GetMutableProximalOutputs() {
+    return proximal_level_outputs_.GetMutableOutputs();
+  }
+
   // Assign range dels aggregator. The various tombstones will potentially
   // be filtered to different outputs.
   void AssignRangeDelAggregator(

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -217,7 +217,8 @@ Status DBImpl::FlushMemTableToOutputFile(
       &event_logger_, mutable_cf_options.report_bg_io_stats,
       true /* sync_output_directory */, true /* write_manifest */, thread_pri,
       io_tracer_, cfd->GetSuperVersion()->ShareSeqnoToTimeMapping(), db_id_,
-      db_session_id_, cfd->GetFullHistoryTsLow(), &blob_callback_);
+      db_session_id_, cfd->GetFullHistoryTsLow(), &blob_callback_,
+      mutable_db_options_.fast_sst_open);
   FileMetaData file_meta;
 
   Status s;
@@ -548,7 +549,8 @@ Status DBImpl::AtomicFlushMemTablesToOutputFiles(
         false /* sync_output_directory */, false /* write_manifest */,
         thread_pri, io_tracer_,
         cfd->GetSuperVersion()->ShareSeqnoToTimeMapping(), db_id_,
-        db_session_id_, cfd->GetFullHistoryTsLow(), &blob_callback_));
+        db_session_id_, cfd->GetFullHistoryTsLow(), &blob_callback_,
+        mutable_db_options_.fast_sst_open));
   }
 
   std::vector<FileMetaData> file_meta(num_cfs);

--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -7781,6 +7781,374 @@ INSTANTIATE_TEST_CASE_P(
         /*allow_concurrent_memtable_write=*/::testing::Bool(),
         /*min_tombstones_for_range_conversion=*/::testing::Values(0, 4)));
 
+// Test file system that supports GetFileOpenMetadata for fast_sst_open testing
+class FastOpenTestRandomAccessFile : public FSRandomAccessFileWrapper {
+ public:
+  explicit FastOpenTestRandomAccessFile(
+      std::unique_ptr<FSRandomAccessFile>&& file, const std::string& fname,
+      std::atomic<int>* metadata_retrieved_count)
+      : FSRandomAccessFileWrapper(file.get()),
+        file_(std::move(file)),
+        fname_(fname),
+        metadata_retrieved_count_(metadata_retrieved_count) {}
+
+  IOStatus GetFileOpenMetadata(std::string* metadata) override {
+    // Return the file name as opaque metadata for testing
+    *metadata = "fast_open_metadata:" + fname_;
+    metadata_retrieved_count_->fetch_add(1, std::memory_order_relaxed);
+    return IOStatus::OK();
+  }
+
+ private:
+  std::unique_ptr<FSRandomAccessFile> file_;
+  std::string fname_;
+  std::atomic<int>* metadata_retrieved_count_;
+};
+
+class FastOpenTestFS : public FileSystemWrapper {
+ public:
+  explicit FastOpenTestFS(const std::shared_ptr<FileSystem>& base)
+      : FileSystemWrapper(base) {}
+
+  const char* Name() const override { return "FastOpenTestFS"; }
+
+  IOStatus NewRandomAccessFile(const std::string& fname,
+                               const FileOptions& file_opts,
+                               std::unique_ptr<FSRandomAccessFile>* result,
+                               IODebugContext* dbg) override {
+    if (file_opts.file_metadata != nullptr) {
+      metadata_passed_on_open_.fetch_add(1, std::memory_order_relaxed);
+      last_metadata_received_ = *file_opts.file_metadata;
+    }
+    IOStatus s = target()->NewRandomAccessFile(fname, file_opts, result, dbg);
+    if (s.ok()) {
+      result->reset(new FastOpenTestRandomAccessFile(
+          std::move(*result), fname, &metadata_retrieved_count_));
+    }
+    return s;
+  }
+
+  int GetMetadataRetrievedCount() const {
+    return metadata_retrieved_count_.load(std::memory_order_relaxed);
+  }
+
+  int GetMetadataPassedOnOpenCount() const {
+    return metadata_passed_on_open_.load(std::memory_order_relaxed);
+  }
+
+  std::string GetLastMetadataReceived() const {
+    return last_metadata_received_;
+  }
+
+  void ResetCounters() {
+    metadata_retrieved_count_.store(0, std::memory_order_relaxed);
+    metadata_passed_on_open_.store(0, std::memory_order_relaxed);
+    last_metadata_received_.clear();
+  }
+
+ private:
+  std::atomic<int> metadata_retrieved_count_{0};
+  std::atomic<int> metadata_passed_on_open_{0};
+  std::string last_metadata_received_;
+};
+
+TEST_F(DBTest2, FastSstOpenDefaultFSReturnsNotSupported) {
+  // Verify that the default FS returns NotSupported for GetFileOpenMetadata.
+  std::string fname = dbname_ + "/000001.sst";
+  // Create a small file so we can open it
+  {
+    std::unique_ptr<FSWritableFile> wf;
+    ASSERT_OK(env_->GetFileSystem()->NewWritableFile(fname, FileOptions(), &wf,
+                                                     nullptr));
+    ASSERT_OK(wf->Append("test", IOOptions(), nullptr));
+    ASSERT_OK(wf->Close(IOOptions(), nullptr));
+  }
+  std::unique_ptr<FSRandomAccessFile> file;
+  ASSERT_OK(env_->GetFileSystem()->NewRandomAccessFile(fname, FileOptions(),
+                                                       &file, nullptr));
+  std::string metadata;
+  IOStatus s = file->GetFileOpenMetadata(&metadata);
+  ASSERT_TRUE(s.IsNotSupported());
+  ASSERT_TRUE(metadata.empty());
+  // Clean up
+  ASSERT_OK(env_->GetFileSystem()->DeleteFile(fname, IOOptions(), nullptr));
+}
+
+TEST_F(DBTest2, FastSstOpenFlushAndReopen) {
+  // Test with default FS (GetFileOpenMetadata returns NotSupported).
+  // Verifies the code path works without crashing.
+  Options options = CurrentOptions();
+  options.fast_sst_open = true;
+  DestroyAndReopen(options);
+
+  ASSERT_OK(Put("key1", "value1"));
+  ASSERT_OK(Put("key2", "value2"));
+  ASSERT_OK(Flush());
+
+  Close();
+  Reopen(options);
+
+  ASSERT_EQ("value1", Get("key1"));
+  ASSERT_EQ("value2", Get("key2"));
+}
+
+TEST_F(DBTest2, FastSstOpenCompactionAndReopen) {
+  Options options = CurrentOptions();
+  options.fast_sst_open = true;
+  options.level0_file_num_compaction_trigger = 2;
+  DestroyAndReopen(options);
+
+  ASSERT_OK(Put("key1", "value1"));
+  ASSERT_OK(Flush());
+  ASSERT_OK(Put("key2", "value2"));
+  ASSERT_OK(Flush());
+  ASSERT_OK(dbfull()->TEST_WaitForCompact());
+
+  Close();
+  Reopen(options);
+
+  ASSERT_EQ("value1", Get("key1"));
+  ASSERT_EQ("value2", Get("key2"));
+}
+
+TEST_F(DBTest2, FastSstOpenWithTestFS) {
+  // Full fast_sst_open flow: flush produces 1 SST, verify exact counts.
+  auto test_fs = std::make_shared<FastOpenTestFS>(env_->GetFileSystem());
+  std::unique_ptr<Env> test_env(new CompositeEnvWrapper(env_, test_fs));
+
+  Options options;
+  options.env = test_env.get();
+  options.fast_sst_open = true;
+  options.create_if_missing = true;
+
+  std::string test_dbname = test::PerThreadDBPath("fast_open_test");
+  ASSERT_OK(DestroyDB(test_dbname, options));
+
+  std::unique_ptr<DB> db;
+  ASSERT_OK(DB::Open(options, test_dbname, &db));
+  test_fs->ResetCounters();
+
+  // One flush produces one SST file -> exactly 1 GetFileOpenMetadata call
+  ASSERT_OK(db->Put(WriteOptions(), "key1", "value1"));
+  ASSERT_OK(db->Put(WriteOptions(), "key2", "value2"));
+  ASSERT_OK(db->Flush(FlushOptions()));
+
+  ASSERT_EQ(1, test_fs->GetMetadataRetrievedCount());
+  ASSERT_EQ(0, test_fs->GetMetadataPassedOnOpenCount());
+
+  test_fs->ResetCounters();
+  db.reset();
+
+  // Reopen: the SST file should be opened with metadata
+  ASSERT_OK(DB::Open(options, test_dbname, &db));
+
+  std::string value;
+  ASSERT_OK(db->Get(ReadOptions(), "key1", &value));
+  ASSERT_EQ("value1", value);
+  ASSERT_OK(db->Get(ReadOptions(), "key2", &value));
+  ASSERT_EQ("value2", value);
+
+  // Exactly 1 SST file was opened with metadata passed
+  ASSERT_EQ(1, test_fs->GetMetadataPassedOnOpenCount());
+  ASSERT_TRUE(test_fs->GetLastMetadataReceived().find("fast_open_metadata:") ==
+              0);
+
+  db.reset();
+  ASSERT_OK(DestroyDB(test_dbname, options));
+}
+
+TEST_F(DBTest2, FastSstOpenCompactionWithTestFS) {
+  // Compaction: 2 flushes trigger compaction, producing 1 output SST.
+  auto test_fs = std::make_shared<FastOpenTestFS>(env_->GetFileSystem());
+  std::unique_ptr<Env> test_env(new CompositeEnvWrapper(env_, test_fs));
+
+  Options options;
+  options.env = test_env.get();
+  options.fast_sst_open = true;
+  options.create_if_missing = true;
+  options.level0_file_num_compaction_trigger = 2;
+
+  std::string test_dbname = test::PerThreadDBPath("fast_open_compact");
+  ASSERT_OK(DestroyDB(test_dbname, options));
+
+  std::unique_ptr<DB> db;
+  ASSERT_OK(DB::Open(options, test_dbname, &db));
+  test_fs->ResetCounters();
+
+  // 2 flushes = 2 SST files -> 2 GetFileOpenMetadata calls from flushes
+  ASSERT_OK(db->Put(WriteOptions(), "key1", "value1"));
+  ASSERT_OK(db->Flush(FlushOptions()));
+  ASSERT_OK(db->Put(WriteOptions(), "key2", "value2"));
+  ASSERT_OK(db->Flush(FlushOptions()));
+  ASSERT_OK(static_cast<DBImpl*>(db.get())->TEST_WaitForCompact());
+
+  // 2 flush SSTs retrieved metadata. Compaction output may or may not
+  // trigger an additional retrieval depending on table cache state.
+  ASSERT_GE(test_fs->GetMetadataRetrievedCount(), 2);
+
+  test_fs->ResetCounters();
+  db.reset();
+
+  ASSERT_OK(DB::Open(options, test_dbname, &db));
+  std::string value;
+  ASSERT_OK(db->Get(ReadOptions(), "key1", &value));
+  ASSERT_EQ("value1", value);
+  ASSERT_OK(db->Get(ReadOptions(), "key2", &value));
+  ASSERT_EQ("value2", value);
+
+  // At least 1 SST opened with metadata on reopen
+  ASSERT_GE(test_fs->GetMetadataPassedOnOpenCount(), 1);
+
+  db.reset();
+  ASSERT_OK(DestroyDB(test_dbname, options));
+}
+
+TEST_F(DBTest2, FastSstOpenDisabledNoMetadata) {
+  // When fast_sst_open is disabled, no metadata should be retrieved or passed.
+  auto test_fs = std::make_shared<FastOpenTestFS>(env_->GetFileSystem());
+  std::unique_ptr<Env> test_env(new CompositeEnvWrapper(env_, test_fs));
+
+  Options options;
+  options.env = test_env.get();
+  options.fast_sst_open = false;
+  options.create_if_missing = true;
+
+  std::string test_dbname = test::PerThreadDBPath("fast_open_disabled");
+  ASSERT_OK(DestroyDB(test_dbname, options));
+
+  std::unique_ptr<DB> db;
+  ASSERT_OK(DB::Open(options, test_dbname, &db));
+  test_fs->ResetCounters();
+
+  ASSERT_OK(db->Put(WriteOptions(), "key1", "value1"));
+  ASSERT_OK(db->Flush(FlushOptions()));
+
+  // No metadata retrieved when disabled
+  ASSERT_EQ(0, test_fs->GetMetadataRetrievedCount());
+
+  test_fs->ResetCounters();
+  db.reset();
+
+  ASSERT_OK(DB::Open(options, test_dbname, &db));
+
+  std::string value;
+  ASSERT_OK(db->Get(ReadOptions(), "key1", &value));
+  ASSERT_EQ("value1", value);
+
+  // No metadata passed on open since none was saved
+  ASSERT_EQ(0, test_fs->GetMetadataPassedOnOpenCount());
+
+  db.reset();
+  ASSERT_OK(DestroyDB(test_dbname, options));
+}
+
+TEST_F(DBTest2, FastSstOpenToggleOption) {
+  // Toggle: disabled for first flush, enabled for second.
+  // Only the second file should have metadata on reopen.
+  auto test_fs = std::make_shared<FastOpenTestFS>(env_->GetFileSystem());
+  std::unique_ptr<Env> test_env(new CompositeEnvWrapper(env_, test_fs));
+
+  Options options;
+  options.env = test_env.get();
+  options.fast_sst_open = false;
+  options.create_if_missing = true;
+  // Prevent compaction so we have 2 separate L0 files
+  options.level0_file_num_compaction_trigger = 100;
+
+  std::string test_dbname = test::PerThreadDBPath("fast_open_toggle");
+  ASSERT_OK(DestroyDB(test_dbname, options));
+
+  std::unique_ptr<DB> db;
+  ASSERT_OK(DB::Open(options, test_dbname, &db));
+
+  ASSERT_OK(db->Put(WriteOptions(), "key1", "value1"));
+  ASSERT_OK(db->Flush(FlushOptions()));
+  ASSERT_EQ(0, test_fs->GetMetadataRetrievedCount());
+  db.reset();
+
+  // Enable fast_sst_open for second session
+  options.fast_sst_open = true;
+  ASSERT_OK(DB::Open(options, test_dbname, &db));
+  test_fs->ResetCounters();
+
+  ASSERT_OK(db->Put(WriteOptions(), "key2", "value2"));
+  ASSERT_OK(db->Flush(FlushOptions()));
+  // Exactly 1 metadata retrieved (for the new flush)
+  ASSERT_EQ(1, test_fs->GetMetadataRetrievedCount());
+
+  test_fs->ResetCounters();
+  db.reset();
+
+  ASSERT_OK(DB::Open(options, test_dbname, &db));
+
+  std::string value;
+  ASSERT_OK(db->Get(ReadOptions(), "key1", &value));
+  ASSERT_EQ("value1", value);
+  ASSERT_OK(db->Get(ReadOptions(), "key2", &value));
+  ASSERT_EQ("value2", value);
+
+  // 2 SST files total, but only 1 has metadata (the one from the enabled
+  // session). The other file opens without metadata.
+  ASSERT_EQ(1, test_fs->GetMetadataPassedOnOpenCount());
+
+  db.reset();
+  ASSERT_OK(DestroyDB(test_dbname, options));
+}
+
+TEST_F(DBTest2, FastSstOpenIngestion) {
+  // Test that file ingestion retrieves and persists metadata.
+  auto test_fs = std::make_shared<FastOpenTestFS>(env_->GetFileSystem());
+  std::unique_ptr<Env> test_env(new CompositeEnvWrapper(env_, test_fs));
+
+  Options options;
+  options.env = test_env.get();
+  options.fast_sst_open = true;
+  options.create_if_missing = true;
+
+  std::string test_dbname = test::PerThreadDBPath("fast_open_ingest");
+  ASSERT_OK(DestroyDB(test_dbname, options));
+
+  std::unique_ptr<DB> db;
+  ASSERT_OK(DB::Open(options, test_dbname, &db));
+
+  // Create an SST file externally
+  std::string sst_file = test_dbname + "/external.sst";
+  SstFileWriter sst_writer(EnvOptions(), options);
+  ASSERT_OK(sst_writer.Open(sst_file));
+  ASSERT_OK(sst_writer.Put("ikey1", "ival1"));
+  ASSERT_OK(sst_writer.Put("ikey2", "ival2"));
+  ASSERT_OK(sst_writer.Finish());
+
+  test_fs->ResetCounters();
+
+  // Ingest the external SST file
+  IngestExternalFileOptions ingest_opts;
+  ingest_opts.move_files = false;
+  ASSERT_OK(db->IngestExternalFile({sst_file}, ingest_opts));
+
+  // Ingestion should retrieve metadata for the ingested file (1 call from
+  // the separate open in the ingestion path)
+  ASSERT_GE(test_fs->GetMetadataRetrievedCount(), 1);
+
+  test_fs->ResetCounters();
+  db.reset();
+
+  // Reopen and verify metadata is passed
+  ASSERT_OK(DB::Open(options, test_dbname, &db));
+
+  std::string value;
+  ASSERT_OK(db->Get(ReadOptions(), "ikey1", &value));
+  ASSERT_EQ("ival1", value);
+  ASSERT_OK(db->Get(ReadOptions(), "ikey2", &value));
+  ASSERT_EQ("ival2", value);
+
+  // Metadata should be passed when opening the ingested SST
+  ASSERT_GE(test_fs->GetMetadataPassedOnOpenCount(), 1);
+
+  db.reset();
+  ASSERT_OK(DestroyDB(test_dbname, options));
+}
+
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {

--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -17,6 +17,7 @@
 #include "file/file_util.h"
 #include "file/random_access_file_reader.h"
 #include "logging/logging.h"
+#include "monitoring/statistics_impl.h"
 #include "table/merging_iterator.h"
 #include "table/sst_file_writer_collectors.h"
 #include "table/table_builder.h"
@@ -719,6 +720,34 @@ Status ExternalSstFileIngestionJob::AssignLevelsForOneBatch(
     // This ensures ingested files have proper timestamp ranges in FileMetaData,
     // similar to files created by flush and compaction.
     ExtractTimestampFromTableProperties(file->table_properties, &f_metadata);
+    // Retrieve file open metadata for fast SST open
+    if (mutable_db_options_.fast_sst_open) {
+      std::unique_ptr<FSRandomAccessFile> readable_file;
+      FileOptions fopts{env_options_};
+      fopts.file_checksum = f_metadata.file_checksum;
+      fopts.file_checksum_func_name = f_metadata.file_checksum_func_name;
+      IOStatus io_s = fs_->NewRandomAccessFile(file->internal_file_path, fopts,
+                                               &readable_file, nullptr);
+      if (io_s.ok()) {
+        io_s =
+            readable_file->GetFileOpenMetadata(&f_metadata.file_open_metadata);
+        if (io_s.ok() && !f_metadata.file_open_metadata.empty() &&
+            f_metadata.file_open_metadata.size() <=
+                FSRandomAccessFile::kMaxFileOpenMetadataSize) {
+          RecordTick(db_options_.stats, FILE_OPEN_METADATA_RETRIEVED);
+        } else {
+          if (io_s.ok() && f_metadata.file_open_metadata.size() >
+                               FSRandomAccessFile::kMaxFileOpenMetadataSize) {
+            ROCKS_LOG_WARN(db_options_.info_log,
+                           "File open metadata for %s too large (%zu bytes), "
+                           "ignoring",
+                           file->internal_file_path.c_str(),
+                           f_metadata.file_open_metadata.size());
+          }
+          f_metadata.file_open_metadata.clear();
+        }
+      }
+    }
     edit_.AddFile(file->picked_level, f_metadata);
 
     *batch_uppermost_level =

--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -101,7 +101,8 @@ FlushJob::FlushJob(
     Env::Priority thread_pri, const std::shared_ptr<IOTracer>& io_tracer,
     std::shared_ptr<const SeqnoToTimeMapping> seqno_to_time_mapping,
     const std::string& db_id, const std::string& db_session_id,
-    std::string full_history_ts_low, BlobFileCompletionCallback* blob_callback)
+    std::string full_history_ts_low, BlobFileCompletionCallback* blob_callback,
+    bool fast_sst_open)
     : dbname_(dbname),
       db_id_(db_id),
       db_session_id_(db_session_id),
@@ -133,6 +134,7 @@ FlushJob::FlushJob(
       clock_(db_options_.clock),
       full_history_ts_low_(std::move(full_history_ts_low)),
       blob_callback_(blob_callback),
+      fast_sst_open_(fast_sst_open),
       seqno_to_time_mapping_(std::move(seqno_to_time_mapping)) {
   assert(job_context->snapshot_context_initialized);
   // Update the thread status to indicate flush.
@@ -1030,8 +1032,8 @@ Status FlushJob::WriteLevel0Table() {
           &io_s, io_tracer_, BlobFileCreationReason::kFlush,
           seqno_to_time_mapping_.get(), event_logger_, job_context_->job_id,
           &table_properties_, write_hint, full_history_ts_low, blob_callback_,
-          base_, &memtable_payload_bytes, &memtable_garbage_bytes,
-          &flush_stats);
+          base_, &memtable_payload_bytes, &memtable_garbage_bytes, &flush_stats,
+          fast_sst_open_);
       TEST_SYNC_POINT_CALLBACK("FlushJob::WriteLevel0Table:s", &s);
       // TODO: Cleanup io_status in BuildTable and table builders
       assert(!s.ok() || io_s.ok());
@@ -1113,16 +1115,8 @@ Status FlushJob::WriteLevel0Table() {
     // threads could be concurrently producing compacted files for
     // that key range.
     // Add file to L0
-    edit_->AddFile(0 /* level */, meta_.fd.GetNumber(), meta_.fd.GetPathId(),
-                   meta_.fd.GetFileSize(), meta_.smallest, meta_.largest,
-                   meta_.fd.smallest_seqno, meta_.fd.largest_seqno,
-                   meta_.marked_for_compaction, meta_.temperature,
-                   meta_.oldest_blob_file_number, meta_.oldest_ancester_time,
-                   meta_.file_creation_time, meta_.epoch_number,
-                   meta_.file_checksum, meta_.file_checksum_func_name,
-                   meta_.unique_id, meta_.compensated_range_deletion_size,
-                   meta_.tail_size, meta_.user_defined_timestamps_persisted,
-                   meta_.min_timestamp, meta_.max_timestamp);
+    TEST_SYNC_POINT_CALLBACK("FileMetaData::FileMetaData", &meta_);
+    edit_->AddFile(0 /* level */, meta_);
     edit_->SetBlobFileAdditions(std::move(blob_file_additions));
 
     for (auto& addition : external_blob_file_additions_) {

--- a/db/flush_job.h
+++ b/db/flush_job.h
@@ -73,7 +73,8 @@ class FlushJob {
            std::shared_ptr<const SeqnoToTimeMapping> seqno_to_time_mapping,
            const std::string& db_id = "", const std::string& db_session_id = "",
            std::string full_history_ts_low = "",
-           BlobFileCompletionCallback* blob_callback = nullptr);
+           BlobFileCompletionCallback* blob_callback = nullptr,
+           bool fast_sst_open = false);
 
   ~FlushJob();
 
@@ -244,6 +245,7 @@ class FlushJob {
 
   const std::string full_history_ts_low_;
   BlobFileCompletionCallback* blob_callback_;
+  bool fast_sst_open_;
   // Write-path blob files that should be committed with this flush.
   std::vector<BlobFileAddition> external_blob_file_additions_;
   // Initial garbage for write-path blob files that were partially abandoned

--- a/db/table_cache.cc
+++ b/db/table_cache.cc
@@ -16,6 +16,7 @@
 #include "file/file_util.h"
 #include "file/filename.h"
 #include "file/random_access_file_reader.h"
+#include "logging/logging.h"
 #include "monitoring/file_read_sample.h"
 #include "monitoring/perf_context_imp.h"
 #include "rocksdb/advanced_options.h"
@@ -95,7 +96,8 @@ Status TableCache::GetTableReader(
     HistogramImpl* file_read_hist, std::unique_ptr<TableReader>* table_reader,
     const MutableCFOptions& mutable_cf_options, bool skip_filters, int level,
     bool prefetch_index_and_filter_in_cache,
-    size_t max_file_size_for_l0_meta_pin, Temperature file_temperature) {
+    size_t max_file_size_for_l0_meta_pin, Temperature file_temperature,
+    std::string* file_open_metadata) {
   std::string fname = TableFileName(
       ioptions_.cf_paths, file_meta.fd.GetNumber(), file_meta.fd.GetPathId());
   std::unique_ptr<FSRandomAccessFile> file;
@@ -103,6 +105,14 @@ Status TableCache::GetTableReader(
   fopts.temperature = file_temperature;
   fopts.file_checksum = file_meta.file_checksum;
   fopts.file_checksum_func_name = file_meta.file_checksum_func_name;
+  // Pass file open metadata for fast SST open. Use a local copy since
+  // fopts.file_metadata is a non-owning pointer and file_meta is const.
+  std::string file_open_metadata_copy;
+  if (!file_meta.file_open_metadata.empty()) {
+    file_open_metadata_copy = file_meta.file_open_metadata;
+    fopts.file_metadata = &file_open_metadata_copy;
+    RecordTick(ioptions_.stats, FILE_OPEN_METADATA_PASSED);
+  }
   Status s = PrepareIOFromReadOptions(ro, ioptions_.clock, fopts.io_options);
   TEST_SYNC_POINT_CALLBACK("TableCache::GetTableReader:BeforeOpenFile",
                            const_cast<Status*>(&s));
@@ -127,6 +137,24 @@ Status TableCache::GetTableReader(
   }
 
   if (s.ok()) {
+    // Retrieve file open metadata before wrapping the file
+    if (file_open_metadata != nullptr) {
+      IOStatus io_s = file->GetFileOpenMetadata(file_open_metadata);
+      if (io_s.ok() && !file_open_metadata->empty() &&
+          file_open_metadata->size() <=
+              FSRandomAccessFile::kMaxFileOpenMetadataSize) {
+        RecordTick(ioptions_.stats, FILE_OPEN_METADATA_RETRIEVED);
+      } else {
+        if (io_s.ok() && file_open_metadata->size() >
+                             FSRandomAccessFile::kMaxFileOpenMetadataSize) {
+          ROCKS_LOG_WARN(ioptions_.logger,
+                         "File open metadata for %s too large (%zu bytes), "
+                         "ignoring",
+                         fname.c_str(), file_open_metadata->size());
+        }
+        file_open_metadata->clear();
+      }
+    }
     if (!sequential_mode && ioptions_.advise_random_on_open) {
       file->Hint(FSRandomAccessFile::kRandom);
     }
@@ -181,7 +209,7 @@ Status TableCache::FindTable(
     const bool no_io, HistogramImpl* file_read_hist, bool skip_filters,
     int level, bool prefetch_index_and_filter_in_cache,
     size_t max_file_size_for_l0_meta_pin, Temperature file_temperature,
-    bool pin_table_handle) {
+    bool pin_table_handle, std::string* file_open_metadata) {
   assert(out_table_reader != nullptr && *out_table_reader == nullptr);
   assert(handle != nullptr && *handle == nullptr);
   PERF_TIMER_GUARD_WITH_CLOCK(find_table_nanos, ioptions_.clock);
@@ -226,7 +254,8 @@ Status TableCache::FindTable(
                          false /* sequential mode */, file_read_hist,
                          &table_reader, mutable_cf_options, skip_filters, level,
                          prefetch_index_and_filter_in_cache,
-                         max_file_size_for_l0_meta_pin, file_temperature);
+                         max_file_size_for_l0_meta_pin, file_temperature,
+                         file_open_metadata);
       if (!s.ok()) {
         assert(table_reader == nullptr);
         RecordTick(ioptions_.stats, NO_FILE_ERRORS);
@@ -280,7 +309,7 @@ InternalIterator* TableCache::NewIterator(
     const InternalKey* largest_compaction_key, bool allow_unprepared_value,
     const SequenceNumber* read_seqno,
     std::unique_ptr<TruncatedRangeDelIterator>* range_del_iter,
-    bool maybe_pin_table_handle) {
+    bool maybe_pin_table_handle, std::string* file_open_metadata) {
   PERF_TIMER_GUARD(new_table_iterator_nanos);
 
   Status s;
@@ -292,13 +321,13 @@ InternalIterator* TableCache::NewIterator(
   bool for_compaction = caller == TableReaderCaller::kCompaction;
   TEST_SYNC_POINT_CALLBACK("TableCache::NewIterator::BeforeFindTable",
                            const_cast<FileDescriptor*>(&file_meta.fd));
-  s = FindTable(options, file_options, icomparator, file_meta, &handle,
-                mutable_cf_options, &table_reader,
-                options.read_tier == kBlockCacheTier /* no_io */,
-                file_read_hist, skip_filters, level,
-                true /* prefetch_index_and_filter_in_cache */,
-                max_file_size_for_l0_meta_pin, file_meta.temperature,
-                maybe_pin_table_handle && should_pin_table_handles_);
+  s = FindTable(
+      options, file_options, icomparator, file_meta, &handle,
+      mutable_cf_options, &table_reader,
+      options.read_tier == kBlockCacheTier /* no_io */, file_read_hist,
+      skip_filters, level, true /* prefetch_index_and_filter_in_cache */,
+      max_file_size_for_l0_meta_pin, file_meta.temperature,
+      maybe_pin_table_handle && should_pin_table_handles_, file_open_metadata);
   InternalIterator* result = nullptr;
   if (s.ok()) {
     if (options.table_filter &&

--- a/db/table_cache.h
+++ b/db/table_cache.h
@@ -100,7 +100,10 @@ class TableCache {
       const InternalKey* largest_compaction_key, bool allow_unprepared_value,
       const SequenceNumber* range_del_read_seqno = nullptr,
       std::unique_ptr<TruncatedRangeDelIterator>* range_del_iter = nullptr,
-      bool maybe_pin_table_handle = false);
+      bool maybe_pin_table_handle = false,
+      // If non-null, and the table reader is newly opened (not cached),
+      // retrieves file open metadata via GetFileOpenMetadata().
+      std::string* file_open_metadata = nullptr);
 
   // If a seek to internal key "k" in specified file finds an entry,
   // call get_context->SaveValue() repeatedly until
@@ -197,7 +200,8 @@ class TableCache {
                    bool prefetch_index_and_filter_in_cache = true,
                    size_t max_file_size_for_l0_meta_pin = 0,
                    Temperature file_temperature = Temperature::kUnknown,
-                   bool pin_table_handle = false);
+                   bool pin_table_handle = false,
+                   std::string* file_open_metadata = nullptr);
 
   // Get the table properties of a given table.
   // @no_io: indicates if we should load table to the cache if it is not present
@@ -277,7 +281,8 @@ class TableCache {
                         bool skip_filters = false, int level = -1,
                         bool prefetch_index_and_filter_in_cache = true,
                         size_t max_file_size_for_l0_meta_pin = 0,
-                        Temperature file_temperature = Temperature::kUnknown);
+                        Temperature file_temperature = Temperature::kUnknown,
+                        std::string* file_open_metadata = nullptr);
 
   // Update the max_covering_tombstone_seq in the GetContext for each key based
   // on the range deletions in the table

--- a/db/version_edit.cc
+++ b/db/version_edit.cc
@@ -361,6 +361,10 @@ void VersionEdit::EncodeToNewFile4(const FileMetaData& f, int level,
     PutVarint32(dst, NewFileCustomTag::kMaxTimestamp);
     PutLengthPrefixedSlice(dst, Slice(f.max_timestamp));
   }
+  if (!f.file_open_metadata.empty()) {
+    PutVarint32(dst, NewFileCustomTag::kFileOpenMetadata);
+    PutLengthPrefixedSlice(dst, Slice(f.file_open_metadata));
+  }
   TEST_SYNC_POINT_CALLBACK("VersionEdit::EncodeTo:NewFile4:CustomizeFields",
                            dst);
 
@@ -505,6 +509,9 @@ const char* VersionEdit::DecodeNewFile4From(Slice* input, int& max_level,
           break;
         case kMaxTimestamp:
           f.max_timestamp = field.ToString();
+          break;
+        case kFileOpenMetadata:
+          f.file_open_metadata = field.ToString();
           break;
         default:
           if ((custom_tag & kCustomTagNonSafeIgnoreMask) != 0) {
@@ -998,6 +1005,10 @@ std::string VersionEdit::DebugString(bool hex_key) const {
     AppendNumberTo(&r, f.tail_size);
     r.append(" User-defined timestamps persisted: ");
     r.append(f.user_defined_timestamps_persisted ? "true" : "false");
+    if (!f.file_open_metadata.empty()) {
+      r.append(" file_open_metadata_size: ");
+      AppendNumberTo(&r, f.file_open_metadata.size());
+    }
   }
 
   for (const auto& blob_file_addition : blob_file_additions_) {
@@ -1120,6 +1131,9 @@ std::string VersionEdit::DebugJSON(int edit_num, bool hex_key) const {
       jw << "TailSize" << f.tail_size;
       jw << "UserDefinedTimestampsPersisted"
          << f.user_defined_timestamps_persisted;
+      if (!f.file_open_metadata.empty()) {
+        jw << "FileOpenMetadataSize" << f.file_open_metadata.size();
+      }
       jw.EndArrayedObject();
     }
 

--- a/db/version_edit.h
+++ b/db/version_edit.h
@@ -112,6 +112,7 @@ enum NewFileCustomTag : uint32_t {
   kCompensatedRangeDeletionSize = 14,
   kTailSize = 15,
   kUserDefinedTimestampsPersisted = 16,
+  kFileOpenMetadata = 17,
 
   // If this bit for the custom tag is set, opening DB should fail if
   // we don't know this field.
@@ -330,6 +331,11 @@ struct FileMetaData {
   // This is populated from the table properties "rocksdb.timestamp_max".
   std::string max_timestamp;
 
+  // Opaque file system metadata that can be used to accelerate file opening.
+  // Retrieved via FSRandomAccessFile::GetFileOpenMetadata() and passed back
+  // via FileOptions::file_metadata on subsequent opens. Empty if not available.
+  std::string file_open_metadata;
+
   FileMetaData() = default;
 
   FileMetaData(uint64_t file, uint32_t file_path_id, uint64_t file_size,
@@ -446,7 +452,7 @@ struct FileMetaData {
 #endif  // ROCKSDB_MALLOC_USABLE_SIZE
     usage += smallest.size() + largest.size() + file_checksum.size() +
              file_checksum_func_name.size() + min_timestamp.size() +
-             max_timestamp.size();
+             max_timestamp.size() + file_open_metadata.size();
     return usage;
   }
 

--- a/db/version_edit_test.cc
+++ b/db/version_edit_test.cc
@@ -1127,6 +1127,93 @@ TEST_F(SubcompactionProgressTest, UnknownTags) {
   ASSERT_TRUE(critical_status.IsNotSupported());
 }
 
+TEST_F(VersionEditTest, FileOpenMetadataEncodeDecode) {
+  static const uint64_t kBig = 1ull << 50;
+
+  // Test 1: File with file_open_metadata set
+  VersionEdit edit;
+  edit.AddFile(3, 300, 0, 100, InternalKey("foo", kBig + 500, kTypeValue),
+               InternalKey("zoo", kBig + 600, kTypeDeletion), kBig + 500,
+               kBig + 600, false, Temperature::kUnknown, kInvalidBlobFileNumber,
+               kUnknownOldestAncesterTime, kUnknownFileCreationTime,
+               300 /* epoch_number */, kUnknownFileChecksum,
+               kUnknownFileChecksumFuncName, kNullUniqueId64x2, 0, 0, true);
+  // Set file_open_metadata on the added file
+  auto& new_files = edit.GetMutableNewFiles();
+  ASSERT_EQ(1u, new_files.size());
+  new_files[0].second.file_open_metadata = "test_metadata_content_12345";
+
+  // Test 2: File without file_open_metadata (empty)
+  edit.AddFile(4, 301, 0, 200, InternalKey("bar", kBig + 501, kTypeValue),
+               InternalKey("zap", kBig + 601, kTypeDeletion), kBig + 501,
+               kBig + 601, false, Temperature::kUnknown, kInvalidBlobFileNumber,
+               kUnknownOldestAncesterTime, kUnknownFileCreationTime,
+               301 /* epoch_number */, kUnknownFileChecksum,
+               kUnknownFileChecksumFuncName, kNullUniqueId64x2, 0, 0, true);
+
+  // Encode and decode
+  std::string encoded;
+  edit.EncodeTo(&encoded, 0 /* ts_sz */);
+  VersionEdit parsed;
+  Status s = parsed.DecodeFrom(encoded);
+  ASSERT_TRUE(s.ok()) << s.ToString();
+
+  auto& parsed_files = parsed.GetNewFiles();
+  ASSERT_EQ(2u, parsed_files.size());
+
+  // First file should have metadata
+  ASSERT_EQ("test_metadata_content_12345",
+            parsed_files[0].second.file_open_metadata);
+
+  // Second file should have empty metadata
+  ASSERT_TRUE(parsed_files[1].second.file_open_metadata.empty());
+}
+
+TEST_F(VersionEditTest, FileOpenMetadataForwardCompatibility) {
+  // Test that a VersionEdit with kFileOpenMetadata can be decoded even if the
+  // reader doesn't know the tag. Tag 17 < kCustomTagNonSafeIgnoreMask (64),
+  // so it should be safely ignored.
+  static const uint64_t kBig = 1ull << 50;
+
+  VersionEdit edit;
+  edit.AddFile(3, 300, 0, 100, InternalKey("foo", kBig + 500, kTypeValue),
+               InternalKey("zoo", kBig + 600, kTypeDeletion), kBig + 500,
+               kBig + 600, false, Temperature::kUnknown, kInvalidBlobFileNumber,
+               kUnknownOldestAncesterTime, kUnknownFileCreationTime,
+               300 /* epoch_number */, kUnknownFileChecksum,
+               kUnknownFileChecksumFuncName, kNullUniqueId64x2, 0, 0, true);
+  auto& new_files = edit.GetMutableNewFiles();
+  new_files[0].second.file_open_metadata = std::string(1024, 'x');
+
+  // Encode
+  std::string encoded;
+  edit.EncodeTo(&encoded, 0 /* ts_sz */);
+
+  // Decode should succeed
+  VersionEdit parsed;
+  ASSERT_OK(parsed.DecodeFrom(encoded));
+  ASSERT_EQ(1u, parsed.GetNewFiles().size());
+  ASSERT_EQ(std::string(1024, 'x'),
+            parsed.GetNewFiles()[0].second.file_open_metadata);
+
+  // Verify the tag value is safe-to-ignore
+  ASSERT_EQ(0u, NewFileCustomTag::kFileOpenMetadata &
+                    NewFileCustomTag::kCustomTagNonSafeIgnoreMask);
+}
+
+TEST_F(VersionEditTest, FileOpenMetadataInApproximateMemoryUsage) {
+  // Use heap allocation because ApproximateMemoryUsage uses
+  // malloc_usable_size which requires heap-allocated memory
+  std::unique_ptr<FileMetaData> meta(new FileMetaData());
+  size_t base_usage = meta->ApproximateMemoryUsage();
+
+  meta->file_open_metadata = std::string(500, 'z');
+  size_t with_metadata_usage = meta->ApproximateMemoryUsage();
+
+  // The metadata should add to the memory usage
+  ASSERT_GE(with_metadata_usage, base_usage + 500);
+}
+
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -364,6 +364,7 @@ DECLARE_bool(adaptive_readahead);
 DECLARE_bool(async_io);
 DECLARE_string(wal_compression);
 DECLARE_bool(verify_sst_unique_id_in_manifest);
+DECLARE_bool(fast_sst_open);
 
 DECLARE_int32(create_timestamped_snapshot_one_in);
 

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -1326,6 +1326,10 @@ DEFINE_bool(
     "DB-open try verifying the SST unique id between MANIFEST and SST "
     "properties.");
 
+DEFINE_bool(fast_sst_open, false,
+            "If true, retrieve and persist file open metadata in the MANIFEST "
+            "for faster SST file re-opening on DB open.");
+
 DEFINE_int32(
     create_timestamped_snapshot_one_in, 0,
     "On non-zero, create timestamped snapshots upon transaction commits.");

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -3781,6 +3781,8 @@ void StressTest::PrintEnv() const {
           FLAGS_wal_compression.c_str());
   fprintf(stdout, "Try verify sst unique id  : %d\n",
           static_cast<int>(FLAGS_verify_sst_unique_id_in_manifest));
+  fprintf(stdout, "Fast SST open             : %d\n",
+          static_cast<int>(FLAGS_fast_sst_open));
 
   fprintf(stdout, "------------------------------------------------\n");
 }
@@ -4676,6 +4678,7 @@ void InitializeOptionsFromFlags(
   options.track_and_verify_wals = FLAGS_track_and_verify_wals;
   options.verify_sst_unique_id_in_manifest =
       FLAGS_verify_sst_unique_id_in_manifest;
+  options.fast_sst_open = FLAGS_fast_sst_open;
   options.memtable_protection_bytes_per_key =
       FLAGS_memtable_protection_bytes_per_key;
   options.block_protection_bytes_per_key = FLAGS_block_protection_bytes_per_key;

--- a/include/rocksdb/file_system.h
+++ b/include/rocksdb/file_system.h
@@ -214,6 +214,14 @@ struct FileOptions : EnvOptions {
   // that is forbidden for checking/auditing purposes.
   std::string file_checksum_func_name;
 
+  // EXPERIMENTAL
+  // This is used to pass file metadata that can be used by the file system
+  // to accelerate file opening. The content is opaque to RocksDB and is
+  // left to the file system to interpret. This is especially useful in the
+  // case of remote file systems to avoid expensive RPCs to retrieve the
+  // metadata.
+  std::string* file_metadata = nullptr;
+
   FileOptions() : EnvOptions(), handoff_checksum_type(ChecksumType::kCRC32c) {}
 
   FileOptions(const DBOptions& opts)
@@ -231,7 +239,8 @@ struct FileOptions : EnvOptions {
         handoff_checksum_type(opts.handoff_checksum_type),
         write_hint(opts.write_hint),
         file_checksum(opts.file_checksum),
-        file_checksum_func_name(opts.file_checksum_func_name) {}
+        file_checksum_func_name(opts.file_checksum_func_name),
+        file_metadata(opts.file_metadata) {}
 
   FileOptions& operator=(const FileOptions&) = default;
 };
@@ -1070,6 +1079,19 @@ class FSRandomAccessFile {
     return IOStatus::NotSupported("GetFileSize Not Supported");
   }
 
+  // EXPERIMENTAL
+  // Returns metadata for the file that can be passed back later to the file
+  // system when reopening this file. This is optional. The implementation
+  // can return NotSupported. The metadata, if returned, is not mandatory
+  // for the file system to use when reopening. It can be ignored and the
+  // only downside is slower file open time.
+  // The returned metadata must not exceed kMaxFileOpenMetadataSize bytes.
+  // Larger metadata will be silently discarded by RocksDB.
+  static constexpr size_t kMaxFileOpenMetadataSize = 8 * 1024;  // 8KB
+  virtual IOStatus GetFileOpenMetadata(std::string* /*metadata*/) {
+    return IOStatus::NotSupported("GetFileOpenMetadata not supported");
+  }
+
   // If you're adding methods here, remember to add them to
   // RandomAccessFileWrapper too.
 };
@@ -1810,6 +1832,9 @@ class FSRandomAccessFileWrapper : public FSRandomAccessFile {
 
   virtual IOStatus GetFileSize(uint64_t* result) override {
     return target_->GetFileSize(result);
+  }
+  IOStatus GetFileOpenMetadata(std::string* metadata) override {
+    return target_->GetFileOpenMetadata(metadata);
   }
 
  private:

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1781,6 +1781,14 @@ struct DBOptions {
   // Default: Enabled in kCompactionStyleLevel mode.
   CompactionStyleSet calculate_sst_write_lifetime_hint_set = {
       CompactionStyle::kCompactionStyleLevel};
+
+  // EXPERIMENTAL
+  // When this is true, save file system metadata (if supported by the FS) for
+  // SST files added to the DB in the MANIFEST, and use it to accelerate
+  // re-opening of those files on DB open. This will help cut down DB open
+  // latency on remote storage systems.
+  bool fast_sst_open = false;
+
   // End EXPERIMENTAL
 };
 

--- a/include/rocksdb/statistics.h
+++ b/include/rocksdb/statistics.h
@@ -593,6 +593,13 @@ enum Tickers : uint32_t {
   // - memtable switched to immutable state
   READ_PATH_RANGE_TOMBSTONES_DISCARDED,
 
+  // Number of times file open metadata was retrieved from the file system
+  // via GetFileOpenMetadata() (when fast_sst_open is enabled)
+  FILE_OPEN_METADATA_RETRIEVED,
+  // Number of times file open metadata was passed to NewRandomAccessFile()
+  // via FileOptions::file_metadata (on DB open / table cache miss)
+  FILE_OPEN_METADATA_PASSED,
+
   TICKER_ENUM_MAX
 };
 

--- a/monitoring/statistics.cc
+++ b/monitoring/statistics.cc
@@ -300,6 +300,8 @@ const std::vector<std::pair<Tickers, std::string>> TickersNameMap = {
      "rocksdb.read.path.range.tombstones.inserted"},
     {READ_PATH_RANGE_TOMBSTONES_DISCARDED,
      "rocksdb.read.path.range.tombstones.discarded"},
+    {FILE_OPEN_METADATA_RETRIEVED, "rocksdb.file.open.metadata.retrieved"},
+    {FILE_OPEN_METADATA_PASSED, "rocksdb.file.open.metadata.passed"},
 };
 
 const std::vector<std::pair<Histograms, std::string>> HistogramsNameMap = {

--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -149,6 +149,10 @@ static std::unordered_map<std::string, OptionTypeInfo>
                    max_compaction_trigger_wakeup_seconds),
           OptionType::kUInt64T, OptionVerificationType::kNormal,
           OptionTypeFlags::kMutable}},
+        {"fast_sst_open",
+         {offsetof(struct MutableDBOptions, fast_sst_open),
+          OptionType::kBoolean, OptionVerificationType::kNormal,
+          OptionTypeFlags::kMutable}},
 };
 
 static std::unordered_map<std::string, OptionTypeInfo>
@@ -1069,6 +1073,7 @@ MutableDBOptions::MutableDBOptions(const DBOptions& options)
       manifest_preallocation_size(options.manifest_preallocation_size),
       verify_manifest_content_on_close(
           options.verify_manifest_content_on_close),
+      fast_sst_open(options.fast_sst_open),
       daily_offpeak_time_utc(options.daily_offpeak_time_utc),
       max_compaction_trigger_wakeup_seconds(
           options.max_compaction_trigger_wakeup_seconds) {}
@@ -1131,6 +1136,8 @@ void MutableDBOptions::Dump(Logger* log) const {
   ROCKS_LOG_HEADER(log,
                    "Options.max_compaction_trigger_wakeup_seconds: %" PRIu64,
                    max_compaction_trigger_wakeup_seconds);
+  ROCKS_LOG_HEADER(log, "                         Options.fast_sst_open: %d",
+                   fast_sst_open);
 }
 
 Status GetMutableDBOptionsFromStrings(

--- a/options/db_options.h
+++ b/options/db_options.h
@@ -149,6 +149,7 @@ struct MutableDBOptions {
   int max_manifest_space_amp_pct;
   size_t manifest_preallocation_size;
   bool verify_manifest_content_on_close;
+  bool fast_sst_open;
   std::string daily_offpeak_time_utc;
   uint64_t max_compaction_trigger_wakeup_seconds;
 };

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -75,6 +75,7 @@ void BuildDBOptions(const ImmutableDBOptions& immutable_db_options,
   options.track_and_verify_wals = immutable_db_options.track_and_verify_wals;
   options.verify_sst_unique_id_in_manifest =
       immutable_db_options.verify_sst_unique_id_in_manifest;
+  options.fast_sst_open = mutable_db_options.fast_sst_open;
   options.env = immutable_db_options.env;
   options.rate_limiter = immutable_db_options.rate_limiter;
   options.sst_file_manager = immutable_db_options.sst_file_manager;

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -425,6 +425,7 @@ TEST_F(OptionsSettableTest, DBOptionsAllFieldsSettable) {
       "track_and_verify_wals_in_manifest=true;"
       "track_and_verify_wals=true;"
       "verify_sst_unique_id_in_manifest=true;"
+      "fast_sst_open=true;"
       "is_fd_close_on_exec=false;"
       "bytes_per_sync=4295013613;"
       "strict_bytes_per_sync=true;"
@@ -490,7 +491,8 @@ TEST_F(OptionsSettableTest, DBOptionsAllFieldsSettable) {
       "write_dbid_to_manifest=true;"
       "write_identity_file=true;"
       "verify_manifest_content_on_close=false;"
-      "prefix_seek_opt_in_only=true;",
+      "prefix_seek_opt_in_only=true;"
+      "fast_sst_open=true;",
       new_options));
 
   ASSERT_EQ(unset_bytes_base, NumUnsetBytes(new_options_ptr, sizeof(DBOptions),

--- a/options/options_test.cc
+++ b/options/options_test.cc
@@ -148,6 +148,7 @@ TEST_F(OptionsTest, GetOptionsFromMapTest) {
       {"track_and_verify_wals_in_manifest", "true"},
       {"track_and_verify_wals", "true"},
       {"verify_sst_unique_id_in_manifest", "true"},
+      {"fast_sst_open", "true"},
       {"max_open_files", "32"},
       {"max_total_wal_size", "33"},
       {"use_fsync", "true"},
@@ -331,6 +332,7 @@ TEST_F(OptionsTest, GetOptionsFromMapTest) {
   ASSERT_EQ(new_db_opt.track_and_verify_wals_in_manifest, true);
   ASSERT_EQ(new_db_opt.track_and_verify_wals, true);
   ASSERT_EQ(new_db_opt.verify_sst_unique_id_in_manifest, true);
+  ASSERT_EQ(new_db_opt.fast_sst_open, true);
   ASSERT_EQ(new_db_opt.max_open_files, 32);
   ASSERT_EQ(new_db_opt.max_total_wal_size, static_cast<uint64_t>(33));
   ASSERT_EQ(new_db_opt.use_fsync, true);
@@ -904,6 +906,7 @@ TEST_F(OptionsTest, OldInterfaceTest) {
       {"track_and_verify_wals_in_manifest", "true"},
       {"track_and_verify_wals", "true"},
       {"verify_sst_unique_id_in_manifest", "true"},
+      {"fast_sst_open", "true"},
       {"max_open_files", "32"},
       {"daily_offpeak_time_utc", "06:30-23:30"},
   };
@@ -920,6 +923,7 @@ TEST_F(OptionsTest, OldInterfaceTest) {
   ASSERT_EQ(new_db_opt.track_and_verify_wals_in_manifest, true);
   ASSERT_EQ(new_db_opt.track_and_verify_wals, true);
   ASSERT_EQ(new_db_opt.verify_sst_unique_id_in_manifest, true);
+  ASSERT_EQ(new_db_opt.fast_sst_open, true);
   ASSERT_EQ(new_db_opt.max_open_files, 32);
   db_options_map["unknown_option"] = "1";
   Status s = GetDBOptionsFromMap(db_config_options, base_db_opt, db_options_map,
@@ -2485,6 +2489,7 @@ TEST_F(OptionsOldApiTest, GetOptionsFromMapTest) {
       {"track_and_verify_wals_in_manifest", "true"},
       {"track_and_verify_wals", "true"},
       {"verify_sst_unique_id_in_manifest", "true"},
+      {"fast_sst_open", "true"},
       {"max_open_files", "32"},
       {"max_total_wal_size", "33"},
       {"use_fsync", "true"},

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -363,6 +363,7 @@ default_params = {
     "async_io": lambda: random.choice([0, 1]),
     "wal_compression": lambda: random.choice(["none", "zstd"]),
     "verify_sst_unique_id_in_manifest": 1,  # always do unique_id verification
+    "fast_sst_open": lambda: random.choice([0, 1]),
     "secondary_cache_uri": lambda: random.choice(
         [
             "",

--- a/unreleased_history/new_features/fast_sst_open.md
+++ b/unreleased_history/new_features/fast_sst_open.md
@@ -1,0 +1,1 @@
+Added experimental `DBOptions::fast_sst_open` option. When enabled, RocksDB retrieves opaque file system metadata for SST files after flush, compaction, and external file ingestion, persists it in the MANIFEST, and passes it back to the file system on subsequent file opens to accelerate DB open time.


### PR DESCRIPTION
Summary:

When DBOptions::fast_sst_open is enabled, RocksDB retrieves opaque file system
metadata for SST files after flush, compaction, and external file ingestion via
FSRandomAccessFile::GetFileOpenMetadata(). This metadata is persisted in the
MANIFEST using a new forward-compatible NewFileCustomTag (kFileOpenMetadata = 17),
and passed back to the file system via FileOptions::file_metadata on subsequent
file opens. This accelerates DB open time on remote storage systems by allowing
the file system to skip expensive metadata RPCs.

The feature is gated by DBOptions::fast_sst_open (default false). Everything
works seamlessly regardless of the option setting, file metadata support, or
presence/absence of the metadata in the MANIFEST. The MANIFEST change is backward
compatible - older RocksDB versions safely ignore the new tag.

Reviewed By: xingbowang

Differential Revision: D100220973
