### PR TITLE
Convert some ROCKSDB_GTEST_SKIP to BYPASS

### DIFF
--- a/db/db_iterator_test.cc
+++ b/db/db_iterator_test.cc
@@ -7097,7 +7097,8 @@ TEST_P(ReadPathRangeTombstoneTest, SeekToLastStaleSavedKey) {
 
 TEST_P(ReadPathRangeTombstoneTest, SeekToLastTombstones) {
   if (Forward()) {
-    ROCKSDB_GTEST_SKIP("SeekToLast tombstone materialization is reverse-only.");
+    ROCKSDB_GTEST_BYPASS(
+        "SeekToLast tombstone materialization is reverse-only.");
   }
 
   Options options = CurrentOptions();

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -8608,7 +8608,7 @@ TEST_P(UserDefinedIndexTest, ValueTypeMappingViaDBFlush) {
   if (is_reverse_comparator_) {
     // Skip for reverse comparator — the key ordering makes this test
     // unnecessarily complex and the mapping logic is comparator-independent.
-    ROCKSDB_GTEST_SKIP("Skipped for reverse comparator");
+    ROCKSDB_GTEST_BYPASS("Skipped for reverse comparator");
     return;
   }
   std::string dbname = test::PerThreadDBPath("udi_valuetype_mapping_test");
@@ -8676,7 +8676,7 @@ TEST_P(UserDefinedIndexTest, CompactionWithSnapshotsAndUDI) {
   // Verify that compaction with snapshots (producing multiple versions of the
   // same user key) works correctly with UDI.
   if (is_reverse_comparator_) {
-    ROCKSDB_GTEST_SKIP("Skipped for reverse comparator");
+    ROCKSDB_GTEST_BYPASS("Skipped for reverse comparator");
     return;
   }
   std::string dbname = test::PerThreadDBPath("udi_compaction_snapshot_test");

--- a/utilities/trie_index/trie_index_db_test.cc
+++ b/utilities/trie_index/trie_index_db_test.cc
@@ -3537,7 +3537,7 @@ TEST_P(TrieIndexDBTest, ReopenWithoutTrieUDI) {
   // behavior where the UDI block is optional and reads fall back to the
   // standard index.
   if (IsPrimaryMode()) {
-    ROCKSDB_GTEST_SKIP("Not applicable in primary mode");
+    ROCKSDB_GTEST_BYPASS("Not applicable in primary mode");
     return;
   }
   ASSERT_OK(OpenDB());
@@ -3573,7 +3573,7 @@ TEST_P(TrieIndexDBTest, MixedSSTsWithAndWithoutUDI) {
   // index is always fully populated). This test validates the secondary-
   // mode mixed-SST fallback path.
   if (IsPrimaryMode()) {
-    ROCKSDB_GTEST_SKIP("Not applicable in primary mode");
+    ROCKSDB_GTEST_BYPASS("Not applicable in primary mode");
     return;
   }
   options_.disable_auto_compactions = true;
@@ -4412,7 +4412,7 @@ TEST_P(TrieIndexDBTest, PrimaryModeTableProperties) {
   // property is set (informational, does not affect read routing), and
   // reads work without setting ReadOptions::table_index_factory.
   if (!IsPrimaryMode()) {
-    ROCKSDB_GTEST_SKIP("Only applicable in primary mode");
+    ROCKSDB_GTEST_BYPASS("Only applicable in primary mode");
     return;
   }
   ASSERT_OK(OpenDB());


### PR DESCRIPTION
Summary:
    Fix false internal warnings about skipped tests (seen on D102718613).
    ROCKSDB_GTEST_SKIP signals a gap in test coverage due to the build/execution
    environment, while ROCKSDB_GTEST_BYPASS is for intentionally and permanently
    omitting certain parameterizations. These six tests skip based on the test
    parameterization (forward vs reverse, primary vs secondary mode), not due to
    any environment limitation, so BYPASS is the correct macro.

Test Plan: these are tests, look at internal signals