### PR TITLE
add scatter-gather APIs to WriteBatch

### DIFF
--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -2261,13 +2261,44 @@ IOStatus DBImpl::WriteToWAL(const WriteBatch& merged_batch,
                             SequenceNumber sequence) {
   assert(log_size != nullptr);
 
-  Slice log_entry = WriteBatchInternal::Contents(&merged_batch);
-  TEST_SYNC_POINT_CALLBACK("DBImpl::WriteToWAL:log_entry", &log_entry);
+  // When WAL compression is enabled the streaming compressor requires a
+  // contiguous input buffer, so a scatter-gather payload would be
+  // concatenated inside log_writer anyway. Materialize the batch up
+  // front instead -- that produces a single-slice gather over rep_ with
+  // the same memcpy cost as the legacy non-SG path (no saving, no
+  // regression) and also keeps the existing single-slice sync point
+  // hook active for corruption tests.
+  if (log_writer->IsCompressing() && merged_batch.HasPendingSG()) {
+    const_cast<WriteBatch&>(merged_batch).MaterializeSG();
+  }
+  // Fast path: no pending SG entries, so the WAL payload is exactly
+  // rep_. Avoid allocating a WalGather (std::string + std::vector) and
+  // instead emit a single Slice directly. This matters on the non-SG
+  // hot path (the common case: most writers never call PutSG) and on
+  // WAL-compression systems where the block above already materialized.
+  const bool sg_path = merged_batch.HasPendingSG();
+  Slice log_entry;
+  WriteBatchInternal::WalGather gather;
+  size_t total_bytes;
+  if (!sg_path) {
+    log_entry = WriteBatchInternal::Contents(&merged_batch);
+    total_bytes = log_entry.size();
+    TEST_SYNC_POINT_CALLBACK("DBImpl::WriteToWAL:log_entry", &log_entry);
+  } else {
+    // SG payload -- references caller-owned key/value buffers directly
+    // so the bytes are not copied through rep_. Use a distinct sync
+    // point name so the single-slice callback contract is preserved;
+    // tests that want to observe or tamper with SG payloads can hook
+    // this variant and receive a WriteBatchInternal::WalGather*.
+    WriteBatchInternal::GatherForWAL(&merged_batch, &gather);
+    total_bytes = gather.total_bytes;
+    TEST_SYNC_POINT_CALLBACK("DBImpl::WriteToWAL:log_entry_sg", &gather);
+  }
   auto s = merged_batch.VerifyChecksum();
   if (!s.ok()) {
     return status_to_io_status(std::move(s));
   }
-  *log_size = log_entry.size();
+  *log_size = total_bytes;
   // When two_write_queues_ WriteToWAL has to be protected from concurretn calls
   // from the two queues anyway and wal_write_mutex_ is already held. Otherwise
   // if manual_wal_flush_ is enabled we need to protect log_writer->AddRecord
@@ -2284,7 +2315,11 @@ IOStatus DBImpl::WriteToWAL(const WriteBatch& merged_batch,
   if (!io_s.ok()) {
     return io_s;
   }
-  io_s = log_writer->AddRecord(write_options, log_entry, sequence);
+  if (!sg_path) {
+    io_s = log_writer->AddRecord(write_options, log_entry, sequence);
+  } else {
+    io_s = log_writer->AddRecord(write_options, gather.slices, sequence);
+  }
 
   if (UNLIKELY(needs_locking)) {
     wal_write_mutex_.Unlock();
@@ -2293,7 +2328,7 @@ IOStatus DBImpl::WriteToWAL(const WriteBatch& merged_batch,
     *wal_used = cur_wal_number_;
     assert(*wal_used == wal_file_number_size.number);
   }
-  wals_total_size_.FetchAddRelaxed(log_entry.size());
+  wals_total_size_.FetchAddRelaxed(total_bytes);
   wal_file_number_size.AddSize(*log_size);
   wal_empty_ = false;
 

--- a/db/log_writer.cc
+++ b/db/log_writer.cc
@@ -87,6 +87,131 @@ bool Writer::PublishIfClosed() {
 }
 
 IOStatus Writer::AddRecord(const WriteOptions& write_options,
+                           const std::vector<Slice>& slices,
+                           const SequenceNumber& seqno) {
+  // Single-slice fast path.
+  if (slices.size() == 1) {
+    return AddRecord(write_options, slices[0], seqno);
+  }
+
+  // Defensive fallback: compression requires a contiguous input
+  // buffer, so concatenate and delegate to the single-slice compressed
+  // path. The primary WAL caller (DBImpl::WriteToWAL) checks
+  // IsCompressing() up front and materializes the WriteBatch there, so
+  // this path is normally unreachable from the hot write path; it is
+  // kept so that any other caller of the multi-slice AddRecord stays
+  // correct under compression.
+  if (compress_) {
+    size_t total = 0;
+    for (const Slice& s : slices) {
+      total += s.size();
+    }
+    std::string concat;
+    concat.reserve(total);
+    for (const Slice& s : slices) {
+      concat.append(s.data(), s.size());
+    }
+    return AddRecord(write_options, Slice(concat), seqno);
+  }
+
+  IOStatus s = MaybeHandleSeenFileWriterError();
+  if (!s.ok()) {
+    return s;
+  }
+
+  size_t total_left = 0;
+  for (const Slice& sl : slices) {
+    total_left += sl.size();
+  }
+  size_t left = total_left;
+  size_t slice_idx = 0;
+  size_t slice_off = 0;
+
+  IOOptions opts;
+  s = WritableFileWriter::PrepareIOOptions(write_options, opts);
+  if (!s.ok()) {
+    return s;
+  }
+
+  // Fragment the record across block boundaries. Note that if the
+  // record is empty, we still want to iterate once to emit a single
+  // zero-length record.
+  bool begin = true;
+  do {
+    const int64_t leftover = kBlockSize - block_offset_;
+    assert(leftover >= 0);
+    if (leftover < header_size_) {
+      if (leftover > 0) {
+        assert(header_size_ <= 11);
+        s = dest_->Append(opts,
+                          Slice("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
+                                static_cast<size_t>(leftover)),
+                          0 /* crc32c_checksum */);
+        if (!s.ok()) {
+          break;
+        }
+      }
+      block_offset_ = 0;
+    }
+
+    assert(static_cast<int64_t>(kBlockSize - block_offset_) >= header_size_);
+
+    const size_t avail = kBlockSize - block_offset_ - header_size_;
+    const size_t fragment_length = (left < avail) ? left : avail;
+
+    RecordType type;
+    const bool end = (left == fragment_length);
+    if (begin && end) {
+      type = recycle_log_files_ ? kRecyclableFullType : kFullType;
+    } else if (begin) {
+      type = recycle_log_files_ ? kRecyclableFirstType : kFirstType;
+    } else if (end) {
+      type = recycle_log_files_ ? kRecyclableLastType : kLastType;
+    } else {
+      type = recycle_log_files_ ? kRecyclableMiddleType : kMiddleType;
+    }
+
+    s = EmitPhysicalRecordSG(write_options, type, slices, slice_idx, slice_off,
+                             fragment_length);
+
+    // Advance cursor by fragment_length bytes through the slice list.
+    size_t remaining = fragment_length;
+    while (remaining > 0) {
+      const size_t avail_in_slice = slices[slice_idx].size() - slice_off;
+      if (remaining >= avail_in_slice) {
+        remaining -= avail_in_slice;
+        ++slice_idx;
+        slice_off = 0;
+      } else {
+        slice_off += remaining;
+        remaining = 0;
+      }
+    }
+    // Skip past any zero-length slices so the next iteration starts on a
+    // non-empty slice (or past-the-end).
+    while (slice_idx < slices.size() && slices[slice_idx].size() == slice_off) {
+      ++slice_idx;
+      slice_off = 0;
+    }
+
+    left -= fragment_length;
+    begin = false;
+  } while (s.ok() && left > 0);
+
+  if (s.ok()) {
+    if (!manual_flush_) {
+      s = dest_->Flush(opts);
+    }
+  }
+
+  if (s.ok()) {
+    last_seqno_recorded_ = std::max(last_seqno_recorded_, seqno);
+  }
+
+  return s;
+}
+
+IOStatus Writer::AddRecord(const WriteOptions& write_options,
                            const Slice& slice, const SequenceNumber& seqno) {
   IOStatus s = MaybeHandleSeenFileWriterError();
   if (!s.ok()) {
@@ -356,6 +481,97 @@ IOStatus Writer::EmitPhysicalRecord(const WriteOptions& write_options,
   }
   if (s.ok()) {
     s = dest_->Append(opts, Slice(ptr, n), payload_crc);
+  }
+  block_offset_ += header_size + n;
+  return s;
+}
+
+IOStatus Writer::EmitPhysicalRecordSG(const WriteOptions& write_options,
+                                      RecordType t,
+                                      const std::vector<Slice>& slices,
+                                      size_t start_idx, size_t start_off,
+                                      size_t n) {
+  assert(n <= 0xffff);  // Must fit in two bytes
+
+  size_t header_size;
+  char buf[kRecyclableHeaderSize];
+
+  buf[4] = static_cast<char>(n & 0xff);
+  buf[5] = static_cast<char>(n >> 8);
+  buf[6] = static_cast<char>(t);
+
+  uint32_t crc = type_crc_[t];
+  if (t < kRecyclableFullType || t == kSetCompressionType ||
+      t == kPredecessorWALInfoType || t == kUserDefinedTimestampSizeType) {
+    assert(block_offset_ + kHeaderSize + n <= kBlockSize);
+    header_size = kHeaderSize;
+  } else {
+    assert(block_offset_ + kRecyclableHeaderSize + n <= kBlockSize);
+    header_size = kRecyclableHeaderSize;
+    EncodeFixed32(buf + 7, static_cast<uint32_t>(log_number_));
+    crc = crc32c::Extend(crc, buf + 7, 4);
+  }
+
+  // Compute payload CRC incrementally across spans.
+  //
+  // The payload is walked twice: once here to compute the CRC and then
+  // again below to Append to dest_. The two passes cannot be folded:
+  // the record header contains CRC(type + payload) and must be written
+  // BEFORE the payload, so the full CRC has to be known before any
+  // payload byte is handed to the writer. WritableFileWriter is
+  // append-only (no seek-back to patch a placeholder), so we cannot
+  // emit the header speculatively. Each pass only touches slice
+  // descriptors plus the payload bytes themselves, which are hot in L1
+  // from the CRC pass when the second pass runs.
+  uint32_t payload_crc = 0;
+  {
+    size_t idx = start_idx;
+    size_t off = start_off;
+    size_t rem = n;
+    while (rem > 0) {
+      const size_t avail_in_slice = slices[idx].size() - off;
+      const size_t take = (rem < avail_in_slice) ? rem : avail_in_slice;
+      payload_crc =
+          crc32c::Extend(payload_crc, slices[idx].data() + off, take);
+      rem -= take;
+      if (take == avail_in_slice) {
+        ++idx;
+        off = 0;
+      } else {
+        off += take;
+      }
+    }
+  }
+  crc = crc32c::Crc32cCombine(crc, payload_crc, n);
+  crc = crc32c::Mask(crc);
+  TEST_SYNC_POINT_CALLBACK("LogWriter::EmitPhysicalRecord:BeforeEncodeChecksum",
+                           &crc);
+  EncodeFixed32(buf, crc);
+
+  IOOptions opts;
+  IOStatus s = WritableFileWriter::PrepareIOOptions(write_options, opts);
+  if (s.ok()) {
+    s = dest_->Append(opts, Slice(buf, header_size), 0 /* crc32c_checksum */);
+  }
+  if (s.ok()) {
+    size_t idx = start_idx;
+    size_t off = start_off;
+    size_t rem = n;
+    while (s.ok() && rem > 0) {
+      const size_t avail_in_slice = slices[idx].size() - off;
+      const size_t take = (rem < avail_in_slice) ? rem : avail_in_slice;
+      // Pass 0 for crc32c_checksum — the downstream writer uses it only
+      // as an optional verification hint.
+      s = dest_->Append(opts, Slice(slices[idx].data() + off, take),
+                        0 /* crc32c_checksum */);
+      rem -= take;
+      if (take == avail_in_slice) {
+        ++idx;
+        off = 0;
+      } else {
+        off += take;
+      }
+    }
   }
   block_offset_ += header_size + n;
   return s;

--- a/db/log_writer.h
+++ b/db/log_writer.h
@@ -92,6 +92,15 @@ class Writer {
 
   IOStatus AddRecord(const WriteOptions& write_options, const Slice& slice,
                      const SequenceNumber& seqno = 0);
+
+  // Scatter-gather variant of AddRecord. Writes the concatenation of
+  // `slices` as a single logical record. The on-disk format is identical
+  // to the single-slice variant; only the input is scattered. Falls back
+  // to concatenation + single-slice AddRecord when WAL compression is
+  // active.
+  IOStatus AddRecord(const WriteOptions& write_options,
+                     const std::vector<Slice>& slices,
+                     const SequenceNumber& seqno = 0);
   IOStatus AddCompressionTypeRecord(const WriteOptions& write_options);
   IOStatus MaybeAddPredecessorWALInfo(const WriteOptions& write_options,
                                       const PredecessorWALInfo& info);
@@ -109,6 +118,13 @@ class Writer {
   const WritableFileWriter* file() const { return dest_.get(); }
 
   uint64_t get_log_number() const { return log_number_; }
+
+  // True iff this writer is actively applying WAL compression. Callers
+  // that can produce a scatter-gather payload should check this and
+  // materialize into a single contiguous buffer instead, because the
+  // streaming compressor requires contiguous input and the multi-slice
+  // AddRecord path will otherwise concatenate internally (no saving).
+  bool IsCompressing() const { return compress_ != nullptr; }
 
   IOStatus WriteBuffer(const WriteOptions& write_options);
 
@@ -139,6 +155,15 @@ class Writer {
 
   IOStatus EmitPhysicalRecord(const WriteOptions& write_options,
                               RecordType type, const char* ptr, size_t length);
+
+  // Scatter-gather variant of EmitPhysicalRecord. The payload is the
+  // sub-range of `slices` that starts at (start_idx, start_off) and has
+  // total length `n` bytes. CRC is computed incrementally across the
+  // spans via crc32c::Extend.
+  IOStatus EmitPhysicalRecordSG(const WriteOptions& write_options,
+                                RecordType type,
+                                const std::vector<Slice>& slices,
+                                size_t start_idx, size_t start_off, size_t n);
 
   IOStatus MaybeHandleSeenFileWriterError();
 

--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -205,7 +205,9 @@ WriteBatch::WriteBatch(std::string&& rep)
       rep_(std::move(rep)) {}
 
 WriteBatch::WriteBatch(const WriteBatch& src)
-    : wal_term_point_(src.wal_term_point_),
+    : sg_entries_(src.sg_entries_),
+      sg_bytes_pending_(src.sg_bytes_pending_),
+      wal_term_point_(src.wal_term_point_),
       content_flags_(src.content_flags_.load(std::memory_order_relaxed)),
       max_bytes_(src.max_bytes_),
       default_cf_ts_sz_(src.default_cf_ts_sz_),
@@ -221,13 +223,17 @@ WriteBatch::WriteBatch(const WriteBatch& src)
 }
 
 WriteBatch::WriteBatch(WriteBatch&& src) noexcept
-    : save_points_(std::move(src.save_points_)),
+    : sg_entries_(std::move(src.sg_entries_)),
+      sg_bytes_pending_(src.sg_bytes_pending_),
+      save_points_(std::move(src.save_points_)),
       wal_term_point_(std::move(src.wal_term_point_)),
       content_flags_(src.content_flags_.load(std::memory_order_relaxed)),
       max_bytes_(src.max_bytes_),
       prot_info_(std::move(src.prot_info_)),
       default_cf_ts_sz_(src.default_cf_ts_sz_),
-      rep_(std::move(src.rep_)) {}
+      rep_(std::move(src.rep_)) {
+  src.sg_bytes_pending_ = 0;
+}
 
 WriteBatch& WriteBatch::operator=(const WriteBatch& src) {
   if (&src != this) {
@@ -273,6 +279,8 @@ void WriteBatch::Clear() {
   }
   wal_term_point_.clear();
   default_cf_ts_sz_ = 0;
+  sg_entries_.clear();
+  sg_bytes_pending_ = 0;
 }
 
 uint32_t WriteBatch::Count() const { return WriteBatchInternal::Count(this); }
@@ -308,6 +316,11 @@ size_t WriteBatch::GetProtectionBytesPerKey() const {
 }
 
 std::string WriteBatch::Release() {
+  // Flush any pending scatter-gather entries into rep_ before moving it
+  // out. An assert-only check would compile away in release builds and
+  // leave the SG entries to be silently dropped by Clear(); the branch
+  // is a no-op on the common (SG-free) path.
+  MaybeMaterializeSG();
   std::string ret = std::move(rep_);
   Clear();
   return ret;
@@ -515,17 +528,60 @@ Status ReadRecordFromWriteBatch(Slice* input, char* tag,
 }
 
 Status WriteBatch::Iterate(Handler* handler) const {
+  // When protection info is enabled we rely on materialization to
+  // compute per-entry checksums; take the simple path.
+  if (prot_info_ != nullptr) {
+    MaybeMaterializeSG();
+  }
   if (rep_.size() < WriteBatchInternal::kHeader) {
     return Status::Corruption("malformed WriteBatch (too small)");
   }
 
-  return WriteBatchInternal::Iterate(this, handler, WriteBatchInternal::kHeader,
-                                     rep_.size());
+  Status s = WriteBatchInternal::Iterate(this, handler,
+                                         WriteBatchInternal::kHeader,
+                                         rep_.size());
+  if (!s.ok() || sg_entries_.empty()) {
+    return s;
+  }
+  // Emit pending scatter-gather entries as synthetic Handler callbacks.
+  // This preserves zero-copy semantics: key/value slices still
+  // reference the caller-owned buffers, not a materialized rep_ copy.
+  for (const SGEntry& e : sg_entries_) {
+    if (!handler->Continue()) {
+      break;
+    }
+    switch (e.type_byte) {
+      case kTypeValue:
+        s = handler->PutCF(e.cf_id, e.key, e.value);
+        break;
+      case kTypeDeletion:
+        s = handler->DeleteCF(e.cf_id, e.key);
+        break;
+      case kTypeSingleDeletion:
+        s = handler->SingleDeleteCF(e.cf_id, e.key);
+        break;
+      case kTypeMerge:
+        s = handler->MergeCF(e.cf_id, e.key, e.value);
+        break;
+      default:
+        assert(false);
+        s = Status::Corruption("unknown SG entry type");
+    }
+    if (!s.ok()) {
+      return s;
+    }
+  }
+  return s;
 }
 
 Status WriteBatchInternal::Iterate(const WriteBatch* wb,
                                    WriteBatch::Handler* handler, size_t begin,
                                    size_t end) {
+  // Callers pass bounds into rep_. WriteBatch::Iterate handles pending
+  // scatter-gather entries separately (after walking rep_). External
+  // callers of this bounded form operate on batches that do not use
+  // the scatter-gather API, so we deliberately do not materialize
+  // here.
   if (begin > wb->rep_.size() || end > wb->rep_.size() || end < begin) {
     return Status::Corruption("Invalid start/end bounds for Iterate");
   }
@@ -763,8 +819,11 @@ Status WriteBatchInternal::Iterate(const WriteBatch* wb,
   if (!s.ok()) {
     return s;
   }
+  // SG entries are counted in the header but live outside rep_; they are
+  // emitted by WriteBatch::Iterate after this rep_ walk returns. Subtract
+  // them so the rep_-only `found` matches the rep_-only portion of Count.
   if (handler_continue && whole_batch &&
-      found != WriteBatchInternal::Count(wb)) {
+      found != WriteBatchInternal::Count(wb) - wb->sg_entries_.size()) {
     return Status::Corruption("WriteBatch has wrong count");
   } else {
     return Status::OK();
@@ -1188,6 +1247,13 @@ Status WriteBatch::PutEntity(const Slice& key,
 }
 
 Status WriteBatchInternal::InsertNoop(WriteBatch* b) {
+  // Transaction marker insertions (InsertNoop, MarkBeginPrepare,
+  // MarkEndPrepare, MarkCommit*, MarkRollback) are produced by the
+  // transactions/ subsystem, which this fork does not use, and they
+  // do not legitimately interleave with caller-issued PutSG/etc.
+  // Asserting empty here flags any future mix-up rather than silently
+  // flushing SG state into rep_ on every (no-op) call.
+  assert(b->sg_entries_.empty());
   b->rep_.push_back(static_cast<char>(kTypeNoop));
   return Status::OK();
 }
@@ -1203,6 +1269,7 @@ ValueType WriteBatchInternal::GetBeginPrepareType(bool write_after_commit,
 Status WriteBatchInternal::InsertBeginPrepare(WriteBatch* b,
                                               bool write_after_commit,
                                               bool unprepared_batch) {
+  assert(b->sg_entries_.empty());  // see InsertNoop comment
   b->rep_.push_back(static_cast<char>(
       GetBeginPrepareType(write_after_commit, unprepared_batch)));
   b->content_flags_.store(b->content_flags_.load(std::memory_order_relaxed) |
@@ -1212,6 +1279,7 @@ Status WriteBatchInternal::InsertBeginPrepare(WriteBatch* b,
 }
 
 Status WriteBatchInternal::InsertEndPrepare(WriteBatch* b, const Slice& xid) {
+  assert(b->sg_entries_.empty());  // see InsertNoop comment
   b->rep_.push_back(static_cast<char>(kTypeEndPrepareXID));
   PutLengthPrefixedSlice(&b->rep_, xid);
   b->content_flags_.store(b->content_flags_.load(std::memory_order_relaxed) |
@@ -1223,6 +1291,7 @@ Status WriteBatchInternal::InsertEndPrepare(WriteBatch* b, const Slice& xid) {
 Status WriteBatchInternal::MarkEndPrepare(WriteBatch* b, const Slice& xid,
                                           bool write_after_commit,
                                           bool unprepared_batch) {
+  assert(b->sg_entries_.empty());  // see InsertNoop comment
   // a manually constructed batch can only contain one prepare section
   assert(b->rep_[12] == static_cast<char>(kTypeNoop));
 
@@ -1248,6 +1317,7 @@ Status WriteBatchInternal::MarkEndPrepare(WriteBatch* b, const Slice& xid,
 }
 
 Status WriteBatchInternal::MarkCommit(WriteBatch* b, const Slice& xid) {
+  assert(b->sg_entries_.empty());  // see InsertNoop comment
   b->rep_.push_back(static_cast<char>(kTypeCommitXID));
   PutLengthPrefixedSlice(&b->rep_, xid);
   b->content_flags_.store(b->content_flags_.load(std::memory_order_relaxed) |
@@ -1260,6 +1330,7 @@ Status WriteBatchInternal::MarkCommitWithTimestamp(WriteBatch* b,
                                                    const Slice& xid,
                                                    const Slice& commit_ts) {
   assert(!commit_ts.empty());
+  assert(b->sg_entries_.empty());  // see InsertNoop comment
   b->rep_.push_back(static_cast<char>(kTypeCommitXIDAndTimestamp));
   PutLengthPrefixedSlice(&b->rep_, commit_ts);
   PutLengthPrefixedSlice(&b->rep_, xid);
@@ -1270,6 +1341,7 @@ Status WriteBatchInternal::MarkCommitWithTimestamp(WriteBatch* b,
 }
 
 Status WriteBatchInternal::MarkRollback(WriteBatch* b, const Slice& xid) {
+  assert(b->sg_entries_.empty());  // see InsertNoop comment
   b->rep_.push_back(static_cast<char>(kTypeRollbackXID));
   PutLengthPrefixedSlice(&b->rep_, xid);
   b->content_flags_.store(b->content_flags_.load(std::memory_order_relaxed) |
@@ -1864,6 +1936,279 @@ Status WriteBatch::PutLogData(const Slice& blob) {
   return save.commit();
 }
 
+size_t WriteBatch::SGEntrySerializedSize(const WriteBatch::SGEntry& e) {
+  size_t n = 1;  // type byte
+  if (e.cf_id != 0) {
+    n += VarintLength(e.cf_id);
+  }
+  n += VarintLength(e.key.size()) + e.key.size();
+  if (e.type_byte == kTypeValue || e.type_byte == kTypeMerge) {
+    n += VarintLength(e.value.size()) + e.value.size();
+  }
+  return n;
+}
+
+Status WriteBatch::AppendSGEntry(WriteBatch* b, uint8_t type_byte,
+                                 uint32_t cf_id, const Slice& key,
+                                 const Slice& value, uint32_t content_flag) {
+  if (key.size() > size_t{std::numeric_limits<uint32_t>::max()}) {
+    return Status::InvalidArgument("key is too large");
+  }
+  if (value.size() > size_t{std::numeric_limits<uint32_t>::max()}) {
+    return Status::InvalidArgument("value is too large");
+  }
+
+  WriteBatch::SGEntry entry;
+  entry.type_byte = type_byte;
+  entry.cf_id = cf_id;
+  entry.key = key;
+  entry.value = (type_byte == kTypeValue || type_byte == kTypeMerge)
+                    ? value
+                    : Slice();
+
+  const size_t delta = SGEntrySerializedSize(entry);
+
+  if (b->max_bytes_ != 0 &&
+      b->rep_.size() + b->sg_bytes_pending_ + delta > b->max_bytes_) {
+    return Status::MemoryLimit();
+  }
+
+  // Reserve once on the first SG append to skip the 1->2->4->8->16
+  // geometric growth sequence for the common small-batch case. Batches
+  // that reuse via Clear() already retain capacity on their own.
+  if (b->sg_entries_.empty()) {
+    b->sg_entries_.reserve(16);
+  }
+  b->sg_entries_.push_back(std::move(entry));
+  b->sg_bytes_pending_ += delta;
+  WriteBatchInternal::SetCount(b, WriteBatchInternal::Count(b) + 1);
+  b->content_flags_.store(
+      b->content_flags_.load(std::memory_order_relaxed) | content_flag,
+      std::memory_order_relaxed);
+  return Status::OK();
+}
+
+Status WriteBatch::PutSG(ColumnFamilyHandle* column_family, const Slice& key,
+                         const Slice& value) {
+  size_t ts_sz = 0;
+  uint32_t cf_id = 0;
+  Status s;
+
+  std::tie(s, cf_id, ts_sz) =
+      WriteBatchInternal::GetColumnFamilyIdAndTimestampSize(this,
+                                                            column_family);
+  if (!s.ok()) {
+    return s;
+  }
+  if (ts_sz != 0) {
+    return Status::InvalidArgument(
+        "PutSG is not supported on a column family with user-defined "
+        "timestamps");
+  }
+  return AppendSGEntry(this, kTypeValue, cf_id, key, value,
+                       ContentFlags::HAS_PUT);
+}
+
+Status WriteBatch::DeleteSG(ColumnFamilyHandle* column_family,
+                            const Slice& key) {
+  size_t ts_sz = 0;
+  uint32_t cf_id = 0;
+  Status s;
+
+  std::tie(s, cf_id, ts_sz) =
+      WriteBatchInternal::GetColumnFamilyIdAndTimestampSize(this,
+                                                            column_family);
+  if (!s.ok()) {
+    return s;
+  }
+  if (ts_sz != 0) {
+    return Status::InvalidArgument(
+        "DeleteSG is not supported on a column family with user-defined "
+        "timestamps");
+  }
+  return AppendSGEntry(this, kTypeDeletion, cf_id, key, Slice(),
+                       ContentFlags::HAS_DELETE);
+}
+
+Status WriteBatch::SingleDeleteSG(ColumnFamilyHandle* column_family,
+                                  const Slice& key) {
+  size_t ts_sz = 0;
+  uint32_t cf_id = 0;
+  Status s;
+
+  std::tie(s, cf_id, ts_sz) =
+      WriteBatchInternal::GetColumnFamilyIdAndTimestampSize(this,
+                                                            column_family);
+  if (!s.ok()) {
+    return s;
+  }
+  if (ts_sz != 0) {
+    return Status::InvalidArgument(
+        "SingleDeleteSG is not supported on a column family with "
+        "user-defined timestamps");
+  }
+  return AppendSGEntry(this, kTypeSingleDeletion, cf_id, key, Slice(),
+                       ContentFlags::HAS_SINGLE_DELETE);
+}
+
+Status WriteBatch::MergeSG(ColumnFamilyHandle* column_family, const Slice& key,
+                           const Slice& value) {
+  size_t ts_sz = 0;
+  uint32_t cf_id = 0;
+  Status s;
+
+  std::tie(s, cf_id, ts_sz) =
+      WriteBatchInternal::GetColumnFamilyIdAndTimestampSize(this,
+                                                            column_family);
+  if (!s.ok()) {
+    return s;
+  }
+  if (ts_sz != 0) {
+    return Status::InvalidArgument(
+        "MergeSG is not supported on a column family with user-defined "
+        "timestamps");
+  }
+  return AppendSGEntry(this, kTypeMerge, cf_id, key, value,
+                       ContentFlags::HAS_MERGE);
+}
+
+void WriteBatch::MaterializeSG() {
+  if (sg_entries_.empty()) {
+    sg_bytes_pending_ = 0;
+    return;
+  }
+  rep_.reserve(rep_.size() + sg_bytes_pending_);
+  for (const SGEntry& e : sg_entries_) {
+    uint8_t type = e.type_byte;
+    if (e.cf_id == 0) {
+      rep_.push_back(static_cast<char>(type));
+    } else {
+      uint8_t cf_type = type;
+      switch (type) {
+        case kTypeValue:
+          cf_type = kTypeColumnFamilyValue;
+          break;
+        case kTypeDeletion:
+          cf_type = kTypeColumnFamilyDeletion;
+          break;
+        case kTypeSingleDeletion:
+          cf_type = kTypeColumnFamilySingleDeletion;
+          break;
+        case kTypeMerge:
+          cf_type = kTypeColumnFamilyMerge;
+          break;
+        default:
+          assert(false);
+      }
+      rep_.push_back(static_cast<char>(cf_type));
+      PutVarint32(&rep_, e.cf_id);
+    }
+    PutLengthPrefixedSlice(&rep_, e.key);
+    if (type == kTypeValue || type == kTypeMerge) {
+      PutLengthPrefixedSlice(&rep_, e.value);
+    }
+    if (prot_info_ != nullptr) {
+      // Match the convention in the regular append path: store the
+      // ValueType *without* the kTypeColumnFamily* suffix; the column
+      // family id is protected separately via ProtectC().
+      const Slice value_for_protection =
+          (type == kTypeValue || type == kTypeMerge) ? e.value : Slice();
+      prot_info_->entries_.emplace_back(
+          ProtectionInfo64()
+              .ProtectKVO(e.key, value_for_protection,
+                          static_cast<ValueType>(type))
+              .ProtectC(e.cf_id));
+    }
+  }
+  sg_entries_.clear();
+  sg_bytes_pending_ = 0;
+}
+
+void WriteBatchInternal::GatherForWAL(const WriteBatch* wb, WalGather* out) {
+  out->scratch.clear();
+  out->slices.clear();
+  out->total_bytes = 0;
+
+  // If protection info is enabled, fall back to materialization so that
+  // prot_info_ stays consistent with rep_. The gather then degenerates
+  // to a single-slice view of rep_.
+  if (wb->prot_info_ != nullptr) {
+    wb->MaybeMaterializeSG();
+  }
+
+  if (wb->sg_entries_.empty()) {
+    out->slices.emplace_back(wb->rep_.data(), wb->rep_.size());
+    out->total_bytes = wb->rep_.size();
+    return;
+  }
+
+  // Pre-compute scratch capacity exactly so the buffer never reallocates
+  // mid-build (Slices taken into it would otherwise be invalidated).
+  size_t scratch_needed = 0;
+  for (const WriteBatch::SGEntry& e : wb->sg_entries_) {
+    scratch_needed += 1;  // type byte
+    if (e.cf_id != 0) {
+      scratch_needed += VarintLength(e.cf_id);
+    }
+    scratch_needed += VarintLength(e.key.size());
+    if (e.type_byte == kTypeValue || e.type_byte == kTypeMerge) {
+      scratch_needed += VarintLength(e.value.size());
+    }
+  }
+  out->scratch.reserve(scratch_needed);
+  // Worst case: 4 slices per SG entry (header-scratch, key, valuelen-scratch,
+  // value) plus one for the existing rep_.
+  out->slices.reserve(1 + wb->sg_entries_.size() * 4);
+
+  out->slices.emplace_back(wb->rep_.data(), wb->rep_.size());
+  out->total_bytes += wb->rep_.size();
+
+  for (const WriteBatch::SGEntry& e : wb->sg_entries_) {
+    const size_t hdr_start = out->scratch.size();
+    uint8_t type = e.type_byte;
+    if (e.cf_id != 0) {
+      switch (type) {
+        case kTypeValue:
+          type = kTypeColumnFamilyValue;
+          break;
+        case kTypeDeletion:
+          type = kTypeColumnFamilyDeletion;
+          break;
+        case kTypeSingleDeletion:
+          type = kTypeColumnFamilySingleDeletion;
+          break;
+        case kTypeMerge:
+          type = kTypeColumnFamilyMerge;
+          break;
+        default:
+          assert(false);
+      }
+    }
+    out->scratch.push_back(static_cast<char>(type));
+    if (e.cf_id != 0) {
+      PutVarint32(&out->scratch, e.cf_id);
+    }
+    PutVarint32(&out->scratch, static_cast<uint32_t>(e.key.size()));
+    const size_t hdr_end = out->scratch.size();
+    out->slices.emplace_back(out->scratch.data() + hdr_start,
+                             hdr_end - hdr_start);
+    out->slices.emplace_back(e.key);
+    out->total_bytes += (hdr_end - hdr_start) + e.key.size();
+    if (e.type_byte == kTypeValue || e.type_byte == kTypeMerge) {
+      const size_t vlen_start = out->scratch.size();
+      PutVarint32(&out->scratch, static_cast<uint32_t>(e.value.size()));
+      const size_t vlen_end = out->scratch.size();
+      out->slices.emplace_back(out->scratch.data() + vlen_start,
+                               vlen_end - vlen_start);
+      out->slices.emplace_back(e.value);
+      out->total_bytes += (vlen_end - vlen_start) + e.value.size();
+    }
+  }
+
+  // Sanity: we reserved the exact scratch capacity.
+  assert(out->scratch.size() == scratch_needed);
+}
+
 void WriteBatch::SetSavePoint() {
   if (save_points_ == nullptr) {
     save_points_.reset(new SavePoints());
@@ -1877,6 +2222,10 @@ Status WriteBatch::RollbackToSavePoint() {
   if (save_points_ == nullptr || save_points_->stack.size() == 0) {
     return Status::NotFound();
   }
+
+  // Pending SG entries must be materialized before we can compare
+  // rep_.size() against the saved `savepoint.size`.
+  MaybeMaterializeSG();
 
   // Pop the most recent savepoint off the stack
   SavePoint savepoint = save_points_->stack.top();
@@ -1928,6 +2277,7 @@ Status WriteBatch::VerifyChecksum() const {
   if (prot_info_ == nullptr) {
     return Status::OK();
   }
+  MaybeMaterializeSG();
   Slice input(rep_.data() + WriteBatchInternal::kHeader,
               rep_.size() - WriteBatchInternal::kHeader);
   Slice key, value, blob, xid;
@@ -3451,6 +3801,10 @@ Status WriteBatchInternal::SetContents(WriteBatch* b, const Slice& contents) {
   assert(contents.size() >= WriteBatchInternal::kHeader);
   assert(b->prot_info_ == nullptr);
 
+  // Any pending scatter-gather entries are about to be superseded by the
+  // incoming serialized contents; drop them.
+  b->sg_entries_.clear();
+  b->sg_bytes_pending_ = 0;
   b->rep_.assign(contents.data(), contents.size());
   b->content_flags_.store(ContentFlags::DEFERRED, std::memory_order_relaxed);
   return Status::OK();
@@ -3458,6 +3812,43 @@ Status WriteBatchInternal::SetContents(WriteBatch* b, const Slice& contents) {
 
 Status WriteBatchInternal::Append(WriteBatch* dst, const WriteBatch* src,
                                   const bool wal_only) {
+  // Scatter-gather fast path: when neither batch carries protection
+  // info and the wal-termination-point path is not in use, we can move
+  // src's pending SG entries into dst without materializing them. The
+  // fast path requires that the ordering we end up with after the
+  // append matches insertion order. That holds when: src's pending SG
+  // entries (if any) have no rep-body content following them in src,
+  // and dst has no pending SG entries when src still has rep-body
+  // content to contribute (otherwise src's body would land after dst's
+  // SG, inverting the call order).
+  const bool wal_term_blocks =
+      wal_only && !src->GetWalTerminationPoint().is_cleared();
+  const bool needs_materialize_both =
+      dst->prot_info_ != nullptr || src->prot_info_ != nullptr ||
+      wal_term_blocks;
+
+  if (needs_materialize_both) {
+    src->MaybeMaterializeSG();
+    dst->MaybeMaterializeSG();
+  } else {
+    const bool src_rep_body_empty =
+        src->rep_.size() == WriteBatchInternal::kHeader;
+    // If src has any rep-body content, that content needs to land
+    // immediately after dst's current logical end. If dst has pending
+    // SG, flatten dst first so src's body is appended past it.
+    if (!src_rep_body_empty && !dst->sg_entries_.empty()) {
+      dst->MaybeMaterializeSG();
+    }
+    // If src has both rep-body and pending SG, those must stay in
+    // their original order relative to each other. Flatten src.
+    if (!src->sg_entries_.empty() && !src_rep_body_empty) {
+      src->MaybeMaterializeSG();
+    }
+    // Otherwise src is either pure rep-body (sg_entries empty) or pure
+    // SG (rep body empty) — both are safe to append without
+    // materialization.
+  }
+
   assert(dst->Count() == 0 ||
          (dst->prot_info_ == nullptr) == (src->prot_info_ == nullptr));
   if ((src->prot_info_ != nullptr &&
@@ -3500,6 +3891,12 @@ Status WriteBatchInternal::Append(WriteBatch* dst, const WriteBatch* src,
   SetCount(dst, Count(dst) + src_count);
   assert(src->rep_.size() >= WriteBatchInternal::kHeader);
   dst->rep_.append(src->rep_.data() + WriteBatchInternal::kHeader, src_len);
+  if (!src->sg_entries_.empty()) {
+    assert(src->rep_.size() == WriteBatchInternal::kHeader);
+    dst->sg_entries_.insert(dst->sg_entries_.end(), src->sg_entries_.begin(),
+                            src->sg_entries_.end());
+    dst->sg_bytes_pending_ += src->sg_bytes_pending_;
+  }
   dst->content_flags_.store(
       dst->content_flags_.load(std::memory_order_relaxed) | src_flags,
       std::memory_order_relaxed);
@@ -3518,6 +3915,7 @@ size_t WriteBatchInternal::AppendedByteSize(size_t leftByteSize,
 Status WriteBatchInternal::UpdateProtectionInfo(WriteBatch* wb,
                                                 size_t bytes_per_key,
                                                 uint64_t* checksum) {
+  wb->MaybeMaterializeSG();
   if (bytes_per_key == 0) {
     if (wb->prot_info_ != nullptr) {
       wb->prot_info_.reset();

--- a/db/write_batch_internal.h
+++ b/db/write_batch_internal.h
@@ -168,9 +168,23 @@ class WriteBatchInternal {
   // This offset is only valid if the batch is not empty.
   static size_t GetFirstOffset(WriteBatch* batch);
 
-  static Slice Contents(const WriteBatch* batch) { return Slice(batch->rep_); }
+  static Slice Contents(const WriteBatch* batch) {
+    batch->MaybeMaterializeSG();
+    return Slice(batch->rep_);
+  }
 
-  static size_t ByteSize(const WriteBatch* batch) { return batch->rep_.size(); }
+  // Serialized size of the batch, including any pending scatter-gather
+  // entries. Deliberately does NOT materialize: on the group-commit hot
+  // path (WriteThread::EnterAsBatchGroupLeader, WriteImpl statistics)
+  // ByteSize is called on every batch before the WAL write, and
+  // materializing here would drain sg_entries_ into rep_ before
+  // DBImpl::WriteToWAL ever sees the batch, defeating the
+  // zero-copy-to-WAL goal of PutSG/etc. sg_bytes_pending_ tracks the
+  // exact bytes a future MaterializeSG() would append, so this sum
+  // matches what a post-materialization rep_.size() would return.
+  static size_t ByteSize(const WriteBatch* batch) {
+    return batch->rep_.size() + batch->sg_bytes_pending_;
+  }
 
   static Status SetContents(WriteBatch* batch, const Slice& contents);
 
@@ -263,6 +277,27 @@ class WriteBatchInternal {
   // If checksum is provided, the batch content is verfied against the checksum.
   static Status UpdateProtectionInfo(WriteBatch* wb, size_t bytes_per_key,
                                      uint64_t* checksum = nullptr);
+
+  // Scatter-gather WAL payload. `scratch` holds small packed metadata
+  // bytes (type byte, cf varint, key/value length varints) and
+  // `slices` is the sequence of Slices whose concatenation equals the
+  // serialized WriteBatch (header + body + any pending SG entries).
+  //
+  // Slices in `slices` may reference either `scratch` or caller-owned
+  // key/value buffers passed to PutSG/DeleteSG/SingleDeleteSG/MergeSG.
+  // Both `scratch` and those caller buffers MUST remain valid for the
+  // duration of any WAL write that uses this gather.
+  struct WalGather {
+    std::string scratch;
+    std::vector<Slice> slices;
+    size_t total_bytes = 0;
+  };
+
+  // Populate `out` with a scatter-gather view of the bytes that the
+  // WAL would see if the batch were fully materialized. Does NOT mutate
+  // the batch's rep_ or sg_entries_. If `wb` has no pending SG entries
+  // the gather contains a single slice over rep_.
+  static void GatherForWAL(const WriteBatch* wb, WalGather* out);
 };
 
 // LocalSavePoint is similar to a scope guard
@@ -270,7 +305,13 @@ class LocalSavePoint {
  public:
   explicit LocalSavePoint(WriteBatch* batch)
       : batch_(batch),
-        savepoint_(batch->GetDataSize(), batch->Count(),
+        // Anchor to rep_.size() specifically, NOT GetDataSize(). Pending
+        // scatter-gather entries live outside rep_ and are not rolled back
+        // by this savepoint; capturing GetDataSize() here would cause the
+        // commit()-time `rep_.resize(savepoint_.size)` below to grow rep_
+        // into the range that MaterializeSG() later appends, leaving the
+        // failed op's partial bytes interleaved with the SG content.
+        savepoint_(batch->rep_.size(), batch->Count(),
                    batch->content_flags_.load(std::memory_order_relaxed))
 #ifndef NDEBUG
         ,

--- a/db/write_batch_test.cc
+++ b/db/write_batch_test.cc
@@ -1449,6 +1449,364 @@ TEST_F(WriteBatchTest, CommitWithTimestamp) {
             handler.seen);
 }
 
+// Scatter-gather (zero-copy) append API tests.
+
+TEST_F(WriteBatchTest, ScatterGatherBasicEquivalence) {
+  // Verify that a batch built entirely from SG appends produces the exact
+  // same serialized representation as an equivalent non-SG batch.
+  const std::string k1 = "alpha";
+  const std::string v1 = "one";
+  const std::string k2 = "beta";
+  const std::string k3 = "gamma";
+  const std::string v3 = "three";
+  const std::string k4 = "delta";
+  const std::string v4 = "four";
+
+  WriteBatch reference;
+  ASSERT_OK(reference.Put(k1, v1));
+  ASSERT_OK(reference.Delete(k2));
+  ASSERT_OK(reference.Merge(k3, v3));
+  ASSERT_OK(reference.SingleDelete(k4));
+
+  WriteBatch sg;
+  ASSERT_FALSE(sg.HasPendingSG());
+  ASSERT_OK(sg.PutSG(k1, v1));
+  ASSERT_TRUE(sg.HasPendingSG());
+  ASSERT_OK(sg.DeleteSG(k2));
+  ASSERT_OK(sg.MergeSG(k3, v3));
+  ASSERT_OK(sg.SingleDeleteSG(k4));
+  ASSERT_TRUE(sg.HasPendingSG());
+
+  // Count and HasXxx are updated eagerly without materialization.
+  ASSERT_EQ(4u, sg.Count());
+  ASSERT_TRUE(sg.HasPut());
+  ASSERT_TRUE(sg.HasDelete());
+  ASSERT_TRUE(sg.HasMerge());
+  ASSERT_TRUE(sg.HasSingleDelete());
+
+  // Calling Data() forces materialization; after that the two batches
+  // must have identical serialized content.
+  ASSERT_EQ(reference.Data(), sg.Data());
+  ASSERT_FALSE(sg.HasPendingSG());
+  ASSERT_EQ(reference.GetDataSize(), sg.GetDataSize());
+
+  // And InsertInto reproduces the same observable effect.
+  ASSERT_EQ(PrintContents(&reference), PrintContents(&sg));
+}
+
+TEST_F(WriteBatchTest, ScatterGatherLazyMaterialization) {
+  WriteBatch batch;
+  ASSERT_OK(batch.PutSG("k1", "v1"));
+  ASSERT_OK(batch.PutSG("k2", "v2"));
+
+  // Count/HasPut/rep_ header count work without materialization.
+  ASSERT_EQ(2u, batch.Count());
+  ASSERT_EQ(2u, WriteBatchInternal::Count(&batch));
+  ASSERT_TRUE(batch.HasPendingSG());
+  ASSERT_TRUE(batch.HasPut());
+
+  // Explicit materialization releases the pending state.
+  batch.MaterializeSG();
+  ASSERT_FALSE(batch.HasPendingSG());
+  ASSERT_EQ(2u, batch.Count());
+
+  // Idempotent.
+  batch.MaterializeSG();
+  ASSERT_FALSE(batch.HasPendingSG());
+}
+
+TEST_F(WriteBatchTest, ScatterGatherMixedWithRegularAppend) {
+  // Interleaving SG and non-SG appends: non-SG entries land in rep_ and
+  // are emitted first; SG entries are emitted after rep_ in their
+  // insertion order. See WriteBatch::PutSG documentation in
+  // include/rocksdb/write_batch.h for the ordering invariant.
+  WriteBatch sg;
+  ASSERT_OK(sg.PutSG("a", "1"));
+  ASSERT_OK(sg.Put("b", "2"));
+  ASSERT_OK(sg.PutSG("c", "3"));
+  ASSERT_OK(sg.Delete("d"));
+
+  // Expected serialization order after materialization: b, d (from rep_)
+  // followed by a, c (from sg_entries_ in insertion order).
+  WriteBatch reference;
+  ASSERT_OK(reference.Put("b", "2"));
+  ASSERT_OK(reference.Delete("d"));
+  ASSERT_OK(reference.Put("a", "1"));
+  ASSERT_OK(reference.Put("c", "3"));
+
+  ASSERT_EQ(reference.Data(), sg.Data());
+  ASSERT_EQ(4u, sg.Count());
+  ASSERT_EQ(PrintContents(&reference), PrintContents(&sg));
+}
+
+TEST_F(WriteBatchTest, ScatterGatherClearDropsPending) {
+  WriteBatch batch;
+  ASSERT_OK(batch.PutSG("k", "v"));
+  ASSERT_TRUE(batch.HasPendingSG());
+  batch.Clear();
+  ASSERT_FALSE(batch.HasPendingSG());
+  ASSERT_EQ(0u, batch.Count());
+  ASSERT_EQ("", PrintContents(&batch));
+}
+
+TEST_F(WriteBatchTest, ScatterGatherRollbackAfterMaterialize) {
+  WriteBatch batch;
+  ASSERT_OK(batch.Put("kept", "v"));
+  batch.SetSavePoint();
+  ASSERT_OK(batch.PutSG("rolled_back", "rb"));
+  ASSERT_OK(batch.MergeSG("rolled_back2", "rb2"));
+  ASSERT_EQ(3u, batch.Count());
+  ASSERT_OK(batch.RollbackToSavePoint());
+  ASSERT_FALSE(batch.HasPendingSG());
+  ASSERT_EQ(1u, batch.Count());
+
+  WriteBatch reference;
+  ASSERT_OK(reference.Put("kept", "v"));
+  ASSERT_EQ(reference.Data(), batch.Data());
+}
+
+TEST_F(WriteBatchTest, ScatterGatherCopyAndMove) {
+  WriteBatch batch;
+  ASSERT_OK(batch.PutSG("a", "1"));
+  ASSERT_OK(batch.DeleteSG("b"));
+
+  // Copy construction keeps the entries pending but they still point at
+  // the same caller-owned buffers.
+  WriteBatch copy(batch);
+  ASSERT_EQ(2u, copy.Count());
+  ASSERT_EQ(batch.Data(), copy.Data());
+  ASSERT_EQ(PrintContents(&batch), PrintContents(&copy));
+
+  WriteBatch source;
+  ASSERT_OK(source.PutSG("m", "n"));
+  WriteBatch moved(std::move(source));
+  ASSERT_EQ(1u, moved.Count());
+  ASSERT_EQ(PrintContents(&moved), "Put(m, n)@0");
+}
+
+TEST_F(WriteBatchTest, ScatterGatherAppendBetweenBatches) {
+  WriteBatch dst;
+  WriteBatch src;
+  ASSERT_OK(src.PutSG("a", "1"));
+  ASSERT_OK(src.PutSG("b", "2"));
+  ASSERT_OK(WriteBatchInternal::Append(&dst, &src));
+  ASSERT_EQ(2u, dst.Count());
+
+  WriteBatch reference;
+  ASSERT_OK(reference.Put("a", "1"));
+  ASSERT_OK(reference.Put("b", "2"));
+  ASSERT_EQ(reference.Data(), dst.Data());
+}
+
+TEST_F(WriteBatchTest, ScatterGatherMaxBytesEnforced) {
+  WriteBatch batch(0 /* reserved */, 64 /* max_bytes */);
+  // Large value that blows the budget on its own.
+  std::string big(128, 'x');
+  ASSERT_TRUE(batch.PutSG("key", big).IsMemoryLimit());
+  ASSERT_EQ(0u, batch.Count());
+  ASSERT_FALSE(batch.HasPendingSG());
+}
+
+TEST_F(WriteBatchTest, ScatterGatherWithProtectionInfo) {
+  // When the batch has per-key-value protection enabled, the SG path
+  // must populate the protection info at materialization time so that
+  // VerifyChecksum() succeeds.
+  WriteBatch batch(0 /* reserved */, 0 /* max_bytes */,
+                   8 /* protection_bytes_per_key */, 0 /* default_cf_ts_sz */);
+  ASSERT_OK(batch.PutSG("k1", "v1"));
+  ASSERT_OK(batch.MergeSG("k2", "v2"));
+  ASSERT_OK(batch.DeleteSG("k3"));
+  ASSERT_OK(batch.VerifyChecksum());
+  ASSERT_FALSE(batch.HasPendingSG());
+}
+
+namespace {
+std::string ConcatSlices(const std::vector<Slice>& slices) {
+  std::string out;
+  for (const Slice& s : slices) {
+    out.append(s.data(), s.size());
+  }
+  return out;
+}
+}  // namespace
+
+TEST_F(WriteBatchTest, GatherForWalMatchesMaterialized) {
+  // The scatter-gather WAL gather must yield byte-identical output to
+  // the materialized rep_.
+  const std::string k1 = "alpha";
+  const std::string v1 = "one";
+  const std::string k2 = "beta";
+  const std::string k3 = "gamma";
+  const std::string v3 = "three";
+  const std::string k4 = "delta";
+
+  WriteBatch reference;
+  ASSERT_OK(reference.Put(k1, v1));
+  ASSERT_OK(reference.Delete(k2));
+  ASSERT_OK(reference.Merge(k3, v3));
+  ASSERT_OK(reference.SingleDelete(k4));
+
+  WriteBatch sg;
+  ASSERT_OK(sg.PutSG(k1, v1));
+  ASSERT_OK(sg.DeleteSG(k2));
+  ASSERT_OK(sg.MergeSG(k3, v3));
+  ASSERT_OK(sg.SingleDeleteSG(k4));
+  ASSERT_TRUE(sg.HasPendingSG());
+
+  WriteBatchInternal::WalGather gather;
+  WriteBatchInternal::GatherForWAL(&sg, &gather);
+  // Gather must not have materialized the pending entries.
+  ASSERT_TRUE(sg.HasPendingSG());
+  ASSERT_EQ(reference.Data(), ConcatSlices(gather.slices));
+  ASSERT_EQ(reference.Data().size(), gather.total_bytes);
+  // And the gathered view should contain more than one slice when SG
+  // entries are pending (otherwise we gained nothing).
+  ASSERT_GT(gather.slices.size(), 1u);
+}
+
+TEST_F(WriteBatchTest, GatherForWalSingleSliceWhenNoSg) {
+  WriteBatch b;
+  ASSERT_OK(b.Put("k", "v"));
+  WriteBatchInternal::WalGather gather;
+  WriteBatchInternal::GatherForWAL(&b, &gather);
+  ASSERT_EQ(1u, gather.slices.size());
+  ASSERT_EQ(b.Data().size(), gather.total_bytes);
+  ASSERT_EQ(b.Data(), ConcatSlices(gather.slices));
+}
+
+TEST_F(WriteBatchTest, GatherForWalWithColumnFamilyId) {
+  // Exercise the CF-id (non-default) encoding path in the gather.
+  ColumnFamilyHandleImplDummy cf7(7);
+  ColumnFamilyHandleImplDummy cf42(42);
+
+  WriteBatch reference;
+  ASSERT_OK(reference.Put(&cf7, "k", "v"));
+  ASSERT_OK(reference.Delete(&cf42, "k2"));
+  ASSERT_OK(reference.Merge(&cf7, "k3", "v3"));
+  ASSERT_OK(reference.SingleDelete(&cf42, "k4"));
+
+  WriteBatch sg;
+  ASSERT_OK(sg.PutSG(&cf7, "k", "v"));
+  ASSERT_OK(sg.DeleteSG(&cf42, "k2"));
+  ASSERT_OK(sg.MergeSG(&cf7, "k3", "v3"));
+  ASSERT_OK(sg.SingleDeleteSG(&cf42, "k4"));
+  ASSERT_TRUE(sg.HasPendingSG());
+
+  WriteBatchInternal::WalGather gather;
+  WriteBatchInternal::GatherForWAL(&sg, &gather);
+  ASSERT_TRUE(sg.HasPendingSG());  // gather did not materialize
+  ASSERT_EQ(reference.Data(), ConcatSlices(gather.slices));
+}
+
+TEST_F(WriteBatchTest, IterateEmitsSgWithoutMaterializing) {
+  // Custom handler that records callbacks and verifies that the slices
+  // it sees point directly at caller buffers, not a materialized rep_.
+  struct RecordingHandler : public WriteBatch::Handler {
+    std::vector<std::string> seen;
+    const char* expected_value_ptr = nullptr;
+    bool value_ptr_matched = false;
+
+    Status PutCF(uint32_t cf, const Slice& key, const Slice& value) override {
+      seen.push_back("Put(" + std::to_string(cf) + "," + key.ToString() + "," +
+                     value.ToString() + ")");
+      if (expected_value_ptr != nullptr &&
+          value.data() == expected_value_ptr) {
+        value_ptr_matched = true;
+      }
+      return Status::OK();
+    }
+    Status DeleteCF(uint32_t cf, const Slice& key) override {
+      seen.push_back("Delete(" + std::to_string(cf) + "," + key.ToString() +
+                     ")");
+      return Status::OK();
+    }
+    Status SingleDeleteCF(uint32_t cf, const Slice& key) override {
+      seen.push_back("SD(" + std::to_string(cf) + "," + key.ToString() + ")");
+      return Status::OK();
+    }
+    Status MergeCF(uint32_t cf, const Slice& key, const Slice& value) override {
+      seen.push_back("Merge(" + std::to_string(cf) + "," + key.ToString() +
+                     "," + value.ToString() + ")");
+      return Status::OK();
+    }
+  };
+
+  std::string k1 = "alpha";
+  std::string v1 = "one";
+  std::string k2 = "beta";
+  WriteBatch sg;
+  ASSERT_OK(sg.PutSG(k1, v1));
+  ASSERT_OK(sg.DeleteSG(k2));
+  ASSERT_TRUE(sg.HasPendingSG());
+
+  RecordingHandler h;
+  h.expected_value_ptr = v1.data();
+  ASSERT_OK(sg.Iterate(&h));
+  // Iterate must have invoked the handler for both SG entries.
+  ASSERT_EQ(2u, h.seen.size());
+  ASSERT_EQ("Put(0,alpha,one)", h.seen[0]);
+  ASSERT_EQ("Delete(0,beta)", h.seen[1]);
+  // The value Slice the handler saw must reference the caller buffer,
+  // proving we bypassed rep_ materialization.
+  ASSERT_TRUE(h.value_ptr_matched);
+  // Iterate must not have materialized.
+  ASSERT_TRUE(sg.HasPendingSG());
+}
+
+TEST_F(WriteBatchTest, AppendPreservesScatterGather) {
+  // Two pure-SG batches merged should end up as one pure-SG batch
+  // (no materialization forced by Append), and the resulting WAL
+  // gather must match a reference non-SG merged batch byte-for-byte.
+  WriteBatch src1;
+  ASSERT_OK(src1.PutSG("a", "1"));
+  ASSERT_OK(src1.DeleteSG("b"));
+
+  WriteBatch src2;
+  ASSERT_OK(src2.MergeSG("c", "3"));
+  ASSERT_OK(src2.SingleDeleteSG("d"));
+
+  WriteBatch dst;
+  ASSERT_OK(WriteBatchInternal::Append(&dst, &src1));
+  ASSERT_OK(WriteBatchInternal::Append(&dst, &src2));
+  ASSERT_EQ(4u, dst.Count());
+  // src1 and src2 should not have been materialized by Append.
+  ASSERT_TRUE(src1.HasPendingSG());
+  ASSERT_TRUE(src2.HasPendingSG());
+  // And dst should carry the merged SG entries without materialization.
+  ASSERT_TRUE(dst.HasPendingSG());
+
+  WriteBatch reference;
+  ASSERT_OK(reference.Put("a", "1"));
+  ASSERT_OK(reference.Delete("b"));
+  ASSERT_OK(reference.Merge("c", "3"));
+  ASSERT_OK(reference.SingleDelete("d"));
+
+  WriteBatchInternal::WalGather gather;
+  WriteBatchInternal::GatherForWAL(&dst, &gather);
+  ASSERT_EQ(reference.Data(), ConcatSlices(gather.slices));
+}
+
+TEST_F(WriteBatchTest, AppendMixedFallsBackToMaterialize) {
+  // If src has rep-body content AND dst has pending SG entries, Append
+  // must materialize dst first (otherwise src's body would land ahead
+  // of dst's SG entries in the serialized order).
+  WriteBatch dst;
+  ASSERT_OK(dst.PutSG("first", "fv"));
+  ASSERT_TRUE(dst.HasPendingSG());
+
+  WriteBatch src;  // pure rep-body
+  ASSERT_OK(src.Put("second", "sv"));
+
+  ASSERT_OK(WriteBatchInternal::Append(&dst, &src));
+  // dst must have been materialized; the merge forced it.
+  ASSERT_FALSE(dst.HasPendingSG());
+
+  WriteBatch reference;
+  ASSERT_OK(reference.Put("first", "fv"));
+  ASSERT_OK(reference.Put("second", "sv"));
+  ASSERT_EQ(reference.Data(), dst.Data());
+}
+
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {

--- a/include/rocksdb/write_batch.h
+++ b/include/rocksdb/write_batch.h
@@ -31,7 +31,9 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
+#include "rocksdb/slice.h"
 #include "rocksdb/status.h"
 #include "rocksdb/write_batch_base.h"
 
@@ -193,6 +195,100 @@ class WriteBatch : public WriteBatchBase {
   Status Merge(const SliceParts& key, const SliceParts& value) override {
     return Merge(nullptr, key, value);
   }
+
+  // ------------------------------------------------------------------
+  // Scatter-gather (zero-copy) append API.
+  //
+  // Unlike Put/Delete/SingleDelete/Merge, these variants do NOT copy the
+  // caller's key and value bytes into the WriteBatch. The WriteBatch
+  // records references to the caller's buffers; the caller MUST keep
+  // those buffers valid until the entries have been materialized into
+  // the serialized representation.
+  //
+  // Scope of the zero-copy optimization:
+  //   * Eliminates the key/value memcpy that the legacy Put/Merge path
+  //     performs into the WriteBatch's internal rep_ buffer, and the
+  //     amortized heap growth of rep_ that goes with it.
+  //   * At WAL write time, the bytes are handed to the log writer as a
+  //     vector<Slice> that still references the caller's buffers, so the
+  //     WAL payload is never materialized into a contiguous WriteBatch
+  //     buffer either. (See WriteBatchInternal::GatherForWAL.)
+  //   * It does NOT avoid the memtable copy. MemTable::Add always
+  //     allocates arena space for every entry and memcpies the key and
+  //     value into it; that copy is unchanged by this API.
+  //   * It also does not avoid the copy into the WritableFileWriter's
+  //     internal buffer on the WAL write path -- that buffer still owns
+  //     the bytes handed to the OS.
+  //
+  // Materialization is performed automatically and transparently the
+  // first time any method that reads the serialized representation is
+  // invoked (for example Data(), Iterate(), VerifyChecksum(),
+  // UpdateTimestamps(), SetSavePoint(), RollbackToSavePoint(),
+  // MarkWalTerminationPoint(), Release(), writing the batch to a DB,
+  // copy construction, or copy/move assignment). Callers may also force
+  // materialization by invoking MaterializeSG() directly -- this is
+  // useful when the caller wants to free the source buffers before
+  // handing the batch off.
+  //
+  // GetDataSize() and WriteBatchInternal::ByteSize() do NOT materialize:
+  // they return rep_.size() plus the exact bytes that pending SG entries
+  // would add on materialization. This preserves the zero-copy WAL path
+  // through group-commit batching decisions.
+  //
+  // Ordering invariant: SG entries and non-SG entries live in separate
+  // queues inside the batch (sg_entries_ vs rep_). At materialization
+  // time the non-SG entries in rep_ are emitted first, followed by the
+  // SG entries in their insertion order. Ordering is NOT preserved
+  // across the SG / non-SG boundary within a single batch: a sequence
+  // of Put(k1); PutSG(k2); Put(k3) will serialize as k1, k3, k2. Do
+  // not interleave SG and non-SG appends on the same batch if relative
+  // order between them matters.
+  //
+  // Thread-safety: like the rest of WriteBatch, the scatter-gather state
+  // is NOT safe for concurrent access from multiple threads. In
+  // particular, lazy materialization triggered by a const reader mutates
+  // rep_ and sg_entries_, so two threads calling Data() or Iterate()
+  // concurrently on the same batch race on that state.
+  //
+  // Restrictions (initial version):
+  //   * Not supported on column families that enable user-defined
+  //     timestamps.
+  //   * Not supported when the batch has per-key-value protection
+  //     information disabled/enabled mid-flight in unusual ways; the
+  //     usual construction-time protection option is honored and the
+  //     protection bytes are computed at materialization time.
+  //   * Not exposed through WriteBatchWithIndex.
+  //   * Under WAL compression, the WAL write path materializes the
+  //     batch up front so the compressor sees a single contiguous
+  //     buffer; in that mode the SG path incurs the same key/value
+  //     memcpy as the legacy Put path (no saving, no regression).
+  Status PutSG(ColumnFamilyHandle* column_family, const Slice& key,
+               const Slice& value);
+  Status PutSG(const Slice& key, const Slice& value) {
+    return PutSG(nullptr, key, value);
+  }
+  Status DeleteSG(ColumnFamilyHandle* column_family, const Slice& key);
+  Status DeleteSG(const Slice& key) { return DeleteSG(nullptr, key); }
+  Status SingleDeleteSG(ColumnFamilyHandle* column_family, const Slice& key);
+  Status SingleDeleteSG(const Slice& key) {
+    return SingleDeleteSG(nullptr, key);
+  }
+  Status MergeSG(ColumnFamilyHandle* column_family, const Slice& key,
+                 const Slice& value);
+  Status MergeSG(const Slice& key, const Slice& value) {
+    return MergeSG(nullptr, key, value);
+  }
+
+  // Returns true if any scatter-gather entries are still pending and
+  // have not yet been materialized into the serialized representation.
+  bool HasPendingSG() const { return !sg_entries_.empty(); }
+
+  // Force materialization of any pending scatter-gather entries into
+  // the serialized representation. After this returns the buffers
+  // passed to prior PutSG/DeleteSG/SingleDeleteSG/MergeSG calls may be
+  // freed. Safe to call at any time (including when no entries are
+  // pending).
+  void MaterializeSG();
 
   using WriteBatchBase::PutLogData;
   // Append a blob of arbitrary size to the records in this batch. The blob will
@@ -375,14 +471,23 @@ class WriteBatch : public WriteBatchBase {
   };
   Status Iterate(Handler* handler) const;
 
-  // Retrieve the serialized version of this batch.
-  const std::string& Data() const { return rep_; }
+  // Retrieve the serialized version of this batch. If any scatter-gather
+  // entries are pending, they are materialized into the serialized
+  // representation first.
+  const std::string& Data() const {
+    MaybeMaterializeSG();
+    return rep_;
+  }
 
   // Release the serialized data and clear this batch.
   std::string Release();
 
-  // Retrieve data size of the batch.
-  size_t GetDataSize() const { return rep_.size(); }
+  // Retrieve data size of the batch. If scatter-gather entries are
+  // pending, the returned value includes the exact bytes they will add
+  // to rep_ on materialization. Does NOT materialize: callers that only
+  // need the size (e.g. group-commit batching decisions) should not
+  // force a materialization that would defeat the zero-copy WAL path.
+  size_t GetDataSize() const { return rep_.size() + sg_bytes_pending_; }
 
   // Returns the number of updates in the batch
   uint32_t Count() const;
@@ -492,6 +597,55 @@ class WriteBatch : public WriteBatchBase {
   size_t GetProtectionBytesPerKey() const;
 
  private:
+  // One pending scatter-gather entry. `key` and `value` reference
+  // caller-owned buffers whose lifetime must extend until the entry is
+  // materialized (serialized) into rep_.
+  //
+  // `type_byte` is always one of the non-CF op types (kTypeValue,
+  // kTypeDeletion, kTypeSingleDeletion, kTypeMerge). The corresponding
+  // kTypeColumnFamily* variant is emitted at materialization time iff
+  // `cf_id != 0`.
+  struct SGEntry {
+    uint8_t type_byte;
+    uint32_t cf_id;
+    Slice key;
+    Slice value;  // empty for Delete / SingleDelete
+  };
+
+  // Pending scatter-gather entries. Cleared on materialization.
+  // `mutable` so that const read methods can trigger lazy
+  // materialization (mirrors the `content_flags_` pattern). Like the
+  // rest of WriteBatch, NOT safe for concurrent access across threads;
+  // two concurrent const readers that both trigger lazy materialization
+  // will race on sg_entries_ and rep_.
+  mutable std::vector<SGEntry> sg_entries_;
+
+  // Exact number of bytes that materializing `sg_entries_` will append
+  // to `rep_`. Kept in sync with sg_entries_ by AppendSGEntry and reset
+  // by MaterializeSG / Clear / SetContents. Used for:
+  //   * eager max_bytes enforcement in the SG append path, and
+  //   * serialized-size queries (WriteBatchInternal::ByteSize,
+  //     WriteBatch::GetDataSize) that deliberately avoid materializing
+  //     on the group-commit hot path.
+  mutable size_t sg_bytes_pending_ = 0;
+
+  // Lazy materialization entry point for const readers. Cheap fast-path
+  // when there are no pending entries. See the thread-safety note on
+  // sg_entries_ above.
+  void MaybeMaterializeSG() const {
+    if (!sg_entries_.empty()) {
+      const_cast<WriteBatch*>(this)->MaterializeSG();
+    }
+  }
+
+  // Serialized byte count that materializing `e` will add to rep_.
+  static size_t SGEntrySerializedSize(const SGEntry& e);
+
+  // Shared entry point for PutSG/DeleteSG/SingleDeleteSG/MergeSG.
+  static Status AppendSGEntry(WriteBatch* b, uint8_t type_byte,
+                              uint32_t cf_id, const Slice& key,
+                              const Slice& value, uint32_t content_flag);
+
   friend class WriteBatchInternal;
   friend class LocalSavePoint;
   // TODO(myabandeh): this is needed for a hack to collapse the write batch and


### PR DESCRIPTION
to save the string append/memcpy when we know the memory isn't getting freed until after the write batch is committed.