### PR TITLE
Add ParseCompressionNameForDisplay API (#14637)

### DIFF
--- a/db/db_table_properties_test.cc
+++ b/db/db_table_properties_test.cc
@@ -812,6 +812,79 @@ TEST_F(DBTablePropertiesTest, KeyLargestSmallestSeqno) {
   }
 }
 
+TEST_F(DBTablePropertiesTest, ParseCompressionNameForDisplay) {
+  // Test empty string
+  EXPECT_EQ("NoCompression", ParseCompressionNameForDisplay(""));
+
+  // Test old format (no semicolon)
+  EXPECT_EQ("ZSTD", ParseCompressionNameForDisplay("ZSTD"));
+  EXPECT_EQ("Snappy", ParseCompressionNameForDisplay("Snappy"));
+  EXPECT_EQ("LZ4", ParseCompressionNameForDisplay("LZ4"));
+  EXPECT_EQ("kZSTD", ParseCompressionNameForDisplay("kZSTD"));
+  EXPECT_EQ("kSnappyCompression",
+            ParseCompressionNameForDisplay("kSnappyCompression"));
+
+  // Test new format version 7 with ZSTD
+  EXPECT_EQ("ZSTD", ParseCompressionNameForDisplay("zstd;07;"));
+  EXPECT_EQ("ZSTD", ParseCompressionNameForDisplay("BuiltinV2;07;"));
+  EXPECT_EQ("ZSTD", ParseCompressionNameForDisplay("builtin_v2;07;"));
+  EXPECT_EQ("ZSTD", ParseCompressionNameForDisplay(";07;"));
+  EXPECT_EQ("ZSTD", ParseCompressionNameForDisplay("custom_mgr;07;extra;"));
+
+  // Test new format with LZ4
+  EXPECT_EQ("LZ4", ParseCompressionNameForDisplay("zstd;04;"));
+  EXPECT_EQ("LZ4", ParseCompressionNameForDisplay("lz4;04;"));
+
+  // Test lowercase hex
+  EXPECT_EQ("ZSTD", ParseCompressionNameForDisplay("test;07;"));
+  EXPECT_EQ("LZ4", ParseCompressionNameForDisplay("test;04;"));
+  EXPECT_EQ("LZ4,ZSTD", ParseCompressionNameForDisplay("test;0407;"));
+
+  // Test multiple compression types
+  EXPECT_EQ("LZ4,ZSTD", ParseCompressionNameForDisplay("test;0407;"));
+  EXPECT_EQ(
+      "ZSTD,LZ4",
+      ParseCompressionNameForDisplay("test;0704;"));  // sorted by appearance
+  EXPECT_EQ("ZSTD", ParseCompressionNameForDisplay("test;0007;"));
+
+  // Test all standard compression types (01-07)
+  EXPECT_EQ("NoCompression", ParseCompressionNameForDisplay("test;00;"));
+  EXPECT_EQ("Snappy", ParseCompressionNameForDisplay("test;01;"));
+  EXPECT_EQ("Zlib", ParseCompressionNameForDisplay("test;02;"));
+  EXPECT_EQ("BZip2", ParseCompressionNameForDisplay("test;03;"));
+  EXPECT_EQ("LZ4", ParseCompressionNameForDisplay("test;04;"));
+  EXPECT_EQ("LZ4HC", ParseCompressionNameForDisplay("test;05;"));
+  EXPECT_EQ("Xpress", ParseCompressionNameForDisplay("test;06;"));
+  EXPECT_EQ("ZSTD", ParseCompressionNameForDisplay("test;07;"));
+
+  // Test custom/reserved types (>= 0x08)
+  // 0x08-0x7F are Reserved, 0x80-0xFE are Custom
+  EXPECT_EQ("Reserved08", ParseCompressionNameForDisplay("test;08;"));
+  EXPECT_EQ("Custom80", ParseCompressionNameForDisplay("test;80;"));
+  EXPECT_EQ("Reserved7F", ParseCompressionNameForDisplay("test;7F;"));
+  EXPECT_EQ("CustomFE", ParseCompressionNameForDisplay("test;FE;"));
+
+  // Test DisableOption (0xFF) - filtered out
+  EXPECT_EQ("NoCompression", ParseCompressionNameForDisplay("test;FF;"));
+
+  // Test NoCompression (empty hex field would be caught by validation, but test
+  // "00")
+  EXPECT_EQ("NoCompression", ParseCompressionNameForDisplay("test;00;"));
+  EXPECT_EQ("NoCompression", ParseCompressionNameForDisplay("BuiltinV2;;"));
+  EXPECT_EQ("NoCompression", ParseCompressionNameForDisplay("test;;"));
+
+  // Test three+ semicolons (future fields ignored)
+  EXPECT_EQ("ZSTD", ParseCompressionNameForDisplay("test;07;extra;fields;"));
+
+  // Test malformed inputs -> "Unknown"
+  EXPECT_EQ("Unknown", ParseCompressionNameForDisplay("only_one;"));
+  EXPECT_EQ("Unknown", ParseCompressionNameForDisplay("bad;0;"));  // odd length
+  EXPECT_EQ("Unknown",
+            ParseCompressionNameForDisplay("bad;0G;"));  // invalid hex
+  EXPECT_EQ("Unknown",
+            ParseCompressionNameForDisplay("bad;GG;"));  // invalid hex
+}
+
 INSTANTIATE_TEST_CASE_P(DBTablePropertiesTest, DBTablePropertiesTest,
                         ::testing::Values("kCompactionStyleLevel",
                                           "kCompactionStyleUniversal"));

--- a/include/rocksdb/table_properties.h
+++ b/include/rocksdb/table_properties.h
@@ -445,6 +445,19 @@ struct TableProperties {
                 std::string* mismatch) const;
 };
 
+// Parse TableProperties::compression_name into human-readable format.
+// Thread-safe: pure utility function with no shared state.
+// For format_version >= 7: "<compatibility_name>;<hex_codes>;" -> "ZSTD",
+// "LZ4", etc. For older versions (no semicolon): returns as-is (e.g., "ZSTD",
+// "Snappy", "kZSTD" are preserved with their original names). Returns
+// "NoCompression" for an empty input, an empty hex field such as
+// "BuiltinV2;;", or when all parsed entries are filtered out as
+// NoCompression/DisableOption. Returns "Unknown" for malformed format_version
+// >= 7 metadata, including a missing second semicolon, odd-length hex payload,
+// or invalid hex characters. If multiple compression types are present,
+// returns a comma-separated list in input order.
+std::string ParseCompressionNameForDisplay(const std::string& compression_name);
+
 // Extra properties
 // Below is a list of non-basic properties that are collected by database
 // itself. Especially some properties regarding to the internal keys (which

--- a/table/table_properties.cc
+++ b/table/table_properties.cc
@@ -13,6 +13,7 @@
 #include "rocksdb/utilities/options_type.h"
 #include "table/table_properties_internal.h"
 #include "table/unique_id_impl.h"
+#include "util/compression.h"
 #include "util/random.h"
 #include "util/string_util.h"
 
@@ -614,5 +615,70 @@ void TEST_SetRandomTableProperties(TableProperties* props) {
   }
 }
 #endif
+
+std::string ParseCompressionNameForDisplay(
+    const std::string& compression_name) {
+  // Empty = no compression
+  if (compression_name.empty()) {
+    return "NoCompression";
+  }
+
+  // Check for format_version 7 format (contains ';')
+  size_t first_semicolon = compression_name.find(';');
+  if (first_semicolon == std::string::npos) {
+    // Old format - return as-is
+    return compression_name;
+  }
+
+  // New format: "<compatibility_name>;<hex_codes>;"
+  size_t second_semicolon = compression_name.find(';', first_semicolon + 1);
+  if (second_semicolon == std::string::npos) {
+    // Malformed - missing second field
+    return "Unknown";
+  }
+
+  // Extract hex codes
+  std::string hex_codes = compression_name.substr(
+      first_semicolon + 1, second_semicolon - first_semicolon - 1);
+
+  // Validate hex string length (must be even)
+  if (hex_codes.size() % 2 != 0) {
+    return "Unknown";
+  }
+
+  // Parse each 2-char hex code to CompressionType.
+  // Note: This intentionally mirrors GetDecompressor()'s decoding shape but
+  // differs in error semantics. GetDecompressor() treats kNoCompression
+  // (0x00) and values >= kDisableCompressionOption (0xFF) as corruption. For
+  // display purposes, we silently filter these out and return "NoCompression"
+  // if no valid types remain.
+  std::vector<std::string> types;
+  for (size_t i = 0; i < hex_codes.size(); i += 2) {
+    const char* ptr = hex_codes.data() + i;
+    uint64_t val = 0;
+    if (!ParseBaseChars<16>(&ptr, 2, &val)) {
+      return "Unknown";
+    }
+    auto ct = static_cast<CompressionType>(val);
+    std::string name = CompressionTypeToString(ct);
+    // Filter out NoCompression
+    if (name != "NoCompression" && name != "DisableOption") {
+      types.push_back(name);
+    }
+  }
+
+  if (types.empty()) {
+    return "NoCompression";
+  } else if (types.size() == 1) {
+    return types[0];
+  } else {
+    // Multiple types - join with commas
+    std::string result = types[0];
+    for (size_t i = 1; i < types.size(); ++i) {
+      result += "," + types[i];
+    }
+    return result;
+  }
+}
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/unreleased_history/new_features/parse_compression_name_for_display.md
+++ b/unreleased_history/new_features/parse_compression_name_for_display.md
@@ -1,0 +1,1 @@
+Added public utility API `ParseCompressionNameForDisplay()` to convert `TableProperties::compression_name` into a human-readable compression name for both legacy and format_version 7+ SST metadata.


### PR DESCRIPTION
Summary:

Add public API ParseCompressionNameForDisplay() to render TableProperties::compression_name in human-readable form for both legacy and format_version >= 7 SST metadata, including BuiltinV2/compression-manager encodings and filtered no-compression markers for display.

Reviewed By: xingbowang

Differential Revision: D101463511
