### PR TITLE
[C API] add rocksdb_set_db_options for dynamic DB option updates

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -4242,6 +4242,15 @@ void rocksdb_set_options(rocksdb_t* db, int count, const char* const keys[],
   SaveError(errptr, db->rep->SetOptions(options_map));
 }
 
+void rocksdb_set_db_options(rocksdb_t* db, int count, const char* const keys[],
+                            const char* const values[], char** errptr) {
+  std::unordered_map<std::string, std::string> options_map;
+  for (int i = 0; i < count; i++) {
+    options_map[keys[i]] = values[i];
+  }
+  SaveError(errptr, db->rep->SetDBOptions(options_map));
+}
+
 void rocksdb_set_options_cf(rocksdb_t* db,
                             rocksdb_column_family_handle_t* handle, int count,
                             const char* const keys[],

--- a/db/c.cc
+++ b/db/c.cc
@@ -4242,8 +4242,7 @@ void rocksdb_set_options(rocksdb_t* db, int count, const char* const keys[],
   SaveError(errptr, db->rep->SetOptions(options_map));
 }
 
-void rocksdb_set_db_options(rocksdb_t* db, int count,
-                            const char* const keys[],
+void rocksdb_set_db_options(rocksdb_t* db, int count, const char* const keys[],
                             const char* const values[], char** errptr) {
   std::unordered_map<std::string, std::string> options_map;
   for (int i = 0; i < count; i++) {

--- a/db/c.cc
+++ b/db/c.cc
@@ -4242,11 +4242,12 @@ void rocksdb_set_options(rocksdb_t* db, int count, const char* const keys[],
   SaveError(errptr, db->rep->SetOptions(options_map));
 }
 
-void rocksdb_set_db_options(rocksdb_t* db, int count, const char* const keys[],
-                            const char* const values[], char** errptr) {
+void rocksdb_set_db_options(rocksdb_t* db, int count,
+                            const char* const opt_keys[],
+                            const char* const opt_values[], char** errptr) {
   std::unordered_map<std::string, std::string> options_map;
   for (int i = 0; i < count; i++) {
-    options_map[keys[i]] = values[i];
+    options_map[opt_keys[i]] = opt_values[i];
   }
   SaveError(errptr, db->rep->SetDBOptions(options_map));
 }

--- a/db/c.cc
+++ b/db/c.cc
@@ -4243,11 +4243,11 @@ void rocksdb_set_options(rocksdb_t* db, int count, const char* const keys[],
 }
 
 void rocksdb_set_db_options(rocksdb_t* db, int count,
-                            const char* const opt_keys[],
-                            const char* const opt_values[], char** errptr) {
+                            const char* const keys[],
+                            const char* const values[], char** errptr) {
   std::unordered_map<std::string, std::string> options_map;
   for (int i = 0; i < count; i++) {
-    options_map[opt_keys[i]] = opt_values[i];
+    options_map[keys[i]] = values[i];
   }
   SaveError(errptr, db->rep->SetDBOptions(options_map));
 }

--- a/db/c_test.c
+++ b/db/c_test.c
@@ -948,6 +948,19 @@ int main(int argc, char** argv) {
   CheckNoError(err);
   CheckGet(db, roptions, "foo", "hello");
 
+  StartPhase("set_db_options");
+  {
+    const char* keys[] = {"stats_dump_period_sec"};
+    const char* values[] = {"10"};
+    rocksdb_set_db_options(db, 1, keys, values, &err);
+    CheckNoError(err);
+
+    keys[0] = "not_a_db_option";
+    rocksdb_set_db_options(db, 1, keys, values, &err);
+    CheckCondition(err != NULL);
+    Free(&err);
+  }
+
   StartPhase("backup_and_restore");
   {
     rocksdb_destroy_db(options, dbbackupname, &err);

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -1426,6 +1426,10 @@ extern ROCKSDB_LIBRARY_API void rocksdb_set_options(rocksdb_t* db, int count,
                                                     const char* const values[],
                                                     char** errptr);
 
+extern ROCKSDB_LIBRARY_API void rocksdb_set_db_options(
+    rocksdb_t* db, int count, const char* const keys[],
+    const char* const values[], char** errptr);
+
 extern ROCKSDB_LIBRARY_API void rocksdb_set_options_cf(
     rocksdb_t* db, rocksdb_column_family_handle_t* handle, int count,
     const char* const keys[], const char* const values[], char** errptr);

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -1427,8 +1427,8 @@ extern ROCKSDB_LIBRARY_API void rocksdb_set_options(rocksdb_t* db, int count,
                                                     char** errptr);
 
 extern ROCKSDB_LIBRARY_API void rocksdb_set_db_options(
-    rocksdb_t* db, int count, const char* const opt_keys[],
-    const char* const opt_values[], char** errptr);
+    rocksdb_t* db, int count, const char* const keys[],
+    const char* const values[], char** errptr);
 
 extern ROCKSDB_LIBRARY_API void rocksdb_set_options_cf(
     rocksdb_t* db, rocksdb_column_family_handle_t* handle, int count,

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -1427,8 +1427,8 @@ extern ROCKSDB_LIBRARY_API void rocksdb_set_options(rocksdb_t* db, int count,
                                                     char** errptr);
 
 extern ROCKSDB_LIBRARY_API void rocksdb_set_db_options(
-    rocksdb_t* db, int count, const char* const keys[],
-    const char* const values[], char** errptr);
+    rocksdb_t* db, int count, const char* const opt_keys[],
+    const char* const opt_values[], char** errptr);
 
 extern ROCKSDB_LIBRARY_API void rocksdb_set_options_cf(
     rocksdb_t* db, rocksdb_column_family_handle_t* handle, int count,


### PR DESCRIPTION
# Context

The C API lacks a SetDBOptions wrapper, so callers using the C bindings cannot dynamically reconfigure DB-level options at runtime without dropping down to the C++ API.

# Changes   
  - Add `rocksdb_set_db_options` to the C API as a wrapper around `DB::SetDBOptions`
  - Adds new tests in `c_test.c` covering both valid and invalid option updates