### PR TITLE
Fix crash test trace file corruption by adding CRC framing (#14666)

### DIFF
--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -1294,13 +1294,27 @@ Status DBImpl::WriteImpl(
           if (writer->CallbackFailed()) {
             continue;
           }
-          // TODO: maybe handle the tracing status?
+          Status trace_s;
           if (wbwi && !ingest_wbwi_for_commit) {
             // for transaction write, tracer only needs the commit marker which
             // is in writer->batch
-            tracer_->Write(wbwi->GetWriteBatch()).PermitUncheckedError();
+            trace_s = tracer_->Write(wbwi->GetWriteBatch());
           } else {
-            tracer_->Write(writer->trace_batch).PermitUncheckedError();
+            trace_s = tracer_->Write(writer->trace_batch);
+          }
+          if (!trace_s.ok()) {
+            // When a trace write fails with preserve_write_order, continuing
+            // to accept DB writes without tracing them would violate the
+            // expected-state trace contract used by db_stress (the trace must
+            // be an ordered superset of recoverable writes). Stop tracing
+            // immediately to prevent a silent gap from accumulating between
+            // the trace file and the WAL.
+            ROCKS_LOG_ERROR(immutable_db_options_.info_log,
+                            "Trace write failed (%s), stopping tracer to "
+                            "prevent silent gap accumulation",
+                            trace_s.ToString().c_str());
+            tracer_.reset();
+            break;
           }
         }
       }
@@ -1629,8 +1643,21 @@ Status DBImpl::PipelinedWriteImpl(const WriteOptions& write_options,
               // not record to trace.
               continue;
             }
-            // TODO: maybe handle the tracing status?
-            tracer_->Write(writer->trace_batch).PermitUncheckedError();
+            Status trace_s = tracer_->Write(writer->trace_batch);
+            if (!trace_s.ok()) {
+              // When a trace write fails with preserve_write_order, continuing
+              // to accept DB writes without tracing them would violate the
+              // expected-state trace contract used by db_stress (the trace must
+              // be an ordered superset of recoverable writes). Stop tracing
+              // immediately to prevent a silent gap from accumulating between
+              // the trace file and the WAL.
+              ROCKS_LOG_ERROR(immutable_db_options_.info_log,
+                              "Trace write failed (%s), stopping tracer to "
+                              "prevent silent gap accumulation",
+                              trace_s.ToString().c_str());
+              tracer_.reset();
+              break;
+            }
           }
         }
       }
@@ -1914,8 +1941,15 @@ Status DBImpl::WriteImplWALOnly(
         if (writer->CallbackFailed()) {
           continue;
         }
-        // TODO: maybe handle the tracing status?
-        tracer_->Write(writer->trace_batch).PermitUncheckedError();
+        Status trace_s = tracer_->Write(writer->trace_batch);
+        if (!trace_s.ok()) {
+          ROCKS_LOG_ERROR(immutable_db_options_.info_log,
+                          "Trace write failed (%s), stopping tracer to "
+                          "prevent silent gap accumulation",
+                          trace_s.ToString().c_str());
+          tracer_.reset();
+          break;
+        }
       }
     }
   }

--- a/db_stress_tool/expected_state.cc
+++ b/db_stress_tool/expected_state.cc
@@ -1189,8 +1189,10 @@ Status FileExpectedStateManager::Restore(DB* db) {
     if (s.ok() && !handler->IsDone()) {
       s = Status::Corruption(
           "Trace ended before replaying all expected write ops",
-          std::to_string(handler->NumWriteOps()) + " < " +
-              std::to_string(seqno - saved_seqno_));
+          "replayed " + std::to_string(handler->NumWriteOps()) + " of " +
+              std::to_string(seqno - saved_seqno_) +
+              " expected ops (saved_seqno=" + std::to_string(saved_seqno_) +
+              " recovered_seqno=" + std::to_string(seqno) + ")");
     }
     if (handler) {
       replayed_write_ops = handler->NumWriteOps();

--- a/include/rocksdb/trace_reader_writer.h
+++ b/include/rocksdb/trace_reader_writer.h
@@ -24,6 +24,11 @@ class TraceWriter {
   virtual Status Write(const Slice& data) = 0;
   virtual Status Close() = 0;
   virtual uint64_t GetFileSize() = 0;
+
+  // Enable CRC32c framing for subsequent Write() calls. Called after the
+  // trace header has been written in the legacy format, so the header remains
+  // readable by older versions.
+  virtual void EnableCRCFraming() {}
 };
 
 // TraceReader allows reading RocksDB traces from any system, one operation at
@@ -38,6 +43,10 @@ class TraceReader {
   // Seek back to the trace header. Replayer can call this method to restart
   // replaying. Note this method may fail if the reader is already closed.
   virtual Status Reset() = 0;
+
+  // Enable CRC32c framing for subsequent Read() calls. Called after the
+  // trace header has been read and the version indicates CRC framing (>= 0.3).
+  virtual void EnableCRCFraming() {}
 };
 
 // Factory methods to write/read traces to/from a file.

--- a/trace_replay/trace_replay.cc
+++ b/trace_replay/trace_replay.cc
@@ -597,7 +597,11 @@ Status Tracer::WriteHeader() {
   trace.ts = clock_->NowMicros();
   trace.type = kTraceBegin;
   trace.payload = header;
-  return WriteTrace(trace);
+  Status st = WriteTrace(trace);
+  if (st.ok()) {
+    trace_writer_->EnableCRCFraming();
+  }
+  return st;
 }
 
 Status Tracer::WriteFooter() {

--- a/trace_replay/trace_replay.h
+++ b/trace_replay/trace_replay.h
@@ -45,7 +45,12 @@ const unsigned int kTraceMetadataSize =
     kTraceTimestampSize + kTraceTypeSize + kTracePayloadLengthSize;
 
 static const int kTraceFileMajorVersion = 0;
-static const int kTraceFileMinorVersion = 2;
+static const int kTraceFileMinorVersion = 3;
+
+// Minimum trace file version (major * 10 + minor) that uses CRC32c framing.
+// The header is always written in legacy format for backward compatibility;
+// subsequent records use [CRC32c][length][data] framing.
+static const int kTraceFileCRCFramingVersion = 3;
 
 // The data structure that defines a single trace.
 struct Trace {

--- a/utilities/trace/file_trace_reader_writer.cc
+++ b/utilities/trace/file_trace_reader_writer.cc
@@ -10,6 +10,7 @@
 #include "file/writable_file_writer.h"
 #include "trace_replay/trace_replay.h"
 #include "util/coding.h"
+#include "util/crc32c.h"
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -36,43 +37,36 @@ Status FileTraceReader::Reset() {
     return Status::IOError("TraceReader is closed.");
   }
   offset_ = 0;
+  crc_framing_ = false;
+  first_read_done_ = false;
   return Status::OK();
 }
 
 Status FileTraceReader::Read(std::string* data) {
   assert(file_reader_ != nullptr);
-  Status s = file_reader_->Read(IOOptions(), offset_, kTraceMetadataSize,
-                                &result_, buffer_, nullptr);
-  if (!s.ok()) {
+  if (!first_read_done_) {
+    first_read_done_ = true;
+    Status s = ReadLegacy(data);
+    if (s.ok()) {
+      DetectCRCFromHeader(*data);
+    }
     return s;
   }
-  if (result_.size() == 0) {
-    // No more data to read
-    // Todo: Come up with a better way to indicate end of data. May be this
-    // could be avoided once footer is introduced.
-    return Status::Incomplete();
-  }
-  if (result_.size() < kTraceMetadataSize) {
-    return Status::Corruption("Corrupted trace file.");
-  }
-  *data = result_.ToString();
-  offset_ += kTraceMetadataSize;
+  return crc_framing_ ? ReadCRC(data) : ReadLegacy(data);
+}
 
-  uint32_t payload_len =
-      DecodeFixed32(&buffer_[kTraceTimestampSize + kTraceTypeSize]);
-
-  // Read Payload
-  unsigned int bytes_to_read = payload_len;
+Status FileTraceReader::ReadData(unsigned int bytes_to_read,
+                                 std::string* data) {
   unsigned int to_read =
       bytes_to_read > kBufferSize ? kBufferSize : bytes_to_read;
   while (to_read > 0) {
-    s = file_reader_->Read(IOOptions(), offset_, to_read, &result_, buffer_,
-                           nullptr);
-    if (!s.ok()) {
-      return s;
+    IOStatus io_s = file_reader_->Read(IOOptions(), offset_, to_read, &result_,
+                                       buffer_, nullptr);
+    if (!io_s.ok()) {
+      return io_s;
     }
     if (result_.size() < to_read) {
-      return Status::Corruption("Corrupted trace file.");
+      return Status::Incomplete("Trace record data truncated");
     }
     data->append(result_.data(), result_.size());
 
@@ -80,8 +74,85 @@ Status FileTraceReader::Read(std::string* data) {
     bytes_to_read -= to_read;
     to_read = bytes_to_read > kBufferSize ? kBufferSize : bytes_to_read;
   }
+  return Status::OK();
+}
 
-  return s;
+Status FileTraceReader::ReadLegacy(std::string* data) {
+  IOStatus io_s = file_reader_->Read(IOOptions(), offset_, kTraceMetadataSize,
+                                     &result_, buffer_, nullptr);
+  if (!io_s.ok()) {
+    return io_s;
+  }
+  if (result_.size() == 0) {
+    return Status::Incomplete();
+  }
+  if (result_.size() < kTraceMetadataSize) {
+    return Status::Incomplete("Trace metadata truncated");
+  }
+  *data = result_.ToString();
+  offset_ += kTraceMetadataSize;
+
+  uint32_t payload_len =
+      DecodeFixed32(&buffer_[kTraceTimestampSize + kTraceTypeSize]);
+  return ReadData(payload_len, data);
+}
+
+Status FileTraceReader::ReadCRC(std::string* data) {
+  IOStatus io_s = file_reader_->Read(
+      IOOptions(), offset_, kTraceFrameHeaderSize, &result_, buffer_, nullptr);
+  if (!io_s.ok()) {
+    return io_s;
+  }
+  if (result_.size() == 0) {
+    return Status::Incomplete();
+  }
+  if (result_.size() < kTraceFrameHeaderSize) {
+    return Status::Incomplete("Trace frame header truncated");
+  }
+
+  uint32_t expected_crc = DecodeFixed32(result_.data());
+  uint32_t data_len = DecodeFixed32(result_.data() + kTraceCRCSize);
+  offset_ += kTraceFrameHeaderSize;
+
+  data->clear();
+  data->reserve(data_len);
+  Status s = ReadData(data_len, data);
+  if (!s.ok()) {
+    return s;
+  }
+
+  uint32_t actual_crc = crc32c::Value(data->data(), data->size());
+  if (actual_crc != expected_crc) {
+    return Status::Incomplete("Trace record CRC mismatch");
+  }
+  return Status::OK();
+}
+
+void FileTraceReader::DetectCRCFromHeader(const std::string& header_data) {
+  if (header_data.size() <= kTraceMetadataSize) {
+    return;
+  }
+  auto pos = header_data.find("Trace Version: ");
+  if (pos == std::string::npos) {
+    return;
+  }
+  std::string ver = header_data.substr(pos + 15);
+  auto tab = ver.find('\t');
+  if (tab != std::string::npos) {
+    ver.resize(tab);
+  }
+  int version = 0;
+  for (char c : ver) {
+    if (c == '.') {
+      continue;
+    }
+    if (isdigit(c)) {
+      version = version * 10 + (c - '0');
+    }
+  }
+  if (version >= kTraceFileCRCFramingVersion) {
+    crc_framing_ = true;
+  }
 }
 
 FileTraceWriter::FileTraceWriter(
@@ -96,7 +167,20 @@ Status FileTraceWriter::Close() {
 }
 
 Status FileTraceWriter::Write(const Slice& data) {
-  return file_writer_->Append(IOOptions(), data);
+  if (!crc_framing_) {
+    return file_writer_->Append(IOOptions(), data);
+  }
+  char frame_header[kTraceFrameHeaderSize];
+  uint32_t crc = crc32c::Value(data.data(), data.size());
+  EncodeFixed32(frame_header, crc);
+  EncodeFixed32(frame_header + kTraceCRCSize,
+                static_cast<uint32_t>(data.size()));
+  Status s = file_writer_->Append(IOOptions(),
+                                  Slice(frame_header, sizeof(frame_header)));
+  if (s.ok()) {
+    s = file_writer_->Append(IOOptions(), data);
+  }
+  return s;
 }
 
 uint64_t FileTraceWriter::GetFileSize() { return file_writer_->GetFileSize(); }

--- a/utilities/trace/file_trace_reader_writer.h
+++ b/utilities/trace/file_trace_reader_writer.h
@@ -12,6 +12,15 @@ namespace ROCKSDB_NAMESPACE {
 class RandomAccessFileReader;
 class WritableFileWriter;
 
+// Each trace record on disk is framed as:
+//   [4-byte CRC32c of data][4-byte data length][data ...]
+// This allows the reader to detect crash-truncated records and return
+// Status::Incomplete() instead of Status::Corruption().
+static constexpr unsigned int kTraceCRCSize = 4;
+static constexpr unsigned int kTraceRecordLengthSize = 4;
+static constexpr unsigned int kTraceFrameHeaderSize =
+    kTraceCRCSize + kTraceRecordLengthSize;
+
 // FileTraceReader allows reading RocksDB traces from a file.
 class FileTraceReader : public TraceReader {
  public:
@@ -21,12 +30,20 @@ class FileTraceReader : public TraceReader {
   Status Read(std::string* data) override;
   Status Close() override;
   Status Reset() override;
+  void EnableCRCFraming() override { crc_framing_ = true; }
 
  private:
+  Status ReadLegacy(std::string* data);
+  Status ReadCRC(std::string* data);
+  Status ReadData(unsigned int bytes_to_read, std::string* data);
+  void DetectCRCFromHeader(const std::string& header_data);
+
   std::unique_ptr<RandomAccessFileReader> file_reader_;
   Slice result_;
   size_t offset_;
   char* const buffer_;
+  bool crc_framing_ = false;
+  bool first_read_done_ = false;
 
   static const unsigned int kBufferSize;
 };
@@ -40,9 +57,11 @@ class FileTraceWriter : public TraceWriter {
   Status Write(const Slice& data) override;
   Status Close() override;
   uint64_t GetFileSize() override;
+  void EnableCRCFraming() override { crc_framing_ = true; }
 
  private:
   std::unique_ptr<WritableFileWriter> file_writer_;
+  bool crc_framing_ = false;
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/utilities/trace/replayer_impl.cc
+++ b/utilities/trace/replayer_impl.cc
@@ -43,6 +43,9 @@ Status ReplayerImpl::Prepare() {
   if (!s.ok()) {
     return s;
   }
+  if (trace_file_version_ >= kTraceFileCRCFramingVersion) {
+    trace_reader_->EnableCRCFraming();
+  }
   header_ts_ = header.ts;
   prepared_ = true;
   trace_end_ = false;


### PR DESCRIPTION
Summary:

The crash test failure in T266384116 (`Corruption: Corrupted trace file`) was caused by the process crashing mid-write to the trace file. The trace file format had no integrity checking, so a crash that truncated a record produced an unrecoverable `Corruption` status that killed the test.

**Root cause**: `FileTraceWriter::Write()` appended raw record data with no framing or checksums. `FileTraceReader::Read()` relied on parsing the trace metadata inline to determine record boundaries. A crash mid-write could truncate either the metadata or payload, producing `Status::Corruption("Corrupted trace file.")` — which `Restore()` treated as fatal.

**Fix**: Add CRC32c framing to the trace file format (version 0.3). Records after the header are now framed as:
```
[4-byte CRC32c][4-byte data length][data ...]
```

The trace header is always written in legacy format so older readers can at least read the header and see the version number. Subsequent records use CRC framing. The `FileTraceReader` auto-detects the format by parsing the version from the header, making it transparent to all callers (both `Replayer` and direct `TraceReader::Read()` usage).

- `FileTraceWriter::Write()`: after `EnableCRCFraming()`, prepends CRC+length frame
- `FileTraceReader::Read()`: auto-detects version from header, then reads subsequent records with CRC verification. Returns `Status::Incomplete()` (not `Corruption`) for truncated records or CRC mismatches
- The existing `Restore()` code already handles `Incomplete` as normal end-of-trace, so crash-truncated trace files are tolerated without any changes to the restore logic

**Backward compatibility**:
- New reader + old trace file (v0.2): reads header, detects legacy version, uses legacy format throughout — fully compatible
- Old reader + new trace file (v0.3): reads header successfully (legacy format), but fails on subsequent CRC-framed records — expected behavior, version mismatch is detectable from the header
- New reader + new trace file (v0.3): reads header in legacy, detects v0.3, switches to CRC framing — full integrity checking

Additionally, the three `preserve_write_order` write paths in `db_impl_write.cc` now check the tracer write status and stop the tracer on failure, preventing silent gap accumulation between the trace file and WAL.

Differential Revision: D102092466


