### PR TITLE
Revert temporary 11.1 remote compaction stats serialization workaround

### DIFF
--- a/db/compaction/compaction_service_job.cc
+++ b/db/compaction/compaction_service_job.cc
@@ -846,16 +846,11 @@ static std::unordered_map<std::string, OptionTypeInfo>
          {offsetof(struct InternalStats::CompactionStats, count),
           OptionType::kUInt64T, OptionVerificationType::kNormal,
           OptionTypeFlags::kNone}},
-        {"counts",
-         OptionTypeInfo::Array<
-             /* In release 11.2, a new compaction reason was added. This broken
-              * the reader and writer. To unblock release 11.1, we temporarily
-              * reduce the count array size to the old one. TODO add a proper
-              * serialization and deserialization method. */
-             int, static_cast<int>(CompactionReason::kNumOfReasons) - 1>(
-             offsetof(struct InternalStats::CompactionStats, counts),
-             OptionVerificationType::kNormal, OptionTypeFlags::kNone,
-             {0, OptionType::kInt})},
+        {"counts", OptionTypeInfo::Array<
+                       int, static_cast<int>(CompactionReason::kNumOfReasons)>(
+                       offsetof(struct InternalStats::CompactionStats, counts),
+                       OptionVerificationType::kNormal, OptionTypeFlags::kNone,
+                       {0, OptionType::kInt})},
 };
 
 static std::unordered_map<std::string, OptionTypeInfo>


### PR DESCRIPTION
## Summary
There is a separate way to handle incompatibility. Revert this.

- revert the temporary workaround from #14656 that serialized `InternalStats::CompactionStats::counts` with the pre-11.2 compaction-reason count
- restore remote compaction stats serialization to use the full `CompactionReason::kNumOfReasons` array size again

## Context
#14656 temporarily shrank the serialized `counts` array to keep remote compaction metadata readable across the 11.1/11.2 boundary. This follow-up removes that special case because the compatibility issue is being handled separately.

## Test Plan
- Not run in this metadata-prep task
