### PR TITLE
IODispatcher: add level-aware prefetch fairness for multiscan (#14682)

### DIFF
--- a/db/db_iterator_test.cc
+++ b/db/db_iterator_test.cc
@@ -10,6 +10,11 @@
 #include <functional>
 #include <iomanip>
 #include <iostream>
+#include <memory>
+#include <mutex>
+#include <tuple>
+#include <unordered_map>
+#include <unordered_set>
 
 #include "db/arena_wrapped_db_iter.h"
 #include "db/db_iter.h"
@@ -22,6 +27,7 @@
 #include "rocksdb/iostats_context.h"
 #include "rocksdb/perf_context.h"
 #include "table/block_based/flush_block_policy_impl.h"
+#include "test_util/sync_point.h"
 #include "test_util/testutil.h"
 #include "util/random.h"
 #include "utilities/merge_operators/string_append/stringappend2.h"
@@ -34,6 +40,15 @@ class DummyReadCallback : public ReadCallback {
   DummyReadCallback() : ReadCallback(kMaxSequenceNumber) {}
   bool IsVisibleFullCheck(SequenceNumber /*seq*/) override { return true; }
   void SetSnapshot(SequenceNumber seq) { max_visible_seq_ = seq; }
+};
+
+class SyncPointScope {
+ public:
+  ~SyncPointScope() {
+    auto* sync_point = SyncPoint::GetInstance();
+    sync_point->DisableProcessing();
+    sync_point->ClearAllCallBacks();
+  }
 };
 
 class DBIteratorBaseTest : public DBTestBase {
@@ -4925,6 +4940,135 @@ class NoAsyncIOFS : public FileSystemWrapper {
   };
 };
 
+enum class ObservedIOType {
+  kRead,
+  kMultiRead,
+  kReadAsync,
+  kPrefetch,
+};
+
+struct ObservedRandomRead {
+  std::string file_name;
+  ObservedIOType type;
+  uint64_t offset;
+  size_t len;
+};
+
+static std::string NormalizeObservedFileName(const std::string& path) {
+  const size_t slash_pos = path.find_last_of("/\\");
+  std::string name =
+      slash_pos == std::string::npos ? path : path.substr(slash_pos + 1);
+  constexpr char kSstSuffix[] = ".sst";
+  constexpr size_t kSstSuffixLen = sizeof(kSstSuffix) - 1;
+  if (name.size() > kSstSuffixLen &&
+      name.compare(name.size() - kSstSuffixLen, kSstSuffixLen, kSstSuffix) ==
+          0) {
+    name.resize(name.size() - kSstSuffixLen);
+  }
+  return name;
+}
+
+class FairnessObservingFS : public FileSystemWrapper {
+ public:
+  explicit FairnessObservingFS(const std::shared_ptr<FileSystem>& target)
+      : FileSystemWrapper(target) {}
+
+  static const char* kClassName() { return "FairnessObservingFS"; }
+  const char* Name() const override { return kClassName(); }
+
+  IOStatus NewRandomAccessFile(const std::string& fname,
+                               const FileOptions& opts,
+                               std::unique_ptr<FSRandomAccessFile>* result,
+                               IODebugContext* dbg) override {
+    IOStatus s = target()->NewRandomAccessFile(fname, opts, result, dbg);
+    if (s.ok()) {
+      *result = std::make_unique<ObservingRandomAccessFile>(
+          std::move(*result), this, NormalizeObservedFileName(fname));
+    }
+    return s;
+  }
+
+  void ClearEvents() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    events_.clear();
+  }
+
+  std::vector<ObservedRandomRead> GetEvents() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return events_;
+  }
+
+ private:
+  class ObservingRandomAccessFile : public FSRandomAccessFileOwnerWrapper {
+   public:
+    ObservingRandomAccessFile(std::unique_ptr<FSRandomAccessFile>&& target,
+                              FairnessObservingFS* observer,
+                              std::string file_name)
+        : FSRandomAccessFileOwnerWrapper(std::move(target)),
+          observer_(observer),
+          file_name_(std::move(file_name)) {}
+
+    IOStatus Read(uint64_t offset, size_t n, const IOOptions& options,
+                  Slice* result, char* scratch,
+                  IODebugContext* dbg) const override {
+      IOStatus s = target()->Read(offset, n, options, result, scratch, dbg);
+      if (s.ok()) {
+        observer_->RecordEvent(file_name_, ObservedIOType::kRead, offset, n);
+      }
+      return s;
+    }
+
+    IOStatus MultiRead(FSReadRequest* reqs, size_t num_reqs,
+                       const IOOptions& options, IODebugContext* dbg) override {
+      IOStatus s = target()->MultiRead(reqs, num_reqs, options, dbg);
+      if (!s.ok()) {
+        return s;
+      }
+      for (size_t i = 0; i < num_reqs; ++i) {
+        observer_->RecordEvent(file_name_, ObservedIOType::kMultiRead,
+                               reqs[i].offset, reqs[i].len);
+      }
+      return s;
+    }
+
+    IOStatus Prefetch(uint64_t offset, size_t n, const IOOptions& options,
+                      IODebugContext* dbg) override {
+      IOStatus s = target()->Prefetch(offset, n, options, dbg);
+      if (s.ok()) {
+        observer_->RecordEvent(file_name_, ObservedIOType::kPrefetch, offset,
+                               n);
+      }
+      return s;
+    }
+
+    IOStatus ReadAsync(FSReadRequest& req, const IOOptions& opts,
+                       std::function<void(FSReadRequest&, void*)> cb,
+                       void* cb_arg, void** io_handle, IOHandleDeleter* del_fn,
+                       IODebugContext* dbg) override {
+      IOStatus s =
+          target()->ReadAsync(req, opts, cb, cb_arg, io_handle, del_fn, dbg);
+      if (s.ok()) {
+        observer_->RecordEvent(file_name_, ObservedIOType::kReadAsync,
+                               req.offset, req.len);
+      }
+      return s;
+    }
+
+   private:
+    FairnessObservingFS* observer_;
+    std::string file_name_;
+  };
+
+  void RecordEvent(const std::string& file_name, ObservedIOType type,
+                   uint64_t offset, size_t len) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    events_.push_back({file_name, type, offset, len});
+  }
+
+  mutable std::mutex mutex_;
+  std::vector<ObservedRandomRead> events_;
+};
+
 TEST_P(DBMultiScanIteratorTest, AsyncIOFallbackWithoutFSSupport) {
   // Verify that MultiScan works correctly when use_async_io = true but the
   // filesystem does NOT support kAsyncIO. The constructor should silently
@@ -5065,6 +5209,292 @@ TEST_P(DBMultiScanIteratorTest, AsyncPrefetchMultipleLevels) {
 
   // Should have keys from all three ranges
   ASSERT_GT(total_keys, 0);
+  iter.reset();
+}
+
+TEST_P(DBMultiScanIteratorTest, IODispatcherFairnessGroupingAcrossLevels) {
+  auto options = CurrentOptions();
+  options.target_file_size_base = 1 << 15;  // 32KiB
+  options.compaction_style = kCompactionStyleUniversal;
+  options.num_levels = 50;
+  options.compression = kNoCompression;
+  DestroyAndReopen(options);
+
+  Random rnd(309);
+
+  for (int i = 0; i < 800; ++i) {
+    std::stringstream ss;
+    ss << "k" << std::setw(5) << std::setfill('0') << i;
+    ASSERT_OK(Put(ss.str(), rnd.RandomString(1 << 10)));
+  }
+  ASSERT_OK(Flush());
+  ASSERT_OK(db_->CompactRange({}, nullptr, nullptr));
+  ASSERT_GT(NumTableFilesAtLevel(49), 2);
+
+  for (int i = 100; i < 160; ++i) {
+    std::stringstream ss;
+    ss << "k" << std::setw(5) << std::setfill('0') << i;
+    ASSERT_OK(Put(ss.str(), rnd.RandomString(1 << 10)));
+  }
+  ASSERT_OK(Flush());
+  for (int i = 120; i < 180; ++i) {
+    std::stringstream ss;
+    ss << "k" << std::setw(5) << std::setfill('0') << i;
+    ASSERT_OK(Put(ss.str(), rnd.RandomString(1 << 10)));
+  }
+  ASSERT_OK(Flush());
+
+  ASSERT_GE(NumTableFilesAtLevel(0), 2);
+  ASSERT_GT(NumTableFilesAtLevel(49), 2);
+
+  ReadOptions ro;
+  ro.fill_cache = false;
+
+  auto dispatcher_stats = CreateDBStatistics();
+  IODispatcherOptions dispatcher_options;
+  dispatcher_options.max_prefetch_memory_bytes = 20 * 1024;
+  dispatcher_options.statistics = dispatcher_stats.get();
+  auto dispatcher =
+      std::shared_ptr<IODispatcher>(NewIODispatcher(dispatcher_options));
+
+  MultiScanArgs scan_options(BytewiseComparator());
+  scan_options.use_async_io = true;
+  scan_options.io_dispatcher = dispatcher;
+  scan_options.insert("k00000", "k00800");
+
+  std::unordered_map<uint64_t, uint64_t> l0_file_to_group;
+  std::unordered_map<uint64_t, uint64_t> non_l0_file_to_group;
+  std::unordered_set<int> non_l0_levels;
+  std::unordered_set<uint64_t> reserved_group_ids;
+
+  SyncPointScope sync_point_scope;
+  auto* sync_point = SyncPoint::GetInstance();
+  sync_point->SetCallBack("IODispatcherImpl::GetFairnessGroup", [&](void* arg) {
+    auto* info = static_cast<std::tuple<int, uint64_t, uint64_t>*>(arg);
+    const int level = std::get<0>(*info);
+    const uint64_t file_number = std::get<1>(*info);
+    const uint64_t group_id = std::get<2>(*info);
+    if (file_number == UINT64_MAX) {
+      return;
+    }
+    if (level == 0) {
+      l0_file_to_group[file_number] = group_id;
+    } else if (level > 0) {
+      non_l0_levels.insert(level);
+      non_l0_file_to_group[file_number] = group_id;
+    }
+  });
+  sync_point->SetCallBack(
+      "IODispatcherImpl::TryAcquireMemory:Granted", [&](void* arg) {
+        auto* info = static_cast<std::tuple<uint64_t, size_t, bool>*>(arg);
+        if (std::get<2>(*info)) {
+          reserved_group_ids.insert(std::get<0>(*info));
+        }
+      });
+  sync_point->EnableProcessing();
+
+  ColumnFamilyHandle* cfh = dbfull()->DefaultColumnFamily();
+  std::unique_ptr<MultiScan> iter =
+      dbfull()->NewMultiScan(ro, cfh, scan_options);
+  ASSERT_NE(iter, nullptr);
+
+  int total_keys = 0;
+  try {
+    for (auto range : *iter) {
+      for (auto it : range) {
+        it.first.ToString();
+        total_keys++;
+      }
+    }
+  } catch (MultiScanException& ex) {
+    ASSERT_NOK(ex.status());
+    std::cerr << "Iterator returned status " << ex.what();
+    abort();
+  } catch (std::logic_error& ex) {
+    std::cerr << "Iterator returned logic error " << ex.what();
+    abort();
+  }
+
+  ASSERT_GT(total_keys, 0);
+  ASSERT_GE(l0_file_to_group.size(), 2);
+  ASSERT_GE(non_l0_file_to_group.size(), 2);
+  ASSERT_EQ(non_l0_levels.size(), 1);
+
+  std::unordered_set<uint64_t> l0_group_ids;
+  for (const auto& [file_number, group_id] : l0_file_to_group) {
+    (void)file_number;
+    l0_group_ids.insert(group_id);
+  }
+  ASSERT_EQ(l0_group_ids.size(), l0_file_to_group.size());
+
+  std::unordered_set<uint64_t> non_l0_group_ids;
+  for (const auto& [file_number, group_id] : non_l0_file_to_group) {
+    (void)file_number;
+    non_l0_group_ids.insert(group_id);
+  }
+  ASSERT_EQ(non_l0_group_ids.size(), 1);
+
+  size_t reserved_l0_group_count = 0;
+  for (const auto group_id : l0_group_ids) {
+    reserved_l0_group_count += reserved_group_ids.count(group_id);
+  }
+  ASSERT_GE(reserved_l0_group_count, 1);
+
+  size_t reserved_non_l0_group_count = 0;
+  for (const auto group_id : non_l0_group_ids) {
+    reserved_non_l0_group_count += reserved_group_ids.count(group_id);
+  }
+  ASSERT_EQ(reserved_non_l0_group_count, non_l0_group_ids.size());
+
+  iter.reset();
+}
+
+TEST_P(DBMultiScanIteratorTest, IODispatcherFairnessFsObservationAcrossLevels) {
+  // Supplemental integration coverage for fairness: observe externally
+  // visible FS-level prefetch progress rather than internal fairness groups.
+  auto options = CurrentOptions();
+  options.target_file_size_base = 4
+                                  << 20;  // Keep each level's data in one SST.
+  options.compaction_style = kCompactionStyleLevel;
+  options.num_levels = 3;
+  options.disable_auto_compactions = true;
+  options.compression = kNoCompression;
+
+  auto tracking_fs =
+      std::make_shared<FairnessObservingFS>(env_->GetFileSystem());
+  std::unique_ptr<Env> wrapped_env(new CompositeEnvWrapper(env_, tracking_fs));
+  struct CloseBeforeEnvReset {
+    DBTestBase* db_test;
+    ~CloseBeforeEnvReset() { db_test->Close(); }
+  } close_before_env_reset{this};
+  options.env = wrapped_env.get();
+  DestroyAndReopen(options);
+
+  Random rnd(310);
+
+  for (int i = 0; i < 800; ++i) {
+    std::stringstream ss;
+    ss << "k" << std::setw(5) << std::setfill('0') << i;
+    ASSERT_OK(Put(ss.str(), rnd.RandomString(1 << 10)));
+  }
+  ASSERT_OK(Flush());
+  MoveFilesToLevel(2);
+
+  for (int i = 100; i < 160; ++i) {
+    std::stringstream ss;
+    ss << "k" << std::setw(5) << std::setfill('0') << i;
+    ASSERT_OK(Put(ss.str(), rnd.RandomString(1 << 10)));
+  }
+  ASSERT_OK(Flush());
+
+  Close();
+  Reopen(options);
+
+  const std::string lower = "k00100";
+  const std::string upper = "k00160";
+
+  ASSERT_EQ(1, NumTableFilesAtLevel(0));
+  ASSERT_EQ(0, NumTableFilesAtLevel(1));
+  ASSERT_EQ(1, NumTableFilesAtLevel(2));
+
+  std::vector<LiveFileMetaData> file_meta;
+  db_->GetLiveFilesMetaData(&file_meta);
+
+  std::unordered_map<std::string, int> tracked_file_levels;
+  std::unordered_set<std::string> level0_files;
+  std::unordered_set<std::string> level2_files;
+  for (const auto& meta : file_meta) {
+    const std::string file_name = NormalizeObservedFileName(meta.name);
+    tracked_file_levels.emplace(file_name, meta.level);
+    if (meta.level == 0) {
+      level0_files.insert(file_name);
+    } else if (meta.level == 2) {
+      level2_files.insert(file_name);
+    }
+  }
+  ASSERT_EQ(level0_files.size(), 1);
+  ASSERT_EQ(level2_files.size(), 1);
+
+  ReadOptions ro;
+  ro.fill_cache = GetParam();
+
+  auto dispatcher_stats = CreateDBStatistics();
+  IODispatcherOptions dispatcher_options;
+  dispatcher_options.max_prefetch_memory_bytes = 20 * 1024;
+  dispatcher_options.statistics = dispatcher_stats.get();
+  auto dispatcher =
+      std::shared_ptr<IODispatcher>(NewIODispatcher(dispatcher_options));
+
+  MultiScanArgs scan_options(BytewiseComparator());
+  scan_options.use_async_io = true;
+  scan_options.io_dispatcher = dispatcher;
+  scan_options.insert(lower, upper);
+
+  tracking_fs->ClearEvents();
+  ColumnFamilyHandle* cfh = dbfull()->DefaultColumnFamily();
+  std::unique_ptr<MultiScan> iter =
+      dbfull()->NewMultiScan(ro, cfh, scan_options);
+  ASSERT_NE(iter, nullptr);
+
+  const auto prepare_events = tracking_fs->GetEvents();
+  std::stringstream raw_prepare_trace;
+  for (const auto& event : prepare_events) {
+    raw_prepare_trace << event.file_name << ":" << static_cast<int>(event.type)
+                      << " ";
+  }
+
+  int total_keys = 0;
+  try {
+    for (auto range : *iter) {
+      for (auto it : range) {
+        it.first.ToString();
+        total_keys++;
+      }
+    }
+  } catch (MultiScanException& ex) {
+    ASSERT_NOK(ex.status());
+    std::cerr << "Iterator returned status " << ex.what();
+    abort();
+  } catch (std::logic_error& ex) {
+    std::cerr << "Iterator returned logic error " << ex.what();
+    abort();
+  }
+
+  ASSERT_GT(total_keys, 0);
+
+  std::unordered_set<std::string> seen_progress_files;
+  bool saw_level0_progress = false;
+  bool saw_level2_progress = false;
+  std::stringstream progress_trace;
+
+  for (const auto& event : prepare_events) {
+    if (event.type != ObservedIOType::kReadAsync &&
+        event.type != ObservedIOType::kMultiRead &&
+        event.type != ObservedIOType::kPrefetch) {
+      continue;
+    }
+    auto level_it = tracked_file_levels.find(event.file_name);
+    if (level_it == tracked_file_levels.end()) {
+      continue;
+    }
+    progress_trace << event.file_name << "@L" << level_it->second << ":"
+                   << static_cast<int>(event.type) << " ";
+    if (level_it->second == 0) {
+      saw_level0_progress = true;
+    } else if (level_it->second == 2) {
+      saw_level2_progress = true;
+    }
+    seen_progress_files.insert(event.file_name);
+  }
+
+  ASSERT_TRUE(saw_level0_progress) << "filtered=" << progress_trace.str()
+                                   << " raw=" << raw_prepare_trace.str();
+  ASSERT_TRUE(saw_level2_progress) << "filtered=" << progress_trace.str()
+                                   << " raw=" << raw_prepare_trace.str();
+  ASSERT_GE(seen_progress_files.size(), 2)
+      << "filtered=" << progress_trace.str()
+      << " raw=" << raw_prepare_trace.str();
+
   iter.reset();
 }
 

--- a/include/rocksdb/io_dispatcher.h
+++ b/include/rocksdb/io_dispatcher.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <atomic>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <unordered_map>
@@ -31,9 +32,13 @@ struct PendingPrefetchRequest;
 
 // Options for configuring IODispatcher behavior
 struct IODispatcherOptions {
-  // Maximum memory (in bytes) for prefetching across all ReadSets.
-  // When this limit is reached, SubmitJob() blocks until memory is released.
-  // Set to 0 (default) for unlimited prefetch memory.
+  // Target memory budget (in bytes) for prefetched blocks across all ReadSets.
+  // SubmitJob() never blocks on this budget. When the dispatcher cannot grant
+  // more bytes immediately, remaining blocks stay pending for later dispatch
+  // and may fall back to synchronous reads on demand. Fairness reservations may
+  // allow outstanding prefetched bytes to temporarily exceed this value so
+  // active levels / L0 files can keep making progress under pressure. Set to 0
+  // (default) for unlimited prefetch memory.
   size_t max_prefetch_memory_bytes = 0;
 
   // Optional statistics for tracking memory limiter metrics
@@ -213,9 +218,15 @@ class ReadSet {
   bool IsBlockAvailable(size_t block_index) const;
 
   // Statistics accessors
-  uint64_t GetNumSyncReads() const { return num_sync_reads_; }
-  uint64_t GetNumAsyncReads() const { return num_async_reads_; }
-  uint64_t GetNumCacheHits() const { return num_cache_hits_; }
+  uint64_t GetNumSyncReads() const {
+    return num_sync_reads_.load(std::memory_order_relaxed);
+  }
+  uint64_t GetNumAsyncReads() const {
+    return num_async_reads_.load(std::memory_order_relaxed);
+  }
+  uint64_t GetNumCacheHits() const {
+    return num_cache_hits_.load(std::memory_order_relaxed);
+  }
 
  private:
   friend class IODispatcherImpl;
@@ -243,8 +254,16 @@ class ReadSet {
   // cycles)
   std::weak_ptr<IODispatcherImplData> dispatcher_data_;
 
-  // Size of each block (parallel to pinned_blocks_) for memory accounting
+  // Actual size of each block (parallel to pinned_blocks_) for pending
+  // prefetch bookkeeping.
   std::vector<size_t> block_sizes_;
+
+  // Bytes actually acquired from the dispatcher for each block. This can
+  // differ from block_sizes_ when blocks are pending or fall back to sync read.
+  std::vector<size_t> acquired_bytes_;
+
+  // Opaque token identifying the fairness group for this ReadSet's job.
+  void* fairness_group_token_ = nullptr;
 
   // Statistics counters
   std::atomic<uint64_t> num_sync_reads_ = 0;

--- a/table/block_based/block_based_table_reader_test.cc
+++ b/table/block_based/block_based_table_reader_test.cc
@@ -19,6 +19,7 @@
 #include "rocksdb/compression_type.h"
 #include "rocksdb/db.h"
 #include "rocksdb/file_system.h"
+#include "rocksdb/io_dispatcher.h"
 #include "rocksdb/options.h"
 #include "table/block_based/block_based_table_builder.h"
 #include "table/block_based/block_based_table_factory.h"
@@ -1346,6 +1347,63 @@ TEST_P(BlockBasedTableReaderMultiScanAsyncIOTest, DISABLED_MultiScanPrepare) {
       last_read_key_index += rnd.Uniform(100);
     }
   }
+}
+
+TEST_P(BlockBasedTableReaderMultiScanAsyncIOTest,
+       MultiScanPrepareUsesProvidedIODispatcher) {
+  auto param = GetParam();
+  auto fill_cache = param.fill_cache;
+  auto use_async_io = param.use_async_io;
+
+  options_.statistics = CreateDBStatistics();
+  ReadOptions read_opts;
+  read_opts.fill_cache = fill_cache;
+  size_t ts_sz = options_.comparator->timestamp_size();
+  std::vector<std::pair<std::string, std::string>> kv =
+      BlockBasedTableReaderBaseTest::GenerateKVMap(
+          20 /* num_block */, true /* mixed_with_human_readable_string_value */,
+          ts_sz, same_key_diff_ts_, comparator_);
+  std::string table_name = "BlockBasedTableReaderTest_ProvidedIODispatcher" +
+                           CompressionTypeToString(compression_type_) +
+                           "_async" + std::to_string(use_async_io);
+  ImmutableOptions ioptions(options_);
+  CreateTable(table_name, ioptions, compression_type_,
+              std::vector<std::pair<std::string, std::string>>{
+                  kv.begin() + 4 * kEntriesPerBlock,
+                  kv.begin() + 16 * kEntriesPerBlock},
+              compression_parallel_threads_, compression_dict_bytes_);
+
+  std::unique_ptr<BlockBasedTable> table;
+  FileOptions foptions;
+  foptions.use_direct_reads = use_direct_reads_;
+  InternalKeyComparator comparator(options_.comparator);
+  NewBlockBasedTableReader(foptions, ioptions, comparator, table_name, &table,
+                           true /* prefetch_index_and_filter_in_cache */,
+                           nullptr /* status */, persist_udt_);
+
+  std::unique_ptr<InternalIterator> iter;
+  iter.reset(table->NewIterator(
+      read_opts, options_.prefix_extractor.get(), /*arena=*/nullptr,
+      /*skip_filters=*/false, TableReaderCaller::kUncategorized));
+
+  auto tracking_dispatcher = std::make_shared<TrackingIODispatcher>();
+
+  MultiScanArgs scan_options(comparator_);
+  scan_options.use_async_io = use_async_io;
+  scan_options.io_dispatcher = tracking_dispatcher;
+  scan_options.insert(ExtractUserKey(kv[5 * kEntriesPerBlock].first),
+                      ExtractUserKey(kv[10 * kEntriesPerBlock].first));
+
+  iter->Prepare(&scan_options);
+  ASSERT_GE(tracking_dispatcher->GetReadSets().size(), 1);
+
+  iter->Seek(kv[5 * kEntriesPerBlock].first);
+  for (size_t i = 5 * kEntriesPerBlock; i < 10 * kEntriesPerBlock; ++i) {
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_EQ(iter->key().ToString(), kv[i].first);
+    iter->Next();
+  }
+  ASSERT_OK(iter->status());
 }
 
 TEST_P(BlockBasedTableReaderMultiScanTest, MultiScanPrefetchSizeLimit) {

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -513,8 +513,9 @@ default_params = {
     "use_multiscan": random.choice([1] + [0] * 3),
     # By default, `statistics` use kExceptDetailedTimers level
     "statistics": random.choice([0, 1]),
-    # TODO: re-enable after resolving "Req failed: Unknown error -14" errors
-    "multiscan_use_async_io": 0,  # random.randint(0, 1),
+    # Keep this low-probability so we exercise async MultiScan/IODispatcher
+    # paths without making every run depend on async FS support.
+    "multiscan_use_async_io": lambda: random.choice([0, 0, 1]),
 }
 
 _TEST_DIR_ENV_VAR = "TEST_TMPDIR"
@@ -924,6 +925,42 @@ multiops_txn_params = {
     "use_attribute_group": 0,
     "commit_bypass_memtable_one_in": random.choice([0] * 4 + [100]),
 }
+
+
+_OPERATION_PERCENT_KEYS = (
+    "readpercent",
+    "prefixpercent",
+    "writepercent",
+    "delpercent",
+    "delrangepercent",
+    "iterpercent",
+    "customopspercent",
+)
+
+
+def normalize_operation_percents(dest_params):
+    total = sum(int(dest_params.get(key, 0) or 0) for key in _OPERATION_PERCENT_KEYS)
+    if total == 100:
+        return
+
+    # Run this after all sanitization. Earlier folds can preserve the total
+    # locally, but later guards can still perturb it again.
+    # When callers also override the operation mix on the command line, the
+    # final total can drift away from db_stress's required 100%. Use reads as
+    # the residual bucket since it is always a valid fallback operation.
+    adjusted_readpercent = int(dest_params.get("readpercent", 0) or 0) + (100 - total)
+    if adjusted_readpercent < 0:
+        raise ValueError(
+            "Cannot normalize db_stress operation percents to 100: "
+            f"current total={total}, readpercent={dest_params.get('readpercent', 0)}"
+        )
+
+    print(
+        "Normalizing db_stress operation percents: "
+        f"total={total}, readpercent={dest_params.get('readpercent', 0)} "
+        f"-> {adjusted_readpercent}"
+    )
+    dest_params["readpercent"] = adjusted_readpercent
 
 
 def finalize_and_sanitize(src_params):
@@ -1524,6 +1561,7 @@ def finalize_and_sanitize(src_params):
         dest_params["async_io"] = 0
         dest_params["delpercent"] += dest_params["delrangepercent"]
         dest_params["delrangepercent"] = 0
+        # MultiScan relies on full keyspace iteration (no prefix extractor).
         dest_params["prefix_size"] = -1
         dest_params["iterpercent"] += dest_params["prefixpercent"]
         dest_params["prefixpercent"] = 0
@@ -1541,6 +1579,9 @@ def finalize_and_sanitize(src_params):
         dest_params["multiscan_max_prefetch_memory_bytes"] = random.choice(
             [0, 0, 64 * 1024, 256 * 1024]
         )
+    else:
+        # Keep async-MultiScan knob meaningful only when MultiScan is active.
+        dest_params["multiscan_use_async_io"] = 0
 
     # open_files_async requires skip_stats_update_on_db_open to avoid
     # synchronous I/O in UpdateAccumulatedStats during DB open
@@ -1566,6 +1607,8 @@ def finalize_and_sanitize(src_params):
     # write presets that force disable_wal=1 earlier in sanitization.
     if dest_params.get("disable_wal", 0) == 1:
         dest_params["test_batches_snapshots"] = 0
+
+    normalize_operation_percents(dest_params)
 
     return dest_params
 

--- a/util/io_dispatcher_imp.cc
+++ b/util/io_dispatcher_imp.cc
@@ -16,6 +16,7 @@
 
 #include <deque>
 #include <memory>
+#include <tuple>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -36,12 +37,20 @@
 
 namespace ROCKSDB_NAMESPACE {
 
+struct PendingPrefetchRequest;
+
+namespace {
+
+constexpr size_t kMinFairnessReservationBytes = 8 * 1024;
+
+}  // namespace
+
 // IODispatcherImplData is the base that provides ReleaseMemory interface
 // for ReadSets to call back when releasing blocks. Defined here so it's
 // visible to ReadSet methods.
 struct IODispatcherImplData {
   virtual ~IODispatcherImplData() = default;
-  virtual void ReleaseMemory(size_t bytes) = 0;
+  virtual void ReleaseMemory(size_t bytes, void* fairness_group_token) = 0;
 };
 
 // Helper function to create and pin a block from a buffer
@@ -111,14 +120,13 @@ struct AsyncIOState {
 // Must call AbortIO before deleting handles to avoid use-after-free when
 // io_uring completions arrive for deleted handles.
 ReadSet::~ReadSet() {
-  // Release memory for any blocks still pinned
-  // Note: block_sizes_[i] is only set for async IO reads where memory
-  // limiting applies. For sync reads, block_sizes_ remains 0, so this
-  // loop is effectively a no-op for sync reads.
+  // Release memory for any blocks that actually acquired prefetch budget.
   if (auto dispatcher_data = dispatcher_data_.lock()) {
-    for (size_t i = 0; i < block_sizes_.size(); ++i) {
-      if (block_sizes_[i] > 0 && pinned_blocks_[i].GetValue()) {
-        dispatcher_data->ReleaseMemory(block_sizes_[i]);
+    for (size_t i = 0; i < acquired_bytes_.size(); ++i) {
+      if (acquired_bytes_[i] > 0) {
+        dispatcher_data->ReleaseMemory(acquired_bytes_[i],
+                                       fairness_group_token_);
+        acquired_bytes_[i] = 0;
       }
     }
   }
@@ -171,11 +179,13 @@ Status ReadSet::ReadIndex(size_t block_index, CachableEntry<Block>* out) {
     // Release memory accounting for prefetched blocks. After moving the value
     // out, ReleaseBlock() and the destructor check pinned_blocks_.GetValue()
     // which will be null, so they won't release memory again.
-    if (block_index < block_sizes_.size() && block_sizes_[block_index] > 0) {
+    if (block_index < acquired_bytes_.size() &&
+        acquired_bytes_[block_index] > 0) {
       if (auto dispatcher_data = dispatcher_data_.lock()) {
-        dispatcher_data->ReleaseMemory(block_sizes_[block_index]);
+        dispatcher_data->ReleaseMemory(acquired_bytes_[block_index],
+                                       fairness_group_token_);
       }
-      block_sizes_[block_index] = 0;
+      acquired_bytes_[block_index] = 0;
     }
     // Note: Statistics for this block were already counted during SubmitJob
     // (either as cache hit or sync read)
@@ -194,18 +204,20 @@ Status ReadSet::ReadIndex(size_t block_index, CachableEntry<Block>* out) {
         return s;
       }
       // Count all blocks that were read in this async request
-      num_async_reads_ += num_blocks_in_request;
+      num_async_reads_.fetch_add(num_blocks_in_request,
+                                 std::memory_order_relaxed);
 
       // After polling, the block should be in pinned_blocks_
       if (pinned_blocks_[block_index].GetValue()) {
         *out = std::move(pinned_blocks_[block_index]);
         // Release memory accounting (same as case 1 above)
-        if (block_index < block_sizes_.size() &&
-            block_sizes_[block_index] > 0) {
+        if (block_index < acquired_bytes_.size() &&
+            acquired_bytes_[block_index] > 0) {
           if (auto dispatcher_data = dispatcher_data_.lock()) {
-            dispatcher_data->ReleaseMemory(block_sizes_[block_index]);
+            dispatcher_data->ReleaseMemory(acquired_bytes_[block_index],
+                                           fairness_group_token_);
           }
-          block_sizes_[block_index] = 0;
+          acquired_bytes_[block_index] = 0;
         }
         return Status::OK();
       }
@@ -225,7 +237,7 @@ Status ReadSet::ReadIndex(size_t block_index, CachableEntry<Block>* out) {
   Status s = SyncRead(block_index);
   if (s.ok()) {
     *out = std::move(pinned_blocks_[block_index]);
-    num_sync_reads_++;
+    num_sync_reads_.fetch_add(1, std::memory_order_relaxed);
   }
   return s;
 }
@@ -273,15 +285,14 @@ void ReadSet::ReleaseBlock(size_t block_index) {
   RemoveFromPending(block_index);
 
   // Release memory BEFORE unpinning
-  // Note: block_sizes_[idx] is only set for async IO reads where memory
-  // limiting applies. For sync reads, block_sizes_ remains 0, so this
-  // check implicitly skips ReleaseMemory for sync reads.
   if (pinned_blocks_[block_index].GetValue() &&
-      block_index < block_sizes_.size() && block_sizes_[block_index] > 0) {
+      block_index < acquired_bytes_.size() &&
+      acquired_bytes_[block_index] > 0) {
     if (auto dispatcher_data = dispatcher_data_.lock()) {
-      dispatcher_data->ReleaseMemory(block_sizes_[block_index]);
+      dispatcher_data->ReleaseMemory(acquired_bytes_[block_index],
+                                     fairness_group_token_);
     }
-    block_sizes_[block_index] = 0;  // Prevent double-release
+    acquired_bytes_[block_index] = 0;  // Prevent double-release
   }
 
   // Unpin the block from cache
@@ -398,7 +409,9 @@ struct PendingPrefetchRequest {
   // Individual block indices still pending (for RemoveFromPending lookup)
   std::unordered_set<size_t> block_indices_to_prefetch;
 
-  std::atomic<size_t> pending_bytes_{0};  // Track remaining bytes
+  // Protected by groups_mutex_ after publication into pending_requests under
+  // pending_mutex_.
+  size_t pending_bytes_ = 0;
   mutable port::Mutex groups_mutex_;  // Protects groups and set modifications
 };
 
@@ -409,7 +422,8 @@ void ReadSet::RemoveFromPending(size_t block_index) {
   }
 
   // Atomic exchange - returns true only if it was previously true
-  if (!pending_prefetch_flags_[block_index].exchange(false)) {
+  if (!pending_prefetch_flags_[block_index].exchange(
+          false, std::memory_order_relaxed)) {
     return;  // Already removed or never pending
   }
 
@@ -423,6 +437,72 @@ void ReadSet::RemoveFromPending(size_t block_index) {
 // IODispatcherImpl::Impl inherits from IODispatcherImplData
 struct IODispatcherImpl::Impl : public IODispatcherImplData,
                                 public std::enable_shared_from_this<Impl> {
+  // Fairness groups partition prefetch reservation by where data lives in the
+  // LSM:
+  // - L1+ files share one group per level.
+  // - L0 files each get their own group (overlapping L0 files are treated
+  //   independently).
+  // - Unknown level/file metadata falls back to the default group.
+  //
+  // Example: for an LSM with L0 files {F101, F102}, L1 files {F201...}, and L2
+  // files {F301...}, the dispatcher tracks four groups:
+  //   1) L0 file F101
+  //   2) L0 file F102
+  //   3) Level 1
+  //   4) Level 2
+  // This lets one hot level/file use its own reserved bytes without starving
+  // prefetch from other levels/files when the global budget is under pressure.
+  //
+  // Scheduling is intentionally two-stage:
+  // - SubmitJob() first tries to dispatch that job's coalesced groups in order.
+  // - Groups that cannot get memory become pending in a FIFO queue owned by
+  //   their fairness group.
+  // - TryDispatchPendingPrefetches() then walks the pending fairness groups
+  //   round-robin, giving each group at most one coalesced prefetch group per
+  //   pass before re-enqueueing it at the back if it still has work.
+  //
+  // In the example above, once prefetch starts queueing, F101, F102, L1, and
+  // L2 each get turns instead of one hot level/file keeping the whole pending
+  // queue in front of the others.
+  enum class FairnessScope {
+    kDefault,
+    kLevel,
+    kL0File,
+  };
+
+  struct FairnessGroupKey {
+    FairnessScope scope = FairnessScope::kDefault;
+    int level = -1;
+    uint64_t file_number = 0;
+
+    bool operator==(const FairnessGroupKey& other) const {
+      return scope == other.scope && level == other.level &&
+             file_number == other.file_number;
+    }
+  };
+
+  struct FairnessGroupKeyHash {
+    size_t operator()(const FairnessGroupKey& key) const {
+      size_t hash = std::hash<int>()(static_cast<int>(key.scope));
+      hash ^=
+          std::hash<int>()(key.level) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
+      hash ^= std::hash<uint64_t>()(key.file_number) + 0x9e3779b9 +
+              (hash << 6) + (hash >> 2);
+      return hash;
+    }
+  };
+
+  struct FairnessGroupState {
+    explicit FairnessGroupState(uint64_t initial_debug_group_id = 0)
+        : debug_group_id(initial_debug_group_id) {}
+
+    std::atomic<size_t> reserved_bytes{0};
+    std::atomic<size_t> memory_used_{0};
+    std::deque<std::shared_ptr<PendingPrefetchRequest>> pending_requests;
+    bool in_dispatch_queue = false;
+    uint64_t debug_group_id = 0;
+  };
+
   explicit Impl(const IODispatcherOptions& options);
   ~Impl() override;
 
@@ -435,19 +515,36 @@ struct IODispatcherImpl::Impl : public IODispatcherImplData,
   Status SubmitJob(const std::shared_ptr<IOJob>& job,
                    std::shared_ptr<ReadSet>* read_set);
 
-  // Memory management methods - non-blocking
-  bool TryAcquireMemory(size_t bytes);
-  void ReleaseMemory(size_t bytes) override;
+  FairnessGroupState* GetOrCreateFairnessGroup(
+      const std::shared_ptr<IOJob>& job);
+  size_t GetReservedBytesForJob(const std::shared_ptr<IOJob>& job) const;
+
+  // Memory management methods.
+  bool TryAcquireMemory(size_t bytes, FairnessGroupState* fairness_group,
+                        bool* used_reserved_bytes = nullptr);
+  bool TryAcquireMemoryLocked(size_t bytes, FairnessGroupState* fairness_group,
+                              bool* used_reserved_bytes = nullptr);
+  void ReleaseMemory(size_t bytes, void* fairness_group_token) override;
 
   // Memory limiting state
   size_t max_prefetch_memory_bytes_ = 0;
   std::atomic<size_t> memory_used_{0};  // Atomic for lock-free accounting
   std::atomic<bool> has_pending_requests_{false};  // Fast-path check
-  port::Mutex memory_mutex_;  // Only for pending_prefetch_queue_ access
-  std::deque<std::shared_ptr<PendingPrefetchRequest>> pending_prefetch_queue_;
+  port::Mutex accounting_mutex_;
+  port::Mutex pending_mutex_;
+  std::unique_ptr<FairnessGroupState> default_fairness_group_;
+  std::unordered_map<FairnessGroupKey, std::unique_ptr<FairnessGroupState>,
+                     FairnessGroupKeyHash>
+      fairness_groups_;
+  std::deque<FairnessGroupState*> pending_fairness_groups_;
   Statistics* statistics_ = nullptr;
+  uint64_t next_fairness_group_id_ = 1;
 
  private:
+  void EnqueuePendingGroupLocked(FairnessGroupState* fairness_group);
+  std::shared_ptr<PendingPrefetchRequest> GetFrontPendingRequestLocked(
+      FairnessGroupState* fairness_group);
+
   void PrepareIORequests(
       const std::shared_ptr<IOJob>& job,
       const std::vector<size_t>& block_indices_to_read,
@@ -487,47 +584,181 @@ struct IODispatcherImpl::Impl : public IODispatcherImplData,
 
 IODispatcherImpl::Impl::Impl(const IODispatcherOptions& options)
     : max_prefetch_memory_bytes_(options.max_prefetch_memory_bytes),
+      default_fairness_group_(std::make_unique<FairnessGroupState>(0)),
       statistics_(options.statistics) {}
 
 IODispatcherImpl::Impl::~Impl() {}
 
-bool IODispatcherImpl::Impl::TryAcquireMemory(size_t bytes) {
+size_t IODispatcherImpl::Impl::GetReservedBytesForJob(
+    const std::shared_ptr<IOJob>& job) const {
+  auto* rep = job->table->get_rep();
+  // Match the normal iterator's readahead policy as closely as possible:
+  // reserve the steady-state max readahead when configured, otherwise fall
+  // back to the initial readahead hint, then to a small floor so each fairness
+  // group still gets some protected headroom.
+  size_t reserved_bytes = rep->table_options.max_auto_readahead_size;
+  if (reserved_bytes == 0) {
+    reserved_bytes = rep->table_options.initial_auto_readahead_size;
+  }
+  if (reserved_bytes == 0) {
+    reserved_bytes = kMinFairnessReservationBytes;
+  }
+  return reserved_bytes;
+}
+
+IODispatcherImpl::Impl::FairnessGroupState*
+IODispatcherImpl::Impl::GetOrCreateFairnessGroup(
+    const std::shared_ptr<IOJob>& job) {
+  auto* rep = job->table ? job->table->get_rep() : nullptr;
+  const int level = rep ? rep->level : -1;
+  const uint64_t file_number = rep ? rep->sst_number_for_tracing() : UINT64_MAX;
+  size_t reserved_bytes = 0;
+
+  FairnessGroupState* fairness_group = default_fairness_group_.get();
+  FairnessGroupKey key;
+  if (rep != nullptr) {
+    if (level == 0 && file_number != UINT64_MAX) {
+      key.scope = FairnessScope::kL0File;
+      key.level = level;
+      key.file_number = file_number;
+    } else if (level > 0) {
+      key.scope = FairnessScope::kLevel;
+      key.level = level;
+    }
+  }
+
+  if (key.scope != FairnessScope::kDefault) {
+    reserved_bytes = GetReservedBytesForJob(job);
+    MutexLock lock(&accounting_mutex_);
+    auto it = fairness_groups_.find(key);
+    if (it == fairness_groups_.end()) {
+      auto new_group =
+          std::make_unique<FairnessGroupState>(next_fairness_group_id_++);
+      new_group->reserved_bytes.store(reserved_bytes,
+                                      std::memory_order_relaxed);
+      fairness_group = new_group.get();
+      fairness_groups_.emplace(key, std::move(new_group));
+    } else {
+      fairness_group = it->second.get();
+      const size_t existing_reserved =
+          fairness_group->reserved_bytes.load(std::memory_order_relaxed);
+      fairness_group->reserved_bytes.store(
+          std::max(existing_reserved, reserved_bytes),
+          std::memory_order_relaxed);
+    }
+  }
+
+#ifndef NDEBUG
+  auto sync_point_info =
+      std::make_tuple(level, file_number, fairness_group->debug_group_id);
+  TEST_SYNC_POINT_CALLBACK("IODispatcherImpl::GetFairnessGroup",
+                           &sync_point_info);
+#endif
+
+  return fairness_group;
+}
+
+bool IODispatcherImpl::Impl::TryAcquireMemory(
+    size_t bytes, IODispatcherImpl::Impl::FairnessGroupState* fairness_group,
+    bool* used_reserved_bytes) {
   if (max_prefetch_memory_bytes_ == 0) {
+    if (used_reserved_bytes != nullptr) {
+      *used_reserved_bytes = false;
+    }
     return true;  // No limit configured
   }
 
-  // Lock-free memory acquisition using compare-exchange
-  size_t current = memory_used_.load(std::memory_order_relaxed);
-  while (true) {
-    if (current + bytes > max_prefetch_memory_bytes_) {
-      // Not enough memory - caller should queue for later
-      RecordTick(statistics_, PREFETCH_MEMORY_REQUESTS_BLOCKED);
-      return false;
-    }
-    if (memory_used_.compare_exchange_weak(current, current + bytes,
-                                           std::memory_order_release,
-                                           std::memory_order_relaxed)) {
-      RecordTick(statistics_, PREFETCH_MEMORY_BYTES_GRANTED, bytes);
-      return true;
-    }
-    // current is updated by compare_exchange_weak on failure, retry
-  }
+  MutexLock lock(&accounting_mutex_);
+  return TryAcquireMemoryLocked(bytes, fairness_group, used_reserved_bytes);
 }
 
-void IODispatcherImpl::Impl::ReleaseMemory(size_t bytes) {
+bool IODispatcherImpl::Impl::TryAcquireMemoryLocked(
+    size_t bytes, IODispatcherImpl::Impl::FairnessGroupState* fairness_group,
+    bool* used_reserved_bytes) {
   if (max_prefetch_memory_bytes_ == 0) {
+    if (used_reserved_bytes != nullptr) {
+      *used_reserved_bytes = false;
+    }
+    return true;
+  }
+
+  const size_t current = memory_used_.load(std::memory_order_relaxed);
+  const size_t group_current =
+      fairness_group != nullptr
+          ? fairness_group->memory_used_.load(std::memory_order_relaxed)
+          : 0;
+  const size_t group_reserved =
+      fairness_group != nullptr
+          ? fairness_group->reserved_bytes.load(std::memory_order_relaxed)
+          : 0;
+  const bool use_reserved = fairness_group != nullptr &&
+                            current + bytes > max_prefetch_memory_bytes_ &&
+                            group_current + bytes <= group_reserved;
+
+  if (!use_reserved && current + bytes > max_prefetch_memory_bytes_) {
+    RecordTick(statistics_, PREFETCH_MEMORY_REQUESTS_BLOCKED);
+    if (used_reserved_bytes != nullptr) {
+      *used_reserved_bytes = false;
+    }
+    return false;
+  }
+
+  memory_used_.fetch_add(bytes, std::memory_order_relaxed);
+  if (fairness_group != nullptr) {
+    fairness_group->memory_used_.fetch_add(bytes, std::memory_order_relaxed);
+  }
+  RecordTick(statistics_, PREFETCH_MEMORY_BYTES_GRANTED, bytes);
+
+  if (used_reserved_bytes != nullptr) {
+    *used_reserved_bytes = use_reserved;
+  }
+
+  if (fairness_group != nullptr) {
+#ifndef NDEBUG
+    auto sync_point_info =
+        std::make_tuple(fairness_group->debug_group_id, bytes, use_reserved);
+    TEST_SYNC_POINT_CALLBACK("IODispatcherImpl::TryAcquireMemory:Granted",
+                             &sync_point_info);
+#endif
+  }
+
+  return true;
+}
+
+void IODispatcherImpl::Impl::ReleaseMemory(size_t bytes,
+                                           void* fairness_group_token) {
+  if (max_prefetch_memory_bytes_ == 0 || bytes == 0) {
     return;  // No limit configured
   }
 
-  // Lock-free memory release using atomic fetch_sub
-  size_t old_val = memory_used_.fetch_sub(bytes, std::memory_order_release);
-  assert(old_val >= bytes);
-  (void)old_val;  // Suppress unused warning in release builds
+  auto* fairness_group =
+      static_cast<IODispatcherImpl::Impl::FairnessGroupState*>(
+          fairness_group_token);
+
+  auto release_bytes = [bytes](std::atomic<size_t>* counter) {
+    size_t current = counter->load(std::memory_order_relaxed);
+    while (true) {
+      const size_t next = current >= bytes ? current - bytes : 0;
+      if (counter->compare_exchange_weak(current, next,
+                                         std::memory_order_relaxed)) {
+        assert(current >= bytes);
+        return;
+      }
+    }
+  };
+
+  // Keep release lock-free, but saturate on unexpected underflow in release
+  // builds so accounting cannot wrap to SIZE_MAX.
+  release_bytes(&memory_used_);
+  if (fairness_group != nullptr) {
+    release_bytes(&fairness_group->memory_used_);
+  }
+
   RecordTick(statistics_, PREFETCH_MEMORY_BYTES_RELEASED, bytes);
 
   // Fast-path: skip dispatch attempt if no pending requests
   // This avoids mutex contention in the common single-threaded iterator case
-  if (!has_pending_requests_.load(std::memory_order_acquire)) {
+  if (!has_pending_requests_.load(std::memory_order_relaxed)) {
     return;
   }
 
@@ -535,102 +766,152 @@ void IODispatcherImpl::Impl::ReleaseMemory(size_t bytes) {
   TryDispatchPendingPrefetches();
 }
 
-void IODispatcherImpl::Impl::TryDispatchPendingPrefetches() {
-  // Process pending prefetch requests - dispatch entire coalesced groups
-  while (true) {
-    std::shared_ptr<PendingPrefetchRequest> pending;
+void IODispatcherImpl::Impl::EnqueuePendingGroupLocked(
+    IODispatcherImpl::Impl::FairnessGroupState* fairness_group) {
+  assert(fairness_group != nullptr);
+  if (fairness_group->in_dispatch_queue ||
+      fairness_group->pending_requests.empty()) {
+    return;
+  }
+  pending_fairness_groups_.push_back(fairness_group);
+  fairness_group->in_dispatch_queue = true;
+  has_pending_requests_.store(true, std::memory_order_relaxed);
+}
 
+std::shared_ptr<PendingPrefetchRequest>
+IODispatcherImpl::Impl::GetFrontPendingRequestLocked(
+    IODispatcherImpl::Impl::FairnessGroupState* fairness_group) {
+  assert(fairness_group != nullptr);
+  while (!fairness_group->pending_requests.empty()) {
+    const auto& pending = fairness_group->pending_requests.front();
+    if (pending != nullptr && !pending->read_set.expired()) {
+      return pending;
+    }
+    fairness_group->pending_requests.pop_front();
+  }
+  return nullptr;
+}
+
+void IODispatcherImpl::Impl::TryDispatchPendingPrefetches() {
+  while (true) {
+    size_t groups_to_process = 0;
     {
-      MutexLock lock(&memory_mutex_);
-      if (pending_prefetch_queue_.empty()) {
-        has_pending_requests_.store(false, std::memory_order_release);
+      MutexLock lock(&pending_mutex_);
+      groups_to_process = pending_fairness_groups_.size();
+      if (groups_to_process == 0) {
+        has_pending_requests_.store(false, std::memory_order_relaxed);
         return;
       }
-
-      // Get the next pending request
-      pending = std::move(pending_prefetch_queue_.front());
-      pending_prefetch_queue_.pop_front();
     }
 
-    // Check if the ReadSet is still alive
-    auto read_set = pending->read_set.lock();
-    if (!read_set) {
-      continue;  // ReadSet was destroyed, skip this request
-    }
-
-    // Try to acquire memory for coalesced groups (entire groups at a time)
-    std::vector<size_t> blocks_to_dispatch;
-    bool has_remaining_groups = false;
-
-    {
-      MutexLock lock(&pending->groups_mutex_);
-
-      while (!pending->coalesced_groups.empty()) {
-        auto& group = pending->coalesced_groups.front();
-
-        // Filter out blocks that were already read (not in pending set anymore)
-        std::vector<size_t> remaining_blocks;
-        size_t remaining_bytes = 0;
-        for (size_t idx : group.block_indices) {
-          if (pending->block_indices_to_prefetch.count(idx) > 0) {
-            remaining_blocks.push_back(idx);
-            remaining_bytes += read_set->block_sizes_[idx];
-          }
+    bool dispatched_in_round = false;
+    while (groups_to_process-- > 0) {
+      IODispatcherImpl::Impl::FairnessGroupState* fairness_group = nullptr;
+      std::shared_ptr<PendingPrefetchRequest> pending;
+      {
+        MutexLock lock(&pending_mutex_);
+        if (pending_fairness_groups_.empty()) {
+          has_pending_requests_.store(false, std::memory_order_relaxed);
+          return;
         }
-
-        // Skip empty groups (all blocks were already read)
-        if (remaining_blocks.empty()) {
-          pending->coalesced_groups.pop_front();
+        fairness_group = pending_fairness_groups_.front();
+        pending_fairness_groups_.pop_front();
+        fairness_group->in_dispatch_queue = false;
+        pending = GetFrontPendingRequestLocked(fairness_group);
+        if (pending == nullptr) {
           continue;
         }
+      }
 
-        // Try to acquire memory for remaining blocks only
-        if (TryAcquireMemory(remaining_bytes)) {
-          // Add all remaining blocks from this group to dispatch
-          for (size_t idx : remaining_blocks) {
-            blocks_to_dispatch.push_back(idx);
-            pending->block_indices_to_prefetch.erase(idx);
+      auto read_set = pending->read_set.lock();
+      if (!read_set) {
+        {
+          MutexLock lock(&pending_mutex_);
+          if (!fairness_group->pending_requests.empty() &&
+              fairness_group->pending_requests.front() == pending) {
+            fairness_group->pending_requests.pop_front();
           }
-          pending->pending_bytes_ -= remaining_bytes;
-          pending->coalesced_groups.pop_front();
-        } else {
-          // Not enough memory for this group - update with remaining blocks
-          group.block_indices = std::move(remaining_blocks);
-          group.total_bytes = remaining_bytes;
-          has_remaining_groups = true;
+          if (GetFrontPendingRequestLocked(fairness_group) != nullptr) {
+            EnqueuePendingGroupLocked(fairness_group);
+          } else if (pending_fairness_groups_.empty()) {
+            has_pending_requests_.store(false, std::memory_order_relaxed);
+          }
+        }
+        continue;
+      }
+
+      std::vector<size_t> blocks_to_dispatch;
+      bool request_complete = false;
+      {
+        MutexLock lock(&pending->groups_mutex_);
+
+        while (!pending->coalesced_groups.empty()) {
+          auto& coalesced_group = pending->coalesced_groups.front();
+
+          std::vector<size_t> remaining_blocks;
+          size_t remaining_bytes = 0;
+          for (size_t idx : coalesced_group.block_indices) {
+            if (pending->block_indices_to_prefetch.count(idx) > 0) {
+              remaining_blocks.push_back(idx);
+              remaining_bytes += read_set->block_sizes_[idx];
+            }
+          }
+
+          if (remaining_blocks.empty()) {
+            pending->coalesced_groups.pop_front();
+            continue;
+          }
+
+          coalesced_group.block_indices = remaining_blocks;
+          coalesced_group.total_bytes = remaining_bytes;
+
+          if (TryAcquireMemory(remaining_bytes, fairness_group)) {
+            blocks_to_dispatch = std::move(coalesced_group.block_indices);
+            for (size_t idx : blocks_to_dispatch) {
+              pending->block_indices_to_prefetch.erase(idx);
+            }
+            pending->pending_bytes_ -= remaining_bytes;
+            pending->coalesced_groups.pop_front();
+          }
           break;
         }
+
+        request_complete = pending->coalesced_groups.empty() ||
+                           pending->block_indices_to_prefetch.empty() ||
+                           pending->pending_bytes_ == 0;
       }
-    }
 
-    // Save job before potential move of pending
-    auto job = pending->job;
+      {
+        MutexLock lock(&pending_mutex_);
+        if (request_complete && !fairness_group->pending_requests.empty() &&
+            fairness_group->pending_requests.front() == pending) {
+          fairness_group->pending_requests.pop_front();
+          read_set->pending_request_.reset();
+        }
 
-    // Requeue if groups remain
-    if (has_remaining_groups) {
-      MutexLock lock(&memory_mutex_);
-      pending_prefetch_queue_.push_front(std::move(pending));
-    } else {
-      // All groups dispatched, clear pending state
-      read_set->pending_request_.reset();
-    }
-
-    // Clear pending flags for dispatched blocks
-    if (read_set->pending_prefetch_flags_) {
-      for (size_t idx : blocks_to_dispatch) {
-        if (idx < read_set->pending_prefetch_flags_size_) {
-          read_set->pending_prefetch_flags_[idx].store(false);
+        if (GetFrontPendingRequestLocked(fairness_group) != nullptr) {
+          EnqueuePendingGroupLocked(fairness_group);
+        } else if (pending_fairness_groups_.empty()) {
+          has_pending_requests_.store(false, std::memory_order_relaxed);
         }
       }
+
+      if (read_set->pending_prefetch_flags_) {
+        for (size_t idx : blocks_to_dispatch) {
+          if (idx < read_set->pending_prefetch_flags_size_) {
+            read_set->pending_prefetch_flags_[idx].store(
+                false, std::memory_order_relaxed);
+          }
+        }
+      }
+
+      if (!blocks_to_dispatch.empty()) {
+        DispatchPrefetch(read_set, pending->job, blocks_to_dispatch);
+        dispatched_in_round = true;
+      }
     }
 
-    // Dispatch acquired blocks
-    if (!blocks_to_dispatch.empty()) {
-      DispatchPrefetch(read_set, job, blocks_to_dispatch);
-    }
-
-    // If we dispatched nothing, stop (no memory available for any group)
-    if (blocks_to_dispatch.empty()) {
+    if (!dispatched_in_round) {
       return;
     }
   }
@@ -639,10 +920,32 @@ void IODispatcherImpl::Impl::TryDispatchPendingPrefetches() {
 void IODispatcherImpl::Impl::DispatchPrefetch(
     const std::shared_ptr<ReadSet>& read_set, const std::shared_ptr<IOJob>& job,
     const std::vector<size_t>& block_indices) {
+  for (size_t idx : block_indices) {
+    read_set->acquired_bytes_[idx] = read_set->block_sizes_[idx];
+  }
+
   // Sync point for testing partial prefetch - passes number of blocks being
   // dispatched
   TEST_SYNC_POINT_CALLBACK("IODispatcherImpl::DispatchPrefetch:BlockCount",
                            const_cast<std::vector<size_t>*>(&block_indices));
+
+  auto release_undelivered_memory = [&]() {
+    for (size_t idx : block_indices) {
+      if (idx >= read_set->acquired_bytes_.size() ||
+          read_set->acquired_bytes_[idx] == 0) {
+        continue;
+      }
+
+      const bool delivered =
+          read_set->pinned_blocks_[idx].GetValue() != nullptr ||
+          read_set->async_io_map_.find(idx) != read_set->async_io_map_.end();
+      if (!delivered) {
+        ReleaseMemory(read_set->acquired_bytes_[idx],
+                      read_set->fairness_group_token_);
+        read_set->acquired_bytes_[idx] = 0;
+      }
+    }
+  };
 
   // Prepare and execute IO for the given blocks
   std::vector<FSReadRequest> read_reqs;
@@ -665,15 +968,19 @@ void IODispatcherImpl::Impl::DispatchPrefetch(
       Status s =
           ExecuteSyncIO(job, read_set, sync_read_reqs, sync_coalesced_indices);
       s.PermitUncheckedError();
-      read_set->num_sync_reads_ += fallback_indices.size();
+      read_set->num_sync_reads_.fetch_add(fallback_indices.size(),
+                                          std::memory_order_relaxed);
     }
     // Async errors are also ignored - user will get the error when reading
     async_status.PermitUncheckedError();
+    release_undelivered_memory();
   } else {
     // Prefetch errors are ignored - user will get the error when reading
     Status s = ExecuteSyncIO(job, read_set, read_reqs, coalesced_block_indices);
     s.PermitUncheckedError();
-    read_set->num_sync_reads_ += block_indices.size();
+    read_set->num_sync_reads_.fetch_add(block_indices.size(),
+                                        std::memory_order_relaxed);
+    release_undelivered_memory();
   }
 }
 
@@ -690,6 +997,9 @@ Status IODispatcherImpl::Impl::SubmitJob(const std::shared_ptr<IOJob>& job,
   rs->fs_ = job->table->get_rep()->ioptions.env->GetFileSystem();
   rs->pinned_blocks_.resize(job->block_handles.size());
   rs->block_sizes_.resize(job->block_handles.size(), 0);
+  rs->acquired_bytes_.resize(job->block_handles.size(), 0);
+  auto* fairness_group = GetOrCreateFairnessGroup(job);
+  rs->fairness_group_token_ = fairness_group;
 
   // Build sorted index for O(log n) ReadOffset lookups via binary search.
   // sorted_block_indices_[i] = original index of i-th smallest block by offset.
@@ -727,14 +1037,16 @@ Status IODispatcherImpl::Impl::SubmitJob(const std::shared_ptr<IOJob>& job,
   // Step 2: Prepare IO requests for blocks not in cache
   if (block_indices_to_read.empty()) {
     // All blocks found in cache - count them as cache hits
-    rs->num_cache_hits_ = job->block_handles.size();
+    rs->num_cache_hits_.store(job->block_handles.size(),
+                              std::memory_order_relaxed);
     *read_set = std::move(rs);
     return Status::OK();
   }
 
   // Count cache hits (blocks that were found in cache during lookup above)
-  rs->num_cache_hits_ =
-      job->block_handles.size() - block_indices_to_read.size();
+  rs->num_cache_hits_.store(
+      job->block_handles.size() - block_indices_to_read.size(),
+      std::memory_order_relaxed);
 
   // Calculate block sizes for uncached blocks
   for (const auto& idx : block_indices_to_read) {
@@ -749,15 +1061,21 @@ Status IODispatcherImpl::Impl::SubmitJob(const std::shared_ptr<IOJob>& job,
   // Pre-coalesce blocks into groups, respecting memory budget per group
   // This ensures we dispatch meaningful IO sizes, not tiny single-block IOs
   // Both memory-limited and non-memory-limited paths use the same coalescing
+  const size_t max_coalesced_group_bytes =
+      max_prefetch_memory_bytes_ == 0
+          ? 0
+          : std::max(
+                max_prefetch_memory_bytes_,
+                fairness_group->reserved_bytes.load(std::memory_order_relaxed));
   auto coalesced_groups = PreCoalesceBlocks(job, rs, block_indices_to_read,
-                                            max_prefetch_memory_bytes_);
+                                            max_coalesced_group_bytes);
 
   std::vector<size_t> blocks_to_dispatch;
   std::deque<CoalescedPrefetchGroup> groups_to_queue;
 
   // Try to acquire memory for entire coalesced groups
   for (auto& group : coalesced_groups) {
-    if (TryAcquireMemory(group.total_bytes)) {
+    if (TryAcquireMemory(group.total_bytes, fairness_group)) {
       // Add all blocks from this group to dispatch
       for (size_t idx : group.block_indices) {
         blocks_to_dispatch.push_back(idx);
@@ -778,7 +1096,6 @@ Status IODispatcherImpl::Impl::SubmitJob(const std::shared_ptr<IOJob>& job,
     auto pending = std::make_shared<PendingPrefetchRequest>();
     pending->read_set = rs;
     pending->job = job;
-
     size_t pending_bytes = 0;
     for (const auto& group : groups_to_queue) {
       for (size_t idx : group.block_indices) {
@@ -795,14 +1112,14 @@ Status IODispatcherImpl::Impl::SubmitJob(const std::shared_ptr<IOJob>& job,
         std::make_unique<std::atomic<bool>[]>(num_blocks);
     rs->pending_prefetch_flags_size_ = num_blocks;
     for (size_t idx : pending->block_indices_to_prefetch) {
-      rs->pending_prefetch_flags_[idx].store(true);
+      rs->pending_prefetch_flags_[idx].store(true, std::memory_order_relaxed);
     }
     rs->pending_request_ = pending;
 
     {
-      MutexLock lock(&memory_mutex_);
-      pending_prefetch_queue_.push_back(std::move(pending));
-      has_pending_requests_.store(true, std::memory_order_release);
+      MutexLock lock(&pending_mutex_);
+      fairness_group->pending_requests.push_back(std::move(pending));
+      EnqueuePendingGroupLocked(fairness_group);
     }
   }
 

--- a/util/io_dispatcher_test.cc
+++ b/util/io_dispatcher_test.cc
@@ -10,12 +10,14 @@
 
 #include "rocksdb/io_dispatcher.h"
 
+#include <atomic>
 #include <memory>
 #include <mutex>
 #include <thread>
 
 #include "db/db_test_util.h"
 #include "db/dbformat.h"
+#include "file/filename.h"
 #include "file/writable_file_writer.h"
 #include "rocksdb/cache.h"
 #include "rocksdb/env.h"
@@ -120,6 +122,22 @@ class ReadTrackingFS : public FileSystemWrapper {
     read_ops_.clear();
   }
 
+  void FailNextMultiRead() {
+    fail_next_multiread_.store(true, std::memory_order_release);
+  }
+
+  void FailNextReadAsync() {
+    fail_next_read_async_.store(true, std::memory_order_release);
+  }
+
+  bool ConsumeFailNextMultiRead() {
+    return fail_next_multiread_.exchange(false, std::memory_order_acq_rel);
+  }
+
+  bool ConsumeFailNextReadAsync() {
+    return fail_next_read_async_.exchange(false, std::memory_order_acq_rel);
+  }
+
   // Get count of MultiRead operations
   size_t GetMultiReadCount() const {
     std::lock_guard<std::mutex> lock(mutex_);
@@ -147,6 +165,8 @@ class ReadTrackingFS : public FileSystemWrapper {
  private:
   mutable std::mutex mutex_;
   std::vector<ReadOp> read_ops_;
+  std::atomic<bool> fail_next_multiread_{false};
+  std::atomic<bool> fail_next_read_async_{false};
 };
 
 IOStatus ReadTrackingRandomAccessFile::MultiRead(FSReadRequest* reqs,
@@ -161,6 +181,10 @@ IOStatus ReadTrackingRandomAccessFile::MultiRead(FSReadRequest* reqs,
   }
   fs_->RecordMultiRead(recorded_reqs);
 
+  if (fs_->ConsumeFailNextMultiRead()) {
+    return IOStatus::IOError("Injected MultiRead failure");
+  }
+
   // Delegate to underlying file
   return target()->MultiRead(reqs, num_reqs, options, dbg);
 }
@@ -172,12 +196,23 @@ IOStatus ReadTrackingRandomAccessFile::ReadAsync(
   // Record the read operation before executing it
   fs_->RecordReadAsync(req.offset, req.len);
 
+  if (fs_->ConsumeFailNextReadAsync()) {
+    return IOStatus::IOError("Injected ReadAsync failure");
+  }
+
   // Delegate to underlying file
   return target()->ReadAsync(req, opts, cb, cb_arg, io_handle, del_fn, dbg);
 }
 
 class IODispatcherTest : public DBTestBase {
  public:
+  struct SSTOptions {
+    int level = -1;
+    uint64_t file_num = 0;
+    size_t block_size = 16 * 1024;
+    size_t max_auto_readahead_size = 0;
+  };
+
   IODispatcherTest()
       : DBTestBase("io_dispatcher_test", /*env_do_fsync=*/false) {}
 
@@ -276,10 +311,17 @@ class IODispatcherTest : public DBTestBase {
   // The BlockBasedTable keeps references to these options
   std::vector<std::unique_ptr<ImmutableOptions>> all_ioptions_;
   std::vector<std::unique_ptr<EnvOptions>> all_env_options_;
+  std::vector<std::unique_ptr<BlockCacheTracer>> all_block_cache_tracers_;
 
   // Helper to create an SST file and open it as a table
   // Following pattern from table_test.cc TableConstructor
   Status CreateAndOpenSST(int num_blocks,
+                          std::unique_ptr<BlockBasedTable>* table,
+                          std::vector<BlockHandle>* block_handles_out) {
+    return CreateAndOpenSST(num_blocks, SSTOptions{}, table, block_handles_out);
+  }
+
+  Status CreateAndOpenSST(int num_blocks, const SSTOptions& sst_options,
                           std::unique_ptr<BlockBasedTable>* table,
                           std::vector<BlockHandle>* block_handles_out) {
     // Create options - store in member variables to avoid use-after-scope
@@ -288,17 +330,23 @@ class IODispatcherTest : public DBTestBase {
     options.statistics = nullptr;
     BlockBasedTableOptions table_options;
     table_options.block_cache = NewLRUCache(8 * 1024 * 1024);
-    table_options.block_size = 16 * 1024;
+    table_options.block_size = sst_options.block_size;
+    table_options.max_auto_readahead_size = sst_options.max_auto_readahead_size;
     table_options.no_block_cache = false;
     options.table_factory.reset(NewBlockBasedTableFactory(table_options));
 
     // Store these in member variables so they outlive the function
     auto ioptions = std::make_unique<ImmutableOptions>(options);
     auto moptions = MutableCFOptions{options};
-    InternalKeyComparator internal_comparator(options.comparator);
+
+    const uint64_t file_num =
+        sst_options.file_num != 0 ? sst_options.file_num : cur_file_num_++;
+    if (sst_options.file_num != 0 && file_num >= cur_file_num_) {
+      cur_file_num_ = file_num + 1;
+    }
 
     // Create in-memory file using StringSink (like table_test.cc)
-    auto table_name = "test_table";
+    auto table_name = MakeTableFileName(file_num);
     std::unique_ptr<WritableFileWriter> file_writer;
     NewFileWriter(table_name, &file_writer);
 
@@ -309,10 +357,13 @@ class IODispatcherTest : public DBTestBase {
     std::vector<std::unique_ptr<InternalTblPropCollFactory>>
         int_tbl_prop_coll_factories;
     TableBuilderOptions builder_options(
-        *ioptions, moptions, read_options, write_options, internal_comparator,
-        &int_tbl_prop_coll_factories, kNoCompression, options.compression_opts,
-        0 /* column_family_id */, column_family_name, -1 /* level */,
-        kUnknownNewestKeyTime);
+        *ioptions, moptions, read_options, write_options,
+        ioptions->internal_comparator, &int_tbl_prop_coll_factories,
+        kNoCompression, options.compression_opts, 0 /* column_family_id */,
+        column_family_name, sst_options.level, kUnknownNewestKeyTime,
+        false /* is_bottommost */, TableFileCreationReason::kMisc,
+        0 /* oldest_key_time */, 0 /* file_creation_time */, "" /* db_id */,
+        "" /* db_session_id */, 0 /* target_file_size */, file_num);
 
     std::unique_ptr<TableBuilder> builder(
         options.table_factory->NewTableBuilder(builder_options,
@@ -349,14 +400,17 @@ class IODispatcherTest : public DBTestBase {
 
     // Store EnvOptions and InternalKeyComparator to avoid use-after-scope
     auto soptions = std::make_unique<EnvOptions>();
-    BlockCacheTracer block_cache_tracer;
+    auto block_cache_tracer = std::make_unique<BlockCacheTracer>();
     std::unique_ptr<TableReader> table_reader;
 
-    auto ikc = InternalKeyComparator(options.comparator);
-    TableReaderOptions reader_options(*ioptions, moptions.prefix_extractor,
-                                      moptions.compression_manager.get(),
-                                      *soptions, ikc,
-                                      0 /* block_protection_bytes_per_key */);
+    TableReaderOptions reader_options(
+        *ioptions, moptions.prefix_extractor,
+        moptions.compression_manager.get(), *soptions,
+        ioptions->internal_comparator, 0 /* block_protection_bytes_per_key */,
+        false /* skip_filters */, false /* immortal */,
+        false /* force_direct_prefetch */, sst_options.level,
+        block_cache_tracer.get(), 0 /* max_file_size_for_l0_meta_pin */,
+        "" /* cur_db_session_id */, file_num);
 
     s = options.table_factory->NewTableReader(reader_options, std::move(file),
                                               file_size, &table_reader);
@@ -378,6 +432,7 @@ class IODispatcherTest : public DBTestBase {
     // Store all options in member variables to keep them alive
     all_ioptions_.push_back(std::move(ioptions));
     all_env_options_.push_back(std::move(soptions));
+    all_block_cache_tracers_.push_back(std::move(block_cache_tracer));
 
     return Status::OK();
   }
@@ -386,6 +441,15 @@ class IODispatcherTest : public DBTestBase {
 };
 
 uint64_t IODispatcherTest::cur_file_num_ = 1;
+
+std::shared_ptr<IOJob> NewSingleBlockJob(BlockBasedTable* table,
+                                         const BlockHandle& block_handle) {
+  auto job = std::make_shared<IOJob>();
+  job->table = table;
+  job->block_handles = {block_handle};
+  job->job_options.read_options.async_io = false;
+  return job;
+}
 
 TEST_F(IODispatcherTest, BasicSSTRead) {
   std::unique_ptr<IODispatcher> dispatcher(NewIODispatcher());
@@ -1788,6 +1852,390 @@ TEST_F(IODispatcherTest, CoalescedGroupsSplitByMemoryBudget) {
   for (size_t i = 0; i < blocks_per_dispatch.size(); ++i) {
     EXPECT_LE(blocks_per_dispatch[i], 5)
         << "Dispatch " << i << " exceeded memory budget";
+  }
+}
+
+TEST_F(IODispatcherTest,
+       FairnessDifferentNonL0LevelsGetSeparateInitialReservation) {
+  SSTOptions l1_options;
+  l1_options.level = 1;
+  l1_options.file_num = 101;
+  l1_options.max_auto_readahead_size = 64 * 1024;
+
+  SSTOptions l2_options;
+  l2_options.level = 2;
+  l2_options.file_num = 202;
+  l2_options.max_auto_readahead_size = 64 * 1024;
+
+  std::unique_ptr<BlockBasedTable> l1_table;
+  std::unique_ptr<BlockBasedTable> l2_table;
+  std::vector<BlockHandle> l1_handles;
+  std::vector<BlockHandle> l2_handles;
+  ASSERT_OK(CreateAndOpenSST(1, l1_options, &l1_table, &l1_handles));
+  ASSERT_OK(CreateAndOpenSST(1, l2_options, &l2_table, &l2_handles));
+  ASSERT_EQ(l1_handles.size(), 1);
+  ASSERT_EQ(l2_handles.size(), 1);
+
+  IODispatcherOptions options;
+  options.max_prefetch_memory_bytes =
+      BlockBasedTable::BlockSizeWithTrailer(l1_handles.front());
+  std::unique_ptr<IODispatcher> dispatcher(NewIODispatcher(options));
+
+  std::vector<size_t> blocks_per_dispatch;
+  SyncPoint::GetInstance()->SetCallBack(
+      "IODispatcherImpl::DispatchPrefetch:BlockCount", [&](void* arg) {
+        auto* indices = static_cast<std::vector<size_t>*>(arg);
+        blocks_per_dispatch.push_back(indices->size());
+      });
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  std::shared_ptr<ReadSet> read_set_l1;
+  ASSERT_OK(dispatcher->SubmitJob(
+      NewSingleBlockJob(l1_table.get(), l1_handles[0]), &read_set_l1));
+  ASSERT_EQ(blocks_per_dispatch, std::vector<size_t>({1}));
+
+  std::shared_ptr<ReadSet> read_set_l2;
+  ASSERT_OK(dispatcher->SubmitJob(
+      NewSingleBlockJob(l2_table.get(), l2_handles[0]), &read_set_l2));
+
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+
+  EXPECT_EQ(blocks_per_dispatch.size(), 2);
+  if (blocks_per_dispatch.size() >= 2) {
+    EXPECT_EQ(blocks_per_dispatch[1], 1);
+  }
+
+  CachableEntry<Block> block;
+  ASSERT_OK(read_set_l1->ReadIndex(0, &block));
+  ASSERT_NE(block.GetValue(), nullptr);
+  block.Reset();
+  ASSERT_OK(read_set_l2->ReadIndex(0, &block));
+  ASSERT_NE(block.GetValue(), nullptr);
+}
+
+TEST_F(IODispatcherTest, FairnessSameNonL0LevelSharesReservationAcrossFiles) {
+  SSTOptions first_options;
+  first_options.level = 3;
+  first_options.file_num = 303;
+  first_options.max_auto_readahead_size = 20 * 1024;
+
+  SSTOptions second_options = first_options;
+  second_options.file_num = 304;
+
+  std::unique_ptr<BlockBasedTable> first_table;
+  std::unique_ptr<BlockBasedTable> second_table;
+  std::vector<BlockHandle> first_handles;
+  std::vector<BlockHandle> second_handles;
+  ASSERT_OK(CreateAndOpenSST(1, first_options, &first_table, &first_handles));
+  ASSERT_OK(
+      CreateAndOpenSST(1, second_options, &second_table, &second_handles));
+  ASSERT_EQ(first_handles.size(), 1);
+  ASSERT_EQ(second_handles.size(), 1);
+
+  const auto first_block_bytes =
+      BlockBasedTable::BlockSizeWithTrailer(first_handles.front());
+
+  IODispatcherOptions options;
+  options.max_prefetch_memory_bytes = first_block_bytes;
+  std::unique_ptr<IODispatcher> dispatcher(NewIODispatcher(options));
+
+  std::vector<size_t> blocks_per_dispatch;
+  SyncPoint::GetInstance()->SetCallBack(
+      "IODispatcherImpl::DispatchPrefetch:BlockCount", [&](void* arg) {
+        auto* indices = static_cast<std::vector<size_t>*>(arg);
+        blocks_per_dispatch.push_back(indices->size());
+      });
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  std::shared_ptr<ReadSet> first_read_set;
+  ASSERT_OK(dispatcher->SubmitJob(
+      NewSingleBlockJob(first_table.get(), first_handles[0]), &first_read_set));
+  ASSERT_EQ(blocks_per_dispatch, std::vector<size_t>({1}));
+
+  std::shared_ptr<ReadSet> second_read_set;
+  ASSERT_OK(dispatcher->SubmitJob(
+      NewSingleBlockJob(second_table.get(), second_handles[0]),
+      &second_read_set));
+
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+
+  EXPECT_EQ(blocks_per_dispatch.size(), 1);
+
+  CachableEntry<Block> block;
+  ASSERT_OK(first_read_set->ReadIndex(0, &block));
+  ASSERT_NE(block.GetValue(), nullptr);
+  block.Reset();
+  ASSERT_OK(second_read_set->ReadIndex(0, &block));
+  ASSERT_NE(block.GetValue(), nullptr);
+}
+
+TEST_F(IODispatcherTest, FairnessDistinctL0FilesGetSeparateReservation) {
+  SSTOptions first_options;
+  first_options.level = 0;
+  first_options.file_num = 401;
+  first_options.max_auto_readahead_size = 64 * 1024;
+
+  SSTOptions second_options = first_options;
+  second_options.file_num = 402;
+
+  std::unique_ptr<BlockBasedTable> first_table;
+  std::unique_ptr<BlockBasedTable> second_table;
+  std::vector<BlockHandle> first_handles;
+  std::vector<BlockHandle> second_handles;
+  ASSERT_OK(CreateAndOpenSST(1, first_options, &first_table, &first_handles));
+  ASSERT_OK(
+      CreateAndOpenSST(1, second_options, &second_table, &second_handles));
+  ASSERT_EQ(first_handles.size(), 1);
+  ASSERT_EQ(second_handles.size(), 1);
+
+  IODispatcherOptions options;
+  options.max_prefetch_memory_bytes =
+      BlockBasedTable::BlockSizeWithTrailer(first_handles.front());
+  std::unique_ptr<IODispatcher> dispatcher(NewIODispatcher(options));
+
+  std::vector<size_t> blocks_per_dispatch;
+  SyncPoint::GetInstance()->SetCallBack(
+      "IODispatcherImpl::DispatchPrefetch:BlockCount", [&](void* arg) {
+        auto* indices = static_cast<std::vector<size_t>*>(arg);
+        blocks_per_dispatch.push_back(indices->size());
+      });
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  std::shared_ptr<ReadSet> first_read_set;
+  ASSERT_OK(dispatcher->SubmitJob(
+      NewSingleBlockJob(first_table.get(), first_handles[0]), &first_read_set));
+  ASSERT_EQ(blocks_per_dispatch, std::vector<size_t>({1}));
+
+  std::shared_ptr<ReadSet> second_read_set;
+  ASSERT_OK(dispatcher->SubmitJob(
+      NewSingleBlockJob(second_table.get(), second_handles[0]),
+      &second_read_set));
+
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+
+  EXPECT_EQ(blocks_per_dispatch.size(), 2);
+  if (blocks_per_dispatch.size() >= 2) {
+    EXPECT_EQ(blocks_per_dispatch[1], 1);
+  }
+
+  CachableEntry<Block> block;
+  ASSERT_OK(first_read_set->ReadIndex(0, &block));
+  ASSERT_NE(block.GetValue(), nullptr);
+  block.Reset();
+  ASSERT_OK(second_read_set->ReadIndex(0, &block));
+  ASSERT_NE(block.GetValue(), nullptr);
+}
+
+TEST_F(IODispatcherTest,
+       FairnessReservedOvercommitStillCountsAgainstParentBudget) {
+  auto stats = CreateDBStatistics();
+
+  SSTOptions l1_options;
+  l1_options.level = 1;
+  l1_options.file_num = 501;
+  l1_options.max_auto_readahead_size = 20 * 1024;
+
+  SSTOptions l2_options;
+  l2_options.level = 2;
+  l2_options.file_num = 502;
+  l2_options.max_auto_readahead_size = 20 * 1024;
+
+  SSTOptions same_level_options = l1_options;
+  same_level_options.file_num = 503;
+
+  std::unique_ptr<BlockBasedTable> l1_table;
+  std::unique_ptr<BlockBasedTable> l2_table;
+  std::unique_ptr<BlockBasedTable> same_level_table;
+  std::vector<BlockHandle> l1_handles;
+  std::vector<BlockHandle> l2_handles;
+  std::vector<BlockHandle> same_level_handles;
+  ASSERT_OK(CreateAndOpenSST(1, l1_options, &l1_table, &l1_handles));
+  ASSERT_OK(CreateAndOpenSST(1, l2_options, &l2_table, &l2_handles));
+  ASSERT_OK(CreateAndOpenSST(1, same_level_options, &same_level_table,
+                             &same_level_handles));
+  ASSERT_EQ(l1_handles.size(), 1);
+  ASSERT_EQ(l2_handles.size(), 1);
+  ASSERT_EQ(same_level_handles.size(), 1);
+
+  const auto l1_block_bytes =
+      BlockBasedTable::BlockSizeWithTrailer(l1_handles.front());
+  const auto l2_block_bytes =
+      BlockBasedTable::BlockSizeWithTrailer(l2_handles.front());
+
+  IODispatcherOptions options;
+  options.max_prefetch_memory_bytes = l1_block_bytes;
+  options.statistics = stats.get();
+  std::unique_ptr<IODispatcher> dispatcher(NewIODispatcher(options));
+
+  std::shared_ptr<ReadSet> l1_read_set;
+  ASSERT_OK(dispatcher->SubmitJob(
+      NewSingleBlockJob(l1_table.get(), l1_handles[0]), &l1_read_set));
+  EXPECT_EQ(stats->getTickerCount(PREFETCH_MEMORY_BYTES_GRANTED),
+            l1_block_bytes);
+
+  std::shared_ptr<ReadSet> l2_read_set;
+  ASSERT_OK(dispatcher->SubmitJob(
+      NewSingleBlockJob(l2_table.get(), l2_handles[0]), &l2_read_set));
+  EXPECT_EQ(stats->getTickerCount(PREFETCH_MEMORY_BYTES_GRANTED),
+            l1_block_bytes + l2_block_bytes);
+  EXPECT_GT(stats->getTickerCount(PREFETCH_MEMORY_BYTES_GRANTED),
+            options.max_prefetch_memory_bytes);
+
+  std::shared_ptr<ReadSet> same_level_read_set;
+  ASSERT_OK(dispatcher->SubmitJob(
+      NewSingleBlockJob(same_level_table.get(), same_level_handles[0]),
+      &same_level_read_set));
+  EXPECT_EQ(stats->getTickerCount(PREFETCH_MEMORY_BYTES_GRANTED),
+            l1_block_bytes + l2_block_bytes);
+
+  CachableEntry<Block> block;
+  ASSERT_OK(l1_read_set->ReadIndex(0, &block));
+  ASSERT_NE(block.GetValue(), nullptr);
+  block.Reset();
+  ASSERT_OK(l2_read_set->ReadIndex(0, &block));
+  ASSERT_NE(block.GetValue(), nullptr);
+  block.Reset();
+  ASSERT_OK(same_level_read_set->ReadIndex(0, &block));
+  ASSERT_NE(block.GetValue(), nullptr);
+}
+
+TEST_F(IODispatcherTest, FairnessPendingRoundRobinAcrossGroups) {
+  SSTOptions l1_options;
+  l1_options.level = 1;
+  l1_options.file_num = 601;
+  l1_options.block_size = 4 * 1024;
+  l1_options.max_auto_readahead_size = 6 * 1024;
+
+  SSTOptions l2_options = l1_options;
+  l2_options.level = 2;
+  l2_options.file_num = 602;
+
+  std::unique_ptr<BlockBasedTable> l1_table;
+  std::unique_ptr<BlockBasedTable> l2_table;
+  std::vector<BlockHandle> l1_handles;
+  std::vector<BlockHandle> l2_handles;
+  ASSERT_OK(CreateAndOpenSST(2, l1_options, &l1_table, &l1_handles));
+  ASSERT_OK(CreateAndOpenSST(2, l2_options, &l2_table, &l2_handles));
+  ASSERT_GE(l1_handles.size(), 2);
+  ASSERT_GE(l2_handles.size(), 2);
+
+  const size_t block_bytes =
+      BlockBasedTable::BlockSizeWithTrailer(l1_handles.front());
+  ASSERT_LT(block_bytes, l1_options.max_auto_readahead_size);
+  ASSERT_GT(block_bytes * 2, l1_options.max_auto_readahead_size);
+
+  IODispatcherOptions options;
+  options.max_prefetch_memory_bytes = block_bytes;
+  std::unique_ptr<IODispatcher> dispatcher(NewIODispatcher(options));
+
+  std::unordered_map<int, uint64_t> level_to_group;
+  std::vector<uint64_t> granted_group_ids;
+  auto* sync_point = SyncPoint::GetInstance();
+  sync_point->SetCallBack("IODispatcherImpl::GetFairnessGroup", [&](void* arg) {
+    auto* info = static_cast<std::tuple<int, uint64_t, uint64_t>*>(arg);
+    const int level = std::get<0>(*info);
+    if (level > 0) {
+      level_to_group[level] = std::get<2>(*info);
+    }
+  });
+  sync_point->SetCallBack(
+      "IODispatcherImpl::TryAcquireMemory:Granted", [&](void* arg) {
+        auto* info = static_cast<std::tuple<uint64_t, size_t, bool>*>(arg);
+        granted_group_ids.push_back(std::get<0>(*info));
+      });
+  sync_point->EnableProcessing();
+
+  auto l1_job = std::make_shared<IOJob>();
+  l1_job->table = l1_table.get();
+  l1_job->block_handles = {l1_handles[0], l1_handles[1]};
+
+  auto l2_job = std::make_shared<IOJob>();
+  l2_job->table = l2_table.get();
+  l2_job->block_handles = {l2_handles[0], l2_handles[1]};
+
+  std::shared_ptr<ReadSet> l1_read_set;
+  ASSERT_OK(dispatcher->SubmitJob(l1_job, &l1_read_set));
+  std::shared_ptr<ReadSet> l2_read_set;
+  ASSERT_OK(dispatcher->SubmitJob(l2_job, &l2_read_set));
+
+  ASSERT_EQ(level_to_group.size(), 2);
+  ASSERT_NE(level_to_group[1], level_to_group[2]);
+  ASSERT_TRUE(l1_read_set->IsBlockAvailable(0));
+  ASSERT_TRUE(l2_read_set->IsBlockAvailable(0));
+
+  granted_group_ids.clear();
+
+  // Level 1 still occupies its reservation, so a FIFO pending queue would stop
+  // on that blocked group here. The fair scheduler should skip it and dispatch
+  // level 2's pending block instead.
+  l2_read_set->ReleaseBlock(0);
+  ASSERT_EQ(granted_group_ids.size(), 1);
+  EXPECT_EQ(granted_group_ids.front(), level_to_group[2]);
+
+  granted_group_ids.clear();
+  l1_read_set->ReleaseBlock(0);
+  ASSERT_EQ(granted_group_ids.size(), 1);
+  EXPECT_EQ(granted_group_ids.front(), level_to_group[1]);
+
+  sync_point->DisableProcessing();
+  sync_point->ClearAllCallBacks();
+
+  CachableEntry<Block> block;
+  ASSERT_OK(l1_read_set->ReadIndex(1, &block));
+  ASSERT_NE(block.GetValue(), nullptr);
+  block.Reset();
+  ASSERT_OK(l2_read_set->ReadIndex(1, &block));
+  ASSERT_NE(block.GetValue(), nullptr);
+}
+
+TEST_F(IODispatcherTest, AcquiredBytesReleasedWhenDispatchDeliversNoBlocks) {
+  for (bool async : {false, true}) {
+    if (async && !kIOUringPresent) {
+      continue;
+    }
+    SCOPED_TRACE("async_io=" + std::to_string(async));
+
+    auto stats = CreateDBStatistics();
+    IODispatcherOptions opts;
+    opts.max_prefetch_memory_bytes = 64 * 1024;
+    opts.statistics = stats.get();
+    std::unique_ptr<IODispatcher> dispatcher(NewIODispatcher(opts));
+
+    std::unique_ptr<BlockBasedTable> table;
+    std::vector<BlockHandle> block_handles;
+    ASSERT_OK(CreateAndOpenSST(1, &table, &block_handles));
+    ASSERT_EQ(block_handles.size(), 1);
+
+    if (async) {
+      tracking_fs_->FailNextReadAsync();
+    } else {
+      tracking_fs_->FailNextMultiRead();
+    }
+
+    auto job = NewSingleBlockJob(table.get(), block_handles.front());
+    job->job_options.read_options.async_io = async;
+
+    std::shared_ptr<ReadSet> read_set;
+    ASSERT_OK(dispatcher->SubmitJob(job, &read_set));
+    ASSERT_NE(read_set, nullptr);
+
+    const uint64_t granted =
+        stats->getTickerCount(PREFETCH_MEMORY_BYTES_GRANTED);
+    const uint64_t released =
+        stats->getTickerCount(PREFETCH_MEMORY_BYTES_RELEASED);
+    ASSERT_GT(granted, 0);
+    EXPECT_EQ(released, granted);
+
+    CachableEntry<Block> block;
+    ASSERT_OK(read_set->ReadIndex(0, &block));
+    ASSERT_NE(block.GetValue(), nullptr);
+    read_set->ReleaseBlock(0);
+
+    EXPECT_EQ(stats->getTickerCount(PREFETCH_MEMORY_BYTES_RELEASED),
+              stats->getTickerCount(PREFETCH_MEMORY_BYTES_GRANTED));
   }
 }
 


### PR DESCRIPTION
Summary:

Associate dispatcher jobs/read sets with level identity so async multiscan prefetching can reserve minimum bytes per level (or per L0 file) and avoid starvation under a tight global prefetch cap.

This wires level-aware dispatcher usage into iterator prepare paths, updates dispatcher accounting/scheduling for fairness, adds coverage in db iterator / block-based table reader / io dispatcher tests, and updates db_crashtest settings to stress this path. Follow-up fixes keep test helper-owned table state alive, document fairness groups, trim dispatcher bookkeeping overhead for the common single-iterator case, clarify the public prefetch-budget semantics, and document why db_crashtest normalizes the final operation mix after sanitization.

Benchmark scenario names below use a starvation-shaped local release `db_bench` `multiscanrandom` workload with `--use_direct_reads=1` and `--cache_size=1048576`:
- `hot`: `--num=100000` hot-range-only run.
- `mix`: `--num=200000` mixed hot+cold run.
- `tight`: shared iterator-global dispatcher cap `32KB`.
- `unlim`: shared iterator-global dispatcher cap `1GB`.

`us/op` in the tables below is `multiscanrandom` operation latency, so lower is better.

No-global-dispatcher control (`--io_dispatcher_max_prefetch_memory_bytes=0`, so no shared dispatcher is passed in `MultiScanArgs`):

| Scenario | Baseline CPU | New CPU | Baseline us/op | New us/op | Delta |
| --- | ---: | ---: | ---: | ---: | ---: |
| hot_tight | 105% | 105% | 41338.540 | 40050.777 | -3.12% |
| hot_unlim | 105% | 105% | 41577.384 | 40277.252 | -3.13% |
| mix_tight | 105% | 106% | 61887.139 | 60986.746 | -1.45% |
| mix_unlim | 105% | 105% | 62072.474 | 60070.075 | -3.23% |

That near-flat control supports this being a fairness-path change rather than a broad multiscan regression.

Shared-dispatcher results:

| Scenario | Baseline us/op | New us/op | Delta |
| --- | ---: | ---: | ---: |
| hot_tight | 79363.336 | 76540.548 | -3.56% |
| hot_unlim | 41536.377 | 40906.507 | -1.52% |
| mix_tight | 118133.863 | 102916.154 | -12.88% |
| mix_unlim | 64317.947 | 61896.175 | -3.77% |

Under the tight cap, granted prefetch bytes also increased about `2.9x` in `hot_tight` and `3.3x` in `mix_tight`, matching the intended fairness behavior.

CPU-timed rerun on the same shared-dispatcher setup:

| Scenario | Baseline CPU | New CPU | Baseline us/op | New us/op | Delta |
| --- | ---: | ---: | ---: | ---: | ---: |
| hot_tight | 33% | 56% | 319308.816 | 169243.211 | -47.00% |
| hot_unlim | 106% | 105% | 54581.514 | 46016.096 | -15.69% |
| mix_tight | 32% | 66% | 476899.000 | 149826.099 | -68.58% |
| mix_unlim | 105% | 105% | 61369.311 | 61010.487 | -0.58% |

The higher CPU in `hot_tight` and `mix_tight` reflects more successful async prefetch/completion work under the tight shared cap rather than a broad regression: the no-global-dispatcher control stays flat, while the shared-dispatcher latency drops materially, especially in `mix_tight`.

___

`Trail`: https://trail.nest.x2p.facebook.net/c/f4d2e6da-fab3-4589-8bd9-229509de5db6

Reviewed By: hx235

Differential Revision: D101838337


