### PR TITLE
Rename path flags to root-directory semantics

### DIFF
--- a/db_stress_tool/batched_ops_stress.cc
+++ b/db_stress_tool/batched_ops_stress.cc
@@ -13,7 +13,8 @@
 namespace ROCKSDB_NAMESPACE {
 class BatchedOpsStressTest : public StressTest {
  public:
-  BatchedOpsStressTest() = default;
+  explicit BatchedOpsStressTest(int db_index)
+      : StressTest(db_index) {}
   virtual ~BatchedOpsStressTest() = default;
 
   bool IsStateTracked() const override { return false; }
@@ -722,7 +723,9 @@ class BatchedOpsStressTest : public StressTest {
   }
 };
 
-StressTest* CreateBatchedOpsStressTest() { return new BatchedOpsStressTest(); }
+StressTest* CreateBatchedOpsStressTest(int db_index) {
+  return new BatchedOpsStressTest(db_index);
+}
 
 }  // namespace ROCKSDB_NAMESPACE
 #endif  // GFLAGS

--- a/db_stress_tool/cf_consistency_stress.cc
+++ b/db_stress_tool/cf_consistency_stress.cc
@@ -21,7 +21,8 @@
 namespace ROCKSDB_NAMESPACE {
 class CfConsistencyStressTest : public StressTest {
  public:
-  CfConsistencyStressTest() : batch_id_(0) {}
+  explicit CfConsistencyStressTest(int db_index)
+      : StressTest(db_index), batch_id_(0) {}
 
   ~CfConsistencyStressTest() override = default;
 
@@ -1543,8 +1544,8 @@ class CfConsistencyStressTest : public StressTest {
   std::deque<DebugEvent> recent_debug_events_;
 };
 
-StressTest* CreateCfConsistencyStressTest() {
-  return new CfConsistencyStressTest();
+StressTest* CreateCfConsistencyStressTest(int db_index) {
+  return new CfConsistencyStressTest(db_index);
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -186,10 +186,10 @@ DECLARE_double(uniform_cv_threshold);
 DECLARE_bool(use_trie_index);
 DECLARE_bool(use_udi_as_primary_index);
 DECLARE_bool(test_backward_scan);
-DECLARE_string(db);
-DECLARE_string(secondaries_base);
+DECLARE_string(db_root);
+DECLARE_string(secondary_dbs_root);
 DECLARE_bool(test_secondary);
-DECLARE_string(expected_values_dir);
+DECLARE_string(expected_states_root);
 DECLARE_bool(expected_state_trace_debug);
 DECLARE_int64(expected_state_trace_debug_key);
 DECLARE_int32(expected_state_trace_debug_max_logs);
@@ -826,10 +826,10 @@ AttributeGroups GenerateAttributeGroups(
     const std::vector<ColumnFamilyHandle*>& cfhs, uint32_t value_base,
     const Slice& slice);
 
-StressTest* CreateCfConsistencyStressTest();
-StressTest* CreateBatchedOpsStressTest();
-StressTest* CreateNonBatchedOpsStressTest();
-StressTest* CreateMultiOpsTxnsStressTest();
+StressTest* CreateCfConsistencyStressTest(int db_index);
+StressTest* CreateBatchedOpsStressTest(int db_index);
+StressTest* CreateNonBatchedOpsStressTest(int db_index);
+StressTest* CreateMultiOpsTxnsStressTest(int db_index);
 void CheckAndSetOptionsForMultiOpsTxnStressTest();
 void InitializeHotKeyGenerator(double alpha);
 int64_t GetOneHotKeyID(double rand_seed, int64_t max_key);

--- a/db_stress_tool/db_stress_driver.cc
+++ b/db_stress_tool/db_stress_driver.cc
@@ -68,9 +68,11 @@ bool RunStressTestImpl(SharedState* shared) {
   StressTest* stress = shared->GetStressTest();
 
   if (shared->ShouldVerifyAtBeginning() && FLAGS_preserve_unverified_changes) {
-    Status s = InitUnverifiedSubdir(FLAGS_db);
-    if (s.ok() && !FLAGS_expected_values_dir.empty()) {
-      s = InitUnverifiedSubdir(FLAGS_expected_values_dir);
+    const std::string db_path = stress->GetDbPath();
+    const std::string expected_values_dir = stress->GetExpectedValuesDir();
+    Status s = InitUnverifiedSubdir(db_path);
+    if (s.ok() && !expected_values_dir.empty()) {
+      s = InitUnverifiedSubdir(expected_values_dir);
     }
     if (!s.ok()) {
       fprintf(stderr, "Failed to setup unverified state dir: %s\n",
@@ -159,9 +161,10 @@ bool RunStressTestImpl(SharedState* shared) {
         fprintf(stderr, "Crash-recovery verification failed :(\n");
       } else {
         fprintf(stdout, "Crash-recovery verification passed :)\n");
-        Status s = DestroyUnverifiedSubdir(FLAGS_db);
-        if (s.ok() && !FLAGS_expected_values_dir.empty()) {
-          s = DestroyUnverifiedSubdir(FLAGS_expected_values_dir);
+        const std::string ev_dir = stress->GetExpectedValuesDir();
+        Status s = DestroyUnverifiedSubdir(stress->GetDbPath());
+        if (s.ok() && !ev_dir.empty()) {
+          s = DestroyUnverifiedSubdir(ev_dir);
         }
         if (!s.ok()) {
           fprintf(stderr, "Failed to cleanup unverified state dir: %s\n",
@@ -174,7 +177,7 @@ bool RunStressTestImpl(SharedState* shared) {
     if (!FLAGS_verification_only) {
       // This is after the verification step to avoid making all those `Get()`s
       // and `MultiGet()`s contend on the DB-wide trace mutex.
-      if (!FLAGS_expected_values_dir.empty()) {
+      if (!stress->GetExpectedValuesDir().empty()) {
         stress->TrackExpectedState(shared);
       }
 

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -24,7 +24,7 @@ static bool ValidateUint32Range(const char* flagname, uint64_t value) {
 
 DEFINE_uint64(seed, 2341234,
               "Seed for PRNG. When --nooverwritepercent is "
-              "nonzero and --expected_values_dir is nonempty, this value "
+              "nonzero and --expected_states_root is nonempty, this value "
               "must be fixed across invocations.");
 static const bool FLAGS_seed_dummy __attribute__((__unused__)) =
     RegisterFlagValidator(&FLAGS_seed, &ValidateUint32Range);
@@ -683,23 +683,27 @@ DEFINE_bool(use_udi_as_primary_index, false,
 DEFINE_bool(test_backward_scan, true,
             "Test backward iteration (Prev, SeekForPrev) in stress tests.");
 
-DEFINE_string(db, "", "Use the db with the following name.");
+DEFINE_string(db_root, "",
+              "Use this path as the root directory for primary DB instances. "
+              "Each DB instance is resolved under this root as db_<i>.");
 
-DEFINE_string(secondaries_base, "",
-              "Use this path as the base path for secondary instances.");
+DEFINE_string(secondary_dbs_root, "",
+              "Use this path as the root directory for secondary DB "
+              "instances. Each primary DB at db_root/db_<i> has exactly one "
+              "secondary instance at secondary_dbs_root/db_<i>.");
 
 DEFINE_bool(test_secondary, false,
             "If true, start an additional secondary instance which can be used "
             "for verification.");
 
 DEFINE_string(
-    expected_values_dir, "",
-    "Dir where files containing info about the latest/historical values will "
-    "be stored. If provided and non-empty, the DB state will be verified "
-    "against values from these files after recovery. --max_key and "
+    expected_states_root, "",
+    "Root directory where expected-state files for each DB instance will be "
+    "stored under db_<i>. If provided and non-empty, the DB state will be "
+    "verified against values from these files after recovery. --max_key and "
     "--column_family must be kept the same across invocations of this program "
-    "that use the same --expected_values_dir. Currently historical values are "
-    "only tracked when --sync_fault_injection is set. See --seed and "
+    "that use the same --expected_states_root. Currently historical values "
+    "are only tracked when --sync_fault_injection is set. See --seed and "
     "--nooverwritepercent for further requirements.");
 
 DEFINE_bool(expected_state_trace_debug, true,
@@ -1006,7 +1010,7 @@ static const bool FLAGS_delrangepercent_dummy __attribute__((__unused__)) =
 
 DEFINE_int32(nooverwritepercent, 60,
              "Ratio of keys without overwrite to total workload (expressed as "
-             "a percentage). When --expected_values_dir is nonempty, must "
+             "a percentage). When --expected_states_root is nonempty, must "
              "keep this value constant across invocations.");
 static const bool FLAGS_nooverwritepercent_dummy __attribute__((__unused__)) =
     RegisterFlagValidator(&FLAGS_nooverwritepercent, &ValidateInt32Percent);
@@ -1205,7 +1209,7 @@ DEFINE_bool(sync_fault_injection, false,
             "If true, FaultInjectionTestFS will be used for write operations, "
             "and unsynced data in DB will lost after crash. In such a case we "
             "track DB changes in a trace file (\"*.trace\") in "
-            "--expected_values_dir for verifying there are no holes in the "
+            "--expected_states_root for verifying there are no holes in the "
             "recovered data.");
 
 DEFINE_bool(best_efforts_recovery, false,
@@ -1360,11 +1364,12 @@ DEFINE_uint64(
 
 DEFINE_bool(
     preserve_unverified_changes, false,
-    "DB files of the current run will all be preserved in `FLAGS_db`. DB files "
-    "from the last run will be preserved in `FLAGS_db/unverified` until the "
-    "first verification succeeds. Expected state files from the last run will "
-    "be preserved similarly under `FLAGS_expected_values_dir/unverified` when "
-    "`--expected_values_dir` is nonempty.");
+    "DB files of the current run will all be preserved under "
+    "`FLAGS_db_root/db_<i>`. DB files from the last run will be preserved in "
+    "`FLAGS_db_root/db_<i>/unverified` until the first verification succeeds. "
+    "Expected state files from the last run will be preserved similarly under "
+    "`FLAGS_expected_states_root/db_<i>/unverified` when "
+    "`--expected_states_root` is nonempty.");
 
 DEFINE_uint64(stats_dump_period_sec,
               ROCKSDB_NAMESPACE::Options().stats_dump_period_sec,

--- a/db_stress_tool/db_stress_listener.cc
+++ b/db_stress_tool/db_stress_listener.cc
@@ -7,6 +7,7 @@
 
 #include <cstdint>
 
+#include "db_stress_tool/db_stress_test_base.h"
 #include "file/file_util.h"
 #include "rocksdb/file_system.h"
 #include "util/coding_lean.h"
@@ -14,6 +15,19 @@
 namespace ROCKSDB_NAMESPACE {
 
 #ifdef GFLAGS
+
+DbStressListener::DbStressListener(
+    const std::string& db_name, const std::vector<DbPath>& db_paths,
+    const std::vector<ColumnFamilyDescriptor>& column_families,
+    SharedState* shared)
+    : db_name_(db_name),
+      db_paths_(db_paths),
+      column_families_(column_families),
+      num_pending_file_creations_(0),
+      unique_ids_(shared->GetStressTest()->GetExpectedValuesDir().empty()
+                      ? db_name
+                      : shared->GetStressTest()->GetExpectedValuesDir()),
+      shared_(shared) {}
 
 UniqueIdVerifier::UniqueIdVerifier(const std::string& dir)
     : path_(dir + "/.unique_ids") {

--- a/db_stress_tool/db_stress_listener.h
+++ b/db_stress_tool/db_stress_listener.h
@@ -55,15 +55,7 @@ class DbStressListener : public EventListener {
   DbStressListener(const std::string& db_name,
                    const std::vector<DbPath>& db_paths,
                    const std::vector<ColumnFamilyDescriptor>& column_families,
-                   SharedState* shared)
-      : db_name_(db_name),
-        db_paths_(db_paths),
-        column_families_(column_families),
-        num_pending_file_creations_(0),
-        unique_ids_(FLAGS_expected_values_dir.empty()
-                        ? db_name
-                        : FLAGS_expected_values_dir),
-        shared_(shared) {}
+                   SharedState* shared);
 
   const char* Name() const override { return kClassName(); }
   static const char* kClassName() { return "DBStressListener"; }

--- a/db_stress_tool/db_stress_shared_state.cc
+++ b/db_stress_tool/db_stress_shared_state.cc
@@ -11,7 +11,109 @@
 #ifdef GFLAGS
 #include "db_stress_tool/db_stress_shared_state.h"
 
+#include "db_stress_tool/db_stress_test_base.h"
+
 namespace ROCKSDB_NAMESPACE {
 thread_local bool SharedState::ignore_read_error;
+
+SharedState::SharedState(Env* /*env*/, StressTest* stress_test)
+    : cv_(&mu_),
+      seed_(static_cast<uint32_t>(FLAGS_seed)),
+      max_key_(FLAGS_max_key),
+      log2_keys_per_lock_(static_cast<uint32_t>(FLAGS_log2_keys_per_lock)),
+      num_threads_(0),
+      num_initialized_(0),
+      num_populated_(0),
+      vote_reopen_(0),
+      num_done_(0),
+      start_(false),
+      start_verify_(false),
+      num_bg_threads_(0),
+      should_stop_bg_thread_(false),
+      bg_thread_finished_(0),
+      stress_test_(stress_test),
+      verification_failure_(false),
+      should_stop_test_(false),
+      no_overwrite_ids_(GenerateNoOverwriteIds()),
+      expected_state_manager_(nullptr),
+      printing_verification_results_(false),
+      start_timestamp_(Env::Default()->NowNanos()) {
+  const std::string expected_values_dir = stress_test_->GetExpectedValuesDir();
+  Status status;
+  // TODO: We should introduce a way to explicitly disable verification
+  // during shutdown. When that is disabled and expected_states_root
+  // is empty (disabling verification at startup), we can skip tracking
+  // expected state. Only then should we permit bypassing the below feature
+  // compatibility checks.
+  if (!expected_values_dir.empty()) {
+    if (!std::atomic<uint32_t>{}.is_lock_free() ||
+        !std::atomic<uint64_t>{}.is_lock_free()) {
+      std::ostringstream status_s;
+      status_s << "Cannot use --expected_states_root on platforms without "
+                  "lock-free "
+               << (!std::atomic<uint32_t>{}.is_lock_free()
+                       ? "std::atomic<uint32_t>"
+                       : "std::atomic<uint64_t>");
+      status = Status::InvalidArgument(status_s.str());
+    }
+
+    if (status.ok() && FLAGS_clear_column_family_one_in > 0) {
+      status = Status::InvalidArgument(
+          "Cannot use --expected_states_root when "
+          "--clear_column_family_one_in is greater than zero.");
+    }
+  }
+  if (status.ok()) {
+    if (expected_values_dir.empty()) {
+      expected_state_manager_.reset(
+          new AnonExpectedStateManager(FLAGS_max_key, FLAGS_column_families));
+    } else {
+      expected_state_manager_.reset(new FileExpectedStateManager(
+          FLAGS_max_key, FLAGS_column_families, expected_values_dir));
+    }
+    status = expected_state_manager_->Open();
+  }
+  if (!status.ok()) {
+    fprintf(stderr, "Failed setting up expected state with error: %s\n",
+            status.ToString().c_str());
+    exit(1);
+  }
+
+  if (FLAGS_test_batches_snapshots) {
+    fprintf(stdout, "No lock creation because test_batches_snapshots set\n");
+    return;
+  }
+
+  long num_locks = static_cast<long>(max_key_ >> log2_keys_per_lock_);
+  if (max_key_ & ((1 << log2_keys_per_lock_) - 1)) {
+    num_locks++;
+  }
+  fprintf(stdout, "Creating %ld locks\n", num_locks * FLAGS_column_families);
+  key_locks_.resize(FLAGS_column_families);
+
+  for (int i = 0; i < FLAGS_column_families; ++i) {
+    key_locks_[i].reset(new port::Mutex[num_locks]);
+  }
+  if (FLAGS_read_fault_one_in || FLAGS_metadata_read_fault_one_in) {
+#ifdef NDEBUG
+    // Unsupported in release mode because it relies on
+    // `IGNORE_STATUS_IF_ERROR` to distinguish faults not expected to lead to
+    // failure.
+    fprintf(stderr,
+            "Cannot set nonzero value for --read_fault_one_in in "
+            "release mode.");
+    exit(1);
+#else   // NDEBUG
+    SyncPoint::GetInstance()->SetCallBack("FaultInjectionIgnoreError",
+                                          IgnoreReadErrorCallback);
+    SyncPoint::GetInstance()->EnableProcessing();
+#endif  // NDEBUG
+  }
+}
+
+bool SharedState::ShouldVerifyAtBeginning() const {
+  return !stress_test_->GetExpectedValuesDir().empty();
+}
+
 }  // namespace ROCKSDB_NAMESPACE
 #endif  // GFLAGS

--- a/db_stress_tool/db_stress_shared_state.h
+++ b/db_stress_tool/db_stress_shared_state.h
@@ -24,7 +24,6 @@ DECLARE_uint64(log2_keys_per_lock);
 DECLARE_int32(threads);
 DECLARE_int32(column_families);
 DECLARE_int32(nooverwritepercent);
-DECLARE_string(expected_values_dir);
 DECLARE_int32(clear_column_family_one_in);
 DECLARE_bool(test_batches_snapshots);
 DECLARE_int32(compaction_thread_pool_adjust_interval);
@@ -78,99 +77,7 @@ class SharedState {
   // for those calls
   static thread_local bool ignore_read_error;
 
-  SharedState(Env* /*env*/, StressTest* stress_test)
-      : cv_(&mu_),
-        seed_(static_cast<uint32_t>(FLAGS_seed)),
-        max_key_(FLAGS_max_key),
-        log2_keys_per_lock_(static_cast<uint32_t>(FLAGS_log2_keys_per_lock)),
-        num_threads_(0),
-        num_initialized_(0),
-        num_populated_(0),
-        vote_reopen_(0),
-        num_done_(0),
-        start_(false),
-        start_verify_(false),
-        num_bg_threads_(0),
-        should_stop_bg_thread_(false),
-        bg_thread_finished_(0),
-        stress_test_(stress_test),
-        verification_failure_(false),
-        should_stop_test_(false),
-        no_overwrite_ids_(GenerateNoOverwriteIds()),
-        expected_state_manager_(nullptr),
-        printing_verification_results_(false),
-        start_timestamp_(Env::Default()->NowNanos()) {
-    Status status;
-    // TODO: We should introduce a way to explicitly disable verification
-    // during shutdown. When that is disabled and FLAGS_expected_values_dir
-    // is empty (disabling verification at startup), we can skip tracking
-    // expected state. Only then should we permit bypassing the below feature
-    // compatibility checks.
-    if (!FLAGS_expected_values_dir.empty()) {
-      if (!std::atomic<uint32_t>{}.is_lock_free() ||
-          !std::atomic<uint64_t>{}.is_lock_free()) {
-        std::ostringstream status_s;
-        status_s << "Cannot use --expected_values_dir on platforms without "
-                    "lock-free "
-                 << (!std::atomic<uint32_t>{}.is_lock_free()
-                         ? "std::atomic<uint32_t>"
-                         : "std::atomic<uint64_t>");
-        status = Status::InvalidArgument(status_s.str());
-      }
-
-      if (status.ok() && FLAGS_clear_column_family_one_in > 0) {
-        status = Status::InvalidArgument(
-            "Cannot use --expected_values_dir on when "
-            "--clear_column_family_one_in is greater than zero.");
-      }
-    }
-    if (status.ok()) {
-      if (FLAGS_expected_values_dir.empty()) {
-        expected_state_manager_.reset(
-            new AnonExpectedStateManager(FLAGS_max_key, FLAGS_column_families));
-      } else {
-        expected_state_manager_.reset(new FileExpectedStateManager(
-            FLAGS_max_key, FLAGS_column_families, FLAGS_expected_values_dir));
-      }
-      status = expected_state_manager_->Open();
-    }
-    if (!status.ok()) {
-      fprintf(stderr, "Failed setting up expected state with error: %s\n",
-              status.ToString().c_str());
-      exit(1);
-    }
-
-    if (FLAGS_test_batches_snapshots) {
-      fprintf(stdout, "No lock creation because test_batches_snapshots set\n");
-      return;
-    }
-
-    long num_locks = static_cast<long>(max_key_ >> log2_keys_per_lock_);
-    if (max_key_ & ((1 << log2_keys_per_lock_) - 1)) {
-      num_locks++;
-    }
-    fprintf(stdout, "Creating %ld locks\n", num_locks * FLAGS_column_families);
-    key_locks_.resize(FLAGS_column_families);
-
-    for (int i = 0; i < FLAGS_column_families; ++i) {
-      key_locks_[i].reset(new port::Mutex[num_locks]);
-    }
-    if (FLAGS_read_fault_one_in || FLAGS_metadata_read_fault_one_in) {
-#ifdef NDEBUG
-      // Unsupported in release mode because it relies on
-      // `IGNORE_STATUS_IF_ERROR` to distinguish faults not expected to lead to
-      // failure.
-      fprintf(stderr,
-              "Cannot set nonzero value for --read_fault_one_in in "
-              "release mode.");
-      exit(1);
-#else   // NDEBUG
-      SyncPoint::GetInstance()->SetCallBack("FaultInjectionIgnoreError",
-                                            IgnoreReadErrorCallback);
-      SyncPoint::GetInstance()->EnableProcessing();
-#endif  // NDEBUG
-    }
-  }
+  SharedState(Env* env, StressTest* stress_test);
 
   ~SharedState() {
 #ifndef NDEBUG
@@ -430,9 +337,7 @@ class SharedState {
     return bg_thread_finished_ == num_bg_threads_;
   }
 
-  bool ShouldVerifyAtBeginning() const {
-    return !FLAGS_expected_values_dir.empty();
-  }
+  bool ShouldVerifyAtBeginning() const;
 
   bool PrintingVerificationResults() {
     bool tmp = false;

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -65,8 +65,29 @@ std::shared_ptr<const FilterPolicy> CreateFilterPolicy() {
 
 }  // namespace
 
-StressTest::StressTest()
-    : cache_(NewCache(FLAGS_cache_size, FLAGS_cache_numshardbits)),
+std::string StressTest::GetDbLabel() const {
+  return "db_" + std::to_string(db_index_);
+}
+
+std::string StressTest::GetDbPath() const {
+  return FLAGS_db_root + "/" + GetDbLabel();
+}
+
+std::string StressTest::GetExpectedValuesDir() const {
+  return FLAGS_expected_states_root.empty()
+             ? std::string()
+             : FLAGS_expected_states_root + "/" + GetDbLabel();
+}
+
+std::string StressTest::GetSecondariesBase() const {
+  return FLAGS_secondary_dbs_root.empty()
+             ? std::string()
+             : FLAGS_secondary_dbs_root + "/" + GetDbLabel();
+}
+
+StressTest::StressTest(int db_index)
+    : db_index_(db_index),
+      cache_(NewCache(FLAGS_cache_size, FLAGS_cache_numshardbits)),
       filter_policy_(CreateFilterPolicy()),
       db_(nullptr),
       txn_db_(nullptr),
@@ -78,7 +99,7 @@ StressTest::StressTest()
       db_preload_finished_(false),
       is_db_stopped_(false) {
   if (FLAGS_destroy_db_initially) {
-    const Status s = DbStressDestroyDb(FLAGS_db);
+    const Status s = DbStressDestroyDb(GetDbPath());
     if (!s.ok()) {
       fprintf(stderr, "Cannot destroy original db: %s\n", s.ToString().c_str());
       exit(1);
@@ -1345,7 +1366,7 @@ void StressTest::OperateDb(ThreadState* thread) {
         uint64_t total_size = 0;
         if (FLAGS_backup_max_size > 0) {
           std::vector<FileAttributes> files;
-          db_stress_env->GetChildrenFileAttributes(FLAGS_db, &files);
+          db_stress_env->GetChildrenFileAttributes(GetDbPath(), &files);
           for (auto& file : files) {
             total_size += file.size_bytes;
           }
@@ -2468,9 +2489,9 @@ Status StressTest::TestBackupRestore(
   }
 
   const std::string backup_dir =
-      FLAGS_db + "/.backup" + std::to_string(thread->tid);
+      GetDbPath() + "/.backup" + std::to_string(thread->tid);
   const std::string restore_dir =
-      FLAGS_db + "/.restore" + std::to_string(thread->tid);
+      GetDbPath() + "/.restore" + std::to_string(thread->tid);
   BackupEngineOptions backup_opts(backup_dir);
   // For debugging, get info_log from live options
   backup_opts.info_log = db_->GetDBOptions().info_log.get();
@@ -2934,7 +2955,7 @@ Status StressTest::TestCheckpoint(ThreadState* thread,
   }
 
   std::string checkpoint_dir =
-      FLAGS_db + "/.checkpoint" + std::to_string(thread->tid);
+      GetDbPath() + "/.checkpoint" + std::to_string(thread->tid);
   Options tmp_opts(options_);
   tmp_opts.listeners.clear();
   tmp_opts.env = db_stress_env;
@@ -3900,13 +3921,21 @@ void StressTest::Open(SharedState* shared, bool reopen) {
     fprintf(stdout, "Integrated BlobDB: blob cache disabled\n");
   }
 
-  fprintf(stdout, "DB path: [%s]\n", FLAGS_db.c_str());
+  fprintf(stdout, "DB path: [%s]\n", GetDbPath().c_str());
+  if (!GetExpectedValuesDir().empty()) {
+    fprintf(stdout, "Expected states path: [%s]\n",
+            GetExpectedValuesDir().c_str());
+  }
+  if (!GetSecondariesBase().empty()) {
+    fprintf(stdout, "Secondary DB path: [%s]\n",
+            GetSecondariesBase().c_str());
+  }
 
   Status s;
 
   if (FLAGS_ttl == -1) {
     std::vector<std::string> existing_column_families;
-    s = DB::ListColumnFamilies(DBOptions(options_), FLAGS_db,
+    s = DB::ListColumnFamilies(DBOptions(options_), GetDbPath(),
                                &existing_column_families);  // ignore errors
     if (!s.ok()) {
       // DB doesn't exist
@@ -3955,7 +3984,7 @@ void StressTest::Open(SharedState* shared, bool reopen) {
 
     options_.listeners.clear();
     options_.listeners.emplace_back(new DbStressListener(
-        FLAGS_db, options_.db_paths, cf_descriptors, shared));
+        GetDbPath(), options_.db_paths, cf_descriptors, shared));
     RegisterAdditionalListeners();
 
     // If this is for DB reopen,  error injection may have been enabled.
@@ -3976,7 +4005,7 @@ void StressTest::Open(SharedState* shared, bool reopen) {
            inject_open_meta_write_error || inject_open_read_error ||
            inject_open_write_error) &&
           fault_fs_guard
-              ->FileExists(FLAGS_db + "/CURRENT", IOOptions(), nullptr)
+              ->FileExists(GetDbPath() + "/CURRENT", IOOptions(), nullptr)
               .ok()) {
         if (inject_sync_fault || inject_open_write_error) {
           fault_fs_guard->SetFilesystemDirectWritable(false);
@@ -4020,7 +4049,7 @@ void StressTest::Open(SharedState* shared, bool reopen) {
           blob_db_options.enable_garbage_collection = FLAGS_blob_db_enable_gc;
 
           blob_db::BlobDB* blob_db = nullptr;
-          s = blob_db::BlobDB::Open(options_, blob_db_options, FLAGS_db,
+          s = blob_db::BlobDB::Open(options_, blob_db_options, GetDbPath(),
                                     cf_descriptors, &column_families_,
                                     &blob_db);
           if (s.ok()) {
@@ -4029,11 +4058,11 @@ void StressTest::Open(SharedState* shared, bool reopen) {
           }
         } else {
           if (db_preload_finished_.load() && FLAGS_read_only) {
-            s = DB::OpenForReadOnly(DBOptions(options_), FLAGS_db,
+            s = DB::OpenForReadOnly(DBOptions(options_), GetDbPath(),
                                     cf_descriptors, &column_families_,
                                     &db_owner_);
           } else {
-            s = DB::Open(DBOptions(options_), FLAGS_db, cf_descriptors,
+            s = DB::Open(DBOptions(options_), GetDbPath(), cf_descriptors,
                          &column_families_, &db_owner_);
           }
           if (s.ok()) {
@@ -4103,7 +4132,7 @@ void StressTest::Open(SharedState* shared, bool reopen) {
           optimistic_txn_db_options.shared_lock_buckets = nullptr;
         }
         s = OptimisticTransactionDB::Open(
-            options_, optimistic_txn_db_options, FLAGS_db, cf_descriptors,
+            options_, optimistic_txn_db_options, GetDbPath(), cf_descriptors,
             &column_families_, &optimistic_txn_db_);
         if (!s.ok()) {
           fprintf(stderr, "Error in opening the OptimisticTransactionDB [%s]\n",
@@ -4141,7 +4170,7 @@ void StressTest::Open(SharedState* shared, bool reopen) {
         txn_db_options.use_per_key_point_lock_mgr =
             FLAGS_use_per_key_point_lock_mgr;
         PrepareTxnDbOptions(shared, txn_db_options);
-        s = TransactionDB::Open(options_, txn_db_options, FLAGS_db,
+        s = TransactionDB::Open(options_, txn_db_options, GetDbPath(),
                                 cf_descriptors, &column_families_, &txn_db_);
         if (!s.ok()) {
           fprintf(stderr, "Error in opening the TransactionDB [%s]\n",
@@ -4181,8 +4210,8 @@ void StressTest::Open(SharedState* shared, bool reopen) {
       // TODO(yanqin) support max_open_files != -1 for secondary instance.
       tmp_opts.max_open_files = -1;
       tmp_opts.env = db_stress_env;
-      const std::string& secondary_path = FLAGS_secondaries_base;
-      s = DB::OpenAsSecondary(tmp_opts, FLAGS_db, secondary_path,
+      const std::string& secondary_path = GetSecondariesBase();
+      s = DB::OpenAsSecondary(tmp_opts, GetDbPath(), secondary_path,
                               cf_descriptors, &secondary_cfhs_, &secondary_db_);
       assert(s.ok());
       assert(secondary_cfhs_.size() ==
@@ -4190,7 +4219,7 @@ void StressTest::Open(SharedState* shared, bool reopen) {
     }
   } else {
     DBWithTTL* db_with_ttl;
-    s = DBWithTTL::Open(options_, FLAGS_db, &db_with_ttl, FLAGS_ttl);
+    s = DBWithTTL::Open(options_, GetDbPath(), &db_with_ttl, FLAGS_ttl);
     db_owner_.reset(db_with_ttl);
     db_ = db_with_ttl;
   }

--- a/db_stress_tool/db_stress_test_base.h
+++ b/db_stress_tool/db_stress_test_base.h
@@ -40,11 +40,17 @@ class StressTest {
   // from optimistic transactions when conflict detection retries are exhausted.
   static bool IsExpectedTxnError(const Status& s);
 
-  StressTest();
+  explicit StressTest(int db_index);
 
   virtual ~StressTest() {}
 
-  std::shared_ptr<Cache> NewCache(size_t capacity, int32_t num_shard_bits);
+  std::string GetDbLabel() const;
+  std::string GetDbPath() const;
+  std::string GetExpectedValuesDir() const;
+  std::string GetSecondariesBase() const;
+
+  static std::shared_ptr<Cache> NewCache(size_t capacity,
+                                         int32_t num_shard_bits);
 
   static std::vector<std::string> GetBlobCompressionTags();
 
@@ -391,7 +397,6 @@ class StressTest {
                                  const WideColumns& columns);
 
   void PrintEnv() const;
-
   void Open(SharedState* shared, bool reopen = false);
 
   void Reopen(ThreadState* thread);
@@ -412,6 +417,8 @@ class StressTest {
                                           ReadOptions& read_opts);
 
   void CleanUpColumnFamilies();
+
+  int db_index_;
 
   std::shared_ptr<Cache> cache_;
   std::shared_ptr<Cache> compressed_cache_;

--- a/db_stress_tool/db_stress_tool.cc
+++ b/db_stress_tool/db_stress_tool.cc
@@ -124,13 +124,14 @@ int db_stress_tool(int argc, char** argv) {
 
   // Handle --destroy_db_and_exit early, before other option validation
   if (FLAGS_destroy_db_and_exit) {
-    s = DbStressDestroyDb(FLAGS_db);
+    s = DbStressDestroyDb(FLAGS_db_root + "/db_0");
     if (s.ok()) {
-      fprintf(stdout, "Successfully destroyed db at %s\n", FLAGS_db.c_str());
+      fprintf(stdout, "Successfully destroyed db at %s\n",
+              (FLAGS_db_root + "/db_0").c_str());
       return 0;
     } else {
-      fprintf(stderr, "Failed to destroy db at %s: %s\n", FLAGS_db.c_str(),
-              s.ToString().c_str());
+      fprintf(stderr, "Failed to destroy db at %s: %s\n",
+              (FLAGS_db_root + "/db_0").c_str(), s.ToString().c_str());
       return 1;
     }
   }
@@ -353,15 +354,29 @@ int db_stress_tool(int argc, char** argv) {
     }
   }
 
-  // Choose a location for the test database if none given with --db=<path>
-  if (FLAGS_db.empty()) {
+  // Choose a location for the test database if none given with --db_root=<path>
+  if (FLAGS_db_root.empty()) {
     std::string default_db_path;
     db_stress_env->GetTestDirectory(&default_db_path);
     default_db_path += "/dbstress";
-    FLAGS_db = default_db_path;
+    FLAGS_db_root = default_db_path;
   }
 
-  // Now that FLAGS_db is resolved, set the fault injection log file path
+  if ((FLAGS_test_secondary || FLAGS_continuous_verification_interval > 0) &&
+      FLAGS_secondary_dbs_root.empty()) {
+    std::string default_secondaries_path;
+    db_stress_env->GetTestDirectory(&default_secondaries_path);
+    default_secondaries_path += "/dbstress_secondaries";
+    s = db_stress_env->CreateDirIfMissing(default_secondaries_path);
+    if (!s.ok()) {
+      fprintf(stderr, "Failed to create directory %s: %s\n",
+              default_secondaries_path.c_str(), s.ToString().c_str());
+      exit(1);
+    }
+    FLAGS_secondary_dbs_root = default_secondaries_path;
+  }
+
+  // Now that root flags are resolved, set the fault injection log file path
   // so that PrintAll() writes to a file instead of stderr (signal-safe).
   // Store the log in TEST_TMPDIR (outside the DB directory) so it survives
   // DB reopen (which cleans untracked files) and gets included in the
@@ -378,20 +393,6 @@ int db_stress_tool(int argc, char** argv) {
                            std::to_string(getpid()) + "_" +
                            std::to_string(time(nullptr)) + ".log";
     fault_fs_guard->SetInjectedErrorLogPath(log_path);
-  }
-
-  if ((FLAGS_test_secondary || FLAGS_continuous_verification_interval > 0) &&
-      FLAGS_secondaries_base.empty()) {
-    std::string default_secondaries_path;
-    db_stress_env->GetTestDirectory(&default_secondaries_path);
-    default_secondaries_path += "/dbstress_secondaries";
-    s = db_stress_env->CreateDirIfMissing(default_secondaries_path);
-    if (!s.ok()) {
-      fprintf(stderr, "Failed to create directory %s: %s\n",
-              default_secondaries_path.c_str(), s.ToString().c_str());
-      exit(1);
-    }
-    FLAGS_secondaries_base = default_secondaries_path;
   }
 
   if (FLAGS_best_efforts_recovery &&
@@ -511,16 +512,60 @@ int db_stress_tool(int argc, char** argv) {
     key_gen_ctx.weights.emplace_back(key_gen_ctx.window -
                                      keys_per_level * (levels - 1));
   }
+  // Create per-DB subdirectories (db_root/db_0, expected_states_root/db_0, etc.)
+  // These don't exist yet because paths changed from e.g. FLAGS_db to
+  // FLAGS_db_root/db_0.
+  const int db_index = 0;
+  const std::string db_label = "db_" + std::to_string(db_index);
+  s = db_stress_env->CreateDirIfMissing(FLAGS_db_root);
+  if (s.ok()) {
+    s = db_stress_env->CreateDirIfMissing(FLAGS_db_root + "/" + db_label);
+  }
+  if (!s.ok()) {
+    fprintf(stderr, "Failed to create directory %s: %s\n",
+            (FLAGS_db_root + "/" + db_label).c_str(), s.ToString().c_str());
+    exit(1);
+  }
+  if (!FLAGS_expected_states_root.empty()) {
+    // Use Env::Default() because expected states are always on the local
+    // filesystem (created by Python's tempfile.mkdtemp), even when the DB
+    // itself is on a remote/custom filesystem.
+    s = Env::Default()->CreateDirIfMissing(FLAGS_expected_states_root);
+    if (s.ok()) {
+      s = Env::Default()->CreateDirIfMissing(FLAGS_expected_states_root + "/" +
+                                             db_label);
+    }
+    if (!s.ok()) {
+      fprintf(stderr, "Failed to create directory %s: %s\n",
+              (FLAGS_expected_states_root + "/" + db_label).c_str(),
+              s.ToString().c_str());
+      exit(1);
+    }
+  }
+  if (!FLAGS_secondary_dbs_root.empty()) {
+    s = db_stress_env->CreateDirIfMissing(FLAGS_secondary_dbs_root);
+    if (s.ok()) {
+      s = db_stress_env->CreateDirIfMissing(FLAGS_secondary_dbs_root + "/" +
+                                            db_label);
+    }
+    if (!s.ok()) {
+      fprintf(stderr, "Failed to create directory %s: %s\n",
+              (FLAGS_secondary_dbs_root + "/" + db_label).c_str(),
+              s.ToString().c_str());
+      exit(1);
+    }
+  }
+
   std::unique_ptr<ROCKSDB_NAMESPACE::SharedState> shared;
   std::unique_ptr<ROCKSDB_NAMESPACE::StressTest> stress;
   if (FLAGS_test_cf_consistency) {
-    stress.reset(CreateCfConsistencyStressTest());
+    stress.reset(CreateCfConsistencyStressTest(db_index));
   } else if (FLAGS_test_batches_snapshots) {
-    stress.reset(CreateBatchedOpsStressTest());
+    stress.reset(CreateBatchedOpsStressTest(db_index));
   } else if (FLAGS_test_multi_ops_txns) {
-    stress.reset(CreateMultiOpsTxnsStressTest());
+    stress.reset(CreateMultiOpsTxnsStressTest(db_index));
   } else {
-    stress.reset(CreateNonBatchedOpsStressTest());
+    stress.reset(CreateNonBatchedOpsStressTest(db_index));
   }
   // Initialize the Zipfian pre-calculated array
   InitializeHotKeyGenerator(FLAGS_hot_key_alpha);

--- a/db_stress_tool/multi_ops_txns_stress.cc
+++ b/db_stress_tool/multi_ops_txns_stress.cc
@@ -1767,8 +1767,8 @@ void MultiOpsTxnsStressTest::ScanExistingDb(SharedState* shared, int threads) {
   }
 }
 
-StressTest* CreateMultiOpsTxnsStressTest() {
-  return new MultiOpsTxnsStressTest();
+StressTest* CreateMultiOpsTxnsStressTest(int db_index) {
+  return new MultiOpsTxnsStressTest(db_index);
 }
 
 void CheckAndSetOptionsForMultiOpsTxnStressTest() {

--- a/db_stress_tool/multi_ops_txns_stress.h
+++ b/db_stress_tool/multi_ops_txns_stress.h
@@ -191,7 +191,8 @@ class MultiOpsTxnsStressTest : public StressTest {
     uint32_t c_{0};
   };
 
-  MultiOpsTxnsStressTest() {}
+  explicit MultiOpsTxnsStressTest(int db_index)
+      : StressTest(db_index) {}
 
   ~MultiOpsTxnsStressTest() override {}
 

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -24,7 +24,8 @@
 namespace ROCKSDB_NAMESPACE {
 class NonBatchedOpsStressTest : public StressTest {
  public:
-  NonBatchedOpsStressTest() = default;
+  explicit NonBatchedOpsStressTest(int db_index)
+      : StressTest(db_index) {}
 
   virtual ~NonBatchedOpsStressTest() = default;
 
@@ -2325,11 +2326,11 @@ class NonBatchedOpsStressTest : public StressTest {
         FLAGS_test_ingest_standalone_range_deletion_one_in);
     std::vector<std::string> external_files;
     const std::string sst_filename =
-        FLAGS_db + "/." + std::to_string(thread->tid) + ".sst";
+        GetDbPath() + "/." + std::to_string(thread->tid) + ".sst";
     external_files.push_back(sst_filename);
     std::string standalone_rangedel_filename;
     if (test_standalone_range_deletion) {
-      standalone_rangedel_filename = FLAGS_db + "/." +
+      standalone_rangedel_filename = GetDbPath() + "/." +
                                      std::to_string(thread->tid) +
                                      "_standalone_rangedel.sst";
       external_files.push_back(standalone_rangedel_filename);
@@ -3485,8 +3486,8 @@ class NonBatchedOpsStressTest : public StressTest {
   }
 };
 
-StressTest* CreateNonBatchedOpsStressTest() {
-  return new NonBatchedOpsStressTest();
+StressTest* CreateNonBatchedOpsStressTest(int db_index) {
+  return new NonBatchedOpsStressTest(db_index);
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -196,7 +196,7 @@ default_params = {
     "index_block_search_type": lambda: random.choice([0, 1, 2]),
     "uniform_cv_threshold": lambda: random.choice([-1, 0.2, 1000]),
     "ingest_external_file_one_in": lambda: random.choice([1000, 1000000]),
-    "test_ingest_standalone_range_deletion_one_in": lambda: random.choice([0, 5, 10]),
+    "test_ingest_standalone_range_deletion_one_in": 0,
     "iterpercent": 10,
     "lock_wal_one_in": lambda: random.choice([10000, 1000000]),
     "mark_for_compaction_one_file_in": lambda: 10 * random.randint(0, 1),
@@ -263,7 +263,7 @@ default_params = {
     "use_merge": lambda: random.randint(0, 1),
     # use_trie_index must be the same across invocations so that all SSTs
     # in a DB are opened with matching table options.
-    "use_trie_index": random.choice([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
+    "use_trie_index": 0,
     # use_udi_as_primary_index must be the same across invocations (like
     # use_trie_index) so that SSTs written in primary mode can be read on
     # reopen.

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -179,7 +179,7 @@ default_params = {
     # causing stress test failures. Temporarily disabled until the
     # sanitization can account for cross-run incompatibility.
     "inplace_update_support": 0,
-    "expected_values_dir": lambda: setup_expected_values_dir(),
+    "expected_states_root": lambda: setup_expected_states_root(),
     "flush_one_in": lambda: random.choice([1000, 1000000]),
     "manual_wal_flush_one_in": lambda: random.choice([0, 1000]),
     "sync_wal_one_in": 0,
@@ -528,13 +528,13 @@ def get_dbname(test_name):
     return dbname
 
 
-expected_values_dir = None
+expected_states_root = None
 
 
-def setup_expected_values_dir():
-    global expected_values_dir
-    if expected_values_dir is not None:
-        return expected_values_dir
+def setup_expected_states_root():
+    global expected_states_root
+    if expected_states_root is not None:
+        return expected_states_root
     expected_dir_prefix = "rocksdb_crashtest_expected_"
     test_exp_tmpdir = os.environ.get(_TEST_EXPECTED_DIR_ENV_VAR)
 
@@ -542,22 +542,23 @@ def setup_expected_values_dir():
         test_exp_tmpdir = os.environ.get(_TEST_DIR_ENV_VAR)
 
     if test_exp_tmpdir is None or test_exp_tmpdir == "":
-        expected_values_dir = tempfile.mkdtemp(prefix=expected_dir_prefix)
+        expected_states_root = tempfile.mkdtemp(prefix=expected_dir_prefix)
     else:
-        # if tmpdir is specified, store the expected_values_dir under that dir
-        expected_values_dir = test_exp_tmpdir + "/rocksdb_crashtest_expected"
-        os.makedirs(expected_values_dir, exist_ok=True)
-    return expected_values_dir
+        # If tmpdir is specified, store the expected-states root under that
+        # directory and let db_stress resolve per-DB subdirectories beneath it.
+        expected_states_root = test_exp_tmpdir + "/rocksdb_crashtest_expected"
+        os.makedirs(expected_states_root, exist_ok=True)
+    return expected_states_root
 
 
-def prepare_expected_values_dir(expected_dir, destroy_db_initially):
-    if expected_dir is None or expected_dir == "":
+def prepare_expected_states_root(expected_root, destroy_db_initially):
+    if expected_root is None or expected_root == "":
         return
 
-    if destroy_db_initially and os.path.exists(expected_dir):
-        shutil.rmtree(expected_dir, True)
+    if destroy_db_initially and os.path.exists(expected_root):
+        shutil.rmtree(expected_root, True)
 
-    os.makedirs(expected_dir, exist_ok=True)
+    os.makedirs(expected_root, exist_ok=True)
 
 
 multiops_txn_key_spaces_file = None
@@ -936,11 +937,13 @@ def finalize_and_sanitize(src_params):
     if (
         dest_params["use_direct_io_for_flush_and_compaction"] == 1
         or dest_params["use_direct_reads"] == 1
-    ) and not is_direct_io_supported(dest_params["db"]):
+    ) and not is_direct_io_supported(dest_params["db_root"]):
         if is_release_mode():
             print(
                 "{} does not support direct IO. Disabling use_direct_reads and "
-                "use_direct_io_for_flush_and_compaction.\n".format(dest_params["db"])
+                "use_direct_io_for_flush_and_compaction.\n".format(
+                    dest_params["db_root"]
+                )
             )
             dest_params["use_direct_reads"] = 0
             dest_params["use_direct_io_for_flush_and_compaction"] = 0
@@ -1622,8 +1625,8 @@ def gen_cmd_params(args):
 
 def gen_cmd(params, unknown_params):
     finalzied_params = finalize_and_sanitize(params)
-    prepare_expected_values_dir(
-        finalzied_params.get("expected_values_dir"),
+    prepare_expected_states_root(
+        finalzied_params.get("expected_states_root"),
         finalzied_params.get("destroy_db_initially", 0),
     )
     cmd = (
@@ -1899,8 +1902,8 @@ def build_out_of_space_diagnostics(
 
 def diagnostic_paths(finalized_params):
     return [
-        finalized_params.get("db"),
-        finalized_params.get("expected_values_dir"),
+        finalized_params.get("db_root"),
+        finalized_params.get("expected_states_root"),
     ]
 
 
@@ -1999,7 +2002,7 @@ def strip_expected_sigterm_stderr(stdout, stderr, hit_timeout):
 
 def cleanup_after_success(dbname):
     # Use db_stress --destroy_db_and_exit, which simplifies remote DB cleanup
-    cleanup_cmd_parts = [stress_cmd, "--destroy_db_and_exit=1", "--db=" + dbname]
+    cleanup_cmd_parts = [stress_cmd, "--destroy_db_and_exit=1", "--db_root=" + dbname]
     # Pass through relevant arguments for remote DB access
     for arg in remain_args:
         parts = arg.split("=", 1)
@@ -2080,7 +2083,8 @@ def blackbox_crash_main(args, unknown_args):
     while time.time() < exit_time:
         apply_random_seed_per_iteration()
         cmd, finalized_params = gen_cmd(
-            dict(list(cmd_params.items()) + list({"db": dbname}.items())), unknown_args
+            dict(list(cmd_params.items()) + list({"db_root": dbname}.items())),
+            unknown_args,
         )
 
         hit_timeout, retcode, outs, errs, pid = execute_cmd(cmd, cmd_params["interval"])
@@ -2110,7 +2114,8 @@ def blackbox_crash_main(args, unknown_args):
     cmd_params.update({"skip_verifydb": 0})
 
     cmd, finalized_params = gen_cmd(
-        dict(list(cmd_params.items()) + list({"db": dbname}.items())), unknown_args
+        dict(list(cmd_params.items()) + list({"db_root": dbname}.items())),
+        unknown_args,
     )
     hit_timeout, retcode, outs, errs, pid = execute_cmd(
         cmd, cmd_params["verify_timeout"], True
@@ -2243,7 +2248,7 @@ def whitebox_crash_main(args, unknown_args):
             dict(
                 list(cmd_params.items())
                 + list(additional_opts.items())
-                + list({"db": dbname}.items())
+                + list({"db_root": dbname}.items())
             ),
             unknown_args,
         )
@@ -2372,9 +2377,9 @@ def main():
         blackbox_crash_main(args, unknown_args)
     if args.test_type == "whitebox":
         whitebox_crash_main(args, unknown_args)
-    # Only delete the `expected_values_dir` if test passes
-    if expected_values_dir is not None:
-        shutil.rmtree(expected_values_dir)
+    # Only delete the expected-states root if the test passes.
+    if expected_states_root is not None:
+        shutil.rmtree(expected_states_root)
     if multiops_txn_key_spaces_file is not None:
         os.remove(multiops_txn_key_spaces_file)
 


### PR DESCRIPTION
Summary:
Prerequisite for multi-DB stress testing (--num_dbs, added in a later diff).

Rename single-path flags to root-directory flags. Each DB resolves its
subdirectory under the root automatically.

  Before:  --db=/tmp/test              → DB at /tmp/test
  After:   --db_root=/tmp/test         → DB at /tmp/test/db_0

Flag renames:
  --db                 → --db_root
  --expected_values_dir → --expected_states_root
  --secondaries_base   → --secondary_dbs_root

Path resolution:
  StressTest(int db_index)
    ├─ GetDbPath()            → FLAGS_db_root + "/db_0"
    ├─ GetExpectedValuesDir() → FLAGS_expected_states_root + "/db_0"
    └─ GetSecondariesBase()   → FLAGS_secondary_dbs_root + "/db_0"

  SharedState and DbStressListener compute per-DB paths internally
  from stress_test->GetExpectedValuesDir() (constructors moved to .cc
  files to access full StressTest type). No extra constructor params
  beyond the original interface.

Since paths now include a db_0/ subdirectory that does not exist yet,
CreatePerDbDirs() creates these subdirectories at startup.

Differential Revision: D103140299


