### PR TITLE
Add DB::KeyExists() public API to skip blob file reads for existence checks

### DIFF
--- a/db/blob/db_blob_basic_test.cc
+++ b/db/blob/db_blob_basic_test.cc
@@ -2640,6 +2640,171 @@ TEST_F(DBBlobBasicTest, GetApproximateSizesIncludingBlobFiles) {
   }
 }
 
+TEST_F(DBBlobBasicTest, KeyExistsSkipsBlobRead) {
+  Options options = GetDefaultOptions();
+  options.enable_blob_files = true;
+  options.min_blob_size = 0;
+  options.disable_auto_compactions = true;
+  options.statistics = CreateDBStatistics();
+
+  Reopen(options);
+
+  constexpr char key[] = "key";
+  constexpr char blob_value[] = "blob_value";
+
+  ASSERT_OK(Put(key, blob_value));
+  ASSERT_OK(Flush());
+
+  // Record baseline blob-read bytes for later comparison
+  uint64_t blob_bytes_before =
+      options.statistics->getTickerCount(BLOB_DB_BLOB_FILE_BYTES_READ);
+
+  // KeyExists should NOT read blob files
+  ASSERT_OK(db_->KeyExists(ReadOptions(), db_->DefaultColumnFamily(),
+                           Slice(key)));
+
+  uint64_t blob_bytes_after_key_exists =
+      options.statistics->getTickerCount(BLOB_DB_BLOB_FILE_BYTES_READ);
+  ASSERT_EQ(blob_bytes_before, blob_bytes_after_key_exists);
+
+  // Get should read blob files (control)
+  std::string value;
+  ASSERT_OK(db_->Get(ReadOptions(), key, &value));
+  ASSERT_EQ(blob_value, value);
+
+  uint64_t blob_bytes_after_get =
+      options.statistics->getTickerCount(BLOB_DB_BLOB_FILE_BYTES_READ);
+  ASSERT_GT(blob_bytes_after_get, blob_bytes_after_key_exists);
+}
+
+TEST_F(DBBlobBasicTest, KeyExistsBasic) {
+  Options options = GetDefaultOptions();
+  options.enable_blob_files = true;
+  options.min_blob_size = 0;
+
+  Reopen(options);
+
+  // Key absent
+  ASSERT_TRUE(db_->KeyExists(ReadOptions(), db_->DefaultColumnFamily(),
+                             Slice("absent"))
+                  .IsNotFound());
+
+  // Key present
+  ASSERT_OK(Put("key1", "value1"));
+  ASSERT_OK(db_->KeyExists(ReadOptions(), db_->DefaultColumnFamily(),
+                           Slice("key1")));
+
+  // Key present after flush (in SST + blob)
+  ASSERT_OK(Flush());
+  ASSERT_OK(db_->KeyExists(ReadOptions(), db_->DefaultColumnFamily(),
+                           Slice("key1")));
+
+  // Key absent after delete + compaction
+  ASSERT_OK(Delete("key1"));
+  ASSERT_OK(Flush());
+  ASSERT_OK(db_->CompactRange(CompactRangeOptions(), nullptr, nullptr));
+  ASSERT_TRUE(db_->KeyExists(ReadOptions(), db_->DefaultColumnFamily(),
+                             Slice("key1"))
+                  .IsNotFound());
+}
+
+TEST_F(DBBlobBasicTest, KeyExistsColumnFamily) {
+  Options options = GetDefaultOptions();
+  options.enable_blob_files = true;
+  options.min_blob_size = 0;
+
+  CreateAndReopenWithCF({"cf1"}, options);
+
+  ASSERT_OK(Put(0, "key_cf0", "value0"));
+  ASSERT_OK(Put(1, "key_cf1", "value1"));
+  ASSERT_OK(Flush(0));
+  ASSERT_OK(Flush(1));
+
+  // key_cf0 in default CF
+  ASSERT_OK(db_->KeyExists(ReadOptions(), handles_[0], Slice("key_cf0")));
+  ASSERT_TRUE(
+      db_->KeyExists(ReadOptions(), handles_[1], Slice("key_cf0")).IsNotFound());
+
+  // key_cf1 in cf1
+  ASSERT_TRUE(
+      db_->KeyExists(ReadOptions(), handles_[0], Slice("key_cf1")).IsNotFound());
+  ASSERT_OK(db_->KeyExists(ReadOptions(), handles_[1], Slice("key_cf1")));
+}
+
+TEST_F(DBBlobBasicTest, KeyExistsMergeOperands) {
+  Options options = GetDefaultOptions();
+  options.merge_operator = MergeOperators::CreateStringAppendOperator();
+  options.enable_blob_files = true;
+  options.min_blob_size = 0;
+
+  Reopen(options);
+
+  // Put base value, flush to blob
+  ASSERT_OK(Put("key1", "v1"));
+  ASSERT_OK(Flush());
+
+  // Merge on top, flush again
+  ASSERT_OK(Merge("key1", "v2"));
+  ASSERT_OK(Flush());
+
+  // KeyExists should return OK for merged key
+  ASSERT_OK(db_->KeyExists(ReadOptions(), db_->DefaultColumnFamily(),
+                           Slice("key1")));
+
+  // Verify Get still returns the merged result
+  std::string value;
+  ASSERT_OK(db_->Get(ReadOptions(), "key1", &value));
+  ASSERT_EQ("v1,v2", value);
+}
+
+TEST_F(DBBlobBasicTest, KeyExistsInvalidIOActivity) {
+  Options options = GetDefaultOptions();
+  Reopen(options);
+  ASSERT_OK(Put("key", "val"));
+
+  ReadOptions read_options;
+  read_options.io_activity = Env::IOActivity::kFlush;
+  ASSERT_TRUE(db_->KeyExists(read_options, db_->DefaultColumnFamily(),
+                             Slice("key"))
+                  .IsInvalidArgument());
+}
+
+TEST_F(DBBlobBasicTest, KeyExistsReadOnlyDB) {
+  Options options = GetDefaultOptions();
+  options.enable_blob_files = true;
+  options.min_blob_size = 0;
+
+  Reopen(options);
+
+  ASSERT_OK(Put("key1", "blob_value1"));
+  ASSERT_OK(Put("key2", "blob_value2"));
+  ASSERT_OK(Flush());
+
+  // Close the read-write DB
+  Close();
+
+  // Reopen as read-only
+  std::unique_ptr<DB> db_read_only;
+  ASSERT_OK(DB::OpenForReadOnly(options, dbname_, &db_read_only));
+
+  // KeyExists should work on read-only DB with BlobDB
+  ASSERT_OK(db_read_only->KeyExists(ReadOptions(),
+                                    db_read_only->DefaultColumnFamily(),
+                                    Slice("key1")));
+  ASSERT_OK(db_read_only->KeyExists(ReadOptions(),
+                                    db_read_only->DefaultColumnFamily(),
+                                    Slice("key2")));
+  ASSERT_TRUE(db_read_only->KeyExists(ReadOptions(),
+                                      db_read_only->DefaultColumnFamily(),
+                                      Slice("absent"))
+                  .IsNotFound());
+
+  db_read_only.reset();
+
+  // Reopen as read-write for cleanup
+  Reopen(options);
+}
+
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -2432,6 +2432,31 @@ ColumnFamilyHandle* DBImpl::PersistentStatsColumnFamily() const {
   return persist_stats_cf_handle_;
 }
 
+Status DB::KeyExists(const ReadOptions& _read_options,
+                     ColumnFamilyHandle* column_family, const Slice& key) {
+  if (_read_options.io_activity != Env::IOActivity::kUnknown &&
+      _read_options.io_activity != Env::IOActivity::kGet) {
+    return Status::InvalidArgument(
+        "Can only call KeyExists with `ReadOptions::io_activity` set to "
+        "`Env::IOActivity::kUnknown` or `Env::IOActivity::kGet`");
+  }
+
+  ReadOptions read_options(_read_options);
+  if (read_options.io_activity == Env::IOActivity::kUnknown) {
+    read_options.io_activity = Env::IOActivity::kGet;
+  }
+
+  // Use GetImpl with a non-null is_blob_index to skip blob file reads.
+  PinnableSlice pinnable_val;
+  DBImpl::GetImplOptions get_impl_options;
+  get_impl_options.column_family = column_family;
+  get_impl_options.value = &pinnable_val;
+  bool is_blob_index = false;
+  get_impl_options.is_blob_index = &is_blob_index;
+  return static_cast<DBImpl*>(this)->GetImpl(read_options, key,
+                                             get_impl_options);
+}
+
 Status DBImpl::GetImpl(const ReadOptions& read_options,
                        ColumnFamilyHandle* column_family, const Slice& key,
                        PinnableSlice* value) {

--- a/db/db_impl/db_impl_readonly.cc
+++ b/db/db_impl/db_impl_readonly.cc
@@ -103,7 +103,8 @@ Status DBImplReadOnly::GetImpl(const ReadOptions& read_options,
           get_impl_options.columns, ts, &s, &merge_context,
           &max_covering_tombstone_seq, read_options,
           false /* immutable_memtable */, &read_cb,
-          /*is_blob_index=*/nullptr, /*do_merge=*/get_impl_options.get_value)) {
+          get_impl_options.is_blob_index,
+          /*do_merge=*/get_impl_options.get_value)) {
     if (get_impl_options.value) {
       get_impl_options.value->PinSelf();
     }
@@ -116,7 +117,7 @@ Status DBImplReadOnly::GetImpl(const ReadOptions& read_options,
         ts, &s, &merge_context, &max_covering_tombstone_seq, &pinned_iters_mgr,
         /*value_found*/ nullptr,
         /*key_exists*/ nullptr, /*seq*/ nullptr, &read_cb,
-        /*is_blob*/ nullptr,
+        get_impl_options.is_blob_index,
         /*do_merge=*/get_impl_options.get_value);
     RecordTick(stats_, MEMTABLE_MISS);
   }

--- a/db/db_impl/db_impl_secondary.cc
+++ b/db/db_impl/db_impl_secondary.cc
@@ -405,7 +405,7 @@ Status DBImplSecondary::GetImpl(const ReadOptions& read_options,
             get_impl_options.columns, ts, &s, &merge_context,
             &max_covering_tombstone_seq, read_options,
             false /* immutable_memtable */, &read_cb,
-            /*is_blob_index=*/nullptr, /*do_merge=*/true)) {
+            get_impl_options.is_blob_index, /*do_merge=*/true)) {
       done = true;
       if (get_impl_options.value) {
         get_impl_options.value->PinSelf();
@@ -417,7 +417,8 @@ Status DBImplSecondary::GetImpl(const ReadOptions& read_options,
                    get_impl_options.value ? get_impl_options.value->GetSelf()
                                           : nullptr,
                    get_impl_options.columns, ts, &s, &merge_context,
-                   &max_covering_tombstone_seq, read_options, &read_cb)) {
+                   &max_covering_tombstone_seq, read_options, &read_cb,
+                   get_impl_options.is_blob_index)) {
       done = true;
       if (get_impl_options.value) {
         get_impl_options.value->PinSelf();
@@ -433,7 +434,7 @@ Status DBImplSecondary::GetImpl(const ReadOptions& read_options,
             get_impl_options.columns, ts, &s, &merge_context,
             &max_covering_tombstone_seq, read_options,
             false /* immutable_memtable */, &read_cb,
-            /*is_blob_index=*/nullptr, /*do_merge=*/false)) {
+            get_impl_options.is_blob_index, /*do_merge=*/false)) {
       done = true;
       RecordTick(stats_, MEMTABLE_HIT);
     } else if ((s.ok() || s.IsMergeInProgress()) &&
@@ -456,7 +457,8 @@ Status DBImplSecondary::GetImpl(const ReadOptions& read_options,
         read_options, lkey, get_impl_options.value, get_impl_options.columns,
         ts, &s, &merge_context, &max_covering_tombstone_seq, &pinned_iters_mgr,
         /*value_found*/ nullptr,
-        /*key_exists*/ nullptr, /*seq*/ nullptr, &read_cb, /*is_blob*/ nullptr,
+        /*key_exists*/ nullptr, /*seq*/ nullptr, &read_cb,
+        get_impl_options.is_blob_index,
         /*do_merge*/ true);
     RecordTick(stats_, MEMTABLE_MISS);
   }

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -981,6 +981,17 @@ class DB {
                        value_found);
   }
 
+  // Check if a key exists in the database without reading the value.
+  // More efficient than Get() for BlobDB (skips blob file reads) and for all
+  // stores (avoids exposing value bytes to the caller).
+  // Returns Status::OK() if key exists, Status::NotFound() if not.
+  virtual Status KeyExists(const ReadOptions& options,
+                           ColumnFamilyHandle* column_family, const Slice& key);
+
+  virtual Status KeyExists(const ReadOptions& options, const Slice& key) {
+    return KeyExists(options, DefaultColumnFamily(), key);
+  }
+
   // Return a heap-allocated iterator over the contents of the database.
   // The result of NewIterator() is initially invalid (caller must
   // call one of the Seek methods on the iterator before using it).

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -220,6 +220,13 @@ class StackableDB : public DB {
     return db_->KeyMayExist(options, column_family, key, value, value_found);
   }
 
+  using DB::KeyExists;
+  Status KeyExists(const ReadOptions& options,
+                   ColumnFamilyHandle* column_family,
+                   const Slice& key) override {
+    return db_->KeyExists(options, column_family, key);
+  }
+
   using DB::Delete;
   Status Delete(const WriteOptions& wopts, ColumnFamilyHandle* column_family,
                 const Slice& key) override {

--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -349,6 +349,7 @@ set(JAVA_TEST_CLASSES
   src/test/java/org/rocksdb/ImportColumnFamilyTest.java
   src/test/java/org/rocksdb/InfoLogLevelTest.java
   src/test/java/org/rocksdb/IngestExternalFileOptionsTest.java
+  src/test/java/org/rocksdb/KeyExistsBlobTest.java
   src/test/java/org/rocksdb/KeyExistsTest.java
   src/test/java/org/rocksdb/KeyMayExistTest.java
   src/test/java/org/rocksdb/LRUCacheTest.java
@@ -467,6 +468,7 @@ set(JAVA_TEST_RUNNING_CLASSES
   org.rocksdb.ImportColumnFamilyTest
   org.rocksdb.InfoLogLevelTest
   org.rocksdb.IngestExternalFileOptionsTest
+  org.rocksdb.KeyExistsBlobTest
   org.rocksdb.KeyExistsTest
   org.rocksdb.KeyMayExistTest
   org.rocksdb.LRUCacheTest

--- a/java/Makefile
+++ b/java/Makefile
@@ -144,6 +144,7 @@ JAVA_TESTS = \
 	org.rocksdb.FlushTest\
 	org.rocksdb.ImportColumnFamilyTest\
 	org.rocksdb.InfoLogLevelTest\
+	org.rocksdb.KeyExistsBlobTest \
 	org.rocksdb.KeyExistsTest \
 	org.rocksdb.KeyMayExistTest\
 	org.rocksdb.ConcurrentTaskLimiterTest\

--- a/java/rocksjni/rocksjni.cc
+++ b/java/rocksjni/rocksjni.cc
@@ -1932,11 +1932,21 @@ bool key_may_exist_direct_helper(JNIEnv* env, jlong jdb_handle,
   return exists;
 }
 
+//////////////////////////////////////////////////////////////////////////////
+// ROCKSDB_NAMESPACE::DB::KeyExists
+// Three-tier key existence check for the Java API:
+// 1. Bloom filter (KeyMayExist) — fast rejection for absent keys.
+// 2. Memtable/cache hit (value_found from KeyMayExist) — confirms presence
+//    without SST reads.
+// 3. GetImpl with blob-skip (KeyExists) — definitive check that reads SST
+//    index but skips blob file values.
+//
+// The C++ DB::KeyExists intentionally omits the KeyMayExist pre-check to
+// avoid issue #12921 false negatives for C++ callers. The JNI layer adds it
+// because the Java keyExists API already had this behavior and Java callers
+// accept the trade-off.
 jboolean key_exists_helper(JNIEnv* env, jlong jdb_handle, jlong jcf_handle,
                            jlong jread_opts_handle, char* key, jint jkey_len) {
-  std::string value;
-  bool value_found = false;
-
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
 
   ROCKSDB_NAMESPACE::ColumnFamilyHandle* cf_handle;
@@ -1955,24 +1965,27 @@ jboolean key_exists_helper(JNIEnv* env, jlong jdb_handle, jlong jcf_handle,
 
   ROCKSDB_NAMESPACE::Slice key_slice(key, jkey_len);
 
+  // Tier 1 & 2: bloom filter rejection + memtable/cache confirmation
+  std::string value;
+  bool value_found = false;
   const bool may_exist =
       db->KeyMayExist(read_opts, cf_handle, key_slice, &value, &value_found);
+  if (!may_exist) {
+    return JNI_FALSE;
+  }
+  if (value_found) {
+    return JNI_TRUE;
+  }
 
-  if (may_exist) {
-    ROCKSDB_NAMESPACE::Status s;
-    {
-      ROCKSDB_NAMESPACE::PinnableSlice pinnable_val;
-      s = db->Get(read_opts, cf_handle, key_slice, &pinnable_val);
-    }
-    if (s.IsNotFound()) {
-      return JNI_FALSE;
-    } else if (s.ok()) {
-      return JNI_TRUE;
-    } else {
-      ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env, s);
-      return JNI_FALSE;
-    }
+  // Tier 3: confirm with KeyExists (blob-skip, no false negatives)
+  ROCKSDB_NAMESPACE::Status s =
+      db->KeyExists(read_opts, cf_handle, key_slice);
+  if (s.ok()) {
+    return JNI_TRUE;
+  } else if (s.IsNotFound()) {
+    return JNI_FALSE;
   } else {
+    ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env, s);
     return JNI_FALSE;
   }
 }

--- a/java/src/test/java/org/rocksdb/KeyExistsBlobTest.java
+++ b/java/src/test/java/org/rocksdb/KeyExistsBlobTest.java
@@ -1,0 +1,251 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+package org.rocksdb;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.ByteBuffer;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Tests that {@link RocksDB#keyExists} works correctly with BlobDB enabled.
+ * keyExists confirms the key is present in the database (memtable or SST files)
+ * without reading blob file values. The JNI implementation calls DB::KeyExists,
+ * which internally uses GetImpl with a non-null is_blob_index pointer to skip
+ * blob resolution.
+ */
+public class KeyExistsBlobTest {
+  @ClassRule
+  public static final RocksNativeLibraryResource ROCKS_NATIVE_LIBRARY_RESOURCE =
+      new RocksNativeLibraryResource();
+
+  @Rule public TemporaryFolder dbFolder = new TemporaryFolder();
+
+  /** Value large enough to be stored in a blob file (exceeds minBlobSize). */
+  private static byte[] largeValue(final int size) {
+    final byte[] value = new byte[size];
+    for (int i = 0; i < size; i++) {
+      value[i] = (byte) (i % 256);
+    }
+    return value;
+  }
+
+  /**
+   * Basic correctness: keyExists returns true for existing keys and false for non-existing keys
+   * when BlobDB is enabled. This validates that the GetImpl-based implementation correctly
+   * handles blob indexes.
+   */
+  @Test
+  public void keyExistsWithBlobDb() throws RocksDBException {
+    try (final Options options = new Options()
+            .setCreateIfMissing(true)
+            .setEnableBlobFiles(true)
+            .setMinBlobSize(100)
+            .setEnableBlobGarbageCollection(true);
+         final RocksDB db = RocksDB.open(options, dbFolder.getRoot().getAbsolutePath())) {
+
+      // Small value (stays in SST, not blob)
+      final byte[] smallKey = "small_key".getBytes(UTF_8);
+      db.put(smallKey, "small_value".getBytes(UTF_8));
+
+      // Large value (goes to blob file)
+      final byte[] largeKey = "large_key".getBytes(UTF_8);
+      db.put(largeKey, largeValue(1024));
+
+      // Flush to ensure data is in SST/blob files (not just memtable)
+      try (final FlushOptions flushOptions = new FlushOptions().setWaitForFlush(true)) {
+        db.flush(flushOptions);
+      }
+
+      // Both should exist
+      assertThat(db.keyExists(smallKey)).isTrue();
+      assertThat(db.keyExists(largeKey)).isTrue();
+
+      // Non-existing key should not exist
+      assertThat(db.keyExists("nonexistent".getBytes(UTF_8))).isFalse();
+
+      // Delete the large key and verify
+      db.delete(largeKey);
+      try (final FlushOptions flushOptions = new FlushOptions().setWaitForFlush(true)) {
+        db.flush(flushOptions);
+      }
+      try (final CompactRangeOptions compactOpts = new CompactRangeOptions()) {
+        db.compactRange(null, null, compactOpts);
+      }
+      assertThat(db.keyExists(largeKey)).isFalse();
+    }
+  }
+
+  /**
+   * Verifies keyExists with ReadOptions works correctly with BlobDB.
+   */
+  @Test
+  public void keyExistsWithBlobDbReadOptions() throws RocksDBException {
+    try (final Options options = new Options()
+            .setCreateIfMissing(true)
+            .setEnableBlobFiles(true)
+            .setMinBlobSize(100);
+         final RocksDB db = RocksDB.open(options, dbFolder.getRoot().getAbsolutePath());
+         final ReadOptions readOptions = new ReadOptions()) {
+
+      final byte[] key = "ro_key".getBytes(UTF_8);
+      db.put(key, largeValue(512));
+
+      try (final FlushOptions flushOptions = new FlushOptions().setWaitForFlush(true)) {
+        db.flush(flushOptions);
+      }
+
+      assertThat(db.keyExists(readOptions, key)).isTrue();
+      assertThat(db.keyExists(readOptions, "nonexistent".getBytes(UTF_8))).isFalse();
+    }
+  }
+
+  /**
+   * Verifies keyExists returns true for a key still in the memtable (before flush).
+   */
+  @Test
+  public void keyExistsInMemtableWithBlobDb() throws RocksDBException {
+    try (final Options options = new Options()
+            .setCreateIfMissing(true)
+            .setEnableBlobFiles(true)
+            .setMinBlobSize(100);
+         final RocksDB db = RocksDB.open(options, dbFolder.getRoot().getAbsolutePath())) {
+
+      final byte[] key = "memtable_key".getBytes(UTF_8);
+      db.put(key, largeValue(512));
+
+      // Key should exist in memtable before any flush
+      assertThat(db.keyExists(key)).isTrue();
+      assertThat(db.keyExists("nonexistent".getBytes(UTF_8))).isFalse();
+    }
+  }
+
+  /**
+   * Verifies that keyExists with BlobDB does NOT read blob files.
+   * Uses PerfContext to measure blob read I/O — keyExists should show zero blob reads
+   * while get() should show non-zero blob reads for the same key.
+   */
+  @Test
+  public void keyExistsSkipsBlobRead() throws RocksDBException {
+    try (final Options options = new Options()
+            .setCreateIfMissing(true)
+            .setEnableBlobFiles(true)
+            .setMinBlobSize(100)
+            .setEnableBlobGarbageCollection(true);
+         final RocksDB db = RocksDB.open(options, dbFolder.getRoot().getAbsolutePath())) {
+
+      final byte[] key = "blob_key".getBytes(UTF_8);
+      db.put(key, largeValue(2048));
+
+      // Flush to force data into SST + blob files
+      try (final FlushOptions flushOptions = new FlushOptions().setWaitForFlush(true)) {
+        db.flush(flushOptions);
+      }
+
+      // Enable perf context to track I/O
+      db.setPerfLevel(PerfLevel.ENABLE_COUNT);
+      final PerfContext perfCtx = db.getPerfContext();
+
+      try {
+        // --- keyExists should NOT read blob files ---
+        perfCtx.reset();
+        assertThat(db.keyExists(key)).isTrue();
+
+        assertThat(perfCtx.getBlobReadCount())
+            .as("keyExists should not read blob files")
+            .isEqualTo(0);
+        assertThat(perfCtx.getBlobReadByte())
+            .as("keyExists should not read blob bytes")
+            .isEqualTo(0);
+
+        // --- get() SHOULD read blob files (control) ---
+        perfCtx.reset();
+        final byte[] value = db.get(key);
+        assertThat(value).isNotNull();
+        assertThat(value.length).isEqualTo(2048);
+
+        assertThat(perfCtx.getBlobReadCount())
+            .as("get() should read blob files")
+            .isGreaterThan(0);
+        assertThat(perfCtx.getBlobReadByte())
+            .as("get() should read blob bytes")
+            .isGreaterThan(0);
+      } finally {
+        db.setPerfLevel(PerfLevel.DISABLE);
+      }
+    }
+  }
+
+  /**
+   * Verifies keyExists correctness with BlobDB across column families.
+   */
+  @Test
+  public void keyExistsWithBlobDbColumnFamily() throws RocksDBException {
+    try (final Options options = new Options()
+            .setCreateIfMissing(true)
+            .setEnableBlobFiles(true)
+            .setMinBlobSize(100);
+         final RocksDB db = RocksDB.open(options, dbFolder.getRoot().getAbsolutePath())) {
+
+      try (final ColumnFamilyOptions cfOptions = new ColumnFamilyOptions()
+              .setEnableBlobFiles(true)
+              .setMinBlobSize(100);
+           final ColumnFamilyHandle cf2 = db.createColumnFamily(
+              new ColumnFamilyDescriptor("cf2".getBytes(UTF_8), cfOptions))) {
+
+        final byte[] key1 = "key_cf1".getBytes(UTF_8);
+        final byte[] key2 = "key_cf2".getBytes(UTF_8);
+
+        db.put(key1, largeValue(512));
+        db.put(cf2, key2, largeValue(512));
+
+        try (final FlushOptions flushOptions = new FlushOptions().setWaitForFlush(true)) {
+          db.flush(flushOptions);
+          db.flush(flushOptions, cf2);
+        }
+
+        assertThat(db.keyExists(key1)).isTrue();
+        assertThat(db.keyExists(cf2, key1)).isFalse();
+
+        assertThat(db.keyExists(key2)).isFalse();
+        assertThat(db.keyExists(cf2, key2)).isTrue();
+      }
+    }
+  }
+
+  /**
+   * Verifies keyExists with DirectByteBuffer works with BlobDB.
+   */
+  @Test
+  public void keyExistsDirectByteBufferWithBlobDb() throws RocksDBException {
+    try (final Options options = new Options()
+            .setCreateIfMissing(true)
+            .setEnableBlobFiles(true)
+            .setMinBlobSize(100);
+         final RocksDB db = RocksDB.open(options, dbFolder.getRoot().getAbsolutePath())) {
+
+      final byte[] key = "direct_blob_key".getBytes(UTF_8);
+      db.put(key, largeValue(1024));
+      try (final FlushOptions flushOptions = new FlushOptions().setWaitForFlush(true)) {
+        db.flush(flushOptions);
+      }
+
+      final ByteBuffer keyBuf = ByteBuffer.allocateDirect(key.length);
+      keyBuf.put(key);
+      keyBuf.flip();
+      assertThat(db.keyExists(keyBuf)).isTrue();
+
+      final ByteBuffer missingBuf = ByteBuffer.allocateDirect(10);
+      missingBuf.put("missing_xx".getBytes(UTF_8));
+      missingBuf.flip();
+      assertThat(db.keyExists(missingBuf)).isFalse();
+    }
+  }
+}

--- a/unreleased_history/public_api_changes/key_exists.md
+++ b/unreleased_history/public_api_changes/key_exists.md
@@ -1,0 +1,1 @@
+Added new `DB::KeyExists()` virtual method to check if a key exists in the database without reading the value. Returns `Status::OK()` if the key exists, `Status::NotFound()` if not. More efficient than `Get()` for BlobDB stores because it skips blob file reads entirely, and for all stores because it avoids copying value bytes to the caller.


### PR DESCRIPTION
## Summary

The Java `keyExists()` was added as a JNI convenience that calls `KeyMayExist` + `Get`. For BlobDB stores, the `Get` step resolves blob indexes and reads potentially large (10KB–1MB+) blob values that are immediately discarded. This PR eliminates that waste by introducing a C++ `DB::KeyExists()` that both C++ and Java callers benefit from.

## Details

Add a new `DB::KeyExists()` virtual method that checks key existence without resolving blob indexes. The existing Java `keyExists()` JNI method internally calls `Get()` which reads the full blob value only to discard it. The new API uses `GetImpl` with a non-null `is_blob_index` pointer, causing `Version::Get` to skip blob file I/O entirely.

- Add `DB::KeyExists(ReadOptions, ColumnFamilyHandle*, Slice)` returning `Status::OK()` or `Status::NotFound()`
- Add `io_activity` validation matching `DB::Get()` pattern
- Add `StackableDB::KeyExists()` override to prevent undefined behavior on `TransactionDB`/`DBWithTTL`
- Propagate `is_blob_index` in `DBImplReadOnly::GetImpl` and `DBImplSecondary::GetImpl` (all `mem->Get`, `imm->Get`, and `Version::Get` call sites)
- Simplify JNI `key_exists_helper` to delegate to `DB::KeyExists()` with a `KeyMayExist` bloom filter pre-check for fast rejection of absent keys
- Add C++ tests: blob-skip verification via `BLOB_DB_BLOB_FILE_BYTES_READ` statistics, basic existence, column families, merge operands, invalid `io_activity`, read-only DB
- Add Java tests: BlobDB correctness, blob-skip verification via `PerfContext`, column families, `ReadOptions` variant, memtable path, `DirectByteBuffer`

Related: #12921 reports `keyExists` false negatives from `KeyMayExist`. The C++ `DB::KeyExists()` avoids this by calling `GetImpl` directly without `KeyMayExist`. The JNI layer retains `KeyMayExist` as a fast-path (accepted trade-off for backward compatibility).

## Testing

- `db_blob_basic_test`: 6 new `KeyExists*` test cases
- `KeyExistsBlobTest.java`: 6 new Java test cases including `PerfContext`-based blob-read verification
- Both test suites verify that `keyExists` produces zero blob reads while `get()` on the same key produces non-zero blob reads (control)