### PR TITLE
Add RocksDb.Net C# library

### DIFF
--- a/LANGUAGE-BINDINGS.md
+++ b/LANGUAGE-BINDINGS.md
@@ -16,6 +16,7 @@ This is the list of all known third-party language bindings for RocksDB. If some
 * C#
     * https://github.com/warrenfalk/rocksdb-sharp
     * https://github.com/curiosity-ai/rocksdb-sharp
+    * https://github.com/zcsizmadia/RocksDb.Net
 * Rust
     * https://github.com/pingcap/rust-rocksdb (used in production fork of https://github.com/spacejam/rust-rocksdb)
     * https://github.com/spacejam/rust-rocksdb


### PR DESCRIPTION
I've created a modernized C# library for RocksDb focusing on:

- Multi platform support for Windows, Linux, MacOS (x86, x64, arm64 and x64 musl)
- Auditable build process using Github to build the all the native libraries
- Comprehensive testing for the C# implemented features, focusing on memory management and object disposal
- Samples for all implemented features
- Detailed API documentation 


C# Library
[RocksDb.Net](https://github.com/zcsizmadia/RocksDb.Net)

Runtimes/Native library (referenced by RocksDb.Net)
[RocksDb.Net.Runtimes](https://github.com/zcsizmadia/RocksDb.Net.Runtimes)
