### PR TITLE
Fix port::Thread to use std::jthread over std::thread

### DIFF
--- a/port/port_posix.h
+++ b/port/port_posix.h
@@ -163,7 +163,7 @@ class CondVar {
   Mutex* mu_;
 };
 
-using Thread = std::thread;
+using Thread = std::jthread;
 
 static inline void AsmVolatilePause() {
 #if defined(__i386__) || defined(__x86_64__)

--- a/port/win/port_win.h
+++ b/port/win/port_win.h
@@ -191,7 +191,7 @@ class CondVar {
 };
 
 #ifdef _POSIX_THREADS
-using Thread = std::thread;
+using Thread = std::jthread;
 #else
 // Wrapper around the platform efficient
 // or otherwise preferrable implementation

--- a/port/win/win_thread.cc
+++ b/port/win/win_thread.cc
@@ -10,7 +10,7 @@
 #if defined(OS_WIN)
 // Most Mingw builds support std::thread only when using posix threads.
 // In that case, some of these functions will be unavailable.
-// Note that we're using either WindowsThread or std::thread, depending on
+// Note that we're using either WindowsThread or std::jthread, depending on
 // which one is available.
 #ifndef _POSIX_THREADS
 
@@ -65,16 +65,12 @@ void WindowsThread::Init(std::function<void()>&& func) {
 WindowsThread::WindowsThread() : data_(nullptr), th_id_(0) {}
 
 WindowsThread::~WindowsThread() {
-  // Must be joined or detached
-  // before destruction.
-  // This is the same as std::thread
-  if (data_) {
-    if (joinable()) {
-      assert(false);
-      std::terminate();
-    }
-    data_.reset();
+  // Is joined and detached on destruction.
+  // This is the same as std::jthread.
+  if (joinable()) {
+    join();
   }
+  data_.reset();
 }
 
 WindowsThread::WindowsThread(WindowsThread&& o) noexcept : WindowsThread() {
@@ -102,7 +98,7 @@ WindowsThread::native_handle_type WindowsThread::native_handle() const {
 }
 
 unsigned WindowsThread::hardware_concurrency() {
-  return std::thread::hardware_concurrency();
+  return std::jthread::hardware_concurrency();
 }
 
 void WindowsThread::join() {

--- a/port/win/win_thread.h
+++ b/port/win/win_thread.h
@@ -20,10 +20,10 @@
 namespace ROCKSDB_NAMESPACE {
 namespace port {
 
-// This class is a replacement for std::thread
-// 2 reasons we do not like std::thread:
+// This class is a replacement for std::jthread
+// 2 reasons we do not like std::jthread:
 //  -- is that it dynamically allocates its internals that are automatically
-//     freed when  the thread terminates and not on the destruction of the
+//     freed when the thread terminates and not necessarily on the destruction of the
 //     object. This makes it difficult to control the source of memory
 //     allocation
 //  -  This implements Pimpl so we can easily replace the guts of the


### PR DESCRIPTION
While discussing #14603 as a solution to #13303, it occurred to me that the real issue is the loss of data when the program is terminated without first existing threads. The solution provided by C++20 is `std::jthread`. This MR floats simply replacing some use of `std::thread` with `std::jthread` in the project as an alternative fix to #14603.