### PR TITLE
Disable min_tombstones_for_range_conversion in crash tests

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -467,7 +467,8 @@ default_params = {
     "auto_refresh_iterator_with_snapshot": lambda: random.choice([0, 1]),
     "memtable_op_scan_flush_trigger": lambda: random.choice([0, 10, 100, 1000]),
     "memtable_avg_op_scan_flush_trigger": lambda: random.choice([0, 2, 20, 200]),
-    "min_tombstones_for_range_conversion": lambda: random.choice([0, 2, 2, 4, 16]),
+    # TODO(jkangs): Change back to [0, 2, 2, 4, 16] once range tombstone conversion stabilizes
+    "min_tombstones_for_range_conversion": lambda: random.choice([0]),
     "ingest_wbwi_one_in": lambda: random.choice([0, 0, 100, 500]),
     "universal_reduce_file_locking": lambda: random.randint(0, 1),
     "compression_manager": lambda: random.choice(


### PR DESCRIPTION
Temporarily disable the feature until all fixes land and crash tests are stabilized. 