### PR TITLE
Support file-wide seqno for external tables

### DIFF
--- a/include/rocksdb/external_table.h
+++ b/include/rocksdb/external_table.h
@@ -35,6 +35,15 @@ class ExternalTableFactory;
 // replacing the column family by ingesting a new set of files. In all cases,
 // the external table files will only be allowed in the bottommost level.
 //
+// Sequence numbers for ingested external table files are owned by RocksDB.
+// External table implementations store and expose user keys; RocksDB assigns a
+// single file-wide sequence number during ingestion and passes it to the
+// adapter through the MANIFEST/TableReaderOptions. External formats must not
+// rely on per-key sequence numbers to resolve visibility. RepairDB currently
+// cannot reconstruct a non-zero ingestion-assigned sequence number from an
+// external table file alone, so RepairDB is not supported for column families
+// containing external table files ingested with non-zero assigned seqnos.
+//
 // The external table can support one or both of the following layouts -
 // 1. Total order seek - All the keys in the files are in sorted order, and a
 //    user can seek to the first, last, or any key in between and iterate
@@ -63,6 +72,11 @@ class ExternalTableFactory;
 class ExternalTableIterator : public IteratorBase {
  public:
   virtual ~ExternalTableIterator() {}
+
+  // If the DB exposes reverse iteration over this table, SeekForPrev() and
+  // Prev() from IteratorBase must be implemented with normal RocksDB iterator
+  // semantics. Returning NotSupported from those methods will surface to user
+  // reverse scans.
 
   // This can optionally be called to prepare the iterator for a series
   // of scans. The scan_opts parameter specifies the order of scans to
@@ -129,7 +143,9 @@ class ExternalTableReader {
   // supports PutPropertiesBlock(), then this must be supported. The
   // properties block should be written to the table file as is (no
   // compression or mutation of any kind), and its offset in the file
-  // should be returned in file_offset.
+  // should be returned in file_offset. The RocksDB-generated properties block
+  // is also used to validate any table-level seqno metadata against the
+  // MANIFEST-provided file-wide seqno.
   virtual Status GetPropertiesBlock(std::unique_ptr<char[]>* /*property_block*/,
                                     uint64_t* /*size*/,
                                     uint64_t* /*file_offset*/) {
@@ -173,6 +189,10 @@ class ExternalTableBuilder {
 
   // Write a single KV to the table file. This is guaranteed to be called
   // in key order, and the write may be buffered and flushed at a later time.
+  // The external format receives user keys only. Internally, RocksDB requires
+  // every key in one external table file to share one sequence number; the
+  // adapter rejects a build that attempts to encode multiple seqnos in one
+  // file.
   virtual void Add(const Slice& key, const Slice& value) = 0;
 
   // Return the current Status. This could return non-ok, for example, if

--- a/table/external_table.cc
+++ b/table/external_table.cc
@@ -6,6 +6,7 @@
 #include "rocksdb/external_table.h"
 
 #include "db/dbformat.h"
+#include "db/pinned_iterators_manager.h"
 #include "logging/logging.h"
 #include "rocksdb/table.h"
 #include "table/block_based/block.h"
@@ -21,8 +22,17 @@ namespace {
 
 class ExternalTableIteratorAdapter : public InternalIterator {
  public:
-  explicit ExternalTableIteratorAdapter(ExternalTableIterator* iterator)
-      : iterator_(iterator), valid_(false) {}
+  ExternalTableIteratorAdapter(ExternalTableIterator* iterator,
+                               const InternalKeyComparator& internal_comparator,
+                               SequenceNumber global_seqno)
+      : iterator_(iterator),
+        internal_comparator_(internal_comparator),
+        global_seqno_(global_seqno),
+        valid_(false) {
+    if (iterator_) {
+      status_ = iterator_->status();
+    }
+  }
 
   // No copying allowed
   ExternalTableIteratorAdapter(const ExternalTableIteratorAdapter&) = delete;
@@ -34,60 +44,84 @@ class ExternalTableIteratorAdapter : public InternalIterator {
   bool Valid() const override { return valid_; }
 
   void SeekToFirst() override {
-    status_ = Status::OK();
-    if (iterator_) {
+    valid_ = false;
+    ResetPinnedValue();
+    if (UsableIterator()) {
+      status_ = Status::OK();
       iterator_->SeekToFirst();
       UpdateKey(OptSlice());
     }
   }
 
   void SeekToLast() override {
-    status_ = Status::OK();
-    if (iterator_) {
+    valid_ = false;
+    ResetPinnedValue();
+    if (UsableIterator()) {
+      status_ = Status::OK();
       iterator_->SeekToLast();
       UpdateKey(OptSlice());
     }
   }
 
   void Seek(const Slice& target) override {
-    status_ = Status::OK();
-    if (iterator_) {
+    valid_ = false;
+    ResetPinnedValue();
+    if (UsableIterator()) {
+      status_ = Status::OK();
       ParsedInternalKey pkey;
       status_ = ParseInternalKey(target, &pkey, /*log_err_key=*/false);
       if (status_.ok()) {
         iterator_->Seek(pkey.user_key);
         UpdateKey(OptSlice());
+        while (valid_ && status_.ok() &&
+               internal_comparator_.Compare(key(), target) < 0) {
+          iterator_->Next();
+          UpdateKey(OptSlice());
+        }
       }
     }
   }
 
   void SeekForPrev(const Slice& target) override {
-    status_ = Status::OK();
-    if (iterator_) {
+    valid_ = false;
+    ResetPinnedValue();
+    if (UsableIterator()) {
+      status_ = Status::OK();
       ParsedInternalKey pkey;
       status_ = ParseInternalKey(target, &pkey, /*log_err_key=*/false);
       if (status_.ok()) {
         iterator_->SeekForPrev(pkey.user_key);
         UpdateKey(OptSlice());
+        while (valid_ && status_.ok() &&
+               internal_comparator_.Compare(key(), target) > 0) {
+          iterator_->Prev();
+          UpdateKey(OptSlice());
+        }
       }
     }
   }
 
   void Next() override {
-    if (iterator_) {
+    ResetPinnedValue();
+    if (UsableIterator()) {
       iterator_->Next();
       UpdateKey(OptSlice());
+    } else {
+      valid_ = false;
     }
   }
 
   bool NextAndGetResult(IterateResult* result) override {
-    if (iterator_) {
+    ResetPinnedValue();
+    if (UsableIterator()) {
       valid_ = iterator_->NextAndGetResult(&result_);
       result->value_prepared = result_.value_prepared;
       result->bound_check_result = result_.bound_check_result;
       if (valid_) {
         UpdateKey(result_.key);
         result->key = key();
+      } else {
+        status_ = iterator_->status();
       }
     } else {
       valid_ = false;
@@ -96,9 +130,10 @@ class ExternalTableIteratorAdapter : public InternalIterator {
   }
 
   bool PrepareValue() override {
-    if (iterator_ && !result_.value_prepared) {
+    if (UsableIterator() && !result_.value_prepared) {
       valid_ = iterator_->PrepareValue();
-      result_.value_prepared = true;
+      status_ = iterator_->status();
+      result_.value_prepared = valid_;
     }
     return valid_;
   }
@@ -111,9 +146,12 @@ class ExternalTableIteratorAdapter : public InternalIterator {
   }
 
   void Prev() override {
-    if (iterator_) {
+    ResetPinnedValue();
+    if (UsableIterator()) {
       iterator_->Prev();
       UpdateKey(OptSlice());
+    } else {
+      valid_ = false;
     }
   }
 
@@ -126,7 +164,18 @@ class ExternalTableIteratorAdapter : public InternalIterator {
 
   Slice value() const override {
     if (iterator_) {
-      return iterator_->value();
+      Slice value = iterator_->value();
+      if (pinned_iters_mgr_ != nullptr && pinned_iters_mgr_->PinningEnabled()) {
+        // DBIter's reverse path requires values to stay valid after moving the
+        // child iterator. ExternalTableIterator only promises movement-scoped
+        // values, so copy only when DBIter explicitly enables pinning.
+        if (pinned_value_ == nullptr) {
+          pinned_value_ = new std::string(value.data(), value.size());
+          pinned_iters_mgr_->PinPtr(pinned_value_, &ReleasePinnedValue);
+        }
+        return Slice(*pinned_value_);
+      }
+      return value;
     }
     return Slice();
   }
@@ -134,38 +183,142 @@ class ExternalTableIteratorAdapter : public InternalIterator {
   Status status() const override { return status_; }
 
   void Prepare(const MultiScanArgs* scan_opts) override {
-    if (iterator_ && scan_opts) {
+    if (!UsableIterator()) {
+      return;
+    }
+    if (scan_opts) {
       iterator_->Prepare(scan_opts->GetScanRanges().data(), scan_opts->size());
-    } else if (iterator_) {
+    } else {
       iterator_->Prepare(nullptr, 0);
     }
   }
 
+  void SetPinnedItersMgr(PinnedIteratorsManager* pinned_iters_mgr) override {
+    if (pinned_iters_mgr_ != pinned_iters_mgr) {
+      ResetPinnedValue();
+    }
+    pinned_iters_mgr_ = pinned_iters_mgr;
+  }
+
+  bool IsValuePinned() const override {
+    // This mirrors BlockIter: pinning capability is reported for the current
+    // position even before value() materializes the pinned backing buffer.
+    return Valid() && pinned_iters_mgr_ != nullptr &&
+           pinned_iters_mgr_->PinningEnabled();
+  }
+
  private:
   std::unique_ptr<ExternalTableIterator> iterator_;
+  // ExternalTableIterator exposes user keys. The adapter exposes internal
+  // keys, so Seek/SeekForPrev boundary checks must use RocksDB's internal
+  // ordering after applying the file-wide seqno.
+  const InternalKeyComparator& internal_comparator_;
+  SequenceNumber global_seqno_;
   IterKey key_;
   bool valid_;
   Status status_;
   IterateResult result_;
+  PinnedIteratorsManager* pinned_iters_mgr_ = nullptr;
+  mutable std::string* pinned_value_ = nullptr;
+
+  static void ReleasePinnedValue(void* ptr) {
+    delete static_cast<std::string*>(ptr);
+  }
+
+  void ResetPinnedValue() const { pinned_value_ = nullptr; }
+
+  bool UsableIterator() {
+    if (!status_.ok()) {
+      valid_ = false;
+      return false;
+    }
+    return iterator_ != nullptr;
+  }
 
   void UpdateKey(OptSlice res) {
     if (iterator_) {
-      valid_ = iterator_->Valid();
       status_ = iterator_->status();
+      valid_ = iterator_->Valid() && status_.ok();
       if (valid_ && status_.ok()) {
         key_.SetInternalKey(res.has_value() ? res.value() : iterator_->key(),
-                            /*s=*/0, ValueType::kTypeValue);
+                            global_seqno_, ValueType::kTypeValue);
       }
     }
   }
 };
 
+Status LoadExternalTableProperties(
+    const ImmutableOptions& ioptions, ExternalTableReader* reader,
+    SequenceNumber global_seqno,
+    std::shared_ptr<const TableProperties>* props) {
+  std::unique_ptr<char[]> property_block;
+  uint64_t property_block_size = 0;
+  uint64_t property_block_offset = 0;
+  Status s = reader->GetPropertiesBlock(&property_block, &property_block_size,
+                                        &property_block_offset);
+  if (s.ok() && property_block_size > 0) {
+    std::unique_ptr<TableProperties> table_properties =
+        std::make_unique<TableProperties>();
+    BlockContents block_contents(std::move(property_block),
+                                 property_block_size);
+    Block block(std::move(block_contents));
+    s = ParsePropertiesBlock(ioptions, property_block_offset, block,
+                             table_properties);
+    if (!s.ok()) {
+      return s;
+    }
+    props->reset(table_properties.release());
+    return Status::OK();
+  }
+  if (!s.ok() && !s.IsNotSupported()) {
+    return s;
+  }
+
+  // Fallback to a minimal properties structure. External formats store user
+  // keys, so the manifest-provided file-wide seqno is the only seqno RocksDB
+  // can expose when there is no RocksDB properties block.
+  std::shared_ptr<const TableProperties> reader_props =
+      reader->GetTableProperties();
+  if (reader_props == nullptr) {
+    return Status::Corruption(
+        "External table reader returned null table properties");
+  }
+  auto mutable_props = std::make_shared<TableProperties>(*reader_props);
+  mutable_props->key_largest_seqno = global_seqno;
+  mutable_props->key_smallest_seqno = global_seqno;
+  *props = std::move(mutable_props);
+  return Status::OK();
+}
+
+Status CheckGlobalSeqnoConsistency(const TableProperties& props,
+                                   SequenceNumber largest_seqno) {
+  if (largest_seqno == kMaxSequenceNumber) {
+    return Status::OK();
+  }
+  // External files produced through SstFileWriter store 0 in the RocksDB
+  // properties block because the file format only contains user keys. Treat 0
+  // as "unknown" and let the MANIFEST-provided seqno be authoritative.
+  if ((props.key_largest_seqno != 0 &&
+       props.key_largest_seqno != largest_seqno) ||
+      (props.key_smallest_seqno != 0 &&
+       props.key_smallest_seqno != largest_seqno)) {
+    return Status::Corruption(
+        "External table seqno properties do not match manifest seqno");
+  }
+  return Status::OK();
+}
+
 class ExternalTableReaderAdapter : public TableReader {
  public:
   explicit ExternalTableReaderAdapter(
-      const ImmutableOptions& ioptions,
-      std::unique_ptr<ExternalTableReader>&& reader)
-      : ioptions_(ioptions), reader_(std::move(reader)) {}
+      const InternalKeyComparator& internal_comparator,
+      std::unique_ptr<ExternalTableReader>&& reader,
+      SequenceNumber global_seqno,
+      std::shared_ptr<const TableProperties>&& table_properties)
+      : internal_comparator_(internal_comparator),
+        reader_(std::move(reader)),
+        global_seqno_(global_seqno),
+        table_properties_(std::move(table_properties)) {}
 
   ~ExternalTableReaderAdapter() override {}
 
@@ -180,11 +333,18 @@ class ExternalTableReaderAdapter : public TableReader {
       size_t /* compaction_readahead_size */ = 0,
       bool /* allow_unprepared_value */ = false) override {
     auto iterator = reader_->NewIterator(read_options, prefix_extractor);
+    if (iterator == nullptr) {
+      return NewErrorInternalIterator<Slice>(
+          Status::Corruption("External table reader returned null iterator"),
+          arena);
+    }
     if (arena == nullptr) {
-      return new ExternalTableIteratorAdapter(iterator);
+      return new ExternalTableIteratorAdapter(iterator, internal_comparator_,
+                                              global_seqno_);
     } else {
       auto* mem = arena->AllocateAligned(sizeof(ExternalTableIteratorAdapter));
-      return new (mem) ExternalTableIteratorAdapter(iterator);
+      return new (mem) ExternalTableIteratorAdapter(
+          iterator, internal_comparator_, global_seqno_);
     }
   }
 
@@ -201,36 +361,7 @@ class ExternalTableReaderAdapter : public TableReader {
   void SetupForCompaction() override {}
 
   std::shared_ptr<const TableProperties> GetTableProperties() const override {
-    std::shared_ptr<TableProperties> props;
-    std::unique_ptr<char[]> property_block;
-    uint64_t property_block_size = 0;
-    uint64_t property_block_offset = 0;
-    Status s;
-    // Get the raw properties block from the external table reader. We don't
-    // support writing the global sequence number, but we still get and return
-    // the correct global seqno offset in the file to prevent accidental
-    // corruption.
-    s = reader_->GetPropertiesBlock(&property_block, &property_block_size,
-                                    &property_block_offset);
-    if (s.ok()) {
-      std::unique_ptr<TableProperties> table_properties =
-          std::make_unique<TableProperties>();
-      BlockContents block_contents(std::move(property_block),
-                                   property_block_size);
-      Block block(std::move(block_contents));
-      s = ParsePropertiesBlock(ioptions_, property_block_offset, block,
-                               table_properties);
-      if (s.ok()) {
-        props.reset(table_properties.release());
-      }
-    } else {
-      // Fallback to getting a minimal table properties structure from the
-      // external table reader
-      props = std::make_shared<TableProperties>(*reader_->GetTableProperties());
-      props->key_largest_seqno = 0;
-      props->key_smallest_seqno = 0;
-    }
-    return props;
+    return table_properties_;
   }
 
   size_t ApproximateMemoryUsage() const override { return 0; }
@@ -243,6 +374,9 @@ class ExternalTableReaderAdapter : public TableReader {
     if (!s.ok()) {
       return s;
     }
+    if (global_seqno_ > parsed_key.sequence) {
+      return Status::OK();
+    }
 
     PinnableSlice value;
     s = reader_->Get(read_options, parsed_key.user_key, prefix_extractor,
@@ -254,8 +388,25 @@ class ExternalTableReaderAdapter : public TableReader {
       return s;
     }
 
-    get_context->SaveValue(value, /*seq=*/0,
-                           value.IsPinned() ? &value : nullptr);
+    bool use_simple_save_value =
+        global_seqno_ == 0 && !get_context->has_callback() &&
+        !get_context->NeedToReadSequence() &&
+        (get_context->max_covering_tombstone_seq() == nullptr ||
+         *get_context->max_covering_tombstone_seq() == 0);
+    if (use_simple_save_value) {
+      get_context->SaveValue(value, /*seq=*/0,
+                             value.IsPinned() ? &value : nullptr);
+    } else {
+      ParsedInternalKey value_key(parsed_key.user_key, global_seqno_,
+                                  ValueType::kTypeValue);
+      bool matched = false;
+      Status read_status;
+      get_context->SaveValue(value_key, value, &matched, &read_status,
+                             value.IsPinned() ? &value : nullptr);
+      if (!read_status.ok()) {
+        return read_status;
+      }
+    }
     return s;
   }
 
@@ -265,8 +416,10 @@ class ExternalTableReaderAdapter : public TableReader {
   }
 
  private:
-  const ImmutableOptions& ioptions_;
+  const InternalKeyComparator& internal_comparator_;
   std::unique_ptr<ExternalTableReader> reader_;
+  SequenceNumber global_seqno_;
+  std::shared_ptr<const TableProperties> table_properties_;
 };
 
 class ExternalTableBuilderAdapter : public TableBuilder {
@@ -316,13 +469,25 @@ class ExternalTableBuilderAdapter : public TableBuilder {
   }
 
   void Add(const Slice& key, const Slice& value) override {
+    if (!status_.ok()) {
+      return;
+    }
     ParsedInternalKey pkey;
     status_ = ParseInternalKey(key, &pkey, /*log_err_key=*/false);
     if (status_.ok()) {
       if (pkey.type != ValueType::kTypeValue) {
         status_ = Status::NotSupported(
-            "Value type " + std::to_string(pkey.type) + "not supported");
+            "Value type " + std::to_string(pkey.type) + " not supported");
       } else {
+        if (properties_.num_entries == 0) {
+          properties_.key_smallest_seqno = pkey.sequence;
+          properties_.key_largest_seqno = pkey.sequence;
+        } else if (pkey.sequence != properties_.key_largest_seqno) {
+          status_ = Status::NotSupported(
+              "External table builder cannot encode multiple sequence "
+              "numbers in one file");
+          return;
+        }
         builder_->Add(pkey.user_key, value);
         properties_.num_entries++;
         properties_.raw_key_size += key.size();
@@ -345,6 +510,16 @@ class ExternalTableBuilderAdapter : public TableBuilder {
   IOStatus io_status() const override { return status_to_io_status(status()); }
 
   Status Finish() override {
+    if (finalized_) {
+      return Status::InvalidArgument(
+          "External table builder already finalized");
+    }
+    finalized_ = true;
+    if (!status_.ok()) {
+      builder_->Abandon();
+      return status_;
+    }
+
     // Approximate the data size
     properties_.data_size =
         properties_.raw_key_size + properties_.raw_value_size;
@@ -361,6 +536,10 @@ class ExternalTableBuilderAdapter : public TableBuilder {
 
     Slice prop_block = property_block_builder.Finish();
     Status s = builder_->PutPropertiesBlock(prop_block);
+    if (!s.ok() && !s.IsNotSupported()) {
+      builder_->Abandon();
+      return s;
+    }
     if (s.ok() || s.IsNotSupported()) {
       // If the builder doesn't support writing the properties block,
       // we still call Finish() and let the external builder handle it.
@@ -370,7 +549,12 @@ class ExternalTableBuilderAdapter : public TableBuilder {
     return s;
   }
 
-  void Abandon() override { builder_->Abandon(); }
+  void Abandon() override {
+    if (!finalized_) {
+      finalized_ = true;
+      builder_->Abandon();
+    }
+  }
 
   uint64_t FileSize() const override { return builder_->FileSize(); }
 
@@ -396,6 +580,7 @@ class ExternalTableBuilderAdapter : public TableBuilder {
   TableProperties properties_;
   std::vector<std::unique_ptr<InternalTblPropColl>>
       table_properties_collectors_;
+  bool finalized_ = false;
 };
 
 class ExternalTableFactoryAdapter : public TableFactory {
@@ -414,10 +599,6 @@ class ExternalTableFactoryAdapter : public TableFactory {
       bool /* prefetch_index_and_filter_in_cache */) const override {
     // SstFileReader specifies largest_seqno as kMaxSequenceNumber to denote
     // that its unknown
-    if (topts.largest_seqno > 0 && topts.largest_seqno != kMaxSequenceNumber) {
-      return Status::NotSupported(
-          "Ingesting file with sequence number larger than 0");
-    }
     if (topts.ioptions.user_comparator != nullptr &&
         topts.ioptions.user_comparator->timestamp_size() != 0) {
       return Status::NotSupported(
@@ -433,8 +614,23 @@ class ExternalTableFactoryAdapter : public TableFactory {
     if (!status.ok()) {
       return status;
     }
-    table_reader->reset(
-        new ExternalTableReaderAdapter(topts.ioptions, std::move(reader)));
+    SequenceNumber global_seqno = topts.largest_seqno;
+    if (global_seqno == kMaxSequenceNumber) {
+      global_seqno = 0;
+    }
+    std::shared_ptr<const TableProperties> props;
+    status = LoadExternalTableProperties(topts.ioptions, reader.get(),
+                                         global_seqno, &props);
+    if (!status.ok()) {
+      return status;
+    }
+    status = CheckGlobalSeqnoConsistency(*props, topts.largest_seqno);
+    if (!status.ok()) {
+      return status;
+    }
+    table_reader->reset(new ExternalTableReaderAdapter(
+        topts.internal_comparator, std::move(reader), global_seqno,
+        std::move(props)));
     file.reset();
     return Status::OK();
   }

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -16,6 +16,7 @@
 #include <cstdio>
 #include <iomanip>
 #include <iostream>
+#include <iterator>
 #include <map>
 #include <memory>
 #include <string>
@@ -6917,10 +6918,7 @@ class ExternalTableTest : public DBTestBase {
         status_ = Status::InvalidArgument();
       } else {
         if (!kv_map_.empty()) {
-          iter_ = kv_map_.begin();
-          for (uint64_t i = 0; i < kv_map_.size() - 1; ++i) {
-            iter_++;
-          }
+          iter_ = std::prev(kv_map_.end());
           valid_ = true;
         } else {
           valid_ = false;
@@ -6931,7 +6929,7 @@ class ExternalTableTest : public DBTestBase {
 
     void Seek(const Slice& target) override {
       if (status_.ok()) {
-        iter_ = kv_map_.find(target.ToString());
+        iter_ = kv_map_.lower_bound(target.ToString());
         valid_ = iter_ != kv_map_.end();
         eof_ = iter_ == kv_map_.end();
       }
@@ -6951,9 +6949,22 @@ class ExternalTableTest : public DBTestBase {
       }
     }
 
-    void SeekForPrev(const Slice& /*target*/) override {
-      valid_ = false;
-      status_ = Status::NotSupported();
+    void SeekForPrev(const Slice& target) override {
+      if (scan_options_) {
+        valid_ = false;
+        status_ = Status::InvalidArgument();
+        return;
+      }
+      if (status_.ok()) {
+        iter_ = kv_map_.upper_bound(target.ToString());
+        if (iter_ == kv_map_.begin()) {
+          valid_ = false;
+        } else {
+          --iter_;
+          valid_ = true;
+        }
+        eof_ = iter_ == kv_map_.end();
+      }
     }
 
     void Next() override {
@@ -6992,8 +7003,12 @@ class ExternalTableTest : public DBTestBase {
     }
 
     void Prev() override {
-      valid_ = false;
-      status_ = Status::NotSupported();
+      if (iter_ == kv_map_.begin()) {
+        valid_ = false;
+      } else {
+        --iter_;
+        valid_ = true;
+      }
     }
 
     Slice key() const override {
@@ -7825,8 +7840,8 @@ TEST_F(ExternalTableTest, IngestionTest) {
   iter.reset();
 
   // Create an overlapping file to ingest without atomic_replace_range option.
-  // This should fail as we don't support ingesting an external file with
-  // non-zero assigned sequence number.
+  // This should assign a file-wide sequence number and use it to overwrite
+  // the lower-level external table file.
   ingest_file += "3";
   writer.reset(new SstFileWriter(EnvOptions(), options));
   ASSERT_OK(writer->Open(ingest_file));
@@ -7837,10 +7852,307 @@ TEST_F(ExternalTableTest, IngestionTest) {
 
   s = db->IngestExternalFiles(
       {{cfh, {ingest_file}, ifo, {}, {}, Temperature::kUnknown, {}}});
-  ASSERT_EQ(s, Status::NotSupported());
+  ASSERT_OK(s);
+
+  iter.reset(db->NewIterator({}, cfh));
+  ASSERT_NE(iter, nullptr);
+  iter->Seek("foo");
+  ASSERT_TRUE(iter->Valid() && iter->status().ok());
+  ASSERT_EQ(iter->value(), "newval");
+  iter->Next();
+  ASSERT_TRUE(iter->Valid() && iter->status().ok());
+  ASSERT_EQ(iter->key(), "foo2");
+  ASSERT_EQ(iter->value(), "newval2");
+  iter->Next();
+  ASSERT_FALSE(iter->Valid());
+  ASSERT_OK(iter->status());
+  iter.reset();
+
+  ColumnFamilyMetaData cf_meta;
+  db->GetColumnFamilyMetaData(cfh, &cf_meta);
+  bool found_assigned_seqno = false;
+  for (const auto& level : cf_meta.levels) {
+    for (const auto& file : level.files) {
+      found_assigned_seqno |= file.largest_seqno > 0;
+    }
+  }
+  ASSERT_TRUE(found_assigned_seqno);
 
   ASSERT_OK(db->DestroyColumnFamilyHandle(cfh));
   ASSERT_OK(db->Close());
+}
+
+TEST_F(ExternalTableTest, BuilderRejectsMixedSequenceNumbers) {
+  // Goal: validate the single-file-wide-seqno invariant enforced by the
+  // ExternalTableBuilder adapter. The test feeds two sorted internal keys with
+  // different seqnos directly into the internal TableBuilder and verifies the
+  // adapter rejects the second key before the external format can persist an
+  // ambiguous file.
+  Options options = GetDefaultOptions();
+  std::shared_ptr<ExternalTableFactory> factory =
+      std::make_shared<DummyExternalTableFactory>(
+          /*support_property_block=*/true);
+  options.table_factory = NewExternalTableFactory(factory);
+
+  ImmutableOptions ioptions(options);
+  MutableCFOptions moptions(options);
+  InternalKeyComparator ikc(options.comparator);
+  InternalTblPropCollFactories internal_tbl_prop_coll_factories;
+  std::string column_family_name;
+  const ReadOptions read_options;
+  const WriteOptions write_options;
+
+  std::unique_ptr<FSWritableFile> sink(new test::StringSink());
+  std::unique_ptr<WritableFileWriter> file_writer(new WritableFileWriter(
+      std::move(sink), "external_table_mixed_seqno", FileOptions()));
+  std::unique_ptr<TableBuilder> builder(options.table_factory->NewTableBuilder(
+      TableBuilderOptions(ioptions, moptions, read_options, write_options, ikc,
+                          &internal_tbl_prop_coll_factories, kNoCompression,
+                          CompressionOptions(), kUnknownColumnFamily,
+                          column_family_name, -1, kUnknownNewestKeyTime),
+      file_writer.get()));
+  ASSERT_NE(builder, nullptr);
+
+  InternalKey first("a", 7, kTypeValue);
+  builder->Add(first.Encode(), "value_a");
+  ASSERT_OK(builder->status());
+
+  InternalKey second("b", 8, kTypeValue);
+  builder->Add(second.Encode(), "value_b");
+  ASSERT_TRUE(builder->status().IsNotSupported());
+
+  Status s = builder->Finish();
+  ASSERT_TRUE(s.IsNotSupported());
+}
+
+TEST_F(ExternalTableTest, ReaderRejectsMismatchedSeqnoProperties) {
+  // Goal: validate the defense-in-depth check between MANIFEST seqno metadata
+  // and the RocksDB properties block embedded in an external table file. The
+  // test writes a dummy external file whose properties claim seqno 7, then
+  // opens it through the table factory with manifest seqno 8 and expects a
+  // clean corruption error instead of silently restamping all keys.
+  Options options = GetDefaultOptions();
+  std::shared_ptr<ExternalTableFactory> factory =
+      std::make_shared<DummyExternalTableFactory>(
+          /*support_property_block=*/true);
+  options.table_factory = NewExternalTableFactory(factory);
+
+  std::string dir = test::PerThreadDBPath("external_table_seqno_mismatch");
+  ASSERT_OK(options.env->CreateDirIfMissing(dir));
+  std::string file_path = dir + "/mismatch.immutable";
+
+  DummyExternalTableFile file(file_path, /*file=*/nullptr);
+  TableProperties props;
+  props.comparator_name = BytewiseComparator()->Name();
+  props.num_entries = 1;
+  props.raw_key_size = 1;
+  props.raw_value_size = 7;
+  props.key_smallest_seqno = 7;
+  props.key_largest_seqno = 7;
+  PropertyBlockBuilder property_block_builder;
+  property_block_builder.AddTableProperty(props);
+  ASSERT_OK(file.PutPropertiesBlock(property_block_builder.Finish()));
+  ASSERT_OK(file.Serialize({{"a", "value_a"}}));
+
+  ImmutableOptions ioptions(options);
+  MutableCFOptions moptions(options);
+  InternalKeyComparator ikc(options.comparator);
+  std::unique_ptr<FSRandomAccessFile> source(
+      new test::StringSource("", 1, ioptions.allow_mmap_reads));
+  std::unique_ptr<RandomAccessFileReader> file_reader(
+      new RandomAccessFileReader(std::move(source), file_path));
+  std::unique_ptr<TableReader> table_reader;
+
+  Status s = options.table_factory->NewTableReader(
+      TableReaderOptions(
+          ioptions, moptions.prefix_extractor,
+          moptions.compression_manager.get(), EnvOptions(), ikc,
+          0 /* block_protection_bytes_per_key */, /*skip_filters=*/false,
+          /*immortal=*/false, /*force_direct_prefetch=*/false, -1,
+          /*block_cache_tracer=*/nullptr,
+          /*max_file_size_for_l0_meta_pin=*/0, "", 1, kNullUniqueId64x2,
+          /*largest_seqno=*/8),
+      std::move(file_reader), file.FileSize(), &table_reader);
+  ASSERT_TRUE(s.IsCorruption());
+}
+
+TEST_F(ExternalTableTest, IngestionAssignedSeqnoSnapshotVisibility) {
+  if (encrypted_env_) {
+    ROCKSDB_GTEST_SKIP("Test requires non-encrypted environment");
+    return;
+  }
+  Options options = GetDefaultOptions();
+  options.disable_auto_compactions = true;
+  std::shared_ptr<ExternalTableFactory> factory =
+      std::make_shared<DummyExternalTableFactory>(
+          /*support_property_block=*/true);
+  options.table_factory = NewExternalTableFactory(factory);
+
+  Reopen(options);
+
+  // Goal: validate the file-wide seqno assigned during overlapping external
+  // table ingestion. The base file remains visible to an old snapshot, while
+  // the later overlapping file is visible to latest reads and after reopen.
+  std::string base_file = dbname_ + "/base.immutable";
+  std::unique_ptr<SstFileWriter> writer;
+  writer.reset(new SstFileWriter(EnvOptions(), options));
+  ASSERT_OK(writer->Open(base_file));
+  ASSERT_OK(writer->Put("foo", "base"));
+  ASSERT_OK(writer->Put("foo2", "base2"));
+  ASSERT_OK(writer->Finish());
+  writer.reset();
+
+  IngestExternalFileOptions ifo;
+  ifo.fill_cache = false;
+  ASSERT_OK(db_->IngestExternalFile({base_file}, ifo));
+
+  // Bump LastSequence() before taking the snapshot. This makes the later
+  // overlapping ingestion receive a strictly newer assigned seqno and verifies
+  // the old snapshot is filtered by that seqno, not by file placement alone.
+  ASSERT_OK(Put("aaa", "bump"));
+
+  const Snapshot* snapshot = db_->GetSnapshot();
+  ASSERT_NE(snapshot, nullptr);
+
+  std::string overlay_file = dbname_ + "/overlay.immutable";
+  writer.reset(new SstFileWriter(EnvOptions(), options));
+  ASSERT_OK(writer->Open(overlay_file));
+  ASSERT_OK(writer->Put("foo", "overlay"));
+  ASSERT_OK(writer->Put("foo2", "overlay2"));
+  ASSERT_OK(writer->Put("foo3", "overlay3"));
+  ASSERT_OK(writer->Finish());
+  writer.reset();
+
+  SequenceNumber overlay_assigned_seqno = 0;
+  SyncPoint::GetInstance()->SetCallBack(
+      "ExternalSstFileIngestionJob::Run", [&](void* arg) {
+        overlay_assigned_seqno = *static_cast<SequenceNumber*>(arg);
+      });
+  SyncPoint::GetInstance()->EnableProcessing();
+  Status ingest_status = db_->IngestExternalFile({overlay_file}, ifo);
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+  ASSERT_OK(ingest_status);
+  ASSERT_GT(overlay_assigned_seqno, snapshot->GetSequenceNumber());
+
+  PinnableSlice value;
+  ASSERT_OK(db_->Get(ReadOptions(), db_->DefaultColumnFamily(), "foo", &value));
+  ASSERT_EQ(value, "overlay");
+  value.Reset();
+  ASSERT_OK(
+      db_->Get(ReadOptions(), db_->DefaultColumnFamily(), "foo3", &value));
+  ASSERT_EQ(value, "overlay3");
+  value.Reset();
+
+  // Also validate the exact visibility boundary. A snapshot taken immediately
+  // after ingestion should have sequence number equal to the file-wide assigned
+  // seqno, and strict `global_seqno > snapshot_seq` filtering must still make
+  // the overlay visible at that boundary.
+  const Snapshot* boundary_snapshot = db_->GetSnapshot();
+  ASSERT_NE(boundary_snapshot, nullptr);
+  ASSERT_EQ(overlay_assigned_seqno, boundary_snapshot->GetSequenceNumber());
+  ReadOptions boundary_ro;
+  boundary_ro.snapshot = boundary_snapshot;
+  ASSERT_OK(db_->Get(boundary_ro, db_->DefaultColumnFamily(), "foo", &value));
+  ASSERT_EQ(value, "overlay");
+  value.Reset();
+  std::unique_ptr<Iterator> boundary_iter(db_->NewIterator(boundary_ro));
+  ASSERT_NE(boundary_iter, nullptr);
+  boundary_iter->Seek("foo");
+  ASSERT_TRUE(boundary_iter->Valid());
+  ASSERT_EQ(boundary_iter->key(), "foo");
+  ASSERT_EQ(boundary_iter->value(), "overlay");
+  boundary_iter->Next();
+  ASSERT_TRUE(boundary_iter->Valid());
+  ASSERT_EQ(boundary_iter->key(), "foo2");
+  ASSERT_EQ(boundary_iter->value(), "overlay2");
+  ASSERT_OK(boundary_iter->status());
+  boundary_iter.reset();
+  db_->ReleaseSnapshot(boundary_snapshot);
+
+  std::unique_ptr<Iterator> latest_iter(db_->NewIterator(ReadOptions()));
+  ASSERT_NE(latest_iter, nullptr);
+  latest_iter->SeekForPrev("foo4");
+  ASSERT_TRUE(latest_iter->Valid());
+  ASSERT_EQ(latest_iter->key(), "foo3");
+  ASSERT_EQ(latest_iter->value(), "overlay3");
+  latest_iter->Prev();
+  ASSERT_TRUE(latest_iter->Valid());
+  ASSERT_EQ(latest_iter->key(), "foo2");
+  ASSERT_EQ(latest_iter->value(), "overlay2");
+  latest_iter->Prev();
+  ASSERT_TRUE(latest_iter->Valid());
+  ASSERT_EQ(latest_iter->key(), "foo");
+  ASSERT_EQ(latest_iter->value(), "overlay");
+  ASSERT_OK(latest_iter->status());
+  latest_iter.reset();
+
+  ReadOptions snapshot_ro;
+  snapshot_ro.snapshot = snapshot;
+  ASSERT_OK(db_->Get(snapshot_ro, db_->DefaultColumnFamily(), "foo", &value));
+  ASSERT_EQ(value, "base");
+  value.Reset();
+  ASSERT_OK(db_->Get(snapshot_ro, db_->DefaultColumnFamily(), "foo2", &value));
+  ASSERT_EQ(value, "base2");
+  value.Reset();
+  Status s = db_->Get(snapshot_ro, db_->DefaultColumnFamily(), "foo3", &value);
+  ASSERT_TRUE(s.IsNotFound());
+  value.Reset();
+
+  std::unique_ptr<Iterator> snapshot_iter(db_->NewIterator(snapshot_ro));
+  ASSERT_NE(snapshot_iter, nullptr);
+  snapshot_iter->Seek("foo");
+  ASSERT_TRUE(snapshot_iter->Valid());
+  ASSERT_EQ(snapshot_iter->key(), "foo");
+  ASSERT_EQ(snapshot_iter->value(), "base");
+  snapshot_iter->Next();
+  ASSERT_TRUE(snapshot_iter->Valid());
+  ASSERT_EQ(snapshot_iter->key(), "foo2");
+  ASSERT_EQ(snapshot_iter->value(), "base2");
+  snapshot_iter->Next();
+  ASSERT_FALSE(snapshot_iter->Valid());
+  ASSERT_OK(snapshot_iter->status());
+  snapshot_iter.reset();
+
+  std::unique_ptr<Iterator> snapshot_reverse_iter(
+      db_->NewIterator(snapshot_ro));
+  ASSERT_NE(snapshot_reverse_iter, nullptr);
+  snapshot_reverse_iter->SeekForPrev("foo3");
+  ASSERT_TRUE(snapshot_reverse_iter->Valid());
+  ASSERT_EQ(snapshot_reverse_iter->key(), "foo2");
+  ASSERT_EQ(snapshot_reverse_iter->value(), "base2");
+  snapshot_reverse_iter->Prev();
+  ASSERT_TRUE(snapshot_reverse_iter->Valid());
+  ASSERT_EQ(snapshot_reverse_iter->key(), "foo");
+  ASSERT_EQ(snapshot_reverse_iter->value(), "base");
+  ASSERT_OK(snapshot_reverse_iter->status());
+  snapshot_reverse_iter.reset();
+
+  db_->ReleaseSnapshot(snapshot);
+
+  auto has_assigned_seqno = [](const ColumnFamilyMetaData& cf_meta) {
+    for (const auto& level : cf_meta.levels) {
+      for (const auto& file : level.files) {
+        if (file.largest_seqno > 0) {
+          return true;
+        }
+      }
+    }
+    return false;
+  };
+
+  ColumnFamilyMetaData cf_meta;
+  db_->GetColumnFamilyMetaData(&cf_meta);
+  ASSERT_TRUE(has_assigned_seqno(cf_meta));
+
+  Reopen(options);
+  ASSERT_OK(db_->Get(ReadOptions(), db_->DefaultColumnFamily(), "foo", &value));
+  ASSERT_EQ(value, "overlay");
+  value.Reset();
+
+  ColumnFamilyMetaData reopened_meta;
+  db_->GetColumnFamilyMetaData(&reopened_meta);
+  ASSERT_TRUE(has_assigned_seqno(reopened_meta));
 }
 
 class UserDefinedIndexTestBase : public BlockBasedTableTestBase {


### PR DESCRIPTION
Summary:

Support multiple layer of LSM tree with external tables. This allows anyone to leverage RocksDB LSM logic with merging iterator and level iterator on top of the external table iterator.

Test:

CI