### PR TITLE
Add bloom-only batch check to SstFileReader

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2088,6 +2088,9 @@ ribbon_bench: $(OBJ_DIR)/microbench/ribbon_bench.o $(LIBRARY)
 db_basic_bench: $(OBJ_DIR)/microbench/db_basic_bench.o $(LIBRARY)
 	$(AM_LINK)
 
+sst_file_reader_bench: $(OBJ_DIR)/microbench/sst_file_reader_bench.o $(LIBRARY)
+	$(AM_LINK)
+
 cache_reservation_manager_test: $(OBJ_DIR)/cache/cache_reservation_manager_test.o $(TEST_LIBRARY) $(LIBRARY)
 	$(AM_LINK)
 

--- a/include/rocksdb/sst_file_reader.h
+++ b/include/rocksdb/sst_file_reader.h
@@ -48,6 +48,14 @@ class SstFileReader {
   Status Get(const ReadOptions& options, const Slice& key,
              PinnableSlice* value);
 
+  // Bloom-only batch check. For each key, false means the key is definitely
+  // absent; true means it may be present or the reader cannot answer safely.
+  void MayMatch(const ReadOptions& options, const Slice* keys, size_t num_keys,
+                bool* results);
+
+  // Equivalent to MayMatch(ReadOptions(), keys, num_keys, results).
+  void MayMatch(const Slice* keys, size_t num_keys, bool* results);
+
   // Returns a new iterator over the table contents as a raw table iterator,
   // a.k.a a `TableIterator`that iterates all point data entries in the table
   // including logically invisible entries like delete entries.

--- a/include/rocksdb/sst_file_reader.h
+++ b/include/rocksdb/sst_file_reader.h
@@ -49,9 +49,16 @@ class SstFileReader {
              PinnableSlice* value);
 
   // Bloom-only batch check. For each key, false means the key is definitely
-  // absent; true means it may be present or the reader cannot answer safely.
-  void MayMatch(const ReadOptions& options, const Slice* keys, size_t num_keys,
-                bool* results);
+  // absent from this SST; true means the key may be present, the table has
+  // no filter, the table type does not support filter-only batch checks, or
+  // the filter block could not be read under the supplied ReadOptions
+  // (e.g. read_tier=kBlockCacheTier and filter not in cache). This call
+  // never reads data blocks; it only consults the filter.
+  //
+  // Errors from the filter read are treated as "may match" and are not
+  // surfaced to the caller. (See MultiGet for an API that returns Status.)
+  void MayMatch(const ReadOptions& read_options, const Slice* keys,
+                size_t num_keys, bool* results);
 
   // Equivalent to MayMatch(ReadOptions(), keys, num_keys, results).
   void MayMatch(const Slice* keys, size_t num_keys, bool* results);

--- a/include/rocksdb/sst_file_reader.h
+++ b/include/rocksdb/sst_file_reader.h
@@ -55,13 +55,17 @@ class SstFileReader {
   // (e.g. read_tier=kBlockCacheTier and filter not in cache). This call
   // never reads data blocks; it only consults the filter.
   //
-  // Errors from the filter read are treated as "may match" and are not
-  // surfaced to the caller. (See MultiGet for an API that returns Status.)
-  void MayMatch(const ReadOptions& read_options, const Slice* keys,
-                size_t num_keys, bool* results);
+  // Returns OK on success. If the underlying filter probe returns a non-OK
+  // status for any batch (e.g. Incomplete from kBlockCacheTier with the
+  // filter not cached, NotSupported from a table type without a filter-only
+  // batch probe, or an I/O / corruption error), the first such status is
+  // returned and the corresponding result entries are left as true so the
+  // results array is always safe for the caller to consult.
+  Status MayMatch(const ReadOptions& read_options, const Slice* keys,
+                  size_t num_keys, bool* results);
 
   // Equivalent to MayMatch(ReadOptions(), keys, num_keys, results).
-  void MayMatch(const Slice* keys, size_t num_keys, bool* results);
+  Status MayMatch(const Slice* keys, size_t num_keys, bool* results);
 
   // Returns a new iterator over the table contents as a raw table iterator,
   // a.k.a a `TableIterator`that iterates all point data entries in the table

--- a/microbench/sst_file_reader_bench.cc
+++ b/microbench/sst_file_reader_bench.cc
@@ -1,0 +1,256 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#ifndef OS_WIN
+#include <unistd.h>
+#endif  // !OS_WIN
+
+#include <algorithm>
+#include <cinttypes>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "benchmark/benchmark.h"
+#include "rocksdb/env.h"
+#include "rocksdb/filter_policy.h"
+#include "rocksdb/options.h"
+#include "rocksdb/slice.h"
+#include "rocksdb/sst_file_reader.h"
+#include "rocksdb/sst_file_writer.h"
+#include "rocksdb/table.h"
+#include "table/multiget_context.h"
+
+namespace ROCKSDB_NAMESPACE {
+namespace {
+
+constexpr size_t kNumTableKeys = 16 * 1024;
+constexpr size_t kMaxBenchmarkBatchSize = 1024;
+constexpr size_t kValueSize = 32;
+
+std::string MakeKey(uint64_t value) {
+  char buf[32];
+  snprintf(buf, sizeof(buf), "key%016" PRIu64, value);
+  return std::string(buf);
+}
+
+std::string MakeMissingKey(uint64_t value) {
+  char buf[32];
+  snprintf(buf, sizeof(buf), "missing%016" PRIu64, value);
+  return std::string(buf);
+}
+
+std::string MakeValue(uint64_t value) {
+  std::string result = "value";
+  result.append(std::to_string(value));
+  result.resize(kValueSize, 'x');
+  return result;
+}
+
+uint64_t ProcessId() {
+#ifndef OS_WIN
+  return static_cast<uint64_t>(getpid());
+#else
+  return 0;
+#endif
+}
+
+char FilePathSeparator() {
+#ifdef OS_WIN
+  return '\\';
+#else
+  return '/';
+#endif
+}
+
+std::vector<Slice> ToSlices(const std::vector<std::string>& keys) {
+  std::vector<Slice> slices;
+  slices.reserve(keys.size());
+  for (const auto& key : keys) {
+    slices.emplace_back(key);
+  }
+  return slices;
+}
+
+void MakeLookupKeys(size_t batch_size, int hit_rate_pct,
+                    std::vector<std::string>* storage) {
+  storage->clear();
+  storage->reserve(batch_size);
+  for (size_t i = 0; i < batch_size; ++i) {
+    const bool hit =
+        hit_rate_pct == 100 ||
+        (hit_rate_pct != 0 && static_cast<int>(i % 100) < hit_rate_pct);
+    if (hit) {
+      storage->emplace_back(MakeKey((i * 131) % kNumTableKeys));
+    } else {
+      storage->emplace_back(MakeMissingKey(i));
+    }
+  }
+}
+
+void SstFileReaderBenchArguments(benchmark::internal::Benchmark* b) {
+  for (int batch_size :
+       {1, 8, 32, 128, static_cast<int>(kMaxBenchmarkBatchSize)}) {
+    for (int hit_rate_pct : {0, 10, 100}) {
+      b->Args({batch_size, hit_rate_pct});
+    }
+  }
+  b->ArgNames({"batch_size", "hit_rate_pct"});
+}
+
+class SstFileReaderBenchFixture {
+ public:
+  SstFileReaderBenchFixture(size_t batch_size, int hit_rate_pct)
+      : options_(MakeOptions()), reader_(options_) {
+    Status s = PrepareFileName();
+    if (s.ok()) {
+      s = BuildSstFile();
+    }
+    if (s.ok()) {
+      s = reader_.Open(file_name_);
+    }
+    if (s.ok()) {
+      MakeLookupKeys(batch_size, hit_rate_pct, &lookup_storage_);
+      lookup_keys_ = ToSlices(lookup_storage_);
+      may_match_results_.reset(new bool[batch_size]);
+      PrepareMultiGetChunks();
+      WarmFilter();
+    }
+    status_ = s;
+  }
+
+  ~SstFileReaderBenchFixture() {
+    if (!file_name_.empty()) {
+      options_.env->DeleteFile(file_name_).PermitUncheckedError();
+    }
+  }
+
+  SstFileReaderBenchFixture(const SstFileReaderBenchFixture&) = delete;
+  SstFileReaderBenchFixture& operator=(const SstFileReaderBenchFixture&) =
+      delete;
+  SstFileReaderBenchFixture(SstFileReaderBenchFixture&&) = delete;
+  SstFileReaderBenchFixture& operator=(SstFileReaderBenchFixture&&) = delete;
+
+  Status status() const { return status_; }
+
+  void RunMayMatch() {
+    reader_.MayMatch(read_options_, lookup_keys_.data(), lookup_keys_.size(),
+                     may_match_results_.get());
+    benchmark::DoNotOptimize(may_match_results_.get());
+  }
+
+  void RunMultiGet() {
+    for (size_t i = 0; i < multiget_keys_.size(); ++i) {
+      std::vector<Status> statuses =
+          reader_.MultiGet(read_options_, multiget_keys_[i], &values_[i]);
+      benchmark::DoNotOptimize(statuses.data());
+      benchmark::DoNotOptimize(values_[i].data());
+    }
+  }
+
+  size_t batch_size() const { return lookup_keys_.size(); }
+
+ private:
+  static Options MakeOptions() {
+    Options options;
+    options.compression = kNoCompression;
+    BlockBasedTableOptions table_options;
+    table_options.filter_policy.reset(NewBloomFilterPolicy(16, false));
+    options.table_factory.reset(NewBlockBasedTableFactory(table_options));
+    return options;
+  }
+
+  Status PrepareFileName() {
+    std::string test_dir;
+    Status s = options_.env->GetTestDirectory(&test_dir);
+    if (!s.ok()) {
+      return s;
+    }
+    file_name_ = test_dir + FilePathSeparator() + "sst_file_reader_bench_" +
+                 std::to_string(ProcessId()) + "_" +
+                 std::to_string(reinterpret_cast<uintptr_t>(this)) + ".sst";
+    options_.env->DeleteFile(file_name_).PermitUncheckedError();
+    return Status::OK();
+  }
+
+  Status BuildSstFile() {
+    SstFileWriter writer(EnvOptions(), options_);
+    Status s = writer.Open(file_name_);
+    for (uint64_t i = 0; s.ok() && i < kNumTableKeys; ++i) {
+      s = writer.Put(MakeKey(i), MakeValue(i));
+    }
+    if (s.ok()) {
+      s = writer.Finish();
+    }
+    return s;
+  }
+
+  void PrepareMultiGetChunks() {
+    for (size_t base = 0; base < lookup_keys_.size();
+         base += MultiGetContext::MAX_BATCH_SIZE) {
+      const size_t chunk_size = std::min<size_t>(
+          MultiGetContext::MAX_BATCH_SIZE, lookup_keys_.size() - base);
+      multiget_keys_.emplace_back(lookup_keys_.begin() + base,
+                                  lookup_keys_.begin() + base + chunk_size);
+      values_.emplace_back();
+      values_.back().reserve(chunk_size);
+    }
+  }
+
+  void WarmFilter() {
+    reader_.MayMatch(read_options_, lookup_keys_.data(), lookup_keys_.size(),
+                     may_match_results_.get());
+  }
+
+  Options options_;
+  ReadOptions read_options_;
+  SstFileReader reader_;
+  std::string file_name_;
+  Status status_;
+  std::vector<std::string> lookup_storage_;
+  std::vector<Slice> lookup_keys_;
+  std::unique_ptr<bool[]> may_match_results_;
+  std::vector<std::vector<Slice>> multiget_keys_;
+  std::vector<std::vector<PinnableSlice>> values_;
+};
+
+void BM_SstFileReaderMayMatch(benchmark::State& state) {
+  SstFileReaderBenchFixture fixture(static_cast<size_t>(state.range(0)),
+                                    static_cast<int>(state.range(1)));
+  if (!fixture.status().ok()) {
+    state.SkipWithError(fixture.status().ToString().c_str());
+    return;
+  }
+
+  for (auto _ : state) {
+    fixture.RunMayMatch();
+  }
+  state.SetItemsProcessed(state.iterations() *
+                          static_cast<int64_t>(fixture.batch_size()));
+}
+
+void BM_SstFileReaderMultiGet(benchmark::State& state) {
+  SstFileReaderBenchFixture fixture(static_cast<size_t>(state.range(0)),
+                                    static_cast<int>(state.range(1)));
+  if (!fixture.status().ok()) {
+    state.SkipWithError(fixture.status().ToString().c_str());
+    return;
+  }
+
+  for (auto _ : state) {
+    fixture.RunMultiGet();
+  }
+  state.SetItemsProcessed(state.iterations() *
+                          static_cast<int64_t>(fixture.batch_size()));
+}
+
+BENCHMARK(BM_SstFileReaderMayMatch)->Apply(SstFileReaderBenchArguments);
+BENCHMARK(BM_SstFileReaderMultiGet)->Apply(SstFileReaderBenchArguments);
+
+}  // namespace
+}  // namespace ROCKSDB_NAMESPACE
+
+BENCHMARK_MAIN();

--- a/microbench/sst_file_reader_bench.cc
+++ b/microbench/sst_file_reader_bench.cc
@@ -137,8 +137,10 @@ class SstFileReaderBenchFixture {
   Status status() const { return status_; }
 
   void RunMayMatch() {
-    reader_.MayMatch(read_options_, lookup_keys_.data(), lookup_keys_.size(),
-                     may_match_results_.get());
+    reader_
+        .MayMatch(read_options_, lookup_keys_.data(), lookup_keys_.size(),
+                  may_match_results_.get())
+        .PermitUncheckedError();
     benchmark::DoNotOptimize(may_match_results_.get());
   }
 
@@ -201,8 +203,10 @@ class SstFileReaderBenchFixture {
   }
 
   void WarmFilter() {
-    reader_.MayMatch(read_options_, lookup_keys_.data(), lookup_keys_.size(),
-                     may_match_results_.get());
+    reader_
+        .MayMatch(read_options_, lookup_keys_.data(), lookup_keys_.size(),
+                  may_match_results_.get())
+        .PermitUncheckedError();
   }
 
   Options options_;

--- a/src.mk
+++ b/src.mk
@@ -695,6 +695,7 @@ WITH_FAISS_TEST_MAIN_SOURCES =                                          \
 MICROBENCH_SOURCES =                                          \
   microbench/ribbon_bench.cc                                  \
   microbench/db_basic_bench.cc                                \
+  microbench/sst_file_reader_bench.cc                         \
 
 JNI_NATIVE_SOURCES =                                          \
   java/rocksjni/backupenginejni.cc                            \

--- a/table/sst_file_reader.cc
+++ b/table/sst_file_reader.cc
@@ -84,6 +84,60 @@ Status SstFileReader::Open(const std::string& file_path) {
   return s;
 }
 
+void SstFileReader::MayMatch(const ReadOptions& roptions, const Slice* keys,
+                             size_t num_keys, bool* results) {
+  for (size_t i = 0; i < num_keys; ++i) {
+    results[i] = true;
+  }
+  if (num_keys == 0) {
+    return;
+  }
+
+  auto r = rep_.get();
+  const auto sequence = roptions.snapshot != nullptr
+                            ? roptions.snapshot->GetSequenceNumber()
+                            : kMaxSequenceNumber;
+
+  for (size_t base = 0; base < num_keys;
+       base += MultiGetContext::MAX_BATCH_SIZE) {
+    const size_t batch_size = std::min<size_t>(
+        MultiGetContext::MAX_BATCH_SIZE, num_keys - base);
+
+    autovector<Status, MultiGetContext::MAX_BATCH_SIZE> statuses;
+    autovector<KeyContext, MultiGetContext::MAX_BATCH_SIZE> key_context;
+    autovector<KeyContext*, MultiGetContext::MAX_BATCH_SIZE> sorted_keys;
+    statuses.resize(batch_size);
+    sorted_keys.resize(batch_size);
+
+    for (size_t i = 0; i < batch_size; ++i) {
+      key_context.emplace_back(nullptr, keys[base + i], nullptr, nullptr,
+                               nullptr /* timestamp */, &statuses[i]);
+      sorted_keys[i] = &key_context[i];
+    }
+
+    MultiGetContext ctx(&sorted_keys, 0, batch_size, sequence, roptions,
+                        r->ioptions.fs.get(), nullptr);
+    MultiGetRange range = ctx.GetMultiGetRange();
+    const Status s = r->table_reader->MultiGetFilter(
+        roptions, r->moptions.prefix_extractor.get(), &range);
+    if (!s.ok()) {
+      continue;
+    }
+
+    for (size_t i = 0; i < batch_size; ++i) {
+      results[base + i] = false;
+    }
+    for (auto iter = range.begin(); iter != range.end(); ++iter) {
+      results[base + iter.index()] = true;
+    }
+  }
+}
+
+void SstFileReader::MayMatch(const Slice* keys, size_t num_keys,
+                             bool* results) {
+  MayMatch(ReadOptions(), keys, num_keys, results);
+}
+
 std::vector<Status> SstFileReader::MultiGet(
     const ReadOptions& roptions, const std::vector<Slice>& keys,
     std::vector<PinnableSlice>* values) {

--- a/table/sst_file_reader.cc
+++ b/table/sst_file_reader.cc
@@ -86,41 +86,48 @@ Status SstFileReader::Open(const std::string& file_path) {
 
 void SstFileReader::MayMatch(const ReadOptions& roptions, const Slice* keys,
                              size_t num_keys, bool* results) {
-  for (size_t i = 0; i < num_keys; ++i) {
-    results[i] = true;
-  }
   if (num_keys == 0) {
     return;
   }
 
   auto r = rep_.get();
+  if (r->table_reader == nullptr) {
+    for (size_t i = 0; i < num_keys; ++i) {
+      results[i] = true;
+    }
+    return;
+  }
   const auto sequence = roptions.snapshot != nullptr
                             ? roptions.snapshot->GetSequenceNumber()
                             : kMaxSequenceNumber;
 
   for (size_t base = 0; base < num_keys;
        base += MultiGetContext::MAX_BATCH_SIZE) {
-    const size_t batch_size = std::min<size_t>(
-        MultiGetContext::MAX_BATCH_SIZE, num_keys - base);
+    const size_t batch_size =
+        std::min<size_t>(MultiGetContext::MAX_BATCH_SIZE, num_keys - base);
 
-    autovector<Status, MultiGetContext::MAX_BATCH_SIZE> statuses;
+    Status status;
     autovector<KeyContext, MultiGetContext::MAX_BATCH_SIZE> key_context;
     autovector<KeyContext*, MultiGetContext::MAX_BATCH_SIZE> sorted_keys;
-    statuses.resize(batch_size);
-    sorted_keys.resize(batch_size);
 
     for (size_t i = 0; i < batch_size; ++i) {
       key_context.emplace_back(nullptr, keys[base + i], nullptr, nullptr,
-                               nullptr /* timestamp */, &statuses[i]);
-      sorted_keys[i] = &key_context[i];
+                               nullptr /* timestamp */, &status);
+      sorted_keys.emplace_back(&key_context[i]);
     }
 
+    // Full filters do not require sorted lookup keys. Partitioned filters can
+    // still answer conservatively with unsorted input; they may just miss the
+    // partition grouping optimization used by full MultiGet.
     MultiGetContext ctx(&sorted_keys, 0, batch_size, sequence, roptions,
                         r->ioptions.fs.get(), nullptr);
     MultiGetRange range = ctx.GetMultiGetRange();
     const Status s = r->table_reader->MultiGetFilter(
         roptions, r->moptions.prefix_extractor.get(), &range);
     if (!s.ok()) {
+      for (size_t i = 0; i < batch_size; ++i) {
+        results[base + i] = true;
+      }
       continue;
     }
 

--- a/table/sst_file_reader.cc
+++ b/table/sst_file_reader.cc
@@ -84,10 +84,10 @@ Status SstFileReader::Open(const std::string& file_path) {
   return s;
 }
 
-void SstFileReader::MayMatch(const ReadOptions& roptions, const Slice* keys,
-                             size_t num_keys, bool* results) {
+Status SstFileReader::MayMatch(const ReadOptions& roptions, const Slice* keys,
+                               size_t num_keys, bool* results) {
   if (num_keys == 0) {
-    return;
+    return Status::OK();
   }
 
   auto r = rep_.get();
@@ -95,12 +95,13 @@ void SstFileReader::MayMatch(const ReadOptions& roptions, const Slice* keys,
     for (size_t i = 0; i < num_keys; ++i) {
       results[i] = true;
     }
-    return;
+    return Status::InvalidArgument("SstFileReader::Open was not called");
   }
   const auto sequence = roptions.snapshot != nullptr
                             ? roptions.snapshot->GetSequenceNumber()
                             : kMaxSequenceNumber;
 
+  Status first_error;
   for (size_t base = 0; base < num_keys;
        base += MultiGetContext::MAX_BATCH_SIZE) {
     const size_t batch_size =
@@ -128,6 +129,9 @@ void SstFileReader::MayMatch(const ReadOptions& roptions, const Slice* keys,
       for (size_t i = 0; i < batch_size; ++i) {
         results[base + i] = true;
       }
+      if (first_error.ok()) {
+        first_error = s;
+      }
       continue;
     }
 
@@ -138,11 +142,12 @@ void SstFileReader::MayMatch(const ReadOptions& roptions, const Slice* keys,
       results[base + iter.index()] = true;
     }
   }
+  return first_error;
 }
 
-void SstFileReader::MayMatch(const Slice* keys, size_t num_keys,
-                             bool* results) {
-  MayMatch(ReadOptions(), keys, num_keys, results);
+Status SstFileReader::MayMatch(const Slice* keys, size_t num_keys,
+                               bool* results) {
+  return MayMatch(ReadOptions(), keys, num_keys, results);
 }
 
 std::vector<Status> SstFileReader::MultiGet(

--- a/table/sst_file_reader_test.cc
+++ b/table/sst_file_reader_test.cc
@@ -5,14 +5,17 @@
 
 #include "rocksdb/sst_file_reader.h"
 
+#include <array>
 #include <cinttypes>
 
 #include "db/db_test_util.h"
 #include "port/stack_trace.h"
 #include "rocksdb/convenience.h"
 #include "rocksdb/db.h"
+#include "rocksdb/snapshot.h"
 #include "rocksdb/sst_file_writer.h"
 #include "rocksdb/utilities/types_util.h"
+#include "table/multiget_context.h"
 #include "table/sst_file_writer_collectors.h"
 #include "test_util/testharness.h"
 #include "test_util/testutil.h"
@@ -31,6 +34,29 @@ std::string EncodeAsUint64(uint64_t v) {
   PutFixed64(&dst, v);
   return dst;
 }
+
+std::vector<Slice> ToSlices(const std::vector<std::string>& keys) {
+  std::vector<Slice> slices;
+  for (const auto& key : keys) {
+    slices.emplace_back(key);
+  }
+  return slices;
+}
+
+class TestSnapshot : public Snapshot {
+ public:
+  explicit TestSnapshot(SequenceNumber sequence_number)
+      : sequence_number_(sequence_number) {}
+
+  SequenceNumber GetSequenceNumber() const override { return sequence_number_; }
+
+  int64_t GetUnixTime() const override { return 0; }
+
+  uint64_t GetTimestamp() const override { return 0; }
+
+ private:
+  SequenceNumber sequence_number_;
+};
 
 class SstFileReaderTest : public testing::Test {
  public:
@@ -128,6 +154,7 @@ TEST_F(SstFileReaderTest, Uint64Comparator) {
 }
 
 TEST_F(SstFileReaderTest, MayMatchUsesBloomFilter) {
+  options_.statistics = CreateDBStatistics();
   BlockBasedTableOptions table_options;
   table_options.filter_policy.reset(NewBloomFilterPolicy(100, false));
   options_.table_factory.reset(NewBlockBasedTableFactory(table_options));
@@ -143,19 +170,19 @@ TEST_F(SstFileReaderTest, MayMatchUsesBloomFilter) {
 
   std::vector<std::string> lookup_storage = {EncodeAsString(0),
                                              EncodeAsString(1), "not-present"};
-  std::vector<Slice> lookup_keys;
-  for (const auto& key : lookup_storage) {
-    lookup_keys.emplace_back(key);
-  }
+  std::vector<Slice> lookup_keys = ToSlices(lookup_storage);
 
   bool may_match[3] = {};
   ReadOptions read_options;
-  read_options.read_tier = kBlockCacheTier;
+  ASSERT_OK(options_.statistics->Reset());
   reader.MayMatch(read_options, lookup_keys.data(), lookup_keys.size(),
                   may_match);
   ASSERT_TRUE(may_match[0]);
   ASSERT_TRUE(may_match[1]);
   ASSERT_FALSE(may_match[2]);
+  ASSERT_EQ(0, options_.statistics->getTickerCount(BLOCK_CACHE_DATA_HIT));
+  ASSERT_EQ(0, options_.statistics->getTickerCount(BLOCK_CACHE_DATA_MISS));
+  ASSERT_EQ(1, options_.statistics->getTickerCount(BLOOM_FILTER_USEFUL));
 }
 
 TEST_F(SstFileReaderTest, MayMatchReturnsAllTrueWithoutFilter) {
@@ -170,16 +197,101 @@ TEST_F(SstFileReaderTest, MayMatchReturnsAllTrueWithoutFilter) {
 
   std::vector<std::string> lookup_storage = {EncodeAsString(0),
                                              EncodeAsString(1), "not-present"};
-  std::vector<Slice> lookup_keys;
-  for (const auto& key : lookup_storage) {
-    lookup_keys.emplace_back(key);
-  }
+  std::vector<Slice> lookup_keys = ToSlices(lookup_storage);
 
   bool may_match[3] = {};
   reader.MayMatch(lookup_keys.data(), lookup_keys.size(), may_match);
   ASSERT_TRUE(may_match[0]);
   ASSERT_TRUE(may_match[1]);
   ASSERT_TRUE(may_match[2]);
+}
+
+TEST_F(SstFileReaderTest, MayMatchKeepsAllPresentKeys) {
+  BlockBasedTableOptions table_options;
+  table_options.filter_policy.reset(NewBloomFilterPolicy(100, false));
+  options_.table_factory.reset(NewBlockBasedTableFactory(table_options));
+
+  std::vector<std::string> keys;
+  for (uint64_t i = 0; i < kNumKeys; i++) {
+    keys.emplace_back(EncodeAsString(i));
+  }
+  CreateFile(sst_name_, keys);
+
+  SstFileReader reader(options_);
+  ASSERT_OK(reader.Open(sst_name_));
+
+  std::vector<std::string> lookup_storage = {
+      EncodeAsString(96), EncodeAsString(0), EncodeAsString(42)};
+  std::vector<Slice> lookup_keys = ToSlices(lookup_storage);
+
+  bool may_match[3] = {};
+  reader.MayMatch(lookup_keys.data(), lookup_keys.size(), may_match);
+  ASSERT_TRUE(may_match[0]);
+  ASSERT_TRUE(may_match[1]);
+  ASSERT_TRUE(may_match[2]);
+}
+
+TEST_F(SstFileReaderTest, MayMatchHandlesMultipleBatches) {
+  BlockBasedTableOptions table_options;
+  table_options.filter_policy.reset(NewBloomFilterPolicy(100, false));
+  options_.table_factory.reset(NewBlockBasedTableFactory(table_options));
+
+  std::vector<std::string> keys;
+  for (uint64_t i = 0; i < kNumKeys; i++) {
+    keys.emplace_back(EncodeAsString(i));
+  }
+  CreateFile(sst_name_, keys);
+
+  SstFileReader reader(options_);
+  ASSERT_OK(reader.Open(sst_name_));
+
+  const size_t num_lookups = MultiGetContext::MAX_BATCH_SIZE + 5;
+  std::vector<std::string> lookup_storage;
+  std::vector<bool> expected;
+  for (size_t i = 0; i < num_lookups; ++i) {
+    if (i % 2 == 0) {
+      lookup_storage.emplace_back(EncodeAsString(num_lookups - i));
+      expected.push_back(true);
+    } else {
+      lookup_storage.emplace_back("missing-" + EncodeAsString(i));
+      expected.push_back(false);
+    }
+  }
+  std::vector<Slice> lookup_keys = ToSlices(lookup_storage);
+
+  std::array<bool, MultiGetContext::MAX_BATCH_SIZE + 5> may_match;
+  may_match.fill(true);
+  reader.MayMatch(lookup_keys.data(), lookup_keys.size(), may_match.data());
+  for (size_t i = 0; i < num_lookups; ++i) {
+    ASSERT_EQ(expected[i], may_match[i]) << "lookup index " << i;
+  }
+}
+
+TEST_F(SstFileReaderTest, MayMatchAcceptsSnapshot) {
+  BlockBasedTableOptions table_options;
+  table_options.filter_policy.reset(NewBloomFilterPolicy(100, false));
+  options_.table_factory.reset(NewBlockBasedTableFactory(table_options));
+
+  std::vector<std::string> keys;
+  for (uint64_t i = 0; i < kNumKeys; i++) {
+    keys.emplace_back(EncodeAsString(i));
+  }
+  CreateFile(sst_name_, keys);
+
+  SstFileReader reader(options_);
+  ASSERT_OK(reader.Open(sst_name_));
+
+  std::vector<std::string> lookup_storage = {EncodeAsString(0), "not-present"};
+  std::vector<Slice> lookup_keys = ToSlices(lookup_storage);
+  TestSnapshot snapshot(42);
+  ReadOptions read_options;
+  read_options.snapshot = &snapshot;
+
+  bool may_match[2] = {};
+  reader.MayMatch(read_options, lookup_keys.data(), lookup_keys.size(),
+                  may_match);
+  ASSERT_TRUE(may_match[0]);
+  ASSERT_FALSE(may_match[1]);
 }
 
 TEST_F(SstFileReaderTest, MayMatchZeroKeysWithFilterDoesNotWriteResults) {

--- a/table/sst_file_reader_test.cc
+++ b/table/sst_file_reader_test.cc
@@ -127,6 +127,81 @@ TEST_F(SstFileReaderTest, Uint64Comparator) {
   CreateFileAndCheck(keys);
 }
 
+TEST_F(SstFileReaderTest, MayMatchUsesBloomFilter) {
+  BlockBasedTableOptions table_options;
+  table_options.filter_policy.reset(NewBloomFilterPolicy(100, false));
+  options_.table_factory.reset(NewBlockBasedTableFactory(table_options));
+
+  std::vector<std::string> keys;
+  for (uint64_t i = 0; i < kNumKeys; i++) {
+    keys.emplace_back(EncodeAsString(i));
+  }
+  CreateFile(sst_name_, keys);
+
+  SstFileReader reader(options_);
+  ASSERT_OK(reader.Open(sst_name_));
+
+  std::vector<std::string> lookup_storage = {EncodeAsString(0),
+                                             EncodeAsString(1), "not-present"};
+  std::vector<Slice> lookup_keys;
+  for (const auto& key : lookup_storage) {
+    lookup_keys.emplace_back(key);
+  }
+
+  bool may_match[3] = {};
+  ReadOptions read_options;
+  read_options.read_tier = kBlockCacheTier;
+  reader.MayMatch(read_options, lookup_keys.data(), lookup_keys.size(),
+                  may_match);
+  ASSERT_TRUE(may_match[0]);
+  ASSERT_TRUE(may_match[1]);
+  ASSERT_FALSE(may_match[2]);
+}
+
+TEST_F(SstFileReaderTest, MayMatchReturnsAllTrueWithoutFilter) {
+  std::vector<std::string> keys;
+  for (uint64_t i = 0; i < kNumKeys; i++) {
+    keys.emplace_back(EncodeAsString(i));
+  }
+  CreateFile(sst_name_, keys);
+
+  SstFileReader reader(options_);
+  ASSERT_OK(reader.Open(sst_name_));
+
+  std::vector<std::string> lookup_storage = {EncodeAsString(0),
+                                             EncodeAsString(1), "not-present"};
+  std::vector<Slice> lookup_keys;
+  for (const auto& key : lookup_storage) {
+    lookup_keys.emplace_back(key);
+  }
+
+  bool may_match[3] = {};
+  reader.MayMatch(lookup_keys.data(), lookup_keys.size(), may_match);
+  ASSERT_TRUE(may_match[0]);
+  ASSERT_TRUE(may_match[1]);
+  ASSERT_TRUE(may_match[2]);
+}
+
+TEST_F(SstFileReaderTest, MayMatchZeroKeysWithFilterDoesNotWriteResults) {
+  BlockBasedTableOptions table_options;
+  table_options.filter_policy.reset(NewBloomFilterPolicy(100, false));
+  options_.table_factory.reset(NewBlockBasedTableFactory(table_options));
+
+  std::vector<std::string> keys;
+  for (uint64_t i = 0; i < kNumKeys; i++) {
+    keys.emplace_back(EncodeAsString(i));
+  }
+  CreateFile(sst_name_, keys);
+
+  SstFileReader reader(options_);
+  ASSERT_OK(reader.Open(sst_name_));
+
+  Slice dummy;
+  bool may_match = false;
+  reader.MayMatch(&dummy, 0, &may_match);
+  ASSERT_FALSE(may_match);
+}
+
 TEST_F(SstFileReaderTest, ReadOptionsOutOfScope) {
   // Repro a bug where the SstFileReader depended on its configured ReadOptions
   // outliving it.

--- a/table/sst_file_reader_test.cc
+++ b/table/sst_file_reader_test.cc
@@ -175,8 +175,8 @@ TEST_F(SstFileReaderTest, MayMatchUsesBloomFilter) {
   bool may_match[3] = {};
   ReadOptions read_options;
   ASSERT_OK(options_.statistics->Reset());
-  reader.MayMatch(read_options, lookup_keys.data(), lookup_keys.size(),
-                  may_match);
+  ASSERT_OK(reader.MayMatch(read_options, lookup_keys.data(),
+                            lookup_keys.size(), may_match));
   ASSERT_TRUE(may_match[0]);
   ASSERT_TRUE(may_match[1]);
   ASSERT_FALSE(may_match[2]);
@@ -200,7 +200,7 @@ TEST_F(SstFileReaderTest, MayMatchReturnsAllTrueWithoutFilter) {
   std::vector<Slice> lookup_keys = ToSlices(lookup_storage);
 
   bool may_match[3] = {};
-  reader.MayMatch(lookup_keys.data(), lookup_keys.size(), may_match);
+  ASSERT_OK(reader.MayMatch(lookup_keys.data(), lookup_keys.size(), may_match));
   ASSERT_TRUE(may_match[0]);
   ASSERT_TRUE(may_match[1]);
   ASSERT_TRUE(may_match[2]);
@@ -225,7 +225,7 @@ TEST_F(SstFileReaderTest, MayMatchKeepsAllPresentKeys) {
   std::vector<Slice> lookup_keys = ToSlices(lookup_storage);
 
   bool may_match[3] = {};
-  reader.MayMatch(lookup_keys.data(), lookup_keys.size(), may_match);
+  ASSERT_OK(reader.MayMatch(lookup_keys.data(), lookup_keys.size(), may_match));
   ASSERT_TRUE(may_match[0]);
   ASSERT_TRUE(may_match[1]);
   ASSERT_TRUE(may_match[2]);
@@ -261,7 +261,8 @@ TEST_F(SstFileReaderTest, MayMatchHandlesMultipleBatches) {
 
   std::array<bool, MultiGetContext::MAX_BATCH_SIZE + 5> may_match;
   may_match.fill(true);
-  reader.MayMatch(lookup_keys.data(), lookup_keys.size(), may_match.data());
+  ASSERT_OK(
+      reader.MayMatch(lookup_keys.data(), lookup_keys.size(), may_match.data()));
   for (size_t i = 0; i < num_lookups; ++i) {
     ASSERT_EQ(expected[i], may_match[i]) << "lookup index " << i;
   }
@@ -288,8 +289,8 @@ TEST_F(SstFileReaderTest, MayMatchAcceptsSnapshot) {
   read_options.snapshot = &snapshot;
 
   bool may_match[2] = {};
-  reader.MayMatch(read_options, lookup_keys.data(), lookup_keys.size(),
-                  may_match);
+  ASSERT_OK(reader.MayMatch(read_options, lookup_keys.data(),
+                            lookup_keys.size(), may_match));
   ASSERT_TRUE(may_match[0]);
   ASSERT_FALSE(may_match[1]);
 }
@@ -310,7 +311,7 @@ TEST_F(SstFileReaderTest, MayMatchZeroKeysWithFilterDoesNotWriteResults) {
 
   Slice dummy;
   bool may_match = false;
-  reader.MayMatch(&dummy, 0, &may_match);
+  ASSERT_OK(reader.MayMatch(&dummy, 0, &may_match));
   ASSERT_FALSE(may_match);
 }
 

--- a/unreleased_history/public_api_changes/sst_file_reader_may_match.md
+++ b/unreleased_history/public_api_changes/sst_file_reader_may_match.md
@@ -1,0 +1,1 @@
+Added `SstFileReader::MayMatch`, a bloom-only batch check for determining which user keys are definitely absent from an SST without reading data blocks.


### PR DESCRIPTION
  ## Motivation

  External systems that manage their own SSTs outside an open RocksDB DB often need a "is this key definitely absent from this file?" probe — secondary-index validation, dedup metadata,  or "covered-by-newer-file" checks. The existing path is `SstFileReader::MultiGet`, which pays full point-lookup overhead (`GetContext` per key, value pinning, status array) even when  the caller only needs the filter answer.

  `SstFileReader::MayMatch` adds a bloom-only batch check on top of `TableReader::MultiGetFilter`. For each key it returns `false` if the filter proves the key absent, or `true` if the  key may be present (or the reader cannot answer: no filter configured, table type doesn't support filter probes, or filter block not in cache).

  ClickHouse's UNIQUE KEY feature is the motivating consumer — negative-key probes against ClickHouse-managed SSTs sit on the upsert-ingestion hot path. The optimization shape applies to  any caller streaming keys against an externally-managed SST.

  ## Experimental result

  Block-based table, full bloom filter (16 bits/key), 16K table keys, 1024-key lookup batches. Release build, single core, means of three repetitions.

  | Hit rate | MayMatch | MultiGet | Speedup |
  |---|---|---|---|
  | 0% (all-absent) | 31.9 ns/key | 99.2 ns/key | 3.1× |
  | 10% (negative-heavy) | 32.5 ns/key | 209 ns/key | 6.4× |
  | 100% (all-present) | 37.3 ns/key | 1010 ns/key | 27× |

  The negative-heavy row is the dominant case for the motivating workloads; the all-present row shows how much of `MultiGet`'s cost is point-lookup machinery that `MayMatch` skips.