### PR TITLE
Fix AI review workflows broken by cc8d9ea04

### DIFF
--- a/.github/scripts/parse-claude-review.js
+++ b/.github/scripts/parse-claude-review.js
@@ -18,7 +18,7 @@ module.exports = function parseClaude({executionFile, conclusion, meta}) {
     if (meta.trigger !== 'auto') {
       return `*Requested by @${meta.reviewer}*`;
     }
-    const shortSha = meta.headSha.substring(0, 7);
+    const shortSha = meta.headSha ? meta.headSha.substring(0, 7) : 'unknown';
     if (meta.autoMode === 'early') {
       return `*Auto-triggered after CI reached the early-review threshold — reviewing commit ${
           shortSha}*`;

--- a/.github/scripts/parse-codex-review.js
+++ b/.github/scripts/parse-codex-review.js
@@ -22,7 +22,7 @@ module.exports = function parseCodex(
     if (meta.trigger !== 'auto') {
       return `*Requested by @${meta.reviewer}*`;
     }
-    const shortSha = meta.headSha.substring(0, 7);
+    const shortSha = meta.headSha ? meta.headSha.substring(0, 7) : 'unknown';
     if (meta.autoMode === 'early') {
       return `*Auto-triggered after CI reached the early-review threshold — reviewing commit ${
           shortSha}*`;

--- a/.github/workflows/ai-review-analysis.yml
+++ b/.github/workflows/ai-review-analysis.yml
@@ -549,6 +549,10 @@ jobs:
           CODEX_HOME: /tmp/codex-home
           CODEX_MODEL: ${{ inputs.default_model }}
         run: |
+          if [ -z "${OPENAI_API_KEY}" ]; then
+            echo "OPENAI_API_KEY not configured, skipping Codex review"
+            exit 0
+          fi
           mkdir -p "${CODEX_HOME}"
           codex exec \
             -m "${CODEX_MODEL}" \
@@ -698,6 +702,10 @@ jobs:
           BASE_SHA: ${{ steps.pr_info.outputs.base_sha }}
           PR_TITLE: ${{ steps.pr_info.outputs.pr_title }}
         run: |
+          if [ -z "${OPENAI_API_KEY}" ]; then
+            echo "OPENAI_API_KEY not configured, skipping Codex review"
+            exit 0
+          fi
           mkdir -p "${CODEX_HOME}"
           set +e
           codex exec review \

--- a/.github/workflows/ai-review-analysis.yml
+++ b/.github/workflows/ai-review-analysis.yml
@@ -423,8 +423,7 @@ jobs:
         if: >-
           steps.pr_info.outputs.skip != 'true' &&
           steps.check_existing.outputs.skip != 'true' &&
-          inputs.provider == 'codex' &&
-          secrets.OPENAI_API_KEY != ''
+          inputs.provider == 'codex'
         uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -433,8 +432,7 @@ jobs:
         if: >-
           steps.pr_info.outputs.skip != 'true' &&
           steps.check_existing.outputs.skip != 'true' &&
-          inputs.provider == 'codex' &&
-          secrets.OPENAI_API_KEY != ''
+          inputs.provider == 'codex'
         run: |
           npm install -g @openai/codex
           codex --version
@@ -545,8 +543,7 @@ jobs:
         if: >-
           steps.pr_info.outputs.skip != 'true' &&
           steps.check_existing.outputs.skip != 'true' &&
-          inputs.provider == 'codex' &&
-          secrets.OPENAI_API_KEY != ''
+          inputs.provider == 'codex'
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CODEX_HOME: /tmp/codex-home
@@ -564,8 +561,7 @@ jobs:
         if: >-
           steps.pr_info.outputs.skip != 'true' &&
           steps.check_existing.outputs.skip != 'true' &&
-          inputs.provider == 'codex' &&
-          secrets.OPENAI_API_KEY != ''
+          inputs.provider == 'codex'
         id: budget_codex
         uses: actions/github-script@v7
         with:
@@ -692,8 +688,7 @@ jobs:
         if: >-
           steps.pr_info.outputs.skip != 'true' &&
           steps.check_existing.outputs.skip != 'true' &&
-          inputs.provider == 'codex' &&
-          secrets.OPENAI_API_KEY != ''
+          inputs.provider == 'codex'
         id: codex
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -723,7 +718,6 @@ jobs:
           steps.pr_info.outputs.skip != 'true' &&
           steps.check_existing.outputs.skip != 'true' &&
           inputs.provider == 'codex' &&
-          secrets.OPENAI_API_KEY != '' &&
           steps.codex.outputs.exit_code != '0' &&
           hashFiles('review-findings.md') != ''
         id: recover_codex
@@ -748,8 +742,7 @@ jobs:
         if: >-
           steps.pr_info.outputs.skip != 'true' &&
           steps.check_existing.outputs.skip != 'true' &&
-          inputs.provider == 'codex' &&
-          secrets.OPENAI_API_KEY != ''
+          inputs.provider == 'codex'
         env:
           RESPONSE_FILE: codex-review-output.md
           RECOVERY_FILE: codex-review-recovery.md
@@ -839,8 +832,7 @@ jobs:
           always() &&
           steps.pr_info.outputs.skip != 'true' &&
           steps.check_existing.outputs.skip != 'true' &&
-          inputs.provider == 'codex' &&
-          secrets.OPENAI_API_KEY != ''
+          inputs.provider == 'codex'
         uses: actions/upload-artifact@v4
         with:
           name: codex-review-logs
@@ -980,13 +972,13 @@ jobs:
           persist-credentials: false
 
       - name: Setup Node.js
-        if: steps.request.outputs.skip != 'true' && inputs.provider == 'codex' && secrets.OPENAI_API_KEY != ''
+        if: steps.request.outputs.skip != 'true' && inputs.provider == 'codex'
         uses: actions/setup-node@v4
         with:
           node-version: 22
 
       - name: Install Codex CLI
-        if: steps.request.outputs.skip != 'true' && inputs.provider == 'codex' && secrets.OPENAI_API_KEY != ''
+        if: steps.request.outputs.skip != 'true' && inputs.provider == 'codex'
         run: |
           npm install -g @openai/codex
           codex --version
@@ -1134,8 +1126,7 @@ jobs:
         if: >-
           steps.request.outputs.skip != 'true' &&
           steps.request.outputs.type == 'review' &&
-          inputs.provider == 'codex' &&
-          secrets.OPENAI_API_KEY != ''
+          inputs.provider == 'codex'
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CODEX_HOME: /tmp/codex-home
@@ -1150,7 +1141,7 @@ jobs:
             - < /tmp/complexity_prompt.txt > codex-complexity.log 2>&1
 
       - name: Pick thinking budget (Codex)
-        if: steps.request.outputs.skip != 'true' && inputs.provider == 'codex' && secrets.OPENAI_API_KEY != ''
+        if: steps.request.outputs.skip != 'true' && inputs.provider == 'codex'
         id: manual_budget_codex
         env:
           OVERRIDE: ${{ inputs.thinking_budget }}
@@ -1290,7 +1281,7 @@ jobs:
             fs.writeFileSync(process.env.COMMENT_FILE, body);
 
       - name: Run Codex
-        if: steps.request.outputs.skip != 'true' && inputs.provider == 'codex' && secrets.OPENAI_API_KEY != ''
+        if: steps.request.outputs.skip != 'true' && inputs.provider == 'codex'
         id: manual_codex
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -1329,7 +1320,6 @@ jobs:
         if: >-
           steps.request.outputs.skip != 'true' &&
           inputs.provider == 'codex' &&
-          secrets.OPENAI_API_KEY != '' &&
           steps.request.outputs.type == 'review' &&
           steps.manual_codex.outputs.exit_code != '0' &&
           hashFiles('review-findings.md') != ''
@@ -1352,7 +1342,7 @@ jobs:
           echo "exit_code=${exit_code}" >> "${GITHUB_OUTPUT}"
 
       - name: Build review comment (Codex)
-        if: steps.request.outputs.skip != 'true' && inputs.provider == 'codex' && secrets.OPENAI_API_KEY != ''
+        if: steps.request.outputs.skip != 'true' && inputs.provider == 'codex'
         env:
           RESPONSE_FILE: codex-review-output.md
           RECOVERY_FILE: codex-review-recovery.md
@@ -1442,7 +1432,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Upload review logs (Codex)
-        if: always() && steps.request.outputs.skip != 'true' && inputs.provider == 'codex' && secrets.OPENAI_API_KEY != ''
+        if: always() && steps.request.outputs.skip != 'true' && inputs.provider == 'codex'
         uses: actions/upload-artifact@v4
         with:
           name: codex-review-logs

--- a/.github/workflows/ai-review-analysis.yml
+++ b/.github/workflows/ai-review-analysis.yml
@@ -423,7 +423,8 @@ jobs:
         if: >-
           steps.pr_info.outputs.skip != 'true' &&
           steps.check_existing.outputs.skip != 'true' &&
-          inputs.provider == 'codex'
+          inputs.provider == 'codex' &&
+          secrets.OPENAI_API_KEY != ''
         uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -432,7 +433,8 @@ jobs:
         if: >-
           steps.pr_info.outputs.skip != 'true' &&
           steps.check_existing.outputs.skip != 'true' &&
-          inputs.provider == 'codex'
+          inputs.provider == 'codex' &&
+          secrets.OPENAI_API_KEY != ''
         run: |
           npm install -g @openai/codex
           codex --version
@@ -543,7 +545,8 @@ jobs:
         if: >-
           steps.pr_info.outputs.skip != 'true' &&
           steps.check_existing.outputs.skip != 'true' &&
-          inputs.provider == 'codex'
+          inputs.provider == 'codex' &&
+          secrets.OPENAI_API_KEY != ''
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CODEX_HOME: /tmp/codex-home
@@ -561,7 +564,8 @@ jobs:
         if: >-
           steps.pr_info.outputs.skip != 'true' &&
           steps.check_existing.outputs.skip != 'true' &&
-          inputs.provider == 'codex'
+          inputs.provider == 'codex' &&
+          secrets.OPENAI_API_KEY != ''
         id: budget_codex
         uses: actions/github-script@v7
         with:
@@ -688,7 +692,8 @@ jobs:
         if: >-
           steps.pr_info.outputs.skip != 'true' &&
           steps.check_existing.outputs.skip != 'true' &&
-          inputs.provider == 'codex'
+          inputs.provider == 'codex' &&
+          secrets.OPENAI_API_KEY != ''
         id: codex
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -718,6 +723,7 @@ jobs:
           steps.pr_info.outputs.skip != 'true' &&
           steps.check_existing.outputs.skip != 'true' &&
           inputs.provider == 'codex' &&
+          secrets.OPENAI_API_KEY != '' &&
           steps.codex.outputs.exit_code != '0' &&
           hashFiles('review-findings.md') != ''
         id: recover_codex
@@ -742,7 +748,8 @@ jobs:
         if: >-
           steps.pr_info.outputs.skip != 'true' &&
           steps.check_existing.outputs.skip != 'true' &&
-          inputs.provider == 'codex'
+          inputs.provider == 'codex' &&
+          secrets.OPENAI_API_KEY != ''
         env:
           RESPONSE_FILE: codex-review-output.md
           RECOVERY_FILE: codex-review-recovery.md
@@ -832,7 +839,8 @@ jobs:
           always() &&
           steps.pr_info.outputs.skip != 'true' &&
           steps.check_existing.outputs.skip != 'true' &&
-          inputs.provider == 'codex'
+          inputs.provider == 'codex' &&
+          secrets.OPENAI_API_KEY != ''
         uses: actions/upload-artifact@v4
         with:
           name: codex-review-logs
@@ -853,6 +861,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: read
 
     if: >-
       github.event_name == 'workflow_dispatch' ||
@@ -971,13 +980,13 @@ jobs:
           persist-credentials: false
 
       - name: Setup Node.js
-        if: steps.request.outputs.skip != 'true' && inputs.provider == 'codex'
+        if: steps.request.outputs.skip != 'true' && inputs.provider == 'codex' && secrets.OPENAI_API_KEY != ''
         uses: actions/setup-node@v4
         with:
           node-version: 22
 
       - name: Install Codex CLI
-        if: steps.request.outputs.skip != 'true' && inputs.provider == 'codex'
+        if: steps.request.outputs.skip != 'true' && inputs.provider == 'codex' && secrets.OPENAI_API_KEY != ''
         run: |
           npm install -g @openai/codex
           codex --version
@@ -1125,7 +1134,8 @@ jobs:
         if: >-
           steps.request.outputs.skip != 'true' &&
           steps.request.outputs.type == 'review' &&
-          inputs.provider == 'codex'
+          inputs.provider == 'codex' &&
+          secrets.OPENAI_API_KEY != ''
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CODEX_HOME: /tmp/codex-home
@@ -1140,7 +1150,7 @@ jobs:
             - < /tmp/complexity_prompt.txt > codex-complexity.log 2>&1
 
       - name: Pick thinking budget (Codex)
-        if: steps.request.outputs.skip != 'true' && inputs.provider == 'codex'
+        if: steps.request.outputs.skip != 'true' && inputs.provider == 'codex' && secrets.OPENAI_API_KEY != ''
         id: manual_budget_codex
         env:
           OVERRIDE: ${{ inputs.thinking_budget }}
@@ -1280,7 +1290,7 @@ jobs:
             fs.writeFileSync(process.env.COMMENT_FILE, body);
 
       - name: Run Codex
-        if: steps.request.outputs.skip != 'true' && inputs.provider == 'codex'
+        if: steps.request.outputs.skip != 'true' && inputs.provider == 'codex' && secrets.OPENAI_API_KEY != ''
         id: manual_codex
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -1319,6 +1329,7 @@ jobs:
         if: >-
           steps.request.outputs.skip != 'true' &&
           inputs.provider == 'codex' &&
+          secrets.OPENAI_API_KEY != '' &&
           steps.request.outputs.type == 'review' &&
           steps.manual_codex.outputs.exit_code != '0' &&
           hashFiles('review-findings.md') != ''
@@ -1341,7 +1352,7 @@ jobs:
           echo "exit_code=${exit_code}" >> "${GITHUB_OUTPUT}"
 
       - name: Build review comment (Codex)
-        if: steps.request.outputs.skip != 'true' && inputs.provider == 'codex'
+        if: steps.request.outputs.skip != 'true' && inputs.provider == 'codex' && secrets.OPENAI_API_KEY != ''
         env:
           RESPONSE_FILE: codex-review-output.md
           RECOVERY_FILE: codex-review-recovery.md
@@ -1431,7 +1442,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Upload review logs (Codex)
-        if: always() && steps.request.outputs.skip != 'true' && inputs.provider == 'codex'
+        if: always() && steps.request.outputs.skip != 'true' && inputs.provider == 'codex' && secrets.OPENAI_API_KEY != ''
         uses: actions/upload-artifact@v4
         with:
           name: codex-review-logs

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -30,10 +30,9 @@ on:
         required: false
         type: choice
         options:
-          - claude-opus-4-7
           - claude-opus-4-6
           - claude-sonnet-4-6
-        default: claude-opus-4-7
+        default: claude-opus-4-6
       thinking_budget:
         description: Override MAX_THINKING_TOKENS (blank = auto-classify)
         required: false
@@ -61,7 +60,7 @@ jobs:
       query_command: /claude-query
       result_artifact_name: claude-review-result
       comment_file: claude-review-comment.md
-      default_model: claude-opus-4-7
+      default_model: claude-opus-4-6
       selected_model: ${{ github.event_name == 'workflow_dispatch' && inputs.model || '' }}
       classifier_model: claude-sonnet-4-6
       recovery_model: claude-sonnet-4-6


### PR DESCRIPTION
Summary:
This commit fixes several potential issues introduced by cc8d9ea04 (CI: AI review workflow improvements) that broke the agent review jobs in GitHub CI.

1. Codex workflows fail when OPENAI_API_KEY is not configured:
   - Added Codex review workflows fail with exit code 1 if the API key secret is missing
   - Added script-level checks to skip Codex steps gracefully when OPENAI_API_KEY is unset, avoiding CI noise

2. Missing pull-requests: read permission in manual-review job:
   - The manual-review job calls github.rest.pulls.get() but lacked the required permission
   - Added 'pull-requests: read' to the manual-review job permissions

3. Potential crash when headSha is undefined:
   - parse-claude-review.js and parse-codex-review.js accessed meta.headSha.substring() without null check
   - Added defensive checks to handle undefined headSha gracefully

4. Claude model claude-opus-4-7 incompatible with thinking API:
   - The commit upgraded default model to claude-opus-4-7, but this model doesn't support the 'thinking.type.enabled' API used by the Claude Code action
   - Error: 'thinking.type.enabled' is not supported for this model. Use 'thinking.type.adaptive' and 'output_config.effort' to control thinking behavior
   - Reverted default model to claude-opus-4-6 and removed claude-opus-4-7 from options

Test Plan:
Created a draft PR with this change and draft production code changes, including a branch on facebook/rocksdb. Go to https://github.com/facebook/rocksdb/actions/workflows/claude-review.yml and choose "Run workflow" with that branch and PR. (Changes in the PR do are not picked up for the agent code review workflows; the only way to test what is outside of main is with a branch on facebook/rocksdb)