### PR TITLE
Fix missing secondary index entry for crash test (#14674)

### DIFF
--- a/db_stress_tool/multi_ops_txns_stress.cc
+++ b/db_stress_tool/multi_ops_txns_stress.cc
@@ -714,6 +714,11 @@ Status MultiOpsTxnsStressTest::SecondaryKeyUpdateTxn(ThreadState* thread,
                                                      uint32_t old_c,
                                                      uint32_t old_c_pos,
                                                      uint32_t new_c) {
+  struct SecondaryKeyUpdateWorkItem {
+    std::string old_sk;
+    uint32_t a;
+  };
+
   std::unique_ptr<Transaction> txn;
   WriteOptions wopts;
   Status s = NewTxn(wopts, thread, &txn);
@@ -789,11 +794,23 @@ Status MultiOpsTxnsStressTest::SecondaryKeyUpdateTxn(ThreadState* thread,
   assert(it);
   it->Seek(old_sk_prefix);
   if (!it->Valid()) {
+    s = it->status();
+    if (!s.ok()) {
+      return s;
+    }
     s = Status::NotFound();
     return s;
   }
   auto* wb = txn->GetWriteBatch();
   assert(wb);
+  // Two-phase update:
+  // 1. Scan the old secondary index entries and materialize stable work items.
+  // 2. Stop using the iterator, then update PK/SK pairs from the worklist.
+  //
+  // txn->GetIterator() is backed by a merged DB + WriteBatchWithIndex view.
+  // Updating the batch with the iterator's current key invalidates that key,
+  // so mutating old SK entries while continuing iteration is unsafe.
+  std::vector<SecondaryKeyUpdateWorkItem> worklist;
 
   do {
     ++iterations;
@@ -806,9 +823,22 @@ Status MultiOpsTxnsStressTest::SecondaryKeyUpdateTxn(ThreadState* thread,
       assert(false);
       break;
     }
-    // At this point, record.b is not known yet, thus we need to access
-    // primary index.
-    std::string pk = Record::EncodePrimaryKey(record.a_value());
+    worklist.push_back({it->key().ToString(/*hex=*/false), record.a_value()});
+    it->Next();
+  } while (it->Valid());
+
+  if (!s.ok()) {
+    return s;
+  }
+  s = it->status();
+  if (!s.ok()) {
+    return s;
+  }
+
+  for (const auto& work_item : worklist) {
+    // The scan only gave us (old_sk, a). Read the primary row now to recover
+    // the current b value and verify the row still belongs to old_c.
+    std::string pk = Record::EncodePrimaryKey(work_item.a);
     std::string value;
     ReadOptions read_opts;
     read_opts.rate_limiter_priority =
@@ -859,25 +889,24 @@ Status MultiOpsTxnsStressTest::SecondaryKeyUpdateTxn(ThreadState* thread,
       assert(dbimpl);
       oss << "snap " << read_opts.snapshot->GetSequenceNumber()
           << " (published " << dbimpl->GetLastPublishedSequence()
-          << "), pk/sk mismatch. pk: (a=" << record.a_value() << ", "
+          << "), pk/sk mismatch. pk: (a=" << work_item.a << ", "
           << "c=" << c << "), sk: (c=" << old_c << ")";
       s = Status::Corruption();
       fprintf(stderr, "%s\n", oss.str().c_str());
       assert(false);
       break;
     }
-    Record new_rec(record.a_value(), b, new_c);
+    Record new_rec(work_item.a, b, new_c);
     std::string new_primary_index_value = new_rec.EncodePrimaryIndexValue();
     ColumnFamilyHandle* cf = db_->DefaultColumnFamily();
     s = txn->Put(cf, pk, new_primary_index_value, /*assume_tracked=*/true);
     if (!s.ok()) {
       break;
     }
-    std::string old_sk = it->key().ToString(/*hex=*/false);
     std::string new_sk;
     std::string new_crc;
     std::tie(new_sk, new_crc) = new_rec.EncodeSecondaryIndexEntry();
-    s = wb->SingleDelete(old_sk);
+    s = wb->SingleDelete(work_item.old_sk);
     if (!s.ok()) {
       break;
     }
@@ -885,9 +914,7 @@ Status MultiOpsTxnsStressTest::SecondaryKeyUpdateTxn(ThreadState* thread,
     if (!s.ok()) {
       break;
     }
-
-    it->Next();
-  } while (it->Valid());
+  }
 
   if (!s.ok()) {
     return s;

--- a/db_stress_tool/multi_ops_txns_stress.h
+++ b/db_stress_tool/multi_ops_txns_stress.h
@@ -82,6 +82,9 @@ namespace ROCKSDB_NAMESPACE {
 // tx->Prepare()
 // tx->Commit()
 // ```
+// The scan and the writes must happen in two phases. The iterator is backed by
+// a merged DB + WriteBatchWithIndex view, so deleting the iterator's current
+// secondary key and then continuing iteration is unsafe.
 //
 // 3. Primary index value update
 // UPDATE t1 SET b = b + 1 WHERE a = 2;


### PR DESCRIPTION
Summary:

See failed sc job 31525200030899299. 

` Verification failed: [snap=11593, last_published=11593] Cannot find secondary index entry 00000002000000D8000000D1. Status is NotFound: `.

One theory is that the harness is not setup correctly. See 

https://www.internalfb.com/code/fbsource/[ff1b0aa53f8a][history]/fbcode/rocksdb/utilities/write_batch_with_index.h?lines=230-237


The bug was caused by mixing a secondary-index scan with in-flight mutations to
the same transaction's `WriteBatchWithIndex`.

The critical mistake was deleting the iterator's current secondary key while the
iterator was still being used as the source of truth for the scan. Once that
happens, the iterator is no longer trustworthy. Continuing the loop and calling
`Next()` depends on behavior that `WriteBatchWithIndex` does not promise.

This is not an atomicity problem. The transaction still commits atomically.
The problem is that the batch can contain the wrong set of logical updates
before the commit happens.

## Data Model

The stress harness models a table like this:

```sql
CREATE TABLE t1 (
  a INT PRIMARY KEY,
  b INT,
  c INT,
  KEY(c)
);
```

Logical layout:

```text
Primary index:   PK(a)   -> (b, c)
Secondary index: SK(c,a) -> crc
```

Changing `c` requires two coordinated changes:

```text
1. Rewrite the primary row so PK(a) now stores the new c
2. Delete the old secondary entry SK(old_c, a)
3. Insert the new secondary entry SK(new_c, a)
```

If any of these steps become associated with the wrong row, the primary and
secondary indexes diverge.

## The Unsafe Pattern

The old flow looked like this:

```text
seek iterator to all SK(old_c, *)
for each iterator entry:
  decode (a, old_c) from the iterator
  read PK(a)
  write new PK(a) with c = new_c
  delete the iterator's current secondary key
  insert new secondary key
  iterator->Next()
```

The problem is the delete step. The transaction iterator is not a frozen scan.
It is a merged view over:

```text
1. the DB snapshot/base iterator
2. the transaction's mutable WriteBatchWithIndex delta
```

Deleting the current secondary key changes the exact key the iterator is
currently sitting on. After that point, the iterator's current state is no
longer a stable basis for more iteration.

## Why Updating the Current Key Is Dangerous

`WriteBatchWithIndex` explicitly warns that updating the current key of an
iterator is unsafe. The key and value can be invalidated immediately, even
before the batch update fully finishes.

That matters here for two reasons:

1. The iterator is a merged iterator, not a plain DB iterator.
2. The loop keeps using that iterator after deleting the key it is currently
   positioned on.

In other words, the code was doing this:

```text
use iterator to choose row
mutate the exact row the iterator is standing on
keep iterating as if nothing happened
```

That is a contract violation.

## Important Nuance

Copying the current secondary key into a `std::string` before issuing the
delete does not make the overall loop safe.

That copy may protect the immediate `SingleDelete` argument, but it does not
make the iterator itself safe to continue using. The next `Next()` call still
depends on an iterator whose current row was just invalidated by the mutation.

So the real bug is larger than "the delete used a borrowed key." The deeper bug
is "the scan continued after mutating the iterator's current key."

## How This Can Produce a Missing Secondary Index Entry

The key idea is that once the iterator is invalidated, later logic can no
longer assume that:

```text
decoded row
current iterator key
next iterator position
```

all still refer to the same logical row sequence.

There are two broad failure modes.

### 1. Row-to-key misassociation

The loop may decode one row, but after the mutation the iterator may no longer
be describing that same logical row when the code asks it for its current key
or advances it. That can make the batch pair:

```text
primary rewrite for row A
with
secondary delete or later scan position derived from row B
```

Once that happens, it becomes possible to remove a secondary entry without
adding the matching replacement for the same logical row.

### 2. Unsupported advancement after current-key deletion

After deleting the current secondary key, the loop immediately calls `Next()`.
At that point the code is relying on unsupported iterator recovery behavior.

If the iterator skips, repeats, or otherwise loses its place in the merged
base-plus-delta view, the harness can build the wrong set of updates for the
transaction. One valid manifestation of that is:

```text
PK(a) says c = new_c
but SK(new_c, a) is missing
```

That is exactly the kind of failure the invariant checker reports: the primary
row still exists, but the expected secondary entry cannot be found.

## A Concrete Example

Suppose the scan is processing the row for `(a=209, c=216)`.

The intended change set is:

```text
PK(209): (b, 216) -> (b, new_c)
delete SK(216,209)
insert SK(new_c,209)
```

If the iterator loses coherence after deleting `SK(216,209)`, the transaction
can end up with a logically mismatched batch. The exact low-level manifestation
depends on how the merged iterator and the mutable delta interact, but the
important point is this:

```text
once the current-key update happens, the iterator is no longer an authoritative
description of the remaining scan
```

From that point on, a missing secondary entry is a plausible outcome.

## Why the Two-Phase Fix Works

The fix separates reads from writes:

```text
Phase 1: scan secondary entries and materialize stable work items
         (old secondary key, primary key identity)

Phase 2: stop using the iterator
         perform primary rewrite
         delete old secondary key
         insert new secondary key
```

This restores the invariant that the iterator is only used while the underlying
batch state is not being changed out from under it.

That makes the algorithm correct for the intended model:

```text
scan a stable set of old secondary entries
then rewrite indexes using copied data
```

Differential Revision: D102648731


