### PR TITLE
Fix BUCK file format check failure

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -378,10 +378,10 @@ cpp_library_wrapper(name="rocksdb_lib", srcs=[
         "utilities/write_batch_with_index/write_batch_with_index_internal.cc",
     ], deps=[
         "//folly/container:f14_hash",
-        "//folly/coro:blocking_wait",
-        "//folly/coro:collect",
-        "//folly/coro:coroutine",
-        "//folly/coro:task",
+        "//folly/experimental/coro:blocking_wait",
+        "//folly/experimental/coro:collect",
+        "//folly/experimental/coro:coroutine",
+        "//folly/experimental/coro:task",
         "//folly/synchronization:distributed_mutex",
     ], headers=glob(["**/*.h"]), link_whole=False, extra_test_libs=False)
 


### PR DESCRIPTION
Summary:

BUCK file is out of sync on folly dependency.

Test Plan:

Build pass