### PR TITLE
Fix implicit uint64_t-to-double conversion in TrackedDataRatio

### DIFF
--- a/include/rocksdb/utilities/table_properties_collectors.h
+++ b/include/rocksdb/utilities/table_properties_collectors.h
@@ -209,7 +209,7 @@ struct DataCollectionUnixWriteTimeInfo {
     }
     uint64_t num_entries_write_time_tracked =
         num_entries_infinitely_old + num_entries_write_time_aggregated;
-    return num_entries_write_time_tracked /
+    return static_cast<double>(num_entries_write_time_tracked) /
            static_cast<double>(num_entries_write_time_tracked +
                                num_entries_write_time_untracked);
   }


### PR DESCRIPTION
If downstream project has -Wimplicit-int-float-conversion enabled and includes pretty much any header, they get an implicit conversion warning otherwise.