### PR TITLE
Fix GetMergeOperands for blob-backed wide-column defaults

### DIFF
--- a/db/wide/db_wide_basic_test.cc
+++ b/db/wide/db_wide_basic_test.cc
@@ -2909,6 +2909,70 @@ TEST_F(DBWideBasicTest, MergeEntityWithBlobColumns) {
   }
 }
 
+TEST_F(DBWideBasicTest, GetMergeOperandsWithBlobBackedEntityDefaultColumn) {
+  // Goal: cover both GetMergeOperands code paths that read a compacted V2
+  // wide-column entity whose default column was moved to a blob file. The
+  // first read exercises the base-value path directly, then a merge operand is
+  // added so the second read exercises the merge-plus-base path.
+  Options options = GetBlobTestOptions();
+  options.min_blob_size = 50;
+  options.merge_operator = MergeOperators::CreateStringAppendOperator("|");
+
+  DestroyAndReopen(options);
+
+  const std::string key = "merge_operands_blob_entity";
+  const std::string default_value = GenerateLargeValue(100, 'd');
+  const std::string large_value = GenerateLargeValue(120, 'l');
+  const std::string small_value = GenerateSmallValue();
+  const std::string merge_operand = "suffix";
+
+  WideColumns columns{{kDefaultWideColumnName, default_value},
+                      {"col_large", large_value},
+                      {"col_small", small_value}};
+  ASSERT_OK(
+      db_->PutEntity(WriteOptions(), db_->DefaultColumnFamily(), key, columns));
+  ASSERT_OK(Flush());
+  ASSERT_OK(db_->CompactRange(CompactRangeOptions(), nullptr, nullptr));
+  ASSERT_FALSE(GetBlobFileNumbers().empty());
+
+  {
+    // The compacted V2 entity becomes the first operand when there are no
+    // newer merge operands above it.
+    GetMergeOperandsOptions get_merge_opts;
+    get_merge_opts.expected_max_number_of_operands = 1;
+
+    std::array<PinnableSlice, 2> merge_operands;
+    int number_of_operands = 0;
+
+    ASSERT_OK(db_->GetMergeOperands(ReadOptions(), db_->DefaultColumnFamily(),
+                                    key, merge_operands.data(), &get_merge_opts,
+                                    &number_of_operands));
+    ASSERT_EQ(number_of_operands, 1);
+    ASSERT_EQ(merge_operands[0], default_value);
+  }
+
+  ASSERT_OK(db_->Merge(WriteOptions(), db_->DefaultColumnFamily(), key,
+                       merge_operand));
+
+  {
+    // After a merge is added, GetMergeOperands must still resolve the blob
+    // backed base default column while traversing the older base entry below
+    // the newer merge operand.
+    GetMergeOperandsOptions get_merge_opts;
+    get_merge_opts.expected_max_number_of_operands = 2;
+
+    std::array<PinnableSlice, 2> merge_operands;
+    int number_of_operands = 0;
+
+    ASSERT_OK(db_->GetMergeOperands(ReadOptions(), db_->DefaultColumnFamily(),
+                                    key, merge_operands.data(), &get_merge_opts,
+                                    &number_of_operands));
+    ASSERT_EQ(number_of_operands, 2);
+    ASSERT_EQ(merge_operands[0], default_value);
+    ASSERT_EQ(merge_operands[1], merge_operand);
+  }
+}
+
 TEST_F(DBWideBasicTest, MergeEntityWithBlobColumnsNoDefault) {
   // Test: Merge on a V2 entity without a default column. The merge result
   // should produce a valid entity with all original columns plus a default

--- a/table/get_context.cc
+++ b/table/get_context.cc
@@ -201,6 +201,37 @@ Status GetContext::SaveWideColumnEntityToColumns(const Slice& user_key,
   return status;
 }
 
+Status GetContext::PushWideColumnEntityDefaultOperand(const Slice& user_key,
+                                                      const Slice& entity,
+                                                      Cleanable* value_pinner) {
+  Slice value_of_default;
+  Slice entity_ref = entity;
+  Status status = WideColumnSerialization::GetValueOfDefaultColumn(
+      entity_ref, value_of_default);
+  if (status.ok()) {
+    push_operand(value_of_default, value_pinner);
+    return status;
+  }
+  if (!status.IsNotSupported()) {
+    return status;
+  }
+  if (blob_fetcher_ == nullptr) {
+    return Status::Corruption(
+        "Cannot resolve blob-backed default column without a blob fetcher");
+  }
+
+  PinnableSlice resolved_default;
+  bool resolved = false;
+  status = WideColumnSerialization::GetValueOfDefaultColumnResolvingBlobs(
+      entity, user_key, blob_fetcher_, resolved_default, resolved);
+  if (status.ok()) {
+    // Resolved blob values are backed by this stack-local PinnableSlice, so
+    // copy them into MergeContext instead of pinning their storage.
+    push_operand(Slice(resolved_default), nullptr);
+  }
+  return status;
+}
+
 void GetContext::SaveValue(const Slice& value, SequenceNumber /*seq*/) {
   assert(state_ == kNotFound);
   assert(ucmp_->timestamp_size() == 0);
@@ -471,17 +502,16 @@ bool GetContext::SaveValue(const ParsedInternalKey& parsed_key,
               Slice blob_value(pin_val);
               push_operand(blob_value, nullptr);
             } else if (type == kTypeWideColumnEntity) {
-              Slice value_copy = unpacked_value;
-              Slice value_of_default;
-
-              if (!WideColumnSerialization::GetValueOfDefaultColumn(
-                       value_copy, value_of_default)
-                       .ok()) {
-                state_ = kCorrupt;
+              const Status s = PushWideColumnEntityDefaultOperand(
+                  parsed_key.user_key, unpacked_value, value_pinner);
+              if (!s.ok()) {
+                if (s.IsIncomplete()) {
+                  MarkKeyMayExist();
+                } else {
+                  state_ = kCorrupt;
+                }
                 return false;
               }
-
-              push_operand(value_of_default, value_pinner);
             } else {
               assert(type == kTypeValue || type == kTypeValuePreferredSeqno);
               push_operand(unpacked_value, value_pinner);
@@ -514,17 +544,16 @@ bool GetContext::SaveValue(const ParsedInternalKey& parsed_key,
               // It means this function is called as part of DB GetMergeOperands
               // API and the current value should be part of
               // merge_context_->operand_list
-              Slice value_copy = unpacked_value;
-              Slice value_of_default;
-
-              if (!WideColumnSerialization::GetValueOfDefaultColumn(
-                       value_copy, value_of_default)
-                       .ok()) {
-                state_ = kCorrupt;
+              const Status s = PushWideColumnEntityDefaultOperand(
+                  parsed_key.user_key, unpacked_value, value_pinner);
+              if (!s.ok()) {
+                if (s.IsIncomplete()) {
+                  MarkKeyMayExist();
+                } else {
+                  state_ = kCorrupt;
+                }
                 return false;
               }
-
-              push_operand(value_of_default, value_pinner);
             }
           } else {
             assert(type == kTypeValue || type == kTypeValuePreferredSeqno);

--- a/table/get_context.h
+++ b/table/get_context.h
@@ -202,6 +202,9 @@ class GetContext {
   Status SaveWideColumnEntityToColumns(const Slice& user_key,
                                        const Slice& entity,
                                        Cleanable* value_pinner);
+  Status PushWideColumnEntityDefaultOperand(const Slice& user_key,
+                                            const Slice& entity,
+                                            Cleanable* value_pinner);
 
   // Helper method that postprocesses the results of merge operations, e.g. it
   // sets the state correctly upon merge errors.


### PR DESCRIPTION
## Summary

Fix `GetMergeOperands()` so it can read the default column from a compacted wide-column entity after that value has been moved into a blob file.

Add a regression test covering both code paths:
- returning the compacted entity's default column as the base operand
- returning that same blob-backed base operand when a newer merge operand is present

## Test Plan

- `git diff --check upstream/main...HEAD`
