### PR TITLE
External Table Get Optimizations

### DIFF
--- a/table/external_table.cc
+++ b/table/external_table.cc
@@ -253,9 +253,9 @@ class ExternalTableReaderAdapter : public TableReader {
       return s;
     }
 
-    ParsedInternalKey found_key(parsed_key.user_key, 0, ValueType::kTypeValue);
-    bool matched = false;
-    get_context->SaveValue(found_key, value, &matched, &s,
+    assert(ioptions_.user_comparator->timestamp_size() == 0);
+
+    get_context->SaveValue(value, /*seq=*/0,
                            value.IsPinned() ? &value : nullptr);
     return s;
   }

--- a/table/external_table.cc
+++ b/table/external_table.cc
@@ -253,8 +253,6 @@ class ExternalTableReaderAdapter : public TableReader {
       return s;
     }
 
-    assert(ioptions_.user_comparator->timestamp_size() == 0);
-
     get_context->SaveValue(value, /*seq=*/0,
                            value.IsPinned() ? &value : nullptr);
     return s;
@@ -418,6 +416,11 @@ class ExternalTableFactoryAdapter : public TableFactory {
     if (topts.largest_seqno > 0 && topts.largest_seqno != kMaxSequenceNumber) {
       return Status::NotSupported(
           "Ingesting file with sequence number larger than 0");
+    }
+    if (topts.ioptions.user_comparator != nullptr &&
+        topts.ioptions.user_comparator->timestamp_size() != 0) {
+      return Status::NotSupported(
+          "External table does not support user-defined timestamps");
     }
     std::unique_ptr<ExternalTableReader> reader;
     FileOptions fopts(topts.env_options);

--- a/table/get_context.cc
+++ b/table/get_context.cc
@@ -206,6 +206,8 @@ void GetContext::SaveValue(const Slice& value, SequenceNumber /*seq*/,
   assert(state_ == kNotFound);
   assert(ucmp_->timestamp_size() == 0);
 
+  TEST_SYNC_POINT_CALLBACK("GetContext::SaveValue::Simple", this);
+
   appendToReplayLog(kTypeValue, value, Slice());
 
   state_ = kFound;

--- a/table/get_context.cc
+++ b/table/get_context.cc
@@ -201,7 +201,8 @@ Status GetContext::SaveWideColumnEntityToColumns(const Slice& user_key,
   return status;
 }
 
-void GetContext::SaveValue(const Slice& value, SequenceNumber /*seq*/) {
+void GetContext::SaveValue(const Slice& value, SequenceNumber /*seq*/,
+                           Cleanable* value_pinner) {
   assert(state_ == kNotFound);
   assert(ucmp_->timestamp_size() == 0);
 
@@ -209,7 +210,11 @@ void GetContext::SaveValue(const Slice& value, SequenceNumber /*seq*/) {
 
   state_ = kFound;
   if (LIKELY(pinnable_val_ != nullptr)) {
-    pinnable_val_->PinSelf(value);
+    if (LIKELY(value_pinner != nullptr)) {
+      pinnable_val_->PinSlice(value, value_pinner);
+    } else {
+      pinnable_val_->PinSelf(value);
+    }
   }
 }
 

--- a/table/get_context.h
+++ b/table/get_context.h
@@ -141,8 +141,13 @@ class GetContext {
                  Cleanable* value_pinner = nullptr);
 
   // Simplified version of the previous function. Should only be used when we
-  // know that the operation is a Put.
-  void SaveValue(const Slice& value, SequenceNumber seq);
+  // know that the operation is a Put and the column family has no
+  // user-defined timestamps.
+  //
+  // value_pinner: if non-null, ownership of the underlying buffer is
+  // transferred via PinSlice (no copy). If null, value is copied via PinSelf.
+  void SaveValue(const Slice& value, SequenceNumber seq,
+                 Cleanable* value_pinner = nullptr);
 
   GetState State() const { return state_; }
 

--- a/table/sst_file_reader.cc
+++ b/table/sst_file_reader.cc
@@ -8,6 +8,7 @@
 #include "db/arena_wrapped_db_iter.h"
 #include "db/db_iter.h"
 #include "db/dbformat.h"
+#include "db/lookup_key.h"
 #include "file/random_access_file_reader.h"
 #include "options/cf_options.h"
 #include "rocksdb/env.h"
@@ -198,9 +199,10 @@ Status SstFileReader::Get(const ReadOptions& roptions, const Slice& key,
                      nullptr /* value_found */, &merge_context, true,
                      &max_covering_tombstone_seq, r->ioptions.clock);
 
-  status = r->table_reader->Get(
-      roptions, InternalKey(key, kMaxSequenceNumber, kTypeValue).Encode(),
-      &get_ctx, r->moptions.prefix_extractor.get(), false /* skip_filters */);
+  LookupKey lkey(key, kMaxSequenceNumber);
+  status = r->table_reader->Get(roptions, lkey.internal_key(), &get_ctx,
+                                r->moptions.prefix_extractor.get(),
+                                false /* skip_filters */);
 
   get_ctx.ReportCounters();
 

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -7321,10 +7321,18 @@ TEST_F(ExternalTableTest, SstReaderTest) {
   ASSERT_FALSE(iter->Valid());
   ASSERT_TRUE(iter->status().ok());
 
+  // Verify external table Get() goes through the simple SaveValue entry point
+  std::atomic<int> simple_save_value_count{0};
+  SyncPoint::GetInstance()->SetCallBack(
+      "GetContext::SaveValue::Simple",
+      [&](void* /*arg*/) { simple_save_value_count.fetch_add(1); });
+  SyncPoint::GetInstance()->EnableProcessing();
+
   // Test MultiGet
   std::vector<Slice> keys = {"a", "b", "missing", "c"};
   std::vector<std::string> values;
   std::vector<Status> statuses = reader->MultiGet(ReadOptions(), keys, &values);
+  ASSERT_EQ(simple_save_value_count, 3);
   ASSERT_EQ(values.size(), keys.size());
   ASSERT_EQ(statuses.size(), keys.size());
   ASSERT_OK(statuses[0]);
@@ -7334,6 +7342,9 @@ TEST_F(ExternalTableTest, SstReaderTest) {
   ASSERT_TRUE(statuses[2].IsNotFound());
   ASSERT_OK(statuses[3]);
   ASSERT_EQ(values[3], "val_c");
+
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
 }
 
 TEST_F(ExternalTableTest, PinnedGetTest) {
@@ -7363,6 +7374,14 @@ TEST_F(ExternalTableTest, PinnedGetTest) {
   factory->last_reader()->SetPinnedData(
       {{"key1", "pinned_val1"}, {"key2", "pinned_val2"}});
 
+  // Verify external table Get() goes through the simple SaveValue entry point
+  // (the no-ParsedInternalKey overload) rather than the complex one.
+  std::atomic<int> simple_save_value_count{0};
+  SyncPoint::GetInstance()->SetCallBack(
+      "GetContext::SaveValue::Simple",
+      [&](void* /*arg*/) { simple_save_value_count.fetch_add(1); });
+  SyncPoint::GetInstance()->EnableProcessing();
+
   PinnableSlice pinnable;
   ASSERT_OK(
       db_->Get(ReadOptions(), db_->DefaultColumnFamily(), "key1", &pinnable));
@@ -7376,13 +7395,17 @@ TEST_F(ExternalTableTest, PinnedGetTest) {
   ASSERT_TRUE(pinnable.IsPinned());
   pinnable.Reset();
 
+  // Two found Gets => simple SaveValue invoked twice.
+  ASSERT_EQ(simple_save_value_count.load(), 2);
+
   // Verify cleanup ran for both Gets
   ASSERT_EQ(factory->last_reader()->pin_cleanup_count(), 2);
 
-  // Verify NotFound still works
+  // Verify NotFound still works (does not invoke SaveValue)
   Status s =
       db_->Get(ReadOptions(), db_->DefaultColumnFamily(), "missing", &pinnable);
   ASSERT_TRUE(s.IsNotFound());
+  ASSERT_EQ(simple_save_value_count.load(), 2);
 
   // Test MultiGet with PinnableSlice to exercise the batched pin path
   const size_t num_keys = 3;
@@ -7408,6 +7431,9 @@ TEST_F(ExternalTableTest, PinnedGetTest) {
     v.Reset();
   }
   ASSERT_EQ(factory->last_reader()->pin_cleanup_count(), 4);
+
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
 }
 
 TEST_F(ExternalTableTest, SstReaderPinnableMultiGetTest) {


### PR DESCRIPTION
## Summary

- External Table is only PUTs with no seqno, so we can route it to the simpler more efficient `GetContext::SaveValue`.
- `SstFileReader::Get` was allocating a string to append key footer, instead use LookUpKey to allocate on stack for short keys.

## Test Plan
CI passes