### PR TITLE
Use unique_ptr for StreamingCompress and StreamingUncompress

### DIFF
--- a/build_tools/check-workflow-yaml.sh
+++ b/build_tools/check-workflow-yaml.sh
@@ -7,6 +7,13 @@ set -euo pipefail
 
 if ! command -v ruby >/dev/null 2>&1; then
   echo "ruby is required to validate GitHub Actions workflow YAML"
+  echo "On CentOS Stream: sudo dnf install ruby rubygems rubygem-psych"
+  exit 1
+fi
+
+if ! ruby -e 'require "psych"' 2>/dev/null; then
+  echo "ruby is installed but cannot load required library 'psych'"
+  echo "On CentOS Stream: sudo dnf install rubygems rubygem-psych"
   exit 1
 fi
 

--- a/db/log_reader.cc
+++ b/db/log_reader.cc
@@ -699,8 +699,8 @@ void Reader::InitCompression(const CompressionTypeRecord& compression_record) {
   compression_type_ = compression_record.GetCompressionType();
   compression_type_record_read_ = true;
   constexpr uint32_t compression_format_version = 2;
-  uncompress_.reset(StreamingUncompress::Create(
-      compression_type_, compression_format_version, kBlockSize));
+  uncompress_ = StreamingUncompress::Create(
+      compression_type_, compression_format_version, kBlockSize);
   assert(uncompress_ != nullptr);
   uncompressed_buffer_ = std::unique_ptr<char[]>(new char[kBlockSize]);
   assert(uncompressed_buffer_);

--- a/db/log_reader.cc
+++ b/db/log_reader.cc
@@ -48,15 +48,12 @@ Reader::Reader(std::shared_ptr<Logger> info_log,
       first_record_read_(false),
       compression_type_(kNoCompression),
       compression_type_record_read_(false),
-      uncompress_(nullptr),
+      uncompress_(),
       hash_state_(nullptr),
       uncompress_hash_state_(nullptr) {}
 
 Reader::~Reader() {
   delete[] backing_store_;
-  if (uncompress_) {
-    delete uncompress_;
-  }
   if (hash_state_) {
     XXH3_freeState(hash_state_);
   }
@@ -702,8 +699,8 @@ void Reader::InitCompression(const CompressionTypeRecord& compression_record) {
   compression_type_ = compression_record.GetCompressionType();
   compression_type_record_read_ = true;
   constexpr uint32_t compression_format_version = 2;
-  uncompress_ = StreamingUncompress::Create(
-      compression_type_, compression_format_version, kBlockSize);
+  uncompress_.reset(StreamingUncompress::Create(
+      compression_type_, compression_format_version, kBlockSize));
   assert(uncompress_ != nullptr);
   uncompressed_buffer_ = std::unique_ptr<char[]>(new char[kBlockSize]);
   assert(uncompressed_buffer_);

--- a/db/log_reader.h
+++ b/db/log_reader.h
@@ -175,7 +175,7 @@ class Reader {
   CompressionType compression_type_;
   // Track whether the compression type record has been read or not.
   bool compression_type_record_read_;
-  StreamingUncompress* uncompress_;
+  std::unique_ptr<StreamingUncompress> uncompress_;
   // Reusable uncompressed output buffer
   std::unique_ptr<char[]> uncompressed_buffer_;
   // Reusable uncompressed record

--- a/db/log_test.cc
+++ b/db/log_test.cc
@@ -1224,10 +1224,10 @@ TEST_P(StreamingCompressionTest, Basic) {
   }
   CompressionOptions opts;
   constexpr uint32_t compression_format_version = 2;
-  std::unique_ptr<StreamingCompress> compress(StreamingCompress::Create(
-      compression_type, opts, compression_format_version, kBlockSize));
-  std::unique_ptr<StreamingUncompress> uncompress(StreamingUncompress::Create(
-      compression_type, compression_format_version, kBlockSize));
+  auto compress = StreamingCompress::Create(
+      compression_type, opts, compression_format_version, kBlockSize);
+  auto uncompress = StreamingUncompress::Create(
+      compression_type, compression_format_version, kBlockSize);
   std::unique_ptr<MemoryAllocator> allocator(new DefaultMemoryAllocator());
   std::string input_buffer = BigString("abc", input_size);
   std::vector<std::string> compressed_buffers;

--- a/db/log_test.cc
+++ b/db/log_test.cc
@@ -1224,11 +1224,11 @@ TEST_P(StreamingCompressionTest, Basic) {
   }
   CompressionOptions opts;
   constexpr uint32_t compression_format_version = 2;
-  StreamingCompress* compress = StreamingCompress::Create(
-      compression_type, opts, compression_format_version, kBlockSize);
-  StreamingUncompress* uncompress = StreamingUncompress::Create(
-      compression_type, compression_format_version, kBlockSize);
-  MemoryAllocator* allocator = new DefaultMemoryAllocator();
+  std::unique_ptr<StreamingCompress> compress(StreamingCompress::Create(
+      compression_type, opts, compression_format_version, kBlockSize));
+  std::unique_ptr<StreamingUncompress> uncompress(StreamingUncompress::Create(
+      compression_type, compression_format_version, kBlockSize));
+  std::unique_ptr<MemoryAllocator> allocator(new DefaultMemoryAllocator());
   std::string input_buffer = BigString("abc", input_size);
   std::vector<std::string> compressed_buffers;
   size_t remaining;
@@ -1266,9 +1266,6 @@ TEST_P(StreamingCompressionTest, Basic) {
     } while (ret_val > 0 || output_pos == kBlockSize);
   }
   allocator->Deallocate((void*)uncompressed_output_buffer);
-  delete allocator;
-  delete compress;
-  delete uncompress;
   // The final return value from uncompress() should be 0.
   ASSERT_EQ(ret_val, 0);
   ASSERT_EQ(input_buffer, uncompressed_buffer);

--- a/db/log_writer.cc
+++ b/db/log_writer.cc
@@ -218,9 +218,9 @@ IOStatus Writer::AddCompressionTypeRecord(const WriteOptions& write_options) {
     const size_t max_output_buffer_len = kBlockSize - header_size_;
     CompressionOptions opts;
     constexpr uint32_t compression_format_version = 2;
-    compress_.reset(StreamingCompress::Create(compression_type_, opts,
-                                              compression_format_version,
-                                              max_output_buffer_len));
+    compress_ = StreamingCompress::Create(compression_type_, opts,
+                                          compression_format_version,
+                                          max_output_buffer_len);
     assert(compress_ != nullptr);
     compressed_buffer_ =
         std::unique_ptr<char[]>(new char[max_output_buffer_len]);

--- a/db/log_writer.cc
+++ b/db/log_writer.cc
@@ -31,7 +31,7 @@ Writer::Writer(std::unique_ptr<WritableFileWriter>&& dest, uint64_t log_number,
       header_size_(recycle_log_files ? kRecyclableHeaderSize : kHeaderSize),
       manual_flush_(manual_flush),
       compression_type_(compression_type),
-      compress_(nullptr),
+      compress_(),
       track_and_verify_wals_(track_and_verify_wals),
       last_seqno_recorded_(0) {
   for (uint8_t i = 0; i <= kMaxRecordType; i++) {
@@ -46,9 +46,6 @@ Writer::~Writer() {
   ThreadStatusUtil::SetThreadOperation(ThreadStatus::OperationType::OP_UNKNOWN);
   if (dest_) {
     WriteBuffer(WriteOptions()).PermitUncheckedError();
-  }
-  if (compress_) {
-    delete compress_;
   }
   ThreadStatusUtil::SetThreadOperation(cur_op_type);
 }
@@ -221,9 +218,9 @@ IOStatus Writer::AddCompressionTypeRecord(const WriteOptions& write_options) {
     const size_t max_output_buffer_len = kBlockSize - header_size_;
     CompressionOptions opts;
     constexpr uint32_t compression_format_version = 2;
-    compress_ = StreamingCompress::Create(compression_type_, opts,
-                                          compression_format_version,
-                                          max_output_buffer_len);
+    compress_.reset(StreamingCompress::Create(compression_type_, opts,
+                                              compression_format_version,
+                                              max_output_buffer_len));
     assert(compress_ != nullptr);
     compressed_buffer_ =
         std::unique_ptr<char[]>(new char[max_output_buffer_len]);

--- a/db/log_writer.h
+++ b/db/log_writer.h
@@ -151,7 +151,7 @@ class Writer {
 
   // Compression Type
   CompressionType compression_type_;
-  StreamingCompress* compress_;
+  std::unique_ptr<StreamingCompress> compress_;
   // Reusable compressed output buffer
   std::unique_ptr<char[]> compressed_buffer_;
 

--- a/util/compression.cc
+++ b/util/compression.cc
@@ -155,24 +155,23 @@ std::string CompressionOptionsToString(
   return result;
 }
 
-StreamingCompress* StreamingCompress::Create(CompressionType compression_type,
-                                             const CompressionOptions& opts,
-                                             uint32_t compress_format_version,
-                                             size_t max_output_len) {
+std::unique_ptr<StreamingCompress> StreamingCompress::Create(
+    CompressionType compression_type, const CompressionOptions& opts,
+    uint32_t compress_format_version, size_t max_output_len) {
   switch (compression_type) {
     case kZSTD: {
       if (!ZSTD_Streaming_Supported()) {
         return nullptr;
       }
-      return new ZSTDStreamingCompress(opts, compress_format_version,
-                                       max_output_len);
+      return std::make_unique<ZSTDStreamingCompress>(
+          opts, compress_format_version, max_output_len);
     }
     default:
       return nullptr;
   }
 }
 
-StreamingUncompress* StreamingUncompress::Create(
+std::unique_ptr<StreamingUncompress> StreamingUncompress::Create(
     CompressionType compression_type, uint32_t compress_format_version,
     size_t max_output_len) {
   switch (compression_type) {
@@ -180,8 +179,8 @@ StreamingUncompress* StreamingUncompress::Create(
       if (!ZSTD_Streaming_Supported()) {
         return nullptr;
       }
-      return new ZSTDStreamingUncompress(compress_format_version,
-                                         max_output_len);
+      return std::make_unique<ZSTDStreamingUncompress>(compress_format_version,
+                                                       max_output_len);
     }
     default:
       return nullptr;

--- a/util/compression.h
+++ b/util/compression.h
@@ -617,10 +617,9 @@ class StreamingCompress {
                        size_t* output_pos) = 0;
   // static method to create object of a class inherited from
   // StreamingCompress based on the actual compression type.
-  static StreamingCompress* Create(CompressionType compression_type,
-                                   const CompressionOptions& opts,
-                                   uint32_t compress_format_version,
-                                   size_t max_output_len);
+  static std::unique_ptr<StreamingCompress> Create(
+      CompressionType compression_type, const CompressionOptions& opts,
+      uint32_t compress_format_version, size_t max_output_len);
   virtual void Reset() = 0;
 
  protected:
@@ -658,9 +657,9 @@ class StreamingUncompress {
   // Returns -1 for errors, remaining input to be processed otherwise.
   virtual int Uncompress(const char* input, size_t input_size, char* output,
                          size_t* output_pos) = 0;
-  static StreamingUncompress* Create(CompressionType compression_type,
-                                     uint32_t compress_format_version,
-                                     size_t max_output_len);
+  static std::unique_ptr<StreamingUncompress> Create(
+      CompressionType compression_type, uint32_t compress_format_version,
+      size_t max_output_len);
   virtual void Reset() = 0;
 
  protected:


### PR DESCRIPTION
Summary:
Replace raw owning pointers with std::unique_ptr for StreamingCompress/Uncompress in Create functions and log::Writer/Reader, eliminating manual delete calls in destructors. Also update the StreamingCompressionTest to use unique_ptr for its local StreamingCompress, StreamingUncompress, and MemoryAllocator objects.

Bonus: improve error message for missing/broken ruby (new build requirement)

Test Plan:
./log_test - all 211 tests pass.