### PR TITLE
Ignore post-SIGTERM io_uring stderr in stress test

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -6,6 +6,7 @@ import glob
 import math
 import os
 import random
+import re
 import shlex
 import shutil
 import subprocess
@@ -16,6 +17,12 @@ import time
 per_iteration_random_seed_override = 0
 remain_argv = None
 is_remote_db = False
+
+_SIGTERM_STDOUT_MARKER = "Received signal 15 (Terminated)"
+_IGNORED_SIGTERM_STDERR_RE = re.compile(
+    r"^PosixRandomAccessFile::MultiRead: io_uring_submit_and_wait "
+    r"returned terminal error: -9\.$"
+)
 
 
 def get_random_seed(override):
@@ -1670,6 +1677,35 @@ def print_output_and_exit_on_error(stdout, stderr, print_stderr_separately=False
     sys.exit(2)
 
 
+def strip_expected_sigterm_stderr(stdout, stderr, hit_timeout):
+    # Blackbox crash tests intentionally terminate db_stress with SIGTERM.
+    # Filter this known post-SIGTERM io_uring stderr so it does not mask other
+    # stderr or fail the timeout path spuriously.
+    if not hit_timeout or _SIGTERM_STDOUT_MARKER not in stdout or len(stderr) == 0:
+        return stdout, stderr
+
+    kept_lines = []
+    ignored_lines = []
+    for line in stderr.splitlines(keepends=True):
+        if _IGNORED_SIGTERM_STDERR_RE.fullmatch(line.rstrip("\n")):
+            ignored_lines.append(line)
+        else:
+            kept_lines.append(line)
+
+    if len(ignored_lines) == 0:
+        return stdout, stderr
+
+    if stdout and not stdout.endswith("\n"):
+        stdout += "\n"
+    stdout += "Ignored expected post-SIGTERM stderr while handling timeout:\n"
+    stdout += "".join(ignored_lines)
+
+    stderr = "".join(kept_lines)
+    if not stderr.strip():
+        stderr = ""
+    return stdout, stderr
+
+
 def cleanup_after_success(dbname):
     # Use db_stress --destroy_db_and_exit, which simplifies remote DB cleanup
     cleanup_cmd_parts = [stress_cmd, "--destroy_db_and_exit=1", "--db=" + dbname]
@@ -1759,6 +1795,7 @@ def blackbox_crash_main(args, unknown_args):
         hit_timeout, retcode, outs, errs, pid = execute_cmd(cmd, cmd_params["interval"])
 
         print_and_cleanup_fault_injection_log(pid)
+        outs, errs = strip_expected_sigterm_stderr(outs, errs, hit_timeout)
 
         # Reset destroy_db_initially after each run (it may have been set by
         # command line for first run only)

--- a/tools/db_crashtest_test.py
+++ b/tools/db_crashtest_test.py
@@ -122,6 +122,69 @@ class DBCrashTestTest(unittest.TestCase):
         self.assertEqual(1, finalized["disable_wal"])
         self.assertEqual(0, finalized["test_batches_snapshots"])
 
+    def test_strip_expected_sigterm_stderr_suppresses_only_known_lines(self):
+        db_crashtest = self.load_db_crashtest()
+        stdout = "Received signal 15 (Terminated)\n"
+        stderr = (
+            "PosixRandomAccessFile::MultiRead: io_uring_submit_and_wait "
+            "returned terminal error: -9.\n"
+            "PosixRandomAccessFile::MultiRead: io_uring_submit_and_wait "
+            "returned terminal error: -9.\n"
+        )
+
+        filtered_stdout, filtered_stderr = db_crashtest.strip_expected_sigterm_stderr(
+            stdout, stderr, True
+        )
+
+        self.assertEqual("", filtered_stderr)
+        self.assertEqual(
+            stdout
+            + "Ignored expected post-SIGTERM stderr while handling timeout:\n"
+            + stderr,
+            filtered_stdout,
+        )
+
+    def test_strip_expected_sigterm_stderr_preserves_other_stderr(self):
+        db_crashtest = self.load_db_crashtest()
+        stdout = "Received signal 15 (Terminated)\n"
+        ignored_line = (
+            "PosixRandomAccessFile::MultiRead: io_uring_submit_and_wait "
+            "returned terminal error: -9.\n"
+        )
+        kept_line = "Different stderr line\n"
+        stderr = ignored_line + kept_line
+
+        filtered_stdout, filtered_stderr = db_crashtest.strip_expected_sigterm_stderr(
+            stdout, stderr, True
+        )
+
+        self.assertEqual(kept_line, filtered_stderr)
+        self.assertEqual(
+            stdout
+            + "Ignored expected post-SIGTERM stderr while handling timeout:\n"
+            + ignored_line,
+            filtered_stdout,
+        )
+
+    def test_strip_expected_sigterm_stderr_requires_timeout_and_sigterm_marker(self):
+        db_crashtest = self.load_db_crashtest()
+        stderr = (
+            "PosixRandomAccessFile::MultiRead: io_uring_submit_and_wait "
+            "returned terminal error: -9.\n"
+        )
+
+        filtered_stdout, filtered_stderr = db_crashtest.strip_expected_sigterm_stderr(
+            "Received signal 15 (Terminated)\n", stderr, False
+        )
+        self.assertEqual("Received signal 15 (Terminated)\n", filtered_stdout)
+        self.assertEqual(stderr, filtered_stderr)
+
+        filtered_stdout, filtered_stderr = db_crashtest.strip_expected_sigterm_stderr(
+            "other stdout\n", stderr, True
+        )
+        self.assertEqual("other stdout\n", filtered_stdout)
+        self.assertEqual(stderr, filtered_stderr)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Blackbox crash tests intentionally terminate `db_stress` with `SIGTERM` on timeout. When `io_uring` is enabled, that shutdown can emit the expected
`PosixRandomAccessFile::MultiRead: io_uring_submit_and_wait returned terminal error: -9.`
message on `stderr`, which currently makes the timeout path look like a real failure.

This change filters only that known post-`SIGTERM` stderr after a timeout when the process output confirms the `SIGTERM` handler ran. Any other stderr is still surfaced and fails the test, while the ignored lines are appended to `stdout` so the signal remains visible in logs.

## Test Plan
- Added unit tests covering fully ignored post-`SIGTERM` stderr
- Added unit tests covering mixed stderr where unrelated lines must still fail
- Added unit tests covering guard conditions when the run did not time out or did not print the `SIGTERM` marker
- Not run (not requested)
