### PR TITLE
ExternalTable Iterator Prefer IterKey over InternalKey

### DIFF
--- a/table/external_table.cc
+++ b/table/external_table.cc
@@ -5,6 +5,7 @@
 
 #include "rocksdb/external_table.h"
 
+#include "db/dbformat.h"
 #include "logging/logging.h"
 #include "rocksdb/table.h"
 #include "table/block_based/block.h"
@@ -118,7 +119,7 @@ class ExternalTableIteratorAdapter : public InternalIterator {
 
   Slice key() const override {
     if (iterator_) {
-      return Slice(*key_.const_rep());
+      return key_.GetInternalKey();
     }
     return Slice();
   }
@@ -142,7 +143,7 @@ class ExternalTableIteratorAdapter : public InternalIterator {
 
  private:
   std::unique_ptr<ExternalTableIterator> iterator_;
-  InternalKey key_;
+  IterKey key_;
   bool valid_;
   Status status_;
   IterateResult result_;
@@ -152,8 +153,8 @@ class ExternalTableIteratorAdapter : public InternalIterator {
       valid_ = iterator_->Valid();
       status_ = iterator_->status();
       if (valid_ && status_.ok()) {
-        key_.Set(res.has_value() ? res.value() : iterator_->key(), 0,
-                 ValueType::kTypeValue);
+        key_.SetInternalKey(res.has_value() ? res.value() : iterator_->key(),
+                            /*s=*/0, ValueType::kTypeValue);
       }
     }
   }


### PR DESCRIPTION
## Summary

Reduces per-step heap allocations in the external table iterator's hot path
by replacing the `InternalKey` member of `ExternalTableIteratorAdapter` with
`IterKey`. `InternalKey` stores its bytes in a `std::string`, which
heap-allocates whenever a key exceeds the small-string threshold. `IterKey`
keeps a 39-byte inline buffer and only spills to the heap for larger keys.
`UpdateKey` runs on every `Next` / `Prev` / `Seek*`, so this swap removes a
recurring per-step allocation for typical key sizes.

## Test Plan
CI