### PR TITLE
Use saved_key_ instead of iter_.key() in forward range conversion (#14672)

### DIFF
--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -774,30 +774,18 @@ bool DBIter::FindNextUserEntryInternal(bool skipping_saved_key) {
     }
   } while (iter_.Valid());
 
-  // If we accumulated tombstones, choose an end_key that doesn't depend on
-  // user-controlled iterate_upper_bound_ memory:
-  //  - iter_ still valid: stopped at the upper-bound break above. iter_'s
-  //    current key is RocksDB-owned and strictly greater than every counted
-  //    tombstone. Use it as the exclusive end_key.
-  //  - iter_ exhausted: no more keys exist past the run, so [first,
-  //    saved_key_) (covering n-1 of n deletes, with the n-th remaining as a
-  //    point delete) is safe. saved_key_ is the largest user key observed.
+  // If we accumulated tombstones, use the last tracked tombstone as the
+  // exclusive end key. It may be more optimal to use iterator upper bound if it
+  // exists, but the current iterator API makes that dangerous as upper bound
+  // points to user memory which is not guaranteed immutable.
   if (contiguous_tombstone_count_ > 0 && iter_.status().ok()) {
-    bool inserted_via_iter = false;
-    if (iter_.Valid()) {
-      Slice end_user_key = ExtractUserKey(iter_.key());
-      Slice end_user_key_no_ts =
-          StripTimestampFromUserKey(end_user_key, timestamp_size_);
-      if (PrefixCheck(end_user_key_no_ts)) {
-        // Copy because iter_'s key buffer may not survive subsequent calls.
-        std::string end_key_copy(end_user_key.data(), end_user_key.size());
-        MaybeInsertRangeTombstone(end_key_copy);
-        inserted_via_iter = true;
-      }
-    }
-    if (!inserted_via_iter) {
-      MaybeInsertRangeTombstone(saved_key_.GetUserKey());
-    }
+    // It is unsafe to use iter_.key() here even when iter_.Valid() and the key
+    // is within the seek prefix. This is because memtable iterators are still
+    // valid past the upper bound, but sst iterators are not. So iter_.key() can
+    // point to a memtable entry that has skipped past real live entries in
+    // ssts.
+    assert(PrefixCheck(saved_key_.GetUserKey()));
+    MaybeInsertRangeTombstone(saved_key_.GetUserKey());
   }
   ResetContiguousTombstoneTracking();
 

--- a/db/db_iterator_test.cc
+++ b/db/db_iterator_test.cc
@@ -6231,6 +6231,55 @@ TEST_P(ReadPathRangeTombstoneTest, PrefixFilterPrefixSameAsStart) {
   }
 }
 
+TEST_P(ReadPathRangeTombstoneTest,
+       PrefixFilterUpperBoundDoesNotCoverSkippedLiveKey) {
+  if (!Forward()) {
+    return;
+  }
+
+  Options options = CurrentOptions();
+  options.min_tombstones_for_range_conversion = 3;
+  options.statistics = CreateDBStatistics();
+  options.disable_auto_compactions = true;
+  options.prefix_extractor.reset(NewFixedPrefixTransform(1));
+  BlockBasedTableOptions table_options;
+  table_options.filter_policy.reset(NewBloomFilterPolicy(10));
+  table_options.whole_key_filtering = false;
+  options.table_factory.reset(NewBlockBasedTableFactory(table_options));
+  DestroyAndReopen(options);
+
+  // Keep a live in-prefix key above the user upper bound in an SST so the
+  // bounded prefix scan cannot return it, then leave a later same-prefix
+  // memtable key available as the internal stop key. If cleanup uses that
+  // late memtable key as the synthetic range end, it will cover "be".
+  ASSERT_OK(Put("be", "live_b"));
+  ASSERT_OK(Flush());
+
+  ASSERT_OK(Delete("ba"));
+  ASSERT_OK(Delete("bb"));
+  ASSERT_OK(Delete("bc"));
+  ASSERT_OK(Put("bz", "live_z"));
+
+  attempted_insert_ranges_.clear();
+  ReadOptions ro;
+  ro.prefix_same_as_start = true;
+  std::string upper_str = "bd";
+  Slice upper(upper_str);
+  ro.iterate_upper_bound = &upper;
+  auto iter = std::unique_ptr<Iterator>(db_->NewIterator(ro));
+
+  std::vector<std::string> keys;
+  for (iter->Seek("ba"); iter->Valid(); iter->Next()) {
+    keys.push_back(iter->key().ToString());
+  }
+  ASSERT_OK(iter->status());
+  ASSERT_TRUE(keys.empty());
+
+  ASSERT_EQ(attempted_insert_ranges_.size(), 1u);
+
+  ASSERT_EQ(Get("be"), "live_b");
+}
+
 TEST_P(ReadPathRangeTombstoneTest, PrefixFilterOutOfDomainSeek) {
   // With an out-of-domain seek target, prefix_same_as_start cannot establish
   // a seek-prefix bound. The iterator therefore behaves like an unrestricted

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -484,8 +484,7 @@ default_params = {
     "auto_refresh_iterator_with_snapshot": lambda: random.choice([0, 1]),
     "memtable_op_scan_flush_trigger": lambda: random.choice([0, 10, 100, 1000]),
     "memtable_avg_op_scan_flush_trigger": lambda: random.choice([0, 2, 20, 200]),
-    # TODO(jkangs): Stabilize range tombstone conversions
-    "min_tombstones_for_range_conversion": 0,  # lambda: random.choice([0, 2, 2, 4, 16]),
+    "min_tombstones_for_range_conversion": lambda: random.choice([0, 2, 2, 4, 16]),
     "ingest_wbwi_one_in": lambda: random.choice([0, 0, 100, 500]),
     "universal_reduce_file_locking": lambda: random.randint(0, 1),
     "compression_manager": lambda: random.choice(
@@ -1517,6 +1516,7 @@ def finalize_and_sanitize(src_params):
         dest_params["read_fault_one_in"] = 0
         dest_params["memtable_prefix_bloom_size_ratio"] = 0
         dest_params["max_sequential_skip_in_iterations"] = sys.maxsize
+        dest_params["min_tombstones_for_range_conversion"] = 0
         # This option ingests a delete range that might partially overlap with
         # existing key range, which will cause a reseek that's currently not
         # supported by multiscan

--- a/tools/db_crashtest_test.py
+++ b/tools/db_crashtest_test.py
@@ -127,6 +127,8 @@ class DBCrashTestTest(unittest.TestCase):
         params = self.build_params(
             db_crashtest.default_params,
             {
+                "test_batches_snapshots": 0,
+                "use_multiscan": 0,
                 "use_sqfc_for_range_queries": 1,
                 "min_tombstones_for_range_conversion": 2,
             },


### PR DESCRIPTION
Summary:

This fixes the forward path introduced in the original pull request: https://www.internalfb.com/diff/D102409405

That change tried to avoid using user-owned `iterate_upper_bound_` memory by reading `iter_.key()` when the internal iterator was still valid and using it as the exclusive end key for the synthetic range tombstone. That is not safe: after the upper-bound break, `iter_.key()` is only the current merged child position, not a key the bounded scan proved safe to read or use as a range endpoint.

Example: run a prefix-bounded scan over prefix `b` with tombstones `ba`, `bb`, `bc`, `iterate_upper_bound = "bd"`, live key `be` in an SST, and later same-prefix key `bz` in the memtable. The SST child can drop out when it notices `be >= bd`, while the memtable child is not upper-bound aware and can still surface `bz`. If cleanup uses `iter_.key() == "bz"`, it inserts `[ba, bz)` and covers the live `be`, even though that key was never safe for the bounded scan to reason about.

The fix is to always end the forward range at `saved_key_`, which is the last tombstone user key the iterator actually proved deleted. That is conservative but safe. The regression test builds the mixed SST/memtable example above and asserts that the live `be` remains visible. The diff also re-enables randomized `min_tombstones_for_range_conversion` in `db_crashtest.py` and forces it back to `0` when `use_multiscan == 1`, since multiscan still does not support read-path range conversion.

Differential Revision: D102493855
