### PR TITLE
env/io_posix: query DIO alignment with statx

### DIFF
--- a/env/env_test.cc
+++ b/env/env_test.cc
@@ -26,9 +26,11 @@
 #ifdef OS_LINUX
 #include <fcntl.h>
 #include <linux/fs.h>
+#include <linux/stat.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/statfs.h>
+#include <sys/syscall.h>
 #include <unistd.h>
 
 #include <cstdlib>
@@ -1279,6 +1281,40 @@ TEST_F(EnvPosixTest, PositionedAppend) {
   ASSERT_EQ('a', result[kBlockSize - 1]);
   ASSERT_EQ('b', result[kBlockSize]);
 }
+
+#if defined(OS_LINUX) && defined(__NR_statx) && defined(STATX_DIOALIGN) && \
+    !defined(NDEBUG)
+TEST_F(EnvPosixTest, GetLogicalBlockSizeUsesStatx) {
+  std::string fname = test::PerThreadDBPath(
+      env_, "logical_block_size_uses_statx_dio_offset_align");
+  int fd = open(fname.c_str(), O_CREAT | O_RDWR | O_TRUNC, 0644);
+  ASSERT_GE(fd, 0);
+
+  const size_t unmocked_alignment = PosixHelper::GetLogicalBlockSizeOfFd(fd);
+  // Use a value distinct from the host alignment so old sysfs-only behavior
+  // fails the assertion below.
+  const size_t filesystem_dio_offset_align =
+      unmocked_alignment == 16 * 1024 ? 32 * 1024 : 16 * 1024;
+
+  SyncPoint::GetInstance()->SetCallBack(
+      "PosixHelper::GetLogicalBlockSizeOfFd:StatxDioAlign", [&](void* arg) {
+        auto* dio_align_info =
+            static_cast<PosixHelper::StatxDioAlignInfo*>(arg);
+        dio_align_info->statx_result = 0;
+        dio_align_info->has_dio_offset_align = true;
+        dio_align_info->dio_offset_align = filesystem_dio_offset_align;
+      });
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  ASSERT_EQ(filesystem_dio_offset_align,
+            PosixHelper::GetLogicalBlockSizeOfFd(fd));
+
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+  close(fd);
+  ASSERT_OK(env_->DeleteFile(fname));
+}
+#endif
 
 // `GetUniqueId()` temporarily returns zero on Windows. `BlockBasedTable` can
 // handle a return value of zero but this test case cannot.

--- a/env/io_posix.cc
+++ b/env/io_posix.cc
@@ -23,11 +23,15 @@
 #include <sys/ioctl.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
+#include <sys/syscall.h>
 #include <sys/types.h>
 
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#if defined(OS_LINUX)
+#include <linux/stat.h>
+#endif
 #if defined(OS_LINUX) || defined(OS_ANDROID)
 #include <sys/statfs.h>
 #include <sys/sysmacros.h>
@@ -483,6 +487,23 @@ Status PosixHelper::GetQueueSysfsFileValueofDirectory(
 }
 
 size_t PosixHelper::GetLogicalBlockSizeOfFd(int fd) {
+#if defined(OS_LINUX) && defined(__NR_statx) && defined(STATX_DIOALIGN)
+  // Prefer the filesystem's DIO alignment when the kernel reports it. The
+  // sysfs fallback only reports the underlying block device's sector size,
+  // which can be too small for the file's filesystem.
+  struct statx stx{};
+  long statx_result =
+      syscall(__NR_statx, fd, "", AT_EMPTY_PATH, STATX_DIOALIGN, &stx);
+  PosixHelper::StatxDioAlignInfo dio_align_info{
+      statx_result, statx_result == 0 && (stx.stx_mask & STATX_DIOALIGN),
+      stx.stx_dio_offset_align};
+  TEST_SYNC_POINT_CALLBACK("PosixHelper::GetLogicalBlockSizeOfFd:StatxDioAlign",
+                           &dio_align_info);
+  if (dio_align_info.statx_result == 0 && dio_align_info.has_dio_offset_align &&
+      dio_align_info.dio_offset_align != 0) {
+    return dio_align_info.dio_offset_align;
+  }
+#endif
   return GetQueueSysfsFileValueOfFd(fd, GetLogicalBlockSizeFileName(),
                                     kDefaultPageSize);
 }

--- a/env/io_posix.h
+++ b/env/io_posix.h
@@ -96,6 +96,12 @@ inline void TsanAnnotateMappedMemory(const volatile void* mem, size_t size) {
 
 class PosixHelper {
  public:
+  struct StatxDioAlignInfo {
+    long statx_result;
+    bool has_dio_offset_align;
+    size_t dio_offset_align;
+  };
+
   static const std::string& GetLogicalBlockSizeFileName() {
     static const std::string kLogicalBlockSizeFileName = "logical_block_size";
     return kLogicalBlockSizeFileName;


### PR DESCRIPTION
### Problem

RocksDB used the block device `logical_block_size` as its direct I/O alignment,
but some filesystems require a larger file-level alignment. This can make
direct I/O writes fail with `EINVAL` on filesystems such as bcachefs,
ZFS, and btrfs RAID.

For context, my usecase is running rocksdb on an aarch64 server whose kernel uses 64kb page sizes, where bcachefs uses 16kb block sizes. I was seeing an error before this fix when attempting to run rocksdb with direct io: `While pwrite to file at offset 0: .../000143.sst: Invalid argument`

### Solution

This commit uses `statx(STATX_DIOALIGN)` when Linux reports it for the
file, and keeps the existing sysfs fallback for older kernels and filesystems
that do not provide it.