### PR TITLE
Add MANIFEST_VALIDATION_FAILURE_COUNT statistic

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -5728,6 +5728,8 @@ Status VersionSet::Close(FSDirectory* db_dir, InstrumentedMutex* mu) {
         // Manifest is healthy, no need to check again
         break;
       }
+      RecordTick(db_options_->statistics.get(),
+                 MANIFEST_VALIDATION_FAILURE_COUNT);
       IOStatus corrupt_io_s =
           IOStatus::Corruption("MANIFEST content validation failed");
       IOErrorInfo io_error_info(corrupt_io_s, FileOperationType::kVerify,

--- a/db/version_set_test.cc
+++ b/db/version_set_test.cc
@@ -20,6 +20,7 @@
 #include "rocksdb/advanced_options.h"
 #include "rocksdb/convenience.h"
 #include "rocksdb/file_system.h"
+#include "rocksdb/statistics.h"
 #include "table/block_based/block_based_table_factory.h"
 #include "table/mock_table.h"
 #include "table/unique_id_impl.h"
@@ -2412,6 +2413,8 @@ TEST_F(VersionSetTest, ManifestContentValidationOnCloseClean) {
   // Enable content validation, perform normal operations, close.
   // Verify no manifest rotation (file number unchanged).
   NewDB();
+  auto stats = CreateDBStatistics();
+  imm_db_options_.statistics = stats;
   mutable_db_options_.verify_manifest_content_on_close = true;
   mutex_.Lock();
   versions_->UpdatedMutableDbOptions(mutable_db_options_, &mutex_);
@@ -2437,6 +2440,9 @@ TEST_F(VersionSetTest, ManifestContentValidationOnCloseClean) {
   // Verify content validation actually ran
   ASSERT_TRUE(content_validation_ran);
 
+  // No corruption — counter should be zero
+  ASSERT_EQ(0, stats->getTickerCount(MANIFEST_VALIDATION_FAILURE_COUNT));
+
   // Manifest path should be unchanged (no rotation)
   std::string manifest_path_after;
   uint64_t manifest_file_number = 0;
@@ -2452,6 +2458,8 @@ TEST_F(VersionSetTest, ManifestContentValidationOnCloseCorruptRecord) {
   // Enable content validation, corrupt the manifest after closing the writer,
   // verify manifest rotation occurs and DB reopens cleanly.
   NewDB();
+  auto stats = CreateDBStatistics();
+  imm_db_options_.statistics = stats;
   mutable_db_options_.verify_manifest_content_on_close = true;
   mutex_.Lock();
   versions_->UpdatedMutableDbOptions(mutable_db_options_, &mutex_);
@@ -2488,6 +2496,9 @@ TEST_F(VersionSetTest, ManifestContentValidationOnCloseCorruptRecord) {
   CloseDB();
   SyncPoint::GetInstance()->DisableProcessing();
 
+  // Corruption detected once, rewrite succeeded
+  ASSERT_EQ(1, stats->getTickerCount(MANIFEST_VALIDATION_FAILURE_COUNT));
+
   // Manifest should have been rotated (new file number)
   std::string manifest_path_after;
   uint64_t manifest_file_number = 0;
@@ -2504,6 +2515,8 @@ TEST_F(VersionSetTest, ManifestContentValidationOnCloseDisabled) {
   // Default (option disabled), corrupt manifest after writer close,
   // verify no rotation occurred — corrupt manifest persists.
   NewDB();
+  auto stats = CreateDBStatistics();
+  imm_db_options_.statistics = stats;
   // verify_manifest_content_on_close defaults to false
 
   VersionEdit edit;
@@ -2525,6 +2538,9 @@ TEST_F(VersionSetTest, ManifestContentValidationOnCloseDisabled) {
 
   ASSERT_FALSE(content_validation_ran);
 
+  // Validation disabled — counter should be zero
+  ASSERT_EQ(0, stats->getTickerCount(MANIFEST_VALIDATION_FAILURE_COUNT));
+
   // Manifest path should be unchanged (no rotation since validation is off)
   std::string manifest_path_after;
   uint64_t manifest_file_number = 0;
@@ -2539,6 +2555,8 @@ TEST_F(VersionSetTest, ManifestContentValidationOnCloseSizeCheckFails) {
   // Verify recovery happens via size-check path. Content validation still
   // runs afterward on the freshly rewritten manifest.
   NewDB();
+  auto stats = CreateDBStatistics();
+  imm_db_options_.statistics = stats;
   mutable_db_options_.verify_manifest_content_on_close = true;
   mutex_.Lock();
   versions_->UpdatedMutableDbOptions(mutable_db_options_, &mutex_);
@@ -2566,6 +2584,10 @@ TEST_F(VersionSetTest, ManifestContentValidationOnCloseSizeCheckFails) {
   ASSERT_NO_FATAL_FAILURE(CloseDB());
   SyncPoint::GetInstance()->DisableProcessing();
 
+  // Size check caught the issue; content validation on rewritten manifest
+  // should pass — no content validation failure recorded
+  ASSERT_EQ(0, stats->getTickerCount(MANIFEST_VALIDATION_FAILURE_COUNT));
+
   // Size check should have triggered rotation
   std::string manifest_path_after;
   uint64_t manifest_file_number = 0;
@@ -2583,6 +2605,8 @@ TEST_F(VersionSetTest, ManifestContentValidationOnCloseCorruptAfterRewrite) {
   // The loop should detect corruption twice: once triggering a rewrite, and
   // once reporting that the rewritten manifest is also corrupt.
   NewDB();
+  auto stats = CreateDBStatistics();
+  imm_db_options_.statistics = stats;
   mutable_db_options_.verify_manifest_content_on_close = true;
   mutex_.Lock();
   versions_->UpdatedMutableDbOptions(mutable_db_options_, &mutex_);
@@ -2636,12 +2660,17 @@ TEST_F(VersionSetTest, ManifestContentValidationOnCloseCorruptAfterRewrite) {
 
   // OnIOError should have fired twice (once per corrupt detection)
   ASSERT_EQ(io_error_count, 2);
+
+  // Validation failure counter should match
+  ASSERT_EQ(2, stats->getTickerCount(MANIFEST_VALIDATION_FAILURE_COUNT));
 }
 
 TEST_F(VersionSetTest, ManifestContentValidationOnCloseOpenFails) {
   // Delete the manifest before content validation so it can't be opened.
   // Close() should surface the I/O error to the caller.
   NewDB();
+  auto stats = CreateDBStatistics();
+  imm_db_options_.statistics = stats;
   mutable_db_options_.verify_manifest_content_on_close = true;
   mutex_.Lock();
   versions_->UpdatedMutableDbOptions(mutable_db_options_, &mutex_);
@@ -2667,6 +2696,9 @@ TEST_F(VersionSetTest, ManifestContentValidationOnCloseOpenFails) {
   SyncPoint::GetInstance()->ClearAllCallBacks();
 
   ASSERT_TRUE(close_s.IsIOError()) << close_s.ToString();
+
+  // File couldn't be opened — no content validation ran
+  ASSERT_EQ(0, stats->getTickerCount(MANIFEST_VALIDATION_FAILURE_COUNT));
 }
 
 TEST_F(VersionStorageInfoTest, AddRangeDeletionCompensatedFileSize) {

--- a/include/rocksdb/statistics.h
+++ b/include/rocksdb/statistics.h
@@ -600,6 +600,9 @@ enum Tickers : uint32_t {
   // via FileOptions::file_metadata (on DB open / table cache miss)
   FILE_OPEN_METADATA_PASSED,
 
+  // # of times MANIFEST content validation detected corruption on DB close
+  MANIFEST_VALIDATION_FAILURE_COUNT,
+
   TICKER_ENUM_MAX
 };
 

--- a/java/rocksjni/portal.h
+++ b/java/rocksjni/portal.h
@@ -5311,6 +5311,8 @@ class TickerTypeJni {
         return -0x69;
       case ROCKSDB_NAMESPACE::Tickers::READ_PATH_RANGE_TOMBSTONES_DISCARDED:
         return -0x6A;
+      case ROCKSDB_NAMESPACE::Tickers::MANIFEST_VALIDATION_FAILURE_COUNT:
+        return -0x6B;
       case ROCKSDB_NAMESPACE::Tickers::TICKER_ENUM_MAX:
         // -0x54 is the max value at this time. Since these values are exposed
         // directly to Java clients, we'll keep the value the same till the next
@@ -5812,6 +5814,8 @@ class TickerTypeJni {
         return ROCKSDB_NAMESPACE::Tickers::READ_PATH_RANGE_TOMBSTONES_INSERTED;
       case -0x6A:
         return ROCKSDB_NAMESPACE::Tickers::READ_PATH_RANGE_TOMBSTONES_DISCARDED;
+      case -0x6B:
+        return ROCKSDB_NAMESPACE::Tickers::MANIFEST_VALIDATION_FAILURE_COUNT;
       case -0x54:
         // -0x54 is the max value at this time. Since these values are exposed
         // directly to Java clients, we'll keep the value the same till the next

--- a/java/src/main/java/org/rocksdb/TickerType.java
+++ b/java/src/main/java/org/rocksdb/TickerType.java
@@ -967,6 +967,11 @@ public enum TickerType {
      */
     READ_PATH_RANGE_TOMBSTONES_DISCARDED((byte) -0x6A),
 
+    /**
+     * # of times MANIFEST content validation detected corruption on DB close
+     */
+    MANIFEST_VALIDATION_FAILURE_COUNT((byte) -0x6B),
+
     TICKER_ENUM_MAX((byte) -0x54);
 
     private final byte value;

--- a/monitoring/statistics.cc
+++ b/monitoring/statistics.cc
@@ -302,6 +302,8 @@ const std::vector<std::pair<Tickers, std::string>> TickersNameMap = {
      "rocksdb.read.path.range.tombstones.discarded"},
     {FILE_OPEN_METADATA_RETRIEVED, "rocksdb.file.open.metadata.retrieved"},
     {FILE_OPEN_METADATA_PASSED, "rocksdb.file.open.metadata.passed"},
+    {MANIFEST_VALIDATION_FAILURE_COUNT,
+     "rocksdb.manifest.validation.failure.count"},
 };
 
 const std::vector<std::pair<Histograms, std::string>> HistogramsNameMap = {


### PR DESCRIPTION
Summary:
CONTEXT: The manifest validation on close feature (verify_manifest_content_on_close) detects corruption but does not increment any statistics counter, making it harder to monitor in production.

WHAT: Add a new ticker MANIFEST_VALIDATION_FAILURE_COUNT that is incremented each time content validation detects manifest corruption during DB::Close(). The counter fires per corruption detection, so it can increment up to 2 times per close (once on initial check, once after rewrite attempt). Updated all existing manifest validation tests to verify the counter value.

Test Plan:
- All 7 manifest validation tests pass with new stat assertions
- 5x repeat with COERCE_CONTEXT_SWITCH=1 shows no flakiness
- Full version_set_test suite (212 tests) passes