### PR TITLE
Avoid setting read option upper bound for range tombstone conversion

### DIFF
--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -774,23 +774,28 @@ bool DBIter::FindNextUserEntryInternal(bool skipping_saved_key) {
     }
   } while (iter_.Valid());
 
-  // If we accumulated tombstones, insert the range tombstone.  Use
-  // iterate_upper_bound_ if within the seek prefix, otherwise fall back to
-  // saved_key_ (the last tracked delete, covering n-1 deletes).
+  // If we accumulated tombstones, choose an end_key that doesn't depend on
+  // user-controlled iterate_upper_bound_ memory:
+  //  - iter_ still valid: stopped at the upper-bound break above. iter_'s
+  //    current key is RocksDB-owned and strictly greater than every counted
+  //    tombstone. Use it as the exclusive end_key.
+  //  - iter_ exhausted: no more keys exist past the run, so [first,
+  //    saved_key_) (covering n-1 of n deletes, with the n-th remaining as a
+  //    point delete) is safe. saved_key_ is the largest user key observed.
   if (contiguous_tombstone_count_ > 0 && iter_.status().ok()) {
-    if (iterate_upper_bound_ != nullptr && PrefixCheck(*iterate_upper_bound_)) {
-      if (timestamp_size_ == 0) {
-        MaybeInsertRangeTombstone(*iterate_upper_bound_);
-      } else {
-        // iterate_upper_bound_ is a plain user key without a timestamp
-        // suffix. Pad with min timestamp so it sorts after all entries with
-        // this user key, preserving the exclusive bound semantics.
-        std::string end_key_with_ts;
-        AppendKeyWithMinTimestamp(&end_key_with_ts, *iterate_upper_bound_,
-                                  timestamp_size_);
-        MaybeInsertRangeTombstone(end_key_with_ts);
+    bool inserted_via_iter = false;
+    if (iter_.Valid()) {
+      Slice end_user_key = ExtractUserKey(iter_.key());
+      Slice end_user_key_no_ts =
+          StripTimestampFromUserKey(end_user_key, timestamp_size_);
+      if (PrefixCheck(end_user_key_no_ts)) {
+        // Copy because iter_'s key buffer may not survive subsequent calls.
+        std::string end_key_copy(end_user_key.data(), end_user_key.size());
+        MaybeInsertRangeTombstone(end_key_copy);
+        inserted_via_iter = true;
       }
-    } else if (prefix_.has_value()) {
+    }
+    if (!inserted_via_iter) {
       MaybeInsertRangeTombstone(saved_key_.GetUserKey());
     }
   }

--- a/db/db_iterator_test.cc
+++ b/db/db_iterator_test.cc
@@ -5820,9 +5820,11 @@ TEST_P(ReadPathRangeTombstoneTest, ExhaustedIteratorWithBounds) {
   // Both directions encounter two tombstone runs (a-d and g-j).
   ASSERT_EQ(attempted_insert_ranges_.size(), 2);
   if (Forward()) {
-    // Forward: sees a-d tombstones first → [a, e), then g-j → [g, z).
+    // Forward: sees a-d tombstones first → live e terminates → [a, e).
+    // Then g-j → exhaustion past j, saved_key_="j" fallback → [g, j),
+    // covering g,h,i. j remains a point tombstone.
     AssertRange(0, "a", "e");
-    AssertRange(1, "g", "z");
+    AssertRange(1, "g", "j");
   } else {
     // Reverse: sees j-g tombstones first, then f,e live, then d-a → exhausts.
     AssertRange(0, "g", "z");
@@ -5860,13 +5862,24 @@ TEST_P(ReadPathRangeTombstoneTest, ExhaustedIteratorNoBounds) {
 
   VerifyIteration({"e", "f"});
 
-  // Without bounds, only the a-d run (which has a live key boundary) gets
-  // inserted. The g-j run at the end has no upper bound → dropped.
-  ASSERT_EQ(attempted_insert_ranges_.size(), 1);
-  AssertRange(0, "a", "e");
-  ASSERT_EQ(
-      options.statistics->getTickerCount(READ_PATH_RANGE_TOMBSTONES_INSERTED),
-      1);
+  if (Forward()) {
+    // Forward: a-d run terminates at live e → [a, e). g-j run exhausts
+    // past j → saved_key_ fallback → [g, j), covering g,h,i with j as a
+    // point tombstone.
+    ASSERT_EQ(attempted_insert_ranges_.size(), 2);
+    AssertRange(0, "a", "e");
+    AssertRange(1, "g", "j");
+    ASSERT_EQ(
+        options.statistics->getTickerCount(READ_PATH_RANGE_TOMBSTONES_INSERTED),
+        2);
+  } else {
+    // Reverse fallback path remains prefix-gated.
+    ASSERT_EQ(attempted_insert_ranges_.size(), 1);
+    AssertRange(0, "a", "e");
+    ASSERT_EQ(
+        options.statistics->getTickerCount(READ_PATH_RANGE_TOMBSTONES_INSERTED),
+        1);
+  }
 }
 
 TEST_P(ReadPathRangeTombstoneTest, DirectionChange) {
@@ -6612,8 +6625,8 @@ TEST_P(ReadPathRangeTombstoneTest, ExhaustedWithUDT) {
 
   ASSERT_EQ(attempted_insert_ranges_.size(), 1);
   if (Forward()) {
-    // Forward exhaustion: range is [e+ts, z+min_ts).
-    AssertRange(0, std::string("e") + ts, std::string("z") + min_ts);
+    // Forward exhaustion past h: saved_key_="h"+ts fallback → [e+ts, h+ts).
+    AssertRange(0, std::string("e") + ts, std::string("h") + ts);
   } else {
     // Reverse exhaustion: range is [a+ts, e+ts).
     AssertRange(0, std::string("a") + ts, std::string("e") + ts);
@@ -6624,8 +6637,9 @@ TEST_P(ReadPathRangeTombstoneTest, ExhaustedWithUDT) {
 }
 
 TEST_P(ReadPathRangeTombstoneTest, SeekForPrevTombstone) {
-  // SeekForPrev lands directly on tombstones. No upper bound, so forward
-  // exhaustion drops the trailing tombstone run (no end key available).
+  // SeekForPrev lands directly on tombstones. No upper bound. Forward
+  // exhaustion past h falls back to saved_key_="h" → [e, h), covering
+  // e,f,g with h as a point tombstone.
   // Reverse: SeekForPrev("h") → Delete(h,g,f,e) → live "d" → range [e, h).
   for (bool use_udt : {false, true}) {
     SCOPED_TRACE(use_udt ? "with UDT" : "without UDT");
@@ -6673,11 +6687,16 @@ TEST_P(ReadPathRangeTombstoneTest, SeekForPrevTombstone) {
     ASSERT_OK(iter->status());
     ASSERT_EQ(keys, (std::vector<std::string>{"a", "b", "c", "d"}));
 
+    ASSERT_EQ(attempted_insert_ranges_.size(), 1);
     if (Forward()) {
-      // No upper bound → trailing tombstone run has no end key → dropped.
-      ASSERT_EQ(attempted_insert_ranges_.size(), 0);
+      // Forward exhausts past h → saved_key_="h" fallback → [e, h),
+      // covering e,f,g with h as a point tombstone.
+      if (use_udt) {
+        AssertRange(0, std::string("e") + ts, std::string("h") + ts);
+      } else {
+        AssertRange(0, "e", "h");
+      }
     } else {
-      ASSERT_EQ(attempted_insert_ranges_.size(), 1);
       if (use_udt) {
         std::string min_ts(sizeof(uint64_t), '\0');
         AssertRange(0, std::string("e") + ts, std::string("h") + min_ts);
@@ -6687,15 +6706,18 @@ TEST_P(ReadPathRangeTombstoneTest, SeekForPrevTombstone) {
     }
     ASSERT_EQ(
         options.statistics->getTickerCount(READ_PATH_RANGE_TOMBSTONES_INSERTED),
-        Forward() ? 0 : 1);
+        1);
   }
 }
 
 TEST_P(ReadPathRangeTombstoneTest, UpperBoundTombstone) {
-  // iterate_upper_bound lands directly on tombstones. Both directions see
-  // tombstones e-h and use upper bound "i" as end key for the range.
-  // Forward: exhaustion at bound → [e, i). Reverse: SeekToLast delegates to
-  // SeekForPrev("i") → [e, i).
+  // iterate_upper_bound lands past the data. Both directions see tombstones
+  // e-h. Forward exhausts naturally past h (no key in DB ≥ upper) so the
+  // forward path falls back to saved_key_ ("h") as the exclusive end_key,
+  // covering n-1 of n deletes — [e, h). The remaining tombstone for h
+  // stays as a point delete. Reverse captures the live key "d" before the
+  // run and uses it via range_tomb_end_key_ — [e, i) when SeekToLast
+  // delegates to SeekForPrev("i").
   for (bool use_udt : {false, true}) {
     SCOPED_TRACE(use_udt ? "with UDT" : "without UDT");
     Options options = CurrentOptions();
@@ -6746,13 +6768,17 @@ TEST_P(ReadPathRangeTombstoneTest, UpperBoundTombstone) {
 
     ASSERT_EQ(attempted_insert_ranges_.size(), 1);
     if (use_udt) {
-      // Forward end key: upper bound padded with min_ts.
-      // Reverse end key: upper bound padded with max_ts (via
-      // SetSavedKeyToSeekForPrevTarget).
-      std::string end_ts(sizeof(uint64_t), Forward() ? '\0' : '\xff');
-      AssertRange(0, std::string("e") + ts, std::string("i") + end_ts);
+      if (Forward()) {
+        // Forward end key: saved_key_ ("h") with the tombstone's own ts.
+        AssertRange(0, std::string("e") + ts, std::string("h") + ts);
+      } else {
+        // Reverse end key: upper bound padded with max_ts (via
+        // SetSavedKeyToSeekForPrevTarget).
+        std::string end_ts(sizeof(uint64_t), '\xff');
+        AssertRange(0, std::string("e") + ts, std::string("i") + end_ts);
+      }
     } else {
-      AssertRange(0, "e", "i");
+      AssertRange(0, "e", Forward() ? "h" : "i");
     }
     ASSERT_EQ(
         options.statistics->getTickerCount(READ_PATH_RANGE_TOMBSTONES_INSERTED),


### PR DESCRIPTION
## Summary

`DBIter::FindNextUserEntryInternal` previously used `iterate_upper_bound_` (user-controlled memory) as the exclusive end-key when flushing an accumulated tombstone run. That pointer is dangerous as it points to user memory space, which can be modified at any moment. 

This PR removes that dependency: the end-key is always derived from RocksDB-owned data — either the live `iter_` key that broke the run, or `saved_key_` when `iter_` is exhausted.

The tradeoff here is that there is potentially 1 less tombstone to get covered in this path, which is reasonable.


## Test Plan
Updated unit tests, CI passes
