### PR TITLE
db_iter: eagerly resolve blob-backed iterator columns

### DIFF
--- a/db/blob/db_blob_index_test.cc
+++ b/db/blob/db_blob_index_test.cc
@@ -1405,6 +1405,83 @@ class BlobResolvingFilterFactory : public CompactionFilterFactory {
   std::string* resolved_large_col_value_;
 };
 
+class BlobResolvingErrorIgnoringFilter : public CompactionFilter {
+ public:
+  BlobResolvingErrorIgnoringFilter(std::atomic<int>* filter_call_count,
+                                   std::atomic<int>* resolve_error_count,
+                                   std::string* resolve_error_status)
+      : filter_call_count_(filter_call_count),
+        resolve_error_count_(resolve_error_count),
+        resolve_error_status_(resolve_error_status) {}
+
+  Decision FilterV4(
+      int /*level*/, const Slice& /*key*/, ValueType value_type,
+      const Slice* /*existing_value*/, const WideColumns* existing_columns,
+      std::string* /*new_value*/,
+      std::vector<std::pair<std::string, std::string>>* /*new_columns*/,
+      std::string* /*skip_until*/,
+      WideColumnBlobResolver* blob_resolver = nullptr) const override {
+    if (value_type != ValueType::kWideColumnEntity ||
+        existing_columns == nullptr || blob_resolver == nullptr) {
+      return Decision::kKeep;
+    }
+
+    ++(*filter_call_count_);
+
+    for (size_t i = 0; i < existing_columns->size(); ++i) {
+      const auto& col = (*existing_columns)[i];
+      if (col.name() == "large_col" && blob_resolver->IsBlobColumn(i)) {
+        Slice resolved_value;
+        const Status s = blob_resolver->ResolveColumn(i, &resolved_value);
+        if (!s.ok()) {
+          ++(*resolve_error_count_);
+          *resolve_error_status_ = s.ToString();
+        }
+        break;
+      }
+    }
+
+    // Even if the filter chooses kKeep after seeing a resolver error, the
+    // compaction path should still fail and surface that read error.
+    return Decision::kKeep;
+  }
+
+  bool SupportsFilterV4() const override { return true; }
+  const char* Name() const override {
+    return "BlobResolvingErrorIgnoringFilter";
+  }
+
+ private:
+  std::atomic<int>* filter_call_count_;
+  std::atomic<int>* resolve_error_count_;
+  std::string* resolve_error_status_;
+};
+
+class BlobResolvingErrorIgnoringFilterFactory : public CompactionFilterFactory {
+ public:
+  BlobResolvingErrorIgnoringFilterFactory(std::atomic<int>* filter_call_count,
+                                          std::atomic<int>* resolve_error_count,
+                                          std::string* resolve_error_status)
+      : filter_call_count_(filter_call_count),
+        resolve_error_count_(resolve_error_count),
+        resolve_error_status_(resolve_error_status) {}
+
+  std::unique_ptr<CompactionFilter> CreateCompactionFilter(
+      const CompactionFilter::Context& /*context*/) override {
+    return std::make_unique<BlobResolvingErrorIgnoringFilter>(
+        filter_call_count_, resolve_error_count_, resolve_error_status_);
+  }
+
+  const char* Name() const override {
+    return "BlobResolvingErrorIgnoringFilterFactory";
+  }
+
+ private:
+  std::atomic<int>* filter_call_count_;
+  std::atomic<int>* resolve_error_count_;
+  std::string* resolve_error_status_;
+};
+
 TEST_F(DBBlobIndexTest, EntityBlobLazyLoadingFilterResolvesBlobs) {
   // Test: When a compaction filter uses blob_resolver->ResolveColumn() to
   // fetch blob values, the values are correctly resolved.
@@ -1474,6 +1551,57 @@ TEST_F(DBBlobIndexTest, EntityBlobLazyLoadingFilterResolvesBlobs) {
   }
 
   Close();
+}
+
+TEST_F(DBBlobIndexTest, EntityBlobLazyLoadingFilterMissingBlobFailsCompaction) {
+  // Goal: keep lazy FilterV4 resolver failures aligned with the eager FilterV3
+  // path. The filter calls ResolveColumn() on a blob-backed column, then
+  // returns kKeep after observing the error. Compaction must still fail and
+  // latch bg_error instead of silently keeping the entry.
+  std::atomic<int> filter_call_count{0};
+  std::atomic<int> resolve_error_count{0};
+  std::string resolve_error_status;
+
+  Options options = GetBlobTestOptions();
+  options.enable_blob_garbage_collection = false;
+  options.paranoid_checks = true;
+  options.compaction_filter_factory =
+      std::make_shared<BlobResolvingErrorIgnoringFilterFactory>(
+          &filter_call_count, &resolve_error_count, &resolve_error_status);
+
+  DestroyAndReopen(options);
+
+  constexpr char key[] = "missing_blob_key_v4";
+  const std::string large_value(10 * 1024, 'L');
+  WideColumns columns{{"large_col", large_value}, {"small_col", "small"}};
+
+  ASSERT_OK(
+      db_->PutEntity(WriteOptions(), db_->DefaultColumnFamily(), key, columns));
+  ASSERT_OK(Flush());
+
+  const auto blob_files = GetBlobFileNumbers();
+  ASSERT_EQ(blob_files.size(), 1U);
+  ASSERT_OK(env_->DeleteFile(BlobFileName(dbname_, blob_files.front())));
+
+  const Status status =
+      db_->CompactRange(CompactRangeOptions(), nullptr, nullptr);
+  ASSERT_FALSE(status.ok())
+      << "Compaction should fail when FilterV4 lazy blob resolution hits a "
+         "read error";
+  ASSERT_TRUE(status.IsCorruption() || status.IsIOError() ||
+              status.IsNotFound())
+      << status.ToString();
+  ASSERT_GE(filter_call_count.load(), 1);
+  ASSERT_EQ(resolve_error_count.load(), 1);
+  ASSERT_FALSE(resolve_error_status.empty());
+
+  const Status bg_error = dbfull()->TEST_GetBGError();
+  ASSERT_FALSE(bg_error.ok());
+  ASSERT_TRUE(bg_error.IsCorruption() || bg_error.IsIOError() ||
+              bg_error.IsNotFound())
+      << bg_error.ToString();
+  ASSERT_GE(static_cast<int>(bg_error.severity()),
+            static_cast<int>(Status::Severity::kHardError));
 }
 
 // Test 8: Verify backward compatibility - old filters that don't

--- a/db/blob/db_blob_index_test.cc
+++ b/db/blob/db_blob_index_test.cc
@@ -336,9 +336,7 @@ TEST_F(DBBlobIndexTest, DirectWritePlainBlobFilterV3FlushUsesResolvedValue) {
       wide_column_test_util::GetDirectWriteOptions(GetTestOptions());
   options.compaction_filter_factory =
       std::make_shared<PlainBlobValueFilterV3Factory>(
-          TableFileCreationReason::kFlush,
-          &filter_call_count,
-          &observed_value);
+          TableFileCreationReason::kFlush, &filter_call_count, &observed_value);
 
   DestroyAndReopen(options);
 
@@ -355,10 +353,9 @@ TEST_F(DBBlobIndexTest, DirectWritePlainBlobFilterV3FlushUsesResolvedValue) {
 
 class PlainBlobValueFilterV4 : public CompactionFilter {
  public:
-  PlainBlobValueFilterV4(
-      std::atomic<int>* filter_call_count,
-      std::string* observed_value,
-      std::atomic<bool>* saw_nonnull_blob_resolver)
+  PlainBlobValueFilterV4(std::atomic<int>* filter_call_count,
+                         std::string* observed_value,
+                         std::atomic<bool>* saw_nonnull_blob_resolver)
       : filter_call_count_(filter_call_count),
         observed_value_(observed_value),
         saw_nonnull_blob_resolver_(saw_nonnull_blob_resolver) {}
@@ -376,8 +373,8 @@ class PlainBlobValueFilterV4 : public CompactionFilter {
 
     ++(*filter_call_count_);
     *observed_value_ = existing_value->ToString();
-    saw_nonnull_blob_resolver_->store(
-        blob_resolver != nullptr, std::memory_order_relaxed);
+    saw_nonnull_blob_resolver_->store(blob_resolver != nullptr,
+                                      std::memory_order_relaxed);
     return Decision::kRemove;
   }
 
@@ -392,11 +389,10 @@ class PlainBlobValueFilterV4 : public CompactionFilter {
 
 class PlainBlobValueFilterV4Factory : public CompactionFilterFactory {
  public:
-  PlainBlobValueFilterV4Factory(
-      TableFileCreationReason reason,
-      std::atomic<int>* filter_call_count,
-      std::string* observed_value,
-      std::atomic<bool>* saw_nonnull_blob_resolver)
+  PlainBlobValueFilterV4Factory(TableFileCreationReason reason,
+                                std::atomic<int>* filter_call_count,
+                                std::string* observed_value,
+                                std::atomic<bool>* saw_nonnull_blob_resolver)
       : reason_(reason),
         filter_call_count_(filter_call_count),
         observed_value_(observed_value),
@@ -434,9 +430,7 @@ TEST_F(DBBlobIndexTest, DirectWritePlainBlobFilterV4FlushUsesResolvedValue) {
       wide_column_test_util::GetDirectWriteOptions(GetTestOptions());
   options.compaction_filter_factory =
       std::make_shared<PlainBlobValueFilterV4Factory>(
-          TableFileCreationReason::kFlush,
-          &filter_call_count,
-          &observed_value,
+          TableFileCreationReason::kFlush, &filter_call_count, &observed_value,
           &saw_nonnull_blob_resolver);
 
   DestroyAndReopen(options);

--- a/db/blob/db_blob_index_test.cc
+++ b/db/blob/db_blob_index_test.cc
@@ -271,6 +271,188 @@ TEST_F(DBBlobIndexTest,
   ASSERT_EQ(static_cast<char>(BlobIndex::Type::kUnknown), blob_index.front());
 }
 
+class PlainBlobValueFilterV3 : public CompactionFilter {
+ public:
+  PlainBlobValueFilterV3(std::atomic<int>* filter_call_count,
+                         std::string* observed_value)
+      : filter_call_count_(filter_call_count),
+        observed_value_(observed_value) {}
+
+  Decision FilterV3(
+      int /*level*/, const Slice& /*key*/, ValueType value_type,
+      const Slice* existing_value, const WideColumns* /*existing_columns*/,
+      std::string* /*new_value*/,
+      std::vector<std::pair<std::string, std::string>>* /*new_columns*/,
+      std::string* /*skip_until*/) const override {
+    if (value_type != ValueType::kValue || existing_value == nullptr) {
+      return Decision::kKeep;
+    }
+
+    ++(*filter_call_count_);
+    *observed_value_ = existing_value->ToString();
+    return Decision::kRemove;
+  }
+
+  const char* Name() const override { return "PlainBlobValueFilterV3"; }
+
+ private:
+  std::atomic<int>* filter_call_count_;
+  std::string* observed_value_;
+};
+
+class PlainBlobValueFilterV3Factory : public CompactionFilterFactory {
+ public:
+  PlainBlobValueFilterV3Factory(TableFileCreationReason reason,
+                                std::atomic<int>* filter_call_count,
+                                std::string* observed_value)
+      : reason_(reason),
+        filter_call_count_(filter_call_count),
+        observed_value_(observed_value) {}
+
+  bool ShouldFilterTableFileCreation(
+      TableFileCreationReason reason) const override {
+    return reason == reason_;
+  }
+
+  std::unique_ptr<CompactionFilter> CreateCompactionFilter(
+      const CompactionFilter::Context& /*context*/) override {
+    return std::make_unique<PlainBlobValueFilterV3>(filter_call_count_,
+                                                    observed_value_);
+  }
+
+  const char* Name() const override { return "PlainBlobValueFilterV3Factory"; }
+
+ private:
+  TableFileCreationReason reason_;
+  std::atomic<int>* filter_call_count_;
+  std::string* observed_value_;
+};
+
+TEST_F(DBBlobIndexTest, DirectWritePlainBlobFilterV3FlushUsesResolvedValue) {
+  std::atomic<int> filter_call_count{0};
+  std::string observed_value;
+
+  Options options =
+      wide_column_test_util::GetDirectWriteOptions(GetTestOptions());
+  options.compaction_filter_factory =
+      std::make_shared<PlainBlobValueFilterV3Factory>(
+          TableFileCreationReason::kFlush,
+          &filter_call_count,
+          &observed_value);
+
+  DestroyAndReopen(options);
+
+  const std::string key = "flush_blob_key";
+  const std::string large_value(10 * 1024, 'F');
+
+  ASSERT_OK(Put(key, large_value));
+  ASSERT_OK(Flush());
+
+  ASSERT_EQ("NOT_FOUND", Get(key));
+  ASSERT_GE(filter_call_count.load(), 1);
+  ASSERT_EQ(observed_value, large_value);
+}
+
+class PlainBlobValueFilterV4 : public CompactionFilter {
+ public:
+  PlainBlobValueFilterV4(
+      std::atomic<int>* filter_call_count,
+      std::string* observed_value,
+      std::atomic<bool>* saw_nonnull_blob_resolver)
+      : filter_call_count_(filter_call_count),
+        observed_value_(observed_value),
+        saw_nonnull_blob_resolver_(saw_nonnull_blob_resolver) {}
+
+  Decision FilterV4(
+      int /*level*/, const Slice& /*key*/, ValueType value_type,
+      const Slice* existing_value, const WideColumns* /*existing_columns*/,
+      std::string* /*new_value*/,
+      std::vector<std::pair<std::string, std::string>>* /*new_columns*/,
+      std::string* /*skip_until*/,
+      WideColumnBlobResolver* blob_resolver = nullptr) const override {
+    if (value_type != ValueType::kValue || existing_value == nullptr) {
+      return Decision::kKeep;
+    }
+
+    ++(*filter_call_count_);
+    *observed_value_ = existing_value->ToString();
+    saw_nonnull_blob_resolver_->store(
+        blob_resolver != nullptr, std::memory_order_relaxed);
+    return Decision::kRemove;
+  }
+
+  bool SupportsFilterV4() const override { return true; }
+  const char* Name() const override { return "PlainBlobValueFilterV4"; }
+
+ private:
+  std::atomic<int>* filter_call_count_;
+  std::string* observed_value_;
+  std::atomic<bool>* saw_nonnull_blob_resolver_;
+};
+
+class PlainBlobValueFilterV4Factory : public CompactionFilterFactory {
+ public:
+  PlainBlobValueFilterV4Factory(
+      TableFileCreationReason reason,
+      std::atomic<int>* filter_call_count,
+      std::string* observed_value,
+      std::atomic<bool>* saw_nonnull_blob_resolver)
+      : reason_(reason),
+        filter_call_count_(filter_call_count),
+        observed_value_(observed_value),
+        saw_nonnull_blob_resolver_(saw_nonnull_blob_resolver) {}
+
+  bool ShouldFilterTableFileCreation(
+      TableFileCreationReason reason) const override {
+    return reason == reason_;
+  }
+
+  std::unique_ptr<CompactionFilter> CreateCompactionFilter(
+      const CompactionFilter::Context& /*context*/) override {
+    return std::make_unique<PlainBlobValueFilterV4>(
+        filter_call_count_, observed_value_, saw_nonnull_blob_resolver_);
+  }
+
+  const char* Name() const override { return "PlainBlobValueFilterV4Factory"; }
+
+ private:
+  TableFileCreationReason reason_;
+  std::atomic<int>* filter_call_count_;
+  std::string* observed_value_;
+  std::atomic<bool>* saw_nonnull_blob_resolver_;
+};
+
+// Blob direct-write forces a clean-shutdown flush on close so active blob
+// files are registered before reopen. Use flush to exercise the non-compaction
+// plain-blob FilterV4 path.
+TEST_F(DBBlobIndexTest, DirectWritePlainBlobFilterV4FlushUsesResolvedValue) {
+  std::atomic<int> filter_call_count{0};
+  std::string observed_value;
+  std::atomic<bool> saw_nonnull_blob_resolver{false};
+
+  Options options =
+      wide_column_test_util::GetDirectWriteOptions(GetTestOptions());
+  options.compaction_filter_factory =
+      std::make_shared<PlainBlobValueFilterV4Factory>(
+          TableFileCreationReason::kFlush,
+          &filter_call_count,
+          &observed_value,
+          &saw_nonnull_blob_resolver);
+
+  DestroyAndReopen(options);
+
+  const std::string key = "flush_v4_blob_key";
+  const std::string large_value(10 * 1024, 'R');
+
+  ASSERT_OK(Put(key, large_value));
+  ASSERT_OK(Flush());
+
+  ASSERT_EQ("NOT_FOUND", Get(key));
+  ASSERT_GE(filter_call_count.load(), 1);
+  ASSERT_EQ(observed_value, large_value);
+  ASSERT_FALSE(saw_nonnull_blob_resolver.load(std::memory_order_relaxed));
+}
+
 // Note: the following test case pertains to the StackableDB-based BlobDB
 // implementation. Get should NOT return Status::NotSupported/Status::Corruption
 // if blob index is updated with a normal value. See the test case above for

--- a/db/builder.cc
+++ b/db/builder.cc
@@ -16,6 +16,7 @@
 #include "db/blob/blob_counting_iterator.h"
 #include "db/blob/blob_file_builder.h"
 #include "db/blob/blob_garbage_meter.h"
+#include "db/column_family.h"
 #include "db/compaction/compaction_iterator.h"
 #include "db/dbformat.h"
 #include "db/event_helpers.h"
@@ -240,6 +241,15 @@ Status BuildTable(
         true /* must_count_input_entries */,
         /*compaction=*/nullptr, compaction_filter.get(),
         /*shutting_down=*/nullptr, db_options.info_log, full_history_ts_low);
+
+    if (version != nullptr) {
+      ColumnFamilyData* const cfd = version->cfd();
+      c_iter.SetBlobFetcher(
+          version, cfd != nullptr ? cfd->blob_file_cache() : nullptr,
+          tboptions.read_options.io_activity,
+          tboptions.reason == TableFileCreationReason::kFlush ||
+              tboptions.reason == TableFileCreationReason::kRecovery);
+    }
 
     SequenceNumber smallest_preferred_seqno = kMaxSequenceNumber;
     std::string key_after_flush_buf;

--- a/db/builder.cc
+++ b/db/builder.cc
@@ -240,7 +240,8 @@ Status BuildTable(
         /*manual_compaction_canceled=*/kManualCompactionCanceledFalse,
         true /* must_count_input_entries */,
         /*compaction=*/nullptr, compaction_filter.get(),
-        /*shutting_down=*/nullptr, db_options.info_log, full_history_ts_low);
+        /*shutting_down=*/nullptr, db_options.info_log, full_history_ts_low,
+        std::nullopt, version, tboptions.read_options.io_activity);
 
     if (version != nullptr) {
       ColumnFamilyData* const cfd = version->cfd();

--- a/db/compaction/compaction_iterator.cc
+++ b/db/compaction/compaction_iterator.cc
@@ -136,7 +136,9 @@ CompactionIterator::CompactionIterator(
     const std::atomic<bool>* shutting_down,
     const std::shared_ptr<Logger> info_log,
     const std::string* full_history_ts_low,
-    std::optional<SequenceNumber> preserve_seqno_min)
+    std::optional<SequenceNumber> preserve_seqno_min,
+    const Version* input_version,
+    Env::IOActivity blob_read_io_activity)
     : CompactionIterator(
           input, cmp, merge_helper, last_sequence, snapshots, earliest_snapshot,
           earliest_write_conflict_snapshot, job_snapshot, snapshot_checker, env,
@@ -145,7 +147,8 @@ CompactionIterator::CompactionIterator(
           manual_compaction_canceled,
           compaction ? std::make_unique<RealCompaction>(compaction) : nullptr,
           must_count_input_entries, compaction_filter, shutting_down, info_log,
-          full_history_ts_low, preserve_seqno_min) {}
+          full_history_ts_low, preserve_seqno_min, input_version,
+          blob_read_io_activity) {}
 
 CompactionIterator::CompactionIterator(
     InternalIterator* input, const Comparator* cmp, MergeHelper* merge_helper,
@@ -163,7 +166,9 @@ CompactionIterator::CompactionIterator(
     const std::atomic<bool>* shutting_down,
     const std::shared_ptr<Logger> info_log,
     const std::string* full_history_ts_low,
-    std::optional<SequenceNumber> preserve_seqno_min)
+    std::optional<SequenceNumber> preserve_seqno_min,
+    const Version* input_version,
+    Env::IOActivity blob_read_io_activity)
     : input_(input, cmp, must_count_input_entries),
       cmp_(cmp),
       merge_helper_(merge_helper),
@@ -198,7 +203,8 @@ CompactionIterator::CompactionIterator(
       merge_out_iter_(merge_helper_),
       blob_garbage_collection_cutoff_file_number_(
           ComputeBlobGarbageCollectionCutoffFileNumber(compaction_.get())),
-      blob_fetcher_(CreateBlobFetcherIfNeeded(compaction_.get())),
+      blob_fetcher_(CreateBlobFetcherIfNeeded(
+          compaction_.get(), input_version, blob_read_io_activity)),
       prefetch_buffers_(
           CreatePrefetchBufferCollectionIfNeeded(compaction_.get())),
       current_key_committed_(false),
@@ -378,9 +384,10 @@ bool CompactionIterator::InvokeFilterIfNeeded(bool* need_skip,
           compaction_filter_skip_until_.rep());
       if (decision == CompactionFilter::Decision::kUndetermined &&
           !compaction_filter_->IsStackedBlobDbInternalCompactionFilter()) {
-        if (!compaction_) {
-          status_ =
-              Status::Corruption("Unexpected blob index outside of compaction");
+        if (!blob_fetcher_) {
+          status_ = Status::NotSupported(
+              "Blob-backed value filtering requires blob read support in the "
+              "current table-file creation context");
           validity_info_.Invalidate();
           return false;
         }
@@ -406,8 +413,6 @@ bool CompactionIterator::InvokeFilterIfNeeded(bool* need_skip,
                               : nullptr;
 
         uint64_t bytes_read = 0;
-
-        assert(blob_fetcher_);
 
         s = blob_fetcher_->FetchBlob(ikey_.user_key, blob_index,
                                      prefetch_buffer, &blob_value_,
@@ -2032,21 +2037,33 @@ uint64_t CompactionIterator::ComputeBlobGarbageCollectionCutoffFileNumber(
 }
 
 std::unique_ptr<BlobFetcher> CompactionIterator::CreateBlobFetcherIfNeeded(
-    const CompactionProxy* compaction) {
-  if (!compaction) {
-    return nullptr;
-  }
-
-  const Version* const version = compaction->input_version();
-  if (!version) {
+    const CompactionProxy* compaction,
+    const Version* input_version,
+    Env::IOActivity blob_read_io_activity) {
+  const Version* const version =
+      compaction != nullptr ? compaction->input_version() : input_version;
+  if (version == nullptr) {
     return nullptr;
   }
 
   ReadOptions read_options;
-  read_options.io_activity = Env::IOActivity::kCompaction;
+  read_options.io_activity = compaction != nullptr
+      ? Env::IOActivity::kCompaction
+      : blob_read_io_activity;
   read_options.fill_cache = false;
 
-  return std::unique_ptr<BlobFetcher>(new BlobFetcher(version, read_options));
+  BlobFileCache* blob_file_cache = nullptr;
+  bool allow_write_path_fallback = false;
+  if (compaction == nullptr) {
+    allow_write_path_fallback = true;
+    auto* cfd = version->cfd();
+    if (cfd != nullptr) {
+      blob_file_cache = cfd->blob_file_cache();
+    }
+  }
+
+  return std::unique_ptr<BlobFetcher>(new BlobFetcher(
+      version, read_options, blob_file_cache, allow_write_path_fallback));
 }
 
 std::unique_ptr<PrefetchBufferCollection>

--- a/db/compaction/compaction_iterator.cc
+++ b/db/compaction/compaction_iterator.cc
@@ -37,12 +37,14 @@ void CompactionBlobResolver::Init(BlobFetcher* blob_fetcher,
 
 void CompactionBlobResolver::Reset(
     const Slice& user_key, const std::vector<WideColumn>* columns,
-    const std::vector<std::pair<size_t, BlobIndex>>* blob_columns) {
+    const std::vector<std::pair<size_t, BlobIndex>>* blob_columns,
+    bool track_resolve_error) {
   user_key_ = user_key;
   columns_ = columns;
   blob_columns_ = blob_columns;
+  track_resolve_error_ = track_resolve_error;
   resolved_cache_.clear();
-  resolve_status_ = Status::OK();
+  resolve_error_.reset();
 }
 
 Status CompactionBlobResolver::ResolveColumn(size_t column_index,
@@ -100,8 +102,8 @@ Status CompactionBlobResolver::ResolveColumn(size_t column_index,
       }
     }
   }
-  if (!status.ok() && resolve_status_.ok()) {
-    resolve_status_ = status;
+  if (!status.ok() && track_resolve_error_ && !resolve_error_.has_value()) {
+    resolve_error_.emplace(status);
   }
   return status;
 }
@@ -493,7 +495,8 @@ bool CompactionIterator::InvokeFilterIfNeeded(bool* need_skip,
             // Reset member blob resolver for this entity - filter can call
             // resolver->ResolveColumn() to fetch blob values on-demand
             blob_resolver_.Reset(ikey_.user_key, &entity_columns_,
-                                 &entity_blob_columns_);
+                                 &entity_blob_columns_,
+                                 /*track_resolve_error=*/true);
             blob_resolver_ptr = &blob_resolver_;
           } else {
             // FilterV3 compatibility: eagerly resolve all blob columns so
@@ -559,15 +562,17 @@ bool CompactionIterator::InvokeFilterIfNeeded(bool* need_skip,
           &compaction_filter_value_, &new_columns,
           compaction_filter_skip_until_.rep(), blob_resolver_ptr);
 
-      if (blob_resolver_ptr != nullptr &&
-          !blob_resolver_.resolve_status().ok()) {
-        // Keep lazy FilterV4 failure semantics aligned with the eager FilterV3
-        // compatibility path: if blob resolution fails while the filter is
-        // inspecting the entry, fail compaction even if the filter returned
-        // kKeep after noticing the error.
-        status_ = blob_resolver_.resolve_status();
-        validity_info_.Invalidate();
-        return false;
+      if (blob_resolver_ptr != nullptr) {
+        Status resolve_status = blob_resolver_.resolve_status();
+        if (!resolve_status.ok()) {
+          // Keep lazy FilterV4 failure semantics aligned with the eager
+          // FilterV3 compatibility path: if blob resolution fails while the
+          // filter is inspecting the entry, fail compaction even if the
+          // filter returned kKeep after noticing the error.
+          status_ = std::move(resolve_status);
+          validity_info_.Invalidate();
+          return false;
+        }
       }
     }
 

--- a/db/compaction/compaction_iterator.cc
+++ b/db/compaction/compaction_iterator.cc
@@ -137,8 +137,7 @@ CompactionIterator::CompactionIterator(
     const std::shared_ptr<Logger> info_log,
     const std::string* full_history_ts_low,
     std::optional<SequenceNumber> preserve_seqno_min,
-    const Version* input_version,
-    Env::IOActivity blob_read_io_activity)
+    const Version* input_version, Env::IOActivity blob_read_io_activity)
     : CompactionIterator(
           input, cmp, merge_helper, last_sequence, snapshots, earliest_snapshot,
           earliest_write_conflict_snapshot, job_snapshot, snapshot_checker, env,
@@ -167,8 +166,7 @@ CompactionIterator::CompactionIterator(
     const std::shared_ptr<Logger> info_log,
     const std::string* full_history_ts_low,
     std::optional<SequenceNumber> preserve_seqno_min,
-    const Version* input_version,
-    Env::IOActivity blob_read_io_activity)
+    const Version* input_version, Env::IOActivity blob_read_io_activity)
     : input_(input, cmp, must_count_input_entries),
       cmp_(cmp),
       merge_helper_(merge_helper),
@@ -203,8 +201,8 @@ CompactionIterator::CompactionIterator(
       merge_out_iter_(merge_helper_),
       blob_garbage_collection_cutoff_file_number_(
           ComputeBlobGarbageCollectionCutoffFileNumber(compaction_.get())),
-      blob_fetcher_(CreateBlobFetcherIfNeeded(
-          compaction_.get(), input_version, blob_read_io_activity)),
+      blob_fetcher_(CreateBlobFetcherIfNeeded(compaction_.get(), input_version,
+                                              blob_read_io_activity)),
       prefetch_buffers_(
           CreatePrefetchBufferCollectionIfNeeded(compaction_.get())),
       current_key_committed_(false),
@@ -2037,8 +2035,7 @@ uint64_t CompactionIterator::ComputeBlobGarbageCollectionCutoffFileNumber(
 }
 
 std::unique_ptr<BlobFetcher> CompactionIterator::CreateBlobFetcherIfNeeded(
-    const CompactionProxy* compaction,
-    const Version* input_version,
+    const CompactionProxy* compaction, const Version* input_version,
     Env::IOActivity blob_read_io_activity) {
   const Version* const version =
       compaction != nullptr ? compaction->input_version() : input_version;
@@ -2048,8 +2045,8 @@ std::unique_ptr<BlobFetcher> CompactionIterator::CreateBlobFetcherIfNeeded(
 
   ReadOptions read_options;
   read_options.io_activity = compaction != nullptr
-      ? Env::IOActivity::kCompaction
-      : blob_read_io_activity;
+                                 ? Env::IOActivity::kCompaction
+                                 : blob_read_io_activity;
   read_options.fill_cache = false;
 
   BlobFileCache* blob_file_cache = nullptr;

--- a/db/compaction/compaction_iterator.cc
+++ b/db/compaction/compaction_iterator.cc
@@ -42,10 +42,15 @@ void CompactionBlobResolver::Reset(
   columns_ = columns;
   blob_columns_ = blob_columns;
   resolved_cache_.clear();
+  resolve_status_ = Status::OK();
 }
 
 Status CompactionBlobResolver::ResolveColumn(size_t column_index,
                                              Slice* resolved_value) {
+  if (!resolve_status_.ok()) {
+    return resolve_status_;
+  }
+
   Status status = Status::OK();
   if (columns_ == nullptr || column_index >= columns_->size()) {
     status = Status::InvalidArgument("Column index out of bounds");
@@ -98,6 +103,9 @@ Status CompactionBlobResolver::ResolveColumn(size_t column_index,
         }
       }
     }
+  }
+  if (!status.ok()) {
+    resolve_status_ = status;
   }
   return status;
 }
@@ -533,6 +541,17 @@ bool CompactionIterator::InvokeFilterIfNeeded(bool* need_skip,
           level_, filter_key, value_type, existing_val, existing_col,
           &compaction_filter_value_, &new_columns,
           compaction_filter_skip_until_.rep(), blob_resolver_ptr);
+
+      if (blob_resolver_ptr != nullptr &&
+          !blob_resolver_.resolve_status().ok()) {
+        // Keep lazy FilterV4 failure semantics aligned with the eager FilterV3
+        // compatibility path: if blob resolution fails while the filter is
+        // inspecting the entry, fail compaction even if the filter returned
+        // kKeep after noticing the error.
+        status_ = blob_resolver_.resolve_status();
+        validity_info_.Invalidate();
+        return false;
+      }
     }
 
     iter_stats_.total_filter_time +=

--- a/db/compaction/compaction_iterator.cc
+++ b/db/compaction/compaction_iterator.cc
@@ -47,10 +47,6 @@ void CompactionBlobResolver::Reset(
 
 Status CompactionBlobResolver::ResolveColumn(size_t column_index,
                                              Slice* resolved_value) {
-  if (!resolve_status_.ok()) {
-    return resolve_status_;
-  }
-
   Status status = Status::OK();
   if (columns_ == nullptr || column_index >= columns_->size()) {
     status = Status::InvalidArgument("Column index out of bounds");
@@ -104,7 +100,7 @@ Status CompactionBlobResolver::ResolveColumn(size_t column_index,
       }
     }
   }
-  if (!status.ok()) {
+  if (!status.ok() && resolve_status_.ok()) {
     resolve_status_ = status;
   }
   return status;
@@ -235,6 +231,24 @@ CompactionIterator::CompactionIterator(
 CompactionIterator::~CompactionIterator() {
   // input_ Iterator lifetime is longer than pinned_iters_mgr_ lifetime
   input_.SetPinnedItersMgr(nullptr);
+}
+
+void CompactionIterator::SetBlobFetcher(const Version* version,
+                                        BlobFileCache* blob_file_cache,
+                                        Env::IOActivity io_activity,
+                                        bool allow_write_path_fallback) {
+  if (blob_fetcher_ != nullptr || version == nullptr) {
+    return;
+  }
+
+  ReadOptions read_options;
+  read_options.io_activity = io_activity;
+  read_options.fill_cache = false;
+
+  blob_fetcher_ = std::make_unique<BlobFetcher>(
+      version, read_options, blob_file_cache, allow_write_path_fallback);
+  blob_resolver_.Init(blob_fetcher_.get(), prefetch_buffers_.get(),
+                      &iter_stats_);
 }
 
 void CompactionIterator::ResetRecordCounts() {

--- a/db/compaction/compaction_iterator.h
+++ b/db/compaction/compaction_iterator.h
@@ -39,7 +39,8 @@ class CompactionBlobResolver : public WideColumnBlobResolver {
         blob_columns_(nullptr),
         blob_fetcher_(nullptr),
         prefetch_buffers_(nullptr),
-        iter_stats_(nullptr) {}
+        iter_stats_(nullptr),
+        resolve_status_() {}
 
   // Set the fixed context (blob fetcher, prefetch buffers, stats) once.
   void Init(BlobFetcher* blob_fetcher,
@@ -49,6 +50,7 @@ class CompactionBlobResolver : public WideColumnBlobResolver {
   Status ResolveColumn(size_t column_index, Slice* resolved_value) override;
   bool IsBlobColumn(size_t column_index) const override;
   size_t NumColumns() const override;
+  const Status& resolve_status() const { return resolve_status_; }
 
   // Reset the resolver for a new entity. Clears resolved cache.
   void Reset(const Slice& user_key, const std::vector<WideColumn>* columns,
@@ -67,6 +69,10 @@ class CompactionBlobResolver : public WideColumnBlobResolver {
   // columns (<5), making linear scan cheaper than hash map overhead.
   std::vector<std::pair<size_t, std::unique_ptr<PinnableSlice>>>
       resolved_cache_;
+  // Sticky resolver error for the current entity. FilterV4 may notice the
+  // error and return kKeep, but compaction should still fail just like the
+  // eager FilterV3 compatibility path does.
+  Status resolve_status_;
 };
 
 // A wrapper of internal iterator whose purpose is to count how

--- a/db/compaction/compaction_iterator.h
+++ b/db/compaction/compaction_iterator.h
@@ -8,6 +8,7 @@
 #include <cinttypes>
 #include <deque>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -42,8 +43,7 @@ class CompactionBlobResolver : public WideColumnBlobResolver {
         blob_columns_(nullptr),
         blob_fetcher_(nullptr),
         prefetch_buffers_(nullptr),
-        iter_stats_(nullptr),
-        resolve_status_() {}
+        iter_stats_(nullptr) {}
 
   // Set the fixed context (blob fetcher, prefetch buffers, stats) once.
   void Init(BlobFetcher* blob_fetcher,
@@ -53,11 +53,17 @@ class CompactionBlobResolver : public WideColumnBlobResolver {
   Status ResolveColumn(size_t column_index, Slice* resolved_value) override;
   bool IsBlobColumn(size_t column_index) const override;
   size_t NumColumns() const override;
-  const Status& resolve_status() const { return resolve_status_; }
+  Status resolve_status() const {
+    if (!resolve_error_.has_value()) {
+      return Status::OK();
+    }
+    return *resolve_error_;
+  }
 
   // Reset the resolver for a new entity. Clears resolved cache.
   void Reset(const Slice& user_key, const std::vector<WideColumn>* columns,
-             const std::vector<std::pair<size_t, BlobIndex>>* blob_columns);
+             const std::vector<std::pair<size_t, BlobIndex>>* blob_columns,
+             bool track_resolve_error = false);
 
  private:
   Slice user_key_;
@@ -66,16 +72,17 @@ class CompactionBlobResolver : public WideColumnBlobResolver {
   BlobFetcher* blob_fetcher_;
   PrefetchBufferCollection* prefetch_buffers_;
   CompactionIterationStats* iter_stats_;
+  bool track_resolve_error_ = false;
 
   // Cache for resolved blob values to avoid re-fetching. Uses a vector of
   // (column_index, PinnableSlice) pairs — typical entities have few blob
   // columns (<5), making linear scan cheaper than hash map overhead.
   std::vector<std::pair<size_t, std::unique_ptr<PinnableSlice>>>
       resolved_cache_;
-  // Sticky resolver error for the current entity. FilterV4 may notice the
-  // error and return kKeep, but compaction should still fail just like the
-  // eager FilterV3 compatibility path does.
-  Status resolve_status_;
+  // Sticky resolver error for the current entity. This is enabled only for the
+  // lazy FilterV4 path so compaction can still fail even if the filter
+  // notices the error and returns kKeep.
+  std::optional<Status> resolve_error_;
 };
 
 // A wrapper of internal iterator whose purpose is to count how

--- a/db/compaction/compaction_iterator.h
+++ b/db/compaction/compaction_iterator.h
@@ -25,9 +25,11 @@
 namespace ROCKSDB_NAMESPACE {
 
 class BlobFileBuilder;
+class BlobFileCache;
 class BlobFetcher;
 class PrefetchBufferCollection;
 class FilePrefetchBuffer;
+class Version;
 
 // Internal implementation of WideColumnBlobResolver for compaction.
 // This class enables lazy loading of blob column values during compaction
@@ -289,6 +291,13 @@ class CompactionIterator {
   ~CompactionIterator();
 
   void ResetRecordCounts();
+
+  // Non-compaction table-file creation (e.g., flush/recovery) can still need
+  // blob resolution when direct-write wide entities already contain blob
+  // references. Plumb a fetcher explicitly in those cases.
+  void SetBlobFetcher(const Version* version, BlobFileCache* blob_file_cache,
+                      Env::IOActivity io_activity,
+                      bool allow_write_path_fallback);
 
   // Seek to the beginning of the compaction iterator output.
   //

--- a/db/compaction/compaction_iterator.h
+++ b/db/compaction/compaction_iterator.h
@@ -270,29 +270,26 @@ class CompactionIterator {
       Env::IOActivity blob_read_io_activity = Env::IOActivity::kCompaction);
 
   // Constructor with custom CompactionProxy, used for tests.
-  CompactionIterator(InternalIterator* input, const Comparator* cmp,
-                     MergeHelper* merge_helper, SequenceNumber last_sequence,
-                     std::vector<SequenceNumber>* snapshots,
-                     SequenceNumber earliest_snapshot,
-                     SequenceNumber earliest_write_conflict_snapshot,
-                     SequenceNumber job_snapshot,
-                     const SnapshotChecker* snapshot_checker, Env* env,
-                     bool report_detailed_time,
-                     CompactionRangeDelAggregator* range_del_agg,
-                     BlobFileBuilder* blob_file_builder,
-                     bool allow_data_in_errors,
-                     bool enforce_single_del_contracts,
-                     const std::atomic<bool>& manual_compaction_canceled,
-                     std::unique_ptr<CompactionProxy> compaction,
-                     bool must_count_input_entries,
-                     const CompactionFilter* compaction_filter = nullptr,
-                     const std::atomic<bool>* shutting_down = nullptr,
-                     const std::shared_ptr<Logger> info_log = nullptr,
-                     const std::string* full_history_ts_low = nullptr,
-                     std::optional<SequenceNumber> preserve_seqno_min = {},
-                     const Version* input_version = nullptr,
-                     Env::IOActivity blob_read_io_activity =
-                         Env::IOActivity::kCompaction);
+  CompactionIterator(
+      InternalIterator* input, const Comparator* cmp, MergeHelper* merge_helper,
+      SequenceNumber last_sequence, std::vector<SequenceNumber>* snapshots,
+      SequenceNumber earliest_snapshot,
+      SequenceNumber earliest_write_conflict_snapshot,
+      SequenceNumber job_snapshot, const SnapshotChecker* snapshot_checker,
+      Env* env, bool report_detailed_time,
+      CompactionRangeDelAggregator* range_del_agg,
+      BlobFileBuilder* blob_file_builder, bool allow_data_in_errors,
+      bool enforce_single_del_contracts,
+      const std::atomic<bool>& manual_compaction_canceled,
+      std::unique_ptr<CompactionProxy> compaction,
+      bool must_count_input_entries,
+      const CompactionFilter* compaction_filter = nullptr,
+      const std::atomic<bool>* shutting_down = nullptr,
+      const std::shared_ptr<Logger> info_log = nullptr,
+      const std::string* full_history_ts_low = nullptr,
+      std::optional<SequenceNumber> preserve_seqno_min = {},
+      const Version* input_version = nullptr,
+      Env::IOActivity blob_read_io_activity = Env::IOActivity::kCompaction);
 
   ~CompactionIterator();
 
@@ -455,8 +452,7 @@ class CompactionIterator {
   static uint64_t ComputeBlobGarbageCollectionCutoffFileNumber(
       const CompactionProxy* compaction);
   static std::unique_ptr<BlobFetcher> CreateBlobFetcherIfNeeded(
-      const CompactionProxy* compaction,
-      const Version* input_version,
+      const CompactionProxy* compaction, const Version* input_version,
       Env::IOActivity blob_read_io_activity);
   static std::unique_ptr<PrefetchBufferCollection>
   CreatePrefetchBufferCollectionIfNeeded(const CompactionProxy* compaction);

--- a/db/compaction/compaction_iterator.h
+++ b/db/compaction/compaction_iterator.h
@@ -27,6 +27,7 @@ namespace ROCKSDB_NAMESPACE {
 class BlobFileBuilder;
 class BlobFileCache;
 class BlobFetcher;
+class Version;
 class PrefetchBufferCollection;
 class FilePrefetchBuffer;
 class Version;
@@ -264,7 +265,9 @@ class CompactionIterator {
       const std::atomic<bool>* shutting_down = nullptr,
       const std::shared_ptr<Logger> info_log = nullptr,
       const std::string* full_history_ts_low = nullptr,
-      std::optional<SequenceNumber> preserve_seqno_min = {});
+      std::optional<SequenceNumber> preserve_seqno_min = {},
+      const Version* input_version = nullptr,
+      Env::IOActivity blob_read_io_activity = Env::IOActivity::kCompaction);
 
   // Constructor with custom CompactionProxy, used for tests.
   CompactionIterator(InternalIterator* input, const Comparator* cmp,
@@ -286,7 +289,10 @@ class CompactionIterator {
                      const std::atomic<bool>* shutting_down = nullptr,
                      const std::shared_ptr<Logger> info_log = nullptr,
                      const std::string* full_history_ts_low = nullptr,
-                     std::optional<SequenceNumber> preserve_seqno_min = {});
+                     std::optional<SequenceNumber> preserve_seqno_min = {},
+                     const Version* input_version = nullptr,
+                     Env::IOActivity blob_read_io_activity =
+                         Env::IOActivity::kCompaction);
 
   ~CompactionIterator();
 
@@ -449,7 +455,9 @@ class CompactionIterator {
   static uint64_t ComputeBlobGarbageCollectionCutoffFileNumber(
       const CompactionProxy* compaction);
   static std::unique_ptr<BlobFetcher> CreateBlobFetcherIfNeeded(
-      const CompactionProxy* compaction);
+      const CompactionProxy* compaction,
+      const Version* input_version,
+      Env::IOActivity blob_read_io_activity);
   static std::unique_ptr<PrefetchBufferCollection>
   CreatePrefetchBufferCollectionIfNeeded(const CompactionProxy* compaction);
 

--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -396,19 +396,14 @@ bool DBIter::SetValueAndColumnsFromEntity(Slice slice) {
     }
   }
 
-  // Resolve only the default column on iterator positioning. Non-default blob
-  // columns stay lazy until columns() is explicitly requested.
+  // Iterator positions must expose fully prepared values and columns once
+  // Valid() becomes true, so resolve and materialize all blob columns here.
   state.BindLazyEntity(saved_key_.GetUserKey());
-
-  if (UNLIKELY(state.HasLazyDefaultColumn())) {
-    const Status s = state.ResolveDefaultLazyColumn();
-    if (!s.ok()) {
-      status_ = s;
-      valid_ = false;
-      state.ClearLazyEntity();
-      return false;
-    }
+  if (!MaterializeLazyEntityColumns()) {
+    state.ClearLazyEntity();
+    return false;
   }
+  state.MaybeSetValueFromMaterializedDefaultColumn();
 
   return true;
 }

--- a/db/db_iter.h
+++ b/db/db_iter.h
@@ -200,16 +200,8 @@ class DBIter final : public Iterator {
 
   const WideColumns& columns() const override {
     assert(valid_);
-
-    if (value_columns_state_.HasMaterializedColumns() ||
-        !value_columns_state_.HasLazyEntityColumns()) {
-      return value_columns_state_.wide_columns();
-    }
-
-    if (!MaterializeLazyEntityColumns()) {
-      return kNoWideColumns;
-    }
-
+    assert(!value_columns_state_.HasLazyEntityColumns() ||
+           value_columns_state_.HasMaterializedColumns());
     return value_columns_state_.wide_columns();
   }
 
@@ -411,22 +403,6 @@ class DBIter final : public Iterator {
       if (WideColumnsHelper::HasDefaultColumn(wide_columns_)) {
         value_ = WideColumnsHelper::GetDefaultColumn(wide_columns_);
       }
-    }
-
-    // Returns true when the deserialized lazy entity has the default column.
-    bool HasLazyDefaultColumn() const {
-      return WideColumnsHelper::HasDefaultColumn(lazy_entity_columns_);
-    }
-
-    // Resolves the lazy default column and stores it in value_.
-    Status ResolveDefaultLazyColumn() {
-      Slice resolved_default_value;
-      Status s = entity_blob_resolver_.ResolveColumn(/*column_index=*/0,
-                                                     &resolved_default_value);
-      if (s.ok()) {
-        value_ = resolved_default_value;
-      }
-      return s;
     }
 
     void SetFromPlain(const Slice& slice) {

--- a/db/merge_helper.cc
+++ b/db/merge_helper.cc
@@ -670,7 +670,8 @@ Status MergeHelper::MergeUntil(InternalIterator* iter,
         // Replace operands with the merge result
         if (UNLIKELY(merge_result.size() >
                      std::numeric_limits<uint32_t>::max())) {
-          return Status::Corruption("PartialMerge result exceeds 4GB limit");
+          s = Status::Corruption("PartialMerge result exceeds 4GB limit");
+          return s;
         }
         merge_context_.Clear();
         merge_context_.PushOperand(merge_result);

--- a/db/wide/db_wide_blob_direct_write_test.cc
+++ b/db/wide/db_wide_blob_direct_write_test.cc
@@ -1220,8 +1220,9 @@ TEST_F(DBWideBlobDirectWriteTest,
   DestroyAndReopen(options);
 
   constexpr char key[] = "wide_entity_key_missing_blob";
+  const std::string blob_attr_value(128, 'b');
   const WideColumns columns{{kDefaultWideColumnName, "inline-default"},
-                            {"blob_attr", std::string(128, 'b')},
+                            {"blob_attr", blob_attr_value},
                             {"ttl", "00000001"}};
 
   ASSERT_OK(

--- a/db/wide/db_wide_blob_direct_write_test.cc
+++ b/db/wide/db_wide_blob_direct_write_test.cc
@@ -445,7 +445,8 @@ class ResolvingWideValueFilter : public CompactionFilter {
   std::string* resolved_default_value_;
 };
 
-class FlushOnlyResolvingWideValueFilterFactory : public CompactionFilterFactory {
+class FlushOnlyResolvingWideValueFilterFactory
+    : public CompactionFilterFactory {
  public:
   FlushOnlyResolvingWideValueFilterFactory(
       std::atomic<int>* filter_call_count,
@@ -460,9 +461,7 @@ class FlushOnlyResolvingWideValueFilterFactory : public CompactionFilterFactory 
   std::unique_ptr<CompactionFilter> CreateCompactionFilter(
       const CompactionFilter::Context& /*context*/) override {
     return std::make_unique<ResolvingWideValueFilter>(
-        filter_call_count_,
-        resolve_attempt_count_,
-        resolve_failure_count_,
+        filter_call_count_, resolve_attempt_count_, resolve_failure_count_,
         resolved_default_value_);
   }
 
@@ -545,8 +544,7 @@ class FlushOnlyBlobResolvingErrorIgnoringFilterFactory
  public:
   FlushOnlyBlobResolvingErrorIgnoringFilterFactory(
       std::atomic<int>* filter_call_count,
-      std::atomic<int>* resolve_error_count,
-      std::string* resolve_error_status)
+      std::atomic<int>* resolve_error_count, std::string* resolve_error_status)
       : filter_call_count_(filter_call_count),
         resolve_error_count_(resolve_error_count),
         resolve_error_status_(resolve_error_status) {}
@@ -1193,7 +1191,8 @@ TEST_F(DBWideBlobDirectWriteTest,
   ASSERT_EQ(cf_meta.blob_files[0].garbage_blob_bytes, 0U);
 }
 
-TEST_F(DBWideBlobDirectWriteTest, DirectWriteWideEntityBlobResolverWorksOnFlush) {
+TEST_F(DBWideBlobDirectWriteTest,
+       DirectWriteWideEntityBlobResolverWorksOnFlush) {
   std::atomic<int> filter_call_count{0};
   std::atomic<int> resolve_attempt_count{0};
   std::atomic<int> resolve_failure_count{0};
@@ -1201,9 +1200,7 @@ TEST_F(DBWideBlobDirectWriteTest, DirectWriteWideEntityBlobResolverWorksOnFlush)
 
   auto filter_factory =
       std::make_shared<FlushOnlyResolvingWideValueFilterFactory>(
-          &filter_call_count,
-          &resolve_attempt_count,
-          &resolve_failure_count,
+          &filter_call_count, &resolve_attempt_count, &resolve_failure_count,
           &resolved_default_value);
 
   Options options = GetDirectWriteOptions();
@@ -1223,8 +1220,8 @@ TEST_F(DBWideBlobDirectWriteTest, DirectWriteWideEntityBlobResolverWorksOnFlush)
   const auto columns_data = BuildTTLWideEntityData(large_value, ttl_value);
   const WideColumns columns = ToWideColumns(columns_data);
 
-  ASSERT_OK(db_->PutEntity(WriteOptions(), db_->DefaultColumnFamily(), key,
-                           columns));
+  ASSERT_OK(
+      db_->PutEntity(WriteOptions(), db_->DefaultColumnFamily(), key, columns));
   ASSERT_OK(Flush());
 
   ASSERT_GE(filter_call_count.load(), 1);

--- a/db/wide/db_wide_blob_direct_write_test.cc
+++ b/db/wide/db_wide_blob_direct_write_test.cc
@@ -1149,19 +1149,16 @@ TEST_F(DBWideBlobDirectWriteTest,
 }
 
 TEST_F(DBWideBlobDirectWriteTest,
-       DirectWriteIteratorValueScanDefersUnneededBlobColumns) {
+       DirectWriteIteratorValueScanEagerlyResolvesBlobColumns) {
   struct IteratorScanCase {
     const char* name;
     std::string default_value;
     std::string blob_attr_value;
-    bool expect_default_blob_read;
   };
 
   const std::array<IteratorScanCase, 2> cases{{
-      {"inline_default", "inline-default", std::string(128, 'b'),
-       /*expect_default_blob_read=*/false},
-      {"blob_default", std::string(128, 'd'), std::string(160, 'e'),
-       /*expect_default_blob_read=*/true},
+      {"inline_default", "inline-default", std::string(128, 'b')},
+      {"blob_default", std::string(128, 'd'), std::string(160, 'e')},
   }};
 
   for (const auto& test_case : cases) {
@@ -1197,23 +1194,56 @@ TEST_F(DBWideBlobDirectWriteTest,
 
     const uint64_t blob_bytes_before_columns =
         options.statistics->getTickerCount(BLOB_DB_BLOB_FILE_BYTES_READ);
-    if (test_case.expect_default_blob_read) {
-      ASSERT_GT(blob_bytes_before_columns, 0U)
-          << "Blob-backed default columns must be resolved for value() scans";
-    } else {
-      ASSERT_EQ(blob_bytes_before_columns, 0U)
-          << "Inline default columns should not trigger blob reads";
-    }
+    ASSERT_GT(blob_bytes_before_columns, 0U)
+        << "Iterator positioning should resolve all blob-backed columns before "
+           "the entry becomes valid";
 
     ASSERT_EQ(iter->columns(), columns);
     ASSERT_OK(iter->status());
 
     const uint64_t blob_bytes_after_columns =
         options.statistics->getTickerCount(BLOB_DB_BLOB_FILE_BYTES_READ);
-    ASSERT_GT(blob_bytes_after_columns, blob_bytes_before_columns)
-        << "Iterator positioning should defer non-default blob resolution "
-           "until columns() is requested";
+    ASSERT_EQ(blob_bytes_after_columns, blob_bytes_before_columns)
+        << "columns() should be a pure accessor for an already-valid iterator";
   }
+}
+
+TEST_F(DBWideBlobDirectWriteTest,
+       DirectWriteIteratorBlobResolutionErrorInvalidatesEntry) {
+  // Goal: verify iterator positioning clears Valid() when resolving a
+  // blob-backed wide column fails. We keep the default column inline so the
+  // old lazy columns() behavior would have exposed a seemingly valid entry
+  // until columns() tried to read the missing blob data.
+  Options options = GetDirectWriteOptions();
+  options.min_blob_size = 64;
+
+  DestroyAndReopen(options);
+
+  constexpr char key[] = "wide_entity_key_missing_blob";
+  const WideColumns columns{{kDefaultWideColumnName, "inline-default"},
+                            {"blob_attr", std::string(128, 'b')},
+                            {"ttl", "00000001"}};
+
+  ASSERT_OK(
+      db_->PutEntity(WriteOptions(), db_->DefaultColumnFamily(), key, columns));
+  ASSERT_OK(Flush());
+
+  const auto blob_files = GetBlobFileNumbers();
+  ASSERT_EQ(blob_files.size(), 1U);
+
+  Close();
+  ASSERT_OK(env_->DeleteFile(BlobFileName(dbname_, blob_files.front())));
+  Reopen(options);
+
+  std::unique_ptr<Iterator> iter(db_->NewIterator(ReadOptions()));
+  iter->SeekToFirst();
+
+  const Status status = iter->status();
+  ASSERT_FALSE(iter->Valid());
+  ASSERT_FALSE(status.ok()) << status.ToString();
+  ASSERT_TRUE(status.IsCorruption() || status.IsIOError() ||
+              status.IsNotFound())
+      << status.ToString();
 }
 
 TEST_F(DBWideBlobDirectWriteTest,

--- a/db/wide/db_wide_blob_direct_write_test.cc
+++ b/db/wide/db_wide_blob_direct_write_test.cc
@@ -383,6 +383,105 @@ class FlushOnlyTTLOnlyLazyDropFilterFactory : public CompactionFilterFactory {
   std::atomic<int>* blob_columns_seen_;
 };
 
+class ResolvingWideValueFilter : public CompactionFilter {
+ public:
+  ResolvingWideValueFilter(std::atomic<int>* filter_call_count,
+                           std::atomic<int>* resolve_attempt_count,
+                           std::atomic<int>* resolve_failure_count,
+                           std::string* resolved_default_value)
+      : filter_call_count_(filter_call_count),
+        resolve_attempt_count_(resolve_attempt_count),
+        resolve_failure_count_(resolve_failure_count),
+        resolved_default_value_(resolved_default_value) {}
+
+  Decision FilterV4(
+      int /*level*/, const Slice& /*key*/, ValueType value_type,
+      const Slice* /*existing_value*/, const WideColumns* existing_columns,
+      std::string* /*new_value*/,
+      std::vector<std::pair<std::string, std::string>>* /*new_columns*/,
+      std::string* /*skip_until*/,
+      WideColumnBlobResolver* blob_resolver = nullptr) const override {
+    if (value_type != ValueType::kWideColumnEntity || !existing_columns) {
+      return Decision::kKeep;
+    }
+
+    ++(*filter_call_count_);
+
+    if (blob_resolver == nullptr) {
+      ++(*resolve_failure_count_);
+      return Decision::kKeep;
+    }
+
+    for (size_t i = 0; i < existing_columns->size(); ++i) {
+      const auto& column = (*existing_columns)[i];
+      if (column.name() != kDefaultWideColumnName ||
+          !blob_resolver->IsBlobColumn(i)) {
+        continue;
+      }
+
+      ++(*resolve_attempt_count_);
+      Slice resolved_value;
+      const Status s = blob_resolver->ResolveColumn(i, &resolved_value);
+      if (!s.ok()) {
+        ++(*resolve_failure_count_);
+        return Decision::kKeep;
+      }
+
+      *resolved_default_value_ = resolved_value.ToString();
+      return Decision::kKeep;
+    }
+
+    ++(*resolve_failure_count_);
+    return Decision::kKeep;
+  }
+
+  bool SupportsFilterV4() const override { return true; }
+  const char* Name() const override { return "ResolvingWideValueFilter"; }
+
+ private:
+  std::atomic<int>* filter_call_count_;
+  std::atomic<int>* resolve_attempt_count_;
+  std::atomic<int>* resolve_failure_count_;
+  std::string* resolved_default_value_;
+};
+
+class FlushOnlyResolvingWideValueFilterFactory : public CompactionFilterFactory {
+ public:
+  FlushOnlyResolvingWideValueFilterFactory(
+      std::atomic<int>* filter_call_count,
+      std::atomic<int>* resolve_attempt_count,
+      std::atomic<int>* resolve_failure_count,
+      std::string* resolved_default_value)
+      : filter_call_count_(filter_call_count),
+        resolve_attempt_count_(resolve_attempt_count),
+        resolve_failure_count_(resolve_failure_count),
+        resolved_default_value_(resolved_default_value) {}
+
+  std::unique_ptr<CompactionFilter> CreateCompactionFilter(
+      const CompactionFilter::Context& /*context*/) override {
+    return std::make_unique<ResolvingWideValueFilter>(
+        filter_call_count_,
+        resolve_attempt_count_,
+        resolve_failure_count_,
+        resolved_default_value_);
+  }
+
+  bool ShouldFilterTableFileCreation(
+      TableFileCreationReason reason) const override {
+    return reason == TableFileCreationReason::kFlush;
+  }
+
+  const char* Name() const override {
+    return "FlushOnlyResolvingWideValueFilterFactory";
+  }
+
+ private:
+  std::atomic<int>* filter_call_count_;
+  std::atomic<int>* resolve_attempt_count_;
+  std::atomic<int>* resolve_failure_count_;
+  std::string* resolved_default_value_;
+};
+
 class BlobResolvingErrorIgnoringFilter : public CompactionFilter {
  public:
   BlobResolvingErrorIgnoringFilter(std::atomic<int>* filter_call_count,
@@ -1092,6 +1191,51 @@ TEST_F(DBWideBlobDirectWriteTest,
   ASSERT_EQ(cf_meta.blob_files[0].total_blob_bytes, live_record_bytes);
   ASSERT_EQ(cf_meta.blob_files[0].garbage_blob_count, 0U);
   ASSERT_EQ(cf_meta.blob_files[0].garbage_blob_bytes, 0U);
+}
+
+TEST_F(DBWideBlobDirectWriteTest, DirectWriteWideEntityBlobResolverWorksOnFlush) {
+  std::atomic<int> filter_call_count{0};
+  std::atomic<int> resolve_attempt_count{0};
+  std::atomic<int> resolve_failure_count{0};
+  std::string resolved_default_value;
+
+  auto filter_factory =
+      std::make_shared<FlushOnlyResolvingWideValueFilterFactory>(
+          &filter_call_count,
+          &resolve_attempt_count,
+          &resolve_failure_count,
+          &resolved_default_value);
+
+  Options options = GetDirectWriteOptions();
+  options.allow_concurrent_memtable_write = false;
+  options.blob_direct_write_partitions = 1;
+  options.min_blob_size = 64;
+  options.blob_file_size = 1 << 20;
+  options.disable_auto_compactions = true;
+  options.enable_blob_garbage_collection = false;
+  options.compaction_filter_factory = filter_factory;
+
+  Reopen(options);
+
+  const std::string key = "resolver_entity";
+  const std::string large_value = GenerateLargeValue(4096, 'Z');
+  const std::string ttl_value = EncodeFixedTTL(5000);
+  const auto columns_data = BuildTTLWideEntityData(large_value, ttl_value);
+  const WideColumns columns = ToWideColumns(columns_data);
+
+  ASSERT_OK(db_->PutEntity(WriteOptions(), db_->DefaultColumnFamily(), key,
+                           columns));
+  ASSERT_OK(Flush());
+
+  ASSERT_GE(filter_call_count.load(), 1);
+  ASSERT_GE(resolve_attempt_count.load(), 1);
+  ASSERT_EQ(resolve_failure_count.load(), 0);
+  ASSERT_EQ(resolved_default_value, large_value);
+
+  PinnableWideColumns result;
+  ASSERT_OK(
+      db_->GetEntity(ReadOptions(), db_->DefaultColumnFamily(), key, &result));
+  ASSERT_EQ(result.columns(), columns);
 }
 
 TEST_F(DBWideBlobDirectWriteTest,

--- a/db/wide/db_wide_blob_direct_write_test.cc
+++ b/db/wide/db_wide_blob_direct_write_test.cc
@@ -383,6 +383,96 @@ class FlushOnlyTTLOnlyLazyDropFilterFactory : public CompactionFilterFactory {
   std::atomic<int>* blob_columns_seen_;
 };
 
+class BlobResolvingErrorIgnoringFilter : public CompactionFilter {
+ public:
+  BlobResolvingErrorIgnoringFilter(std::atomic<int>* filter_call_count,
+                                   std::atomic<int>* resolve_error_count,
+                                   std::string* resolve_error_status)
+      : filter_call_count_(filter_call_count),
+        resolve_error_count_(resolve_error_count),
+        resolve_error_status_(resolve_error_status) {}
+
+  Decision FilterV4(
+      int /*level*/, const Slice& /*key*/, ValueType value_type,
+      const Slice* /*existing_value*/, const WideColumns* existing_columns,
+      std::string* /*new_value*/,
+      std::vector<std::pair<std::string, std::string>>* /*new_columns*/,
+      std::string* /*skip_until*/,
+      WideColumnBlobResolver* blob_resolver = nullptr) const override {
+    if (value_type != ValueType::kWideColumnEntity || !existing_columns ||
+        blob_resolver == nullptr) {
+      return Decision::kKeep;
+    }
+
+    ++(*filter_call_count_);
+
+    for (size_t i = 0; i < existing_columns->size(); ++i) {
+      if (!blob_resolver->IsBlobColumn(i)) {
+        continue;
+      }
+
+      const auto& column = (*existing_columns)[i];
+      if (column.name() != "blob_attr") {
+        continue;
+      }
+
+      Slice resolved_value;
+      const Status s = blob_resolver->ResolveColumn(i, &resolved_value);
+      if (!s.ok()) {
+        ++(*resolve_error_count_);
+        *resolve_error_status_ = s.ToString();
+      }
+      break;
+    }
+
+    // Even if the filter returns kKeep after observing the read failure,
+    // flush must fail and surface the resolver error.
+    return Decision::kKeep;
+  }
+
+  bool SupportsFilterV4() const override { return true; }
+  const char* Name() const override {
+    return "BlobResolvingErrorIgnoringFilter";
+  }
+
+ private:
+  std::atomic<int>* filter_call_count_;
+  std::atomic<int>* resolve_error_count_;
+  std::string* resolve_error_status_;
+};
+
+class FlushOnlyBlobResolvingErrorIgnoringFilterFactory
+    : public CompactionFilterFactory {
+ public:
+  FlushOnlyBlobResolvingErrorIgnoringFilterFactory(
+      std::atomic<int>* filter_call_count,
+      std::atomic<int>* resolve_error_count,
+      std::string* resolve_error_status)
+      : filter_call_count_(filter_call_count),
+        resolve_error_count_(resolve_error_count),
+        resolve_error_status_(resolve_error_status) {}
+
+  std::unique_ptr<CompactionFilter> CreateCompactionFilter(
+      const CompactionFilter::Context& /*context*/) override {
+    return std::make_unique<BlobResolvingErrorIgnoringFilter>(
+        filter_call_count_, resolve_error_count_, resolve_error_status_);
+  }
+
+  bool ShouldFilterTableFileCreation(
+      TableFileCreationReason reason) const override {
+    return reason == TableFileCreationReason::kFlush;
+  }
+
+  const char* Name() const override {
+    return "FlushOnlyBlobResolvingErrorIgnoringFilterFactory";
+  }
+
+ private:
+  std::atomic<int>* filter_call_count_;
+  std::atomic<int>* resolve_error_count_;
+  std::string* resolve_error_status_;
+};
+
 class NameBasedWideColumnPartitionStrategy : public BlobFilePartitionStrategy {
  public:
   using BlobFilePartitionStrategy::SelectPartition;
@@ -808,6 +898,69 @@ TEST_F(DBWideBlobDirectWriteTest,
             expired_record_bytes + live_record_bytes);
   ASSERT_EQ(blob_meta.garbage_blob_count, 1U);
   ASSERT_EQ(blob_meta.garbage_blob_bytes, expired_record_bytes);
+}
+
+TEST_F(DBWideBlobDirectWriteTest,
+       DirectWriteWideEntityLazyResolverMissingBlobFailsFlush) {
+  // Goal: verify flush-time FilterV4 lazy resolution errors fail the flush for
+  // direct-write wide entities. The filter resolves one blob-backed column,
+  // records the resulting read error, and still returns kKeep; flush must
+  // propagate the resolver status and latch bg_error instead of silently
+  // preserving the entry.
+  std::atomic<int> filter_call_count{0};
+  std::atomic<int> resolve_error_count{0};
+  std::string resolve_error_status;
+
+  Options options = GetDirectWriteOptions();
+  options.min_blob_size = 64;
+  options.compaction_filter_factory =
+      std::make_shared<FlushOnlyBlobResolvingErrorIgnoringFilterFactory>(
+          &filter_call_count, &resolve_error_count, &resolve_error_status);
+
+  Reopen(options);
+
+  constexpr char key[] = "flush_missing_blob_key";
+  const WideColumns columns{{kDefaultWideColumnName, "inline-default"},
+                            {"blob_attr", std::string(128, 'b')},
+                            {"ttl", "00000001"}};
+
+  ASSERT_OK(
+      db_->PutEntity(WriteOptions(), db_->DefaultColumnFamily(), key, columns));
+  ASSERT_OK(dbfull()->TEST_SwitchMemtable());
+
+  auto* cfh = static_cast_with_check<ColumnFamilyHandleImpl>(
+      db_->DefaultColumnFamily());
+  auto* mgr = cfh->cfd()->blob_partition_manager();
+  ASSERT_NE(mgr, nullptr);
+
+  std::vector<BlobFileAddition> additions;
+  std::vector<BlobFileGarbage> garbages;
+  ASSERT_OK(mgr->PrepareFlushAdditions(WriteOptions(), /*num_generations=*/1,
+                                       &additions, &garbages));
+  ASSERT_EQ(additions.size(), 1U);
+  ASSERT_TRUE(garbages.empty());
+
+  ASSERT_OK(env_->DeleteFile(
+      BlobFileName(dbname_, additions.front().GetBlobFileNumber())));
+
+  const Status status = Flush();
+  ASSERT_FALSE(status.ok())
+      << "Flush should fail when FilterV4 lazy blob resolution hits a "
+         "missing blob file";
+  ASSERT_TRUE(status.IsCorruption() || status.IsIOError() ||
+              status.IsNotFound())
+      << status.ToString();
+  ASSERT_GE(filter_call_count.load(), 1);
+  ASSERT_EQ(resolve_error_count.load(), 1);
+  ASSERT_FALSE(resolve_error_status.empty());
+
+  const Status bg_error = dbfull()->TEST_GetBGError();
+  ASSERT_FALSE(bg_error.ok());
+  ASSERT_TRUE(bg_error.IsCorruption() || bg_error.IsIOError() ||
+              bg_error.IsNotFound())
+      << bg_error.ToString();
+  ASSERT_GE(static_cast<int>(bg_error.severity()),
+            static_cast<int>(Status::Severity::kHardError));
 }
 
 TEST_F(DBWideBlobDirectWriteTest,

--- a/db/wide/db_wide_blob_direct_write_test.cc
+++ b/db/wide/db_wide_blob_direct_write_test.cc
@@ -1017,8 +1017,9 @@ TEST_F(DBWideBlobDirectWriteTest,
   Reopen(options);
 
   constexpr char key[] = "flush_missing_blob_key";
+  const std::string blob_attr_value(128, 'b');
   const WideColumns columns{{kDefaultWideColumnName, "inline-default"},
-                            {"blob_attr", std::string(128, 'b')},
+                            {"blob_attr", blob_attr_value},
                             {"ttl", "00000001"}};
 
   ASSERT_OK(

--- a/include/rocksdb/compaction_filter.h
+++ b/include/rocksdb/compaction_filter.h
@@ -377,6 +377,10 @@ class CompactionFilter : public Customizable {
   // Extends FilterV3 with blob column lazy loading support. Called for plain
   // values, merge operands, and wide-column entities.
   //
+  // For `ValueType::kValue`, `existing_value` contains the user value. This
+  // is true whether the value was stored inline or behind a BlobIndex; plain
+  // blob-backed values are eagerly resolved before FilterV4() is invoked.
+  //
   // When the entity has blob columns (columns whose values are stored in blob
   // files), the `blob_resolver` parameter provides a way to lazily resolve
   // blob values on-demand. If `blob_resolver` is non-null:
@@ -446,8 +450,12 @@ class CompactionFilter : public Customizable {
   // Keys where the value is stored separately in a blob file will be
   // passed to this method. If the method returns a supported decision other
   // than kUndetermined, it will be considered final and performed without
-  // reading the existing value. Returning kUndetermined will cause FilterV4()
-  // to be called to make a decision as usual. The output parameters
+  // reading the existing value. Returning kUndetermined continues with the
+  // usual value-based filtering path: RocksDB eagerly resolves the blob and
+  // invokes FilterV4()/FilterV3()/FilterV2() with ValueType::kValue so legacy
+  // filters observe the underlying user value rather than the BlobIndex
+  // encoding. If RocksDB cannot access the blob in the current table-file
+  // creation context, table-file creation fails. The output parameters
   // `new_value` and `skip_until` are applicable to the decisions kChangeValue
   // and kRemoveAndSkipUntil respectively, and have the same semantics as
   // the corresponding parameters of FilterV2/V3/V4.

--- a/include/rocksdb/compaction_filter.h
+++ b/include/rocksdb/compaction_filter.h
@@ -58,8 +58,10 @@ class WideColumnBlobResolver {
   // - column_index is out of bounds
   // - I/O error occurred while fetching the blob
   //
-  // If ResolveColumn fails, the compaction filter should return
-  // kKeep to avoid data loss.
+  // If ResolveColumn fails, the compaction filter should stop processing the
+  // current entry and return kKeep to avoid applying a partial decision.
+  // RocksDB will fail the compaction after FilterV4() returns so the resolver
+  // error is surfaced without silently keeping the entry.
   virtual Status ResolveColumn(size_t column_index, Slice* resolved_value) = 0;
 
   // Resolve multiple columns in the order provided by `column_indices`.


### PR DESCRIPTION
## Summary

Restore the iterator contract for blob-backed wide-column entities by eagerly materializing all blob-backed columns before a `DBIter` entry is exposed as valid. Also capture similar error inside compaction filter V4, so that the error is captured a surfaced up like older compaction filter V3.

## Problem

Lazy wide-column blob resolution let `DBIter` report `Valid() == true` before all columns were actually prepared. Callers could read `value()` successfully, then hit a blob-read failure in `columns()`, which flipped the iterator to invalid after the entry had already been observed as valid.

## Solution

- Restore back to old behavior.
- Resolve and materialize all blob-backed wide columns during iterator positioning.
- Keep `columns()` as a pure accessor once `Valid()` is true.
- Add coverage for eager blob resolution on iterator scans.
- Add coverage for blob resolution failures invalidating the iterator before the entry is exposed.
- Capture the same error in compaction filter and set db to bg error status if the error is not retriable.

## Next step
If we want lazy iterator resolution in the future, we will need an API that can surface lazy resolution failures explicitly instead of hiding I/O and status transitions inside value() or columns().

## Testing

- `make -j14 db_wide_blob_direct_write_test`
- `timeout 60s ./db_wide_blob_direct_write_test --gtest_filter='*DirectWriteIteratorValueScanEagerlyResolvesBlobColumns:*DirectWriteIteratorBlobResolutionErrorInvalidatesEntry'`

## Task
T265294130

# Bonus fix

  ## Non-compaction blob filtering fixes

  ### 1. Flush-time wide-entity lazy blob resolution now works correctly

  Blob direct-write can leave wide-entity blob references in memtables before flush. Flush already runs through `CompactionIterator`, but outside a real compaction it did not have blob read support. As a result, `FilterV4` lazy resolution on flush could fail immediately with
  `NotSupported("Blob fetcher not available")` instead of either:
  - resolving the blob successfully, or
  - surfacing the real blob read error and failing the flush

  This stack fixes that by plumbing blob read support into non-compaction table-file creation. `BuildTable()` now gives `CompactionIterator` enough context to construct a `BlobFetcher` for flush/recovery table building, including write-path fallback for direct-write blob files
  that are not yet manifest-visible.

  With that in place:
  - flush-time `FilterV4` can lazily resolve blob-backed wide columns
  - if resolution fails, the failure is latched and flush fails after `FilterV4()` returns
  - `bg_error` is set instead of silently preserving the entry

  ### 2. Plain blob fallback outside compaction now uses the resolved user value

  For plain blob-backed values, `FilterBlobByKey()` is allowed to return `kUndetermined`, which is supposed to fall back to the normal value-based filter path. That fallback worked in compaction, but the non-compaction `BuildTable()` path still treated plain blob indexes as
  unsupported/corrupt because it could not read the blob.

  This stack fixes that behavior for flush/recovery table-file creation:
  - when `FilterBlobByKey()` returns `kUndetermined`, RocksDB now eagerly resolves the plain blob value
  - `FilterV2`/`FilterV3`/`FilterV4` then see the actual user value as `ValueType::kValue`, not the `BlobIndex` encoding
  - legacy filters therefore behave the same way outside compaction as they already do inside compaction

  Wide-column entities still use the `FilterV4` lazy resolver path. The plain-blob fix is specifically about restoring the documented fallback behavior for blob-backed `kValue` records outside compaction.

  ## Why this matters

  Without these last two commits, flush-time filtering still had two inconsistent behaviors:
  - wide-entity lazy resolution could not actually read blob-backed columns in the direct-write case
  - plain blob-backed values could not fall back to normal value-based filtering outside compaction

  So even after fixing iterator validity and compaction error propagation, non-compaction table-file creation still had remaining contract holes. These commits make flush/recovery behave consistently with compaction.

  ## Coverage added

  The tests added in these commits cover:
  - flush-time plain-blob `FilterV3` fallback using the resolved user value
  - flush-time plain-blob `FilterV4` fallback using the resolved user value
  - flush-time direct-write wide-entity lazy resolver success
  - flush-time direct-write wide-entity lazy resolver failure on missing blob file, including flush failure and `bg_error` latching
