### PR TITLE
db_stress: fix crashes during concurrent column family drop+recreate …

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -110,6 +110,10 @@ void StressTest::CleanUpColumnFamilies() {
     delete cf;
   }
   column_families_.clear();
+  for (auto* cf : old_column_families_) {
+    delete cf;
+  }
+  old_column_families_.clear();
   for (auto* cf : secondary_cfhs_) {
     delete cf;
   }
@@ -796,9 +800,17 @@ Status StressTest::SetOptions(ThreadState* thread) {
 }
 
 Options StressTest::GetOptions(int cf_id) {
-  auto cfh = column_families_[cf_id];
-  assert(cfh);
-  return db_->GetOptions(cfh);
+  // cf_id is the RocksDB internal column family ID, not the index into
+  // column_families_. After a CF drop+recreate, the new CF gets a higher ID
+  // that may exceed column_families_.size(). Search for the matching handle.
+  for (auto* cfh : column_families_) {
+    if (cfh && cfh->GetID() == static_cast<uint32_t>(cf_id)) {
+      return db_->GetOptions(cfh);
+    }
+  }
+  // CF was dropped and recreated with a new ID. Return base options since the
+  // remote compaction for the old CF will fail anyway.
+  return options_;
 }
 
 void StressTest::ProcessRecoveredPreparedTxns(SharedState* shared) {

--- a/db_stress_tool/db_stress_test_base.h
+++ b/db_stress_tool/db_stress_test_base.h
@@ -427,6 +427,9 @@ class StressTest {
   Options options_;
   SystemClock* clock_;
   std::vector<ColumnFamilyHandle*> column_families_;
+  // Handles from dropped column families whose deletion is deferred because
+  // other threads may still hold pointers to them.
+  std::vector<ColumnFamilyHandle*> old_column_families_;
   std::vector<std::string> column_family_names_;
   std::atomic<int> new_column_family_name_;
   int num_times_reopened_;

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -607,14 +607,22 @@ class NonBatchedOpsStressTest : public StressTest {
         }
         thread->shared->LockColumnFamily(cf);
         Status s = db_->DropColumnFamily(column_families_[cf]);
-        delete column_families_[cf];
         if (!s.ok()) {
           fprintf(stderr, "dropping column family error: %s\n",
                   s.ToString().c_str());
           thread->shared->SafeTerminate();
         }
+        // Use a local variable for CreateColumnFamily to avoid setting
+        // column_families_[cf] to nullptr (CreateColumnFamilyImpl zeroes the
+        // output handle first). Other threads may concurrently read
+        // column_families_[cf] without holding the CF lock.
+        ColumnFamilyHandle* new_cfh = nullptr;
         s = db_->CreateColumnFamily(ColumnFamilyOptions(options_), new_name,
-                                    &column_families_[cf]);
+                                    &new_cfh);
+        // Defer deletion of the old handle because other threads may still
+        // hold pointers to it. It will be cleaned up in CleanUpColumnFamilies.
+        old_column_families_.push_back(column_families_[cf]);
+        column_families_[cf] = new_cfh;
         column_family_names_[cf] = new_name;
         thread->shared->ClearColumnFamily(cf);
         if (!s.ok()) {


### PR DESCRIPTION
…(#14601)

Fix two bugs in db_stress that cause crashes when column families are dropped and recreated (via clear_column_family_one_in):

1. Out-of-bounds access in GetOptions (introduced in 217e075df, #13800): GetOptions(cf_id) used the RocksDB internal CF ID as a direct index into column_families_. After a CF drop+recreate, the new CF gets a monotonically increasing ID (e.g., 10 for an initially 10-CF setup) that exceeds column_families_.size(), causing undefined behavior. Fix: search column_families_ for the handle matching the CF ID, falling back to base options if the CF was dropped.

2. Use-after-free on CF handles (present since 457c78eb8, 2014): MaybeClearOneColumnFamily had two issues:
   - It called delete on the old CF handle immediately while other threads could still hold pointers to it (use-after-free/segfault).
   - CreateColumnFamilyImpl zeroes its output handle (*handle = nullptr) before writing the new one. Since it was called with &column_families_[cf], this created a window where concurrent readers see nullptr (assertion failure). Fix: use a local variable for CreateColumnFamily output to avoid the nullptr window, and defer deletion of old handles to CleanUpColumnFamilies when all threads have stopped.