### PR TITLE
Fix std::terminate in LoadTableHandlersHelper

### DIFF
--- a/db/version_util.cc
+++ b/db/version_util.cc
@@ -7,13 +7,13 @@
 
 #include <atomic>
 #include <functional>
+#include <system_error>
 #include <thread>
 #include <utility>
 #include <vector>
 
 #include "db/internal_stats.h"
 #include "db/table_cache.h"
-#include "port/port.h"
 #include "test_util/sync_point.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -28,6 +28,10 @@ Status LoadTableHandlersHelper(
     size_t max_file_size_for_l0_meta_pin, const ReadOptions& read_options,
     std::atomic<bool>* stop) {
   assert(table_cache != nullptr);
+
+  if (files_meta.empty()) {
+    return Status::OK();
+  }
 
   std::atomic<size_t> next_file_meta_idx(0);
   std::atomic<bool> has_error(false);
@@ -82,14 +86,15 @@ Status LoadTableHandlersHelper(
     }
   });
 
-  std::vector<port::Thread> threads;
+  std::vector<std::jthread> threads;
   for (int i = 1; i < max_threads; i++) {
-    threads.emplace_back(load_handlers_func);
+    try {
+      threads.emplace_back(load_handlers_func);
+    } catch (const std::system_error&) {
+      break;
+    }
   }
   load_handlers_func();
-  for (auto& t : threads) {
-    t.join();
-  }
   return ret;
 }
 


### PR DESCRIPTION
LoadTableHandlersHelper spawns background threads into a std::vector using emplace_back in a loop. If emplace_back throws (e.g. std::bad_alloc from vector reallocation, or std::system_error from pthread_create failing under resource limits), stack unwinding destroys the vector, which calls ~thread() on already-started but unjoined threads. Per the C++ standard, destroying a joinable std::thread calls std::terminate, crashing the process unconditionally.
 
Fix by switching from port::Thread (std::thread) to std::jthread, which auto-joins on destruction. This guarantees that if an exception propagates (e.g. std::bad_alloc from a per-query memory limit), all running threads are safely joined during stack unwinding rather than triggering std::terminate. Additionally catch std::system_error from thread creation to degrade gracefully to fewer threads rather than aborting. Also add an early return when files_meta is empty to avoid unnecessary work.

Fixes #13303
