### PR TITLE
Fix CompareDbtEndpoints crash with timestamp-aware comparators (#14601)

### DIFF
--- a/utilities/transactions/lock/range/range_locking_test.cc
+++ b/utilities/transactions/lock/range/range_locking_test.cc
@@ -15,6 +15,7 @@
 #include "rocksdb/options.h"
 #include "rocksdb/utilities/transaction.h"
 #include "rocksdb/utilities/transaction_db.h"
+#include "test_util/testutil.h"
 #include "utilities/transactions/lock/point/any_lock_manager_test.h"
 #include "utilities/transactions/transaction_db_mutex_impl.h"
 
@@ -97,6 +98,46 @@ TEST_F(RangeLockingTest, BasicRangeLocking) {
   ASSERT_OK(txn0->Commit());
   txn1->Rollback();
 
+  delete txn0;
+  delete txn1;
+}
+
+// CompareDbtEndpoints must use CompareWithoutTimestamp for range lock
+// endpoints, which never contain user-defined timestamps.
+TEST_F(RangeLockingTest, RangeLockWithTimestampComparator) {
+  // Close the DB opened by the fixture (uses default comparator).
+  delete db;
+  db = nullptr;
+  ASSERT_OK(DestroyDB(dbname, options));
+
+  // Reopen with a timestamp-aware comparator.
+  options.comparator = test::BytewiseComparatorWithU64TsWrapper();
+  range_lock_mgr.reset(NewRangeLockManager(nullptr));
+  txn_db_options.lock_mgr_handle = range_lock_mgr;
+
+  ASSERT_OK(TransactionDB::Open(options, txn_db_options, dbname, &db));
+
+  WriteOptions write_options;
+  TransactionOptions txn_options;
+  txn_options.lock_timeout = 50;
+  auto cf = db->DefaultColumnFamily();
+
+  Transaction* txn0 = db->BeginTransaction(write_options, txn_options);
+  Transaction* txn1 = db->BeginTransaction(write_options, txn_options);
+
+  // Acquire a range lock [a, c]. This calls CompareDbtEndpoints internally.
+  // With the bug, debug builds abort here.
+  ASSERT_OK(txn0->GetRangeLock(cf, Endpoint("a"), Endpoint("c")));
+
+  // Overlapping range [b, z] should time out.
+  auto s = txn1->GetRangeLock(cf, Endpoint("b"), Endpoint("z"));
+  ASSERT_TRUE(s.IsTimedOut());
+
+  // Non-overlapping range [d, f] should succeed.
+  ASSERT_OK(txn1->GetRangeLock(cf, Endpoint("d"), Endpoint("f")));
+
+  txn0->Rollback();
+  txn1->Rollback();
   delete txn0;
   delete txn1;
 }

--- a/utilities/transactions/lock/range/range_tree/range_tree_lock_manager.cc
+++ b/utilities/transactions/lock/range/range_tree/range_tree_lock_manager.cc
@@ -214,7 +214,9 @@ int RangeTreeLockManager::CompareDbtEndpoints(void* arg, const DBT* a_key,
   // Compare the values. The first byte encodes the endpoint type, its value
   // is either SUFFIX_INFIMUM or SUFFIX_SUPREMUM.
   Comparator* cmp = (Comparator*)arg;
-  int res = cmp->Compare(Slice(a + 1, min_len - 1), Slice(b + 1, min_len - 1));
+  int res = cmp->CompareWithoutTimestamp(
+      Slice(a + 1, min_len - 1), /*a_has_ts=*/false, Slice(b + 1, min_len - 1),
+      /*b_has_ts=*/false);
   if (!res) {
     if (b_len > min_len) {
       // a is shorter;


### PR DESCRIPTION
Summary:
`RangeTreeLockManager::CompareDbtEndpoints()` called `Comparator::Compare()` on range lock endpoint keys that never contain user-defined timestamps. With a timestamp-aware comparator (`timestamp_size() > 0`), this caused assertion failures in debug builds and silent endpoint misordering in release builds.

Replace `Compare()` with the 4-argument `CompareWithoutTimestamp()` using `a_has_ts=false, b_has_ts=false`, which is the correct contract for serialized range lock endpoints (format: `[1-byte suffix][key bytes]`, no timestamp).

Test Plan:
- New test `RangeLockWithTimestampComparator` reopens with `BytewiseComparatorWithU64Ts` and exercises range lock acquisition, conflict detection, and non-overlapping success with short keys.
- Verified RED (assertion failure) before fix, GREEN after.
- Full `range_locking_test` suite passes (16/16).
- Stress tested with `COERCE_CONTEXT_SWITCH=1 --gtest_repeat=5`.