### PR TITLE
db_stress: exclude info logs from metadata read faults

### DIFF
--- a/db_stress_tool/db_stress_driver.cc
+++ b/db_stress_tool/db_stress_driver.cc
@@ -178,14 +178,6 @@ bool RunStressTestImpl(SharedState* shared) {
         stress->TrackExpectedState(shared);
       }
 
-      if (FLAGS_metadata_read_fault_one_in > 0) {
-        // AutoRollLogger probes old/current info log paths with FileExists()
-        // and may ignore those errors. Excluding info log metadata reads keeps
-        // db_stress fault accounting focused on operations whose failures can
-        // propagate back to the stressed DB operation.
-        fault_fs_guard->SetFileTypesExcludedFromMetadataReadFaultInjection(
-            {FileType::kInfoLogFile});
-      }
       if (FLAGS_sync_fault_injection || FLAGS_write_fault_one_in > 0) {
         fault_fs_guard->SetFilesystemDirectWritable(false);
         fault_fs_guard->SetInjectUnsyncedDataLoss(FLAGS_sync_fault_injection);

--- a/db_stress_tool/db_stress_driver.cc
+++ b/db_stress_tool/db_stress_driver.cc
@@ -178,6 +178,14 @@ bool RunStressTestImpl(SharedState* shared) {
         stress->TrackExpectedState(shared);
       }
 
+      if (FLAGS_metadata_read_fault_one_in > 0) {
+        // AutoRollLogger probes old/current info log paths with FileExists()
+        // and may ignore those errors. Excluding info log metadata reads keeps
+        // db_stress fault accounting focused on operations whose failures can
+        // propagate back to the stressed DB operation.
+        fault_fs_guard->SetFileTypesExcludedFromMetadataReadFaultInjection(
+            {FileType::kInfoLogFile});
+      }
       if (FLAGS_sync_fault_injection || FLAGS_write_fault_one_in > 0) {
         fault_fs_guard->SetFilesystemDirectWritable(false);
         fault_fs_guard->SetInjectUnsyncedDataLoss(FLAGS_sync_fault_injection);

--- a/db_stress_tool/db_stress_tool.cc
+++ b/db_stress_tool/db_stress_tool.cc
@@ -93,6 +93,10 @@ int db_stress_tool(int argc, char** argv) {
     FaultInjectionTestFS* fs =
         new FaultInjectionTestFS(raw_env->GetFileSystem());
     fault_fs_guard.reset(fs);
+    // Info logs are debugging artifacts, so exclude them from fault injection
+    // and keep error accounting focused on DB data and metadata.
+    fault_fs_guard->SetFileTypesExcludedFromFaultInjection(
+        {FileType::kInfoLogFile});
     // Set it to direct writable here to initially bypass any fault injection
     // during DB open This will correspondingly be overwritten in
     // StressTest::Open() for open fault injection and in RunStressTestImpl()

--- a/db_stress_tool/db_stress_tool.cc
+++ b/db_stress_tool/db_stress_tool.cc
@@ -93,12 +93,6 @@ int db_stress_tool(int argc, char** argv) {
     FaultInjectionTestFS* fs =
         new FaultInjectionTestFS(raw_env->GetFileSystem());
     fault_fs_guard.reset(fs);
-    // AutoRollLogger probes old/current info log paths with FileExists() and
-    // may ignore those errors. Excluding info log metadata reads keeps
-    // db_stress fault accounting focused on operations whose failures can
-    // propagate back to the stressed DB operation.
-    fault_fs_guard->SetFileTypesExcludedFromMetadataReadFaultInjection(
-        {FileType::kInfoLogFile});
     // Set it to direct writable here to initially bypass any fault injection
     // during DB open This will correspondingly be overwritten in
     // StressTest::Open() for open fault injection and in RunStressTestImpl()

--- a/db_stress_tool/db_stress_tool.cc
+++ b/db_stress_tool/db_stress_tool.cc
@@ -93,6 +93,12 @@ int db_stress_tool(int argc, char** argv) {
     FaultInjectionTestFS* fs =
         new FaultInjectionTestFS(raw_env->GetFileSystem());
     fault_fs_guard.reset(fs);
+    // AutoRollLogger probes old/current info log paths with FileExists() and
+    // may ignore those errors. Excluding info log metadata reads keeps
+    // db_stress fault accounting focused on operations whose failures can
+    // propagate back to the stressed DB operation.
+    fault_fs_guard->SetFileTypesExcludedFromMetadataReadFaultInjection(
+        {FileType::kInfoLogFile});
     // Set it to direct writable here to initially bypass any fault injection
     // during DB open This will correspondingly be overwritten in
     // StressTest::Open() for open fault injection and in RunStressTestImpl()

--- a/utilities/fault_injection_fs.cc
+++ b/utilities/fault_injection_fs.cc
@@ -1451,7 +1451,8 @@ IOStatus FaultInjectionTestFS::MaybeInjectThreadLocalReadError(
   ErrorContext* ctx =
       static_cast<ErrorContext*>(injected_thread_local_read_error_.Get());
   if (ctx == nullptr || !ctx->enable_error_injection || !ctx->one_in ||
-      ShouldIOActivitiesExcludedFromFaultInjection(io_options.io_activity)) {
+      ShouldIOActivitiesExcludedFromFaultInjection(io_options.io_activity) ||
+      ShouldExcludeFromFaultInjection(file_name, FaultInjectionIOType::kRead)) {
     return IOStatus::OK();
   }
 
@@ -1553,13 +1554,7 @@ IOStatus FaultInjectionTestFS::MaybeInjectThreadLocalError(
   ErrorContext* ctx = GetErrorContextFromFaultInjectionIOType(type);
   if (ctx == nullptr || !ctx->enable_error_injection || !ctx->one_in ||
       ShouldIOActivitiesExcludedFromFaultInjection(io_options.io_activity) ||
-      (type == FaultInjectionIOType::kWrite &&
-       ShouldExcludeFromFaultInjection(
-           file_name, file_types_excluded_from_write_fault_injection_)) ||
-      (type == FaultInjectionIOType::kMetadataRead &&
-       ShouldExcludeFromFaultInjection(
-           file_name,
-           file_types_excluded_from_metadata_read_fault_injection_))) {
+      ShouldExcludeFromFaultInjection(file_name, type)) {
     return IOStatus::OK();
   }
 

--- a/utilities/fault_injection_fs.cc
+++ b/utilities/fault_injection_fs.cc
@@ -39,6 +39,40 @@ namespace ROCKSDB_NAMESPACE {
 
 const std::string kNewFileNoOverwrite;
 
+namespace {
+
+bool TryParseInfoLogFileName(const std::string& file_name, uint64_t* number) {
+  auto try_parse_suffix = [number](Slice suffix) {
+    if (suffix.empty() || suffix == ".old") {
+      *number = 0;
+      return true;
+    }
+    if (!suffix.starts_with(".old.")) {
+      return false;
+    }
+    suffix.remove_prefix(sizeof(".old.") - 1);
+    return ConsumeDecimalNumber(&suffix, number) && suffix.empty();
+  };
+
+  Slice base(file_name);
+  if (base.starts_with("LOG")) {
+    Slice suffix = base;
+    suffix.remove_prefix(sizeof("LOG") - 1);
+    return try_parse_suffix(suffix);
+  }
+
+  size_t info_log_pos = file_name.rfind("_LOG");
+  if (info_log_pos == std::string::npos) {
+    return false;
+  }
+
+  Slice suffix(file_name);
+  suffix.remove_prefix(info_log_pos + sizeof("_LOG") - 1);
+  return try_parse_suffix(suffix);
+}
+
+}  // namespace
+
 // Assume a filename, and not a directory name like "/foo/bar/"
 std::string TestFSGetDirName(const std::string filename) {
   size_t found = filename.find_last_of("/\\");
@@ -1501,9 +1535,17 @@ IOStatus FaultInjectionTestFS::MaybeInjectThreadLocalReadError(
 
 bool FaultInjectionTestFS::TryParseFileName(const std::string& file_name,
                                             uint64_t* number, FileType* type) {
-  std::size_t found = file_name.find_last_of('/');
-  std::string file = file_name.substr(found);
-  return ParseFileName(file, number, type);
+  std::size_t found = file_name.find_last_of("/\\");
+  std::string file =
+      found == std::string::npos ? file_name : file_name.substr(found + 1);
+  if (ParseFileName(file, number, type)) {
+    return true;
+  }
+  if (!TryParseInfoLogFileName(file, number)) {
+    return false;
+  }
+  *type = kInfoLogFile;
+  return true;
 }
 
 IOStatus FaultInjectionTestFS::MaybeInjectThreadLocalError(
@@ -1521,7 +1563,12 @@ IOStatus FaultInjectionTestFS::MaybeInjectThreadLocalError(
   if (ctx == nullptr || !ctx->enable_error_injection || !ctx->one_in ||
       ShouldIOActivitiesExcludedFromFaultInjection(io_options.io_activity) ||
       (type == FaultInjectionIOType::kWrite &&
-       ShouldExcludeFromWriteFaultInjection(file_name))) {
+       ShouldExcludeFromFaultInjection(
+           file_name, file_types_excluded_from_write_fault_injection_)) ||
+      (type == FaultInjectionIOType::kMetadataRead &&
+       ShouldExcludeFromFaultInjection(
+           file_name,
+           file_types_excluded_from_metadata_read_fault_injection_))) {
     return IOStatus::OK();
   }
 

--- a/utilities/fault_injection_fs.cc
+++ b/utilities/fault_injection_fs.cc
@@ -41,34 +41,29 @@ const std::string kNewFileNoOverwrite;
 
 namespace {
 
-bool TryParseInfoLogFileName(const std::string& file_name, uint64_t* number) {
-  auto try_parse_suffix = [number](Slice suffix) {
-    if (suffix.empty() || suffix == ".old") {
-      *number = 0;
-      return true;
+bool TryParseInfoLogFileName(const std::string& file_name, uint64_t* number,
+                             FileType* type) {
+  size_t prefix_len = std::string::npos;
+  if (file_name == "LOG" ||
+      (file_name.size() > 3 && file_name.compare(0, 7, "LOG.old") == 0)) {
+    prefix_len = sizeof("LOG") - 1;
+  } else {
+    size_t info_log_pos = file_name.rfind("_LOG");
+    if (info_log_pos != std::string::npos) {
+      size_t suffix_pos = info_log_pos + sizeof("_LOG") - 1;
+      if (suffix_pos == file_name.size() ||
+          (suffix_pos < file_name.size() &&
+           file_name.compare(suffix_pos, 4, ".old") == 0)) {
+        prefix_len = suffix_pos;
+      }
     }
-    if (!suffix.starts_with(".old.")) {
-      return false;
-    }
-    suffix.remove_prefix(sizeof(".old.") - 1);
-    return ConsumeDecimalNumber(&suffix, number) && suffix.empty();
-  };
-
-  Slice base(file_name);
-  if (base.starts_with("LOG")) {
-    Slice suffix = base;
-    suffix.remove_prefix(sizeof("LOG") - 1);
-    return try_parse_suffix(suffix);
   }
-
-  size_t info_log_pos = file_name.rfind("_LOG");
-  if (info_log_pos == std::string::npos) {
+  if (prefix_len == std::string::npos) {
     return false;
   }
-
-  Slice suffix(file_name);
-  suffix.remove_prefix(info_log_pos + sizeof("_LOG") - 1);
-  return try_parse_suffix(suffix);
+  Slice info_log_name_prefix(file_name.data(), prefix_len);
+  return ParseFileName(file_name, number, info_log_name_prefix, type) &&
+         *type == kInfoLogFile;
 }
 
 }  // namespace
@@ -1541,11 +1536,7 @@ bool FaultInjectionTestFS::TryParseFileName(const std::string& file_name,
   if (ParseFileName(file, number, type)) {
     return true;
   }
-  if (!TryParseInfoLogFileName(file, number)) {
-    return false;
-  }
-  *type = kInfoLogFile;
-  return true;
+  return TryParseInfoLogFileName(file, number, type);
 }
 
 IOStatus FaultInjectionTestFS::MaybeInjectThreadLocalError(

--- a/utilities/fault_injection_fs.h
+++ b/utilities/fault_injection_fs.h
@@ -821,6 +821,12 @@ class FaultInjectionTestFS : public FileSystemWrapper {
     file_types_excluded_from_write_fault_injection_ = types;
   }
 
+  void SetFileTypesExcludedFromMetadataReadFaultInjection(
+      const std::set<FileType>& types) {
+    MutexLock l(&mutex_);
+    file_types_excluded_from_metadata_read_fault_injection_ = types;
+  }
+
   void EnableThreadLocalErrorInjection(FaultInjectionIOType type) {
     ErrorContext* ctx = GetErrorContextFromFaultInjectionIOType(type);
     if (ctx) {
@@ -932,6 +938,7 @@ class FaultInjectionTestFS : public FileSystemWrapper {
   };
 
   std::set<FileType> file_types_excluded_from_write_fault_injection_;
+  std::set<FileType> file_types_excluded_from_metadata_read_fault_injection_;
   std::set<Env::IOActivity> io_activities_excluded_from_fault_injection;
   ThreadLocalPtr injected_thread_local_read_error_;
   ThreadLocalPtr injected_thread_local_write_error_;
@@ -956,15 +963,15 @@ class FaultInjectionTestFS : public FileSystemWrapper {
       ErrorOperation op, Slice* slice, bool direct_io, char* scratch,
       bool need_count_increase, bool* fault_injected);
 
-  bool ShouldExcludeFromWriteFaultInjection(const std::string& file_name) {
+  bool ShouldExcludeFromFaultInjection(
+      const std::string& file_name, const std::set<FileType>& excluded_types) {
     MutexLock l(&mutex_);
     FileType file_type = kTempFile;
     uint64_t file_number = 0;
     if (!TryParseFileName(file_name, &file_number, &file_type)) {
       return false;
     }
-    return file_types_excluded_from_write_fault_injection_.find(file_type) !=
-           file_types_excluded_from_write_fault_injection_.end();
+    return excluded_types.find(file_type) != excluded_types.end();
   }
 
   // Extract number of type from file name. Return false if failing to fine

--- a/utilities/fault_injection_fs.h
+++ b/utilities/fault_injection_fs.h
@@ -821,10 +821,9 @@ class FaultInjectionTestFS : public FileSystemWrapper {
     file_types_excluded_from_write_fault_injection_ = types;
   }
 
-  void SetFileTypesExcludedFromMetadataReadFaultInjection(
-      const std::set<FileType>& types) {
+  void SetFileTypesExcludedFromFaultInjection(const std::set<FileType>& types) {
     MutexLock l(&mutex_);
-    file_types_excluded_from_metadata_read_fault_injection_ = types;
+    file_types_excluded_from_fault_injection_ = types;
   }
 
   void EnableThreadLocalErrorInjection(FaultInjectionIOType type) {
@@ -937,8 +936,8 @@ class FaultInjectionTestFS : public FileSystemWrapper {
     }
   };
 
+  std::set<FileType> file_types_excluded_from_fault_injection_;
   std::set<FileType> file_types_excluded_from_write_fault_injection_;
-  std::set<FileType> file_types_excluded_from_metadata_read_fault_injection_;
   std::set<Env::IOActivity> io_activities_excluded_from_fault_injection;
   ThreadLocalPtr injected_thread_local_read_error_;
   ThreadLocalPtr injected_thread_local_write_error_;
@@ -963,15 +962,27 @@ class FaultInjectionTestFS : public FileSystemWrapper {
       ErrorOperation op, Slice* slice, bool direct_io, char* scratch,
       bool need_count_increase, bool* fault_injected);
 
-  bool ShouldExcludeFromFaultInjection(
-      const std::string& file_name, const std::set<FileType>& excluded_types) {
+  bool ShouldExcludeFromFaultInjection(const std::string& file_name,
+                                       FaultInjectionIOType type) {
     MutexLock l(&mutex_);
     FileType file_type = kTempFile;
     uint64_t file_number = 0;
     if (!TryParseFileName(file_name, &file_number, &file_type)) {
       return false;
     }
-    return excluded_types.find(file_type) != excluded_types.end();
+    if (file_types_excluded_from_fault_injection_.count(file_type) > 0) {
+      return true;
+    }
+    switch (type) {
+      case FaultInjectionIOType::kWrite:
+        return file_types_excluded_from_write_fault_injection_.count(
+                   file_type) > 0;
+      case FaultInjectionIOType::kRead:
+      case FaultInjectionIOType::kMetadataRead:
+      case FaultInjectionIOType::kMetadataWrite:
+        return false;
+    }
+    return false;
   }
 
   // Extract number of type from file name. Return false if failing to fine

--- a/utilities/fault_injection_fs_test.cc
+++ b/utilities/fault_injection_fs_test.cc
@@ -90,9 +90,12 @@ TEST_F(FaultInjectionTestFSTest, MetadataReadFaultExcludesInfoLogFiles) {
   Env* env = Env::Default();
   const std::string dbname =
       test::PerThreadDBPath("fault_injection_fs_test_metadata_read");
+  const std::string log_dir = dbname + "_logs";
   ASSERT_OK(env->CreateDirIfMissing(dbname));
+  ASSERT_OK(env->CreateDirIfMissing(log_dir));
 
-  const std::string old_info_log = OldInfoLogFileName(dbname, 123);
+  const std::string old_info_log = OldInfoLogFileName(dbname, 123, dbname,
+                                                      log_dir);
   const std::string manifest = DescriptorFileName(dbname, 1);
   ASSERT_OK(
       WriteStringToFile(env, "old log", old_info_log, false /* should_sync */));

--- a/utilities/fault_injection_fs_test.cc
+++ b/utilities/fault_injection_fs_test.cc
@@ -94,8 +94,8 @@ TEST_F(FaultInjectionTestFSTest, MetadataReadFaultExcludesInfoLogFiles) {
   ASSERT_OK(env->CreateDirIfMissing(dbname));
   ASSERT_OK(env->CreateDirIfMissing(log_dir));
 
-  const std::string old_info_log = OldInfoLogFileName(dbname, 123, dbname,
-                                                      log_dir);
+  const std::string old_info_log =
+      OldInfoLogFileName(dbname, 123, dbname, log_dir);
   const std::string manifest = DescriptorFileName(dbname, 1);
   ASSERT_OK(
       WriteStringToFile(env, "old log", old_info_log, false /* should_sync */));

--- a/utilities/fault_injection_fs_test.cc
+++ b/utilities/fault_injection_fs_test.cc
@@ -16,6 +16,21 @@ namespace ROCKSDB_NAMESPACE {
 class InjectedErrorLogTest : public testing::Test {};
 class FaultInjectionTestFSTest : public testing::Test {};
 
+namespace {
+
+std::shared_ptr<FaultInjectionTestFS> NewFaultFsExcludingInfoLogs(
+    Env* env, FaultInjectionIOType type) {
+  auto fault_fs = std::make_shared<FaultInjectionTestFS>(env->GetFileSystem());
+  fault_fs->SetFileTypesExcludedFromFaultInjection({FileType::kInfoLogFile});
+  fault_fs->SetThreadLocalErrorContext(type, /*seed=*/0, /*one_in=*/1,
+                                       /*retryable=*/false,
+                                       /*has_data_loss=*/false);
+  fault_fs->EnableThreadLocalErrorInjection(type);
+  return fault_fs;
+}
+
+}  // namespace
+
 // Test basic Record and PrintAll functionality.
 TEST_F(InjectedErrorLogTest, BasicRecordAndPrint) {
   InjectedErrorLog log;
@@ -86,7 +101,7 @@ TEST_F(InjectedErrorLogTest, HexHead) {
   ASSERT_EQ(result, "01 02 ...");
 }
 
-TEST_F(FaultInjectionTestFSTest, MetadataReadFaultExcludesInfoLogFiles) {
+TEST_F(FaultInjectionTestFSTest, FaultInjectionExcludesInfoLogFiles) {
   Env* env = Env::Default();
   const std::string dbname =
       test::PerThreadDBPath("fault_injection_fs_test_metadata_read");
@@ -94,32 +109,91 @@ TEST_F(FaultInjectionTestFSTest, MetadataReadFaultExcludesInfoLogFiles) {
   ASSERT_OK(env->CreateDirIfMissing(dbname));
   ASSERT_OK(env->CreateDirIfMissing(log_dir));
 
+  const std::string current_info_log = InfoLogFileName(dbname, dbname, log_dir);
   const std::string old_info_log =
       OldInfoLogFileName(dbname, 123, dbname, log_dir);
   const std::string manifest = DescriptorFileName(dbname, 1);
+  const std::string manifest_for_write = DescriptorFileName(dbname, 2);
+  const std::string manifest_for_delete = DescriptorFileName(dbname, 3);
   ASSERT_OK(
       WriteStringToFile(env, "old log", old_info_log, false /* should_sync */));
   ASSERT_OK(
       WriteStringToFile(env, "manifest", manifest, false /* should_sync */));
+  ASSERT_OK(WriteStringToFile(env, "manifest delete", manifest_for_delete,
+                              false /* should_sync */));
 
-  auto fault_fs = std::make_shared<FaultInjectionTestFS>(env->GetFileSystem());
-  fault_fs->SetFileTypesExcludedFromMetadataReadFaultInjection(
-      {FileType::kInfoLogFile});
-  fault_fs->SetThreadLocalErrorContext(
-      FaultInjectionIOType::kMetadataRead, /*seed=*/0, /*one_in=*/1,
-      /*retryable=*/false, /*has_data_loss=*/false);
-  fault_fs->EnableThreadLocalErrorInjection(
-      FaultInjectionIOType::kMetadataRead);
+  {
+    auto fault_fs =
+        NewFaultFsExcludingInfoLogs(env, FaultInjectionIOType::kMetadataRead);
 
-  ASSERT_OK(fault_fs->FileExists(old_info_log, IOOptions(), nullptr));
-  ASSERT_EQ(0, fault_fs->GetAndResetInjectedThreadLocalErrorCount(
-                   FaultInjectionIOType::kMetadataRead));
+    ASSERT_OK(fault_fs->FileExists(old_info_log, IOOptions(), nullptr));
+    ASSERT_EQ(0, fault_fs->GetAndResetInjectedThreadLocalErrorCount(
+                     FaultInjectionIOType::kMetadataRead));
 
-  IOStatus s = fault_fs->FileExists(manifest, IOOptions(), nullptr);
-  ASSERT_NOK(s);
-  ASSERT_TRUE(s.IsIOError()) << s.ToString();
-  ASSERT_EQ(1, fault_fs->GetAndResetInjectedThreadLocalErrorCount(
-                   FaultInjectionIOType::kMetadataRead));
+    IOStatus s = fault_fs->FileExists(manifest, IOOptions(), nullptr);
+    ASSERT_NOK(s);
+    ASSERT_TRUE(s.IsIOError()) << s.ToString();
+    ASSERT_EQ(1, fault_fs->GetAndResetInjectedThreadLocalErrorCount(
+                     FaultInjectionIOType::kMetadataRead));
+  }
+
+  {
+    auto fault_fs =
+        NewFaultFsExcludingInfoLogs(env, FaultInjectionIOType::kRead);
+    std::unique_ptr<FSSequentialFile> seq_file;
+    ASSERT_OK(fault_fs->NewSequentialFile(old_info_log, FileOptions(),
+                                          &seq_file, nullptr /* dbg */));
+    char scratch[16];
+    Slice result;
+    ASSERT_OK(seq_file->Read(sizeof(scratch), IOOptions(), &result, scratch,
+                             nullptr /* dbg */));
+    ASSERT_EQ("old log", result.ToString());
+    ASSERT_EQ(0, fault_fs->GetAndResetInjectedThreadLocalErrorCount(
+                     FaultInjectionIOType::kRead));
+
+    std::unique_ptr<FSSequentialFile> manifest_seq_file;
+    IOStatus s = fault_fs->NewSequentialFile(
+        manifest, FileOptions(), &manifest_seq_file, nullptr /* dbg */);
+    ASSERT_NOK(s);
+    ASSERT_TRUE(s.IsIOError()) << s.ToString();
+    ASSERT_EQ(1, fault_fs->GetAndResetInjectedThreadLocalErrorCount(
+                     FaultInjectionIOType::kRead));
+  }
+
+  {
+    auto fault_fs =
+        NewFaultFsExcludingInfoLogs(env, FaultInjectionIOType::kWrite);
+    std::unique_ptr<FSWritableFile> info_log_writer;
+    ASSERT_OK(fault_fs->NewWritableFile(current_info_log, FileOptions(),
+                                        &info_log_writer, nullptr /* dbg */));
+    ASSERT_OK(
+        info_log_writer->Append("current log", IOOptions(), nullptr /* dbg */));
+    ASSERT_EQ(0, fault_fs->GetAndResetInjectedThreadLocalErrorCount(
+                     FaultInjectionIOType::kWrite));
+
+    std::unique_ptr<FSWritableFile> manifest_writer;
+    IOStatus s = fault_fs->NewWritableFile(manifest_for_write, FileOptions(),
+                                           &manifest_writer, nullptr /* dbg */);
+    ASSERT_NOK(s);
+    ASSERT_TRUE(s.IsIOError()) << s.ToString();
+    ASSERT_EQ(1, fault_fs->GetAndResetInjectedThreadLocalErrorCount(
+                     FaultInjectionIOType::kWrite));
+  }
+
+  {
+    auto fault_fs =
+        NewFaultFsExcludingInfoLogs(env, FaultInjectionIOType::kMetadataWrite);
+    ASSERT_OK(fault_fs->DeleteFile(old_info_log, IOOptions(), nullptr));
+    ASSERT_EQ(0, fault_fs->GetAndResetInjectedThreadLocalErrorCount(
+                     FaultInjectionIOType::kMetadataWrite));
+
+    IOStatus s =
+        fault_fs->DeleteFile(manifest_for_delete, IOOptions(), nullptr);
+    ASSERT_NOK(s);
+    ASSERT_TRUE(s.IsIOError()) << s.ToString();
+    ASSERT_EQ(1, fault_fs->GetAndResetInjectedThreadLocalErrorCount(
+                     FaultInjectionIOType::kMetadataWrite));
+  }
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/utilities/fault_injection_fs_test.cc
+++ b/utilities/fault_injection_fs_test.cc
@@ -14,6 +14,7 @@
 namespace ROCKSDB_NAMESPACE {
 
 class InjectedErrorLogTest : public testing::Test {};
+class FaultInjectionTestFSTest : public testing::Test {};
 
 // Test basic Record and PrintAll functionality.
 TEST_F(InjectedErrorLogTest, BasicRecordAndPrint) {
@@ -83,6 +84,39 @@ TEST_F(InjectedErrorLogTest, HexHead) {
 
   result = InjectedErrorLog::HexHead(data, 4, 2);
   ASSERT_EQ(result, "01 02 ...");
+}
+
+TEST_F(FaultInjectionTestFSTest, MetadataReadFaultExcludesInfoLogFiles) {
+  Env* env = Env::Default();
+  const std::string dbname =
+      test::PerThreadDBPath("fault_injection_fs_test_metadata_read");
+  ASSERT_OK(env->CreateDirIfMissing(dbname));
+
+  const std::string old_info_log = OldInfoLogFileName(dbname, 123);
+  const std::string manifest = DescriptorFileName(dbname, 1);
+  ASSERT_OK(
+      WriteStringToFile(env, "old log", old_info_log, false /* should_sync */));
+  ASSERT_OK(
+      WriteStringToFile(env, "manifest", manifest, false /* should_sync */));
+
+  auto fault_fs = std::make_shared<FaultInjectionTestFS>(env->GetFileSystem());
+  fault_fs->SetFileTypesExcludedFromMetadataReadFaultInjection(
+      {FileType::kInfoLogFile});
+  fault_fs->SetThreadLocalErrorContext(
+      FaultInjectionIOType::kMetadataRead, /*seed=*/0, /*one_in=*/1,
+      /*retryable=*/false, /*has_data_loss=*/false);
+  fault_fs->EnableThreadLocalErrorInjection(
+      FaultInjectionIOType::kMetadataRead);
+
+  ASSERT_OK(fault_fs->FileExists(old_info_log, IOOptions(), nullptr));
+  ASSERT_EQ(0, fault_fs->GetAndResetInjectedThreadLocalErrorCount(
+                   FaultInjectionIOType::kMetadataRead));
+
+  IOStatus s = fault_fs->FileExists(manifest, IOOptions(), nullptr);
+  ASSERT_NOK(s);
+  ASSERT_TRUE(s.IsIOError()) << s.ToString();
+  ASSERT_EQ(1, fault_fs->GetAndResetInjectedThreadLocalErrorCount(
+                   FaultInjectionIOType::kMetadataRead));
 }
 
 }  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
## Summary
- fix a false positive in `db_stress` PrefixScan fault accounting caused by info-log `FileExists()` probes going through metadata-read fault injection
- exclude `kInfoLogFile` from metadata-read injection and extend `FaultInjectionTestFS` filename parsing so LOG/LOG.old.* and `db_log_dir` info-log paths are recognized consistently
- add regression coverage showing info-log `FileExists()` bypasses metadata-read injection while manifest lookups still inject

## Testing
- make format-auto
- make -j48 fault_injection_fs_test db_stress
- timeout 60 ./fault_injection_fs_test
- timeout 60 ./fault_injection_fs_test --gtest_filter='*MetadataReadFaultExcludesInfoLogFiles*' --gtest_repeat=5