### PR TITLE
Expose CreateBackupOptions with progress callback in the C API

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -55,6 +55,7 @@
 using ROCKSDB_NAMESPACE::BackgroundErrorReason;
 using ROCKSDB_NAMESPACE::BackupEngine;
 using ROCKSDB_NAMESPACE::BackupEngineOptions;
+using ROCKSDB_NAMESPACE::CreateBackupOptions;
 using ROCKSDB_NAMESPACE::BackupID;
 using ROCKSDB_NAMESPACE::BackupInfo;
 using ROCKSDB_NAMESPACE::BatchResult;
@@ -177,6 +178,9 @@ struct rocksdb_backup_engine_info_t {
 };
 struct rocksdb_restore_options_t {
   RestoreOptions rep;
+};
+struct rocksdb_create_backup_options_t {
+  CreateBackupOptions rep;
 };
 struct rocksdb_iterator_t {
   Iterator* rep;
@@ -1305,6 +1309,35 @@ void rocksdb_backup_engine_create_new_backup_flush(
     rocksdb_backup_engine_t* be, rocksdb_t* db,
     unsigned char flush_before_backup, char** errptr) {
   SaveError(errptr, be->rep->CreateNewBackup(db->rep, flush_before_backup));
+}
+
+rocksdb_create_backup_options_t* rocksdb_create_backup_options_create() {
+  return new rocksdb_create_backup_options_t;
+}
+
+void rocksdb_create_backup_options_destroy(
+    rocksdb_create_backup_options_t* options) {
+  delete options;
+}
+
+void rocksdb_create_backup_options_set_flush_before_backup(
+    rocksdb_create_backup_options_t* options, unsigned char v) {
+  options->rep.flush_before_backup = v;
+}
+
+void rocksdb_create_backup_options_set_progress_callback(
+    rocksdb_create_backup_options_t* options, void* callback_arg,
+    void (*callback)(void* arg)) {
+  options->rep.progress_callback = [callback, callback_arg]() {
+    callback(callback_arg);
+  };
+}
+
+void rocksdb_backup_engine_create_new_backup_with_options(
+    rocksdb_backup_engine_t* be, rocksdb_t* db,
+    const rocksdb_create_backup_options_t* options, char** errptr) {
+  SaveError(errptr,
+            be->rep->CreateNewBackup(options->rep, db->rep));
 }
 
 void rocksdb_backup_engine_purge_old_backups(rocksdb_backup_engine_t* be,

--- a/db/c_test.c
+++ b/db/c_test.c
@@ -299,6 +299,11 @@ static void CheckMergeCF(void* ptr, uint32_t cfid, const char* k, size_t klen,
   (*state)++;
 }
 
+static void BackupProgressCallback(void* arg) {
+  int* count = (int*)arg;
+  (*count)++;
+}
+
 static void CmpDestroy(void* arg) { (void)arg; }
 
 static int CmpCompare(void* arg, const char* a, size_t alen, const char* b,
@@ -947,6 +952,35 @@ int main(int argc, char** argv) {
   rocksdb_put(db, woptions, "foo", 3, "hello", 5, &err);
   CheckNoError(err);
   CheckGet(db, roptions, "foo", "hello");
+
+  StartPhase("backup_with_progress_callback");
+  {
+    rocksdb_backup_engine_options_t* beo =
+        rocksdb_backup_engine_options_create(dbbackupname);
+    rocksdb_backup_engine_options_set_destroy_old_data(beo, 1);
+    rocksdb_env_t* benv = rocksdb_create_default_env();
+    rocksdb_backup_engine_t* be =
+        rocksdb_backup_engine_open_opts(beo, benv, &err);
+    rocksdb_backup_engine_options_destroy(beo);
+    rocksdb_env_destroy(benv);
+    CheckNoError(err);
+
+    int progress_count = 0;
+    rocksdb_create_backup_options_t* cbo =
+        rocksdb_create_backup_options_create();
+    rocksdb_create_backup_options_set_progress_callback(
+        cbo, &progress_count, BackupProgressCallback);
+    rocksdb_backup_engine_create_new_backup_with_options(be, db, cbo, &err);
+    CheckNoError(err);
+    rocksdb_create_backup_options_destroy(cbo);
+
+    const rocksdb_backup_engine_info_t* bei =
+        rocksdb_backup_engine_get_backup_info(be);
+    CheckCondition(rocksdb_backup_engine_info_count(bei) == 1);
+    rocksdb_backup_engine_info_destroy(bei);
+
+    rocksdb_backup_engine_close(be);
+  }
 
   StartPhase("backup_and_restore");
   {

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -74,6 +74,7 @@ typedef struct rocksdb_backup_engine_t rocksdb_backup_engine_t;
 typedef struct rocksdb_backup_engine_info_t rocksdb_backup_engine_info_t;
 typedef struct rocksdb_backup_engine_options_t rocksdb_backup_engine_options_t;
 typedef struct rocksdb_restore_options_t rocksdb_restore_options_t;
+typedef struct rocksdb_create_backup_options_t rocksdb_create_backup_options_t;
 typedef struct rocksdb_memory_allocator_t rocksdb_memory_allocator_t;
 typedef struct rocksdb_lru_cache_options_t rocksdb_lru_cache_options_t;
 typedef struct rocksdb_hyper_clock_cache_options_t
@@ -226,6 +227,26 @@ extern ROCKSDB_LIBRARY_API void rocksdb_backup_engine_create_new_backup(
 extern ROCKSDB_LIBRARY_API void rocksdb_backup_engine_create_new_backup_flush(
     rocksdb_backup_engine_t* be, rocksdb_t* db,
     unsigned char flush_before_backup, char** errptr);
+
+extern ROCKSDB_LIBRARY_API rocksdb_create_backup_options_t*
+rocksdb_create_backup_options_create(void);
+
+extern ROCKSDB_LIBRARY_API void rocksdb_create_backup_options_destroy(
+    rocksdb_create_backup_options_t* options);
+
+extern ROCKSDB_LIBRARY_API void
+rocksdb_create_backup_options_set_flush_before_backup(
+    rocksdb_create_backup_options_t* options, unsigned char v);
+
+extern ROCKSDB_LIBRARY_API void
+rocksdb_create_backup_options_set_progress_callback(
+    rocksdb_create_backup_options_t* options, void* callback_arg,
+    void (*callback)(void* arg));
+
+extern ROCKSDB_LIBRARY_API void
+rocksdb_backup_engine_create_new_backup_with_options(
+    rocksdb_backup_engine_t* be, rocksdb_t* db,
+    const rocksdb_create_backup_options_t* options, char** errptr);
 
 extern ROCKSDB_LIBRARY_API void rocksdb_backup_engine_purge_old_backups(
     rocksdb_backup_engine_t* be, uint32_t num_backups_to_keep, char** errptr);


### PR DESCRIPTION
## Summary

   - Add `rocksdb_create_backup_options_t` (wrapping `CreateBackupOptions`) to the C API with:
     - `rocksdb_create_backup_options_create` / `_destroy`
     - `rocksdb_create_backup_options_set_flush_before_backup`
     - `rocksdb_create_backup_options_set_progress_callback` (fn pointer + userdata)
     - `rocksdb_backup_engine_create_new_backup_with_options`
   - Allows C API consumers (e.g. Rust via `librocksdb-sys`) to receive progress notifications during backup — fired every `callback_trigger_interval_size` bytes — without needing a C++ shim
   - The existing `rocksdb_backup_engine_create_new_backup` and `_create_new_backup_flush` are unchanged for backward compatibility

   ## Context

   The C++ `CreateBackupOptions::progress_callback` (`std::function<void()>`) was not reachable from the C API. The only existing C API backup creation functions (`create_new_backup`, `create_new_backup_flush`)
   have no way to pass a callback. This PR introduces a proper options struct following the same pattern as `rocksdb_restore_options_t` and `rocksdb_backup_engine_options_t`.

   The progress callback is bridged from the C `void (*callback)(void* arg)` + `void* callback_arg` convention into a `std::function<void()>` lambda in the implementation.

   This complements two related pending PRs on branches `rajsuvariya/add-stop-backup-c-api` and `rajsuvariya/add-backup-rate-limiter-c-api`, all aimed at making the backup engine fully usable from C API
   consumers.

   ## Test plan

   - [ ] `make c_test` builds cleanly
   - [ ] `./c_test` passes `backup_with_progress_callback` and `backup_and_restore` phases
   - [ ] New test uses `destroy_old_data=true` for a clean starting state regardless of prior runs
