### PR TITLE
Expose BackupEngine::StopBackup() in the C API

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -1384,6 +1384,10 @@ void rocksdb_backup_engine_info_destroy(
   delete info;
 }
 
+void rocksdb_backup_engine_stop_backup(rocksdb_backup_engine_t* be) {
+  be->rep->StopBackup();
+}
+
 void rocksdb_backup_engine_close(rocksdb_backup_engine_t* be) {
   delete be->rep;
   delete be;

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -271,6 +271,9 @@ extern ROCKSDB_LIBRARY_API uint32_t rocksdb_backup_engine_info_number_files(
 extern ROCKSDB_LIBRARY_API void rocksdb_backup_engine_info_destroy(
     const rocksdb_backup_engine_info_t* info);
 
+extern ROCKSDB_LIBRARY_API void rocksdb_backup_engine_stop_backup(
+    rocksdb_backup_engine_t* be);
+
 extern ROCKSDB_LIBRARY_API void rocksdb_backup_engine_close(
     rocksdb_backup_engine_t* be);
 


### PR DESCRIPTION
## Summary

  `BackupEngine::StopBackup()` has no corresponding entry in RocksDB's C API (`c.h`), which means language bindings that consume the C API (e.g. Rust via `librocksdb-sys`) cannot cancel an in-progress backup
  without writing a custom C++ shim.

  This PR adds `rocksdb_backup_engine_stop_backup()`:
  - Declaration in `include/rocksdb/c.h` alongside the other `rocksdb_backup_engine_*` functions
  - One-line implementation in `db/c.cc` delegating to `be->rep->StopBackup()`

  No existing behavior is changed. The function follows the exact same pattern as every other `rocksdb_backup_engine_*` wrapper in the C API.

## Test plan
  - [x] Existing C API tests (`make c_test`) pass
  - [x] `StopBackup()` is lock-free (atomic store) so no concurrency concerns with the wrapper