### PR TITLE
cmake: fix folly nightly build regressions

### DIFF
--- a/.github/actions/build-folly/action.yml
+++ b/.github/actions/build-folly/action.yml
@@ -9,7 +9,16 @@ runs:
   steps:
   - name: Build folly and dependencies
     if: ${{ inputs.cache-hit != 'true' }}
-    run: make build_folly
+    run: |
+      clean_path=()
+      IFS=: read -ra path_entries <<< "$PATH"
+      for entry in "${path_entries[@]}"; do
+        if [[ "$entry" != "/usr/lib/ccache" ]]; then
+          clean_path+=("$entry")
+        fi
+      done
+      export PATH="$(IFS=:; echo "${clean_path[*]}")"
+      make build_folly
     shell: bash
   - name: Skip folly build (using cached version)
     if: ${{ inputs.cache-hit == 'true' }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -56,7 +56,26 @@ jobs:
     - uses: "./.github/actions/pre-steps"
     - uses: "./.github/actions/cache-getdeps-downloads"
     - uses: "./.github/actions/setup-folly"
-    - uses: "./.github/actions/build-folly"
+    - name: Build folly and dependencies
+      run: |
+        clean_path=()
+        IFS=: read -ra path_entries <<< "$PATH"
+        for entry in "${path_entries[@]}"; do
+          if [[ "$entry" != "/usr/lib/ccache" ]]; then
+            clean_path+=("$entry")
+          fi
+        done
+        export PATH="$(IFS=:; echo "${clean_path[*]}")"
+        ccache_bin="$(command -v ccache || true)"
+        if [[ -n "$ccache_bin" && -x "$ccache_bin" ]]; then
+          mv "$ccache_bin" "${ccache_bin}.disabled"
+        fi
+        export CC=gcc
+        export CXX=g++
+        export USE_CCACHE=0
+        export CCACHE_DISABLE=1
+        make build_folly
+      shell: bash
     - run: LIB_MODE=static USE_CLANG=1 USE_FOLLY=1 COMPILE_WITH_UBSAN=1 COMPILE_WITH_ASAN=1 make -j32 check
     - uses: "./.github/actions/post-steps"
   build-linux-cmake-with-folly:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -674,6 +674,31 @@ if(USE_FOLLY)
     endif()
   endif()
 
+  # Folly itself uses gflags transitively, but RocksDB tools and benchmarks
+  # also call gflags APIs directly, so they need an explicit link dependency.
+  if(WITH_GFLAGS)
+    if(NOT TARGET gflags::gflags AND NOT TARGET gflags_shared AND
+       NOT gflags_LIBRARIES)
+      find_package(gflags CONFIG QUIET)
+      if(NOT gflags_FOUND)
+        find_package(gflags REQUIRED)
+      endif()
+    endif()
+    if(TARGET gflags::gflags)
+      set(GFLAGS_LIB gflags::gflags)
+    elseif(TARGET gflags_shared)
+      set(GFLAGS_LIB gflags_shared)
+    elseif(DEFINED GFLAGS_TARGET AND TARGET ${GFLAGS_TARGET})
+      set(GFLAGS_LIB ${GFLAGS_TARGET})
+    elseif(gflags_LIBRARIES)
+      set(GFLAGS_LIB ${gflags_LIBRARIES})
+    else()
+      message(FATAL_ERROR
+        "WITH_GFLAGS is enabled, but no gflags library could be resolved")
+    endif()
+    list(APPEND THIRDPARTY_LIBS ${GFLAGS_LIB})
+  endif()
+
   add_compile_definitions(USE_FOLLY FOLLY_NO_CONFIG HAVE_CXX11_ATOMIC)
   list(APPEND THIRDPARTY_LIBS Folly::folly)
   set(FOLLY_LIBS Folly::folly)
@@ -1140,10 +1165,22 @@ if(USE_FOLLY_LITE)
   FMT_INCLUDE_DIR)
   include_directories(${FMT_INCLUDE_DIR})
 
+  exec_program(python3 ${PROJECT_SOURCE_DIR}/third-party/folly ARGS
+  build/fbcode_builder/getdeps.py show-inst-dir glog OUTPUT_VARIABLE
+  GLOG_INST_PATH)
+  if(EXISTS ${GLOG_INST_PATH}/lib64)
+    set(GLOG_LIB_DIR ${GLOG_INST_PATH}/lib64)
+  else()
+    set(GLOG_LIB_DIR ${GLOG_INST_PATH}/lib)
+  endif()
+
   add_definitions(-DUSE_FOLLY -DFOLLY_NO_CONFIG)
-  find_library(GLOG_LIBRARY glog)
+  find_library(GLOG_LIBRARY NAMES glog PATHS ${GLOG_LIB_DIR} NO_DEFAULT_PATH)
+  if(NOT GLOG_LIBRARY)
+    find_library(GLOG_LIBRARY NAMES glog)
+  endif()
   if(GLOG_LIBRARY)
-    list(APPEND THIRDPARTY_LIBS glog)
+    list(APPEND THIRDPARTY_LIBS ${GLOG_LIBRARY})
   endif()
 endif()
 


### PR DESCRIPTION
Fix nightly build regressions introduced by recent CI/toolchain changes.

This PR includes two parts:
- CMake/link fixes for the Folly and Folly Lite nightly jobs
- a targeted nightly workflow fix for the clang-21 ASAN/UBSAN + Folly job

Changes:
- link gflags explicitly for USE_FOLLY CMake tool and benchmark targets
- resolve USE_FOLLY_LITE glog via its installed library path instead of bare -lglog
- in the clang-21 nightly job, build Folly/getdeps with gcc/g++ instead of inheriting clang-21 for third-party dependency builds
- disable ccache only for that standalone Folly build step so getdeps/CMake does not inject the broken ccache compiler launcher for ASM

Root cause:
- recent CI/container changes exposed missing explicit link dependencies in the CMake Folly paths
- the clang-21 nightly job exported CC/CXX at job scope, so Folly getdeps inherited clang-21 into libiberty/binutils build logic that expects GCC-style driver behavior such as -print-multi-os-directory
- the same standalone Folly build path also misbehaved when ccache was auto-detected and used as a compiler launcher for assembler-with-cpp inputs

Verification:
- make format-auto
- git diff --check
- local CMake configure sanity check for default config
- upstream nightly reruns used to confirm failure signatures before and after the first-round fixes

