### PR TITLE
Disable range tombstone conversions again

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -484,7 +484,8 @@ default_params = {
     "auto_refresh_iterator_with_snapshot": lambda: random.choice([0, 1]),
     "memtable_op_scan_flush_trigger": lambda: random.choice([0, 10, 100, 1000]),
     "memtable_avg_op_scan_flush_trigger": lambda: random.choice([0, 2, 20, 200]),
-    "min_tombstones_for_range_conversion": lambda: random.choice([0, 2, 2, 4, 16]),
+    # TODO(jkangs): Stabilize range tombstone conversions
+    "min_tombstones_for_range_conversion": 0,  # lambda: random.choice([0, 2, 2, 4, 16]),
     "ingest_wbwi_one_in": lambda: random.choice([0, 0, 100, 500]),
     "universal_reduce_file_locking": lambda: random.randint(0, 1),
     "compression_manager": lambda: random.choice(


### PR DESCRIPTION
Seems like crashtests are failing more often now, disabling again to investigate.