### PR TITLE
env: suppress liburing TSAN false positives

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -384,6 +384,10 @@ endif
 # TSAN doesn't work well with jemalloc. If we're compiling with TSAN, we should use regular malloc.
 ifdef COMPILE_WITH_TSAN
 	DISABLE_JEMALLOC=1
+	# Use a suppressions file instead of the process-wide TSAN default
+	# suppressions hook, which belongs to the final application.
+	TSAN_OPTIONS?=suppressions=$(CURDIR)/tools/tsan_suppressions.txt
+	export TSAN_OPTIONS
 	EXEC_LDFLAGS += -fsanitize=thread
 	PLATFORM_CCFLAGS += -fsanitize=thread -fPIC -DFOLLY_SANITIZE_THREAD
 	PLATFORM_CXXFLAGS += -fsanitize=thread -fPIC -DFOLLY_SANITIZE_THREAD

--- a/crash_test.mk
+++ b/crash_test.mk
@@ -7,6 +7,13 @@ DB_STRESS_CMD?=./db_stress
 
 include common.mk
 
+ifdef COMPILE_WITH_TSAN
+	# Keep direct `make -f crash_test.mk COMPILE_WITH_TSAN=1 ...` runs
+	# aligned with the main Makefile's TSAN runtime options.
+	TSAN_OPTIONS?=suppressions=$(CURDIR)/tools/tsan_suppressions.txt
+	export TSAN_OPTIONS
+endif
+
 CRASHTEST_MAKE=$(MAKE) -f crash_test.mk
 CRASHTEST_PY=$(PYTHON) -u tools/db_crashtest.py --stress_cmd=$(DB_STRESS_CMD) --cleanup_cmd='$(DB_CLEANUP_CMD)' --destroy_db_initially=1
 

--- a/env/io_posix.cc
+++ b/env/io_posix.cc
@@ -46,6 +46,26 @@
 #define F_SET_RW_HINT (F_LINUX_SPECIFIC_BASE + 12)
 #endif
 
+// Suppress known TSAN false positives in third-party liburing code.
+// liburing's io_uring_mmap() uses __sys_mmap (raw syscall) which bypasses
+// TSAN's mmap interceptor, then immediately reads from the mapped memory in
+// io_uring_setup_ring_pointers(). When the kernel reuses a virtual address
+// that was previously mmap'd through libc (and thus tracked by TSAN), TSAN
+// flags a data race between the old mapping's write and the new io_uring
+// read. The TsanAnnotateIOUringMemory() call in CreateIOUring() resets shadow
+// state, but only after io_uring_queue_init() returns, too late for reads that
+// happen inside io_uring_mmap() during init.
+//
+// The suppression is safe because io_uring_setup_ring_pointers() is pure
+// pointer arithmetic plus reads from kernel-managed shared memory; there are no
+// real data races in that code path.
+#if defined(__SANITIZE_THREAD__) && defined(ROCKSDB_IOURING_PRESENT)
+extern "C" const char* __tsan_default_suppressions() {
+  return "race:io_uring_mmap\n"
+         "race:io_uring_setup_ring_pointers\n";
+}
+#endif  // __SANITIZE_THREAD__ && ROCKSDB_IOURING_PRESENT
+
 namespace ROCKSDB_NAMESPACE {
 
 std::string IOErrorMsg(const std::string& context,

--- a/env/io_posix.cc
+++ b/env/io_posix.cc
@@ -46,26 +46,6 @@
 #define F_SET_RW_HINT (F_LINUX_SPECIFIC_BASE + 12)
 #endif
 
-// Suppress known TSAN false positives in third-party liburing code.
-// liburing's io_uring_mmap() uses __sys_mmap (raw syscall) which bypasses
-// TSAN's mmap interceptor, then immediately reads from the mapped memory in
-// io_uring_setup_ring_pointers(). When the kernel reuses a virtual address
-// that was previously mmap'd through libc (and thus tracked by TSAN), TSAN
-// flags a data race between the old mapping's write and the new io_uring
-// read. The TsanAnnotateIOUringMemory() call in CreateIOUring() resets shadow
-// state, but only after io_uring_queue_init() returns, too late for reads that
-// happen inside io_uring_mmap() during init.
-//
-// The suppression is safe because io_uring_setup_ring_pointers() is pure
-// pointer arithmetic plus reads from kernel-managed shared memory; there are no
-// real data races in that code path.
-#if defined(__SANITIZE_THREAD__) && defined(ROCKSDB_IOURING_PRESENT)
-extern "C" const char* __tsan_default_suppressions() {
-  return "race:io_uring_mmap\n"
-         "race:io_uring_setup_ring_pointers\n";
-}
-#endif  // __SANITIZE_THREAD__ && ROCKSDB_IOURING_PRESENT
-
 namespace ROCKSDB_NAMESPACE {
 
 std::string IOErrorMsg(const std::string& context,

--- a/include/rocksdb/advanced_cache.h
+++ b/include/rocksdb/advanced_cache.h
@@ -152,7 +152,12 @@ class Cache : public Customizable {
 
     // For helpers without SecondaryCache support
     explicit CacheItemHelper(CacheEntryRole _role, DeleterFn _del_cb = nullptr)
-        : CacheItemHelper(_role, _del_cb, nullptr, nullptr, nullptr, this) {}
+        : del_cb(_del_cb),
+          size_cb(nullptr),
+          saveto_cb(nullptr),
+          create_cb(nullptr),
+          role(_role),
+          without_secondary_compat(this) {}
 
     // For helpers with SecondaryCache support
     explicit CacheItemHelper(CacheEntryRole _role, DeleterFn _del_cb,

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -30,6 +30,10 @@ _NO_SPACE_SUBSTRINGS = (
     "enospc",
 )
 _OUTPUT_PATH_RE = re.compile(r"(/[^\s]+)")
+_TSAN_OPTIONS_ENV_VAR = "TSAN_OPTIONS"
+_TSAN_SUPPRESSIONS_FILE = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "tsan_suppressions.txt")
+)
 
 
 def get_random_seed(override):
@@ -49,6 +53,16 @@ def quote_arg_for_display(arg):
         return arg
     flag, value = arg.split("=", 1)
     return f"{flag}={shlex.quote(value)}"
+
+
+def stress_cmd_env():
+    env = os.environ.copy()
+    if (
+        _TSAN_OPTIONS_ENV_VAR not in env
+        and os.path.exists(_TSAN_SUPPRESSIONS_FILE)
+    ):
+        env[_TSAN_OPTIONS_ENV_VAR] = "suppressions=" + _TSAN_SUPPRESSIONS_FILE
+    return env
 
 
 def early_argument_parsing_before_main():
@@ -1905,7 +1919,9 @@ def diagnostic_paths(finalized_params):
 
 
 def execute_cmd(cmd, timeout=None, timeout_pstack=False):
-    child = subprocess.Popen(cmd, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+    child = subprocess.Popen(
+        cmd, stderr=subprocess.PIPE, stdout=subprocess.PIPE, env=stress_cmd_env()
+    )
     print(
         "Running db_stress with pid=%d: %s\n\n"
         % (child.pid, " ".join(quote_arg_for_display(arg) for arg in cmd))
@@ -2006,7 +2022,7 @@ def cleanup_after_success(dbname):
         if parts[0] in ["--env_uri", "--fs_uri"]:
             cleanup_cmd_parts.append(arg)
     print("Running DB cleanup command - %s\n" % " ".join(cleanup_cmd_parts))
-    ret = subprocess.call(cleanup_cmd_parts)
+    ret = subprocess.call(cleanup_cmd_parts, env=stress_cmd_env())
     if ret != 0:
         print("ERROR: DB cleanup returned error %d\n" % ret)
         sys.exit(2)

--- a/tools/db_crashtest_test.py
+++ b/tools/db_crashtest_test.py
@@ -16,6 +16,7 @@ import unittest
 _DB_CRASHTEST_PATH = os.path.join(os.path.dirname(__file__), "db_crashtest.py")
 _TEST_DIR_ENV_VAR = "TEST_TMPDIR"
 _TEST_EXPECTED_DIR_ENV_VAR = "TEST_TMPDIR_EXPECTED"
+_TSAN_OPTIONS_ENV_VAR = "TSAN_OPTIONS"
 
 
 def load_db_crashtest_module():
@@ -40,6 +41,7 @@ class DBCrashTestTest(unittest.TestCase):
         )
         self.old_test_tmpdir = os.environ.get(_TEST_DIR_ENV_VAR)
         self.old_test_expected_tmpdir = os.environ.get(_TEST_EXPECTED_DIR_ENV_VAR)
+        self.old_tsan_options = os.environ.get(_TSAN_OPTIONS_ENV_VAR)
         os.environ[_TEST_DIR_ENV_VAR] = self.test_tmpdir
         os.environ.pop(_TEST_EXPECTED_DIR_ENV_VAR, None)
 
@@ -54,6 +56,11 @@ class DBCrashTestTest(unittest.TestCase):
         else:
             os.environ[_TEST_EXPECTED_DIR_ENV_VAR] = self.old_test_expected_tmpdir
 
+        if self.old_tsan_options is None:
+            os.environ.pop(_TSAN_OPTIONS_ENV_VAR, None)
+        else:
+            os.environ[_TSAN_OPTIONS_ENV_VAR] = self.old_tsan_options
+
         shutil.rmtree(self.test_tmpdir)
 
     def load_db_crashtest(self):
@@ -65,6 +72,28 @@ class DBCrashTestTest(unittest.TestCase):
         if overrides:
             params.update(overrides)
         return params
+
+    def test_stress_cmd_env_defaults_tsan_suppressions(self):
+        os.environ.pop(_TSAN_OPTIONS_ENV_VAR, None)
+        db_crashtest = self.load_db_crashtest()
+
+        env = db_crashtest.stress_cmd_env()
+
+        self.assertEqual(
+            "suppressions="
+            + os.path.abspath(
+                os.path.join(os.path.dirname(__file__), "tsan_suppressions.txt")
+            ),
+            env[_TSAN_OPTIONS_ENV_VAR],
+        )
+
+    def test_stress_cmd_env_preserves_tsan_options(self):
+        os.environ[_TSAN_OPTIONS_ENV_VAR] = "halt_on_error=1"
+        db_crashtest = self.load_db_crashtest()
+
+        env = db_crashtest.stress_cmd_env()
+
+        self.assertEqual("halt_on_error=1", env[_TSAN_OPTIONS_ENV_VAR])
 
     def test_setup_expected_values_dir_preserves_existing_contents(self):
         os.makedirs(self.expected_dir)

--- a/tools/tsan_suppressions.txt
+++ b/tools/tsan_suppressions.txt
@@ -1,0 +1,20 @@
+# ThreadSanitizer suppressions for known third-party false positives.
+#
+# Use with:
+#   TSAN_OPTIONS="suppressions=/path/to/rocksdb/tools/tsan_suppressions.txt"
+#
+# If the final application already has a TSAN suppressions file, merge these
+# entries into that application-owned file.
+#
+# liburing's io_uring_mmap() uses __sys_mmap, which bypasses TSAN's mmap
+# interceptor, then immediately reads from the mapped memory in
+# io_uring_setup_ring_pointers(). When the kernel reuses a virtual address that
+# was previously mmap'd through libc and tracked by TSAN, TSAN can report a race
+# between the old mapping's write and the new io_uring read. RocksDB annotates
+# the io_uring mappings after io_uring_queue_init() returns, but that is too
+# late for reads that happen inside liburing during initialization.
+#
+# Revisit these suppressions when RocksDB upgrades to a liburing version that no
+# longer uses the raw mmap syscall for io_uring_mmap().
+race:io_uring_mmap
+race:io_uring_setup_ring_pointers


### PR DESCRIPTION
Summary:
- Use the liburing TSAN suppressions in `tools/tsan_suppressions.txt` instead of defining the process-wide `__tsan_default_suppressions()` hook, avoiding conflicts with downstream applications.
- Wire RocksDB TSAN make and crash-test flows to use that suppressions file by default without overriding caller-provided `TSAN_OPTIONS`.
- Cover direct `db_crashtest.py` launches by passing the default suppressions to `db_stress` subprocesses.
- Fix the GCC 16 unity-build warning in `CacheItemHelper` by directly initializing the no-secondary-cache helper fields instead of delegating with `this`.

Imported from D101303486.

Test Plan:
- `COMPILE_WITH_TSAN=1 make -j128 env_test`
- `timeout 60s ./env_test --gtest_filter=EnvPosixTest.IOUringAddressReuseNoTsanFalsePositive`
- `python3 tools/db_crashtest_test.py`
- `python3 -m py_compile tools/db_crashtest.py tools/db_crashtest_test.py`
- CI: `build-linux-unity-and-headers` passed after the `CacheItemHelper` fix
