### PR TITLE
Set default uniform_cv_threshold = 0.2

### DIFF
--- a/include/rocksdb/table.h
+++ b/include/rocksdb/table.h
@@ -699,7 +699,7 @@ struct BlockBasedTableOptions {
   //
   // NOTE: Currently only supports index blocks. May update to include data
   // blocks in the future.
-  double uniform_cv_threshold = -1;
+  double uniform_cv_threshold = 0.2;
 
   // Store index blocks on disk in compressed format. Changing this option to
   // false  will avoid the overhead of decompression if index blocks are evicted


### PR DESCRIPTION
## Summary

Change the default value of `BlockBasedTableOptions::uniform_cv_threshold` from `-1` (disabled) to `0.2` so that index blocks are evaluated for uniform key distribution by default. This enables the `is_uniform` block-footer hint at write time, which downstream readers can consume (via `BlockSearchType::kAuto`) to pick interpolation search over binary search on uniform blocks. With the previous default of `-1`, the feature was opt-in only and the hint was never set, so readers couldn't benefit from it without explicit configuration.

## Forwards-Compatibility
This change will go into 11.3.0 and can be safely read by 11.0.0 since https://github.com/facebook/rocksdb/pull/14332 was landed, which ensures num_restarts does not read last 4 bits of the footer. Any earlier release will not silently fail but instead see `bad block contents` corruption error. 

## Test Plan

- Workload: `fillseq -num=1000000 -value_size=100 -write_buffer_size=1048576 -compression_type=none -seed=1` (single-threaded, DB on `/dev/shm`).
- Both variants produced 142 SST files / 118 MB DB — identical write work.
- Two binaries: `db_bench` built at `HEAD~1` (baseline, default `-1`) and at HEAD (this commit, default `0.2`). 3 runs per variant on a quiet host.

| Variant | Run 1 | Run 2 | Run 3 | Mean ops/sec | Mean MB/s |
|---|---:|---:|---:|---:|---:|
| Without commit (default `-1`) | 481,602 | 431,031 | 482,878 | **465,170** | 51.47 |
| With commit (default `0.2`)   | 483,073 | 450,232 | 454,225 | **462,510** | 51.13 |
| **Δ** |  |  |  | **−0.6%** | −0.7% |

Conclusion: No regression as a result of enabling it. 
