### PR TITLE
Return exact terminal sequence number from CreateCheckpoint

### DIFF
--- a/db/db_filesnapshot.cc
+++ b/db/db_filesnapshot.cc
@@ -198,6 +198,13 @@ Status DBImpl::GetCurrentWalFile(std::unique_ptr<WalFile>* current_wal_file) {
 Status DBImpl::GetLiveFilesStorageInfo(
     const LiveFilesStorageInfoOptions& opts,
     std::vector<LiveFileStorageInfo>* files) {
+  return GetLiveFilesStorageInfo(opts, files, /*last_sequence=*/nullptr);
+}
+
+Status DBImpl::GetLiveFilesStorageInfo(
+    const LiveFilesStorageInfoOptions& opts,
+    std::vector<LiveFileStorageInfo>* files,
+    SequenceNumber* last_sequence) {
   // To avoid returning partial results, only move results to files on success.
   assert(files);
   files->clear();
@@ -347,6 +354,12 @@ Status DBImpl::GetLiveFilesStorageInfo(
   const uint64_t min_log_num = MinLogNumberToKeep();
   // Ensure consistency with manifest for track_and_verify_wals_in_manifest
   const uint64_t max_log_num = cur_wal_number_;
+  // Capture the last sequence number while holding the DB mutex so it is
+  // synchronized with the returned file set: the optional flush above has
+  // completed, and no further writes can be assigned until we unlock.
+  if (last_sequence != nullptr) {
+    *last_sequence = versions_->LastSequence();
+  }
 
   mutex_.Unlock();
 

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -573,6 +573,11 @@ class DBImpl : public DB {
       const LiveFilesStorageInfoOptions& opts,
       std::vector<LiveFileStorageInfo>* files) override;
 
+  Status GetLiveFilesStorageInfo(
+      const LiveFilesStorageInfoOptions& opts,
+      std::vector<LiveFileStorageInfo>* files,
+      SequenceNumber* last_sequence) override;
+
   // Obtains the meta data of the specified column family of the DB.
   // TODO(yhchiang): output parameter is placed in the end in this codebase.
   void GetColumnFamilyMetaData(ColumnFamilyHandle* column_family,

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1909,6 +1909,26 @@ class DB {
       const LiveFilesStorageInfoOptions& opts,
       std::vector<LiveFileStorageInfo>* files) = 0;
 
+  // Same as the above, but on success, additionally writes to `*last_sequence`
+  // (if non-null) a sequence number bound for the returned file set: no write
+  // with a strictly greater sequence number is reflected in the returned
+  // files. On error, the value written to `*last_sequence` is unspecified.
+  //
+  // The default implementation captures `GetLatestSequenceNumber()` prior to
+  // enumerating live files, so `*last_sequence` is only a lower bound on the
+  // terminal sequence number of the returned set. Subclasses that synchronize
+  // file enumeration with writes (such as `DBImpl`) override this to provide
+  // an exact value.
+  virtual Status GetLiveFilesStorageInfo(
+      const LiveFilesStorageInfoOptions& opts,
+      std::vector<LiveFileStorageInfo>* files,
+      SequenceNumber* last_sequence) {
+    if (last_sequence != nullptr) {
+      *last_sequence = GetLatestSequenceNumber();
+    }
+    return GetLiveFilesStorageInfo(opts, files);
+  }
+
   // Obtains the LSM-tree meta data of the specified column family of the DB,
   // including metadata for each live table (SST) file in that column family.
   virtual void GetColumnFamilyMetaData(ColumnFamilyHandle* /*column_family*/,

--- a/include/rocksdb/utilities/checkpoint.h
+++ b/include/rocksdb/utilities/checkpoint.h
@@ -40,8 +40,10 @@ class Checkpoint {
   // if WAL writing is not always enabled.
   // Flush will always trigger if it is 2PC.
   // sequence_number_ptr: if it is not nullptr, the value it points to will be
-  // set to a sequence number guaranteed to be part of the DB, not necessarily
-  // the latest. The default value of this parameter is nullptr.
+  // set to the checkpoint's terminal sequence number: the largest sequence
+  // number included in the checkpoint, captured atomically with the file set
+  // so that no write with a greater sequence number is reflected in the
+  // checkpoint. The default value of this parameter is nullptr.
   // NOTE: db_paths and cf_paths are not supported for creating checkpoints
   // and NotSupported will be returned when the DB (without WALs) uses more
   // than one directory.

--- a/utilities/checkpoint/checkpoint_impl.cc
+++ b/utilities/checkpoint/checkpoint_impl.cc
@@ -231,8 +231,6 @@ Status CheckpointImpl::CreateCustomCheckpoint(
         create_file_cb,
     uint64_t* sequence_number, uint64_t log_size_for_flush,
     bool get_live_table_checksum, bool atomic_flush) {
-  *sequence_number = db_->GetLatestSequenceNumber();
-
   LiveFilesStorageInfoOptions opts;
   opts.include_checksum_info = get_live_table_checksum;
   opts.wal_size_for_flush = log_size_for_flush;
@@ -240,7 +238,11 @@ Status CheckpointImpl::CreateCustomCheckpoint(
 
   std::vector<LiveFileStorageInfo> infos;
   {
-    Status s = db_->GetLiveFilesStorageInfo(opts, &infos);
+    // Route sequence_number through GetLiveFilesStorageInfo so it is captured
+    // under the DB mutex after the flush (if any) has completed. Reading
+    // db_->GetLatestSequenceNumber() here (before the flush) would return
+    // only a lower bound on the checkpoint's terminal sequence number.
+    Status s = db_->GetLiveFilesStorageInfo(opts, &infos, sequence_number);
     if (!s.ok()) {
       return s;
     }

--- a/utilities/checkpoint/checkpoint_test.cc
+++ b/utilities/checkpoint/checkpoint_test.cc
@@ -786,6 +786,34 @@ TEST_F(CheckpointTest, CheckpointWithParallelWrites) {
   thread.join();
 }
 
+TEST_F(CheckpointTest, CreateCheckpointReturnsTerminalSequenceNumber) {
+  // The sequence number returned via sequence_number_ptr must equal the
+  // checkpoint's terminal sequence number, not a pre-flush lower bound:
+  // reopening the checkpoint and reading GetLatestSequenceNumber() must
+  // return the same value.
+  Options options = CurrentOptions();
+  Reopen(options);
+
+  for (int i = 0; i < 100; ++i) {
+    ASSERT_OK(Put("k" + std::to_string(i), "v" + std::to_string(i)));
+  }
+
+  Checkpoint* checkpoint;
+  ASSERT_OK(Checkpoint::Create(db_.get(), &checkpoint));
+  uint64_t reported_seq = 0;
+  ASSERT_OK(checkpoint->CreateCheckpoint(snapshot_name_,
+                                         /*log_size_for_flush=*/0,
+                                         &reported_seq));
+  delete checkpoint;
+
+  DB* checkpoint_db = nullptr;
+  ASSERT_OK(DB::OpenForReadOnly(options, snapshot_name_, &checkpoint_db));
+  const uint64_t actual_seq = checkpoint_db->GetLatestSequenceNumber();
+  delete checkpoint_db;
+
+  EXPECT_EQ(reported_seq, actual_seq);
+}
+
 class CheckpointTestWithWalParams
     : public CheckpointTest,
       public testing::WithParamInterface<


### PR DESCRIPTION
## Problem

`Checkpoint::CreateCheckpoint(dir, log_size_for_flush, sequence_number_ptr)` currently writes a **lower bound** to `*sequence_number_ptr` rather than the checkpoint's terminal sequence number.

In `CheckpointImpl::CreateCustomCheckpoint`, the value is captured by calling `db_->GetLatestSequenceNumber()` at the top of the function, *before* `GetLiveFilesStorageInfo` triggers the checkpoint's internal flush:

```cpp
*sequence_number = db_->GetLatestSequenceNumber();   // pre-flush read
// ...
s = db_->GetLiveFilesStorageInfo(opts, &infos);      // does the flush
```

Writes that arrive between the pre-flush read and the flush sealing point land in the flushed SSTs and thus in the checkpoint, so the checkpoint's actual terminal LSN can be strictly greater than the value reported back.

The public doc comment on `sequence_number_ptr` acknowledges this: *"guaranteed to be part of the DB, not necessarily the latest."* Callers that need an exact LSN today have to reopen the checkpoint read-only and read `GetLatestSequenceNumber()` — a surprising extra step (and one that pays for an extra SST-footer prewarm unless `max_open_files` is tuned down).

## Fix

Capture the sequence number atomically inside `DBImpl::GetLiveFilesStorageInfo`, while the DB mutex is still held — after the optional flush has completed, before any subsequent write can be assigned a sequence number. Plumb it out through a new overload.

- **`include/rocksdb/db.h`** — Add a new, non-pure overload of `GetLiveFilesStorageInfo` that takes a `SequenceNumber* last_sequence`. The default implementation is a best-effort wrapper that captures `GetLatestSequenceNumber()` before delegating to the existing overload, preserving the current lower-bound behavior for stackable DBs that don't override. Existing subclasses and callers stay source- and ABI-compatible.
- **`db/db_impl/db_impl.h` + `db/db_filesnapshot.cc`** — `DBImpl` overrides the new overload and writes `*last_sequence = versions_->LastSequence()` inside the existing "Capture some final info before releasing mutex" block, synchronized with the file enumeration.
- **`utilities/checkpoint/checkpoint_impl.cc`** — Drop the pre-flush `GetLatestSequenceNumber()` read; route `sequence_number_ptr` through the new overload. `BackupEngine`, which shares `CreateCustomCheckpoint`, gets the fix for free.
- **`include/rocksdb/utilities/checkpoint.h`** — Update the `sequence_number_ptr` doc to reflect the new, stronger contract.
- **`utilities/checkpoint/checkpoint_test.cc`** — New regression test `CreateCheckpointReturnsTerminalSequenceNumber`: write N keys, checkpoint with `sequence_number_ptr`, reopen the checkpoint, assert `reported_seq == checkpoint_db->GetLatestSequenceNumber()`.

## Compatibility

- No signature change on the existing pure-virtual `GetLiveFilesStorageInfo(opts, files)`. All existing overrides keep compiling unchanged.
- The new overload is non-pure with a default impl, so stackable DBs that don't override continue to return the current lower-bound value — same semantics as before.
- Strengthening the `sequence_number_ptr` contract is backward-compatible for callers: any caller that was treating the returned value as a lower bound continues to work; callers that wanted the terminal LSN now get it without the reopen workaround.

## Motivation

Hit this in a downstream project where leader→follower snapshot reuse requires an exact terminal LSN to decide whether a cached checkpoint covers the WAL archive cutoff. The current workaround is to reopen the checkpoint read-only and read `GetLatestSequenceNumber()`, which doubles the open cost on the hot path.