### PR TITLE
Expose backup_rate_limiter and restore_rate_limiter in the C API

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -1465,6 +1465,20 @@ uint64_t rocksdb_backup_engine_options_get_restore_rate_limit(
   return options->rep.restore_rate_limit;
 }
 
+void rocksdb_backup_engine_options_set_backup_rate_limiter(
+    rocksdb_backup_engine_options_t* options, rocksdb_ratelimiter_t* limiter) {
+  if (limiter) {
+    options->rep.backup_rate_limiter = limiter->rep;
+  }
+}
+
+void rocksdb_backup_engine_options_set_restore_rate_limiter(
+    rocksdb_backup_engine_options_t* options, rocksdb_ratelimiter_t* limiter) {
+  if (limiter) {
+    options->rep.restore_rate_limiter = limiter->rep;
+  }
+}
+
 void rocksdb_backup_engine_options_set_max_background_operations(
     rocksdb_backup_engine_options_t* options, int val) {
   options->rep.max_background_operations = val;

--- a/db/c_test.c
+++ b/db/c_test.c
@@ -3674,6 +3674,15 @@ int main(int argc, char** argv) {
     CheckCondition(37 ==
                    rocksdb_backup_engine_options_get_restore_rate_limit(bdo));
 
+    {
+      rocksdb_ratelimiter_t* limiter =
+          rocksdb_ratelimiter_create_with_mode(1024 * 1024, 100 * 1000, 10, 2,
+                                               0);
+      rocksdb_backup_engine_options_set_backup_rate_limiter(bdo, limiter);
+      rocksdb_backup_engine_options_set_restore_rate_limiter(bdo, limiter);
+      rocksdb_ratelimiter_destroy(limiter);
+    }
+
     rocksdb_backup_engine_options_set_max_background_operations(bdo, 20);
     CheckCondition(
         20 == rocksdb_backup_engine_options_get_max_background_operations(bdo));

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -378,6 +378,14 @@ rocksdb_backup_engine_options_get_restore_rate_limit(
     rocksdb_backup_engine_options_t* options);
 
 extern ROCKSDB_LIBRARY_API void
+rocksdb_backup_engine_options_set_backup_rate_limiter(
+    rocksdb_backup_engine_options_t* options, rocksdb_ratelimiter_t* limiter);
+
+extern ROCKSDB_LIBRARY_API void
+rocksdb_backup_engine_options_set_restore_rate_limiter(
+    rocksdb_backup_engine_options_t* options, rocksdb_ratelimiter_t* limiter);
+
+extern ROCKSDB_LIBRARY_API void
 rocksdb_backup_engine_options_set_max_background_operations(
     rocksdb_backup_engine_options_t* options, int val);
 


### PR DESCRIPTION
## Summary

  - Add `rocksdb_backup_engine_options_set_backup_rate_limiter()` and
    `rocksdb_backup_engine_options_set_restore_rate_limiter()` to `c.h` and `db/c.cc`
  - Allows language bindings (e.g. Rust via `librocksdb-sys`) to pass a full `RateLimiter`
    object — including `kAllIo` mode for read+write throttling — without needing a custom
    C++ shim
  - The existing `backup_rate_limit` / `restore_rate_limit` uint64_t setters only throttle
    writes; these new functions expose the richer `shared_ptr<RateLimiter>` fields
    (`backup_rate_limiter` / `restore_rate_limiter`) that override the uint64_t limits

  ## Context

  The C API already has `rocksdb_ratelimiter_create_with_mode()` to create a limiter with
  `kAllIo` mode, but there was no way to attach it to `BackupEngineOptions`. This gap meant
  C API consumers had to fall back to the write-only uint64_t limit or write a C++ shim.

  This follows the same pattern as `rocksdb_options_set_ratelimiter()` in `db/c.cc` and
  complements the pending StopBackup C API PR on branch `rajsuvariya/add-stop-backup-c-api`,
  both aimed at making the backup engine fully usable from C API consumers.

  ## Test plan

  - [x] `make c_test` builds cleanly
  - [x] `./c_test` passes all phases including `backup_engine_option`
  - [x] New test exercises both setters with a `kAllIo` limiter (mode=2), verifying
        shared_ptr handoff works correctly
