### PR TITLE
Fix range tombstone conversion + ingest sst and re-enable crash tests

### DIFF
--- a/db/column_family.h
+++ b/db/column_family.h
@@ -734,6 +734,8 @@ class ColumnFamilyData {
 
   std::atomic<uint64_t> next_epoch_number_;
 
+  // Used to synchronize IngestExternalFile with range tombstone conversion. See
+  // also Memtable::ingest_seqno_barrier_.
   port::RWMutex ingest_sst_lock_;
 };
 

--- a/db/column_family.h
+++ b/db/column_family.h
@@ -619,6 +619,10 @@ class ColumnFamilyData {
     return ioptions_.cf_allow_ingest_behind || ioptions_.allow_ingest_behind;
   }
 
+  // Per-CF reader-writer lock that serializes IngestExternalFiles with range
+  // tombstone conversion.
+  port::RWMutex& GetIngestSstLock() { return ingest_sst_lock_; }
+
  private:
   friend class ColumnFamilySet;
   ColumnFamilyData(
@@ -729,6 +733,8 @@ class ColumnFamilyData {
   bool mempurge_used_;
 
   std::atomic<uint64_t> next_epoch_number_;
+
+  port::RWMutex ingest_sst_lock_;
 };
 
 // ColumnFamilySet has interesting thread-safety requirements

--- a/db/db_flush_test.cc
+++ b/db/db_flush_test.cc
@@ -3946,8 +3946,12 @@ TEST_F(DBFlushTest, FlushAfterReadPathRangeTombstoneInsertion) {
         // MarkImmutable), this returns false because the memtable is
         // already immutable. Without the fix, this succeeds and creates
         // an entry count mismatch.
-        cfh->cfd()->mem()->AddLogicallyRedundantRangeTombstone(1 /* seq */, "b",
-                                                               "f");
+        // Try to insert a range tombstone. With the fix (Construct after
+        // MarkImmutable), this returns false because the memtable is
+        // already immutable. Without the fix, this succeeds and creates
+        // an entry count mismatch.
+        cfh->cfd()->mem()->AddLogicallyRedundantRangeTombstone(
+            1 /* seq */, "b", "f", cfh->cfd()->GetIngestSstLock());
       });
   SyncPoint::GetInstance()->EnableProcessing();
 

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -6490,6 +6490,19 @@ Status DBImpl::IngestExternalFiles(
   TEST_SYNC_POINT("DBImpl::IngestExternalFiles:BeforeJobsRun:0");
   TEST_SYNC_POINT("DBImpl::IngestExternalFiles:BeforeJobsRun:1");
   TEST_SYNC_POINT("DBImpl::AddFile:Start");
+
+  // Acquire per-CF ingest_sst_lock as ReadLocks (shared) BEFORE the DB
+  // mutex so the lock-acquisition order is ingest_sst_lock -> DB mutex
+  // throughout. Use readlock so we still allow concurrent ingestions.
+  std::vector<std::unique_ptr<ReadLock>> ingest_read_locks;
+  ingest_read_locks.reserve(num_cfs);
+  for (size_t i = 0; i != num_cfs; ++i) {
+    auto* cfd = ingestion_jobs[i].GetColumnFamilyData();
+    if (!cfd->IsDropped()) {
+      ingest_read_locks.emplace_back(
+          std::make_unique<ReadLock>(&cfd->GetIngestSstLock()));
+    }
+  }
   {
     InstrumentedMutexLock l(&mutex_);
     TEST_SYNC_POINT("DBImpl::AddFile:MutexLock");
@@ -6577,6 +6590,21 @@ Status DBImpl::IngestExternalFiles(
           break;
         }
         ingestion_jobs[i].RegisterRange();
+      }
+    }
+    // Now that Run() has assigned the actual seqno for each ingested file,
+    // bump each affected memtable's ingest_seqno_barrier_ to that exact
+    // value. We still hold the per-CF ingest_sst_lock as a ReadLock, so
+    // synthesis is blocked from CASing — the bump publishes the barrier
+    // cleanly. Once we release the ReadLocks at function exit, future
+    // synthesis with insert_seq < assigned is refused by the barrier check.
+    if (status.ok()) {
+      for (size_t i = 0; i != num_cfs; ++i) {
+        auto* cfd = ingestion_jobs[i].GetColumnFamilyData();
+        SequenceNumber assigned = ingestion_jobs[i].MaxAssignedSequenceNumber();
+        if (assigned > 0) {
+          cfd->mem()->BumpIngestSeqnoBarrier(assigned);
+        }
       }
     }
     if (status.ok()) {

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -6594,10 +6594,12 @@ Status DBImpl::IngestExternalFiles(
     }
     // Now that Run() has assigned the actual seqno for each ingested file,
     // bump each affected memtable's ingest_seqno_barrier_ to that exact
-    // value. We still hold the per-CF ingest_sst_lock as a ReadLock, so
-    // synthesis is blocked from CASing — the bump publishes the barrier
-    // cleanly. Once we release the ReadLocks at function exit, future
-    // synthesis with insert_seq < assigned is refused by the barrier check.
+    // value. We still hold the per-CF ingest_sst_lock as a ReadLock; any
+    // concurrent conversion's TryWriteLock on the same lock fails, so no
+    // converter can be reading or about to read the barrier while we
+    // update it. After we release the ReadLocks at function exit, the
+    // next conversion observes the new barrier and refuses any insert
+    // with insert_seq < assigned.
     if (status.ok()) {
       for (size_t i = 0; i != num_cfs; ++i) {
         auto* cfd = ingestion_jobs[i].GetColumnFamilyData();

--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -1788,7 +1788,7 @@ void DBIter::MaybeInsertRangeTombstone(const Slice& end_key) {
     return;
   }
 
-  // Insert at the read sequence so the synthesized tombstone is visible only
+  // Insert at the read sequence so the converted tombstone is visible only
   // to readers that could already observe the deletion run.
   SequenceNumber insert_seq = sequence_;
 

--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -1819,8 +1819,10 @@ void DBIter::MaybeInsertRangeTombstone(const Slice& end_key) {
     }
   }
 
+  assert(cfh_ != nullptr);
   if (active_mem_->AddLogicallyRedundantRangeTombstone(
-          insert_seq, range_tomb_first_key_.GetUserKey(), end_key)) {
+          insert_seq, range_tomb_first_key_.GetUserKey(), end_key,
+          cfh_->cfd()->GetIngestSstLock())) {
     RecordTick(statistics_, READ_PATH_RANGE_TOMBSTONES_INSERTED);
     ROCKS_LOG_DEBUG(logger_,
                     "Inserted range tombstone [%s, %s) @ seq %" PRIu64

--- a/db/db_iterator_test.cc
+++ b/db/db_iterator_test.cc
@@ -5698,10 +5698,10 @@ TEST_P(ReadPathRangeTombstoneTest, BasicInsertion) {
 
     if (flush_before_read) {
       ASSERT_OK(Flush());
-      // After dropping the IsEmpty() fast-path in synthesis, the now-empty
-      // active memtable is a valid synthesis target; the per-CF
+      // After dropping the IsEmpty() fast-path in conversion, the now-empty
+      // active memtable is a valid conversion target; the per-CF
       // ingest_sst_lock (held shared by ingestion) is the mechanism that
-      // gates synthesis vs ingestion, not memtable emptiness.
+      // gates conversion vs ingestion, not memtable emptiness.
       inserted_ranges_.clear();
       VerifyIteration({"a", "g", "h", "n"});
       ASSERT_EQ(inserted_ranges_.size(), 2);
@@ -6006,7 +6006,7 @@ TEST_P(ReadPathRangeTombstoneTest, PrefixFilterDefaultReadOptions) {
   // total_order_seek=false (default) with prefix extractor. Even when the
   // visible scan contains a valid in-prefix tombstone run [ba, bc), read-path
   // range conversion is disabled in this legacy prefix mode, so no
-  // synthesized memtable tombstone is inserted.
+  // converted memtable tombstone is inserted.
   Options options = CurrentOptions();
   options.min_tombstones_for_range_conversion = 2;
   options.statistics = CreateDBStatistics();
@@ -6130,7 +6130,7 @@ TEST_P(ReadPathRangeTombstoneTest, PrefixFilterTotalOrderSeek) {
 TEST_P(ReadPathRangeTombstoneTest, PrefixFilterPrefixSameAsStart) {
   // prefix_same_as_start=true: prefix filtering active, DBIter bounds the
   // scan to the seek prefix. An out-of-prefix tombstone ends the visible run,
-  // but the synthesized range still stays within prefix by flushing to the
+  // but the converted range still stays within prefix by flushing to the
   // last tracked in-prefix tombstone.
   // total_order_seek should not matter as we are guaranteed a total order view
   // within the prefix bounds.
@@ -6288,7 +6288,7 @@ TEST_P(ReadPathRangeTombstoneTest, TableFilterNotAllowed) {
   ASSERT_OK(Flush());
 
   // Keep the active memtable non-empty so the read path has somewhere to store
-  // the synthesized memtable range tombstone.
+  // the converted memtable range tombstone.
   ASSERT_OK(Put("zz", "tail_mem"));
 
   inserted_ranges_.clear();
@@ -6313,7 +6313,7 @@ TEST_P(ReadPathRangeTombstoneTest, TableFilterNotAllowed) {
       return props.num_entries != 2;
     };
     // Hiding the two-delete SST would otherwise leave this iterator with a
-    // partial SST view plus the previously synthesized memtable tombstone,
+    // partial SST view plus the previously converted memtable tombstone,
     // allowing hidden SST state to affect the filtered read result.
     AssertTableFilterRangeConversionRejected(filtered_ro);
   }
@@ -6511,7 +6511,7 @@ TEST_P(ReadPathRangeTombstoneTest, UDTBasicScan) {
 
 // Regression test: an older UDT read timestamp can hide newer live versions
 // inside a delete run. Range conversion must stay disabled in that case, or
-// the synthesized range tombstone will incorrectly hide those newer versions
+// the converted range tombstone will incorrectly hide those newer versions
 // for later max-timestamp reads.
 TEST_P(ReadPathRangeTombstoneTest, UDTOlderTimestampDisablesInsertion) {
   Options options = CurrentOptions();
@@ -6869,7 +6869,7 @@ TEST_P(ReadPathRangeTombstoneTest,
   ASSERT_OK(Delete("c"));
 
   // Iterate at the latest sequence. Both b and c hit the reseek path and
-  // synthesize a range tombstone [b, d) for later readers at the same seq.
+  // convert a range tombstone [b, d) for later readers at the same seq.
   inserted_ranges_.clear();
   VerifyIteration({"a", "d"});
 
@@ -6926,7 +6926,7 @@ TEST_P(ReadPathRangeTombstoneTest, InvisibleKeysDontBreakTombstoneRun) {
   db_->ReleaseSnapshot(snap);
 }
 
-// Regression test: a synthesized tombstone can land in the current memtable at
+// Regression test: a converted tombstone can land in the current memtable at
 // an older snapshot sequence than a live point already ingested into an older
 // L0 file. Latest point lookups must continue searching that older file when
 // its sequence range can still contain a newer point version.
@@ -6947,7 +6947,7 @@ TEST_P(ReadPathRangeTombstoneTest, NewerPointInOlderFileStillVisible) {
   ASSERT_OK(Flush());
 
   // Keep the active memtable older than the snapshot so the read path is
-  // allowed to synthesize a tombstone into it later.
+  // allowed to convert a tombstone into it later.
   ASSERT_OK(Put("z", "vz_anchor"));
   const Snapshot* snap = db_->GetSnapshot();
 
@@ -7061,7 +7061,7 @@ TEST_P(ReadPathRangeTombstoneTest, SeekToLastTombstones) {
 
 // Regression test for a crash-test pattern where the interior between two
 // point tombstones is hidden by a later DeleteRange. A latest iterator may
-// still synthesize a redundant range tombstone, but an older snapshot must
+// still convert a redundant range tombstone, but an older snapshot must
 // continue to see the pre-DeleteRange live key after iteration.
 TEST_P(ReadPathRangeTombstoneTest,
        RangeDeletedInteriorPreservesOlderSnapshots) {

--- a/db/db_iterator_test.cc
+++ b/db/db_iterator_test.cc
@@ -5583,13 +5583,13 @@ class ReadPathRangeTombstoneTest : public DBIteratorBaseTest,
   bool Forward() const { return GetParam(); }
 
   void SetUp() override {
-    inserted_ranges_.clear();
+    attempted_insert_ranges_.clear();
     SyncPoint::GetInstance()->SetCallBack(
         "MemTable::AddLogicallyRedundantRangeTombstone:AddRange",
         [this](void* arg) {
           auto* range = static_cast<std::pair<Slice, Slice>*>(arg);
-          inserted_ranges_.emplace_back(range->first.ToString(),
-                                        range->second.ToString());
+          attempted_insert_ranges_.emplace_back(range->first.ToString(),
+                                                range->second.ToString());
         });
     SyncPoint::GetInstance()->EnableProcessing();
   }
@@ -5633,9 +5633,9 @@ class ReadPathRangeTombstoneTest : public DBIteratorBaseTest,
 
   void AssertRange(size_t idx, const std::string& start,
                    const std::string& end) {
-    ASSERT_LT(idx, inserted_ranges_.size());
-    ASSERT_EQ(inserted_ranges_[idx].first, start);
-    ASSERT_EQ(inserted_ranges_[idx].second, end);
+    ASSERT_LT(idx, attempted_insert_ranges_.size());
+    ASSERT_EQ(attempted_insert_ranges_[idx].first, start);
+    ASSERT_EQ(attempted_insert_ranges_[idx].second, end);
   }
 
   Slice MaxTimestamp(std::string* storage) const {
@@ -5675,7 +5675,7 @@ class ReadPathRangeTombstoneTest : public DBIteratorBaseTest,
         << iter->status().ToString();
   }
 
-  std::vector<std::pair<std::string, std::string>> inserted_ranges_;
+  std::vector<std::pair<std::string, std::string>> attempted_insert_ranges_;
 };
 
 INSTANTIATE_TEST_CASE_P(ReadPathRangeTombstoneTest, ReadPathRangeTombstoneTest,
@@ -5702,9 +5702,9 @@ TEST_P(ReadPathRangeTombstoneTest, BasicInsertion) {
       // active memtable is a valid conversion target; the per-CF
       // ingest_sst_lock (held shared by ingestion) is the mechanism that
       // gates conversion vs ingestion, not memtable emptiness.
-      inserted_ranges_.clear();
+      attempted_insert_ranges_.clear();
       VerifyIteration({"a", "g", "h", "n"});
-      ASSERT_EQ(inserted_ranges_.size(), 2);
+      ASSERT_EQ(attempted_insert_ranges_.size(), 2);
       if (forward) {
         AssertRange(0, "b", "g");
         AssertRange(1, "i", "n");
@@ -5715,11 +5715,11 @@ TEST_P(ReadPathRangeTombstoneTest, BasicInsertion) {
       break;
     }
 
-    inserted_ranges_.clear();
+    attempted_insert_ranges_.clear();
 
     VerifyIteration({"a", "g", "h", "n"});
 
-    ASSERT_EQ(inserted_ranges_.size(), 2);
+    ASSERT_EQ(attempted_insert_ranges_.size(), 2);
     if (forward) {
       AssertRange(0, "b", "g");
       AssertRange(1, "i", "n");
@@ -5731,9 +5731,9 @@ TEST_P(ReadPathRangeTombstoneTest, BasicInsertion) {
         options.statistics->getTickerCount(READ_PATH_RANGE_TOMBSTONES_INSERTED),
         2);
 
-    inserted_ranges_.clear();
+    attempted_insert_ranges_.clear();
     VerifyIteration({"a", "g", "h", "n"});
-    ASSERT_EQ(inserted_ranges_.size(), 0);
+    ASSERT_EQ(attempted_insert_ranges_.size(), 0);
     ASSERT_EQ(
         options.statistics->getTickerCount(READ_PATH_RANGE_TOMBSTONES_INSERTED),
         2);
@@ -5770,13 +5770,13 @@ TEST_P(ReadPathRangeTombstoneTest, MemtableSwitch) {
                 /*flushed_point_dels=*/{},
                 /*memtable_point_dels=*/{"b", "c", "d", "e", "f"});
 
-  inserted_ranges_.clear();
+  attempted_insert_ranges_.clear();
   SyncPoint::GetInstance()->SetCallBack(
       "MemTable::AddLogicallyRedundantRangeTombstone:AddRange",
       [this](void* arg) {
         auto* range = static_cast<std::pair<Slice, Slice>*>(arg);
-        inserted_ranges_.emplace_back(range->first.ToString(),
-                                      range->second.ToString());
+        attempted_insert_ranges_.emplace_back(range->first.ToString(),
+                                              range->second.ToString());
         auto* cfh =
             static_cast<ColumnFamilyHandleImpl*>(db_->DefaultColumnFamily());
         cfh->cfd()->mem()->MarkImmutable();
@@ -5785,7 +5785,7 @@ TEST_P(ReadPathRangeTombstoneTest, MemtableSwitch) {
 
   VerifyIteration({"a", "g", "h"});
 
-  ASSERT_EQ(inserted_ranges_.size(), 1);
+  ASSERT_EQ(attempted_insert_ranges_.size(), 1);
   AssertRange(0, "b", "g");
   ASSERT_EQ(
       options.statistics->getTickerCount(READ_PATH_RANGE_TOMBSTONES_DISCARDED),
@@ -5818,7 +5818,7 @@ TEST_P(ReadPathRangeTombstoneTest, ExhaustedIteratorWithBounds) {
   VerifyIteration({"e", "f"}, ro);
 
   // Both directions encounter two tombstone runs (a-d and g-j).
-  ASSERT_EQ(inserted_ranges_.size(), 2);
+  ASSERT_EQ(attempted_insert_ranges_.size(), 2);
   if (Forward()) {
     // Forward: sees a-d tombstones first → [a, e), then g-j → [g, z).
     AssertRange(0, "a", "e");
@@ -5839,9 +5839,9 @@ TEST_P(ReadPathRangeTombstoneTest, ExhaustedIteratorWithBounds) {
   ASSERT_EQ(Get("j"), "NOT_FOUND");
 
   // Second read: range tombstones already in memtable, no new insertion.
-  inserted_ranges_.clear();
+  attempted_insert_ranges_.clear();
   VerifyIteration({"e", "f"}, ro);
-  ASSERT_EQ(inserted_ranges_.size(), 0);
+  ASSERT_EQ(attempted_insert_ranges_.size(), 0);
   ASSERT_EQ(
       options.statistics->getTickerCount(READ_PATH_RANGE_TOMBSTONES_INSERTED),
       2);
@@ -5862,7 +5862,7 @@ TEST_P(ReadPathRangeTombstoneTest, ExhaustedIteratorNoBounds) {
 
   // Without bounds, only the a-d run (which has a live key boundary) gets
   // inserted. The g-j run at the end has no upper bound → dropped.
-  ASSERT_EQ(inserted_ranges_.size(), 1);
+  ASSERT_EQ(attempted_insert_ranges_.size(), 1);
   AssertRange(0, "a", "e");
   ASSERT_EQ(
       options.statistics->getTickerCount(READ_PATH_RANGE_TOMBSTONES_INSERTED),
@@ -5880,7 +5880,7 @@ TEST_P(ReadPathRangeTombstoneTest, DirectionChange) {
                 /*flushed_point_dels=*/{"c", "d", "e"},
                 /*memtable_point_dels=*/{"f", "g", "j", "k", "l", "m", "n"});
 
-  inserted_ranges_.clear();
+  attempted_insert_ranges_.clear();
 
   {
     ReadOptions ro;
@@ -5927,7 +5927,7 @@ TEST_P(ReadPathRangeTombstoneTest, DirectionChange) {
     ASSERT_OK(iter->status());
   }
 
-  ASSERT_EQ(inserted_ranges_.size(), 2);
+  ASSERT_EQ(attempted_insert_ranges_.size(), 2);
   if (forward_first) {
     AssertRange(0, "c", "h");
     AssertRange(1, "j", "o");
@@ -5957,11 +5957,11 @@ TEST_P(ReadPathRangeTombstoneTest, MixedDeleteAndSingleDelete) {
   ASSERT_OK(SingleDelete("c"));
   ASSERT_OK(SingleDelete("e"));
 
-  inserted_ranges_.clear();
+  attempted_insert_ranges_.clear();
 
   VerifyIteration({"a", "g", "h"});
 
-  ASSERT_EQ(inserted_ranges_.size(), 1);
+  ASSERT_EQ(attempted_insert_ranges_.size(), 1);
   AssertRange(0, "b", "g");
   ASSERT_EQ(
       options.statistics->getTickerCount(READ_PATH_RANGE_TOMBSTONES_INSERTED),
@@ -5991,11 +5991,11 @@ TEST_P(ReadPathRangeTombstoneTest, SingleDeleteOnlyRun) {
   ASSERT_OK(SingleDelete("e"));
   ASSERT_OK(SingleDelete("f"));
 
-  inserted_ranges_.clear();
+  attempted_insert_ranges_.clear();
 
   VerifyIteration({"a", "g", "h"});
 
-  ASSERT_EQ(inserted_ranges_.size(), 1);
+  ASSERT_EQ(attempted_insert_ranges_.size(), 1);
   AssertRange(0, "b", "g");
   ASSERT_EQ(
       options.statistics->getTickerCount(READ_PATH_RANGE_TOMBSTONES_INSERTED),
@@ -6026,7 +6026,7 @@ TEST_P(ReadPathRangeTombstoneTest, PrefixFilterDefaultReadOptions) {
   ASSERT_OK(Delete("ba"));
   ASSERT_OK(Delete("bb"));
 
-  inserted_ranges_.clear();
+  attempted_insert_ranges_.clear();
   auto it = std::unique_ptr<Iterator>(db_->NewIterator(ReadOptions()));
   if (Forward()) {
     it->Seek("b");
@@ -6041,7 +6041,7 @@ TEST_P(ReadPathRangeTombstoneTest, PrefixFilterDefaultReadOptions) {
     }
   }
   ASSERT_OK(it->status());
-  ASSERT_EQ(inserted_ranges_.size(), 0u);
+  ASSERT_EQ(attempted_insert_ranges_.size(), 0u);
   ASSERT_EQ(
       options.statistics->getTickerCount(READ_PATH_RANGE_TOMBSTONES_INSERTED),
       0u);
@@ -6097,7 +6097,7 @@ TEST_P(ReadPathRangeTombstoneTest, PrefixFilterTotalOrderSeek) {
     ASSERT_OK(del("ca"));
     ASSERT_OK(put("fa", "above"));
 
-    inserted_ranges_.clear();
+    attempted_insert_ranges_.clear();
     ReadOptions ro;
     ro.total_order_seek = true;
     if (use_udt) {
@@ -6118,7 +6118,7 @@ TEST_P(ReadPathRangeTombstoneTest, PrefixFilterTotalOrderSeek) {
     }
     ASSERT_OK(it->status());
     // Tombstone crosses from prefix 'b' into 'c', terminated by live "cb".
-    ASSERT_EQ(inserted_ranges_.size(), 1u);
+    ASSERT_EQ(attempted_insert_ranges_.size(), 1u);
     if (use_udt) {
       AssertRange(0, std::string("ba") + ts, std::string("cb") + ts);
     } else {
@@ -6178,7 +6178,7 @@ TEST_P(ReadPathRangeTombstoneTest, PrefixFilterPrefixSameAsStart) {
       ASSERT_OK(del("ca"));
       ASSERT_OK(put("fa", "above"));
 
-      inserted_ranges_.clear();
+      attempted_insert_ranges_.clear();
       ReadOptions ro;
       ro.prefix_same_as_start = true;
       ro.total_order_seek = total_order;
@@ -6196,7 +6196,7 @@ TEST_P(ReadPathRangeTombstoneTest, PrefixFilterPrefixSameAsStart) {
         ASSERT_FALSE(it->Valid());
       }
       ASSERT_OK(it->status());
-      ASSERT_EQ(inserted_ranges_.size(), 1u);
+      ASSERT_EQ(attempted_insert_ranges_.size(), 1u);
       ASSERT_EQ(options.statistics->getTickerCount(
                     READ_PATH_RANGE_TOMBSTONES_INSERTED),
                 1u);
@@ -6244,7 +6244,7 @@ TEST_P(ReadPathRangeTombstoneTest, PrefixFilterOutOfDomainSeek) {
   ASSERT_OK(Put("bbdd", "v2"));
   ASSERT_OK(Put("cccc", "v3"));
 
-  inserted_ranges_.clear();
+  attempted_insert_ranges_.clear();
   ReadOptions ro;
   ro.prefix_same_as_start = true;
   auto it = std::unique_ptr<Iterator>(db_->NewIterator(ro));
@@ -6263,7 +6263,7 @@ TEST_P(ReadPathRangeTombstoneTest, PrefixFilterOutOfDomainSeek) {
     }
   }
   ASSERT_OK(it->status());
-  ASSERT_EQ(inserted_ranges_.size(), 1u);
+  ASSERT_EQ(attempted_insert_ranges_.size(), 1u);
   AssertRange(0, "bbbb", "bbdd");
 }
 
@@ -6291,7 +6291,7 @@ TEST_P(ReadPathRangeTombstoneTest, TableFilterNotAllowed) {
   // the converted memtable range tombstone.
   ASSERT_OK(Put("zz", "tail_mem"));
 
-  inserted_ranges_.clear();
+  attempted_insert_ranges_.clear();
   {
     // First iterator sees the full SST set, so converting [a, c) into a
     // memtable range tombstone is safe.
@@ -6304,7 +6304,7 @@ TEST_P(ReadPathRangeTombstoneTest, TableFilterNotAllowed) {
     ASSERT_OK(it->status());
   }
 
-  ASSERT_GE(inserted_ranges_.size(), 1u);
+  ASSERT_GE(attempted_insert_ranges_.size(), 1u);
   AssertRange(0, "a", "c");
 
   {
@@ -6338,7 +6338,7 @@ TEST_P(ReadPathRangeTombstoneTest, SnapshotPredatesMemtable) {
   ASSERT_OK(Flush());
   ASSERT_OK(Put("y", "vy"));
 
-  inserted_ranges_.clear();
+  attempted_insert_ranges_.clear();
 
   ReadOptions ro;
   ro.snapshot = snap;
@@ -6411,7 +6411,7 @@ TEST_P(ReadPathRangeTombstoneTest, NoInsertionOnBlockCacheTierIncomplete) {
 
   // No range tombstone should have been inserted despite meeting threshold,
   // because the iterator terminated with Incomplete (cache miss).
-  ASSERT_EQ(inserted_ranges_.size(), 0);
+  ASSERT_EQ(attempted_insert_ranges_.size(), 0);
   ASSERT_EQ(
       options.statistics->getTickerCount(READ_PATH_RANGE_TOMBSTONES_INSERTED),
       0);
@@ -6442,7 +6442,7 @@ TEST_P(ReadPathRangeTombstoneTest, SkipInsertionWhenCoveredByExistingRange) {
     ASSERT_OK(Delete(std::string(1, c)));
   }
 
-  inserted_ranges_.clear();
+  attempted_insert_ranges_.clear();
   ReadOptions ro;
   Slice upper("z");
   ro.iterate_upper_bound = &upper;
@@ -6502,7 +6502,7 @@ TEST_P(ReadPathRangeTombstoneTest, UDTBasicScan) {
   ASSERT_EQ(keys, (std::vector<std::string>{"a", "g", "h"}));
 
   // Range covers [b+ts, g+ts).
-  ASSERT_EQ(inserted_ranges_.size(), 1);
+  ASSERT_EQ(attempted_insert_ranges_.size(), 1);
   AssertRange(0, std::string("b") + ts, std::string("g") + ts);
   ASSERT_EQ(
       options.statistics->getTickerCount(READ_PATH_RANGE_TOMBSTONES_INSERTED),
@@ -6544,12 +6544,12 @@ TEST_P(ReadPathRangeTombstoneTest, UDTOlderTimestampDisablesInsertion) {
   ASSERT_OK(db_->Put(WriteOptions(), "b", ts3_slice, "vb3"));
   ASSERT_OK(db_->Put(WriteOptions(), "c", ts3_slice, "vc3"));
 
-  inserted_ranges_.clear();
+  attempted_insert_ranges_.clear();
   ReadOptions old_ro;
   old_ro.timestamp = &ts2_slice;
   VerifyIteration({"d"}, old_ro);
 
-  ASSERT_EQ(inserted_ranges_.size(), 0u);
+  ASSERT_EQ(attempted_insert_ranges_.size(), 0u);
   ASSERT_EQ(
       options.statistics->getTickerCount(READ_PATH_RANGE_TOMBSTONES_INSERTED),
       0);
@@ -6610,7 +6610,7 @@ TEST_P(ReadPathRangeTombstoneTest, ExhaustedWithUDT) {
   ASSERT_OK(iter->status());
   ASSERT_EQ(keys.size(), 4);
 
-  ASSERT_EQ(inserted_ranges_.size(), 1);
+  ASSERT_EQ(attempted_insert_ranges_.size(), 1);
   if (Forward()) {
     // Forward exhaustion: range is [e+ts, z+min_ts).
     AssertRange(0, std::string("e") + ts, std::string("z") + min_ts);
@@ -6650,7 +6650,7 @@ TEST_P(ReadPathRangeTombstoneTest, SeekForPrevTombstone) {
     }
     SetupTestData('a', 'h', /*flushed_point_dels=*/{},
                   /*memtable_point_dels=*/{"e", "f", "g", "h"}, ts_ptr);
-    inserted_ranges_.clear();
+    attempted_insert_ranges_.clear();
 
     ReadOptions ro;
     if (use_udt) {
@@ -6675,9 +6675,9 @@ TEST_P(ReadPathRangeTombstoneTest, SeekForPrevTombstone) {
 
     if (Forward()) {
       // No upper bound → trailing tombstone run has no end key → dropped.
-      ASSERT_EQ(inserted_ranges_.size(), 0);
+      ASSERT_EQ(attempted_insert_ranges_.size(), 0);
     } else {
-      ASSERT_EQ(inserted_ranges_.size(), 1);
+      ASSERT_EQ(attempted_insert_ranges_.size(), 1);
       if (use_udt) {
         std::string min_ts(sizeof(uint64_t), '\0');
         AssertRange(0, std::string("e") + ts, std::string("h") + min_ts);
@@ -6719,7 +6719,7 @@ TEST_P(ReadPathRangeTombstoneTest, UpperBoundTombstone) {
     }
     SetupTestData('a', 'h', /*flushed_point_dels=*/{},
                   /*memtable_point_dels=*/{"e", "f", "g", "h"}, ts_ptr);
-    inserted_ranges_.clear();
+    attempted_insert_ranges_.clear();
 
     ReadOptions ro;
     if (use_udt) {
@@ -6744,7 +6744,7 @@ TEST_P(ReadPathRangeTombstoneTest, UpperBoundTombstone) {
     ASSERT_OK(iter->status());
     ASSERT_EQ(keys, (std::vector<std::string>{"a", "b", "c", "d"}));
 
-    ASSERT_EQ(inserted_ranges_.size(), 1);
+    ASSERT_EQ(attempted_insert_ranges_.size(), 1);
     if (use_udt) {
       // Forward end key: upper bound padded with min_ts.
       // Reverse end key: upper bound padded with max_ts (via
@@ -6789,7 +6789,7 @@ TEST_P(ReadPathRangeTombstoneTest, LowerBoundTruncatesReverse) {
         'a', 'j', /*flushed_point_dels=*/{},
         /*memtable_point_dels=*/{"a", "b", "c", "d", "e", "f", "g", "h"},
         ts_ptr);
-    inserted_ranges_.clear();
+    attempted_insert_ranges_.clear();
 
     ReadOptions ro;
     if (use_udt) {
@@ -6818,7 +6818,7 @@ TEST_P(ReadPathRangeTombstoneTest, LowerBoundTruncatesReverse) {
     ASSERT_EQ(keys, (std::vector<std::string>{"i", "j"}));
 
     // Both directions produce one range covering tombstones e-h.
-    ASSERT_EQ(inserted_ranges_.size(), 1);
+    ASSERT_EQ(attempted_insert_ranges_.size(), 1);
     if (use_udt) {
       AssertRange(0, std::string("e") + ts, std::string("i") + ts);
     } else {
@@ -6870,10 +6870,10 @@ TEST_P(ReadPathRangeTombstoneTest,
 
   // Iterate at the latest sequence. Both b and c hit the reseek path and
   // convert a range tombstone [b, d) for later readers at the same seq.
-  inserted_ranges_.clear();
+  attempted_insert_ranges_.clear();
   VerifyIteration({"a", "d"});
 
-  ASSERT_EQ(inserted_ranges_.size(), 1);
+  ASSERT_EQ(attempted_insert_ranges_.size(), 1);
   AssertRange(0, "b", "d");
 
   // Read with the earlier snapshot. The point deletes (seq 11-12) are not
@@ -6915,12 +6915,12 @@ TEST_P(ReadPathRangeTombstoneTest, InvisibleKeysDontBreakTombstoneRun) {
 
   ReadOptions ro;
   ro.snapshot = snap;
-  inserted_ranges_.clear();
+  attempted_insert_ranges_.clear();
   VerifyIteration({"a", "f"}, ro);
 
   // Invisible keys c and e should not break the tombstone run.
   // 2 tombstones (b, d) ≥ threshold → range [b, f).
-  ASSERT_EQ(inserted_ranges_.size(), 1);
+  ASSERT_EQ(attempted_insert_ranges_.size(), 1);
   AssertRange(0, "b", "f");
 
   db_->ReleaseSnapshot(snap);
@@ -6964,12 +6964,12 @@ TEST_P(ReadPathRangeTombstoneTest, NewerPointInOlderFileStillVisible) {
   ASSERT_OK(db_->IngestExternalFile({ingest_file}, ifo));
   ASSERT_EQ(Get("c"), "vc_live");
 
-  inserted_ranges_.clear();
+  attempted_insert_ranges_.clear();
   ReadOptions snap_ro;
   snap_ro.snapshot = snap;
   VerifyIteration({"d", "z"}, snap_ro);
 
-  ASSERT_EQ(inserted_ranges_.size(), 1);
+  ASSERT_EQ(attempted_insert_ranges_.size(), 1);
   AssertRange(0, "b", "d");
 
   const Snapshot* latest = db_->GetSnapshot();
@@ -7038,7 +7038,7 @@ TEST_P(ReadPathRangeTombstoneTest, SeekToLastTombstones) {
   ASSERT_OK(Delete("x"));
   ASSERT_OK(Delete("y"));
   auto iter = std::unique_ptr<Iterator>(db_->NewIterator(ReadOptions()));
-  inserted_ranges_.clear();
+  attempted_insert_ranges_.clear();
 
   iter->Seek("a");
   ASSERT_TRUE(iter->Valid());
@@ -7048,14 +7048,14 @@ TEST_P(ReadPathRangeTombstoneTest, SeekToLastTombstones) {
   ASSERT_TRUE(iter->Valid());
   ASSERT_OK(iter->status());
   ASSERT_EQ("z", iter->key().ToString());
-  ASSERT_EQ(inserted_ranges_.size(), 0u);
+  ASSERT_EQ(attempted_insert_ranges_.size(), 0u);
 
   // Reverse iteration skips deleted x and y.
   iter->Prev();
   ASSERT_TRUE(iter->Valid());
   ASSERT_OK(iter->status());
   ASSERT_EQ("w", iter->key().ToString());
-  ASSERT_EQ(inserted_ranges_.size(), 1u);
+  ASSERT_EQ(attempted_insert_ranges_.size(), 1u);
   AssertRange(0, "x", "z");
 }
 
@@ -7091,11 +7091,11 @@ TEST_P(ReadPathRangeTombstoneTest,
   ASSERT_OK(
       db_->DeleteRange(WriteOptions(), db_->DefaultColumnFamily(), "c", "m"));
 
-  inserted_ranges_.clear();
+  attempted_insert_ranges_.clear();
   VerifyIteration({"a", "n"});
 
   // Materialize the redundant tombstone at the latest read sequence only.
-  ASSERT_EQ(inserted_ranges_.size(), 1);
+  ASSERT_EQ(attempted_insert_ranges_.size(), 1);
   AssertRange(0, "b", "n");
 
   snap_value.clear();

--- a/db/db_iterator_test.cc
+++ b/db/db_iterator_test.cc
@@ -5698,11 +5698,20 @@ TEST_P(ReadPathRangeTombstoneTest, BasicInsertion) {
 
     if (flush_before_read) {
       ASSERT_OK(Flush());
-      // Memtable is empty after flush. AddLogicallyRedundantRangeTombstone
-      // skips empty memtables.
+      // After dropping the IsEmpty() fast-path in synthesis, the now-empty
+      // active memtable is a valid synthesis target; the per-CF
+      // ingest_sst_lock (held shared by ingestion) is the mechanism that
+      // gates synthesis vs ingestion, not memtable emptiness.
       inserted_ranges_.clear();
       VerifyIteration({"a", "g", "h", "n"});
-      ASSERT_EQ(inserted_ranges_.size(), 0);
+      ASSERT_EQ(inserted_ranges_.size(), 2);
+      if (forward) {
+        AssertRange(0, "b", "g");
+        AssertRange(1, "i", "n");
+      } else {
+        AssertRange(0, "i", "n");
+        AssertRange(1, "b", "g");
+      }
       break;
     }
 
@@ -6914,6 +6923,60 @@ TEST_P(ReadPathRangeTombstoneTest, InvisibleKeysDontBreakTombstoneRun) {
   ASSERT_EQ(inserted_ranges_.size(), 1);
   AssertRange(0, "b", "f");
 
+  db_->ReleaseSnapshot(snap);
+}
+
+// Regression test: a synthesized tombstone can land in the current memtable at
+// an older snapshot sequence than a live point already ingested into an older
+// L0 file. Latest point lookups must continue searching that older file when
+// its sequence range can still contain a newer point version.
+TEST_P(ReadPathRangeTombstoneTest, NewerPointInOlderFileStillVisible) {
+  Options options = CurrentOptions();
+  options.min_tombstones_for_range_conversion = 2;
+  options.disable_auto_compactions = true;
+  options.statistics = CreateDBStatistics();
+  DestroyAndReopen(options);
+
+  ASSERT_OK(Put("b", "vb"));
+  ASSERT_OK(Put("c", "vc"));
+  ASSERT_OK(Put("d", "vd"));
+  ASSERT_OK(Flush());
+
+  ASSERT_OK(Delete("b"));
+  ASSERT_OK(Delete("c"));
+  ASSERT_OK(Flush());
+
+  // Keep the active memtable older than the snapshot so the read path is
+  // allowed to synthesize a tombstone into it later.
+  ASSERT_OK(Put("z", "vz_anchor"));
+  const Snapshot* snap = db_->GetSnapshot();
+
+  const std::string ingest_file = dbname_ + "_live_c.sst";
+  {
+    SstFileWriter writer(EnvOptions(), options);
+    ASSERT_OK(writer.Open(ingest_file));
+    ASSERT_OK(writer.Put("c", "vc_live"));
+    ASSERT_OK(writer.Finish());
+  }
+
+  IngestExternalFileOptions ifo;
+  ifo.allow_blocking_flush = false;
+  ASSERT_OK(db_->IngestExternalFile({ingest_file}, ifo));
+  ASSERT_EQ(Get("c"), "vc_live");
+
+  inserted_ranges_.clear();
+  ReadOptions snap_ro;
+  snap_ro.snapshot = snap;
+  VerifyIteration({"d", "z"}, snap_ro);
+
+  ASSERT_EQ(inserted_ranges_.size(), 1);
+  AssertRange(0, "b", "d");
+
+  const Snapshot* latest = db_->GetSnapshot();
+  ASSERT_EQ(Get("c", latest), "vc_live");
+  ASSERT_EQ(MultiGet({"c"}, latest), (std::vector<std::string>{"vc_live"}));
+
+  db_->ReleaseSnapshot(latest);
   db_->ReleaseSnapshot(snap);
 }
 

--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -958,7 +958,7 @@ bool MemTable::AddLogicallyRedundantRangeTombstone(
     return false;
   }
   // After ingestion releases its WriteLock, an iterator with an older
-  // snapshot could still try to synthesize a tombstone whose seq sits
+  // snapshot could still try to convert a tombstone whose seq sits
   // below the just-ingested file's seq. The barrier persists past the end
   // of the ingestion that bumped it and refuses such inserts.
   if (seq < ingest_seqno_barrier_.LoadRelaxed()) {

--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -918,12 +918,11 @@ void MemTable::ConstructFragmentedRangeTombstones() {
   }
 }
 
-bool MemTable::AddLogicallyRedundantRangeTombstone(SequenceNumber seq,
-                                                   const Slice& start_key,
-                                                   const Slice& end_key) {
-  // Fast path: skip if already immutable or empty. Some code paths (i.e.
-  // ExternalFileIngestion) rely ensuring memtable is empty after flushing.
-  if (is_immutable_.LoadRelaxed() || IsEmpty()) {
+bool MemTable::AddLogicallyRedundantRangeTombstone(
+    SequenceNumber seq, const Slice& start_key, const Slice& end_key,
+    port::RWMutex& ingest_sst_lock) {
+  // Fast path: skip if already immutable.
+  if (is_immutable_.LoadRelaxed()) {
     return false;
   }
 
@@ -939,6 +938,33 @@ bool MemTable::AddLogicallyRedundantRangeTombstone(SequenceNumber seq,
     return false;
   }
 
+  // Range tombstone reads have an assumption that all levels below it have a
+  // LOWER seqno than it, so it is safe to skip reading files. Normally, this is
+  // true, but range tombstone conversion creates an exception.
+  //
+  // The inserted range tombstone uses iterator seqno. There are guards to
+  // ensure that we only insert it if it is within current memtable's bounds,
+  // BUT an external file ingestion can break that still, as the newly ingested
+  // L0 file will be assigned a higher seqno than an earlier iterator.
+  //
+  // So the solution here is to use a RW lock + ingest seqno to gate range
+  // tombstone conversions. An added side effect is also we can no longer insert
+  // to memtables while a file ingestion is in progress, which is an expectation
+  // of file ingestion. Note we expect this insertion to be rare, and we do not
+  // want to limit concurrent external file ingestions so the conversion path
+  // uses a write lock while the ingestion path uses a read lock.
+  TryWriteLock ingest_wl(&ingest_sst_lock);
+  if (!ingest_wl.OwnsLock()) {
+    return false;
+  }
+  // After ingestion releases its WriteLock, an iterator with an older
+  // snapshot could still try to synthesize a tombstone whose seq sits
+  // below the just-ingested file's seq. The barrier persists past the end
+  // of the ingestion that bumped it and refuses such inserts.
+  if (seq < ingest_seqno_barrier_.LoadRelaxed()) {
+    return false;
+  }
+
   MemTablePostProcessInfo post_process_info;
   Status s = Add(seq, kTypeRangeDeletion, start_key, end_key,
                  nullptr /* kv_prot_info */, true /* allow_concurrent */,
@@ -948,6 +974,12 @@ bool MemTable::AddLogicallyRedundantRangeTombstone(SequenceNumber seq,
     return true;
   }
   return false;
+}
+
+void MemTable::BumpIngestSeqnoBarrier(SequenceNumber y) {
+  if (ingest_seqno_barrier_.LoadRelaxed() < y) {
+    ingest_seqno_barrier_.StoreRelaxed(y);
+  }
 }
 
 port::RWMutex* MemTable::GetLock(const Slice& key) {

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -328,11 +328,13 @@ class ReadOnlyMemTable {
   // Adding a range tombstone may fail if
   // - memtable switches to immutable state
   // - a range tombstone with the same key+seq already exists (duplicate insert)
-  //
+  // - the per-memtable ingest seqno barrier already exceeds `seq` (an
+  //   ingestion has committed an L0 file at a seq that this synthesized
+  //   tombstone would shadow) or an ingestion is in progress.
   // Returns true if the range tombstone was inserted, false if skipped.
-  virtual bool AddLogicallyRedundantRangeTombstone(SequenceNumber /*seq*/,
-                                                   const Slice& /*start_key*/,
-                                                   const Slice& /*end_key*/) {
+  virtual bool AddLogicallyRedundantRangeTombstone(
+      SequenceNumber /*seq*/, const Slice& /*start_key*/,
+      const Slice& /*end_key*/, port::RWMutex& /*ingest_sst_lock*/) {
     return false;
   }
 
@@ -858,9 +860,12 @@ class MemTable final : public ReadOnlyMemTable {
   // SwitchMemtable() may fail.
   void ConstructFragmentedRangeTombstones();
 
-  bool AddLogicallyRedundantRangeTombstone(SequenceNumber seq,
-                                           const Slice& start_key,
-                                           const Slice& end_key) override;
+  bool AddLogicallyRedundantRangeTombstone(
+      SequenceNumber seq, const Slice& start_key, const Slice& end_key,
+      port::RWMutex& ingest_sst_lock) override;
+
+  // Should be called while ingest_seqno_barrier_ lock is held
+  void BumpIngestSeqnoBarrier(SequenceNumber y);
 
   bool IsFragmentedRangeTombstonesConstructed() const override {
     return fragmented_range_tombstone_list_.get() != nullptr ||
@@ -921,6 +926,9 @@ class MemTable final : public ReadOnlyMemTable {
   // The db sequence number at the time of creation or kMaxSequenceNumber
   // if not set.
   std::atomic<SequenceNumber> earliest_seqno_;
+
+  // Seqno of the latest ingested external SST.
+  RelaxedAtomic<SequenceNumber> ingest_seqno_barrier_{0};
 
   SequenceNumber creation_seq_;
 

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -329,7 +329,7 @@ class ReadOnlyMemTable {
   // - memtable switches to immutable state
   // - a range tombstone with the same key+seq already exists (duplicate insert)
   // - the per-memtable ingest seqno barrier already exceeds `seq` (an
-  //   ingestion has committed an L0 file at a seq that this synthesized
+  //   ingestion has committed an L0 file at a seq that this converted
   //   tombstone would shadow) or an ingestion is in progress.
   // Returns true if the range tombstone was inserted, false if skipped.
   virtual bool AddLogicallyRedundantRangeTombstone(
@@ -864,7 +864,14 @@ class MemTable final : public ReadOnlyMemTable {
       SequenceNumber seq, const Slice& start_key, const Slice& end_key,
       port::RWMutex& ingest_sst_lock) override;
 
-  // Should be called while ingest_seqno_barrier_ lock is held
+  // Monotonically raises ingest_seqno_barrier_ to `y` (no-op if `y` is not
+  // greater than the current value). The conversion's barrier check
+  // (`seq < ingest_seqno_barrier_.LoadRelaxed()`) refuses converted
+  // range tombstones that would shadow a just-installed L0 file.
+  //
+  // REQUIRES: DB mutex held by the caller. The DB mutex serializes all
+  // callers, so the load-then-store pattern is race-free without needing
+  // a CAS loop. Only IngestExternalFiles calls this.
   void BumpIngestSeqnoBarrier(SequenceNumber y);
 
   bool IsFragmentedRangeTombstonesConstructed() const override {

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -934,7 +934,8 @@ class MemTable final : public ReadOnlyMemTable {
   // if not set.
   std::atomic<SequenceNumber> earliest_seqno_;
 
-  // Seqno of the latest ingested external SST.
+  // Seqno of the latest ingested external SST. See also
+  // ColumnFamilyData::ingest_sst_lock_.
   RelaxedAtomic<SequenceNumber> ingest_seqno_barrier_{0};
 
   SequenceNumber creation_seq_;

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -1419,8 +1419,18 @@ struct AdvancedColumnFamilyOptions {
   //   (ReadOptions::total_order_seek / ReadOptions::auto_prefix_mode) nor
   //   bounded by ReadOptions::prefix_same_as_start
   //
-  // It also requires an active mutable memtable, and insertion is skipped when
-  // that memtable is empty.
+  // Even if the above restrictions are met, there are still scenarios where a
+  // converted range tombstone may be discarded:
+  //   * The snapshot's active mutable memtable has already become immutable.
+  //   * The iterator's snapshot seq is below the active memtable's earliest
+  //     sequence number.
+  //   * A range tombstone covering [first_tombstone_key, next_live_key) is
+  //     already present in the memtable.
+  //   * A WritePrepared/WriteUnprepared transaction read callback is in use
+  //     and the snapshot seq is at or above its min uncommitted seq.
+  //   * An IngestExternalFile call is currently in flight on this column
+  //     family OR the inserted range tombstone seqno would be lower than the
+  //     ingested file seqno.
   //
   // Read-write iterators using ReadOptions::table_filter are rejected while
   // this option is enabled, see more details in ReadOptions::table_filter

--- a/port/port_posix.cc
+++ b/port/port_posix.cc
@@ -161,8 +161,32 @@ void RWMutex::ReadLock() {
   PthreadCall("read lock", pthread_rwlock_rdlock(&mu_));
 }
 
+bool RWMutex::TryReadLock() {
+  int result = pthread_rwlock_tryrdlock(&mu_);
+  if (result == 0) {
+    return true;
+  }
+  if (result == EBUSY) {
+    return false;
+  }
+  PthreadCall("try read lock", result);
+  return false;
+}
+
 void RWMutex::WriteLock() {
   PthreadCall("write lock", pthread_rwlock_wrlock(&mu_));
+}
+
+bool RWMutex::TryWriteLock() {
+  int result = pthread_rwlock_trywrlock(&mu_);
+  if (result == 0) {
+    return true;
+  }
+  if (result == EBUSY) {
+    return false;
+  }
+  PthreadCall("try write lock", result);
+  return false;
 }
 
 void RWMutex::ReadUnlock() {

--- a/port/port_posix.h
+++ b/port/port_posix.h
@@ -136,7 +136,9 @@ class RWMutex {
   ~RWMutex();
 
   void ReadLock();
+  bool TryReadLock();
   void WriteLock();
+  bool TryWriteLock();
   void ReadUnlock();
   void WriteUnlock();
   void AssertHeld() const {}

--- a/port/win/port_win.h
+++ b/port/win/port_win.h
@@ -152,7 +152,11 @@ class RWMutex {
 
   void ReadLock() { AcquireSRWLockShared(&srwLock_); }
 
+  bool TryReadLock() { return TryAcquireSRWLockShared(&srwLock_) != 0; }
+
   void WriteLock() { AcquireSRWLockExclusive(&srwLock_); }
+
+  bool TryWriteLock() { return TryAcquireSRWLockExclusive(&srwLock_) != 0; }
 
   void ReadUnlock() { ReleaseSRWLockShared(&srwLock_); }
 

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -484,8 +484,7 @@ default_params = {
     "auto_refresh_iterator_with_snapshot": lambda: random.choice([0, 1]),
     "memtable_op_scan_flush_trigger": lambda: random.choice([0, 10, 100, 1000]),
     "memtable_avg_op_scan_flush_trigger": lambda: random.choice([0, 2, 20, 200]),
-    # TODO(jkangs): Change back to [0, 2, 2, 4, 16] once range tombstone conversion stabilizes
-    "min_tombstones_for_range_conversion": lambda: random.choice([0]),
+    "min_tombstones_for_range_conversion": lambda: random.choice([0, 2, 2, 4, 16]),
     "ingest_wbwi_one_in": lambda: random.choice([0, 0, 100, 500]),
     "universal_reduce_file_locking": lambda: random.randint(0, 1),
     "compression_manager": lambda: random.choice(
@@ -932,6 +931,8 @@ def finalize_and_sanitize(src_params):
         # range tombstone conversion is enabled, because conversion must see
         # the full relevant SST set before synthesizing a memtable tombstone.
         dest_params["use_sqfc_for_range_queries"] = 0
+        # Delete range not compatible with inplace_update_support
+        dest_params["inplace_update_support"] = 0
     if (
         dest_params["use_direct_io_for_flush_and_compaction"] == 1
         or dest_params["use_direct_reads"] == 1
@@ -1720,9 +1721,7 @@ def collect_diagnostic_roots(base_paths, stdout, stderr):
     pruned_roots = []
     for root in sorted(roots, key=lambda path: (len(path), path)):
         if any(
-            root == existing
-            or existing == os.sep
-            or root.startswith(existing + os.sep)
+            root == existing or existing == os.sep or root.startswith(existing + os.sep)
             for existing in pruned_roots
         ):
             continue
@@ -1774,9 +1773,7 @@ def collect_directory_usage(root):
             with os.scandir(dirpath) as iterator:
                 children = sorted(list(iterator), key=lambda entry: entry.name)
         except OSError as exc:
-            errors.append(
-                (dirpath, f"failed to enumerate directory contents: {exc}")
-            )
+            errors.append((dirpath, f"failed to enumerate directory contents: {exc}"))
             return summary
 
         for child in children:
@@ -1784,9 +1781,7 @@ def collect_directory_usage(root):
                 if child.is_dir(follow_symlinks=False):
                     summary["local_dir_count"] += 1
                     child_summary = walk(child.path)
-                    summary["subtree_file_count"] += child_summary[
-                        "subtree_file_count"
-                    ]
+                    summary["subtree_file_count"] += child_summary["subtree_file_count"]
                     summary["subtree_bytes"] += child_summary["subtree_bytes"]
                     continue
 
@@ -1809,9 +1804,7 @@ def collect_directory_usage(root):
             local_usage["count"] += 1
             local_usage["bytes"] += file_size
 
-            global_usage = global_suffixes.setdefault(
-                suffix, {"count": 0, "bytes": 0}
-            )
+            global_usage = global_suffixes.setdefault(suffix, {"count": 0, "bytes": 0})
             global_usage["count"] += 1
             global_usage["bytes"] += file_size
 
@@ -1823,9 +1816,7 @@ def collect_directory_usage(root):
 
 
 def sorted_suffix_usage(suffixes):
-    return sorted(
-        suffixes.items(), key=lambda item: (-item[1]["bytes"], item[0])
-    )
+    return sorted(suffixes.items(), key=lambda item: (-item[1]["bytes"], item[0]))
 
 
 def format_directory_usage(root):

--- a/unreleased_history/bug_fixes/range_tombstone_synthesis
+++ b/unreleased_history/bug_fixes/range_tombstone_synthesis
@@ -1,0 +1,1 @@
+Fix bug in range tombstone synthesis that covers live keys added during an IngestExternalFile

--- a/util/mutexlock.h
+++ b/util/mutexlock.h
@@ -64,6 +64,30 @@ class ReadLock {
 };
 
 //
+// Try to acquire a ReadLock on the specified RWMutex without blocking.
+//
+class TryReadLock {
+ public:
+  explicit TryReadLock(port::RWMutex* mu)
+      : mu_(mu), owns_(mu_->TryReadLock()) {}
+  // No copying allowed
+  TryReadLock(const TryReadLock&) = delete;
+  void operator=(const TryReadLock&) = delete;
+
+  ~TryReadLock() {
+    if (owns_) {
+      mu_->ReadUnlock();
+    }
+  }
+
+  bool OwnsLock() const { return owns_; }
+
+ private:
+  port::RWMutex* const mu_;
+  const bool owns_;
+};
+
+//
 // Automatically unlock a locked mutex when the object is destroyed
 //
 class ReadUnlock {
@@ -95,6 +119,33 @@ class WriteLock {
 
  private:
   port::RWMutex* const mu_;
+};
+
+//
+// Try to acquire a WriteLock on the specified RWMutex without blocking.
+// If acquired, the lock is released when the object goes out of scope.
+// If not acquired, the destructor is a no-op. Use OwnsLock() to check
+// whether the lock was acquired.
+//
+class TryWriteLock {
+ public:
+  explicit TryWriteLock(port::RWMutex* mu)
+      : mu_(mu), owns_(mu_->TryWriteLock()) {}
+  // No copying allowed
+  TryWriteLock(const TryWriteLock&) = delete;
+  void operator=(const TryWriteLock&) = delete;
+
+  ~TryWriteLock() {
+    if (owns_) {
+      mu_->WriteUnlock();
+    }
+  }
+
+  bool OwnsLock() const { return owns_; }
+
+ private:
+  port::RWMutex* const mu_;
+  const bool owns_;
 };
 
 //


### PR DESCRIPTION
## Summary

Fixes a correctness bug in read-path range-tombstone synthesis when it races with `IngestExternalFile`. The synthesis path could insert a tombstone into the active memtable at a snapshot's sequence number, while ingestion installed an L0 SST at `LastSequence + 1` — a higher seqno than the synthesized tombstone. This breaks the main assumption of range tombstone reads that all lower levels have lower seqno.

The fix introduces a per-CF `port::RWMutex` (`ColumnFamilyData::ingest_sst_lock_`) plus a per-memtable `ingest_seqno_barrier_`. Ingestion takes the read lock and range tombstone synthesis **tries** to take a write lock. 

If iterator lock is successful, then we have a new updated barrier seqno that we can validate the iterator seqno against. An added benefit is we no longer need to gate against empty memtable. This was originally added as an easy fix to prevent memtables from being inserted into while ingestion was happening. 

## The bug, by example

`ReadPathRangeTombstoneTest.NewerPointInOlderFileStillVisible` (`db/db_iterator_test.cc:6929`):

1. L0 file `b@1, c@2, d@3`, then L0 file `Delete(b)@4, Delete(c)@5`.
2. Active memtable: `Put(z)@6`. Snapshot taken at seq 6.
3. `IngestExternalFile({c → "vc_live"})` → installed at L0 with seq 7.
4. Iterator at snap 6 walks the deletion run and synthesizes `[b, d) @ seq 6` into the active memtable via `MemTable::AddLogicallyRedundantRangeTombstone`.
5. `Get("c")` at the latest snapshot: memtable returns covering tombstone (seq 6), `Version::Get` short-circuits, **never reads `c@7`** — returns `NotFound` instead of `"vc_live"`.

The invariant `Version::Get` relies on (memtable seqs ≥ any L0 seq for the same key) is broken because synthesis writes at the *snapshot's* seq while ingestion writes at `LastSequence + 1`.


## Test Plan
- Updated regression test
- Re-enable crashtests and manually run

| Flavor | Jobs |
|---|---:|
| `fbcode_blackbox_crash_test` | 200 |
| `fbcode_whitebox_crash_test` | 30 |
| `fbcode_asan_blackbox_crash_test` | 30 |
| `fbcode_tsan_blackbox_crash_test` | 30 |
| `fbcode_crash_test_with_atomic_flush` | 30 |
| `fbcode_crash_test_with_wc_txn` | 30 |
| `fbcode_crash_test_with_ts` | 30 |
| **Total** | **380** |
