### PR TITLE
Preserve original error status in GetContext kCorrupt state

### DIFF
--- a/db/blob/db_blob_basic_test.cc
+++ b/db/blob/db_blob_basic_test.cc
@@ -1620,6 +1620,56 @@ TEST_P(DBBlobBasicIOErrorTest, GetBlob_IOError) {
   SyncPoint::GetInstance()->ClearAllCallBacks();
 }
 
+TEST_P(DBBlobBasicIOErrorTest, GetEntityMergeWithBlobBaseIOError) {
+  // Reproduces a bug where GetEntity() with a merge operand on top of a
+  // blob-backed base value returns Corruption instead of IOError when the
+  // blob read fails. The root cause was that GetContext::GetBlobValue() set
+  // state_ = kCorrupt for IOErrors, and version_set created a generic
+  // Corruption status, losing the original IOError. The stress test's
+  // IsErrorInjectedAndRetryable() couldn't recognize the injected error,
+  // causing a false positive verification failure.
+  Options options;
+  options.env = fault_injection_env_.get();
+  options.enable_blob_files = true;
+  options.min_blob_size = 0;
+  options.merge_operator = MergeOperators::CreateStringAppendOperator();
+
+  Reopen(options);
+
+  constexpr char key[] = "key";
+  constexpr char base_value[] = "base_value";
+
+  // Write a base value that will be stored in a blob file
+  ASSERT_OK(Put(key, base_value));
+  ASSERT_OK(Flush());
+
+  // Write a merge operand on top - this creates merge + blob index base
+  ASSERT_OK(Merge(key, "merge_operand"));
+  ASSERT_OK(Flush());
+
+  // Inject IOError on blob file read
+  SyncPoint::GetInstance()->SetCallBack(sync_point_, [this](void* /* arg */) {
+    fault_injection_env_->SetFilesystemActive(false,
+                                              Status::IOError(sync_point_));
+  });
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  // Before the fix, GetEntity() would return Corruption("corrupted key for ...")
+  // instead of the original IOError. After the fix, the IOError is preserved.
+  PinnableWideColumns result;
+  Status s =
+      db_->GetEntity(ReadOptions(), db_->DefaultColumnFamily(), key, &result);
+  ASSERT_TRUE(s.IsIOError()) << "Expected IOError but got: " << s.ToString();
+
+  // Also verify regular Get preserves IOError in the same scenario
+  PinnableSlice get_result;
+  s = db_->Get(ReadOptions(), db_->DefaultColumnFamily(), key, &get_result);
+  ASSERT_TRUE(s.IsIOError()) << "Expected IOError but got: " << s.ToString();
+
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+}
+
 TEST_P(DBBlobBasicIOErrorMultiGetTest, MultiGetBlobs_IOError) {
   Options options = GetDefaultOptions();
   options.env = fault_injection_env_.get();

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -2867,7 +2867,11 @@ void Version::Get(const ReadOptions& read_options, const LookupKey& k,
         }
         return;
       case GetContext::kCorrupt:
-        *status = Status::Corruption("corrupted key for ", user_key);
+        if (get_context.corrupt_status().ok()) {
+          *status = Status::Corruption("corrupted key for ", user_key);
+        } else {
+          *status = get_context.corrupt_status();
+        }
         return;
       case GetContext::kUnexpectedBlobIndex:
         ROCKS_LOG_ERROR(info_log_, "Encounter unexpected blob index.");

--- a/db/version_set_sync_and_async.h
+++ b/db/version_set_sync_and_async.h
@@ -148,8 +148,12 @@ DEFINE_SYNC_AND_ASYNC(Status, Version::MultiGetFromSST)
         file_range.MarkKeyDone(iter);
         continue;
       case GetContext::kCorrupt:
-        *status =
-            Status::Corruption("corrupted key for ", iter->lkey->user_key());
+        if (get_context.corrupt_status().ok()) {
+          *status =
+              Status::Corruption("corrupted key for ", iter->lkey->user_key());
+        } else {
+          *status = get_context.corrupt_status();
+        }
         file_range.MarkKeyDone(iter);
         continue;
       case GetContext::kUnexpectedBlobIndex:

--- a/table/get_context.cc
+++ b/table/get_context.cc
@@ -426,6 +426,7 @@ bool GetContext::SaveValue(const ParsedInternalKey& parsed_key,
                     MarkKeyMayExist();
                   } else {
                     state_ = kCorrupt;
+                    corrupt_status_ = s;
                   }
                   return false;
                 }
@@ -451,6 +452,7 @@ bool GetContext::SaveValue(const ParsedInternalKey& parsed_key,
                     MarkKeyMayExist();
                   } else {
                     state_ = kCorrupt;
+                    corrupt_status_ = s;
                   }
                   return false;
                 }
@@ -657,6 +659,7 @@ void GetContext::MergeWithWideColumnBaseValue(const Slice& entity) {
       return;
     }
     state_ = kCorrupt;
+    corrupt_status_ = s_resolve;
     return;
   }
 
@@ -684,6 +687,7 @@ bool GetContext::GetBlobValue(const Slice& user_key, const Slice& blob_index,
       return false;
     }
     state_ = kCorrupt;
+    corrupt_status_ = *read_status;
     return false;
   }
   *is_blob_index_ = false;

--- a/table/get_context.h
+++ b/table/get_context.h
@@ -193,6 +193,12 @@ class GetContext {
 
   uint64_t get_tracing_get_id() const { return tracing_get_id_; }
 
+  // Returns the original error status that caused the kCorrupt state, if any.
+  // When state_ == kCorrupt and an underlying error (e.g. IOError from blob
+  // fetch) caused the corruption state, this preserves the original status
+  // instead of losing it to a generic Corruption status.
+  const Status& corrupt_status() const { return corrupt_status_; }
+
   void push_operand(const Slice& value, Cleanable* value_pinner);
 
  private:
@@ -255,6 +261,11 @@ class GetContext {
   // Get or a MultiGet.
   const uint64_t tracing_get_id_;
   BlobFetcher* blob_fetcher_;
+  // Preserves the original error status when state_ is set to kCorrupt.
+  // This is needed because some code paths (e.g. blob fetch failure) set
+  // state_ = kCorrupt for non-corruption errors like IOError, and the
+  // original error type needs to be preserved for proper error handling.
+  Status corrupt_status_;
 };
 
 // Call this to replay a log and bring the get_context up to date. The replay


### PR DESCRIPTION
Summary:
When GetContext blob resolution fails with IOError (e.g., from fault
injection), state_ is set to kCorrupt and version_set creates a generic
Corruption status, losing the original error type. This causes false
positives in stress tests since IsErrorInjectedAndRetryable() cannot
recognize injected IOErrors wrapped in Corruption.

Fix: Add corrupt_status_ member to GetContext to preserve the original
error. Update version_set kCorrupt handlers to use the preserved status.

Differential Revision: D101678126


