### PR TITLE
Update buckifier to use folly/coro instead of folly/experimental/coro (#14685)

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -378,10 +378,10 @@ cpp_library_wrapper(name="rocksdb_lib", srcs=[
         "utilities/write_batch_with_index/write_batch_with_index_internal.cc",
     ], deps=[
         "//folly/container:f14_hash",
-        "//folly/experimental/coro:blocking_wait",
-        "//folly/experimental/coro:collect",
-        "//folly/experimental/coro:coroutine",
-        "//folly/experimental/coro:task",
+        "//folly/coro:blocking_wait",
+        "//folly/coro:collect",
+        "//folly/coro:coroutine",
+        "//folly/coro:task",
         "//folly/synchronization:distributed_mutex",
     ], headers=glob(["**/*.h"]), link_whole=False, extra_test_libs=False)
 

--- a/buckifier/buckify_rocksdb.py
+++ b/buckifier/buckify_rocksdb.py
@@ -146,10 +146,10 @@ def generate_buck(repo_path, deps_map):
         src_mk["RANGE_TREE_SOURCES"] + src_mk["TOOL_LIB_SOURCES"],
         deps=[
             "//folly/container:f14_hash",
-            "//folly/experimental/coro:blocking_wait",
-            "//folly/experimental/coro:collect",
-            "//folly/experimental/coro:coroutine",
-            "//folly/experimental/coro:task",
+            "//folly/coro:blocking_wait",
+            "//folly/coro:collect",
+            "//folly/coro:coroutine",
+            "//folly/coro:task",
             "//folly/synchronization:distributed_mutex",
         ],
         headers=LiteralValue("glob([\"**/*.h\"])")


### PR DESCRIPTION
Summary:

D102823090 migrated the generated RocksDB BUCK file from
`//folly/experimental/coro:*` to `//folly/coro:*`, but did not update
the buckifier script that generates it. This leaves the BUCK file and
buckifier out of sync — the next buckifier run would revert the BUCK
change.

Update buckify_rocksdb.py to match, so the generated BUCK file stays
consistent with the folly coro migration.

Reviewed By: nmk70

Differential Revision: D103096688


