### PR TITLE
Fix reverse SeekForPrev range tombstone classification

### DIFF
--- a/table/merger_test.cc
+++ b/table/merger_test.cc
@@ -4,15 +4,118 @@
 //  (found in the LICENSE.Apache file in the root directory).
 
 #include <string>
+#include <utility>
 #include <vector>
 
+#include "db/range_tombstone_fragmenter.h"
+#include "memory/arena.h"
 #include "table/merging_iterator.h"
+#include "test_util/sync_point.h"
 #include "test_util/testharness.h"
 #include "test_util/testutil.h"
-#include "util/random.h"
 #include "util/vector_iterator.h"
 
 namespace ROCKSDB_NAMESPACE {
+
+namespace {
+
+// Test-only input for one merge level. This regression only needs range
+// tombstones, but MergeIteratorBuilder still expects one child per level.
+struct LevelData {
+  std::vector<RangeTombstone> tombstones;
+};
+
+std::unique_ptr<InternalIterator> MakeEmptyPointIter(
+    const InternalKeyComparator& icmp) {
+  return std::unique_ptr<InternalIterator>(new VectorIterator({}, {}, &icmp));
+}
+
+std::unique_ptr<InternalIterator> MakeRangeDelBlockIter(
+    const std::vector<RangeTombstone>& tombstones) {
+  static const InternalKeyComparator bytewise_icmp(BytewiseComparator());
+  std::vector<std::string> keys;
+  std::vector<std::string> values;
+  for (const auto& tombstone : tombstones) {
+    auto key_and_value = tombstone.Serialize();
+    keys.push_back(key_and_value.first.Encode().ToString());
+    values.push_back(key_and_value.second.ToString());
+  }
+  return std::unique_ptr<InternalIterator>(
+      new VectorIterator(std::move(keys), std::move(values), &bytewise_icmp));
+}
+
+std::unique_ptr<TruncatedRangeDelIterator> MakeRangeDelIter(
+    const InternalKeyComparator& icmp,
+    const std::vector<RangeTombstone>& tombstones) {
+  if (tombstones.empty()) {
+    return nullptr;
+  }
+  // MergeIteratorBuilder consumes the same fragmented/truncated tombstone
+  // iterator stack used by table readers, so build that shape explicitly.
+  auto range_del_block_iter = MakeRangeDelBlockIter(tombstones);
+  auto fragment_list = std::make_shared<FragmentedRangeTombstoneList>(
+      std::move(range_del_block_iter), icmp);
+  auto fragment_iter = std::make_unique<FragmentedRangeTombstoneIterator>(
+      fragment_list, icmp, kMaxSequenceNumber);
+  return std::make_unique<TruncatedRangeDelIterator>(std::move(fragment_iter),
+                                                     &icmp, nullptr, nullptr);
+}
+
+std::unique_ptr<InternalIterator> BuildMergeIter(
+    const InternalKeyComparator& icmp, const std::vector<LevelData>& levels) {
+  auto arena = std::make_unique<Arena>();
+  auto* arena_ptr = arena.get();
+  MergeIteratorBuilder builder(&icmp, arena_ptr, false /* prefix_seek_mode */);
+  for (const auto& level : levels) {
+    auto point_iter = MakeEmptyPointIter(icmp);
+    auto tombstone_iter = MakeRangeDelIter(icmp, level.tombstones);
+    builder.AddPointAndTombstoneIterator(point_iter.release(),
+                                         std::move(tombstone_iter));
+  }
+  InternalIterator* iter = builder.Finish();
+  // MergeIteratorBuilder placement-news the iterator into `arena`, so keep the
+  // arena alive for the lifetime of the returned iterator in this test.
+  struct ArenaOwnedIter : public InternalIterator {
+    ArenaOwnedIter(std::unique_ptr<Arena>&& a, InternalIterator* i)
+        : arena(std::move(a)), iter(i) {}
+    ~ArenaOwnedIter() override { iter->~InternalIterator(); }
+    bool Valid() const override { return iter->Valid(); }
+    void SeekToFirst() override { iter->SeekToFirst(); }
+    void SeekToLast() override { iter->SeekToLast(); }
+    void Seek(const Slice& target) override { iter->Seek(target); }
+    void SeekForPrev(const Slice& target) override {
+      iter->SeekForPrev(target);
+    }
+    void Next() override { iter->Next(); }
+    void Prev() override { iter->Prev(); }
+    Slice key() const override { return iter->key(); }
+    Slice value() const override { return iter->value(); }
+    Status status() const override { return iter->status(); }
+    bool IsKeyPinned() const override { return iter->IsKeyPinned(); }
+    bool IsValuePinned() const override { return iter->IsValuePinned(); }
+    void SetPinnedItersMgr(PinnedIteratorsManager* m) override {
+      iter->SetPinnedItersMgr(m);
+    }
+    std::unique_ptr<Arena> arena;
+    InternalIterator* iter;
+  };
+  return std::unique_ptr<InternalIterator>(
+      new ArenaOwnedIter(std::move(arena), iter));
+}
+
+std::string SeekForPrevTarget(const std::string& user_key) {
+  return InternalKey(user_key, kMaxSequenceNumber, kValueTypeForSeekForPrev)
+      .Encode()
+      .ToString();
+}
+
+std::string DecodeHexString(const std::string& hex) {
+  std::string decoded;
+  assert(Slice(hex).DecodeHex(&decoded));
+  return decoded;
+}
+
+}  // namespace
 
 class MergerTest : public testing::Test {
  public:
@@ -171,6 +274,45 @@ TEST_F(MergerTest, SeekToLastTest) {
     AssertEquivalence();
     Prev(50000);
   }
+}
+
+TEST_F(MergerTest, SeekForPrevUsesMovedTargetForRangeTombstoneChoice) {
+  // Mirror the proven stale-target pattern from the crash artifact:
+  // base target ...010C is first pulled left to ...0103 by a newer tombstone.
+  // The older tombstone [...0102, ...010C) must then be classified against the
+  // moved target (...0103), not the stale original base target (...010C).
+  const std::string older_start =
+      DecodeHexString("00000000000001A3000000000000012B0000000000000102");
+  const std::string reseek_start =
+      DecodeHexString("00000000000001A3000000000000012B0000000000000103");
+  const std::string base_target =
+      DecodeHexString("00000000000001A3000000000000012B000000000000010C");
+  const std::string newer_end =
+      DecodeHexString("00000000000001A3000000000000012B000000000000010D");
+
+  std::vector<LevelData> levels(2);
+  levels[0].tombstones.emplace_back(reseek_start, newer_end, 200);
+  levels[1].tombstones.emplace_back(older_start, base_target, 100);
+
+  bool saw_older_level_choice = false;
+  bool older_level_choose_end = true;
+  SyncPoint::GetInstance()->SetCallBack(
+      "MergingIterator::SeekForPrevImpl:RangeTombstoneChoice", [&](void* arg) {
+        const auto* info = static_cast<const std::pair<size_t, bool>*>(arg);
+        if (info->first == 1) {
+          saw_older_level_choice = true;
+          older_level_choose_end = info->second;
+        }
+      });
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  auto merge_iter = BuildMergeIter(icomp_, levels);
+  merge_iter->SeekForPrev(SeekForPrevTarget(base_target));
+
+  ASSERT_FALSE(merge_iter->Valid());
+  ASSERT_OK(merge_iter->status());
+  ASSERT_TRUE(saw_older_level_choice);
+  ASSERT_FALSE(older_level_choose_end);
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/table/merging_iterator.cc
+++ b/table/merging_iterator.cc
@@ -9,10 +9,14 @@
 
 #include "table/merging_iterator.h"
 
+#include <utility>
+
 #include "db/arena_wrapped_db_iter.h"
 #include "monitoring/file_read_sample.h"
+#include "test_util/sync_point.h"
 
 namespace ROCKSDB_NAMESPACE {
+
 // MergingIterator uses a min/max heap to combine data from point iterators.
 // Range tombstones can be added and keys covered by range tombstones will be
 // skipped.
@@ -1084,10 +1088,6 @@ void MergingIterator::SeekForPrevImpl(const Slice& target,
   // active range tombstones before `starting_level` remain active
   ClearHeaps(false /* clear_active */);
   InitMaxHeap();
-  ParsedInternalKey pik;
-  if (!range_tombstone_iters_.empty()) {
-    ParseInternalKey(target, &pik, false).PermitUncheckedError();
-  }
   for (size_t level = 0; level < starting_level; ++level) {
     PERF_TIMER_GUARD(seek_max_heap_time);
     AddToMaxHeapOrCheckStatus(&children_[level]);
@@ -1138,9 +1138,20 @@ void MergingIterator::SeekForPrevImpl(const Slice& target,
       if (range_tombstone_iter) {
         range_tombstone_iter->SeekForPrev(current_search_key.GetUserKey());
         if (range_tombstone_iter->Valid()) {
-          InsertRangeTombstoneToMaxHeap(
-              level, comparator_->Compare(range_tombstone_iter->end_key(),
-                                          pik) <= 0 /* end_key */);
+          // Reverse cascading seek can move left after encountering a newer
+          // tombstone. Classify this tombstone against the moved seek key, not
+          // the original target, or older tombstones can be inserted in the
+          // wrong active/inactive state.
+          const bool choose_end =
+              comparator_->Compare(range_tombstone_iter->end_key(),
+                                   current_search_key.GetInternalKey()) <= 0;
+#ifndef NDEBUG
+          std::pair<size_t, bool> sync_point_arg(level, choose_end);
+          TEST_SYNC_POINT_CALLBACK(
+              "MergingIterator::SeekForPrevImpl:RangeTombstoneChoice",
+              &sync_point_arg);
+#endif
+          InsertRangeTombstoneToMaxHeap(level, choose_end);
           // start key <= current_search_key guaranteed by the Seek() call above
           // Only interested in user key coverage since older sorted runs must
           // have smaller sequence numbers than this tombstone.


### PR DESCRIPTION
## Summary
Reverse cascading `SeekForPrev()` can move the effective search target left after encountering a newer range tombstone. The older tombstone was still being classified against the original seek target, which can leave it in the wrong active/inactive state and hide live keys.

Compare older tombstones against the moved `current_search_key` instead, and add a `MergerTest` regression that reproduces the stale-target pattern from the crash artifact.

## Test Plan
- Not run (not requested)