### PR TITLE
env: avoid unused info in TSAN mapping helper

### DIFF
--- a/env/io_posix.h
+++ b/env/io_posix.h
@@ -82,6 +82,7 @@ extern "C" void AnnotateNewMemory(const char* file, int line,
 inline void TsanAnnotateMappedMemory(const volatile void* mem, size_t size) {
   TsanMappedMemoryInfo info{const_cast<const void*>(mem), size};
   TEST_SYNC_POINT_CALLBACK("TsanAnnotateMappedMemory", &info);
+  (void)info;
 #ifdef __SANITIZE_THREAD__
   if (mem != nullptr && size != 0) {
     // TSAN does not understand that a new mmap or io_uring setup can legally
@@ -90,8 +91,6 @@ inline void TsanAnnotateMappedMemory(const volatile void* mem, size_t size) {
     // accesses are not reported against stale accesses from the old mapping.
     AnnotateNewMemory(__FILE__, __LINE__, mem, static_cast<long>(size));
   }
-#else
-  (void)info;
 #endif  // __SANITIZE_THREAD__
 }
 


### PR DESCRIPTION
TsanAnnotateMappedMemory() always builds a TsanMappedMemoryInfo payload
for TEST_SYNC_POINT_CALLBACK(), but in builds where sync points compile to a
no-op the local variable becomes unused and Clang fails with
-Werror,-Wunused-variable.

Move the explicit (void)info cast so it applies regardless of whether
__SANITIZE_THREAD__ is enabled. This keeps the helper warning-free in:
- non-TSAN builds
- builds where TEST_SYNC_POINT_CALLBACK expands to nothing
- TSAN builds that still want the SyncPoint payload for tests

This was missed by CI because the warning only appears in the
COMPILE_WITH_TSAN=1 + NDEBUG/release configuration. Our CI matrix covers
release builds without TSAN and TSAN builds in debug mode, but not the
TSAN+NDEBUG combination.

No behavior change is intended. The helper still:
- exposes the mapping metadata to SyncPoint-based tests
- calls AnnotateNewMemory() in TSAN builds
- remains a no-op with respect to runtime behavior in non-TSAN builds