### PR TITLE
IODispatcher: fall back to synchronous coalesced reads when async IO is unavailable (#14633)

### DIFF
--- a/unreleased_history/bug_fixes/multiscan_async_io_sync_fallback.md
+++ b/unreleased_history/bug_fixes/multiscan_async_io_sync_fallback.md
@@ -1,0 +1,1 @@
+Fix MultiScan to fall back to synchronous coalesced reads when async I/O is unsupported at runtime.

--- a/util/io_dispatcher_imp.cc
+++ b/util/io_dispatcher_imp.cc
@@ -985,6 +985,15 @@ std::vector<size_t> IODispatcherImpl::Impl::ExecuteAsyncIO(
                              &async_state->del_fn,
                              direct_io ? &async_state->aligned_buf : nullptr);
 
+    if (s.IsNotSupported()) {
+      // Async IO may be compiled in but unavailable at runtime. Fall back to
+      // the synchronous coalesced path for these blocks.
+      for (const auto idx : coalesced_block_indices[i]) {
+        fallback_block_indices.push_back(idx);
+      }
+      continue;
+    }
+
     if (!s.ok()) {
       // Actual error - surface to caller
       *out_status = s;

--- a/util/io_dispatcher_test.cc
+++ b/util/io_dispatcher_test.cc
@@ -1910,6 +1910,85 @@ TEST_F(IODispatcherTest, DestructorReleasesMemoryAfterReadIndex) {
   }
 }
 
+// Regression test: when ReadAsync returns NotSupported (e.g., io_uring
+// unavailable at runtime due to seccomp), ExecuteAsyncIO must fall back to
+// sync IO during SubmitJob. Without the fix, no MultiRead is issued during
+// SubmitJob and ReadIndex later fetches each block individually via SyncRead.
+TEST_F(IODispatcherTest, AsyncNotSupportedFallsBackToSync) {
+  auto* sync_point = SyncPoint::GetInstance();
+  struct SyncPointGuard {
+    explicit SyncPointGuard(SyncPoint* sp) : sync_point(sp) {}
+    ~SyncPointGuard() {
+      sync_point->DisableProcessing();
+      sync_point->ClearAllCallBacks();
+    }
+
+    SyncPoint* sync_point;
+  } sync_point_guard(sync_point);
+
+  // Inject NotSupported into ReadAsync via SyncPoint
+  sync_point->SetCallBack(
+      "RandomAccessFileReader::ReadAsync:InjectStatus", [](void* arg) {
+        auto* s = static_cast<IOStatus*>(arg);
+        *s = IOStatus::NotSupported("simulated io_uring unavailability");
+      });
+  sync_point->EnableProcessing();
+
+  std::unique_ptr<BlockBasedTable> table;
+  std::vector<BlockHandle> block_handles;
+  Status s = CreateAndOpenSST(20, &table, &block_handles);
+  ASSERT_OK(s);
+  ASSERT_GT(block_handles.size(), 4);
+
+  tracking_fs_->ClearReadOps();
+
+  // Use only the first 4 adjacent blocks
+  std::vector<BlockHandle> test_handles(block_handles.begin(),
+                                        block_handles.begin() + 4);
+
+  std::unique_ptr<IODispatcher> dispatcher(NewIODispatcher());
+
+  auto job = std::make_shared<IOJob>();
+  job->block_handles = test_handles;
+  job->table = table.get();
+  job->job_options.read_options.async_io = true;         // Request async IO
+  job->job_options.io_coalesce_threshold = 1024 * 1024;  // Force coalescing
+
+  std::shared_ptr<ReadSet> read_set;
+  s = dispatcher->SubmitJob(job, &read_set);
+  ASSERT_OK(s);
+  ASSERT_NE(read_set, nullptr);
+
+  // The sync fallback should happen during SubmitJob, using one coalesced
+  // MultiRead for the adjacent blocks. Without the fix, no MultiRead happens
+  // here and num_sync_reads remains zero until ReadIndex() issues one SyncRead
+  // per block later.
+  auto read_ops = tracking_fs_->GetReadOps();
+  size_t multiread_count = 0;
+  size_t total_requests_in_multireads = 0;
+  for (const auto& op : read_ops) {
+    if (op.type == ReadOp::kMultiRead) {
+      multiread_count++;
+      total_requests_in_multireads += op.requests.size();
+    } else if (op.type == ReadOp::kReadAsync) {
+      FAIL() << "ReadAsync should not reach the filesystem when NotSupported "
+                "is injected";
+    }
+  }
+  ASSERT_EQ(read_set->GetNumSyncReads(), test_handles.size());
+  ASSERT_EQ(read_set->GetNumAsyncReads(), 0);
+  ASSERT_EQ(multiread_count, 1);
+  ASSERT_EQ(total_requests_in_multireads, 1);
+
+  // All blocks should then be readable from the prefetched sync fallback.
+  for (size_t i = 0; i < test_handles.size(); ++i) {
+    CachableEntry<Block> block;
+    ASSERT_OK(read_set->ReadIndex(i, &block));
+    ASSERT_NE(block.GetValue(), nullptr)
+        << "Block " << i << " should be readable after sync fallback";
+  }
+}
+
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Summary: Pull Request resolved: https://github.com/facebook/rocksdb/pull/14633

Reviewed By: xingbowang

Differential Revision: D101299989
