### PR TITLE
Fix mutex deadlock in FlushJob::MemPurge error path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1463,6 +1463,7 @@ if(WITH_TESTS)
         db/db_kv_checksum_test.cc
         db/db_log_iter_test.cc
         db/db_memtable_test.cc
+        db/db_mempurge_test.cc
         db/db_merge_operator_test.cc
         db/db_merge_operand_test.cc
         db/db_open_with_config_test.cc

--- a/db/db_mempurge_test.cc
+++ b/db/db_mempurge_test.cc
@@ -1,0 +1,64 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include "db/db_test_util.h"
+#include "port/stack_trace.h"
+#include "rocksdb/compaction_filter.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+class DBMempurgeTest : public DBTestBase {
+ public:
+  DBMempurgeTest() : DBTestBase("db_mempurge_test", /*env_do_fsync=*/true) {}
+};
+
+class SnapshotCompactionFilter : public CompactionFilter {
+ public:
+  bool Filter(int /*level*/, const Slice& /*key*/, const Slice& /*existing_value*/,
+              std::string* /*new_value*/, bool* /*value_changed*/) const override {
+    return false;
+  }
+  const char* Name() const override { return "SnapshotCompactionFilter"; }
+  bool IgnoreSnapshots() const override { return false; }
+};
+
+class SnapshotCompactionFilterFactory : public CompactionFilterFactory {
+ public:
+  std::unique_ptr<CompactionFilter> CreateCompactionFilter(
+      const CompactionFilter::Context& /*context*/) override {
+    return std::unique_ptr<CompactionFilter>(new SnapshotCompactionFilter());
+  }
+  const char* Name() const override { return "SnapshotCompactionFilterFactory"; }
+  bool ShouldFilterTableFileCreation(TableFileCreationReason reason) const override {
+      return reason == TableFileCreationReason::kFlush;
+  }
+};
+
+TEST_F(DBMempurgeTest, MemPurgeCompactionFilterDeadlock) {
+  Options options = CurrentOptions();
+  options.write_buffer_size = 1024; // Small buffer
+  options.experimental_mempurge_threshold = 1.0;
+  options.compaction_filter_factory = std::make_shared<SnapshotCompactionFilterFactory>();
+  
+  Reopen(options);
+  
+  // Large value to trigger automatic flush (kWriteBufferFull)
+  std::string value(2048, 'v');
+  ASSERT_OK(Put("key", value));
+
+  // Wait for background flush to finish
+  dbfull()->TEST_WaitForFlushMemTable();
+
+  // Verify data persisted correctly
+  ASSERT_EQ(value, Get("key"));
+}
+
+}  // namespace ROCKSDB_NAMESPACE
+
+int main(int argc, char** argv) {
+  ROCKSDB_NAMESPACE::port::InstallStackTraceHandler();
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -492,10 +492,10 @@ Status FlushJob::MemPurge() {
           ioptions.compaction_filter_factory->CreateCompactionFilter(ctx);
       if (compaction_filter != nullptr &&
           !compaction_filter->IgnoreSnapshots()) {
-        s = Status::NotSupported(
+        db_mutex_->Lock();
+        return Status::NotSupported(
             "CompactionFilter::IgnoreSnapshots() = false is not supported "
             "anymore.");
-        return s;
       }
     }
 


### PR DESCRIPTION
Fix mutex deadlock in FlushJob::MemPurge error path

Closes #12918

Problem
FlushJob::MemPurge() unlocks db_mutex_ at entry and is contractually required to re-acquire it before returning. An early-return path triggered by unsupported CompactionFilter configurations (IgnoreSnapshots() == false) violated this contract by returning Status::NotSupported() without re-locking. This left the mutex in an inconsistent state, causing assertion failures or deadlocks when the calling thread (typically a background flush worker) continued execution expecting the mutex to be held.

Fix
Re-acquire db_mutex_ before the early return in the CompactionFilter validation block, matching the locking pattern used at the function's normal exit.

Test
Added regression test DBMempurgeTest.MemPurgeCompactionFilterDeadlock that:

Configures a CompactionFilter with IgnoreSnapshots() == false
Triggers flush with experimental_mempurge_threshold enabled
Verifies flush completes without deadlock and data persists correctly
Without the fix, the test fails with Assertion failed: locked_ in port_win.h:122. With the fix, the test passes.

