### PR TITLE
Fix WAL corruption: reset checksum after abandoned fragments

### DIFF
--- a/db/log_reader.cc
+++ b/db/log_reader.cc
@@ -86,6 +86,19 @@ bool Reader::ReadRecord(Slice* record, std::string* scratch,
   if (uncompress_) {
     uncompress_->Reset();
   }
+  // A bad physical record can make us abandon a fragmented logical record and
+  // keep scanning in this same call:
+  //
+  //   FIRST(A) -> MIDDLE(A) -> BAD -> MIDDLE(A) -> LAST(A) -> FIRST(B)
+  //      hash += A fragments     abandon A, skip rest        hash must start B
+  //
+  // Reset the streamed logical-record checksum before hashing fragments from
+  // the next candidate record.
+  auto ResetRecordChecksum = [&]() {
+    if (record_checksum != nullptr) {
+      XXH3_64bits_reset(hash_state_);
+    }
+  };
   bool in_fragmented_record = false;
   // Record offset of the logical record that we're reading
   // 0 is a dummy value to make compilers happy
@@ -129,7 +142,7 @@ bool Reader::ReadRecord(Slice* record, std::string* scratch,
           // of a block followed by a kFullType or kFirstType record
           // at the beginning of the next block.
           ReportCorruption(scratch->size(), "partial record without end(2)");
-          XXH3_64bits_reset(hash_state_);
+          ResetRecordChecksum();
         }
         if (record_checksum != nullptr) {
           XXH3_64bits_update(hash_state_, fragment.data(), fragment.size());
@@ -298,6 +311,7 @@ bool Reader::ReadRecord(Slice* record, std::string* scratch,
       case kBadRecord:
         if (in_fragmented_record) {
           ReportCorruption(scratch->size(), "error in middle of record");
+          ResetRecordChecksum();
           in_fragmented_record = false;
           scratch->clear();
         }
@@ -331,6 +345,7 @@ bool Reader::ReadRecord(Slice* record, std::string* scratch,
         }
         if (in_fragmented_record) {
           ReportCorruption(scratch->size(), "error in middle of record");
+          ResetRecordChecksum();
           in_fragmented_record = false;
           scratch->clear();
         }
@@ -344,7 +359,10 @@ bool Reader::ReadRecord(Slice* record, std::string* scratch,
               (fragment.size() + (in_fragmented_record ? scratch->size() : 0)),
               reason.c_str());
         }
-        in_fragmented_record = false;
+        if (in_fragmented_record) {
+          ResetRecordChecksum();
+          in_fragmented_record = false;
+        }
         scratch->clear();
         break;  // switch
       }
@@ -609,11 +627,12 @@ uint8_t Reader::ReadPhysicalRecord(Slice* result, size_t* drop_size,
     }
 
     if (type == kZeroType && length == 0) {
-      // Skip zero length record without reporting any drops since
-      // such records are produced by the mmap based writing code in
-      // env_posix.cc that preallocates file regions.
-      // NOTE: this should never happen in DB written by new RocksDB versions,
-      // since we turn off mmap writes to manifest and log files
+      // Skip zero-length records without reporting any drops.
+      //
+      // Historically these could come from mmap-based preallocation. Newer WAL
+      // writers can also produce all-zero block trailers when there is not
+      // enough room left in the block for the next physical record header. See
+      // Writer::AddRecord().
       buffer_.clear();
       return kBadRecord;
     }
@@ -1015,6 +1034,7 @@ bool FragmentBufferedReader::TryReadFragment(Slice* fragment, size_t* drop_size,
   }
 
   if (type == kZeroType && length == 0) {
+    // See ReadPhysicalRecord().
     buffer_.clear();
     *fragment_type_or_err = kBadRecord;
     return true;

--- a/db/log_test.cc
+++ b/db/log_test.cc
@@ -211,7 +211,7 @@ class LogTest
         // support record checksum yet.
         uint64_t actual_record_checksum =
             XXH3_64bits(record.data(), record.size());
-        assert(actual_record_checksum == record_checksum);
+        EXPECT_EQ(actual_record_checksum, record_checksum);
       }
       return record.ToString();
     } else {
@@ -582,6 +582,33 @@ TEST_P(LogTest, UnexpectedFirstType) {
   ASSERT_EQ("EOF", Read());
   ASSERT_EQ(3U, DroppedBytes());
   ASSERT_EQ("OK", MatchError("partial record without end"));
+}
+
+// Regression test derived from a physical WAL observed during recovery: a
+// fragmented record is abandoned after a zero-length kZeroType padding record,
+// and the next fragmented record must start with a fresh logical checksum.
+TEST_P(LogTest, BadRecordInFragmentedRecordResetsRecordChecksum) {
+  if (allow_retry_read_) {
+    return;
+  }
+
+  bool recyclable_log = (std::get<0>(GetParam()) != 0);
+  int header_size = recyclable_log ? kRecyclableHeaderSize : kHeaderSize;
+  int payload_size = kBlockSize - header_size;
+  Write(BigString("foo", 3 * payload_size));
+  std::string second = BigString("bar", 3 * payload_size);
+  Write(second);
+
+  // Make the middle physical record look like the zero-length padding record
+  // that ReadPhysicalRecord() maps to kBadRecord.
+  int middle_header = kBlockSize;
+  SetByte(middle_header + 4, 0);
+  SetByte(middle_header + 5, 0);
+  SetByte(middle_header + 6, static_cast<char>(kZeroType));
+
+  ASSERT_EQ(second, Read());
+  ASSERT_EQ("EOF", Read());
+  ASSERT_EQ("OK", MatchError("error in middle of record"));
 }
 
 TEST_P(LogTest, MissingLastIsIgnored) {


### PR DESCRIPTION
## Summary

Fix WAL recovery checksum state after `log::Reader` abandons a fragmented logical record and continues scanning in the same `ReadRecord()` call.

Without this reset, the next fragmented record can inherit checksum state from the abandoned record. DB recovery then passes that stale checksum into write batch protection validation and can fail with:

```
Corruption: Write batch content corrupted.
```

## How I found it

I enabled WAL compression and `recycle_log_file_num = 2`. After a service restart, DB recovery failed with:

```
Corruption: Write batch content corrupted.
```

I inspected the WAL and found that the bytes for the record itself were valid, but the checksum returned by `log::Reader::ReadRecord()` did not match `XXH3_64bits(record.data(), record.size())` for the returned logical record.

## Root cause

Large write batches can be split into multiple physical WAL fragments:

```
record A:
  FIRST(A) -> MIDDLE(A) -> MIDDLE(A) -> LAST(A)

record B:
  FIRST(B) -> MIDDLE(B) -> LAST(B)
```

With recyclable WALs, the physical record header is larger than the legacy WAL header. When there is not enough room left in a 32 KiB block for the next recyclable header, the writer pads the remaining trailer bytes with zeroes and starts the next physical record in the next block.

That padding is intentional writer behavior:
https://github.com/facebook/rocksdb/blob/b874d2546eb07856636783729b4a9354ea422549/db/log_writer.cc#L110-L121

Example layout:

```
block N:
  [ FIRST(A) ][ MIDDLE(A) ][ 00000000 ]

block N+1:
  [ MIDDLE(A) ][ LAST(A) ][ FIRST(B) ][ MIDDLE(B) ][ LAST(B) ]
```

During recovery, the reader can see the zero trailer as a zero-length `kZeroType` record. That path returns `kBadRecord`:
https://github.com/facebook/rocksdb/blob/b874d2546eb07856636783729b4a9354ea422549/db/log_reader.cc#L611-L618

So the logical flow becomes:

```
FIRST(A) -> MIDDLE(A) -> BAD -> MIDDLE(A) -> LAST(A) -> FIRST(B)
   hash += A fragments      abandon A, skip rest        should start hash(B)
```

The reader correctly abandons record A after `BAD`, but before this patch it did not reset the streamed checksum state. If the next valid record B was also fragmented, its checksum was effectively computed as:

```
hash(A prefix + B)
```

instead of:

```
hash(B)
```

DB recovery reads WAL records with `record_checksum` enabled:
https://github.com/facebook/rocksdb/blob/b874d2546eb07856636783729b4a9354ea422549/db/db_impl/db_impl_open.cc#L1313-L1315

Then write batch protection compares that checksum with the actual write batch bytes and reports `Write batch content corrupted` on mismatch:
https://github.com/facebook/rocksdb/blob/b874d2546eb07856636783729b4a9354ea422549/db/write_batch.cc#L3534-L3538

So the WAL content was not necessarily corrupted. The reader checksum state leaked across an abandoned fragmented record.

## Fix

Reset the streamed logical-record checksum whenever `ReadRecord()` abandons an in-progress fragmented record but continues scanning in the same call.

## Tested with

```bash
make log_test -j32
./log_test --gtest_filter='*/LogTest.BadRecordInFragmentedRecordResetsRecordChecksum*'
./log_test --gtest_filter='*LogTest*Bad*:*LogTest*Unexpected*:*CompressionLogTest*Checksum*'
```

The new regression fails before the fix with a mismatch between `record_checksum` and `XXH3_64bits(record.data(), record.size())`, and passes after the fix.