### PR TITLE
Keep remote compaction stats serialization compatible with 11.1

### DIFF
--- a/db/compaction/compaction_service_job.cc
+++ b/db/compaction/compaction_service_job.cc
@@ -846,11 +846,16 @@ static std::unordered_map<std::string, OptionTypeInfo>
          {offsetof(struct InternalStats::CompactionStats, count),
           OptionType::kUInt64T, OptionVerificationType::kNormal,
           OptionTypeFlags::kNone}},
-        {"counts", OptionTypeInfo::Array<
-                       int, static_cast<int>(CompactionReason::kNumOfReasons)>(
-                       offsetof(struct InternalStats::CompactionStats, counts),
-                       OptionVerificationType::kNormal, OptionTypeFlags::kNone,
-                       {0, OptionType::kInt})},
+        {"counts",
+         OptionTypeInfo::Array<
+             /* In release 11.2, a new compaction reason was added. This broken
+              * the reader and writer. To unblock release 11.1, we temporarily
+              * reduce the count array size to the old one. TODO add a proper
+              * serialization and deserialization method. */
+             int, static_cast<int>(CompactionReason::kNumOfReasons) - 1>(
+             offsetof(struct InternalStats::CompactionStats, counts),
+             OptionVerificationType::kNormal, OptionTypeFlags::kNone,
+             {0, OptionType::kInt})},
 };
 
 static std::unordered_map<std::string, OptionTypeInfo>


### PR DESCRIPTION
Summary:
- Reapply c4941760c9e4f3af9f838a20cd4974215902c36c so remote compaction serializes InternalStats::CompactionStats::counts with the pre-11.2 compaction-reason count.
- Keep remote compaction result metadata compatible with 11.1 readers and writers until the stats serialization path has version-aware array handling.

Test Plan:
- make format-auto
- make -j$(sysctl -n hw.ncpu) compaction_job_test compaction_service_test
- /usr/local/bin/timeout 60 ./compaction_job_test --gtest_filter=CompactionJobTest.ResultSerialization
- /usr/local/bin/timeout 60 ./compaction_service_test --gtest_filter=CompactionServiceTest.VerifyStats