### PR TITLE
Replace ENSURE_POD with precise type trait checks in range_tree

### DIFF
--- a/utilities/transactions/lock/range/range_tree/lib/locktree/txnid_set.h
+++ b/utilities/transactions/lock/range/range_tree/lib/locktree/txnid_set.h
@@ -87,6 +87,6 @@ class txnid_set {
 
   friend class txnid_set_unit_test;
 };
-ENSURE_POD(txnid_set);
+static_assert(std::is_trivially_default_constructible_v<txnid_set>);
 
 } /* namespace toku */

--- a/utilities/transactions/lock/range/range_tree/lib/locktree/wfg.h
+++ b/utilities/transactions/lock/range/range_tree/lib/locktree/wfg.h
@@ -106,7 +106,7 @@ class wfg {
 
     static void free(node *n);
   };
-  ENSURE_POD(node);
+  static_assert(std::is_trivially_default_constructible_v<node>);
 
   toku::omt<node *> m_nodes;
 
@@ -119,6 +119,5 @@ class wfg {
 
   static int find_by_txnid(node *const &node_a, const TXNID &txnid_b);
 };
-ENSURE_POD(wfg);
 
 } /* namespace toku */

--- a/utilities/transactions/lock/range/range_tree/lib/portability/toku_assert_subst.h
+++ b/utilities/transactions/lock/range/range_tree/lib/portability/toku_assert_subst.h
@@ -32,11 +32,6 @@
 #define paranoid_invariant_notnull(a) assert(a)
 #define paranoid_invariant(a) assert(a)
 
-#define ENSURE_POD(type)                                                    \
-  static_assert(                                                            \
-      std::is_standard_layout<type>::value && std::is_trivial<type>::value, \
-      #type "isn't POD")
-
 inline int get_error_errno(void) {
   invariant(errno);
   return errno;

--- a/utilities/transactions/lock/range/range_tree/lib/util/omt.h
+++ b/utilities/transactions/lock/range/range_tree/lib/util/omt.h
@@ -632,7 +632,8 @@ class omt {
   typedef uint32_t node_idx;
   typedef omt_internal::subtree_templated<supports_marks> subtree;
   typedef omt_internal::omt_node_templated<omtdata_t, supports_marks> omt_node;
-  ENSURE_POD(subtree);
+  static_assert(std::is_trivially_copy_constructible_v<subtree>
+                    && std::is_trivially_copy_assignable_v<subtree>);
 
   struct omt_array {
     uint32_t start_idx;


### PR DESCRIPTION
ENSURE_POD uses std::is_trivial which is deprecated in C++26. The commit replaces each usage of the macro with the targeted check that each affected type actually needs:
 - is_trivially_default_constructible for calloc'd `wfg::node` and `txnid_set`;
 - is_trivially_copy_constructible/assignable for memcpy'd `subtree`;
 - none for the `wfg`.