### PR TITLE
Fix BackgroundJobPressure flakiness with TEST_WaitForBackgroundWork (#14708)

### DIFF
--- a/db/listener_test.cc
+++ b/db/listener_test.cc
@@ -1869,7 +1869,7 @@ TEST_F(EventListenerTest, BackgroundJobPressure) {
   listener->Reset();
   sleeping_task.WakeUp();
   sleeping_task.WaitUntilDone();
-  ASSERT_OK(dbfull()->TEST_WaitForCompact());
+  ASSERT_OK(dbfull()->TEST_WaitForBackgroundWork());
 
   snapshots = listener->GetSnapshots();
   CheckInvariants(snapshots);


### PR DESCRIPTION
Summary:
BackgroundJobPressure test was flaky because Phase 3 used TEST_WaitForCompact() which waits for bg_compaction_scheduled_ but NOT bg_pressure_callback_in_progress_. The final "healthy" pressure callback could still be in-flight when the test checked snapshots.back(), causing compaction_scheduled=1 instead of 0.

Fix: replace TEST_WaitForCompact() with TEST_WaitForBackgroundWork() which explicitly checks bg_pressure_callback_in_progress_ (db_impl.cc:478-484). Also add TEST_WaitForBackgroundWork() before Phase 1 and Phase 2 snapshot checks for consistency, ensuring all pressure callbacks are delivered before assertions.


Reviewed By: jaykorean

Differential Revision: D103784101


