### PR TITLE
Add iterator block pinning with retained buffers

### DIFF
--- a/db/arena_wrapped_db_iter.cc
+++ b/db/arena_wrapped_db_iter.cc
@@ -9,6 +9,7 @@
 
 #include "db/arena_wrapped_db_iter.h"
 
+#include "db/iterator_mutable_options.h"
 #include "memory/arena.h"
 #include "rocksdb/env.h"
 #include "rocksdb/iterator.h"
@@ -37,6 +38,35 @@ Status ArenaWrappedDBIter::GetProperty(std::string prop_name,
     return Status::OK();
   }
   return db_iter_->GetProperty(prop_name, prop);
+}
+
+Status ArenaWrappedDBIter::SetMutableOptions(
+    const IteratorMutableOptions& options) {
+  Status s = ValidateIteratorMutableOptions(
+      options, cfh_ != nullptr
+                   ? cfh_->cfd()->initial_cf_options().table_factory.get()
+                   : nullptr);
+  if (!s.ok()) {
+    return s;
+  }
+  ApplyIteratorMutableOptions(options, &read_options_.iterator_mutable_options);
+  if (db_iter_ != nullptr) {
+    if (cfh_ == nullptr) {
+      db_iter_->ApplyMutableOptionsAndInvalidate(options);
+    } else {
+      DoRefresh(read_options_.snapshot, sv_number_);
+    }
+  }
+  return Status::OK();
+}
+
+Status ArenaWrappedDBIter::GetMutableOptions(
+    IteratorMutableOptions* options) const {
+  if (options == nullptr) {
+    return Status::InvalidArgument("IteratorMutableOptions is nullptr");
+  }
+  *options = read_options_.iterator_mutable_options;
+  return Status::OK();
 }
 
 void ArenaWrappedDBIter::Init(

--- a/db/arena_wrapped_db_iter.h
+++ b/db/arena_wrapped_db_iter.h
@@ -102,6 +102,17 @@ class ArenaWrappedDBIter : public Iterator {
     db_iter_->Prepare(scan_opts);
   }
 
+  Status PinCurrent(PinnableKeyValue* out) override {
+    return db_iter_->PinCurrent(out);
+  }
+
+  Status AppendPinnedCurrent(PinnableKeyValueBatch* batch) override {
+    return db_iter_->AppendPinnedCurrent(batch);
+  }
+
+  Status SetMutableOptions(const IteratorMutableOptions& options) override;
+  Status GetMutableOptions(IteratorMutableOptions* options) const override;
+
   // FIXME: we could just pass SV in for mutable cf option, version and version
   // number, but this is used by SstFileReader which does not have a SV.
   void Init(Env* env, const ReadOptions& read_options,

--- a/db/blob/blob_counting_iterator.h
+++ b/db/blob/blob_counting_iterator.h
@@ -119,6 +119,11 @@ class BlobCountingIterator : public InternalIterator {
     return iter_->IsValuePinned();
   }
 
+  Status PinCurrentKeyValue(PinnedIterKeyValue* out) override {
+    assert(Valid());
+    return iter_->PinCurrentKeyValue(out);
+  }
+
   Status GetProperty(std::string prop_name, std::string* prop) override {
     return iter_->GetProperty(prop_name, prop);
   }

--- a/db/compaction/clipping_iterator.h
+++ b/db/compaction/clipping_iterator.h
@@ -184,6 +184,11 @@ class ClippingIterator : public InternalIterator {
     return iter_->IsValuePinned();
   }
 
+  Status PinCurrentKeyValue(PinnedIterKeyValue* out) override {
+    assert(valid_);
+    return iter_->PinCurrentKeyValue(out);
+  }
+
   Status GetProperty(std::string prop_name, std::string* prop) override {
     return iter_->GetProperty(prop_name, prop);
   }

--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -17,6 +17,7 @@
 #include "db/blob/blob_file_partition_manager.h"
 #include "db/blob/blob_index.h"
 #include "db/dbformat.h"
+#include "db/iterator_mutable_options.h"
 #include "db/merge_context.h"
 #include "db/merge_helper.h"
 #include "db/pinned_iterators_manager.h"
@@ -94,6 +95,7 @@ DBIter::DBIter(Env* _env, const ReadOptions& read_options,
       timestamp_ub_(read_options.timestamp),
       timestamp_lb_(read_options.iter_start_ts),
       timestamp_size_(timestamp_ub_ ? timestamp_ub_->size() : 0),
+      mutable_options_(read_options.iterator_mutable_options),
       active_mem_(active_mem),
       memtable_seqno_lb_(kMaxSequenceNumber),
       memtable_op_scan_flush_trigger_(0),
@@ -192,6 +194,162 @@ Status DBIter::GetProperty(std::string prop_name, std::string* prop) {
     return Status::OK();
   }
   return Status::InvalidArgument("Unidentified property.");
+}
+
+Status DBIter::PrepareForPinCurrent() {
+  if (!Valid()) {
+    return Status::InvalidArgument("Iterator is not valid");
+  }
+  if (direction_ != kForward) {
+    return Status::NotSupported(
+        "Pinning the current row is only supported during forward iteration");
+  }
+  if (timestamp_size_ != 0 || timestamp_lb_ != nullptr) {
+    return Status::NotSupported(
+        "Pinning the current row does not yet support user-defined timestamps");
+  }
+  if (current_entry_is_merged_) {
+    return Status::NotSupported(
+        "Pinning the current row does not support merge results");
+  }
+  if (!iter_.Valid()) {
+    return Status::NotSupported(
+        "Pinning the current row requires the current internal entry to "
+        "remain positioned");
+  }
+  if (!iter_.IsValuePrepared() && !PrepareValue()) {
+    return status();
+  }
+  if (ikey_.type != kTypeValue) {
+    return Status::NotSupported(
+        "Pinning the current row only supports kTypeValue rows");
+  }
+  return Status::OK();
+}
+
+Status DBIter::TryPinCurrentKeyValue(Slice* current_key, Slice* current_value,
+                                     PinnedIterKeyValue* pinned_kv) {
+  assert(current_key != nullptr);
+  assert(current_value != nullptr);
+  assert(pinned_kv != nullptr);
+
+  *current_key = key();
+  *current_value = value();
+  pinned_kv->Reset();
+  return iter_.PinCurrentKeyValue(pinned_kv);
+}
+
+Status DBIter::PinCurrent(PinnableKeyValue* out) {
+  if (out == nullptr) {
+    return Status::InvalidArgument("PinnableKeyValue is nullptr");
+  }
+  out->Reset();
+  Status prepare_status = PrepareForPinCurrent();
+  if (!prepare_status.ok()) {
+    return prepare_status;
+  }
+
+  Slice current_key;
+  Slice current_value;
+  PinnedIterKeyValue pinned_kv;
+  Status pin_status =
+      TryPinCurrentKeyValue(&current_key, &current_value, &pinned_kv);
+  if (!pin_status.ok()) {
+    if (!pin_status.IsNotSupported()) {
+      return pin_status;
+    }
+    out->CopyKey(current_key);
+    out->CopyValue(current_value);
+    return Status::OK();
+  }
+
+  out->SetCleanup(std::move(pinned_kv.cleanup));
+  out->SetPinnedBlockCacheUsage(pinned_kv.pinned_block_cache_usage);
+  if (pinned_kv.value_pinned) {
+    out->PinValue(pinned_kv.value);
+  } else {
+    out->CopyValue(current_value);
+  }
+
+  if (!pinned_kv.key_pinned) {
+    out->CopyKey(current_key);
+    return Status::OK();
+  }
+
+  out->PinKey(pinned_kv.user_key);
+  return Status::OK();
+}
+
+Status DBIter::AppendPinnedCurrent(PinnableKeyValueBatch* batch) {
+  if (batch == nullptr) {
+    return Status::InvalidArgument("PinnableKeyValueBatch is nullptr");
+  }
+
+  Status prepare_status = PrepareForPinCurrent();
+  if (!prepare_status.ok()) {
+    return prepare_status;
+  }
+
+  Slice current_key;
+  Slice current_value;
+  PinnedIterKeyValue pinned_kv;
+  Status pin_status =
+      TryPinCurrentKeyValue(&current_key, &current_value, &pinned_kv);
+  if (!pin_status.ok()) {
+    if (!pin_status.IsNotSupported()) {
+      return pin_status;
+    }
+    batch->Append(current_key, false /* pin_key */, current_value,
+                  false /* pin_value */, SharedCleanablePtr(),
+                  nullptr /* cleanup_dedupe_token */,
+                  0 /* pinned_block_cache_usage */);
+    return Status::OK();
+  }
+
+  const Slice key_slice =
+      pinned_kv.key_pinned ? pinned_kv.user_key : current_key;
+  const Slice value_slice =
+      pinned_kv.value_pinned ? pinned_kv.value : current_value;
+
+  batch->Append(key_slice, pinned_kv.key_pinned, value_slice,
+                pinned_kv.value_pinned, std::move(pinned_kv.cleanup),
+                pinned_kv.cleanup_dedupe_token,
+                pinned_kv.pinned_block_cache_usage);
+  return Status::OK();
+}
+
+Status DBIter::SetMutableOptions(const IteratorMutableOptions& options) {
+  Status s = ValidateIteratorMutableOptions(
+      options, cfh_ != nullptr
+                   ? cfh_->cfd()->initial_cf_options().table_factory.get()
+                   : nullptr);
+  if (!s.ok()) {
+    return s;
+  }
+  if (iter_.iter() == nullptr) {
+    ApplyMutableOptionsAndInvalidate(options);
+    return Status::OK();
+  }
+  s = iter_.iter()->SetMutableOptions(options);
+  if (!s.ok()) {
+    return s;
+  }
+  ApplyMutableOptionsAndInvalidate(options);
+  return Status::OK();
+}
+
+Status DBIter::GetMutableOptions(IteratorMutableOptions* options) const {
+  if (options == nullptr) {
+    return Status::InvalidArgument("IteratorMutableOptions is nullptr");
+  }
+  *options = mutable_options_;
+  return Status::OK();
+}
+
+void DBIter::ApplyMutableOptionsAndInvalidate(
+    const IteratorMutableOptions& options) {
+  ApplyIteratorMutableOptions(options, &mutable_options_);
+  InvalidateCurrentPosition();
 }
 
 bool DBIter::ParseKey(ParsedInternalKey* ikey) {

--- a/db/db_iter.h
+++ b/db/db_iter.h
@@ -252,6 +252,11 @@ class DBIter final : public Iterator {
   bool PrepareValue() override;
 
   void Prepare(const MultiScanArgs& scan_opts) override;
+  Status PinCurrent(PinnableKeyValue* out) override;
+  Status AppendPinnedCurrent(PinnableKeyValueBatch* batch) override;
+  Status SetMutableOptions(const IteratorMutableOptions& options) override;
+  Status GetMutableOptions(IteratorMutableOptions* options) const override;
+  void ApplyMutableOptionsAndInvalidate(const IteratorMutableOptions& options);
   Status ValidateScanOptions(const MultiScanArgs& multiscan_opts) const;
 
  private:
@@ -532,6 +537,9 @@ class DBIter final : public Iterator {
                                       const Slice& blob_index);
   bool SetValueAndColumnsFromBlob(const Slice& user_key,
                                   const Slice& blob_index);
+  Status PrepareForPinCurrent();
+  Status TryPinCurrentKeyValue(Slice* current_key, Slice* current_value,
+                               PinnedIterKeyValue* pinned_kv);
 
   bool SetValueAndColumnsFromEntity(Slice slice);
   bool MaterializeLazyEntityColumns() const;
@@ -626,6 +634,21 @@ class DBIter final : public Iterator {
     prefix_.reset();
   }
 
+  void InvalidateCurrentPosition() {
+    ReleaseTempPinnedData();
+    ResetBlobData();
+    ResetValueAndColumns();
+    ResetInternalKeysSkippedCounter();
+    ResetContiguousTombstoneTracking();
+    saved_key_.Clear();
+    saved_timestamp_.clear();
+    prefix_.reset();
+    current_entry_is_merged_ = false;
+    is_key_seqnum_zero_ = false;
+    valid_ = false;
+    status_ = Status::OK();
+  }
+
   void MarkMemtableForFlushForAvgTrigger() {
     if (avg_op_scan_flush_trigger_ &&
         mem_hidden_op_scanned_since_seek_ >= memtable_op_scan_flush_trigger_ &&
@@ -713,6 +736,7 @@ class DBIter final : public Iterator {
   std::string saved_timestamp_;
   std::optional<MultiScanArgs> scan_opts_;
   size_t scan_index_{0};
+  IteratorMutableOptions mutable_options_;
   ReadOnlyMemTable* const active_mem_;
   SequenceNumber memtable_seqno_lb_;
   uint32_t memtable_op_scan_flush_trigger_;

--- a/db/db_iter_test.cc
+++ b/db/db_iter_test.cc
@@ -1424,6 +1424,45 @@ TEST_F(DBIteratorTest, DBIteratorTimedPutBasic) {
   ASSERT_OK(db_iter->status());
 }
 
+// Verifies the new row-pinning APIs explicitly reject
+// kTypeValuePreferredSeqno rows. This injects a TimedPut directly into the
+// internal iterator so DBIter sees the unsupported value type without relying
+// on flush or compaction setup, then checks both PinCurrent() and
+// AppendPinnedCurrent() leave caller-owned outputs empty on failure.
+TEST_F(DBIteratorTest, DBIteratorPinAPIsRejectTimedPutRows) {
+  ReadOptions ro;
+  Options options;
+
+  TestIterator* internal_iter = new TestIterator(BytewiseComparator());
+  internal_iter->AddTimedPut("a", "value", /*write_unix_time=*/0);
+  internal_iter->Finish();
+
+  std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
+      env_, ro, ImmutableOptions(options), MutableCFOptions(options),
+      BytewiseComparator(), internal_iter, nullptr /* version */,
+      7 /* sequence */, nullptr /* read_callback */, /*active_mem=*/nullptr));
+  db_iter->SeekToFirst();
+  ASSERT_TRUE(db_iter->Valid());
+  ASSERT_EQ("a", db_iter->key().ToString());
+  ASSERT_EQ("value", db_iter->value().ToString());
+
+  PinnableKeyValue pinned_kv;
+  PinnableKeyValueBatch batch;
+
+  Status pin_status = db_iter->PinCurrent(&pinned_kv);
+  ASSERT_TRUE(pin_status.IsNotSupported());
+  ASSERT_TRUE(pinned_kv.key().empty());
+  ASSERT_TRUE(pinned_kv.value().empty());
+  ASSERT_EQ(0U, pinned_kv.GetCopiedBytes());
+  ASSERT_EQ(0U, pinned_kv.GetPinnedBlockCacheUsage());
+
+  Status append_status = db_iter->AppendPinnedCurrent(&batch);
+  ASSERT_TRUE(append_status.IsNotSupported());
+  ASSERT_EQ(0U, batch.size());
+  ASSERT_EQ(0U, batch.GetCopiedBytes());
+  ASSERT_EQ(0U, batch.GetPinnedBlockCacheUsage());
+}
+
 TEST_F(DBIteratorTest, DBIterator1) {
   ReadOptions ro;
   Options options;

--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -36,6 +36,624 @@ namespace ROCKSDB_NAMESPACE {
 class DBTest2 : public DBTestBase {
  public:
   DBTest2() : DBTestBase("db_test2", /*env_do_fsync=*/true) {}
+
+ protected:
+  struct PinnedKVBatchSnapshot {
+    std::vector<std::string> keys;
+    std::vector<std::string> values;
+    std::vector<bool> key_pinned;
+    std::vector<bool> value_pinned;
+    size_t pinned_block_cache_usage = 0;
+    size_t copied_bytes = 0;
+  };
+
+  static std::string PinnedKVTestKey(int index) {
+    return "prefix" + std::to_string(100000 + index);
+  }
+
+  Options CurrentPinnedKVOptions(
+      size_t block_size, bool use_block_cache,
+      std::shared_ptr<Cache>* block_cache, bool use_delta_encoding = true,
+      std::shared_ptr<RetainedBlockBufferProvider> block_buffer_provider =
+          nullptr,
+      CompressionType compression = kNoCompression) const {
+    Options options = CurrentOptions();
+    options.compression = compression;
+    BlockBasedTableOptions bbto;
+    if (use_block_cache) {
+      bbto.block_cache = NewLRUCache(1 << 20);
+      if (block_cache != nullptr) {
+        *block_cache = bbto.block_cache;
+      }
+    } else {
+      bbto.no_block_cache = true;
+    }
+    bbto.block_size = block_size;
+    bbto.block_restart_interval = 16;
+    bbto.use_delta_encoding = use_delta_encoding;
+    bbto.block_buffer_provider = std::move(block_buffer_provider);
+    options.table_factory.reset(NewBlockBasedTableFactory(bbto));
+    return options;
+  }
+
+  void PutPinnedKVRows(int count, size_t value_size,
+                       std::vector<std::string>* values) {
+    assert(values != nullptr);
+    values->clear();
+    values->reserve(count);
+    for (int i = 0; i < count; ++i) {
+      values->emplace_back(value_size, static_cast<char>('a' + (i % 26)));
+      ASSERT_OK(Put(PinnedKVTestKey(i), values->back()));
+    }
+  }
+
+  void AssertPinnedBatchEntry(const PinnableKeyValueBatch& batch, size_t index,
+                              const std::string& expected_key,
+                              const std::string& expected_value,
+                              bool expect_key_pinned,
+                              bool expect_value_pinned) {
+    ASSERT_LT(index, batch.size());
+    ASSERT_EQ(expected_key, batch.key(index).ToString());
+    ASSERT_EQ(expected_value, batch.value(index).ToString());
+    ASSERT_EQ(expect_key_pinned, batch.IsKeyPinned(index));
+    ASSERT_EQ(expect_value_pinned, batch.IsValuePinned(index));
+  }
+
+  void AssertEmptyPinnedKeyValue(const PinnableKeyValue& pinned_kv) {
+    ASSERT_TRUE(pinned_kv.key().empty());
+    ASSERT_TRUE(pinned_kv.value().empty());
+    ASSERT_FALSE(pinned_kv.IsKeyPinned());
+    ASSERT_FALSE(pinned_kv.IsValuePinned());
+    ASSERT_EQ(0U, pinned_kv.GetPinnedBlockCacheUsage());
+    ASSERT_EQ(0U, pinned_kv.GetCopiedBytes());
+  }
+
+  void AssertEmptyPinnedKeyValueBatch(const PinnableKeyValueBatch& batch) {
+    ASSERT_TRUE(batch.empty());
+    ASSERT_EQ(0U, batch.GetPinnedBlockCacheUsage());
+    ASSERT_EQ(0U, batch.GetCopiedBytes());
+  }
+
+  void AssertPinAPIsNotSupportedForCurrentRow(Iterator* iter) {
+    assert(iter != nullptr);
+    assert(iter->Valid());
+
+    PinnableKeyValue pinned_kv;
+    PinnableKeyValueBatch batch;
+
+    Status pin_status = iter->PinCurrent(&pinned_kv);
+    ASSERT_TRUE(pin_status.IsNotSupported());
+    AssertEmptyPinnedKeyValue(pinned_kv);
+
+    Status append_status = iter->AppendPinnedCurrent(&batch);
+    ASSERT_TRUE(append_status.IsNotSupported());
+    AssertEmptyPinnedKeyValueBatch(batch);
+  }
+
+  PinnedKVBatchSnapshot CaptureBatchSnapshot(
+      const PinnableKeyValueBatch& batch) {
+    PinnedKVBatchSnapshot snapshot;
+    snapshot.pinned_block_cache_usage = batch.GetPinnedBlockCacheUsage();
+    snapshot.copied_bytes = batch.GetCopiedBytes();
+    snapshot.keys.reserve(batch.size());
+    snapshot.values.reserve(batch.size());
+    snapshot.key_pinned.reserve(batch.size());
+    snapshot.value_pinned.reserve(batch.size());
+    for (size_t i = 0; i < batch.size(); ++i) {
+      snapshot.keys.push_back(batch.key(i).ToString());
+      snapshot.values.push_back(batch.value(i).ToString());
+      snapshot.key_pinned.push_back(batch.IsKeyPinned(i));
+      snapshot.value_pinned.push_back(batch.IsValuePinned(i));
+    }
+    return snapshot;
+  }
+
+  void AssertBatchMatchesSnapshot(const PinnableKeyValueBatch& batch,
+                                  const PinnedKVBatchSnapshot& snapshot) {
+    ASSERT_EQ(snapshot.keys.size(), batch.size());
+    ASSERT_EQ(snapshot.pinned_block_cache_usage,
+              batch.GetPinnedBlockCacheUsage());
+    ASSERT_EQ(snapshot.copied_bytes, batch.GetCopiedBytes());
+    for (size_t i = 0; i < snapshot.keys.size(); ++i) {
+      AssertPinnedBatchEntry(batch, i, snapshot.keys[i], snapshot.values[i],
+                             snapshot.key_pinned[i], snapshot.value_pinned[i]);
+    }
+  }
+
+  class TestRetainedBlockBufferProvider : public RetainedBlockBufferProvider {
+   public:
+    struct Allocation {
+      TestRetainedBlockBufferProvider* owner = nullptr;
+      char* data = nullptr;
+      size_t size = 0;
+      size_t alignment = 1;
+      AlignedBuffer storage;
+    };
+
+    struct AllocationRange {
+      const char* data = nullptr;
+      size_t size = 0;
+    };
+
+    Status Allocate(size_t size, size_t alignment, Lease* out) override {
+      if (out == nullptr) {
+        return Status::InvalidArgument("lease output is nullptr");
+      }
+      if (alignment == 0 || (alignment & (alignment - 1)) != 0) {
+        return Status::InvalidArgument("alignment must be a power of two");
+      }
+      auto* allocation = new Allocation();
+      allocation->owner = this;
+      allocation->size = size;
+      allocation->alignment = alignment;
+      allocation->storage.Alignment(alignment);
+      allocation->storage.AllocateNewBuffer(size);
+      allocation->data = allocation->storage.BufferStart();
+      bytes_outstanding_.fetch_add(size, std::memory_order_relaxed);
+      allocations_.fetch_add(1, std::memory_order_relaxed);
+      size_t current_alignment =
+          max_requested_alignment_.load(std::memory_order_relaxed);
+      while (current_alignment < alignment &&
+             !max_requested_alignment_.compare_exchange_weak(
+                 current_alignment, alignment, std::memory_order_relaxed,
+                 std::memory_order_relaxed)) {
+      }
+      {
+        std::lock_guard<std::mutex> lock(live_allocations_mutex_);
+        live_allocations_.push_back(AllocationRange{allocation->data, size});
+      }
+
+      out->data = allocation->data;
+      out->size = size;
+      out->cleanup.Allocate();
+      out->cleanup->RegisterCleanup(&ReleaseAllocation, allocation, nullptr);
+      out->dedupe_token = allocation;
+      return Status::OK();
+    }
+
+    size_t allocations() const {
+      return allocations_.load(std::memory_order_relaxed);
+    }
+
+    size_t releases() const {
+      return releases_.load(std::memory_order_relaxed);
+    }
+
+    size_t bytes_outstanding() const {
+      return bytes_outstanding_.load(std::memory_order_relaxed);
+    }
+
+    size_t max_requested_alignment() const {
+      return max_requested_alignment_.load(std::memory_order_relaxed);
+    }
+
+    bool OwnsLiveAddressRange(const Slice& slice) const {
+      if (slice.data() == nullptr) {
+        return false;
+      }
+      const uintptr_t slice_begin = reinterpret_cast<uintptr_t>(slice.data());
+      const uintptr_t slice_end = slice_begin + slice.size();
+
+      std::lock_guard<std::mutex> lock(live_allocations_mutex_);
+      for (const auto& allocation : live_allocations_) {
+        const uintptr_t allocation_begin =
+            reinterpret_cast<uintptr_t>(allocation.data);
+        const uintptr_t allocation_end = allocation_begin + allocation.size;
+        if (slice_begin >= allocation_begin && slice_end <= allocation_end) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+   private:
+    static void ReleaseAllocation(void* arg1, void* /*arg2*/) {
+      auto* allocation = static_cast<Allocation*>(arg1);
+      allocation->owner->bytes_outstanding_.fetch_sub(
+          allocation->size, std::memory_order_relaxed);
+      allocation->owner->releases_.fetch_add(1, std::memory_order_relaxed);
+      {
+        std::lock_guard<std::mutex> lock(
+            allocation->owner->live_allocations_mutex_);
+        auto& live_allocations = allocation->owner->live_allocations_;
+        for (auto it = live_allocations.begin(); it != live_allocations.end();
+             ++it) {
+          if (it->data == allocation->data) {
+            live_allocations.erase(it);
+            break;
+          }
+        }
+      }
+      delete allocation;
+    }
+
+    std::atomic<size_t> allocations_{0};
+    std::atomic<size_t> releases_{0};
+    std::atomic<size_t> bytes_outstanding_{0};
+    std::atomic<size_t> max_requested_alignment_{1};
+    mutable std::mutex live_allocations_mutex_;
+    std::vector<AllocationRange> live_allocations_;
+  };
+
+  class InvalidRetainedBlockBufferProvider
+      : public RetainedBlockBufferProvider {
+   public:
+    enum class Mode {
+      kReturnError,
+      kNullData,
+      kShortSize,
+      kMissingCleanup,
+    };
+
+    explicit InvalidRetainedBlockBufferProvider(Mode mode) : mode_(mode) {}
+    ~InvalidRetainedBlockBufferProvider() override {
+      for (char* ptr : owned_buffers_) {
+        delete[] ptr;
+      }
+    }
+
+    Status Allocate(size_t size, size_t /*alignment*/, Lease* out) override {
+      if (out == nullptr) {
+        return Status::InvalidArgument("lease output is nullptr");
+      }
+      switch (mode_) {
+        case Mode::kReturnError:
+          return Status::MemoryLimit("injected allocate failure");
+        case Mode::kNullData:
+          out->size = size;
+          out->cleanup.Allocate();
+          return Status::OK();
+        case Mode::kShortSize:
+          out->data = new char[size];
+          owned_buffers_.push_back(out->data);
+          out->size = size - 1;
+          out->cleanup.Allocate();
+          return Status::OK();
+        case Mode::kMissingCleanup:
+          out->data = new char[size];
+          owned_buffers_.push_back(out->data);
+          out->size = size;
+          return Status::OK();
+      }
+      return Status::InvalidArgument("unknown invalid provider mode");
+    }
+
+   private:
+    Mode mode_;
+    std::vector<char*> owned_buffers_;
+  };
+
+  class ObservedDirectIOFS : public FileSystemWrapper {
+   public:
+    struct ScratchRange {
+      const char* data = nullptr;
+      size_t size = 0;
+    };
+
+    explicit ObservedDirectIOFS(const std::shared_ptr<FileSystem>& target)
+        : FileSystemWrapper(target) {}
+
+    static const char* kClassName() { return "ObservedDirectIOFS"; }
+    const char* Name() const override { return kClassName(); }
+
+    void SupportedOps(int64_t& supported_ops) override {
+      target()->SupportedOps(supported_ops);
+      supported_ops |= (1 << FSSupportedOps::kAsyncIO);
+    }
+
+    IOStatus NewRandomAccessFile(const std::string& fname,
+                                 const FileOptions& opts,
+                                 std::unique_ptr<FSRandomAccessFile>* result,
+                                 IODebugContext* dbg) override {
+      std::unique_ptr<FSRandomAccessFile> file;
+      IOStatus s = target()->NewRandomAccessFile(fname, opts, &file, dbg);
+      if (s.ok()) {
+        result->reset(new ObservedDirectIOFile(*this, std::move(file)));
+      }
+      return s;
+    }
+
+    IOStatus Poll(std::vector<void*>& io_handles,
+                  size_t /*min_completions*/) override {
+      {
+        std::lock_guard<std::mutex> lock(mutex_);
+        ++poll_calls_;
+      }
+      for (void* io_handle : io_handles) {
+        auto* handle = static_cast<AsyncReadHandle*>(io_handle);
+        if (handle == nullptr || handle->completed) {
+          continue;
+        }
+        handle->completed = true;
+        handle->req.status =
+            handle->file->CompleteAsyncRead(handle->req, handle->opts);
+        handle->cb(handle->req, handle->cb_arg);
+      }
+      return IOStatus::OK();
+    }
+
+    IOStatus AbortIO(std::vector<void*>& io_handles) override {
+      for (void* io_handle : io_handles) {
+        auto* handle = static_cast<AsyncReadHandle*>(io_handle);
+        if (handle == nullptr || handle->completed) {
+          continue;
+        }
+        handle->completed = true;
+        handle->req.status = IOStatus::Aborted();
+        handle->cb(handle->req, handle->cb_arg);
+      }
+      return IOStatus::OK();
+    }
+
+    std::vector<ScratchRange> sync_scratch_ranges() const {
+      std::lock_guard<std::mutex> lock(mutex_);
+      return sync_scratch_ranges_;
+    }
+
+    std::vector<ScratchRange> async_scratch_ranges() const {
+      std::lock_guard<std::mutex> lock(mutex_);
+      return async_scratch_ranges_;
+    }
+
+    size_t async_read_calls() const {
+      std::lock_guard<std::mutex> lock(mutex_);
+      return async_read_calls_;
+    }
+
+    size_t poll_calls() const {
+      std::lock_guard<std::mutex> lock(mutex_);
+      return poll_calls_;
+    }
+
+   private:
+    class ObservedDirectIOFile;
+
+    struct AsyncReadHandle {
+      ObservedDirectIOFile* file = nullptr;
+      FSReadRequest req;
+      IOOptions opts;
+      std::function<void(FSReadRequest&, void*)> cb;
+      void* cb_arg = nullptr;
+      bool completed = false;
+    };
+
+    class ObservedDirectIOFile : public FSRandomAccessFileOwnerWrapper {
+     public:
+      ObservedDirectIOFile(ObservedDirectIOFS& owner,
+                           std::unique_ptr<FSRandomAccessFile>&& target)
+          : FSRandomAccessFileOwnerWrapper(std::move(target)), owner_(owner) {}
+
+      IOStatus Read(uint64_t offset, size_t n, const IOOptions& options,
+                    Slice* result, char* scratch,
+                    IODebugContext* dbg) const override {
+        owner_.RecordSyncScratch(scratch, n);
+        return target()->Read(offset, n, options, result, scratch, dbg);
+      }
+
+      IOStatus MultiRead(FSReadRequest* reqs, size_t num_reqs,
+                         const IOOptions& options,
+                         IODebugContext* dbg) override {
+        for (size_t i = 0; i < num_reqs; ++i) {
+          owner_.RecordSyncScratch(reqs[i].scratch, reqs[i].len);
+        }
+        return target()->MultiRead(reqs, num_reqs, options, dbg);
+      }
+
+      IOStatus ReadAsync(FSReadRequest& req, const IOOptions& opts,
+                         std::function<void(FSReadRequest&, void*)> cb,
+                         void* cb_arg, void** io_handle,
+                         IOHandleDeleter* del_fn,
+                         IODebugContext* /*dbg*/) override {
+        owner_.RecordAsyncScratch(req.scratch, req.len);
+        auto* handle = new AsyncReadHandle();
+        handle->file = this;
+        handle->req.offset = req.offset;
+        handle->req.len = req.len;
+        handle->req.scratch = req.scratch;
+        handle->req.result = req.result;
+        handle->req.status = req.status;
+        handle->opts = opts;
+        handle->cb = std::move(cb);
+        handle->cb_arg = cb_arg;
+        if (io_handle != nullptr) {
+          *io_handle = handle;
+        }
+        if (del_fn != nullptr) {
+          *del_fn = [](void* arg) {
+            delete static_cast<AsyncReadHandle*>(arg);
+          };
+        }
+        return IOStatus::OK();
+      }
+
+      IOStatus CompleteAsyncRead(FSReadRequest& req, const IOOptions& opts) {
+        return target()->Read(req.offset, req.len, opts, &req.result,
+                              req.scratch, nullptr);
+      }
+
+     private:
+      ObservedDirectIOFS& owner_;
+    };
+
+    void RecordSyncScratch(char* scratch, size_t size) {
+      if (scratch == nullptr) {
+        return;
+      }
+      std::lock_guard<std::mutex> lock(mutex_);
+      sync_scratch_ranges_.push_back(ScratchRange{scratch, size});
+    }
+
+    void RecordAsyncScratch(char* scratch, size_t size) {
+      std::lock_guard<std::mutex> lock(mutex_);
+      ++async_read_calls_;
+      if (scratch != nullptr) {
+        async_scratch_ranges_.push_back(ScratchRange{scratch, size});
+      }
+    }
+
+    friend class ObservedDirectIOFile;
+
+    mutable std::mutex mutex_;
+    std::vector<ScratchRange> sync_scratch_ranges_;
+    std::vector<ScratchRange> async_scratch_ranges_;
+    size_t async_read_calls_ = 0;
+    size_t poll_calls_ = 0;
+  };
+
+  size_t CountObservedScratchRangesBackedByRetainedProvider(
+      const std::vector<ObservedDirectIOFS::ScratchRange>& scratch_ranges,
+      const TestRetainedBlockBufferProvider& block_buffer_provider,
+      size_t alignment) {
+    size_t matching_ranges = 0;
+    for (const auto& scratch_range : scratch_ranges) {
+      EXPECT_NE(scratch_range.data, nullptr);
+      EXPECT_GT(scratch_range.size, 0U);
+      if (block_buffer_provider.OwnsLiveAddressRange(
+              Slice(scratch_range.data, scratch_range.size))) {
+        EXPECT_EQ(0U, reinterpret_cast<uintptr_t>(scratch_range.data) &
+                          (alignment - 1));
+        ++matching_ranges;
+      }
+    }
+    return matching_ranges;
+  }
+
+  void RunIteratorPrepareMultiScanUsesRetainedProviderAcrossRanges(
+      bool use_direct_io, bool use_async_io = false,
+      CompressionType compression = kNoCompression) {
+    auto block_buffer_provider =
+        std::make_shared<TestRetainedBlockBufferProvider>();
+    std::shared_ptr<Cache> block_cache;
+    Options options = CurrentPinnedKVOptions(
+        160 /* block_size */, true /* use_block_cache */, &block_cache,
+        true /* use_delta_encoding */, block_buffer_provider, compression);
+    if (compression != kNoCompression) {
+      options.statistics = ROCKSDB_NAMESPACE::CreateDBStatistics();
+    }
+    std::shared_ptr<ObservedDirectIOFS> observed_fs;
+    std::unique_ptr<Env> wrapped_env;
+    if (use_direct_io) {
+      observed_fs = std::make_shared<ObservedDirectIOFS>(env_->GetFileSystem());
+      wrapped_env.reset(new CompositeEnvWrapper(env_, observed_fs));
+      options.env = wrapped_env.get();
+      options.use_direct_reads = true;
+      options.allow_mmap_reads = false;
+    }
+    Reopen(options);
+    Defer close_db([this]() { Close(); });
+
+    std::vector<std::string> values;
+    PutPinnedKVRows(18, 48, &values);
+    ASSERT_OK(Flush());
+
+    const size_t baseline_allocations = block_buffer_provider->allocations();
+    const size_t baseline_releases = block_buffer_provider->releases();
+    const size_t baseline_bytes = block_buffer_provider->bytes_outstanding();
+
+    struct ScanRange {
+      int start_index = 0;
+      int limit_index = 0;
+      std::string start_key;
+      std::string limit_key;
+    };
+
+    const std::vector<ScanRange> scan_ranges = {
+        {1, 4, PinnedKVTestKey(1), PinnedKVTestKey(4)},
+        {6, 9, PinnedKVTestKey(6), PinnedKVTestKey(9)},
+        {11, 14, PinnedKVTestKey(11), PinnedKVTestKey(14)},
+    };
+
+    std::vector<std::string> expected_keys;
+    std::vector<std::string> expected_values;
+    for (const auto& range : scan_ranges) {
+      for (int i = range.start_index; i < range.limit_index; ++i) {
+        expected_keys.push_back(PinnedKVTestKey(i));
+        expected_values.push_back(values[i]);
+      }
+    }
+
+    Slice upper_bound;
+    std::string upper_bound_storage;
+    ReadOptions read_options;
+    read_options.iterate_upper_bound = &upper_bound;
+    read_options.iterator_mutable_options.pinned_block_backing =
+        PinnedBlockBackingConfig{
+            PinnedBlockBackingPolicy::kUseRetainedBlockBuffer};
+
+    MultiScanArgs scan_options(BytewiseComparator());
+    scan_options.use_async_io = use_async_io;
+    for (const auto& range : scan_ranges) {
+      scan_options.insert(range.start_key, range.limit_key);
+    }
+
+    std::vector<std::string> seen_keys;
+    std::vector<std::string> seen_values;
+    bool saw_provider_backed_value = false;
+    std::unique_ptr<Iterator> iter(db_->NewIterator(read_options));
+    ASSERT_NE(iter, nullptr);
+    iter->Prepare(scan_options);
+    ASSERT_OK(iter->status()) << iter->status().ToString();
+    ASSERT_GT(block_buffer_provider->allocations(), baseline_allocations);
+    if (compression == kNoCompression) {
+      ASSERT_EQ(baseline_releases, block_buffer_provider->releases());
+    }
+    ASSERT_GT(block_buffer_provider->bytes_outstanding(), baseline_bytes);
+    if (use_direct_io) {
+      ASSERT_GT(block_buffer_provider->max_requested_alignment(), 1U);
+      ASSERT_NE(observed_fs, nullptr);
+      if (use_async_io) {
+        ASSERT_GT(observed_fs->async_read_calls(), 0U);
+        ASSERT_EQ(
+            observed_fs->async_scratch_ranges().size(),
+            CountObservedScratchRangesBackedByRetainedProvider(
+                observed_fs->async_scratch_ranges(), *block_buffer_provider,
+                block_buffer_provider->max_requested_alignment()));
+      } else {
+        ASSERT_EQ(0U, observed_fs->async_read_calls());
+        ASSERT_GT(
+            CountObservedScratchRangesBackedByRetainedProvider(
+                observed_fs->sync_scratch_ranges(), *block_buffer_provider,
+                block_buffer_provider->max_requested_alignment()),
+            0U);
+      }
+    } else {
+      ASSERT_EQ(1U, block_buffer_provider->max_requested_alignment());
+    }
+
+    for (const auto& range : scan_ranges) {
+      upper_bound_storage = range.limit_key;
+      upper_bound = upper_bound_storage;
+
+      iter->Seek(range.start_key);
+      while (iter->status().ok() && iter->Valid()) {
+        const Slice value_slice = iter->value();
+        ASSERT_TRUE(block_buffer_provider->OwnsLiveAddressRange(value_slice));
+        ASSERT_GT(block_buffer_provider->allocations(), baseline_allocations);
+        saw_provider_backed_value = true;
+
+        seen_keys.push_back(iter->key().ToString());
+        seen_values.push_back(value_slice.ToString());
+        iter->Next();
+      }
+
+      ASSERT_OK(iter->status()) << iter->status().ToString();
+      ASSERT_FALSE(iter->Valid());
+    }
+
+    ASSERT_TRUE(saw_provider_backed_value);
+    ASSERT_EQ(expected_keys, seen_keys);
+    ASSERT_EQ(expected_values, seen_values);
+    if (compression != kNoCompression) {
+      ASSERT_GT(TestGetTickerCount(options, NUMBER_BLOCK_DECOMPRESSED), 0U);
+    }
+    if (use_direct_io && use_async_io) {
+      ASSERT_GT(observed_fs->poll_calls(), 0U);
+    }
+
+    iter.reset();
+    ASSERT_GT(block_buffer_provider->releases(), baseline_releases);
+    ASSERT_EQ(baseline_bytes, block_buffer_provider->bytes_outstanding());
+  }
 };
 
 TEST_F(DBTest2, OpenForReadOnly) {
@@ -4544,6 +5162,969 @@ TEST_F(DBTest2, PinnableSliceAndMmapReads) {
   ASSERT_EQ(pinned_value.ToString(), "bar");
 }
 
+TEST_F(DBTest2, IteratorPinCurrentDeltaEncodedKeyAndPinnedValue) {
+  std::shared_ptr<Cache> block_cache;
+  Options options = CurrentPinnedKVOptions(
+      160 /* block_size */, true /* use_block_cache */, &block_cache);
+  Reopen(options);
+
+  std::vector<std::string> values;
+  PutPinnedKVRows(20, 48, &values);
+  ASSERT_OK(Flush());
+  const size_t baseline_pinned_usage = block_cache->GetPinnedUsage();
+
+  PinnableKeyValue pinned_kv;
+  {
+    ReadOptions read_options;
+    std::unique_ptr<Iterator> iter(db_->NewIterator(read_options));
+    iter->Seek(PinnedKVTestKey(1));
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_OK(iter->PinCurrent(&pinned_kv));
+    ASSERT_EQ(PinnedKVTestKey(1), pinned_kv.key().ToString());
+    ASSERT_EQ(values[1], pinned_kv.value().ToString());
+    ASSERT_FALSE(pinned_kv.IsKeyPinned());
+    ASSERT_TRUE(pinned_kv.IsValuePinned());
+    ASSERT_EQ(pinned_kv.GetCopiedBytes(), pinned_kv.key().size());
+    ASSERT_GT(pinned_kv.GetPinnedBlockCacheUsage(), 0);
+    ASSERT_GE(block_cache->GetPinnedUsage(),
+              pinned_kv.GetPinnedBlockCacheUsage());
+
+    iter->Seek(PinnedKVTestKey(10));
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_EQ(PinnedKVTestKey(1), pinned_kv.key().ToString());
+    ASSERT_EQ(values[1], pinned_kv.value().ToString());
+  }
+
+  ASSERT_EQ(PinnedKVTestKey(1), pinned_kv.key().ToString());
+  ASSERT_EQ(values[1], pinned_kv.value().ToString());
+  const size_t row_pinned_usage = pinned_kv.GetPinnedBlockCacheUsage();
+  const size_t pinned_usage_before_reset = block_cache->GetPinnedUsage();
+  ASSERT_GE(pinned_usage_before_reset,
+            baseline_pinned_usage + row_pinned_usage);
+
+  pinned_kv.Reset();
+  const size_t pinned_usage_after_reset = block_cache->GetPinnedUsage();
+  ASSERT_GT(pinned_usage_before_reset, pinned_usage_after_reset);
+  ASSERT_GE(pinned_usage_before_reset - pinned_usage_after_reset,
+            row_pinned_usage);
+  ASSERT_EQ(baseline_pinned_usage, pinned_usage_after_reset);
+}
+
+TEST_F(DBTest2, IteratorPinAPIsPinNonDeltaEncodedKeyAndValue) {
+  std::shared_ptr<Cache> block_cache;
+  Options options =
+      CurrentPinnedKVOptions(160 /* block_size */, true /* use_block_cache */,
+                             &block_cache, false /* use_delta_encoding */);
+  Reopen(options);
+
+  std::vector<std::string> values;
+  PutPinnedKVRows(3, 48, &values);
+  ASSERT_OK(Flush());
+
+  PinnableKeyValue pinned_kv;
+  PinnableKeyValueBatch batch;
+  const size_t baseline_pinned_usage = block_cache->GetPinnedUsage();
+  {
+    std::unique_ptr<Iterator> iter(db_->NewIterator(ReadOptions()));
+    iter->Seek(PinnedKVTestKey(1));
+    ASSERT_TRUE(iter->Valid());
+
+    ASSERT_OK(iter->PinCurrent(&pinned_kv));
+    ASSERT_EQ(PinnedKVTestKey(1), pinned_kv.key().ToString());
+    ASSERT_EQ(values[1], pinned_kv.value().ToString());
+    ASSERT_TRUE(pinned_kv.IsKeyPinned());
+    ASSERT_TRUE(pinned_kv.IsValuePinned());
+    ASSERT_EQ(0U, pinned_kv.GetCopiedBytes());
+    ASSERT_GT(pinned_kv.GetPinnedBlockCacheUsage(), 0);
+
+    ASSERT_OK(iter->AppendPinnedCurrent(&batch));
+    ASSERT_EQ(1U, batch.size());
+    AssertPinnedBatchEntry(batch, 0, PinnedKVTestKey(1), values[1],
+                           true /* expect_key_pinned */,
+                           true /* expect_value_pinned */);
+    ASSERT_EQ(0U, batch.GetCopiedBytes());
+
+    iter->Seek(PinnedKVTestKey(2));
+    ASSERT_TRUE(iter->Valid());
+  }
+
+  ASSERT_EQ(PinnedKVTestKey(1), pinned_kv.key().ToString());
+  ASSERT_EQ(values[1], pinned_kv.value().ToString());
+  AssertPinnedBatchEntry(batch, 0, PinnedKVTestKey(1), values[1],
+                         true /* expect_key_pinned */,
+                         true /* expect_value_pinned */);
+
+  pinned_kv.Reset();
+  batch.Reset();
+  ASSERT_EQ(baseline_pinned_usage, block_cache->GetPinnedUsage());
+}
+
+TEST_F(DBTest2, IteratorPinCurrentFallsBackToCopyWithoutBlockCache) {
+  Options options =
+      CurrentPinnedKVOptions(160 /* block_size */, false /* use_block_cache */,
+                             nullptr /* block_cache */);
+  Reopen(options);
+
+  std::vector<std::string> values;
+  PutPinnedKVRows(3, 48, &values);
+  ASSERT_OK(Flush());
+
+  PinnableKeyValue pinned_kv;
+  {
+    std::unique_ptr<Iterator> iter(db_->NewIterator(ReadOptions()));
+    iter->Seek(PinnedKVTestKey(1));
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_OK(iter->PinCurrent(&pinned_kv));
+    ASSERT_EQ(PinnedKVTestKey(1), pinned_kv.key().ToString());
+    ASSERT_EQ(values[1], pinned_kv.value().ToString());
+    ASSERT_FALSE(pinned_kv.IsKeyPinned());
+    ASSERT_FALSE(pinned_kv.IsValuePinned());
+    ASSERT_EQ(pinned_kv.GetCopiedBytes(),
+              pinned_kv.key().size() + pinned_kv.value().size());
+    ASSERT_EQ(0, pinned_kv.GetPinnedBlockCacheUsage());
+  }
+
+  ASSERT_EQ(PinnedKVTestKey(1), pinned_kv.key().ToString());
+  ASSERT_EQ(values[1], pinned_kv.value().ToString());
+}
+
+TEST_F(DBTest2, IteratorPinCurrentUsesRetainedProviderWithoutBlockCache) {
+  auto block_buffer_provider =
+      std::make_shared<TestRetainedBlockBufferProvider>();
+  Options options = CurrentPinnedKVOptions(
+      160 /* block_size */, false /* use_block_cache */,
+      nullptr /* block_cache */, true /* use_delta_encoding */,
+      block_buffer_provider);
+  Reopen(options);
+
+  std::vector<std::string> values;
+  PutPinnedKVRows(3, 48, &values);
+  ASSERT_OK(Flush());
+  const size_t baseline_allocations = block_buffer_provider->allocations();
+  const size_t baseline_releases = block_buffer_provider->releases();
+  const size_t baseline_bytes = block_buffer_provider->bytes_outstanding();
+
+  PinnableKeyValue pinned_kv;
+  {
+    std::unique_ptr<Iterator> iter(db_->NewIterator(ReadOptions()));
+    iter->Seek(PinnedKVTestKey(1));
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_OK(iter->PinCurrent(&pinned_kv));
+    ASSERT_EQ(PinnedKVTestKey(1), pinned_kv.key().ToString());
+    ASSERT_EQ(values[1], pinned_kv.value().ToString());
+    ASSERT_FALSE(pinned_kv.IsKeyPinned());
+    ASSERT_TRUE(pinned_kv.IsValuePinned());
+    ASSERT_EQ(pinned_kv.GetCopiedBytes(), pinned_kv.key().size());
+    ASSERT_EQ(0U, pinned_kv.GetPinnedBlockCacheUsage());
+    ASSERT_GT(block_buffer_provider->allocations(), baseline_allocations);
+    ASSERT_EQ(baseline_releases, block_buffer_provider->releases());
+    ASSERT_GT(block_buffer_provider->bytes_outstanding(), baseline_bytes);
+
+    iter->Seek(PinnedKVTestKey(2));
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_EQ(PinnedKVTestKey(1), pinned_kv.key().ToString());
+    ASSERT_EQ(values[1], pinned_kv.value().ToString());
+  }
+
+  ASSERT_EQ(PinnedKVTestKey(1), pinned_kv.key().ToString());
+  ASSERT_EQ(values[1], pinned_kv.value().ToString());
+  ASSERT_EQ(baseline_releases, block_buffer_provider->releases());
+  ASSERT_GT(block_buffer_provider->bytes_outstanding(), baseline_bytes);
+
+  pinned_kv.Reset();
+  ASSERT_GT(block_buffer_provider->releases(), baseline_releases);
+  ASSERT_EQ(baseline_bytes, block_buffer_provider->bytes_outstanding());
+}
+
+TEST_F(DBTest2, IteratorAppendPinnedCurrentKeepsProviderBackedBlockAlive) {
+  auto block_buffer_provider =
+      std::make_shared<TestRetainedBlockBufferProvider>();
+  Options options = CurrentPinnedKVOptions(
+      4096 /* block_size */, false /* use_block_cache */,
+      nullptr /* block_cache */, true /* use_delta_encoding */,
+      block_buffer_provider);
+  Reopen(options);
+
+  std::vector<std::string> values;
+  PutPinnedKVRows(3, 32, &values);
+  ASSERT_OK(Flush());
+  const size_t baseline_allocations = block_buffer_provider->allocations();
+  const size_t baseline_releases = block_buffer_provider->releases();
+  const size_t baseline_bytes = block_buffer_provider->bytes_outstanding();
+
+  PinnableKeyValueBatch batch;
+  {
+    std::unique_ptr<Iterator> iter(db_->NewIterator(ReadOptions()));
+    iter->Seek(PinnedKVTestKey(1));
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_OK(iter->AppendPinnedCurrent(&batch));
+    ASSERT_EQ(1U, batch.size());
+    AssertPinnedBatchEntry(batch, 0, PinnedKVTestKey(1), values[1],
+                           false /* expect_key_pinned */,
+                           true /* expect_value_pinned */);
+    ASSERT_EQ(PinnedKVTestKey(1).size(), batch.GetCopiedBytes());
+    ASSERT_EQ(0U, batch.GetPinnedBlockCacheUsage());
+
+    iter->Next();
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_OK(iter->AppendPinnedCurrent(&batch));
+    ASSERT_EQ(2U, batch.size());
+    AssertPinnedBatchEntry(batch, 1, PinnedKVTestKey(2), values[2],
+                           false /* expect_key_pinned */,
+                           true /* expect_value_pinned */);
+    ASSERT_EQ(PinnedKVTestKey(1).size() + PinnedKVTestKey(2).size(),
+              batch.GetCopiedBytes());
+    ASSERT_GT(block_buffer_provider->allocations(), baseline_allocations);
+    ASSERT_EQ(baseline_releases, block_buffer_provider->releases());
+    ASSERT_GT(block_buffer_provider->bytes_outstanding(), baseline_bytes);
+  }
+
+  AssertPinnedBatchEntry(batch, 0, PinnedKVTestKey(1), values[1],
+                         false /* expect_key_pinned */,
+                         true /* expect_value_pinned */);
+  AssertPinnedBatchEntry(batch, 1, PinnedKVTestKey(2), values[2],
+                         false /* expect_key_pinned */,
+                         true /* expect_value_pinned */);
+  ASSERT_EQ(baseline_releases, block_buffer_provider->releases());
+
+  batch.Reset();
+  ASSERT_GT(block_buffer_provider->releases(), baseline_releases);
+  ASSERT_EQ(baseline_bytes, block_buffer_provider->bytes_outstanding());
+}
+
+TEST_F(DBTest2,
+       IteratorPinCurrentProviderPinsNonDeltaEncodedKeyAndValueWithoutCache) {
+  auto block_buffer_provider =
+      std::make_shared<TestRetainedBlockBufferProvider>();
+  Options options = CurrentPinnedKVOptions(
+      160 /* block_size */, false /* use_block_cache */,
+      nullptr /* block_cache */, false /* use_delta_encoding */,
+      block_buffer_provider);
+  Reopen(options);
+
+  std::vector<std::string> values;
+  PutPinnedKVRows(3, 48, &values);
+  ASSERT_OK(Flush());
+  const size_t baseline_releases = block_buffer_provider->releases();
+  const size_t baseline_bytes = block_buffer_provider->bytes_outstanding();
+
+  PinnableKeyValue pinned_kv;
+  {
+    std::unique_ptr<Iterator> iter(db_->NewIterator(ReadOptions()));
+    iter->Seek(PinnedKVTestKey(1));
+    ASSERT_TRUE(iter->Valid());
+
+    ASSERT_OK(iter->PinCurrent(&pinned_kv));
+    ASSERT_EQ(PinnedKVTestKey(1), pinned_kv.key().ToString());
+    ASSERT_EQ(values[1], pinned_kv.value().ToString());
+    ASSERT_TRUE(pinned_kv.IsKeyPinned());
+    ASSERT_TRUE(pinned_kv.IsValuePinned());
+    ASSERT_EQ(0U, pinned_kv.GetCopiedBytes());
+    ASSERT_EQ(0U, pinned_kv.GetPinnedBlockCacheUsage());
+    ASSERT_EQ(baseline_releases, block_buffer_provider->releases());
+    ASSERT_GT(block_buffer_provider->bytes_outstanding(), baseline_bytes);
+  }
+
+  ASSERT_EQ(PinnedKVTestKey(1), pinned_kv.key().ToString());
+  ASSERT_EQ(values[1], pinned_kv.value().ToString());
+  ASSERT_EQ(baseline_releases, block_buffer_provider->releases());
+
+  pinned_kv.Reset();
+  ASSERT_GT(block_buffer_provider->releases(), baseline_releases);
+  ASSERT_EQ(baseline_bytes, block_buffer_provider->bytes_outstanding());
+}
+
+TEST_F(DBTest2, IteratorPinCurrentProviderRetainsBlockUntilAllPinsReset) {
+  auto block_buffer_provider =
+      std::make_shared<TestRetainedBlockBufferProvider>();
+  Options options = CurrentPinnedKVOptions(
+      4096 /* block_size */, false /* use_block_cache */,
+      nullptr /* block_cache */, true /* use_delta_encoding */,
+      block_buffer_provider);
+  Reopen(options);
+
+  std::vector<std::string> values;
+  PutPinnedKVRows(3, 32, &values);
+  ASSERT_OK(Flush());
+  const size_t baseline_releases = block_buffer_provider->releases();
+  const size_t baseline_bytes = block_buffer_provider->bytes_outstanding();
+
+  PinnableKeyValue first_pin;
+  PinnableKeyValue second_pin;
+  {
+    std::unique_ptr<Iterator> iter(db_->NewIterator(ReadOptions()));
+    iter->Seek(PinnedKVTestKey(1));
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_OK(iter->PinCurrent(&first_pin));
+
+    iter->Next();
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_OK(iter->PinCurrent(&second_pin));
+  }
+
+  ASSERT_EQ(PinnedKVTestKey(1), first_pin.key().ToString());
+  ASSERT_EQ(values[1], first_pin.value().ToString());
+  ASSERT_EQ(PinnedKVTestKey(2), second_pin.key().ToString());
+  ASSERT_EQ(values[2], second_pin.value().ToString());
+  ASSERT_EQ(baseline_releases, block_buffer_provider->releases());
+  ASSERT_GT(block_buffer_provider->bytes_outstanding(), baseline_bytes);
+
+  first_pin.Reset();
+  ASSERT_EQ(baseline_releases, block_buffer_provider->releases());
+  ASSERT_GT(block_buffer_provider->bytes_outstanding(), baseline_bytes);
+
+  second_pin.Reset();
+  ASSERT_GT(block_buffer_provider->releases(), baseline_releases);
+  ASSERT_EQ(baseline_bytes, block_buffer_provider->bytes_outstanding());
+}
+
+TEST_F(DBTest2, IteratorPinCurrentUsesRetainedProviderForCompressedBlocks) {
+  if (!Snappy_Supported()) {
+    ROCKSDB_GTEST_SKIP("Test requires Snappy support");
+    return;
+  }
+
+  auto block_buffer_provider =
+      std::make_shared<TestRetainedBlockBufferProvider>();
+  Options options = CurrentOptions();
+  options.compression = kSnappyCompression;
+  BlockBasedTableOptions bbto;
+  bbto.no_block_cache = true;
+  bbto.block_size = 160;
+  bbto.block_restart_interval = 16;
+  bbto.use_delta_encoding = false;
+  bbto.block_buffer_provider = block_buffer_provider;
+  options.table_factory.reset(NewBlockBasedTableFactory(bbto));
+  Reopen(options);
+
+  std::vector<std::string> values;
+  PutPinnedKVRows(3, 256, &values);
+  ASSERT_OK(Flush());
+  const size_t baseline_releases = block_buffer_provider->releases();
+  const size_t baseline_bytes = block_buffer_provider->bytes_outstanding();
+
+  PinnableKeyValue pinned_kv;
+  {
+    std::unique_ptr<Iterator> iter(db_->NewIterator(ReadOptions()));
+    iter->Seek(PinnedKVTestKey(1));
+    ASSERT_TRUE(iter->Valid());
+
+    ASSERT_OK(iter->PinCurrent(&pinned_kv));
+    ASSERT_EQ(PinnedKVTestKey(1), pinned_kv.key().ToString());
+    ASSERT_EQ(values[1], pinned_kv.value().ToString());
+    ASSERT_TRUE(pinned_kv.IsKeyPinned());
+    ASSERT_TRUE(pinned_kv.IsValuePinned());
+    ASSERT_EQ(0U, pinned_kv.GetCopiedBytes());
+    ASSERT_EQ(0U, pinned_kv.GetPinnedBlockCacheUsage());
+    ASSERT_EQ(baseline_releases, block_buffer_provider->releases());
+    ASSERT_GT(block_buffer_provider->bytes_outstanding(), baseline_bytes);
+  }
+
+  ASSERT_EQ(PinnedKVTestKey(1), pinned_kv.key().ToString());
+  ASSERT_EQ(values[1], pinned_kv.value().ToString());
+  pinned_kv.Reset();
+  ASSERT_GT(block_buffer_provider->releases(), baseline_releases);
+  ASSERT_EQ(baseline_bytes, block_buffer_provider->bytes_outstanding());
+}
+
+TEST_F(DBTest2,
+       IteratorPinCurrentUsesRetainedProviderWithBlockCacheWhenRequested) {
+  auto block_buffer_provider =
+      std::make_shared<TestRetainedBlockBufferProvider>();
+  std::shared_ptr<Cache> block_cache;
+  Options options = CurrentPinnedKVOptions(
+      160 /* block_size */, true /* use_block_cache */, &block_cache,
+      true /* use_delta_encoding */, block_buffer_provider);
+  Reopen(options);
+
+  std::vector<std::string> values;
+  PutPinnedKVRows(4, 48, &values);
+  ASSERT_OK(Flush());
+  const size_t baseline_allocations = block_buffer_provider->allocations();
+  const size_t baseline_releases = block_buffer_provider->releases();
+  const size_t baseline_bytes = block_buffer_provider->bytes_outstanding();
+  const size_t baseline_pinned_usage = block_cache->GetPinnedUsage();
+
+  ReadOptions read_options;
+  read_options.iterator_mutable_options.pinned_block_backing =
+      PinnedBlockBackingConfig{
+          PinnedBlockBackingPolicy::kUseRetainedBlockBuffer};
+
+  PinnableKeyValue pinned_kv;
+  {
+    std::unique_ptr<Iterator> iter(db_->NewIterator(read_options));
+    iter->Seek(PinnedKVTestKey(1));
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_OK(iter->PinCurrent(&pinned_kv));
+    ASSERT_EQ(PinnedKVTestKey(1), pinned_kv.key().ToString());
+    ASSERT_EQ(values[1], pinned_kv.value().ToString());
+    ASSERT_EQ(0U, pinned_kv.GetPinnedBlockCacheUsage());
+    ASSERT_GT(block_buffer_provider->allocations(), baseline_allocations);
+    ASSERT_EQ(baseline_releases, block_buffer_provider->releases());
+    ASSERT_GT(block_buffer_provider->bytes_outstanding(), baseline_bytes);
+    ASSERT_EQ(baseline_pinned_usage, block_cache->GetPinnedUsage());
+  }
+  pinned_kv.Reset();
+  ASSERT_GT(block_buffer_provider->releases(), baseline_releases);
+  ASSERT_EQ(baseline_bytes, block_buffer_provider->bytes_outstanding());
+  ASSERT_EQ(baseline_pinned_usage, block_cache->GetPinnedUsage());
+}
+
+TEST_F(DBTest2, IteratorPrepareMultiScanUsesRetainedProviderAcrossRanges) {
+  RunIteratorPrepareMultiScanUsesRetainedProviderAcrossRanges(
+      false /* use_direct_io */);
+}
+
+TEST_F(DBTest2,
+       IteratorPrepareMultiScanUsesRetainedProviderForCompressedBlocks) {
+  if (!Snappy_Supported()) {
+    ROCKSDB_GTEST_SKIP("Test requires Snappy support");
+    return;
+  }
+
+  RunIteratorPrepareMultiScanUsesRetainedProviderAcrossRanges(
+      false /* use_direct_io */, false /* use_async_io */, kSnappyCompression);
+}
+
+TEST_F(DBTest2,
+       IteratorPrepareMultiScanUsesRetainedProviderAcrossRangesWithDirectIO) {
+  if (!IsDirectIOSupported()) {
+    return;
+  }
+  RunIteratorPrepareMultiScanUsesRetainedProviderAcrossRanges(
+      true /* use_direct_io */);
+}
+
+TEST_F(
+    DBTest2,
+    IteratorPrepareMultiScanUsesRetainedProviderAcrossRangesWithDirectIOAsync) {
+  if (!IsDirectIOSupported()) {
+    return;
+  }
+  RunIteratorPrepareMultiScanUsesRetainedProviderAcrossRanges(
+      true /* use_direct_io */, true /* use_async_io */);
+}
+
+TEST_F(DBTest2, IteratorSetMutableOptionsInvalidatesAndRequiresReseek) {
+  auto block_buffer_provider =
+      std::make_shared<TestRetainedBlockBufferProvider>();
+  std::shared_ptr<Cache> block_cache;
+  Options options = CurrentPinnedKVOptions(
+      160 /* block_size */, true /* use_block_cache */, &block_cache,
+      true /* use_delta_encoding */, block_buffer_provider);
+  Reopen(options);
+
+  std::vector<std::string> values;
+  PutPinnedKVRows(8, 64, &values);
+  ASSERT_OK(Flush());
+
+  const size_t baseline_allocations = block_buffer_provider->allocations();
+  const size_t baseline_releases = block_buffer_provider->releases();
+  const size_t baseline_bytes = block_buffer_provider->bytes_outstanding();
+  const size_t baseline_pinned_usage = block_cache->GetPinnedUsage();
+
+  PinnableKeyValue cache_backed_before_switch;
+  PinnableKeyValue current_block_after_retained_switch;
+  PinnableKeyValue retained_backed;
+  PinnableKeyValue current_block_after_cache_switch;
+  PinnableKeyValue cache_backed_after_switch;
+  {
+    std::unique_ptr<Iterator> iter(db_->NewIterator(ReadOptions()));
+
+    iter->Seek(PinnedKVTestKey(1));
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_OK(iter->PinCurrent(&cache_backed_before_switch));
+    ASSERT_GT(cache_backed_before_switch.GetPinnedBlockCacheUsage(), 0U);
+    const size_t cache_pin_usage_before_switch =
+        cache_backed_before_switch.GetPinnedBlockCacheUsage();
+    ASSERT_GE(block_cache->GetPinnedUsage(),
+              baseline_pinned_usage + cache_pin_usage_before_switch);
+    ASSERT_EQ(baseline_allocations, block_buffer_provider->allocations());
+    ASSERT_EQ(baseline_bytes, block_buffer_provider->bytes_outstanding());
+
+    IteratorMutableOptions retained_options;
+    retained_options.pinned_block_backing = PinnedBlockBackingConfig{
+        PinnedBlockBackingPolicy::kUseRetainedBlockBuffer};
+    ASSERT_OK(iter->SetMutableOptions(retained_options));
+    ASSERT_FALSE(iter->Valid());
+    ASSERT_TRUE(iter->PinCurrent(&current_block_after_retained_switch)
+                    .IsInvalidArgument());
+    ASSERT_EQ(PinnedKVTestKey(1), cache_backed_before_switch.key().ToString());
+    ASSERT_EQ(values[1], cache_backed_before_switch.value().ToString());
+    ASSERT_GE(block_cache->GetPinnedUsage(),
+              baseline_pinned_usage + cache_pin_usage_before_switch);
+    ASSERT_EQ(baseline_bytes, block_buffer_provider->bytes_outstanding());
+
+    IteratorMutableOptions got_options;
+    ASSERT_OK(iter->GetMutableOptions(&got_options));
+    ASSERT_TRUE(got_options.pinned_block_backing.has_value());
+    ASSERT_EQ(PinnedBlockBackingPolicy::kUseRetainedBlockBuffer,
+              got_options.pinned_block_backing->policy);
+
+    iter->Seek(PinnedKVTestKey(7));
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_OK(iter->PinCurrent(&retained_backed));
+    ASSERT_EQ(0U, retained_backed.GetPinnedBlockCacheUsage());
+    ASSERT_EQ(PinnedKVTestKey(7), retained_backed.key().ToString());
+    ASSERT_EQ(values[7], retained_backed.value().ToString());
+    ASSERT_GT(block_buffer_provider->allocations(), baseline_allocations);
+    ASSERT_EQ(baseline_releases, block_buffer_provider->releases());
+    ASSERT_GT(block_buffer_provider->bytes_outstanding(), baseline_bytes);
+    const size_t pinned_usage_with_retained_and_cache_pin =
+        block_cache->GetPinnedUsage();
+    ASSERT_GE(pinned_usage_with_retained_and_cache_pin,
+              baseline_pinned_usage + cache_pin_usage_before_switch);
+
+    IteratorMutableOptions cache_options;
+    cache_options.pinned_block_backing =
+        PinnedBlockBackingConfig{PinnedBlockBackingPolicy::kUseBlockCache};
+    ASSERT_OK(iter->SetMutableOptions(cache_options));
+    ASSERT_FALSE(iter->Valid());
+    ASSERT_TRUE(iter->PinCurrent(&current_block_after_cache_switch)
+                    .IsInvalidArgument());
+    ASSERT_EQ(PinnedKVTestKey(7), retained_backed.key().ToString());
+    ASSERT_EQ(values[7], retained_backed.value().ToString());
+    ASSERT_EQ(pinned_usage_with_retained_and_cache_pin,
+              block_cache->GetPinnedUsage());
+    ASSERT_GT(block_buffer_provider->bytes_outstanding(), baseline_bytes);
+
+    iter->Seek(PinnedKVTestKey(1));
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_OK(iter->PinCurrent(&cache_backed_after_switch));
+    ASSERT_GT(cache_backed_after_switch.GetPinnedBlockCacheUsage(), 0U);
+    const size_t pinned_usage_before_resets = block_cache->GetPinnedUsage();
+    ASSERT_GE(pinned_usage_before_resets,
+              baseline_pinned_usage + cache_pin_usage_before_switch);
+
+    ASSERT_EQ(PinnedKVTestKey(7), retained_backed.key().ToString());
+    ASSERT_EQ(values[7], retained_backed.value().ToString());
+
+    retained_backed.Reset();
+    ASSERT_GT(block_buffer_provider->releases(), baseline_releases);
+    ASSERT_EQ(baseline_bytes, block_buffer_provider->bytes_outstanding());
+    ASSERT_EQ(pinned_usage_before_resets, block_cache->GetPinnedUsage());
+
+    cache_backed_before_switch.Reset();
+    const size_t pinned_usage_after_first_cache_reset =
+        block_cache->GetPinnedUsage();
+    ASSERT_LE(pinned_usage_after_first_cache_reset, pinned_usage_before_resets);
+    ASSERT_GE(pinned_usage_after_first_cache_reset, baseline_pinned_usage);
+
+    cache_backed_after_switch.Reset();
+    ASSERT_GE(block_cache->GetPinnedUsage(), baseline_pinned_usage);
+  }
+  ASSERT_EQ(baseline_pinned_usage, block_cache->GetPinnedUsage());
+}
+
+TEST_F(DBTest2, IteratorSetMutableOptionsValidatesPinnedBackingRequirements) {
+  {
+    Options options = CurrentPinnedKVOptions(160 /* block_size */,
+                                             false /* use_block_cache */,
+                                             nullptr /* block_cache */);
+    Reopen(options);
+    std::vector<std::string> values;
+    PutPinnedKVRows(2, 48, &values);
+    ASSERT_OK(Flush());
+
+    std::unique_ptr<Iterator> iter(db_->NewIterator(ReadOptions()));
+    IteratorMutableOptions cache_only_options;
+    cache_only_options.pinned_block_backing =
+        PinnedBlockBackingConfig{PinnedBlockBackingPolicy::kUseBlockCache};
+    Status s = iter->SetMutableOptions(cache_only_options);
+    ASSERT_TRUE(s.IsInvalidArgument());
+
+    IteratorMutableOptions got_options;
+    ASSERT_OK(iter->GetMutableOptions(&got_options));
+    ASSERT_FALSE(got_options.pinned_block_backing.has_value());
+  }
+
+  {
+    std::shared_ptr<Cache> block_cache;
+    Options options = CurrentPinnedKVOptions(
+        160 /* block_size */, true /* use_block_cache */, &block_cache);
+    Reopen(options);
+    std::vector<std::string> values;
+    PutPinnedKVRows(2, 48, &values);
+    ASSERT_OK(Flush());
+
+    std::unique_ptr<Iterator> iter(db_->NewIterator(ReadOptions()));
+    IteratorMutableOptions retained_options;
+    retained_options.pinned_block_backing = PinnedBlockBackingConfig{
+        PinnedBlockBackingPolicy::kUseRetainedBlockBuffer};
+    Status s = iter->SetMutableOptions(retained_options);
+    ASSERT_TRUE(s.IsInvalidArgument());
+
+    IteratorMutableOptions got_options;
+    ASSERT_OK(iter->GetMutableOptions(&got_options));
+    ASSERT_FALSE(got_options.pinned_block_backing.has_value());
+  }
+}
+
+TEST_F(DBTest2, ReopenFailsWhenRetainedProviderReturnsError) {
+  Options options =
+      CurrentPinnedKVOptions(160 /* block_size */, false /* use_block_cache */,
+                             nullptr /* block_cache */);
+  Reopen(options);
+
+  std::vector<std::string> values;
+  PutPinnedKVRows(3, 48, &values);
+  ASSERT_OK(Flush());
+  Close();
+
+  auto block_buffer_provider =
+      std::make_shared<InvalidRetainedBlockBufferProvider>(
+          InvalidRetainedBlockBufferProvider::Mode::kReturnError);
+  options = CurrentPinnedKVOptions(
+      160 /* block_size */, false /* use_block_cache */,
+      nullptr /* block_cache */, true /* use_delta_encoding */,
+      block_buffer_provider);
+  Status s = TryReopen(options);
+  ASSERT_TRUE(s.IsMemoryLimit());
+}
+
+TEST_F(DBTest2, ReopenRejectsMalformedRetainedProviderLeases) {
+  const auto run_case = [this](InvalidRetainedBlockBufferProvider::Mode mode) {
+    Options options = CurrentPinnedKVOptions(160 /* block_size */,
+                                             false /* use_block_cache */,
+                                             nullptr /* block_cache */);
+    Reopen(options);
+
+    std::vector<std::string> values;
+    PutPinnedKVRows(3, 48, &values);
+    ASSERT_OK(Flush());
+    Close();
+
+    auto block_buffer_provider =
+        std::make_shared<InvalidRetainedBlockBufferProvider>(mode);
+    options = CurrentPinnedKVOptions(
+        160 /* block_size */, false /* use_block_cache */,
+        nullptr /* block_cache */, true /* use_delta_encoding */,
+        block_buffer_provider);
+    Status s = TryReopen(options);
+    ASSERT_TRUE(s.IsInvalidArgument());
+    ASSERT_TRUE(s.ToString().find("invalid lease") != std::string::npos);
+  };
+
+  run_case(InvalidRetainedBlockBufferProvider::Mode::kNullData);
+  run_case(InvalidRetainedBlockBufferProvider::Mode::kShortSize);
+  run_case(InvalidRetainedBlockBufferProvider::Mode::kMissingCleanup);
+}
+
+TEST_F(DBTest2, IteratorAppendPinnedCurrentDedupesSameBlockLease) {
+  std::shared_ptr<Cache> block_cache;
+  Options options = CurrentPinnedKVOptions(
+      4096 /* block_size */, true /* use_block_cache */, &block_cache);
+  Reopen(options);
+
+  std::vector<std::string> values;
+  PutPinnedKVRows(3, 32, &values);
+  ASSERT_OK(Flush());
+  const size_t baseline_pinned_usage = block_cache->GetPinnedUsage();
+
+  PinnableKeyValueBatch batch;
+  size_t first_row_pinned_usage = 0;
+  {
+    std::unique_ptr<Iterator> iter(db_->NewIterator(ReadOptions()));
+    iter->Seek(PinnedKVTestKey(1));
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_OK(iter->AppendPinnedCurrent(&batch));
+    first_row_pinned_usage = batch.GetPinnedBlockCacheUsage();
+    ASSERT_GT(first_row_pinned_usage, 0);
+    AssertPinnedBatchEntry(batch, 0, PinnedKVTestKey(1), values[1],
+                           false /* expect_key_pinned */,
+                           true /* expect_value_pinned */);
+
+    iter->Next();
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_OK(iter->AppendPinnedCurrent(&batch));
+    ASSERT_EQ(2U, batch.size());
+    AssertPinnedBatchEntry(batch, 1, PinnedKVTestKey(2), values[2],
+                           false /* expect_key_pinned */,
+                           true /* expect_value_pinned */);
+    ASSERT_EQ(first_row_pinned_usage, batch.GetPinnedBlockCacheUsage());
+    ASSERT_EQ(batch.key(0).size() + batch.key(1).size(),
+              batch.GetCopiedBytes());
+
+    iter->Seek(PinnedKVTestKey(0));
+    ASSERT_TRUE(iter->Valid());
+  }
+
+  AssertPinnedBatchEntry(batch, 0, PinnedKVTestKey(1), values[1],
+                         false /* expect_key_pinned */,
+                         true /* expect_value_pinned */);
+  AssertPinnedBatchEntry(batch, 1, PinnedKVTestKey(2), values[2],
+                         false /* expect_key_pinned */,
+                         true /* expect_value_pinned */);
+  const size_t batch_pinned_usage = batch.GetPinnedBlockCacheUsage();
+  const size_t pinned_usage_before_reset = block_cache->GetPinnedUsage();
+  ASSERT_GE(pinned_usage_before_reset,
+            baseline_pinned_usage + batch_pinned_usage);
+
+  batch.Reset();
+  const size_t pinned_usage_after_reset = block_cache->GetPinnedUsage();
+  ASSERT_GT(pinned_usage_before_reset, pinned_usage_after_reset);
+  ASSERT_GE(pinned_usage_before_reset - pinned_usage_after_reset,
+            batch_pinned_usage);
+  ASSERT_EQ(baseline_pinned_usage, pinned_usage_after_reset);
+}
+
+TEST_F(DBTest2, IteratorAppendPinnedCurrentTracksDistinctBlockUsage) {
+  std::shared_ptr<Cache> block_cache;
+  Options options = CurrentPinnedKVOptions(
+      160 /* block_size */, true /* use_block_cache */, &block_cache);
+  Reopen(options);
+
+  std::vector<std::string> values;
+  PutPinnedKVRows(20, 48, &values);
+  ASSERT_OK(Flush());
+  const size_t baseline_pinned_usage = block_cache->GetPinnedUsage();
+
+  PinnableKeyValueBatch batch;
+  {
+    std::unique_ptr<Iterator> iter(db_->NewIterator(ReadOptions()));
+    iter->Seek(PinnedKVTestKey(1));
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_OK(iter->AppendPinnedCurrent(&batch));
+    const size_t first_block_usage = batch.GetPinnedBlockCacheUsage();
+    ASSERT_GT(first_block_usage, 0);
+
+    iter->Seek(PinnedKVTestKey(10));
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_OK(iter->AppendPinnedCurrent(&batch));
+    ASSERT_EQ(2U, batch.size());
+    ASSERT_GT(batch.GetPinnedBlockCacheUsage(), first_block_usage);
+  }
+
+  ASSERT_EQ(PinnedKVTestKey(1), batch.key(0).ToString());
+  ASSERT_EQ(values[1], batch.value(0).ToString());
+  ASSERT_TRUE(batch.IsValuePinned(0));
+  ASSERT_EQ(PinnedKVTestKey(10), batch.key(1).ToString());
+  ASSERT_EQ(values[10], batch.value(1).ToString());
+  ASSERT_TRUE(batch.IsValuePinned(1));
+  const size_t batch_pinned_usage = batch.GetPinnedBlockCacheUsage();
+  const size_t pinned_usage_before_reset = block_cache->GetPinnedUsage();
+  ASSERT_GE(pinned_usage_before_reset,
+            baseline_pinned_usage + batch_pinned_usage);
+
+  batch.Reset();
+  const size_t pinned_usage_after_reset = block_cache->GetPinnedUsage();
+  ASSERT_GT(pinned_usage_before_reset, pinned_usage_after_reset);
+  ASSERT_GE(pinned_usage_before_reset - pinned_usage_after_reset,
+            batch_pinned_usage);
+  ASSERT_EQ(baseline_pinned_usage, pinned_usage_after_reset);
+}
+
+TEST_F(DBTest2, IteratorAppendPinnedCurrentFallsBackToCopyWithoutBlockCache) {
+  Options options =
+      CurrentPinnedKVOptions(160 /* block_size */, false /* use_block_cache */,
+                             nullptr /* block_cache */);
+  Reopen(options);
+
+  std::vector<std::string> values;
+  PutPinnedKVRows(3, 48, &values);
+  ASSERT_OK(Flush());
+
+  PinnableKeyValueBatch batch;
+  {
+    std::unique_ptr<Iterator> iter(db_->NewIterator(ReadOptions()));
+    iter->Seek(PinnedKVTestKey(0));
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_OK(iter->AppendPinnedCurrent(&batch));
+    iter->Next();
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_OK(iter->AppendPinnedCurrent(&batch));
+  }
+
+  ASSERT_EQ(2U, batch.size());
+  AssertPinnedBatchEntry(batch, 0, PinnedKVTestKey(0), values[0],
+                         false /* expect_key_pinned */,
+                         false /* expect_value_pinned */);
+  AssertPinnedBatchEntry(batch, 1, PinnedKVTestKey(1), values[1],
+                         false /* expect_key_pinned */,
+                         false /* expect_value_pinned */);
+  ASSERT_EQ(batch.key(0).size() + batch.value(0).size() + batch.key(1).size() +
+                batch.value(1).size(),
+            batch.GetCopiedBytes());
+  ASSERT_EQ(0, batch.GetPinnedBlockCacheUsage());
+}
+
+TEST_F(DBTest2, IteratorPinCurrentClearsOutputOnReverseIterationNotSupported) {
+  Options options =
+      CurrentPinnedKVOptions(160 /* block_size */, true /* use_block_cache */,
+                             nullptr /* block_cache */);
+  Reopen(options);
+
+  std::vector<std::string> values;
+  PutPinnedKVRows(3, 48, &values);
+  ASSERT_OK(Flush());
+
+  PinnableKeyValue pinned_kv;
+  std::unique_ptr<Iterator> iter(db_->NewIterator(ReadOptions()));
+  iter->Seek(PinnedKVTestKey(0));
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_OK(iter->PinCurrent(&pinned_kv));
+  ASSERT_EQ(PinnedKVTestKey(0), pinned_kv.key().ToString());
+  ASSERT_EQ(values[0], pinned_kv.value().ToString());
+
+  iter->SeekToLast();
+  ASSERT_TRUE(iter->Valid());
+  Status status = iter->PinCurrent(&pinned_kv);
+  ASSERT_TRUE(status.IsNotSupported());
+  AssertEmptyPinnedKeyValue(pinned_kv);
+}
+
+TEST_F(DBTest2, IteratorPinAPIsHandleReverseIterationSafely) {
+  Options options =
+      CurrentPinnedKVOptions(160 /* block_size */, true /* use_block_cache */,
+                             nullptr /* block_cache */);
+  Reopen(options);
+
+  std::vector<std::string> values;
+  PutPinnedKVRows(3, 48, &values);
+  ASSERT_OK(Flush());
+
+  PinnableKeyValue pinned_kv;
+  PinnableKeyValueBatch batch;
+  std::unique_ptr<Iterator> iter(db_->NewIterator(ReadOptions()));
+
+  iter->Seek(PinnedKVTestKey(0));
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_OK(iter->PinCurrent(&pinned_kv));
+  ASSERT_OK(iter->AppendPinnedCurrent(&batch));
+  const PinnedKVBatchSnapshot snapshot = CaptureBatchSnapshot(batch);
+
+  iter->SeekToLast();
+  ASSERT_TRUE(iter->Valid());
+  Status pin_status = iter->PinCurrent(&pinned_kv);
+  ASSERT_TRUE(pin_status.IsNotSupported());
+  AssertEmptyPinnedKeyValue(pinned_kv);
+
+  Status append_status = iter->AppendPinnedCurrent(&batch);
+  ASSERT_TRUE(append_status.IsNotSupported());
+  AssertBatchMatchesSnapshot(batch, snapshot);
+}
+
+TEST_F(DBTest2, IteratorAppendPinnedCurrentResetReleasesAndReusesBatch) {
+  std::shared_ptr<Cache> block_cache;
+  Options options = CurrentPinnedKVOptions(
+      160 /* block_size */, true /* use_block_cache */, &block_cache);
+  Reopen(options);
+
+  std::vector<std::string> values;
+  PutPinnedKVRows(20, 48, &values);
+  ASSERT_OK(Flush());
+  const size_t baseline_pinned_usage = block_cache->GetPinnedUsage();
+
+  PinnableKeyValueBatch batch;
+  std::unique_ptr<Iterator> iter(db_->NewIterator(ReadOptions()));
+  iter->Seek(PinnedKVTestKey(1));
+  ASSERT_TRUE(iter->Valid());
+  const size_t pinned_usage_before_first_append = block_cache->GetPinnedUsage();
+  ASSERT_OK(iter->AppendPinnedCurrent(&batch));
+  const size_t first_batch_pinned_usage = batch.GetPinnedBlockCacheUsage();
+  ASSERT_GT(first_batch_pinned_usage, 0);
+
+  batch.Reset();
+  ASSERT_TRUE(batch.empty());
+  ASSERT_EQ(0U, batch.GetPinnedBlockCacheUsage());
+  ASSERT_EQ(0U, batch.GetCopiedBytes());
+  ASSERT_EQ(pinned_usage_before_first_append, block_cache->GetPinnedUsage());
+
+  iter->Seek(PinnedKVTestKey(10));
+  ASSERT_TRUE(iter->Valid());
+  const size_t pinned_usage_before_second_append =
+      block_cache->GetPinnedUsage();
+  ASSERT_OK(iter->AppendPinnedCurrent(&batch));
+  ASSERT_EQ(1U, batch.size());
+  AssertPinnedBatchEntry(batch, 0, PinnedKVTestKey(10), values[10],
+                         false /* expect_key_pinned */,
+                         true /* expect_value_pinned */);
+  ASSERT_GT(batch.GetPinnedBlockCacheUsage(), 0);
+  ASSERT_EQ(batch.key(0).size(), batch.GetCopiedBytes());
+
+  const size_t second_batch_pinned_usage = batch.GetPinnedBlockCacheUsage();
+  batch.Reset();
+  ASSERT_GT(second_batch_pinned_usage, 0);
+  ASSERT_EQ(pinned_usage_before_second_append, block_cache->GetPinnedUsage());
+
+  iter.reset();
+  ASSERT_EQ(baseline_pinned_usage, block_cache->GetPinnedUsage());
+}
+
+TEST_F(DBTest2, IteratorPinAPIsRejectNullOutputPointers) {
+  Options options =
+      CurrentPinnedKVOptions(160 /* block_size */, true /* use_block_cache */,
+                             nullptr /* block_cache */);
+  Reopen(options);
+
+  std::vector<std::string> values;
+  PutPinnedKVRows(1, 48, &values);
+  ASSERT_OK(Flush());
+
+  std::unique_ptr<Iterator> iter(db_->NewIterator(ReadOptions()));
+  iter->Seek(PinnedKVTestKey(0));
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_TRUE(iter->PinCurrent(nullptr).IsInvalidArgument());
+  ASSERT_TRUE(iter->AppendPinnedCurrent(nullptr).IsInvalidArgument());
+}
+
+TEST_F(DBTest2, IteratorPinAPIsRejectBlobRowsAfterPrepareValue) {
+  Options options = CurrentOptions();
+  options.enable_blob_files = true;
+  options.min_blob_size = 0;
+  DestroyAndReopen(options);
+
+  const std::string blob_value(128, 'b');
+  ASSERT_OK(Put("blob-key", blob_value));
+  ASSERT_OK(Flush());
+
+  ReadOptions read_options;
+  read_options.allow_unprepared_value = true;
+  std::unique_ptr<Iterator> iter(db_->NewIterator(read_options));
+  iter->Seek("blob-key");
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_TRUE(iter->PrepareValue());
+  ASSERT_EQ(blob_value, iter->value().ToString());
+  AssertPinAPIsNotSupportedForCurrentRow(iter.get());
+}
+
+TEST_F(DBTest2, IteratorPinAPIsRejectWideColumnEntityRows) {
+  Options options = CurrentOptions();
+  DestroyAndReopen(options);
+
+  const WideColumns columns{{kDefaultWideColumnName, "default"},
+                            {"attr", "value"}};
+  ASSERT_OK(db_->PutEntity(WriteOptions(), db_->DefaultColumnFamily(),
+                           "wide-key", columns));
+  ASSERT_OK(Flush());
+
+  std::unique_ptr<Iterator> iter(db_->NewIterator(ReadOptions()));
+  iter->Seek("wide-key");
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ("default", iter->value().ToString());
+  AssertPinAPIsNotSupportedForCurrentRow(iter.get());
+}
+
+TEST_F(DBTest2, IteratorPinAPIsRejectUserDefinedTimestampRows) {
+  Options options = CurrentOptions();
+  options.comparator = test::BytewiseComparatorWithU64TsWrapper();
+  DestroyAndReopen(options);
+
+  std::string ts;
+  PutFixed64(&ts, 7);
+  ASSERT_OK(db_->Put(WriteOptions(), "ts-key", ts, "value"));
+  ASSERT_OK(Flush());
+
+  const Slice read_ts_slice(ts);
+  ReadOptions read_options;
+  read_options.timestamp = &read_ts_slice;
+  std::unique_ptr<Iterator> iter(db_->NewIterator(read_options));
+  iter->Seek("ts-key");
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ("value", iter->value().ToString());
+  AssertPinAPIsNotSupportedForCurrentRow(iter.get());
+}
+
 TEST_F(DBTest2, DISABLED_IteratorPinnedMemory) {
   Options options = CurrentOptions();
   options.create_if_missing = true;
@@ -8144,47 +9725,6 @@ TEST_F(DBTest2, FastSstOpenIngestion) {
 
   // Metadata should be passed when opening the ingested SST
   ASSERT_GE(test_fs->GetMetadataPassedOnOpenCount(), 1);
-
-  db.reset();
-  ASSERT_OK(DestroyDB(test_dbname, options));
-}
-
-TEST_F(DBTest2, FastSstOpenDisableAfterMetadataPersisted) {
-  // Verify that disabling fast_sst_open prevents previously-persisted
-  // metadata from being passed to NewRandomAccessFile. This is critical
-  // for cases where stale metadata (e.g. expired credentials) would
-  // cause file open failures.
-  auto test_fs = std::make_shared<FastOpenTestFS>(env_->GetFileSystem());
-  std::unique_ptr<Env> test_env(new CompositeEnvWrapper(env_, test_fs));
-
-  Options options;
-  options.env = test_env.get();
-  options.fast_sst_open = true;
-  options.create_if_missing = true;
-
-  std::string test_dbname = test::PerThreadDBPath("fast_open_disable_after");
-  ASSERT_OK(DestroyDB(test_dbname, options));
-
-  // Open with fast_sst_open enabled, write and flush to persist metadata
-  std::unique_ptr<DB> db;
-  ASSERT_OK(DB::Open(options, test_dbname, &db));
-  ASSERT_OK(db->Put(WriteOptions(), "key1", "value1"));
-  ASSERT_OK(db->Flush(FlushOptions()));
-  ASSERT_EQ(1, test_fs->GetMetadataRetrievedCount());
-  db.reset();
-
-  // Reopen with fast_sst_open DISABLED — metadata is in the MANIFEST
-  // but should NOT be passed to the filesystem
-  options.fast_sst_open = false;
-  test_fs->ResetCounters();
-  ASSERT_OK(DB::Open(options, test_dbname, &db));
-
-  std::string value;
-  ASSERT_OK(db->Get(ReadOptions(), "key1", &value));
-  ASSERT_EQ("value1", value);
-
-  // No metadata should have been passed despite being in the MANIFEST
-  ASSERT_EQ(0, test_fs->GetMetadataPassedOnOpenCount());
 
   db.reset();
   ASSERT_OK(DestroyDB(test_dbname, options));

--- a/db/forward_iterator.cc
+++ b/db/forward_iterator.cc
@@ -13,6 +13,7 @@
 #include "db/db_impl/db_impl.h"
 #include "db/db_iter.h"
 #include "db/dbformat.h"
+#include "db/iterator_mutable_options.h"
 #include "db/job_context.h"
 #include "db/range_del_aggregator.h"
 #include "db/range_tombstone_fragmenter.h"
@@ -195,6 +196,16 @@ class ForwardLevelIterator : public InternalIterator {
     return pinned_iters_mgr_ && pinned_iters_mgr_->PinningEnabled() &&
            file_iter_->IsValuePinned();
   }
+  Status PinCurrentKeyValue(PinnedIterKeyValue* out) override {
+    if (out == nullptr) {
+      return Status::InvalidArgument("PinnedIterKeyValue is nullptr");
+    }
+    out->Reset();
+    if (!valid_) {
+      return Status::InvalidArgument("Iterator is not valid");
+    }
+    return file_iter_->PinCurrentKeyValue(out);
+  }
   void SetPinnedItersMgr(PinnedIteratorsManager* pinned_iters_mgr) override {
     pinned_iters_mgr_ = pinned_iters_mgr;
     if (file_iter_) {
@@ -361,6 +372,13 @@ bool ForwardIterator::IsOverUpperBound(const Slice& internal_key) const {
            cfd_->internal_comparator().user_comparator()->Compare(
                ExtractUserKey(internal_key),
                *read_options_.iterate_upper_bound) < 0);
+}
+
+void ForwardIterator::InvalidateCurrentPosition() {
+  current_ = nullptr;
+  valid_ = false;
+  current_over_upper_bound_ = false;
+  is_prev_set_ = false;
 }
 
 void ForwardIterator::Seek(const Slice& internal_key) {
@@ -657,6 +675,31 @@ Status ForwardIterator::GetProperty(std::string prop_name, std::string* prop) {
   return Status::InvalidArgument("Unrecognized property: " + prop_name);
 }
 
+Status ForwardIterator::SetMutableOptions(
+    const IteratorMutableOptions& options) {
+  Status s = ValidateIteratorMutableOptions(
+      options, cfd_ != nullptr ? cfd_->initial_cf_options().table_factory.get()
+                               : nullptr);
+  if (!s.ok()) {
+    return s;
+  }
+  ApplyIteratorMutableOptions(options, &read_options_.iterator_mutable_options);
+  if (sv_ != nullptr) {
+    RebuildIterators(false /* refresh_sv */);
+  }
+  InvalidateCurrentPosition();
+  return Status::OK();
+}
+
+Status ForwardIterator::GetMutableOptions(
+    IteratorMutableOptions* options) const {
+  if (options == nullptr) {
+    return Status::InvalidArgument("IteratorMutableOptions is nullptr");
+  }
+  *options = read_options_.iterator_mutable_options;
+  return Status::OK();
+}
+
 void ForwardIterator::SetPinnedItersMgr(
     PinnedIteratorsManager* pinned_iters_mgr) {
   pinned_iters_mgr_ = pinned_iters_mgr;
@@ -699,6 +742,17 @@ bool ForwardIterator::IsKeyPinned() const {
 bool ForwardIterator::IsValuePinned() const {
   return pinned_iters_mgr_ && pinned_iters_mgr_->PinningEnabled() &&
          current_->IsValuePinned();
+}
+
+Status ForwardIterator::PinCurrentKeyValue(PinnedIterKeyValue* out) {
+  if (out == nullptr) {
+    return Status::InvalidArgument("PinnedIterKeyValue is nullptr");
+  }
+  out->Reset();
+  if (!valid_ || current_ == nullptr) {
+    return Status::InvalidArgument("Iterator is not valid");
+  }
+  return current_->PinCurrentKeyValue(out);
 }
 
 void ForwardIterator::RebuildIterators(bool refresh_sv) {

--- a/db/forward_iterator.h
+++ b/db/forward_iterator.h
@@ -80,9 +80,12 @@ class ForwardIterator : public InternalIterator {
   Status status() const override;
   bool PrepareValue() override;
   Status GetProperty(std::string prop_name, std::string* prop) override;
+  Status SetMutableOptions(const IteratorMutableOptions& options) override;
+  Status GetMutableOptions(IteratorMutableOptions* options) const override;
   void SetPinnedItersMgr(PinnedIteratorsManager* pinned_iters_mgr) override;
   bool IsKeyPinned() const override;
   bool IsValuePinned() const override;
+  Status PinCurrentKeyValue(PinnedIterKeyValue* out) override;
 
   bool TEST_CheckDeletedIters(int* deleted_iters, int* num_iters);
 
@@ -112,6 +115,7 @@ class ForwardIterator : public InternalIterator {
                            uint32_t right);
 
   bool IsOverUpperBound(const Slice& internal_key) const;
+  void InvalidateCurrentPosition();
 
   // Set PinnedIteratorsManager for all children Iterators, this function should
   // be called whenever we update children Iterators or pinned_iters_mgr_.

--- a/db/history_trimming_iterator.h
+++ b/db/history_trimming_iterator.h
@@ -82,6 +82,10 @@ class HistoryTrimmingIterator : public InternalIterator {
 
   bool IsValuePinned() const override { return input_->IsValuePinned(); }
 
+  Status PinCurrentKeyValue(PinnedIterKeyValue* out) override {
+    return input_->PinCurrentKeyValue(out);
+  }
+
   bool IsDeleteRangeSentinelKey() const override {
     return input_->IsDeleteRangeSentinelKey();
   }

--- a/db/iterator_mutable_options.h
+++ b/db/iterator_mutable_options.h
@@ -1,0 +1,74 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+//
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+
+#pragma once
+
+#include "rocksdb/options.h"
+#include "rocksdb/table.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+inline Status ValidateIteratorMutableOptions(
+    const IteratorMutableOptions& options, const TableFactory* table_factory) {
+  if (!options.pinned_block_backing.has_value()) {
+    return Status::OK();
+  }
+
+  const auto* table_options =
+      table_factory != nullptr
+          ? table_factory->GetOptions<BlockBasedTableOptions>()
+          : nullptr;
+  if (table_factory != nullptr && table_options == nullptr) {
+    return Status::InvalidArgument(
+        "Iterator mutable options require a block-based table factory");
+  }
+
+  const auto& pinned_block_backing = *options.pinned_block_backing;
+  switch (pinned_block_backing.policy) {
+    case PinnedBlockBackingPolicy::kAuto:
+      return Status::OK();
+    case PinnedBlockBackingPolicy::kUseBlockCache:
+      if (table_options == nullptr || table_options->block_cache == nullptr) {
+        return Status::InvalidArgument(
+            "PinnedBlockBackingPolicy::kUseBlockCache requires block cache");
+      }
+      return Status::OK();
+    case PinnedBlockBackingPolicy::kUseRetainedBlockBuffer:
+      if (pinned_block_backing.retained_block_buffer_provider != nullptr) {
+        return Status::OK();
+      }
+      if (table_options != nullptr &&
+          table_options->block_buffer_provider != nullptr) {
+        return Status::OK();
+      }
+      return Status::InvalidArgument(
+          "PinnedBlockBackingPolicy::kUseRetainedBlockBuffer requires a "
+          "retained block buffer provider");
+  }
+
+  return Status::InvalidArgument("Unknown pinned block backing policy");
+}
+
+inline void ApplyIteratorMutableOptions(const IteratorMutableOptions& options,
+                                        IteratorMutableOptions* current) {
+  if (current == nullptr) {
+    return;
+  }
+
+  if (options.pinned_block_backing.has_value()) {
+    current->pinned_block_backing = options.pinned_block_backing;
+  }
+}
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1105,6 +1105,20 @@ class LevelIterator final : public InternalIterator {
            file_iter_.iter() && file_iter_.IsValuePinned();
   }
 
+  Status PinCurrentKeyValue(PinnedIterKeyValue* out) override {
+    if (out == nullptr) {
+      return Status::InvalidArgument("PinnedIterKeyValue is nullptr");
+    }
+    out->Reset();
+    if (to_return_sentinel_) {
+      return Status::NotSupported("Current entry is a file boundary sentinel");
+    }
+    if (!Valid()) {
+      return Status::InvalidArgument("Iterator is not valid");
+    }
+    return file_iter_.PinCurrentKeyValue(out);
+  }
+
   bool IsDeleteRangeSentinelKey() const override { return to_return_sentinel_; }
 
   void SetRangeDelReadSeqno(SequenceNumber read_seq) override {

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -455,6 +455,8 @@ DECLARE_int32(remote_compaction_worker_interval);
 DECLARE_bool(remote_compaction_failure_fall_back_to_local);
 DECLARE_int32(allow_resumption_one_in);
 DECLARE_bool(auto_refresh_iterator_with_snapshot);
+DECLARE_bool(use_retained_block_buffer_provider);
+DECLARE_int32(test_iterator_pin_current_one_in);
 DECLARE_uint32(memtable_op_scan_flush_trigger);
 DECLARE_uint32(memtable_avg_op_scan_flush_trigger);
 DECLARE_uint32(min_tombstones_for_range_conversion);

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -1669,6 +1669,15 @@ DEFINE_bool(
     ROCKSDB_NAMESPACE::ReadOptions().auto_refresh_iterator_with_snapshot,
     "ReadOptions.auto_refresh_iterator_with_snapshot");
 
+DEFINE_bool(use_retained_block_buffer_provider, false,
+            "If true, configure BlockBasedTableOptions.block_buffer_provider "
+            "and force iterator data blocks to use retained block buffers.");
+
+DEFINE_int32(test_iterator_pin_current_one_in, 0,
+             "If non-zero, call Iterator::PinCurrent() and "
+             "Iterator::AppendPinnedCurrent() once every N iterator "
+             "verification points on average.");
+
 DEFINE_uint32(
     memtable_op_scan_flush_trigger,
     ROCKSDB_NAMESPACE::ColumnFamilyOptions().memtable_op_scan_flush_trigger,

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -32,11 +32,13 @@
 #include "rocksdb/io_dispatcher.h"
 #include "rocksdb/secondary_cache.h"
 #include "rocksdb/sst_file_manager.h"
+#include "rocksdb/table.h"
 #include "rocksdb/table_properties.h"
 #include "rocksdb/types.h"
 #include "rocksdb/utilities/object_registry.h"
 #include "rocksdb/utilities/write_batch_with_index.h"
 #include "test_util/testutil.h"
+#include "util/aligned_buffer.h"
 #include "util/cast_util.h"
 #include "util/simple_mixed_compressor.h"
 #include "utilities/backup/backup_engine_impl.h"
@@ -61,6 +63,45 @@ std::shared_ptr<const FilterPolicy> CreateFilterPolicy() {
         NewRibbonFilterPolicy(FLAGS_bloom_bits, FLAGS_bloom_before_level);
   }
   return std::shared_ptr<const FilterPolicy>(new_policy);
+}
+
+class DbStressRetainedBlockBufferProvider : public RetainedBlockBufferProvider {
+ public:
+  Status Allocate(size_t size, size_t alignment, Lease* out) override {
+    if (out == nullptr) {
+      return Status::InvalidArgument("lease output is nullptr");
+    }
+    if (alignment == 0 || (alignment & (alignment - 1)) != 0) {
+      return Status::InvalidArgument("alignment must be a power of two");
+    }
+
+    auto* allocation = new Allocation();
+    allocation->storage.Alignment(alignment);
+    allocation->storage.AllocateNewBuffer(size);
+
+    out->data = allocation->storage.BufferStart();
+    out->size = size;
+    out->cleanup.Allocate();
+    out->cleanup->RegisterCleanup(&ReleaseAllocation, allocation, nullptr);
+    out->dedupe_token = allocation;
+    return Status::OK();
+  }
+
+ private:
+  struct Allocation {
+    AlignedBuffer storage;
+  };
+
+  static void ReleaseAllocation(void* arg1, void* /*arg2*/) {
+    delete static_cast<Allocation*>(arg1);
+  }
+};
+
+void UseRetainedBlockBufferBacking(ReadOptions* read_options) {
+  assert(read_options != nullptr);
+  read_options->iterator_mutable_options.pinned_block_backing =
+      PinnedBlockBackingConfig{
+          PinnedBlockBackingPolicy::kUseRetainedBlockBuffer};
 }
 
 }  // namespace
@@ -1003,6 +1044,9 @@ void StressTest::OperateDb(ThreadState* thread) {
   read_opts.allow_unprepared_value = FLAGS_allow_unprepared_value;
   read_opts.auto_refresh_iterator_with_snapshot =
       FLAGS_auto_refresh_iterator_with_snapshot;
+  if (FLAGS_use_retained_block_buffer_provider) {
+    UseRetainedBlockBufferBacking(&read_opts);
+  }
   if (FLAGS_use_trie_index && !FLAGS_use_udi_as_primary_index && udi_factory_) {
     read_opts.table_index_factory = udi_factory_.get();
   }
@@ -1640,7 +1684,7 @@ Status StressTest::TestIterate(ThreadState* thread,
     }
   };
 
-  auto verify_func = [](Iterator* iter) {
+  auto verify_func = [this, thread](Iterator* iter) {
     if (!VerifyWideColumns(iter->value(), iter->columns())) {
       fprintf(stderr,
               "Value and columns inconsistent for iterator: value: %s, "
@@ -1649,11 +1693,68 @@ Status StressTest::TestIterate(ThreadState* thread,
               WideColumnsToHex(iter->columns()).c_str());
       return false;
     }
-    return true;
+    return MaybeVerifyIteratorPinning(thread, iter);
   };
 
   return TestIterateImpl<Iterator>(thread, read_opts, rand_column_families,
                                    rand_keys, new_iter_func, verify_func);
+}
+
+bool StressTest::MaybeVerifyIteratorPinning(ThreadState* thread,
+                                            Iterator* iter) const {
+  assert(thread != nullptr);
+  assert(iter != nullptr);
+
+  if (!thread->rand.OneInOpt(FLAGS_test_iterator_pin_current_one_in)) {
+    return true;
+  }
+  if (!iter->Valid()) {
+    return true;
+  }
+
+  const std::string expected_key = iter->key().ToString();
+  const std::string expected_value = iter->value().ToString();
+
+  PinnableKeyValue pinned;
+  Status s = iter->PinCurrent(&pinned);
+  if (s.IsNotSupported()) {
+    return true;
+  }
+  if (!s.ok()) {
+    fprintf(stderr, "Iterator::PinCurrent() failed: %s\n",
+            s.ToString().c_str());
+    return false;
+  }
+  if (pinned.key() != Slice(expected_key) ||
+      pinned.value() != Slice(expected_value)) {
+    fprintf(stderr,
+            "Iterator::PinCurrent() returned unexpected row. Expected key %s "
+            "value %s, got key %s value %s\n",
+            Slice(expected_key).ToString(/*hex=*/true).c_str(),
+            Slice(expected_value).ToString(/*hex=*/true).c_str(),
+            pinned.key().ToString(/*hex=*/true).c_str(),
+            pinned.value().ToString(/*hex=*/true).c_str());
+    return false;
+  }
+
+  PinnableKeyValueBatch batch;
+  s = iter->AppendPinnedCurrent(&batch);
+  if (!s.ok()) {
+    fprintf(stderr, "Iterator::AppendPinnedCurrent() failed: %s\n",
+            s.ToString().c_str());
+    return false;
+  }
+  if (batch.size() != 1 || batch.key(0) != Slice(expected_key) ||
+      batch.value(0) != Slice(expected_value)) {
+    fprintf(stderr,
+            "Iterator::AppendPinnedCurrent() returned unexpected row. "
+            "Expected key %s value %s, batch size %zu\n",
+            Slice(expected_key).ToString(/*hex=*/true).c_str(),
+            Slice(expected_value).ToString(/*hex=*/true).c_str(), batch.size());
+    return false;
+  }
+
+  return true;
 }
 
 Status StressTest::TestIterateAttributeGroups(
@@ -1748,7 +1849,7 @@ Status StressTest::TestMultiScan(ThreadState* thread,
 
   constexpr size_t kOpLogsLimit = 50000;
 
-  auto verify_func = [](Iterator* iterator) {
+  auto verify_func = [this, thread](Iterator* iterator) {
     if (!VerifyWideColumns(iterator->value(), iterator->columns())) {
       fprintf(stderr,
               "Value and columns inconsistent for iterator: value: %s, "
@@ -1757,7 +1858,7 @@ Status StressTest::TestMultiScan(ThreadState* thread,
               WideColumnsToHex(iterator->columns()).c_str());
       return false;
     }
-    return true;
+    return MaybeVerifyIteratorPinning(thread, iterator);
   };
 
   for (const ScanOptions& scan_opt : scan_opts.GetScanRanges()) {
@@ -4443,6 +4544,10 @@ void InitializeOptionsFromFlags(
   block_based_options.decouple_partitioned_filters =
       FLAGS_decouple_partitioned_filters;
   block_based_options.block_cache = cache;
+  if (FLAGS_use_retained_block_buffer_provider) {
+    block_based_options.block_buffer_provider =
+        std::make_shared<DbStressRetainedBlockBufferProvider>();
+  }
   block_based_options.cache_index_and_filter_blocks =
       FLAGS_cache_index_and_filter_blocks;
   block_based_options.metadata_cache_options.top_level_index_pinning =
@@ -4884,6 +4989,10 @@ void InitializeOptionsGeneral(
   if (table_options) {
     if (FLAGS_cache_size > 0) {
       table_options->block_cache = cache;
+    }
+    if (FLAGS_use_retained_block_buffer_provider) {
+      table_options->block_buffer_provider =
+          std::make_shared<DbStressRetainedBlockBufferProvider>();
     }
     if (!table_options->filter_policy) {
       table_options->filter_policy = filter_policy;

--- a/db_stress_tool/db_stress_test_base.h
+++ b/db_stress_tool/db_stress_test_base.h
@@ -269,6 +269,8 @@ class StressTest {
                              const std::vector<int>& rand_column_families,
                              const std::vector<int64_t>& rand_keys);
 
+  bool MaybeVerifyIteratorPinning(ThreadState* thread, Iterator* iter) const;
+
   // Given a key K, this creates an attribute group iterator which scans to K
   // and then does a random sequence of Next/Prev operations. Called only when
   // use_attribute_group=1

--- a/docs/components/read_flow/12_retained_block_backing_for_pin_api.md
+++ b/docs/components/read_flow/12_retained_block_backing_for_pin_api.md
@@ -1,0 +1,479 @@
+# Retained Block Backing For Iterator Pin APIs
+
+**Status:** implemented
+
+**Related files:** `include/rocksdb/iterator.h`, `include/rocksdb/table.h`, `table/block_fetcher.h`, `table/block_fetcher.cc`, `table/block_based/block_based_table_reader.cc`, `table/block_based/block_based_table_iterator.cc`, `table/block_based/reader_common.h`, `table/block_based/block.h`, `table/block_based/block.cc`
+
+## Problem Statement
+
+The existing `Iterator::PinCurrent()` and `Iterator::AppendPinnedCurrent()` APIs support zero-copy pinning when the current row is backed by a block-cache entry. In that case, the pinning lifetime is implemented by retaining a block-cache handle.
+
+The missing capability is zero-copy pinning for reads that do **not** use block cache:
+
+1. Application provides a custom source of block memory.
+2. SST data blocks read from disk are stored in that memory.
+3. The backing storage lifetime is decoupled from iterator lifetime.
+4. A pinned key/value remains valid after iterator movement or destruction.
+5. The design remains generic and does not hard-code a particular backing implementation such as `IOBuf`.
+
+## Current Behavior
+
+### Cache-backed pinning
+
+When the current row comes from `BlockBasedTableIterator`, `PinCurrentKeyValue()` in `table/block_based/block_based_table_iterator.cc` retains the block-cache handle and returns it through `PinnedIterKeyValue.cleanup`.
+
+This gives:
+
+- zero-copy key/value slices
+- lifetime independent of iterator movement
+- per-block dedupe in `PinnableKeyValueBatch` via `cleanup_dedupe_token`
+
+### Non-cache reads
+
+The block-read path already accepts `MemoryAllocator*` in `BlockFetcher`, but the allocator currently comes from block cache only:
+
+```cpp
+inline MemoryAllocator* GetMemoryAllocator(
+    const BlockBasedTableOptions& table_options) {
+  return table_options.block_cache.get()
+             ? table_options.block_cache->memory_allocator()
+             : nullptr;
+}
+```
+
+Without block cache, block bytes can still be allocated and copied, but there is no general retained backing object for `Pin*` to hold onto. As a result, `DBIter::PinCurrent()` falls back to copying when true pinning is unavailable.
+
+## Requirements
+
+The new design should satisfy all of the following:
+
+1. Keep the current block-cache pinning behavior unchanged.
+2. Support a custom block-memory source even when `no_block_cache=true`.
+3. Support zero-copy pinning from that custom backing store.
+4. Keep the feature generic. RocksDB core should not depend on `IOBuf`.
+5. Keep the disabled case close to the current fast path with negligible regression risk.
+6. Preserve same-block multi-key behavior:
+   - multiple pinned rows from one block remain valid
+   - batch pinning dedupes backing retention by block
+
+## Design Summary
+
+The core change is to generalize the retained backing object, not to extend `MemoryAllocator` directly.
+
+`MemoryAllocator` is an allocation interface. The new feature needs a stronger contract:
+
+- writable contiguous memory for a loaded block
+- a retained lifetime object
+- a stable dedupe token for block-level sharing
+
+That contract fits a new abstraction such as `RetainedBlockBufferProvider`.
+
+## Proposed Abstractions
+
+### 1. New retained block buffer provider
+
+```cpp
+class RetainedBlockBufferProvider {
+ public:
+  struct Lease {
+    char* data = nullptr;
+    size_t size = 0;
+    SharedCleanablePtr cleanup;
+    const void* dedupe_token = nullptr;
+  };
+
+  virtual Status Allocate(size_t size, size_t alignment, Lease* out) = 0;
+};
+```
+
+Properties:
+
+- `data` must reference writable contiguous memory
+- `data` must be aligned to `alignment`
+- `cleanup` must keep that memory alive until cleanup runs
+- `dedupe_token` must be identical for leases that represent the same backing block
+
+The provider is intentionally a programmatic hook rather than a `Customizable`
+option. It is registered with the options framework as non-serializable so
+OPTIONS files cannot accidentally require an application-specific allocator.
+
+### 2. New `BlockBasedTableOptions` hook
+
+Add a new optional field:
+
+```cpp
+std::shared_ptr<RetainedBlockBufferProvider> block_buffer_provider;
+```
+
+This keeps the feature table-reader scoped instead of making `MemoryAllocator` responsible for retention semantics.
+
+### 3. Extend `BlockContents` to carry retained backing
+
+`BlockContents` is already the transport object for block bytes between fetch, decompression, and parsed block creation. It is the natural place to carry generic lifetime retention.
+
+Proposed extension:
+
+```cpp
+struct BlockContents {
+  Slice data;
+  CacheAllocationPtr allocation;
+
+  // New generic retained owner for externally managed block memory.
+  SharedCleanablePtr cleanup;
+  const void* cleanup_dedupe_token = nullptr;
+
+  bool own_bytes() const {
+    return allocation.get() != nullptr || cleanup.get() != nullptr;
+  }
+};
+```
+
+This allows the same object to represent:
+
+- heap-owned bytes
+- cache-allocator-owned bytes
+- provider-backed retained bytes
+
+## End-to-End Flow
+
+### Block cache path
+
+No semantic change is needed.
+
+1. `BlockFetcher` reads and/or decompresses block bytes.
+2. Parsed block is inserted into block cache.
+3. `BlockBasedTableIterator::PinCurrentKeyValue()` retains the cache handle.
+4. `PinnedIterKeyValue.cleanup` owns the cache-handle release.
+
+`BlockContents.cleanup` can remain empty in this mode.
+
+### Provider path with block cache disabled
+
+1. `BlockFetcher` requests a `Lease` from `block_buffer_provider`.
+2. Block bytes are read into `Lease.data`.
+3. `BlockContents` stores:
+   - `data`
+   - empty or unused `allocation`
+   - `cleanup`
+   - `cleanup_dedupe_token`
+4. Parsed `Block` retains the moved `BlockContents`.
+5. `BlockBasedTableIterator::PinCurrentKeyValue()` retains the same `cleanup`.
+6. Pinned row remains valid after iterator movement or destruction.
+
+## Critical Sample Code
+
+### Option lookup
+
+```cpp
+inline RetainedBlockBufferProvider* GetBlockBufferProvider(
+    const BlockBasedTableOptions& table_options) {
+  return table_options.block_buffer_provider.get();
+}
+```
+
+### `BlockFetcher` constructor extension
+
+```cpp
+class BlockFetcher {
+ public:
+  BlockFetcher(...,
+               RetainedBlockBufferProvider* block_buffer_provider = nullptr,
+               MemoryAllocator* memory_allocator = nullptr,
+               MemoryAllocator* memory_allocator_compressed = nullptr,
+               bool for_compaction = false);
+
+  const SharedCleanablePtr& block_cleanup() const { return block_cleanup_; }
+  const void* block_dedupe_token() const { return block_dedupe_token_; }
+
+ private:
+  RetainedBlockBufferProvider* block_buffer_provider_ = nullptr;
+  SharedCleanablePtr block_cleanup_;
+  const void* block_dedupe_token_ = nullptr;
+};
+```
+
+### Provider-backed read buffer selection
+
+```cpp
+inline void BlockFetcher::PrepareBufferForBlockFromFile() {
+  if (UNLIKELY(block_buffer_provider_ != nullptr) && !maybe_compressed_) {
+    RetainedBlockBufferProvider::Lease lease;
+    Status s =
+        block_buffer_provider_->Allocate(block_size_with_trailer_, 1, &lease);
+    if (!s.ok()) {
+      io_status_ = IOStatus::FromStatus(s);
+      return;
+    }
+    used_buf_ = lease.data;
+    block_cleanup_ = std::move(lease.cleanup);
+    block_dedupe_token_ = lease.dedupe_token;
+    return;
+  }
+
+  // Existing stack / heap / compressed-buffer path.
+}
+```
+
+### Attach retained ownership to `BlockContents`
+
+```cpp
+void BlockFetcher::GetBlockContents() {
+  if (block_buffer_provider_ != nullptr &&
+      compression_type() == kNoCompression &&
+      used_buf_ != nullptr) {
+    *contents_ = BlockContents(Slice(used_buf_, block_size_));
+    contents_->cleanup = block_cleanup_;
+    contents_->cleanup_dedupe_token = block_dedupe_token_;
+    return;
+  }
+
+  // Existing logic.
+}
+```
+
+### Generalized iterator pinning
+
+```cpp
+Status BlockBasedTableIterator::PinCurrentKeyValue(PinnedIterKeyValue* out) {
+  if (out == nullptr) {
+    return Status::InvalidArgument("PinnedIterKeyValue is nullptr");
+  }
+  out->Reset();
+  if (!Valid()) {
+    return Status::InvalidArgument("Iterator is not valid");
+  }
+  if (!PrepareValue()) {
+    return status();
+  }
+
+  if (TryPinFromBlockCache(out).ok()) {
+    return Status::OK();
+  }
+
+  const SharedCleanablePtr backing_cleanup = block_iter_.GetBlockBackingCleanup();
+  if (backing_cleanup.get() == nullptr) {
+    return Status::NotSupported("Current entry has no retainable block backing");
+  }
+
+  out->cleanup = backing_cleanup;
+  out->cleanup_dedupe_token = block_iter_.GetBlockBackingDedupeToken();
+  out->key = block_iter_.key();
+  out->user_key = block_iter_.user_key();
+  out->value = block_iter_.value();
+  out->key_pinned = block_iter_.IsKeyPinned();
+  out->value_pinned = true;
+  out->pinned_block_cache_usage = 0;
+  return Status::OK();
+}
+```
+
+## Why `BlockContents` Works For Both Paths
+
+`BlockContents` is the narrow waist between:
+
+- block fetch / decompression
+- parsed block creation
+
+That makes it the right place to carry generic retained ownership.
+
+Behavior by mode:
+
+- **Block cache enabled:** pinning continues to retain cache handles; `BlockContents.cleanup` is not required for correctness.
+- **Provider enabled without block cache:** `BlockContents.cleanup` becomes the retained owner for the current block bytes.
+
+This keeps the current block-cache fast path intact while enabling a new zero-copy path for provider-backed reads.
+
+## Same-Block Multi-Key Behavior
+
+The design supports multiple pinned rows from the same block.
+
+Expected semantics:
+
+- `PinCurrent()` on different keys in the same block is correct.
+- Multiple pinned rows can reference the same block backing.
+- `AppendPinnedCurrent()` dedupes backing retention by `cleanup_dedupe_token`.
+
+This matches the existing batch behavior in `PinnableKeyValueBatch`.
+
+One important detail:
+
+- Separate `PinnableKeyValue` instances may each retain the same backing independently.
+- This is correct, though less efficient than batch dedupe.
+- Cross-object dedupe is not required for correctness.
+
+## Why `MemoryAllocator` Alone Is Not Enough
+
+`MemoryAllocator` only defines:
+
+- allocate
+- free
+- optional usable-size reporting
+
+It does not define:
+
+- retained ownership
+- block-level dedupe identity
+- safe lifetime sharing across iterator reset
+
+Extending `MemoryAllocator` to return a retention handle would mix two separate concerns:
+
+- where bytes come from
+- how block backing remains alive
+
+The new provider abstraction keeps these concerns separate and keeps the RocksDB core generic.
+
+## Applicability To `IOBuf`
+
+The design is generic and does not require RocksDB to depend on `IOBuf`.
+
+An application can implement `RetainedBlockBufferProvider` using:
+
+- `IOBuf`
+- refcounted heap slabs
+- mmap-backed extents
+- shared-memory pools
+- custom arenas
+
+The only hard requirement is contiguous writable memory for each loaded block.
+
+`IOBuf` is one implementation strategy, not part of the RocksDB core API contract.
+
+## Main Concerns
+
+### 1. Lifetime and overwrite safety
+
+The provider must not recycle or overwrite a block extent until all outstanding cleanups referring to it are released.
+
+### 2. Capacity exhaustion
+
+If too many blocks stay pinned, the provider can run out of space.
+
+The design should define a policy:
+
+- fail with `MemoryLimit`
+- fall back to non-zero-copy copy path
+- retry / block
+
+Fallback-to-copy is usually the safest first implementation.
+
+### 3. Fragmentation
+
+An implementation based on one large region may fragment if block sizes vary.
+Size classes or slab buckets may be needed for production-quality pools.
+
+### 4. Compression path
+
+The pinned row must reference the final uncompressed block bytes. Temporary compressed buffers should not be used as the retained backing for iterator pinning.
+
+### 5. Sharing semantics
+
+If two iterators read the same SST block with block cache disabled, the provider path must decide whether they:
+
+- share the same retained extent, or
+- each receive separate backing
+
+The design works either way. Sharing is an optimization, not a correctness requirement.
+
+### 6. Performance regression risk when unused
+
+The feature must be null-default and explicitly opt-in.
+
+To avoid measurable regression:
+
+- make provider lookup a cheap null check
+- preserve current block-cache path
+- avoid touching `SharedCleanablePtr` when provider is disabled
+- avoid adding extra copies to the normal cache path
+
+The biggest regression risk is object-size growth in hot structures such as `BlockContents` and `Block`. If needed, retained backing can be moved to an optional side object instead of inline fields.
+
+## Benchmark Plan
+
+The benchmark plan should validate both correctness and unused-path cost.
+
+### Functional benchmarks
+
+1. `no_block_cache=true`, provider disabled
+   - baseline current behavior
+2. `no_block_cache=true`, provider enabled, `PinCurrent()`
+   - validate zero-copy and lifetime retention
+3. `no_block_cache=true`, provider enabled, `AppendPinnedCurrent()`
+   - validate batch dedupe
+4. block cache enabled, provider disabled
+   - validate no regression in the existing cache-backed path
+
+### Performance measurements
+
+For each configuration, collect:
+
+- point lookup throughput
+- forward scan throughput
+- CPU per operation
+- bytes copied per pinned row
+- provider allocation / release counts
+- peak retained backing bytes
+
+### Microbenchmarks
+
+Recommended focused cases:
+
+1. single iterator, sequential scan, pin every row
+2. single iterator, pin sparse rows
+3. multiple iterators scanning the same SST
+4. same-block repeated pinning into `PinnableKeyValueBatch`
+5. provider exhaustion scenario with many outstanding pins
+
+### Regression gate
+
+When provider is disabled, throughput and CPU should remain within noise relative to the current code on:
+
+- block-cache-enabled scans
+- block-cache-disabled scans without pinning
+
+## Implementation Plan
+
+### Phase 1: plumbing
+
+1. Add `RetainedBlockBufferProvider`.
+2. Add `block_buffer_provider` to `BlockBasedTableOptions`.
+3. Add provider lookup helper in `reader_common.h`.
+
+### Phase 2: block backing propagation
+
+1. Extend `BlockContents` with generic retained cleanup.
+2. Teach `BlockFetcher` to allocate from provider when configured.
+3. Preserve retained ownership through parsed block creation.
+
+### Phase 3: iterator integration
+
+1. Add accessors from block iterator / block object to current block backing cleanup.
+2. Generalize `BlockBasedTableIterator::PinCurrentKeyValue()` to use:
+   - block cache handle first
+   - provider-backed cleanup second
+   - copy fallback otherwise
+
+### Phase 4: testing
+
+1. Add a fake retained-buffer provider for unit tests.
+2. Add tests for:
+   - zero-copy `PinCurrent()` without block cache
+   - `AppendPinnedCurrent()` dedupe on same block
+   - lifetime survives iterator destruction
+   - fallback behavior when provider is exhausted
+
+### Phase 5: benchmarking
+
+1. Add a focused microbenchmark or test harness.
+2. Measure provider-disabled and provider-enabled cases.
+3. Confirm that unused-path overhead stays within noise.
+
+## Open Questions
+
+1. Should provider behavior be table-wide (`BlockBasedTableOptions`) or per-read (`ReadOptions`)?
+   - Recommendation: table-wide first.
+2. Should provider exhaustion fall back to copy or fail?
+   - Recommendation: copy fallback first.
+3. Should provider-backed reads try to dedupe same-SST-block fetches without block cache?
+   - Recommendation: not in v1.
+4. Should compressed temporary buffers ever use the provider?
+   - Recommendation: no. Only final uncompressed block backing should be retained for `Pin*`.

--- a/docs/components/read_flow/index.md
+++ b/docs/components/read_flow/index.md
@@ -21,6 +21,7 @@ RocksDB serves reads through a layered search path: memtables, then SST files or
 | 9. Merge Operator Resolution | [09_merge_resolution.md](09_merge_resolution.md) | MergeContext operand collection, full vs partial merge, resolution in Get/Iterator/Compaction paths, and snapshot boundary constraints. |
 | 10. Prefetching and Async I/O | [10_prefetching_and_async_io.md](10_prefetching_and_async_io.md) | FilePrefetchBuffer, auto-readahead for scans, adaptive readahead, async I/O integration, and MultiGet I/O coalescing. |
 | 11. ReadOptions and Tuning | [11_read_options_and_tuning.md](11_read_options_and_tuning.md) | Key ReadOptions fields, prefix seek modes, iterator bounds, read tiers, performance characteristics, and common read patterns. |
+| 12. Retained Block Backing for Pin API | [12_retained_block_backing_for_pin_api.md](12_retained_block_backing_for_pin_api.md) | Retained block-buffer provider design for zero-copy iterator pinning when block cache is disabled or bypassed. |
 
 ## Key Characteristics
 

--- a/file/random_access_file_reader.cc
+++ b/file/random_access_file_reader.cc
@@ -116,6 +116,23 @@ inline void RecordIOStats(Statistics* stats, Temperature file_temperature,
   }
 }
 
+inline void SaveRetainedBufferMetadata(
+    const AlignedBuffer& buffer, RetainedBufferAllocation* retained_buffer) {
+  if (retained_buffer == nullptr) {
+    return;
+  }
+
+  retained_buffer->Reset();
+  if (!buffer.HasRetainedBuffer()) {
+    return;
+  }
+
+  retained_buffer->data = const_cast<char*>(buffer.BufferStart());
+  retained_buffer->size = buffer.retained_backing_size();
+  retained_buffer->cleanup = buffer.retained_cleanup();
+  retained_buffer->dedupe_token = buffer.retained_dedupe_token();
+}
+
 IOStatus RandomAccessFileReader::Create(
     const std::shared_ptr<FileSystem>& fs, const std::string& fname,
     const FileOptions& file_opts,
@@ -128,11 +145,24 @@ IOStatus RandomAccessFileReader::Create(
   return io_s;
 }
 
-IOStatus RandomAccessFileReader::Read(const IOOptions& opts, uint64_t offset,
-                                      size_t n, Slice* result, char* scratch,
-                                      AlignedBuf* aligned_buf,
-                                      IODebugContext* dbg) const {
+IOStatus RandomAccessFileReader::Read(
+    const IOOptions& opts, uint64_t offset, size_t n, Slice* result,
+    char* scratch, AlignedBuf* aligned_buf, IODebugContext* dbg,
+    char* direct_io_scratch,
+    const RetainedBufferAllocator* retained_buffer_allocator,
+    RetainedBufferAllocation* retained_buffer) const {
   (void)aligned_buf;
+  assert(direct_io_scratch == nullptr || aligned_buf == nullptr);
+  assert(direct_io_scratch == nullptr || retained_buffer_allocator == nullptr);
+  if (direct_io_scratch != nullptr &&
+      (aligned_buf != nullptr || retained_buffer_allocator != nullptr)) {
+    return IOStatus::InvalidArgument(
+        "direct_io_scratch cannot be combined with aligned_buf or "
+        "retained_buffer_allocator");
+  }
+  if (retained_buffer != nullptr) {
+    retained_buffer->Reset();
+  }
   const Env::IOPriority rate_limiter_priority = opts.rate_limiter_priority;
 
   TEST_SYNC_POINT_CALLBACK("RandomAccessFileReader::Read", nullptr);
@@ -172,18 +202,32 @@ IOStatus RandomAccessFileReader::Read(const IOOptions& opts, uint64_t offset,
       size_t read_size =
           Roundup(static_cast<size_t>(offset + n), alignment) - aligned_offset;
       AlignedBuffer buf;
-      buf.Alignment(alignment);
-      buf.AllocateNewBuffer(read_size);
-      while (buf.CurrentSize() < read_size) {
+      char* aligned_scratch = direct_io_scratch;
+      size_t aligned_size = 0;
+      if (direct_io_scratch == nullptr) {
+        buf.Alignment(alignment);
+        if (retained_buffer_allocator != nullptr) {
+          Status s =
+              buf.AllocateNewBuffer(read_size, *retained_buffer_allocator);
+          if (!s.ok()) {
+            return status_to_io_status(std::move(s));
+          }
+          SaveRetainedBufferMetadata(buf, retained_buffer);
+        } else {
+          buf.AllocateNewBuffer(read_size);
+        }
+        aligned_scratch = buf.BufferStart();
+      }
+      while (aligned_size < read_size) {
         size_t allowed;
         if (rate_limiter_priority != Env::IO_TOTAL &&
             rate_limiter_ != nullptr) {
           allowed = rate_limiter_->RequestToken(
-              buf.Capacity() - buf.CurrentSize(), buf.Alignment(),
-              rate_limiter_priority, stats_, RateLimiter::OpType::kRead);
+              read_size - aligned_size, alignment, rate_limiter_priority,
+              stats_, RateLimiter::OpType::kRead);
         } else {
-          assert(buf.CurrentSize() == 0);
-          allowed = read_size;
+          assert(aligned_size == 0);
+          allowed = read_size - aligned_size;
         }
         Slice tmp;
 
@@ -191,7 +235,7 @@ IOStatus RandomAccessFileReader::Read(const IOOptions& opts, uint64_t offset,
         uint64_t orig_offset = 0;
         if (ShouldNotifyListeners()) {
           start_ts = FileOperationInfo::StartNow();
-          orig_offset = aligned_offset + buf.CurrentSize();
+          orig_offset = aligned_offset + aligned_size;
         }
 
         {
@@ -201,8 +245,8 @@ IOStatus RandomAccessFileReader::Read(const IOOptions& opts, uint64_t offset,
           // one iteration of this loop, so we don't need to check and adjust
           // the opts.timeout before calling file_->Read
           assert(!opts.timeout.count() || allowed == read_size);
-          io_s = file_->Read(aligned_offset + buf.CurrentSize(), allowed, opts,
-                             &tmp, buf.Destination(), dbg);
+          io_s = file_->Read(aligned_offset + aligned_size, allowed, opts, &tmp,
+                             aligned_scratch + aligned_size, dbg);
         }
         if (ShouldNotifyListeners()) {
           auto finish_ts = FileOperationInfo::FinishNow();
@@ -214,15 +258,22 @@ IOStatus RandomAccessFileReader::Read(const IOOptions& opts, uint64_t offset,
           }
         }
 
-        buf.Size(buf.CurrentSize() + tmp.size());
+        aligned_size += tmp.size();
         if (!io_s.ok() || tmp.size() < allowed) {
           break;
         }
       }
       size_t res_len = 0;
-      if (io_s.ok() && offset_advance < buf.CurrentSize()) {
-        res_len = std::min(buf.CurrentSize() - offset_advance, n);
-        if (aligned_buf == nullptr) {
+      if (io_s.ok() && offset_advance < aligned_size) {
+        res_len = std::min(aligned_size - offset_advance, n);
+        if (direct_io_scratch != nullptr) {
+          scratch = direct_io_scratch + offset_advance;
+        } else if (retained_buffer_allocator != nullptr) {
+          scratch = buf.BufferStart() + offset_advance;
+          if (aligned_buf != nullptr) {
+            *aligned_buf = buf.Release();
+          }
+        } else if (aligned_buf == nullptr) {
           buf.Read(scratch, offset_advance, res_len);
         } else {
           scratch = buf.BufferStart() + offset_advance;
@@ -335,13 +386,16 @@ bool TryMerge(FSReadRequest* dest, const FSReadRequest& src) {
   return true;
 }
 
-IOStatus RandomAccessFileReader::MultiRead(const IOOptions& opts,
-                                           FSReadRequest* read_reqs,
-                                           size_t num_reqs,
-                                           AlignedBuf* aligned_buf,
-                                           IODebugContext* dbg) const {
+IOStatus RandomAccessFileReader::MultiRead(
+    const IOOptions& opts, FSReadRequest* read_reqs, size_t num_reqs,
+    AlignedBuf* aligned_buf, IODebugContext* dbg,
+    const RetainedBufferAllocator* retained_buffer_allocator,
+    RetainedBufferAllocation* retained_buffer) const {
   (void)aligned_buf;  // suppress warning of unused variable in LITE mode
   assert(num_reqs > 0);
+  if (retained_buffer != nullptr) {
+    retained_buffer->Reset();
+  }
 
 #ifndef NDEBUG
   for (size_t i = 0; i < num_reqs - 1; ++i) {
@@ -405,7 +459,15 @@ IOStatus RandomAccessFileReader::MultiRead(const IOOptions& opts,
       }
       AlignedBuffer buf;
       buf.Alignment(alignment);
-      buf.AllocateNewBuffer(total_len);
+      if (retained_buffer_allocator != nullptr) {
+        Status s = buf.AllocateNewBuffer(total_len, *retained_buffer_allocator);
+        if (!s.ok()) {
+          return status_to_io_status(std::move(s));
+        }
+        SaveRetainedBufferMetadata(buf, retained_buffer);
+      } else {
+        buf.AllocateNewBuffer(total_len);
+      }
       char* scratch = buf.BufferStart();
       for (auto& r : aligned_reqs) {
         r.scratch = scratch;
@@ -517,16 +579,32 @@ IOStatus RandomAccessFileReader::PrepareIOOptions(const ReadOptions& ro,
 
 // Notes for when direct_io is enabled:
 // Unless req.offset, req.len, req.scratch are all already aligned,
-// RandomAccessFileReader will creats aligned requests and aligned buffer for
-// the request. User should only provide either req.scratch or aligned_buf. If
-// only req.scratch is provided, result will be copied from allocated aligned
-// buffer to req.scratch. If only alignd_buf is provided, it will be set to
-// the ailgned buf allocated by RandomAccessFileReader and saves a copy.
+// RandomAccessFileReader will create an aligned request. If
+// direct_io_scratch is provided, it is used as the aligned scratch buffer and
+// saves a copy. Otherwise, RandomAccessFileReader allocates an aligned buffer.
+// User should only provide one of req.scratch, aligned_buf, or
+// direct_io_scratch. If only req.scratch is provided, result will be copied
+// from the aligned buffer to req.scratch. If only aligned_buf is provided, it
+// will be set to the aligned buffer allocated by RandomAccessFileReader and
+// saves a copy.
 IOStatus RandomAccessFileReader::ReadAsync(
     FSReadRequest& req, const IOOptions& opts,
     std::function<void(FSReadRequest&, void*)> cb, void* cb_arg,
     void** io_handle, IOHandleDeleter* del_fn, AlignedBuf* aligned_buf,
-    IODebugContext* dbg) {
+    IODebugContext* dbg, char* direct_io_scratch,
+    const RetainedBufferAllocator* retained_buffer_allocator,
+    RetainedBufferAllocation* retained_buffer) {
+  assert(direct_io_scratch == nullptr || aligned_buf == nullptr);
+  assert(direct_io_scratch == nullptr || retained_buffer_allocator == nullptr);
+  if (direct_io_scratch != nullptr &&
+      (aligned_buf != nullptr || retained_buffer_allocator != nullptr)) {
+    return IOStatus::InvalidArgument(
+        "direct_io_scratch cannot be combined with aligned_buf or "
+        "retained_buffer_allocator");
+  }
+  if (retained_buffer != nullptr) {
+    retained_buffer->Reset();
+  }
   IOStatus s;
   TEST_SYNC_POINT_CALLBACK("RandomAccessFileReader::ReadAsync:InjectStatus",
                            &s);
@@ -556,21 +634,39 @@ IOStatus RandomAccessFileReader::ReadAsync(
     FSReadRequest aligned_req = Align(req, alignment);
     aligned_req.status.PermitUncheckedError();
 
-    // Allocate aligned buffer.
-    read_async_info->buf_.Alignment(alignment);
-    read_async_info->buf_.AllocateNewBuffer(aligned_req.len);
-
-    // Set rem fields in aligned FSReadRequest.
-    aligned_req.scratch = read_async_info->buf_.BufferStart();
-
     // Set user provided fields to populate back in callback.
     read_async_info->user_scratch_ = req.scratch;
     read_async_info->user_aligned_buf_ = aligned_buf;
     read_async_info->user_len_ = req.len;
     read_async_info->user_offset_ = req.offset;
     read_async_info->user_result_ = req.result;
+    read_async_info->use_external_direct_io_scratch_ =
+        direct_io_scratch != nullptr;
+    read_async_info->use_retained_direct_io_buffer_ =
+        retained_buffer_allocator != nullptr;
 
-    assert(read_async_info->buf_.CurrentSize() == 0);
+    if (direct_io_scratch != nullptr) {
+      aligned_req.scratch = direct_io_scratch;
+    } else {
+      // Allocate aligned buffer.
+      read_async_info->buf_.Alignment(alignment);
+      if (retained_buffer_allocator != nullptr) {
+        Status alloc_status = read_async_info->buf_.AllocateNewBuffer(
+            aligned_req.len, *retained_buffer_allocator);
+        if (!alloc_status.ok()) {
+          delete read_async_info;
+          return status_to_io_status(std::move(alloc_status));
+        }
+        SaveRetainedBufferMetadata(read_async_info->buf_, retained_buffer);
+      } else {
+        read_async_info->buf_.AllocateNewBuffer(aligned_req.len);
+      }
+
+      // Set rem fields in aligned FSReadRequest.
+      aligned_req.scratch = read_async_info->buf_.BufferStart();
+
+      assert(read_async_info->buf_.CurrentSize() == 0);
+    }
 
     StopWatch sw(clock_, stats_, hist_type_,
                  GetFileReadHistograms(stats_, opts.io_activity),
@@ -618,20 +714,30 @@ void RandomAccessFileReader::ReadAsyncCallback(FSReadRequest& req,
     user_req.result = req.result;
     user_req.status = req.status;
 
-    read_async_info->buf_.Size(read_async_info->buf_.CurrentSize() +
-                               req.result.size());
+    size_t aligned_result_size = req.result.size();
+    if (!read_async_info->use_external_direct_io_scratch_) {
+      read_async_info->buf_.Size(read_async_info->buf_.CurrentSize() +
+                                 req.result.size());
+      aligned_result_size = read_async_info->buf_.CurrentSize();
+    }
 
     size_t offset_advance_len = static_cast<size_t>(
         /*offset_passed_by_user=*/read_async_info->user_offset_ -
         /*aligned_offset=*/req.offset);
 
     size_t res_len = 0;
-    if (req.status.ok() &&
-        offset_advance_len < read_async_info->buf_.CurrentSize()) {
-      res_len =
-          std::min(read_async_info->buf_.CurrentSize() - offset_advance_len,
-                   read_async_info->user_len_);
-      if (read_async_info->user_aligned_buf_ == nullptr) {
+    if (req.status.ok() && offset_advance_len < aligned_result_size) {
+      res_len = std::min(aligned_result_size - offset_advance_len,
+                         read_async_info->user_len_);
+      if (read_async_info->use_external_direct_io_scratch_ ||
+          read_async_info->use_retained_direct_io_buffer_) {
+        user_req.scratch =
+            const_cast<char*>(req.result.data()) + offset_advance_len;
+        if (read_async_info->use_retained_direct_io_buffer_ &&
+            read_async_info->user_aligned_buf_ != nullptr) {
+          *read_async_info->user_aligned_buf_ = read_async_info->buf_.Release();
+        }
+      } else if (read_async_info->user_aligned_buf_ == nullptr) {
         // Copy the data into user's scratch.
 // Clang analyzer assumes that it will take use_direct_io() == false in
 // ReadAsync and use_direct_io() == true in Callback which cannot be true.

--- a/file/random_access_file_reader.h
+++ b/file/random_access_file_reader.h
@@ -99,6 +99,8 @@ class RandomAccessFileReader {
           user_aligned_buf_(nullptr),
           user_offset_(0),
           user_len_(0),
+          use_external_direct_io_scratch_(false),
+          use_retained_direct_io_buffer_(false),
           is_aligned_(false) {}
 
     std::function<void(FSReadRequest&, void*)> cb_;
@@ -111,6 +113,8 @@ class RandomAccessFileReader {
     uint64_t user_offset_;
     size_t user_len_;
     Slice user_result_;
+    bool use_external_direct_io_scratch_;
+    bool use_retained_direct_io_buffer_;
     // Used in case of direct_io
     AlignedBuffer buf_;
     bool is_aligned_;
@@ -163,18 +167,31 @@ class RandomAccessFileReader {
   // 2. Otherwise, scratch is not used and can be null, the aligned_buf owns
   // the internally allocated buffer on return, and the result refers to a
   // region in aligned_buf.
-  IOStatus Read(const IOOptions& opts, uint64_t offset, size_t n, Slice* result,
-                char* scratch, AlignedBuf* aligned_buf,
-                IODebugContext* dbg = nullptr) const;
+  // 3. Alternatively, direct_io_scratch can be provided as caller-owned
+  // aligned storage for the internally aligned direct I/O read, and result
+  // will refer into it without an extra copy.
+  // 4. Alternatively, retained_buffer_allocator can provide the internally
+  // aligned direct I/O buffer, and retained_buffer receives the cleanup
+  // metadata needed to keep the result slice alive.
+  IOStatus Read(
+      const IOOptions& opts, uint64_t offset, size_t n, Slice* result,
+      char* scratch, AlignedBuf* aligned_buf, IODebugContext* dbg = nullptr,
+      char* direct_io_scratch = nullptr,
+      const RetainedBufferAllocator* retained_buffer_allocator = nullptr,
+      RetainedBufferAllocation* retained_buffer = nullptr) const;
 
   // REQUIRES:
   // num_reqs > 0, reqs do not overlap, and offsets in reqs are increasing.
   // In non-direct IO mode, aligned_buf should be null;
   // In direct IO mode, aligned_buf stores the aligned buffer allocated inside
   // MultiRead, the result Slices in reqs refer to aligned_buf.
-  IOStatus MultiRead(const IOOptions& opts, FSReadRequest* reqs,
-                     size_t num_reqs, AlignedBuf* aligned_buf,
-                     IODebugContext* dbg = nullptr) const;
+  // If retained_buffer_allocator is provided in direct IO mode, retained_buffer
+  // receives the cleanup metadata for the aligned buffer.
+  IOStatus MultiRead(
+      const IOOptions& opts, FSReadRequest* reqs, size_t num_reqs,
+      AlignedBuf* aligned_buf, IODebugContext* dbg = nullptr,
+      const RetainedBufferAllocator* retained_buffer_allocator = nullptr,
+      RetainedBufferAllocation* retained_buffer = nullptr) const;
 
   IOStatus Prefetch(const IOOptions& opts, uint64_t offset, size_t n,
                     IODebugContext* dbg = nullptr) const {
@@ -190,10 +207,13 @@ class RandomAccessFileReader {
   IOStatus PrepareIOOptions(const ReadOptions& ro, IOOptions& opts,
                             IODebugContext* dbg = nullptr) const;
 
-  IOStatus ReadAsync(FSReadRequest& req, const IOOptions& opts,
-                     std::function<void(FSReadRequest&, void*)> cb,
-                     void* cb_arg, void** io_handle, IOHandleDeleter* del_fn,
-                     AlignedBuf* aligned_buf, IODebugContext* dbg = nullptr);
+  IOStatus ReadAsync(
+      FSReadRequest& req, const IOOptions& opts,
+      std::function<void(FSReadRequest&, void*)> cb, void* cb_arg,
+      void** io_handle, IOHandleDeleter* del_fn, AlignedBuf* aligned_buf,
+      IODebugContext* dbg = nullptr, char* direct_io_scratch = nullptr,
+      const RetainedBufferAllocator* retained_buffer_allocator = nullptr,
+      RetainedBufferAllocation* retained_buffer = nullptr);
 
   void ReadAsyncCallback(FSReadRequest& req, void* cb_arg);
 };

--- a/file/random_access_file_reader_test.cc
+++ b/file/random_access_file_reader_test.cc
@@ -55,6 +55,9 @@ class RandomAccessFileReaderTest : public testing::Test {
     }
   }
 
+  const std::shared_ptr<FileSystem>& file_system() const { return fs_; }
+  std::string TestPath(const std::string& fname) { return Path(fname); }
+
  private:
   Env* env_;
   std::shared_ptr<FileSystem> fs_;
@@ -62,6 +65,62 @@ class RandomAccessFileReaderTest : public testing::Test {
 
   std::string Path(const std::string& fname) { return test_dir_ + "/" + fname; }
 };
+
+namespace {
+
+struct TestRetainedBufferAllocatorState {
+  size_t allocations = 0;
+};
+
+void DeleteRetainedBufferForTest(void* arg1, void* /*arg2*/) {
+  delete[] static_cast<char*>(arg1);
+}
+
+Status AllocateRetainedBufferForTest(void* state, size_t size, size_t alignment,
+                                     RetainedBufferAllocation* out) {
+  assert(out != nullptr);
+  auto* allocator_state = static_cast<TestRetainedBufferAllocatorState*>(state);
+  allocator_state->allocations++;
+
+  const size_t extra = alignment > 1 ? alignment - 1 : 0;
+  char* raw = new char[size + extra];
+  uintptr_t aligned = reinterpret_cast<uintptr_t>(raw);
+  if (alignment > 1) {
+    aligned =
+        (aligned + alignment - 1) & ~static_cast<uintptr_t>(alignment - 1);
+  }
+
+  out->Reset();
+  out->data = reinterpret_cast<char*>(aligned);
+  out->size = size;
+  out->cleanup.Allocate();
+  out->cleanup->RegisterCleanup(&DeleteRetainedBufferForTest, raw, nullptr);
+  out->dedupe_token = out->data;
+  return Status::OK();
+}
+
+class SyncReadAsyncFile : public FSRandomAccessFileOwnerWrapper {
+ public:
+  explicit SyncReadAsyncFile(std::unique_ptr<FSRandomAccessFile>&& target)
+      : FSRandomAccessFileOwnerWrapper(std::move(target)) {}
+
+  IOStatus ReadAsync(FSReadRequest& req, const IOOptions& opts,
+                     std::function<void(FSReadRequest&, void*)> cb,
+                     void* cb_arg, void** io_handle, IOHandleDeleter* del_fn,
+                     IODebugContext* dbg) override {
+    req.status = Read(req.offset, req.len, opts, &req.result, req.scratch, dbg);
+    if (io_handle != nullptr) {
+      *io_handle = nullptr;
+    }
+    if (del_fn != nullptr) {
+      *del_fn = nullptr;
+    }
+    cb(req, cb_arg);
+    return IOStatus::OK();
+  }
+};
+
+}  // namespace
 
 // Skip the following tests in lite mode since direct I/O is unsupported.
 
@@ -297,6 +356,174 @@ TEST_F(RandomAccessFileReaderTest, MultiReadDirectIO) {
 
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->ClearAllCallBacks();
+}
+
+TEST_F(RandomAccessFileReaderTest, ReadAsyncDirectIOExternalScratch) {
+  std::string fname = "read-async-direct-io-external-scratch";
+  Random rand(0);
+  std::string content = rand.RandomString(2 * kDefaultPageSize);
+  Write(fname, content);
+
+  FileOptions opts;
+  opts.use_direct_reads = true;
+  std::string fpath = TestPath(fname);
+  std::unique_ptr<FSRandomAccessFile> file;
+  ASSERT_OK(file_system()->NewRandomAccessFile(fpath, opts, &file, nullptr));
+  std::unique_ptr<FSRandomAccessFile> sync_async_file(
+      new SyncReadAsyncFile(std::move(file)));
+  std::unique_ptr<RandomAccessFileReader> r(new RandomAccessFileReader(
+      std::move(sync_async_file), fpath, SystemClock::Default().get()));
+  ASSERT_TRUE(r->use_direct_io());
+
+  const size_t page_size = r->file()->GetRequiredBufferAlignment();
+
+  FSReadRequest req;
+  req.offset = page_size / 2;
+  req.len = page_size / 3;
+  req.scratch = nullptr;
+  req.status.PermitUncheckedError();
+
+  const FSReadRequest aligned_req = Align(req, page_size);
+  ASSERT_OK(aligned_req.status);
+  std::unique_ptr<char[]> raw_scratch(
+      new char[aligned_req.len + page_size - 1]);
+  const uintptr_t raw = reinterpret_cast<uintptr_t>(raw_scratch.get());
+  const uintptr_t aligned = ((raw + page_size - 1) / page_size) * page_size;
+  char* aligned_scratch = reinterpret_cast<char*>(aligned);
+
+  bool callback_called = false;
+  Slice callback_result;
+  IOStatus callback_status;
+  void* io_handle = nullptr;
+  IOHandleDeleter del_fn;
+  auto cb = [&](FSReadRequest& cb_req, void* /*cb_arg*/) {
+    callback_called = true;
+    callback_result = cb_req.result;
+    callback_status = cb_req.status;
+  };
+
+  ASSERT_OK(r->ReadAsync(req, IOOptions(), cb, nullptr, &io_handle, &del_fn,
+                         /*aligned_buf=*/nullptr, /*dbg=*/nullptr,
+                         aligned_scratch));
+  ASSERT_EQ(nullptr, io_handle);
+
+  ASSERT_TRUE(callback_called);
+  ASSERT_OK(callback_status);
+  ASSERT_EQ(content.substr(req.offset, req.len), callback_result.ToString());
+  ASSERT_GE(callback_result.data(), aligned_scratch);
+  ASSERT_LE(callback_result.data() + callback_result.size(),
+            aligned_scratch + aligned_req.len);
+}
+
+TEST_F(RandomAccessFileReaderTest, ReadAsyncDirectIORetainedBuffer) {
+  std::string fname = "read-async-direct-io-retained-buffer";
+  Random rand(0);
+  std::string content = rand.RandomString(2 * kDefaultPageSize);
+  Write(fname, content);
+
+  FileOptions opts;
+  opts.use_direct_reads = true;
+  std::string fpath = TestPath(fname);
+  std::unique_ptr<FSRandomAccessFile> file;
+  ASSERT_OK(file_system()->NewRandomAccessFile(fpath, opts, &file, nullptr));
+  std::unique_ptr<FSRandomAccessFile> sync_async_file(
+      new SyncReadAsyncFile(std::move(file)));
+  std::unique_ptr<RandomAccessFileReader> r(new RandomAccessFileReader(
+      std::move(sync_async_file), fpath, SystemClock::Default().get()));
+  ASSERT_TRUE(r->use_direct_io());
+
+  const size_t page_size = r->file()->GetRequiredBufferAlignment();
+
+  FSReadRequest req;
+  req.offset = page_size / 2;
+  req.len = page_size / 3;
+  req.scratch = nullptr;
+  req.status.PermitUncheckedError();
+
+  TestRetainedBufferAllocatorState allocator_state;
+  RetainedBufferAllocator allocator(&allocator_state,
+                                    &AllocateRetainedBufferForTest);
+  RetainedBufferAllocation retained_buffer;
+
+  bool callback_called = false;
+  Slice callback_result;
+  IOStatus callback_status;
+  void* io_handle = nullptr;
+  IOHandleDeleter del_fn;
+  auto cb = [&](FSReadRequest& cb_req, void* /*cb_arg*/) {
+    callback_called = true;
+    callback_result = cb_req.result;
+    callback_status = cb_req.status;
+  };
+
+  ASSERT_OK(r->ReadAsync(req, IOOptions(), cb, nullptr, &io_handle, &del_fn,
+                         /*aligned_buf=*/nullptr, /*dbg=*/nullptr,
+                         /*direct_io_scratch=*/nullptr, &allocator,
+                         &retained_buffer));
+  ASSERT_EQ(nullptr, io_handle);
+
+  ASSERT_TRUE(callback_called);
+  ASSERT_OK(callback_status);
+  ASSERT_EQ(1U, allocator_state.allocations);
+  ASSERT_NE(nullptr, retained_buffer.cleanup.get());
+  ASSERT_EQ(content.substr(req.offset, req.len), callback_result.ToString());
+  ASSERT_GE(reinterpret_cast<uintptr_t>(callback_result.data()),
+            reinterpret_cast<uintptr_t>(retained_buffer.data));
+  ASSERT_LE(
+      reinterpret_cast<uintptr_t>(callback_result.data() +
+                                  callback_result.size()),
+      reinterpret_cast<uintptr_t>(retained_buffer.data + retained_buffer.size));
+}
+
+TEST_F(RandomAccessFileReaderTest, MultiReadDirectIORetainedBuffer) {
+  std::string fname = "multi-read-direct-io-retained-buffer";
+  Random rand(0);
+  std::string content = rand.RandomString(2 * kDefaultPageSize);
+  Write(fname, content);
+
+  FileOptions opts;
+  opts.use_direct_reads = true;
+  std::unique_ptr<RandomAccessFileReader> r;
+  Read(fname, opts, &r);
+  ASSERT_TRUE(r->use_direct_io());
+
+  const size_t page_size = r->file()->GetRequiredBufferAlignment();
+
+  FSReadRequest r0;
+  r0.offset = page_size / 4;
+  r0.len = page_size / 4;
+  r0.scratch = nullptr;
+
+  FSReadRequest r1;
+  r1.offset = page_size + page_size / 4;
+  r1.len = page_size / 2;
+  r1.scratch = nullptr;
+
+  std::vector<FSReadRequest> reqs;
+  reqs.push_back(std::move(r0));
+  reqs.push_back(std::move(r1));
+
+  TestRetainedBufferAllocatorState allocator_state;
+  RetainedBufferAllocator allocator(&allocator_state,
+                                    &AllocateRetainedBufferForTest);
+  RetainedBufferAllocation retained_buffer;
+  AlignedBuf aligned_buf;
+  IODebugContext dbg;
+  ASSERT_OK(r->MultiRead(IOOptions(), reqs.data(), reqs.size(), &aligned_buf,
+                         &dbg, &allocator, &retained_buffer));
+
+  AssertResult(content, reqs);
+  ASSERT_EQ(1U, allocator_state.allocations);
+  ASSERT_NE(nullptr, retained_buffer.cleanup.get());
+  ASSERT_EQ(retained_buffer.data, aligned_buf.get());
+  for (const auto& req : reqs) {
+    ASSERT_GE(reinterpret_cast<uintptr_t>(req.result.data()),
+              reinterpret_cast<uintptr_t>(retained_buffer.data));
+    ASSERT_LE(
+        reinterpret_cast<uintptr_t>(req.result.data() + req.result.size()),
+        reinterpret_cast<uintptr_t>(retained_buffer.data +
+                                    retained_buffer.size));
+  }
 }
 
 TEST(FSReadRequest, Align) {

--- a/include/rocksdb/cleanable.h
+++ b/include/rocksdb/cleanable.h
@@ -107,6 +107,7 @@ class SharedCleanablePtr {
   Cleanable* operator->();
   // Get as raw pointer to Cleanable
   Cleanable* get();
+  const Cleanable* get() const;
 
   // Creates a (virtual) copy of this SharedCleanablePtr and registers its
   // destruction with target, so that the cleanups registered with the

--- a/include/rocksdb/iterator.h
+++ b/include/rocksdb/iterator.h
@@ -18,13 +18,170 @@
 
 #pragma once
 
+#include <cassert>
 #include <string>
+#include <unordered_set>
+#include <utility>
+#include <vector>
 
 #include "rocksdb/iterator_base.h"
 #include "rocksdb/options.h"
+#include "rocksdb/slice.h"
 #include "rocksdb/wide_columns.h"
 
 namespace ROCKSDB_NAMESPACE {
+
+// A self-contained key-value pair returned by Iterator::PinCurrent(). The
+// slices remain valid until Reset() or object destruction, regardless of
+// subsequent iterator movement.
+class PinnableKeyValue {
+ public:
+  PinnableKeyValue() = default;
+  PinnableKeyValue(PinnableKeyValue&&) = default;
+  PinnableKeyValue& operator=(PinnableKeyValue&&) = default;
+
+  PinnableKeyValue(const PinnableKeyValue&) = delete;
+  PinnableKeyValue& operator=(const PinnableKeyValue&) = delete;
+
+  Slice key() const { return key_; }
+  Slice value() const { return value_; }
+
+  bool IsKeyPinned() const { return key_.IsPinned(); }
+  bool IsValuePinned() const { return value_.IsPinned(); }
+
+  size_t GetPinnedBlockCacheUsage() const { return pinned_block_cache_usage_; }
+  size_t GetCopiedBytes() const { return copied_bytes_; }
+
+  void Reset() {
+    key_.Reset();
+    value_.Reset();
+    cleanup_.Reset();
+    pinned_block_cache_usage_ = 0;
+    copied_bytes_ = 0;
+  }
+
+ private:
+  friend class DBIter;
+
+  void PinKey(const Slice& key) { key_.PinSlice(key, nullptr); }
+  void CopyKey(const Slice& key) {
+    key_.PinSelf(key);
+    copied_bytes_ += key.size();
+  }
+
+  void PinValue(const Slice& value) { value_.PinSlice(value, nullptr); }
+  void CopyValue(const Slice& value) {
+    value_.PinSelf(value);
+    copied_bytes_ += value.size();
+  }
+
+  void SetCleanup(SharedCleanablePtr&& cleanup) {
+    cleanup_ = std::move(cleanup);
+  }
+
+  void SetPinnedBlockCacheUsage(size_t pinned_block_cache_usage) {
+    pinned_block_cache_usage_ = pinned_block_cache_usage;
+  }
+
+  PinnableSlice key_;
+  PinnableSlice value_;
+  SharedCleanablePtr cleanup_;
+  size_t pinned_block_cache_usage_ = 0;
+  size_t copied_bytes_ = 0;
+};
+
+// A self-contained batch of key-value pairs returned by
+// Iterator::AppendPinnedCurrent(). Each appended row remains valid until
+// Reset() or object destruction, regardless of subsequent iterator movement.
+class PinnableKeyValueBatch {
+ public:
+  PinnableKeyValueBatch() = default;
+  PinnableKeyValueBatch(PinnableKeyValueBatch&&) = default;
+  PinnableKeyValueBatch& operator=(PinnableKeyValueBatch&&) = default;
+
+  PinnableKeyValueBatch(const PinnableKeyValueBatch&) = delete;
+  PinnableKeyValueBatch& operator=(const PinnableKeyValueBatch&) = delete;
+
+  size_t size() const { return entries_.size(); }
+  bool empty() const { return entries_.empty(); }
+
+  Slice key(size_t index) const {
+    assert(index < entries_.size());
+    return entries_[index].key;
+  }
+
+  Slice value(size_t index) const {
+    assert(index < entries_.size());
+    return entries_[index].value;
+  }
+
+  bool IsKeyPinned(size_t index) const {
+    assert(index < entries_.size());
+    return entries_[index].key.IsPinned();
+  }
+
+  bool IsValuePinned(size_t index) const {
+    assert(index < entries_.size());
+    return entries_[index].value.IsPinned();
+  }
+
+  size_t GetPinnedBlockCacheUsage() const { return pinned_block_cache_usage_; }
+  size_t GetCopiedBytes() const { return copied_bytes_; }
+
+  void Reset() {
+    entries_.clear();
+    cleanups_.clear();
+    cleanup_dedupe_tokens_.clear();
+    pinned_block_cache_usage_ = 0;
+    copied_bytes_ = 0;
+  }
+
+ private:
+  friend class DBIter;
+
+  struct Entry {
+    PinnableSlice key;
+    PinnableSlice value;
+  };
+
+  void Append(const Slice& key, bool pin_key, const Slice& value,
+              bool pin_value, SharedCleanablePtr&& cleanup,
+              const void* cleanup_dedupe_token,
+              size_t pinned_block_cache_usage) {
+    if (cleanup.get() != nullptr) {
+      bool retain_cleanup = true;
+      if (cleanup_dedupe_token != nullptr) {
+        retain_cleanup =
+            cleanup_dedupe_tokens_.insert(cleanup_dedupe_token).second;
+      }
+      if (retain_cleanup) {
+        cleanups_.push_back(std::move(cleanup));
+        pinned_block_cache_usage_ += pinned_block_cache_usage;
+      }
+    }
+
+    entries_.emplace_back();
+    Entry& entry = entries_.back();
+    if (pin_key) {
+      entry.key.PinSlice(key, nullptr);
+    } else {
+      entry.key.PinSelf(key);
+      copied_bytes_ += key.size();
+    }
+    if (pin_value) {
+      entry.value.PinSlice(value, nullptr);
+    } else {
+      entry.value.PinSelf(value);
+      copied_bytes_ += value.size();
+    }
+  }
+
+  std::vector<Entry> entries_;
+  std::vector<SharedCleanablePtr> cleanups_;
+  std::unordered_set<const void*> cleanup_dedupe_tokens_;
+  size_t pinned_block_cache_usage_ = 0;
+  size_t copied_bytes_ = 0;
+};
 
 class Iterator : public IteratorBase {
  public:
@@ -110,6 +267,31 @@ class Iterator : public IteratorBase {
   // If Prepare() is called, it overrides the iterate_upper_bound in
   // ReadOptions
   virtual void Prepare(const MultiScanArgs& /*scan_opts*/) {}
+
+  // Populate `out` with the current key-value pair. Implementations may pin the
+  // underlying storage or copy into `out` as needed. The result remains valid
+  // until `out->Reset()` or object destruction. On any error, `out` is cleared.
+  //
+  // The initial DB iterator implementation supports only valid forward
+  // iterators positioned at plain kTypeValue rows. It returns NotSupported for
+  // reverse iteration, merge results, user-defined timestamps, wide-column
+  // entities, blobs, deletions, and other internal value types.
+  virtual Status PinCurrent(PinnableKeyValue* out);
+
+  // Append the current key-value pair to `batch`. Implementations may pin the
+  // underlying storage or copy into `batch` as needed. Appended rows remain
+  // valid until `batch->Reset()` or object destruction.
+  //
+  // This has the same DB iterator support limits as PinCurrent().
+  virtual Status AppendPinnedCurrent(PinnableKeyValueBatch* batch);
+
+  // Update mutable iterator settings and invalidate the iterator's current
+  // position. Callers must reseek before reading more entries. Any already
+  // pinned results remain valid until their owning objects are reset.
+  virtual Status SetMutableOptions(const IteratorMutableOptions& options);
+
+  // Returns the iterator's current mutable settings.
+  virtual Status GetMutableOptions(IteratorMutableOptions* options) const;
 };
 
 // Return an empty iterator (yields nothing).

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -52,6 +52,7 @@ class MergeOperator;
 class Snapshot;
 class MemTableRepFactory;
 class RateLimiter;
+class RetainedBlockBufferProvider;
 class Slice;
 class Statistics;
 class InternalKeyComparator;
@@ -2050,6 +2051,36 @@ class MultiScanArgs {
   std::vector<ScanOptions> original_ranges_;
 };
 
+enum class PinnedBlockBackingPolicy : uint8_t {
+  // Preserve the default behavior for the target table:
+  // - prefer block cache when it is configured
+  // - otherwise use BlockBasedTableOptions::block_buffer_provider if set
+  kAuto = 0,
+  // Require iterator data blocks to use block cache-backed storage.
+  kUseBlockCache = 1,
+  // Require iterator data blocks to bypass data block cache and use
+  // retainable provider-backed storage instead.
+  kUseRetainedBlockBuffer = 2,
+};
+
+struct PinnedBlockBackingConfig {
+  PinnedBlockBackingPolicy policy = PinnedBlockBackingPolicy::kAuto;
+
+  // Optional per-iterator override. When nullptr, the iterator falls back to
+  // BlockBasedTableOptions::block_buffer_provider.
+  std::shared_ptr<RetainedBlockBufferProvider> retained_block_buffer_provider;
+};
+
+// Mutable iterator settings that can be provided at iterator creation time via
+// ReadOptions and updated later through Iterator::SetMutableOptions().
+//
+// Fields are optional so callers can update only the subset they care about.
+// For a given field, std::nullopt means "leave the current setting unchanged"
+// when used with Iterator::SetMutableOptions().
+struct IteratorMutableOptions {
+  std::optional<PinnedBlockBackingConfig> pinned_block_backing;
+};
+
 // Options that control read operations
 struct ReadOptions {
   // *** BEGIN options relevant to point lookups as well as scans ***
@@ -2367,6 +2398,10 @@ struct ReadOptions {
   // the UDI is a secondary index and you want to explicitly select it for
   // reads.
   const UserDefinedIndexFactory* table_index_factory = nullptr;
+
+  // Initial mutable settings for iterators created with this ReadOptions.
+  // These settings only affect iterators and are ignored by point-lookups.
+  IteratorMutableOptions iterator_mutable_options;
 
   // *** END options only relevant to iterators or scans ***
 

--- a/include/rocksdb/table.h
+++ b/include/rocksdb/table.h
@@ -23,6 +23,7 @@
 #include <unordered_map>
 
 #include "rocksdb/cache.h"
+#include "rocksdb/cleanable.h"
 #include "rocksdb/customizable.h"
 #include "rocksdb/env.h"
 #include "rocksdb/options.h"
@@ -45,6 +46,50 @@ class WritableFileWriter;
 struct ConfigOptions;
 struct EnvOptions;
 class UserDefinedIndexFactory;
+
+// Programmatic-only hook for providing retainable storage for iterator data
+// blocks read from SST files.
+//
+// Requirements:
+// - `Allocate()` can be called concurrently by multiple readers and must be
+//   thread-safe.
+// - `Lease::data` must point to at least `size` bytes of writable contiguous
+//   memory that remains valid until every copy of `Lease::cleanup` is reset.
+// - `Lease::data` must be aligned to `alignment` bytes, where `alignment` is a
+//   power of two and `1` means no special alignment requirement.
+// - `Lease::cleanup` must be non-null on success.
+// - `Lease::dedupe_token` identifies a shared backing allocation so batch pin
+//   operations can avoid retaining the same block more than once.
+//
+// Example:
+//   class MyProvider : public RetainedBlockBufferProvider {
+//    public:
+//     Status Allocate(size_t size, size_t alignment, Lease* out) override;
+//   };
+//
+//   BlockBasedTableOptions bbto;
+//   bbto.block_buffer_provider = std::make_shared<MyProvider>();
+//
+//   ReadOptions ro;
+//   ro.iterator_mutable_options.pinned_block_backing =
+//       PinnedBlockBackingConfig{
+//           PinnedBlockBackingPolicy::kUseRetainedBlockBuffer};
+class RetainedBlockBufferProvider {
+ public:
+  struct Lease {
+    // Writable contiguous memory for the loaded block.
+    char* data = nullptr;
+    size_t size = 0;
+    // Keeps `data` alive for all derived pinned key/value slices.
+    SharedCleanablePtr cleanup;
+    // Opaque identity for de-duplicating multiple pins from the same block.
+    const void* dedupe_token = nullptr;
+  };
+
+  virtual ~RetainedBlockBufferProvider() = default;
+
+  virtual Status Allocate(size_t size, size_t alignment, Lease* out) = 0;
+};
 
 // Types of checksums to use for checking integrity of logical blocks within
 // files. All checksums currently use 32 bits of checking power (1 in 4B
@@ -326,6 +371,14 @@ struct BlockBasedTableOptions {
   // old block cache would go away. For now, dynamic changes to block cache
   // should be through the Cache object, e.g. Cache::SetCapacity().
   std::shared_ptr<Cache> block_cache = nullptr;
+
+  // Optional default provider for retainable iterator data-block buffers.
+  // When block cache is disabled, the iterator default (`kAuto`) will use this
+  // provider automatically. When block cache is enabled, iterators can opt into
+  // this provider through ReadOptions::iterator_mutable_options or
+  // Iterator::SetMutableOptions(). This option must be configured
+  // programmatically and the provider implementation must be thread-safe.
+  std::shared_ptr<RetainedBlockBufferProvider> block_buffer_provider;
 
   // If non-NULL use the specified cache for pages read from device
   // IF NULL, no page cache is used

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -123,6 +123,8 @@ TEST_F(OptionsSettableTest, BlockBasedTableOptionsAllFieldsSettable) {
        sizeof(std::shared_ptr<FlushBlockPolicyFactory>)},
       {offsetof(struct BlockBasedTableOptions, block_cache),
        sizeof(std::shared_ptr<Cache>)},
+      {offsetof(struct BlockBasedTableOptions, block_buffer_provider),
+       sizeof(std::shared_ptr<RetainedBlockBufferProvider>)},
       {offsetof(struct BlockBasedTableOptions, persistent_cache),
        sizeof(std::shared_ptr<PersistentCache>)},
       {offsetof(struct BlockBasedTableOptions, cache_usage_options),

--- a/table/block_based/block.cc
+++ b/table/block_based/block.cc
@@ -1610,6 +1610,7 @@ size_t Block::ApproximateMemoryUsage() const {
   if (read_amp_bitmap_) {
     usage += read_amp_bitmap_->ApproximateMemoryUsage();
   }
+  usage += contents_.retained_metadata_memory_usage();
   usage += checksum_size_;
   return usage;
 }

--- a/table/block_based/block.h
+++ b/table/block_based/block.h
@@ -11,6 +11,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -172,6 +173,13 @@ class Block {
   size_t usable_size() const { return contents_.usable_size(); }
   uint32_t NumRestarts() const { return num_restarts_; }
   bool own_bytes() const { return contents_.own_bytes(); }
+  bool HasRetainedContentsBacking() const { return contents_.has_cleanup(); }
+  const SharedCleanablePtr& contents_cleanup() const {
+    return contents_.retained_cleanup();
+  }
+  const void* contents_cleanup_dedupe_token() const {
+    return contents_.retained_cleanup_dedupe_token();
+  }
   bool IsUniform() const { return is_uniform_; }
 
   BlockBasedTableOptions::DataBlockIndexType IndexType() const;
@@ -450,6 +458,29 @@ class BlockIter : public InternalIteratorBase<TValue> {
 
   Cache::Handle* cache_handle() { return cache_handle_; }
 
+  void SetBlockContentsCleanup(const SharedCleanablePtr& cleanup,
+                               const void* dedupe_token) {
+    if (cleanup.get() == nullptr) {
+      block_contents_retained_backing_.reset();
+    } else {
+      block_contents_retained_backing_ =
+          std::make_unique<RetainedBlockContentsBacking>(
+              SharedCleanablePtr(cleanup), dedupe_token, 0 /* backing_size */);
+    }
+  }
+
+  SharedCleanablePtr block_contents_cleanup() const {
+    return block_contents_retained_backing_ != nullptr
+               ? block_contents_retained_backing_->cleanup
+               : SharedCleanablePtr();
+  }
+
+  const void* block_contents_cleanup_dedupe_token() const {
+    return block_contents_retained_backing_ != nullptr
+               ? block_contents_retained_backing_->cleanup_dedupe_token
+               : nullptr;
+  }
+
  protected:
   InternalKeyComparator icmp_;
   const char* data_;       // underlying block contents
@@ -576,6 +607,7 @@ class BlockIter : public InternalIteratorBase<TValue> {
     pad_min_timestamp_ = ts_sz_ > 0 && !user_defined_timestamp_persisted;
     block_contents_pinned_ = block_contents_pinned;
     cache_handle_ = nullptr;
+    block_contents_retained_backing_.reset();
     cur_entry_idx_ = -1;
     protection_bytes_per_key_ = protection_bytes_per_key;
     kv_checksum_ = kv_checksum;
@@ -693,6 +725,8 @@ class BlockIter : public InternalIteratorBase<TValue> {
   // PinnableSlices reference the block, they need the cache handle in order
   // to bump up the ref count
   Cache::Handle* cache_handle_;
+  std::unique_ptr<RetainedBlockContentsBacking>
+      block_contents_retained_backing_;
 
  public:
   // Return the offset in data_ just past the end of the current entry.

--- a/table/block_based/block_based_table_factory.cc
+++ b/table/block_based/block_based_table_factory.cc
@@ -411,6 +411,15 @@ static struct BlockBasedTableTypeInfo {
             auto* cache = static_cast<std::shared_ptr<Cache>*>(addr);
             return Cache::CreateFromString(opts, value, cache);
           }}},
+        {"block_buffer_provider",
+         {offsetof(struct BlockBasedTableOptions, block_buffer_provider),
+          OptionType::kUnknown, OptionVerificationType::kNormal,
+          (OptionTypeFlags::kCompareNever | OptionTypeFlags::kDontSerialize),
+          [](const ConfigOptions&, const std::string&, const std::string&,
+             void*) {
+            return Status::NotSupported(
+                "block_buffer_provider must be configured programmatically");
+          }}},
         {"block_cache_compressed",
          {0, OptionType::kUnknown, OptionVerificationType::kDeprecated}},
         {"max_auto_readahead_size",

--- a/table/block_based/block_based_table_factory.h
+++ b/table/block_based/block_based_table_factory.h
@@ -87,6 +87,8 @@ class BlockBasedTableFactory : public TableFactory {
     return &shared_state_->tail_prefetch_stats;
   }
 
+  const BlockBasedTableOptions& table_options() const { return table_options_; }
+
  protected:
   const void* GetOptionsPtr(const std::string& name) const override;
   Status ParseOption(const ConfigOptions& config_options,

--- a/table/block_based/block_based_table_iterator.cc
+++ b/table/block_based/block_based_table_iterator.cc
@@ -10,10 +10,79 @@
 
 namespace ROCKSDB_NAMESPACE {
 
+namespace {
+
+void ReleasePinnedBlockCacheHandle(void* arg1, void* arg2) {
+  auto* cache = static_cast<Cache*>(arg1);
+  auto* cache_handle = static_cast<Cache::Handle*>(arg2);
+  assert(cache != nullptr);
+  assert(cache_handle != nullptr);
+  cache->Release(cache_handle);
+}
+
+}  // namespace
+
 void BlockBasedTableIterator::SeekToFirst() { SeekImpl(nullptr, false); }
 
 void BlockBasedTableIterator::Seek(const Slice& target) {
   SeekImpl(&target, true);
+}
+
+Status BlockBasedTableIterator::PinCurrentKeyValue(PinnedIterKeyValue* out) {
+  if (out == nullptr) {
+    return Status::InvalidArgument("PinnedIterKeyValue is nullptr");
+  }
+  out->Reset();
+  if (!Valid()) {
+    return Status::InvalidArgument("Iterator is not valid");
+  }
+  if (!PrepareValue()) {
+    return status();
+  }
+  if (!block_iter_points_to_real_block_ || !block_iter_.Valid()) {
+    return Status::NotSupported("Current entry is not backed by a data block");
+  }
+  if (!block_iter_.IsValuePinned()) {
+    return Status::NotSupported(
+        "Current entry is not backed by pinned block contents");
+  }
+
+  Cache* block_cache = table_->get_rep()->table_options.block_cache.get();
+  Cache::Handle* cache_handle = block_iter_.cache_handle();
+  if (block_cache != nullptr && cache_handle != nullptr) {
+    if (!block_cache->Ref(cache_handle)) {
+      return Status::NotSupported(
+          "Failed to reference current data block cache entry");
+    }
+
+    out->cleanup.Allocate();
+    out->cleanup->RegisterCleanup(&ReleasePinnedBlockCacheHandle, block_cache,
+                                  cache_handle);
+    out->cleanup_dedupe_token = cache_handle;
+    out->key = block_iter_.key();
+    out->user_key = block_iter_.user_key();
+    out->value = block_iter_.value();
+    out->key_pinned = block_iter_.IsKeyPinned();
+    out->value_pinned = true;
+    out->pinned_block_cache_usage = block_cache->GetCharge(cache_handle);
+    return Status::OK();
+  }
+
+  SharedCleanablePtr cleanup = block_iter_.block_contents_cleanup();
+  if (cleanup.get() == nullptr) {
+    return Status::NotSupported(
+        "Current entry is not backed by a retainable block buffer");
+  }
+
+  out->cleanup = cleanup;
+  out->cleanup_dedupe_token = block_iter_.block_contents_cleanup_dedupe_token();
+  out->key = block_iter_.key();
+  out->user_key = block_iter_.user_key();
+  out->value = block_iter_.value();
+  out->key_pinned = block_iter_.IsKeyPinned();
+  out->value_pinned = true;
+  out->pinned_block_cache_usage = 0;
+  return Status::OK();
 }
 
 void BlockBasedTableIterator::SeekSecondPass(const Slice* target) {
@@ -71,6 +140,8 @@ void BlockBasedTableIterator::SeekImpl(const Slice* target,
       (read_options_.iterate_upper_bound || read_options_.prefix_same_as_start);
 
   if (autotune_readaheadsize && !multi_scan_read_set_ &&
+      ShouldUseBlockCacheForIteratorDataBlocks(table_->get_rep()->table_options,
+                                               read_options_) &&
       table_->get_rep()->table_options.block_cache.get() &&
       direction_ == IterDirection::kForward) {
     readahead_cache_lookup_ = true;
@@ -373,6 +444,11 @@ void BlockBasedTableIterator::Prev() {
 }
 
 void BlockBasedTableIterator::InitDataBlock() {
+  if (!ShouldUseBlockCacheForIteratorDataBlocks(
+          table_->get_rep()->table_options, read_options_)) {
+    ResetBlockCacheLookupVar();
+  }
+
   // MultiScan path: load block from ReadSet
   if (multi_scan_read_set_) {
     BlockHandle data_block_handle = index_iter_->value().handle;
@@ -485,6 +561,11 @@ void BlockBasedTableIterator::InitDataBlock() {
 }
 
 void BlockBasedTableIterator::AsyncInitDataBlock(bool is_first_pass) {
+  if (!ShouldUseBlockCacheForIteratorDataBlocks(
+          table_->get_rep()->table_options, read_options_)) {
+    ResetBlockCacheLookupVar();
+  }
+
   BlockHandle data_block_handle;
   bool is_for_compaction =
       lookup_context_.caller == TableReaderCaller::kCompaction;

--- a/table/block_based/block_based_table_iterator.h
+++ b/table/block_based/block_based_table_iterator.h
@@ -99,6 +99,8 @@ class BlockBasedTableIterator : public InternalIteratorBase<Slice> {
         ->MaterializeCurrentBlock();
   }
 
+  Status PinCurrentKeyValue(PinnedIterKeyValue* out) override;
+
   uint64_t write_unix_time() const override {
     assert(Valid());
     ParsedInternalKey pikey;

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -77,15 +77,6 @@
 #include "util/string_util.h"
 
 namespace ROCKSDB_NAMESPACE {
-namespace {
-
-CacheAllocationPtr CopyBufferToHeap(MemoryAllocator* allocator, Slice& buf) {
-  CacheAllocationPtr heap_buf;
-  heap_buf = AllocateBlock(buf.size(), allocator);
-  memcpy(heap_buf.get(), buf.data(), buf.size());
-  return heap_buf;
-}
-}  // namespace
 
 // Explicitly instantiate templates for each "blocklike" type we use (and
 // before implicit specialization).
@@ -204,7 +195,8 @@ Status ReadAndParseBlockFromFile(
     BlockCreateContext& create_context, bool maybe_compressed,
     UnownedPtr<Decompressor> decomp,
     const PersistentCacheOptions& cache_options,
-    MemoryAllocator* memory_allocator, bool for_compaction, bool async_read) {
+    MemoryAllocator* memory_allocator, bool for_compaction, bool async_read,
+    RetainedBlockBufferProvider* block_buffer_provider) {
   assert(result);
 
   BlockContents contents;
@@ -212,7 +204,7 @@ Status ReadAndParseBlockFromFile(
       file, prefetch_buffer, footer, options, handle, &contents, ioptions,
       /*do_uncompress*/ maybe_compressed, maybe_compressed,
       TBlocklike::kBlockType, decomp, cache_options, memory_allocator, nullptr,
-      for_compaction);
+      for_compaction, block_buffer_provider);
   Status s;
   // If prefetch_buffer is not allocated, it will fallback to synchronous
   // reading of block contents.
@@ -1492,7 +1484,8 @@ Status BlockBasedTable::ReadMetaIndexBlock(
       rep_->footer.metaindex_handle(), &metaindex, rep_->ioptions,
       rep_->create_context, true /*maybe_compressed*/, rep_->decompressor.get(),
       rep_->persistent_cache_options, GetMemoryAllocator(rep_->table_options),
-      false /* for_compaction */, false /* async_read */);
+      false /* for_compaction */, false /* async_read */,
+      GetRetainedBlockBufferProvider(rep_->table_options));
 
   if (!s.ok()) {
     ROCKS_LOG_ERROR(rep_->ioptions.logger,
@@ -1588,6 +1581,7 @@ WithBlocklikeCheck<Status, TBlocklike> BlockBasedTable::PutDataBlockToCache(
     BlockContents&& uncompressed_block_contents,
     BlockContents&& compressed_block_contents, CompressionType block_comp_type,
     UnownedPtr<Decompressor> decomp, MemoryAllocator* memory_allocator,
+    RetainedBlockBufferProvider* block_buffer_provider,
     GetContext* get_context) const {
   const ImmutableOptions& ioptions = rep_->ioptions;
   assert(out_parsed_block);
@@ -1601,10 +1595,11 @@ WithBlocklikeCheck<Status, TBlocklike> BlockBasedTable::PutDataBlockToCache(
       uncompressed_block_contents.data.empty()) {
     assert(compressed_block_contents.data.data());
     // Retrieve the uncompressed contents into a new buffer
-    s = DecompressBlockData(
-        compressed_block_contents.data.data(),
-        compressed_block_contents.data.size(), block_comp_type, *decomp,
-        &uncompressed_block_contents, ioptions, memory_allocator);
+    s = DecompressBlockData(compressed_block_contents.data.data(),
+                            compressed_block_contents.data.size(),
+                            block_comp_type, *decomp,
+                            &uncompressed_block_contents, ioptions,
+                            memory_allocator, nullptr, block_buffer_provider);
     if (!s.ok()) {
       return s;
     }
@@ -1777,20 +1772,23 @@ Status BlockBasedTable::CreateAndPinBlockInCache(
     UnownedPtr<Decompressor> decomp, BlockContents* contents,
     CachableEntry<TBlocklike>* out_parsed_block) const {
   CompressionType compression_type = GetBlockCompressionType(*contents);
+  Status s;
   // If we don't own the contents and we don't need to decompress, copy
   // the block to heap in order to have ownership. If decompression is
   // needed, then the decompressor will allocate a buffer.
   if (!contents->own_bytes() && compression_type == kNoCompression) {
     Slice src = Slice(contents->data.data(), BlockSizeWithTrailer(handle));
-    *contents = BlockContents(
-        CopyBufferToHeap(GetMemoryAllocator(rep_->table_options), src),
-        handle.size());
+    s = CopyBufferToOwnedBlockContents(
+        src, handle.size(), GetMemoryAllocator(rep_->table_options),
+        GetRetainedBlockBufferProvider(rep_->table_options), contents);
+    if (!s.ok()) {
+      return s;
+    }
 #ifndef NDEBUG
     contents->has_trailer = true;
 #endif
   }
 
-  Status s;
   if (ro.fill_cache) {
     s = MaybeReadBlockAndLoadToCache(nullptr, ro, handle, decomp,
                                      /*for_compaction=*/false, out_parsed_block,
@@ -1808,10 +1806,11 @@ Status BlockBasedTable::CreateAndPinBlockInCache(
   if (out_parsed_block->GetValue() == nullptr && contents != nullptr) {
     BlockContents tmp_contents;
     if (compression_type != kNoCompression) {
-      s = DecompressSerializedBlock(contents->data.data(), handle.size(),
-                                    compression_type, *decomp, &tmp_contents,
-                                    rep_->ioptions,
-                                    GetMemoryAllocator(rep_->table_options));
+      s = DecompressSerializedBlock(
+          contents->data.data(), handle.size(), compression_type, *decomp,
+          &tmp_contents, rep_->ioptions,
+          GetMemoryAllocator(rep_->table_options),
+          GetRetainedBlockBufferProvider(rep_->table_options));
     } else {
       tmp_contents = std::move(*contents);
     }
@@ -1912,7 +1911,8 @@ BlockBasedTable::MaybeReadBlockAndLoadToCache(
             &tmp_contents, rep_->ioptions, do_uncompress, maybe_compressed,
             TBlocklike::kBlockType, decomp, rep_->persistent_cache_options,
             GetMemoryAllocator(rep_->table_options),
-            /*allocator=*/nullptr);
+            /*allocator=*/nullptr, for_compaction,
+            GetRetainedBlockBufferProvider(rep_->table_options));
 
         // If prefetch_buffer is not allocated, it will fallback to synchronous
         // reading of block contents.
@@ -1958,7 +1958,8 @@ BlockBasedTable::MaybeReadBlockAndLoadToCache(
           s = PutDataBlockToCache(
               key, block_cache, out_parsed_block, std::move(uncomp_contents),
               std::move(comp_contents), contents_comp_type, decomp,
-              GetMemoryAllocator(rep_->table_options), get_context);
+              GetMemoryAllocator(rep_->table_options),
+              GetRetainedBlockBufferProvider(rep_->table_options), get_context);
         }
       } else {
         contents_comp_type = GetBlockCompressionType(*contents);
@@ -1974,7 +1975,8 @@ BlockBasedTable::MaybeReadBlockAndLoadToCache(
           s = PutDataBlockToCache(
               key, block_cache, out_parsed_block, std::move(uncomp_contents),
               std::move(comp_contents), contents_comp_type, decomp,
-              GetMemoryAllocator(rep_->table_options), get_context);
+              GetMemoryAllocator(rep_->table_options),
+              GetRetainedBlockBufferProvider(rep_->table_options), get_context);
         }
       }
     }
@@ -2129,11 +2131,15 @@ WithBlocklikeCheck<Status, TBlocklike> BlockBasedTable::RetrieveBlock(
     Histograms histogram =
         for_compaction ? READ_BLOCK_COMPACTION_MICROS : READ_BLOCK_GET_MICROS;
     StopWatch sw(rep_->ioptions.clock, rep_->ioptions.stats, histogram);
+    RetainedBlockBufferProvider* block_buffer_provider =
+        TBlocklike::kBlockType == BlockType::kData
+            ? GetRetainedBlockBufferProvider(rep_->table_options, ro)
+            : GetRetainedBlockBufferProvider(rep_->table_options);
     s = ReadAndParseBlockFromFile(
         rep_->file.get(), prefetch_buffer, rep_->footer, ro, handle, &block,
         rep_->ioptions, rep_->create_context, maybe_compressed, decomp,
         rep_->persistent_cache_options, GetMemoryAllocator(rep_->table_options),
-        for_compaction, async_read);
+        for_compaction, async_read, block_buffer_provider);
 
     if (get_context) {
       switch (TBlocklike::kBlockType) {

--- a/table/block_based/block_based_table_reader.h
+++ b/table/block_based/block_based_table_reader.h
@@ -466,7 +466,9 @@ class BlockBasedTable : public TableReader {
       BlockContents&& uncompressed_block_contents,
       BlockContents&& compressed_block_contents,
       CompressionType block_comp_type, UnownedPtr<Decompressor> decomp,
-      MemoryAllocator* memory_allocator, GetContext* get_context) const;
+      MemoryAllocator* memory_allocator,
+      RetainedBlockBufferProvider* block_buffer_provider,
+      GetContext* get_context) const;
 
   // Calls (*handle_result)(arg, ...) repeatedly, starting with the entry found
   // after a call to Seek(key), until handle_result returns false.

--- a/table/block_based/block_based_table_reader_impl.h
+++ b/table/block_based/block_based_table_reader_impl.h
@@ -59,6 +59,10 @@ TBlockIter* BlockBasedTable::NewDataBlockIterator(
     return iter;
   }
 
+  const bool use_block_cache_for_data_blocks =
+      block_type != BlockType::kData ||
+      ShouldUseBlockCacheForIteratorDataBlocks(rep_->table_options, ro);
+
   CachableEntry<Block> block;
   {
     CachableEntry<DecompressorDict> dict;
@@ -85,15 +89,18 @@ TBlockIter* BlockBasedTable::NewDataBlockIterator(
     }
 
     if (block_type == BlockType::kRangeDeletion) {
-      s = RetrieveBlock(prefetch_buffer, ro, handle, decomp,
-                        &block.As<Block_kRangeDeletion>(), get_context,
-                        lookup_context, for_compaction, /* use_cache */ true,
-                        async_read, use_block_cache_for_lookup);
+      s = RetrieveBlock(
+          prefetch_buffer, ro, handle, decomp,
+          &block.As<Block_kRangeDeletion>(), get_context, lookup_context,
+          for_compaction,
+          /* use_cache */ use_block_cache_for_data_blocks, async_read,
+          use_block_cache_for_lookup && use_block_cache_for_data_blocks);
     } else {
       s = RetrieveBlock(
           prefetch_buffer, ro, handle, decomp, &block.As<IterBlocklike>(),
           get_context, lookup_context, for_compaction,
-          /* use_cache */ true, async_read, use_block_cache_for_lookup);
+          /* use_cache */ use_block_cache_for_data_blocks, async_read,
+          use_block_cache_for_lookup && use_block_cache_for_data_blocks);
     }
   }
 
@@ -116,17 +123,18 @@ TBlockIter* BlockBasedTable::NewDataBlockIterator(
   // is destroyed as long as cleanup functions are moved to another object,
   // when:
   // 1. block cache handle is set to be released in cleanup function, or
-  // 2. it's pointing to immortal source. If own_bytes is true then we are
+  // 2. block contents are backed by a retained external provider, or
+  // 3. it's pointing to immortal source. If own_bytes is true then we are
   //    not reading data from the original source, whether immortal or not.
   //    Otherwise, the block is pinned iff the source is immortal.
   const bool block_contents_pinned =
-      block.IsCached() ||
+      block.IsCached() || block.GetValue()->HasRetainedContentsBacking() ||
       (!block.GetValue()->own_bytes() && rep_->immortal_table);
   iter = InitBlockIterator<TBlockIter>(rep_, block.GetValue(), block_type, iter,
                                        block_contents_pinned);
 
   if (!block.IsCached()) {
-    if (!ro.fill_cache) {
+    if (!ro.fill_cache && use_block_cache_for_data_blocks) {
       IterPlaceholderCacheInterface block_cache{
           rep_->table_options.block_cache.get()};
       if (block_cache) {
@@ -147,6 +155,11 @@ TBlockIter* BlockBasedTable::NewDataBlockIterator(
     }
   } else {
     iter->SetCacheHandle(block.GetCacheHandle());
+  }
+  if (block.GetValue()->HasRetainedContentsBacking()) {
+    iter->SetBlockContentsCleanup(
+        block.GetValue()->contents_cleanup(),
+        block.GetValue()->contents_cleanup_dedupe_token());
   }
 
   block.TransferTo(iter);
@@ -178,17 +191,19 @@ TBlockIter* BlockBasedTable::NewDataBlockIterator(const ReadOptions& ro,
   // is destroyed as long as cleanup functions are moved to another object,
   // when:
   // 1. block cache handle is set to be released in cleanup function, or
-  // 2. it's pointing to immortal source. If own_bytes is true then we are
+  // 2. block contents are backed by a retained external provider, or
+  // 3. it's pointing to immortal source. If own_bytes is true then we are
   //    not reading data from the original source, whether immortal or not.
   //    Otherwise, the block is pinned iff the source is immortal.
   const bool block_contents_pinned =
-      block.IsCached() ||
+      block.IsCached() || block.GetValue()->HasRetainedContentsBacking() ||
       (!block.GetValue()->own_bytes() && rep_->immortal_table);
   iter = InitBlockIterator<TBlockIter>(rep_, block.GetValue(), BlockType::kData,
                                        iter, block_contents_pinned);
 
   if (!block.IsCached()) {
-    if (!ro.fill_cache) {
+    if (!ro.fill_cache &&
+        ShouldUseBlockCacheForIteratorDataBlocks(rep_->table_options, ro)) {
       IterPlaceholderCacheInterface block_cache{
           rep_->table_options.block_cache.get()};
       if (block_cache) {
@@ -209,6 +224,11 @@ TBlockIter* BlockBasedTable::NewDataBlockIterator(const ReadOptions& ro,
     }
   } else {
     iter->SetCacheHandle(block.GetCacheHandle());
+  }
+  if (block.GetValue()->HasRetainedContentsBacking()) {
+    iter->SetBlockContentsCleanup(
+        block.GetValue()->contents_cleanup(),
+        block.GetValue()->contents_cleanup_dedupe_token());
   }
 
   block.TransferTo(iter);

--- a/table/block_based/reader_common.h
+++ b/table/block_based/reader_common.h
@@ -25,6 +25,47 @@ inline MemoryAllocator* GetMemoryAllocator(
              : nullptr;
 }
 
+inline RetainedBlockBufferProvider* GetRetainedBlockBufferProvider(
+    const BlockBasedTableOptions& table_options) {
+  return table_options.block_cache == nullptr
+             ? table_options.block_buffer_provider.get()
+             : nullptr;
+}
+
+inline RetainedBlockBufferProvider* GetRetainedBlockBufferProvider(
+    const BlockBasedTableOptions& table_options,
+    const ReadOptions& read_options) {
+  const auto& iterator_mutable_options = read_options.iterator_mutable_options;
+  if (!iterator_mutable_options.pinned_block_backing.has_value()) {
+    return GetRetainedBlockBufferProvider(table_options);
+  }
+
+  const auto& config = *iterator_mutable_options.pinned_block_backing;
+  switch (config.policy) {
+    case PinnedBlockBackingPolicy::kAuto:
+      if (table_options.block_cache == nullptr) {
+        return config.retained_block_buffer_provider != nullptr
+                   ? config.retained_block_buffer_provider.get()
+                   : table_options.block_buffer_provider.get();
+      }
+      return nullptr;
+    case PinnedBlockBackingPolicy::kUseBlockCache:
+      return nullptr;
+    case PinnedBlockBackingPolicy::kUseRetainedBlockBuffer:
+      return config.retained_block_buffer_provider != nullptr
+                 ? config.retained_block_buffer_provider.get()
+                 : table_options.block_buffer_provider.get();
+  }
+
+  return nullptr;
+}
+
+inline bool ShouldUseBlockCacheForIteratorDataBlocks(
+    const BlockBasedTableOptions& table_options,
+    const ReadOptions& read_options) {
+  return GetRetainedBlockBufferProvider(table_options, read_options) == nullptr;
+}
+
 // Assumes block has a trailer past `data + block_size` as in format.h.
 // `file_name` provided for generating diagnostic message in returned status.
 // `offset` might be required for proper verification (also used for message).

--- a/table/block_fetcher.cc
+++ b/table/block_fetcher.cc
@@ -54,6 +54,26 @@ inline void RecordBlockReadBytePerfCounter(BlockType block_type,
   }
 }
 
+Status AllocateRetainedBufferForAlignedBuffer(void* state, size_t size,
+                                              size_t alignment,
+                                              RetainedBufferAllocation* out) {
+  auto* block_buffer_provider =
+      static_cast<RetainedBlockBufferProvider*>(state);
+  assert(block_buffer_provider != nullptr);
+  assert(out != nullptr);
+
+  RetainedBlockBufferProvider::Lease lease;
+  Status s = block_buffer_provider->Allocate(size, alignment, &lease);
+  if (!s.ok()) {
+    return s;
+  }
+  out->data = lease.data;
+  out->size = lease.size;
+  out->cleanup = std::move(lease.cleanup);
+  out->dedupe_token = lease.dedupe_token;
+  return Status::OK();
+}
+
 }  // namespace
 
 inline void BlockFetcher::ProcessTrailerIfPresent() {
@@ -150,6 +170,18 @@ inline bool BlockFetcher::TryGetSerializedBlockFromPersistentCache() {
 }
 
 inline void BlockFetcher::PrepareBufferForBlockFromFile() {
+  if (block_buffer_provider_ != nullptr && !maybe_compressed_) {
+    Status s = AllocateOwnedBlockContents(
+        block_size_with_trailer_, block_size_with_trailer_, memory_allocator_,
+        block_buffer_provider_, &retained_buf_contents_);
+    if (!s.ok()) {
+      io_status_ = status_to_io_status(std::move(s));
+      return;
+    }
+    used_buf_ = const_cast<char*>(retained_buf_contents_.data.data());
+    return;
+  }
+
   // cache miss read from device
   if ((do_uncompress_ || ioptions_.allow_mmap_reads) &&
       block_size_with_trailer_ < kDefaultStackBufferSize) {
@@ -238,7 +270,33 @@ inline void BlockFetcher::CopyBufferToCompressedBuf() {
 // compressed_buf_ and heap_buf_ points to compressed_buf_, otherwise should be
 // in heap_buf_.
 inline void BlockFetcher::GetBlockContents() {
-  if (slice_.data() != used_buf_) {
+  if (block_buffer_provider_ != nullptr &&
+      compression_type() == kNoCompression) {
+    if (!retained_buf_contents_.data.empty() &&
+        slice_.data() == retained_buf_contents_.data.data()) {
+      *contents_ = std::move(retained_buf_contents_);
+      contents_->data = Slice(contents_->data.data(), block_size_);
+    } else if (direct_io_retained_buf_.cleanup.get() != nullptr) {
+      *contents_ = BlockContents();
+      contents_->data = Slice(slice_.data(), block_size_);
+      contents_->SetRetainedBacking(std::move(direct_io_retained_buf_.cleanup),
+                                    direct_io_retained_buf_.dedupe_token,
+                                    direct_io_retained_buf_.size);
+      direct_io_retained_buf_.Reset();
+    } else {
+      // Provider-backed pinning needs retained ownership. This branch handles
+      // reads whose bytes came from a transient source such as prefetch,
+      // persistent cache, mmap, or a stack/heap scratch buffer.
+      Status s = CopyBufferToOwnedBlockContents(
+          Slice(slice_.data(), block_size_with_trailer_), block_size_,
+          memory_allocator_, block_buffer_provider_, contents_);
+      if (!s.ok()) {
+        io_status_ = status_to_io_status(std::move(s));
+        return;
+      }
+      retained_buf_contents_ = BlockContents();
+    }
+  } else if (slice_.data() != used_buf_) {
     // the slice content is not the buffer provided
     *contents_ = BlockContents(Slice(slice_.data(), block_size_));
   } else {
@@ -281,13 +339,22 @@ void BlockFetcher::ReadBlock(bool retry) {
   // Actual file read
   if (io_status_.ok()) {
     if (file_->use_direct_io()) {
+      RetainedBufferAllocator retained_buffer_allocator;
+      const RetainedBufferAllocator* retained_buffer_allocator_ptr = nullptr;
+      if (block_buffer_provider_ != nullptr) {
+        retained_buffer_allocator = RetainedBufferAllocator(
+            block_buffer_provider_, &AllocateRetainedBufferForAlignedBuffer);
+        retained_buffer_allocator_ptr = &retained_buffer_allocator;
+      }
       PERF_TIMER_GUARD(block_read_time);
       PERF_CPU_TIMER_GUARD(
           block_read_cpu_time,
           ioptions_.env ? ioptions_.env->GetSystemClock().get() : nullptr);
       io_status_ =
           file_->Read(opts, handle_.offset(), block_size_with_trailer_, &slice_,
-                      /*scratch=*/nullptr, &direct_io_buf_, &dbg);
+                      /*scratch=*/nullptr, &direct_io_buf_, &dbg,
+                      /*direct_io_scratch=*/nullptr,
+                      retained_buffer_allocator_ptr, &direct_io_retained_buf_);
       PERF_COUNTER_ADD(block_read_count, 1);
       used_buf_ = const_cast<char*>(slice_.data());
     } else if (use_fs_scratch_) {
@@ -307,6 +374,9 @@ void BlockFetcher::ReadBlock(bool retry) {
     } else {
       // It allocates/assign used_buf_
       PrepareBufferForBlockFromFile();
+      if (!io_status_.ok()) {
+        return;
+      }
 
       PERF_TIMER_GUARD(block_read_time);
       PERF_CPU_TIMER_GUARD(
@@ -383,6 +453,8 @@ void BlockFetcher::ReadBlock(bool retry) {
     direct_io_buf_.reset();
     compressed_buf_.reset();
     heap_buf_.reset();
+    retained_buf_contents_ = BlockContents();
+    direct_io_retained_buf_.Reset();
     used_buf_ = nullptr;
   }
 }
@@ -423,7 +495,8 @@ IOStatus BlockFetcher::ReadBlockContents() {
     slice_.size_ = block_size_;
     decomp_args_.compressed_data = slice_;
     io_status_ = status_to_io_status(DecompressSerializedBlock(
-        decomp_args_, *decompressor_, contents_, ioptions_, memory_allocator_));
+        decomp_args_, *decompressor_, contents_, ioptions_, memory_allocator_,
+        block_buffer_provider_));
 #ifndef NDEBUG
     num_heap_buf_memcpy_++;
 #endif
@@ -477,9 +550,9 @@ IOStatus BlockFetcher::ReadAsyncBlockContents() {
           // Process the compressed block without trailer
           slice_.size_ = block_size_;
           decomp_args_.compressed_data = slice_;
-          io_status_ = status_to_io_status(
-              DecompressSerializedBlock(decomp_args_, *decompressor_, contents_,
-                                        ioptions_, memory_allocator_));
+          io_status_ = status_to_io_status(DecompressSerializedBlock(
+              decomp_args_, *decompressor_, contents_, ioptions_,
+              memory_allocator_, block_buffer_provider_));
 #ifndef NDEBUG
           num_heap_buf_memcpy_++;
 #endif

--- a/table/block_fetcher.h
+++ b/table/block_fetcher.h
@@ -14,6 +14,7 @@
 #include "table/block_based/block_type.h"
 #include "table/format.h"
 #include "table/persistent_cache_options.h"
+#include "util/aligned_buffer.h"
 #include "util/cast_util.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -51,7 +52,8 @@ class BlockFetcher {
                const PersistentCacheOptions& cache_options /* ref retained */,
                MemoryAllocator* memory_allocator = nullptr,
                MemoryAllocator* memory_allocator_compressed = nullptr,
-               bool for_compaction = false)
+               bool for_compaction = false,
+               RetainedBlockBufferProvider* block_buffer_provider = nullptr)
       : file_(file),
         prefetch_buffer_(prefetch_buffer),
         footer_(footer),
@@ -68,7 +70,8 @@ class BlockFetcher {
         cache_options_(cache_options),
         memory_allocator_(memory_allocator),
         memory_allocator_compressed_(memory_allocator_compressed),
-        for_compaction_(for_compaction) {
+        for_compaction_(for_compaction),
+        block_buffer_provider_(block_buffer_provider) {
     io_status_.PermitUncheckedError();  // TODO(AR) can we improve on this?
     if (CheckFSFeatureSupport(ioptions_.fs.get(), FSSupportedOps::kFSBuffer)) {
       use_fs_scratch_ = true;
@@ -133,8 +136,10 @@ class BlockFetcher {
   Slice slice_;
   char* used_buf_ = nullptr;
   AlignedBuf direct_io_buf_;
+  RetainedBufferAllocation direct_io_retained_buf_;
   CacheAllocationPtr heap_buf_;
   CacheAllocationPtr compressed_buf_;
+  BlockContents retained_buf_contents_;
   char stack_buf_[kDefaultStackBufferSize];
   bool got_from_prefetch_buffer_ = false;
   bool for_compaction_ = false;
@@ -142,6 +147,7 @@ class BlockFetcher {
   bool retry_corrupt_read_ = false;
   FSAllocationPtr fs_buf_;
   Decompressor::Args decomp_args_;
+  RetainedBlockBufferProvider* block_buffer_provider_ = nullptr;
 
   // return true if found
   bool TryGetUncompressBlockFromPersistentCache();

--- a/table/format.cc
+++ b/table/format.cc
@@ -11,6 +11,7 @@
 
 #include <cinttypes>
 #include <cstdint>
+#include <cstring>
 #include <string>
 
 #include "block_fetcher.h"
@@ -614,6 +615,54 @@ inline uint32_t ModifyChecksumForLastByte(uint32_t checksum, char last_byte) {
 }
 }  // namespace
 
+Status AllocateOwnedBlockContents(
+    size_t allocation_size, size_t data_size, MemoryAllocator* allocator,
+    RetainedBlockBufferProvider* block_buffer_provider,
+    BlockContents* out_contents) {
+  assert(out_contents != nullptr);
+  assert(data_size <= allocation_size);
+
+  if (block_buffer_provider != nullptr) {
+    RetainedBlockBufferProvider::Lease lease;
+    Status s = block_buffer_provider->Allocate(allocation_size, 1, &lease);
+    if (!s.ok()) {
+      return s;
+    }
+    if (lease.data == nullptr || lease.size < allocation_size ||
+        lease.cleanup.get() == nullptr) {
+      return Status::InvalidArgument(
+          "RetainedBlockBufferProvider returned an invalid lease");
+    }
+
+    BlockContents contents;
+    contents.data = Slice(lease.data, data_size);
+    contents.SetRetainedBacking(std::move(lease.cleanup), lease.dedupe_token,
+                                lease.size);
+    *out_contents = std::move(contents);
+    return Status::OK();
+  }
+
+  CacheAllocationPtr buffer = AllocateBlock(allocation_size, allocator);
+  *out_contents = BlockContents(std::move(buffer), data_size);
+  return Status::OK();
+}
+
+Status CopyBufferToOwnedBlockContents(
+    const Slice& src, size_t data_size, MemoryAllocator* allocator,
+    RetainedBlockBufferProvider* block_buffer_provider,
+    BlockContents* out_contents) {
+  Status s = AllocateOwnedBlockContents(src.size(), data_size, allocator,
+                                        block_buffer_provider, out_contents);
+  if (!s.ok()) {
+    return s;
+  }
+  memcpy(const_cast<char*>(out_contents->data.data()), src.data(), src.size());
+#ifndef NDEBUG
+  out_contents->has_trailer = src.size() > data_size;
+#endif
+  return Status::OK();
+}
+
 uint32_t ComputeBuiltinChecksum(ChecksumType type, const char* data,
                                 size_t data_size) {
   switch (type) {
@@ -686,7 +735,8 @@ uint32_t ComputeBuiltinChecksumWithLastByte(ChecksumType type, const char* data,
 Status DecompressBlockData(Decompressor::Args& args, Decompressor& decompressor,
                            BlockContents* out_contents,
                            const ImmutableOptions& ioptions,
-                           MemoryAllocator* allocator) {
+                           MemoryAllocator* allocator,
+                           RetainedBlockBufferProvider* block_buffer_provider) {
   assert(args.compression_type != kNoCompression && "Invalid compression type");
 
   StopWatchNano timer(ioptions.clock,
@@ -696,13 +746,17 @@ Status DecompressBlockData(Decompressor::Args& args, Decompressor& decompressor,
   if (UNLIKELY(!s.ok())) {
     return s;
   }
-  CacheAllocationPtr ubuf = AllocateBlock(args.uncompressed_size, allocator);
-  s = decompressor.DecompressBlock(args, ubuf.get());
+  s = AllocateOwnedBlockContents(args.uncompressed_size, args.uncompressed_size,
+                                 allocator, block_buffer_provider,
+                                 out_contents);
   if (UNLIKELY(!s.ok())) {
     return s;
   }
-
-  *out_contents = BlockContents(std::move(ubuf), args.uncompressed_size);
+  s = decompressor.DecompressBlock(
+      args, const_cast<char*>(out_contents->data.data()));
+  if (UNLIKELY(!s.ok())) {
+    return s;
+  }
 
   if (ShouldReportDetailedTime(ioptions.env, ioptions.stats)) {
     RecordTimeToHistogram(ioptions.stats, DECOMPRESSION_TIMES_NANOS,
@@ -727,38 +781,39 @@ Status DecompressBlockData(const char* data, size_t size, CompressionType type,
                            BlockContents* out_contents,
                            const ImmutableOptions& ioptions,
                            MemoryAllocator* allocator,
-                           Decompressor::ManagedWorkingArea* working_area) {
+                           Decompressor::ManagedWorkingArea* working_area,
+                           RetainedBlockBufferProvider* block_buffer_provider) {
   Decompressor::Args args;
   args.compressed_data = Slice(data, size);
   args.compression_type = type;
   args.working_area = working_area;
   return DecompressBlockData(args, decompressor, out_contents, ioptions,
-                             allocator);
+                             allocator, block_buffer_provider);
 }
 
-Status DecompressSerializedBlock(const char* data, size_t size,
-                                 CompressionType type,
-                                 Decompressor& decompressor,
-                                 BlockContents* out_contents,
-                                 const ImmutableOptions& ioptions,
-                                 MemoryAllocator* allocator) {
+Status DecompressSerializedBlock(
+    const char* data, size_t size, CompressionType type,
+    Decompressor& decompressor, BlockContents* out_contents,
+    const ImmutableOptions& ioptions, MemoryAllocator* allocator,
+    RetainedBlockBufferProvider* block_buffer_provider) {
   assert(data[size] != kNoCompression);
   assert(data[size] == static_cast<char>(type));
   return DecompressBlockData(data, size, type, decompressor, out_contents,
-                             ioptions, allocator);
+                             ioptions, allocator, nullptr,
+                             block_buffer_provider);
 }
 
-Status DecompressSerializedBlock(Decompressor::Args& args,
-                                 Decompressor& decompressor,
-                                 BlockContents* out_contents,
-                                 const ImmutableOptions& ioptions,
-                                 MemoryAllocator* allocator) {
+Status DecompressSerializedBlock(
+    Decompressor::Args& args, Decompressor& decompressor,
+    BlockContents* out_contents, const ImmutableOptions& ioptions,
+    MemoryAllocator* allocator,
+    RetainedBlockBufferProvider* block_buffer_provider) {
   assert(args.compressed_data.data()[args.compressed_data.size()] !=
          kNoCompression);
   assert(args.compressed_data.data()[args.compressed_data.size()] ==
          static_cast<char>(args.compression_type));
   return DecompressBlockData(args, decompressor, out_contents, ioptions,
-                             allocator);
+                             allocator, block_buffer_provider);
 }
 
 // Replace the contents of db_host_id with the actual hostname, if db_host_id

--- a/table/format.h
+++ b/table/format.h
@@ -11,6 +11,7 @@
 
 #include <array>
 #include <cstdint>
+#include <memory>
 #include <string>
 
 #include "file/file_prefetch_buffer.h"
@@ -400,10 +401,25 @@ uint32_t ComputeBuiltinChecksumWithLastByte(ChecksumType type, const char* data,
 // block type (see block_cache.h). Only trivially parsable block types
 // use BlockContents as the parsed form.
 //
+struct RetainedBlockContentsBacking {
+  SharedCleanablePtr cleanup;
+  const void* cleanup_dedupe_token = nullptr;
+  size_t backing_size = 0;
+
+  RetainedBlockContentsBacking() = default;
+  RetainedBlockContentsBacking(SharedCleanablePtr&& _cleanup,
+                               const void* _cleanup_dedupe_token,
+                               size_t _backing_size)
+      : cleanup(std::move(_cleanup)),
+        cleanup_dedupe_token(_cleanup_dedupe_token),
+        backing_size(_backing_size) {}
+};
+
 struct BlockContents {
   // Points to block payload (without trailer)
   Slice data;
   CacheAllocationPtr allocation;
+  std::unique_ptr<RetainedBlockContentsBacking> retained_backing;
 
 #ifndef NDEBUG
   // Whether there is a known trailer after what is pointed to by `data`.
@@ -412,6 +428,8 @@ struct BlockContents {
 #endif  // NDEBUG
 
   BlockContents() {}
+  BlockContents(const BlockContents&) = delete;
+  BlockContents& operator=(const BlockContents&) = delete;
 
   // Does not take ownership of the underlying data bytes.
   BlockContents(const Slice& _data) : data(_data) {}
@@ -427,7 +445,48 @@ struct BlockContents {
   }
 
   // Returns whether the object has ownership of the underlying data bytes.
-  bool own_bytes() const { return allocation.get() != nullptr; }
+  bool own_bytes() const {
+    return allocation.get() != nullptr || has_cleanup();
+  }
+
+  bool has_cleanup() const {
+    return retained_backing != nullptr &&
+           retained_backing->cleanup.get() != nullptr;
+  }
+
+  void SetRetainedBacking(SharedCleanablePtr&& cleanup,
+                          const void* cleanup_dedupe_token,
+                          size_t backing_size) {
+    assert(cleanup.get() != nullptr);
+    allocation.reset();
+    retained_backing = std::make_unique<RetainedBlockContentsBacking>(
+        std::move(cleanup), cleanup_dedupe_token, backing_size);
+  }
+
+  const SharedCleanablePtr& retained_cleanup() const {
+    assert(has_cleanup());
+    return retained_backing->cleanup;
+  }
+
+  const void* retained_cleanup_dedupe_token() const {
+    return retained_backing != nullptr ? retained_backing->cleanup_dedupe_token
+                                       : nullptr;
+  }
+
+  size_t retained_backing_size() const {
+    return retained_backing != nullptr ? retained_backing->backing_size : 0;
+  }
+
+  size_t retained_metadata_memory_usage() const {
+    if (retained_backing == nullptr) {
+      return 0;
+    }
+#ifdef ROCKSDB_MALLOC_USABLE_SIZE
+    return malloc_usable_size(retained_backing.get());
+#else
+    return sizeof(*retained_backing);
+#endif  // ROCKSDB_MALLOC_USABLE_SIZE
+  }
 
   // The additional memory space taken by the block data.
   size_t usable_size() const {
@@ -442,13 +501,16 @@ struct BlockContents {
 #else
       return data.size();
 #endif  // ROCKSDB_MALLOC_USABLE_SIZE
+    } else if (has_cleanup()) {
+      size_t backing_size = retained_backing_size();
+      return backing_size > 0 ? backing_size : data.size();
     } else {
       return 0;  // no extra memory is occupied by the data
     }
   }
 
   size_t ApproximateMemoryUsage() const {
-    return usable_size() + sizeof(*this);
+    return usable_size() + sizeof(*this) + retained_metadata_memory_usage();
   }
 
   BlockContents(BlockContents&& other) noexcept { *this = std::move(other); }
@@ -456,29 +518,43 @@ struct BlockContents {
   BlockContents& operator=(BlockContents&& other) {
     data = std::move(other.data);
     allocation = std::move(other.allocation);
+    retained_backing = std::move(other.retained_backing);
 #ifndef NDEBUG
     has_trailer = other.has_trailer;
+#endif  // NDEBUG
+    other.data = Slice();
+#ifndef NDEBUG
+    other.has_trailer = false;
 #endif  // NDEBUG
     return *this;
   }
 };
 
+Status AllocateOwnedBlockContents(
+    size_t allocation_size, size_t data_size, MemoryAllocator* allocator,
+    RetainedBlockBufferProvider* block_buffer_provider,
+    BlockContents* out_contents);
+
+Status CopyBufferToOwnedBlockContents(
+    const Slice& src, size_t data_size, MemoryAllocator* allocator,
+    RetainedBlockBufferProvider* block_buffer_provider,
+    BlockContents* out_contents);
+
 // The `data` points to serialized block contents read in from file, which
 // must be compressed and include a trailer beyond `size`. A new buffer is
 // allocated with the given allocator (or default) and the uncompressed
 // contents are returned in `out_contents`. Statistics updated.
-Status DecompressSerializedBlock(const char* data, size_t size,
-                                 CompressionType type,
-                                 Decompressor& decompressor,
-                                 BlockContents* out_contents,
-                                 const ImmutableOptions& ioptions,
-                                 MemoryAllocator* allocator = nullptr);
+Status DecompressSerializedBlock(
+    const char* data, size_t size, CompressionType type,
+    Decompressor& decompressor, BlockContents* out_contents,
+    const ImmutableOptions& ioptions, MemoryAllocator* allocator = nullptr,
+    RetainedBlockBufferProvider* block_buffer_provider = nullptr);
 
-Status DecompressSerializedBlock(Decompressor::Args& args,
-                                 Decompressor& decompressor,
-                                 BlockContents* out_contents,
-                                 const ImmutableOptions& ioptions,
-                                 MemoryAllocator* allocator = nullptr);
+Status DecompressSerializedBlock(
+    Decompressor::Args& args, Decompressor& decompressor,
+    BlockContents* out_contents, const ImmutableOptions& ioptions,
+    MemoryAllocator* allocator = nullptr,
+    RetainedBlockBufferProvider* block_buffer_provider = nullptr);
 
 // This is a variant of DecompressSerializedBlock that does not expect a
 // block trailer beyond `size`. (CompressionType is passed in.)
@@ -486,12 +562,14 @@ Status DecompressBlockData(
     const char* data, size_t size, CompressionType type,
     Decompressor& decompressor, BlockContents* out_contents,
     const ImmutableOptions& ioptions, MemoryAllocator* allocator = nullptr,
-    Decompressor::ManagedWorkingArea* working_area = nullptr);
+    Decompressor::ManagedWorkingArea* working_area = nullptr,
+    RetainedBlockBufferProvider* block_buffer_provider = nullptr);
 
-Status DecompressBlockData(Decompressor::Args& args, Decompressor& decompressor,
-                           BlockContents* out_contents,
-                           const ImmutableOptions& ioptions,
-                           MemoryAllocator* allocator = nullptr);
+Status DecompressBlockData(
+    Decompressor::Args& args, Decompressor& decompressor,
+    BlockContents* out_contents, const ImmutableOptions& ioptions,
+    MemoryAllocator* allocator = nullptr,
+    RetainedBlockBufferProvider* block_buffer_provider = nullptr);
 
 // Replace db_host_id contents with the real hostname if necessary
 Status ReifyDbHostIdProperty(Env* env, std::string* db_host_id);

--- a/table/internal_iterator.h
+++ b/table/internal_iterator.h
@@ -20,6 +20,28 @@ namespace ROCKSDB_NAMESPACE {
 
 class PinnedIteratorsManager;
 
+struct PinnedIterKeyValue {
+  Slice key;
+  Slice user_key;
+  Slice value;
+  SharedCleanablePtr cleanup;
+  const void* cleanup_dedupe_token = nullptr;
+  bool key_pinned = false;
+  bool value_pinned = false;
+  size_t pinned_block_cache_usage = 0;
+
+  void Reset() {
+    key.clear();
+    user_key.clear();
+    value.clear();
+    cleanup.Reset();
+    cleanup_dedupe_token = nullptr;
+    key_pinned = false;
+    value_pinned = false;
+    pinned_block_cache_usage = 0;
+  }
+};
+
 template <class TValue>
 class InternalIteratorBase : public Cleanable {
  public:
@@ -177,8 +199,26 @@ class InternalIteratorBase : public Cleanable {
   // REQUIRES: Same as for value().
   virtual bool IsValuePinned() const { return false; }
 
+  virtual Status PinCurrentKeyValue(PinnedIterKeyValue* out) {
+    if (out != nullptr) {
+      out->Reset();
+    }
+    return Status::NotSupported("PinCurrentKeyValue is not supported");
+  }
+
   virtual Status GetProperty(std::string /*prop_name*/, std::string* /*prop*/) {
     return Status::NotSupported("");
+  }
+
+  virtual Status SetMutableOptions(const IteratorMutableOptions& /*options*/) {
+    return Status::NotSupported("SetMutableOptions is not supported");
+  }
+
+  virtual Status GetMutableOptions(IteratorMutableOptions* options) const {
+    if (options == nullptr) {
+      return Status::InvalidArgument("IteratorMutableOptions is nullptr");
+    }
+    return Status::NotSupported("GetMutableOptions is not supported");
   }
 
   // When iterator moves from one file to another file at same level, new file's

--- a/table/iterator.cc
+++ b/table/iterator.cc
@@ -30,6 +30,32 @@ Status Iterator::GetProperty(std::string prop_name, std::string* prop) {
   return Status::InvalidArgument("Unidentified property.");
 }
 
+Status Iterator::PinCurrent(PinnableKeyValue* out) {
+  if (out == nullptr) {
+    return Status::InvalidArgument("PinnableKeyValue is nullptr");
+  }
+  out->Reset();
+  return Status::NotSupported("PinCurrent is not supported");
+}
+
+Status Iterator::AppendPinnedCurrent(PinnableKeyValueBatch* batch) {
+  if (batch == nullptr) {
+    return Status::InvalidArgument("PinnableKeyValueBatch is nullptr");
+  }
+  return Status::NotSupported("AppendPinnedCurrent is not supported");
+}
+
+Status Iterator::SetMutableOptions(const IteratorMutableOptions& /*options*/) {
+  return Status::NotSupported("SetMutableOptions is not supported");
+}
+
+Status Iterator::GetMutableOptions(IteratorMutableOptions* options) const {
+  if (options == nullptr) {
+    return Status::InvalidArgument("IteratorMutableOptions is nullptr");
+  }
+  return Status::NotSupported("GetMutableOptions is not supported");
+}
+
 namespace {
 class EmptyIterator : public Iterator {
  public:

--- a/table/iterator_wrapper.h
+++ b/table/iterator_wrapper.h
@@ -176,6 +176,11 @@ class IteratorWrapperBase {
     return iter_->IsValuePinned();
   }
 
+  Status PinCurrentKeyValue(PinnedIterKeyValue* out) {
+    assert(Valid());
+    return iter_->PinCurrentKeyValue(out);
+  }
+
   bool IsValuePrepared() const { return result_.value_prepared; }
 
   Slice user_key() const {

--- a/table/merging_iterator.cc
+++ b/table/merging_iterator.cc
@@ -483,6 +483,11 @@ class MergingIterator : public InternalIterator {
            current_->IsValuePinned();
   }
 
+  Status PinCurrentKeyValue(PinnedIterKeyValue* out) override {
+    assert(Valid());
+    return current_->PinCurrentKeyValue(out);
+  }
+
   void Prepare(const MultiScanArgs* scan_opts) override {
     for (auto& child : children_) {
       child.iter.Prepare(scan_opts);

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -78,6 +78,7 @@
 #include "test_util/testutil.h"
 #include "test_util/transaction_test_util.h"
 #include "tools/simulated_hybrid_file_system.h"
+#include "util/aligned_buffer.h"
 #include "util/cast_util.h"
 #include "util/compression.h"
 #include "util/crc32c.h"
@@ -754,6 +755,15 @@ DEFINE_bool(separate_key_value_in_data_block,
             ROCKSDB_NAMESPACE::BlockBasedTableOptions()
                 .separate_key_value_in_data_block,
             "If true, data blocks store keys and values separately.");
+
+DEFINE_bool(use_retained_block_buffer_provider, false,
+            "If true, configure BlockBasedTableOptions.block_buffer_provider "
+            "for retained iterator data-block buffers.");
+
+DEFINE_string(
+    iterator_pinned_block_backing_policy, "auto",
+    "Mutable iterator pinned-block backing policy: auto, block_cache, or "
+    "retained_block_buffer.");
 
 DEFINE_int64(prepopulate_block_cache, 0,
              "Pre-populate hot/warm blocks in block cache. 0 to disable, 1 "
@@ -1990,6 +2000,66 @@ static Status CreateMemTableRepFactory(
     }
   }
   return s;
+}
+
+class DbBenchRetainedBlockBufferProvider : public RetainedBlockBufferProvider {
+ public:
+  Status Allocate(size_t size, size_t alignment, Lease* out) override {
+    if (out == nullptr) {
+      return Status::InvalidArgument("lease output is nullptr");
+    }
+    if (alignment == 0 || (alignment & (alignment - 1)) != 0) {
+      return Status::InvalidArgument("alignment must be a power of two");
+    }
+
+    auto* allocation = new Allocation();
+    allocation->storage.Alignment(alignment);
+    allocation->storage.AllocateNewBuffer(size);
+
+    out->data = allocation->storage.BufferStart();
+    out->size = size;
+    out->cleanup.Allocate();
+    out->cleanup->RegisterCleanup(&ReleaseAllocation, allocation, nullptr);
+    out->dedupe_token = allocation;
+    return Status::OK();
+  }
+
+ private:
+  struct Allocation {
+    AlignedBuffer storage;
+  };
+
+  static void ReleaseAllocation(void* arg1, void* /*arg2*/) {
+    delete static_cast<Allocation*>(arg1);
+  }
+};
+
+std::shared_ptr<RetainedBlockBufferProvider>
+NewDbBenchRetainedBlockBufferProvider() {
+  return std::make_shared<DbBenchRetainedBlockBufferProvider>();
+}
+
+void ConfigureIteratorPinnedBlockBacking(ReadOptions* read_options) {
+  assert(read_options != nullptr);
+
+  if (FLAGS_iterator_pinned_block_backing_policy == "auto") {
+    return;
+  }
+
+  PinnedBlockBackingConfig config;
+  if (FLAGS_iterator_pinned_block_backing_policy == "block_cache") {
+    config.policy = PinnedBlockBackingPolicy::kUseBlockCache;
+  } else if (FLAGS_iterator_pinned_block_backing_policy ==
+             "retained_block_buffer") {
+    config.policy = PinnedBlockBackingPolicy::kUseRetainedBlockBuffer;
+  } else {
+    fprintf(stderr, "Unknown iterator_pinned_block_backing_policy: %s\n",
+            FLAGS_iterator_pinned_block_backing_policy.c_str());
+    db_bench_exit(1);
+  }
+
+  read_options->iterator_mutable_options.pinned_block_backing =
+      std::move(config);
 }
 
 }  // namespace
@@ -3688,6 +3758,7 @@ class Benchmark {
       read_options_.auto_readahead_size = FLAGS_auto_readahead_size;
       read_options_.auto_refresh_iterator_with_snapshot =
           FLAGS_auto_refresh_iterator_with_snapshot;
+      ConfigureIteratorPinnedBlockBacking(&read_options_);
       if (FLAGS_use_trie_index && udi_factory_) {
         read_options_.table_index_factory = udi_factory_.get();
       }
@@ -4717,6 +4788,12 @@ class Benchmark {
       if (cache_ == nullptr) {
         block_based_options.no_block_cache = true;
       }
+      if (FLAGS_use_retained_block_buffer_provider ||
+          FLAGS_iterator_pinned_block_backing_policy ==
+              "retained_block_buffer") {
+        block_based_options.block_buffer_provider =
+            NewDbBenchRetainedBlockBufferProvider();
+      }
       block_based_options.cache_index_and_filter_blocks =
           FLAGS_cache_index_and_filter_blocks;
       block_based_options.pin_l0_filter_and_index_blocks_in_cache =
@@ -5136,6 +5213,12 @@ class Benchmark {
         // nullptr), and our regression tests assume this will be the shared
         // block cache, even with OPTIONS file provided.
         table_options->block_cache = cache_;
+      }
+      if (FLAGS_use_retained_block_buffer_provider ||
+          FLAGS_iterator_pinned_block_backing_policy ==
+              "retained_block_buffer") {
+        table_options->block_buffer_provider =
+            NewDbBenchRetainedBlockBufferProvider();
       }
       if (table_options->filter_policy == nullptr) {
         if (FLAGS_bloom_bits < 0) {

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -496,6 +496,8 @@ default_params = {
     # TODO(jaykorean): Change to lambda: random.choice([0, 1]) after addressing all remote compaction failures
     "remote_compaction_failure_fall_back_to_local": 1,
     "auto_refresh_iterator_with_snapshot": lambda: random.choice([0, 1]),
+    "use_retained_block_buffer_provider": lambda: random.choice([0, 0, 0, 1]),
+    "test_iterator_pin_current_one_in": lambda: random.choice([0, 4, 16, 100]),
     "memtable_op_scan_flush_trigger": lambda: random.choice([0, 10, 100, 1000]),
     "memtable_avg_op_scan_flush_trigger": lambda: random.choice([0, 2, 20, 200]),
     "min_tombstones_for_range_conversion": lambda: random.choice([0, 2, 2, 4, 16]),

--- a/unreleased_history/public_api_changes/iterator_pin_current_retained_buffers.md
+++ b/unreleased_history/public_api_changes/iterator_pin_current_retained_buffers.md
@@ -1,0 +1,1 @@
+Added `Iterator::PinCurrent()` and `Iterator::AppendPinnedCurrent()` APIs for obtaining self-contained current key/value results. Added `Iterator::SetMutableOptions()` / `GetMutableOptions()`, `IteratorMutableOptions`, `PinnedBlockBackingPolicy`, and `BlockBasedTableOptions::block_buffer_provider` for selecting block-cache or retained block-buffer backing for iterator pinning.

--- a/util/aligned_buffer.h
+++ b/util/aligned_buffer.h
@@ -10,10 +10,13 @@
 
 #include <algorithm>
 #include <cassert>
+#include <functional>
 
 #include "port/malloc.h"
 #include "port/port.h"
+#include "rocksdb/cleanable.h"
 #include "rocksdb/file_system.h"
+#include "rocksdb/status.h"
 namespace ROCKSDB_NAMESPACE {
 
 // This file contains utilities to handle the alignment of pages and buffers.
@@ -41,6 +44,45 @@ inline size_t Roundup(size_t x, size_t y) { return ((x + y - 1) / y) * y; }
 //   Rounddown(201, 16) => 192
 inline size_t Rounddown(size_t x, size_t y) { return (x / y) * y; }
 
+struct RetainedBufferAllocation {
+  char* data = nullptr;
+  size_t size = 0;
+  SharedCleanablePtr cleanup;
+  const void* dedupe_token = nullptr;
+
+  void Reset() {
+    data = nullptr;
+    size = 0;
+    cleanup.Reset();
+    dedupe_token = nullptr;
+  }
+};
+
+class RetainedBufferAllocator {
+ public:
+  using AllocateFunction = Status (*)(void* state, size_t size,
+                                      size_t alignment,
+                                      RetainedBufferAllocation* out);
+
+  RetainedBufferAllocator() = default;
+  RetainedBufferAllocator(void* state, AllocateFunction allocate)
+      : state_(state), allocate_(allocate) {
+    assert(allocate_ != nullptr);
+  }
+
+  bool IsSet() const { return allocate_ != nullptr; }
+
+  Status Allocate(size_t size, size_t alignment,
+                  RetainedBufferAllocation* out) const {
+    assert(allocate_ != nullptr);
+    return allocate_(state_, size, alignment, out);
+  }
+
+ private:
+  void* state_ = nullptr;
+  AllocateFunction allocate_ = nullptr;
+};
+
 // AlignedBuffer manages a buffer by taking alignment into consideration, and
 // aligns the buffer start and end positions. It is mainly used for direct I/O,
 // though it can be used other purposes as well.
@@ -61,6 +103,9 @@ class AlignedBuffer {
   size_t capacity_;
   size_t cursize_;
   char* bufstart_;
+  SharedCleanablePtr retained_cleanup_;
+  const void* retained_dedupe_token_ = nullptr;
+  size_t retained_backing_size_ = 0;
 
  public:
   AlignedBuffer()
@@ -74,6 +119,14 @@ class AlignedBuffer {
     capacity_ = std::move(o.capacity_);
     cursize_ = std::move(o.cursize_);
     bufstart_ = std::move(o.bufstart_);
+    retained_cleanup_ = std::move(o.retained_cleanup_);
+    retained_dedupe_token_ = o.retained_dedupe_token_;
+    retained_backing_size_ = o.retained_backing_size_;
+    o.capacity_ = 0;
+    o.cursize_ = 0;
+    o.bufstart_ = nullptr;
+    o.retained_dedupe_token_ = nullptr;
+    o.retained_backing_size_ = 0;
     return *this;
   }
 
@@ -99,9 +152,33 @@ class AlignedBuffer {
 
   char* BufferStart() { return bufstart_; }
 
+  bool HasRetainedBuffer() const { return retained_cleanup_.get() != nullptr; }
+
+  const SharedCleanablePtr& retained_cleanup() const {
+    return retained_cleanup_;
+  }
+
+  const void* retained_dedupe_token() const { return retained_dedupe_token_; }
+
+  size_t retained_backing_size() const { return retained_backing_size_; }
+
   void Clear() { cursize_ = 0; }
 
   FSAllocationPtr Release() {
+    if (retained_cleanup_.get() != nullptr) {
+      SharedCleanablePtr cleanup = retained_cleanup_;
+      retained_cleanup_.Reset();
+      retained_dedupe_token_ = nullptr;
+      retained_backing_size_ = 0;
+      void* raw = buf_.release();
+      cursize_ = 0;
+      capacity_ = 0;
+      bufstart_ = nullptr;
+      // The retained provider owns the bytes. Keep a cleanup reference in the
+      // returned FSAllocationPtr so users can treat it like an owned buffer.
+      return FSAllocationPtr(raw,
+                             [cleanup](void*) mutable { cleanup.Reset(); });
+    }
     cursize_ = 0;
     capacity_ = 0;
     bufstart_ = nullptr;
@@ -123,6 +200,9 @@ class AlignedBuffer {
     capacity_ = result.size();
     cursize_ = result.size();
     buf_ = std::move(new_buf);
+    retained_cleanup_.Reset();
+    retained_dedupe_token_ = nullptr;
+    retained_backing_size_ = 0;
     assert(buf_.get() != nullptr);
     // Note: bufstart_ must point to result.data() and not new_buf, which can
     // point to any arbitrary object
@@ -172,11 +252,60 @@ class AlignedBuffer {
 
     bufstart_ = new_bufstart;
     capacity_ = new_capacity;
+    retained_cleanup_.Reset();
+    retained_dedupe_token_ = nullptr;
+    retained_backing_size_ = 0;
     // buf_ is a FSAllocationPtr which takes in a deleter
     // we can just wrap the regular default delete that would have been called
     buf_ = std::unique_ptr<void, std::function<void(void*)>>(
         static_cast<void*>(new_buf),
         [](void* p) { delete[] static_cast<char*>(p); });
+  }
+
+  Status AllocateNewBuffer(size_t requested_capacity,
+                           const RetainedBufferAllocator& allocator,
+                           bool copy_data = false, uint64_t copy_offset = 0,
+                           size_t copy_len = 0) {
+    assert(alignment_ > 0);
+    assert((alignment_ & (alignment_ - 1)) == 0);
+
+    copy_len = copy_len > 0 ? copy_len : cursize_;
+    if (copy_data && requested_capacity < copy_len) {
+      // Match AllocateNewBuffer(): retain the old buffer as-is.
+      return Status::OK();
+    }
+
+    const size_t new_capacity = Roundup(requested_capacity, alignment_);
+    RetainedBufferAllocation allocation;
+    Status s = allocator.Allocate(new_capacity, alignment_, &allocation);
+    if (!s.ok()) {
+      return s;
+    }
+    if (allocation.data == nullptr || allocation.size < new_capacity ||
+        allocation.cleanup.get() == nullptr) {
+      return Status::InvalidArgument(
+          "Retained buffer allocator returned an invalid allocation");
+    }
+    if (!isAligned(allocation.data, alignment_)) {
+      return Status::InvalidArgument(
+          "Retained buffer allocator returned a misaligned allocation");
+    }
+
+    if (copy_data) {
+      assert(bufstart_ + copy_offset + copy_len <= bufstart_ + cursize_);
+      memcpy(allocation.data, bufstart_ + copy_offset, copy_len);
+      cursize_ = copy_len;
+    } else {
+      cursize_ = 0;
+    }
+
+    bufstart_ = allocation.data;
+    capacity_ = new_capacity;
+    buf_ = FSAllocationPtr(static_cast<void*>(allocation.data), [](void*) {});
+    retained_cleanup_ = std::move(allocation.cleanup);
+    retained_dedupe_token_ = allocation.dedupe_token;
+    retained_backing_size_ = allocation.size;
+    return Status::OK();
   }
 
   // Append to the buffer.

--- a/util/cleanable.cc
+++ b/util/cleanable.cc
@@ -162,6 +162,10 @@ Cleanable* SharedCleanablePtr::get() {
   return ptr_;  // implicit upcast
 }
 
+const Cleanable* SharedCleanablePtr::get() const {
+  return ptr_;  // implicit upcast
+}
+
 void SharedCleanablePtr::RegisterCopyWith(Cleanable* target) {
   if (ptr_) {
     // "Virtual" copy of the pointer

--- a/util/io_dispatcher_imp.cc
+++ b/util/io_dispatcher_imp.cc
@@ -44,13 +44,66 @@ struct IODispatcherImplData {
   virtual void ReleaseMemory(size_t bytes) = 0;
 };
 
+static Status ValidateRetainedBufferAllocation(
+    size_t requested_size, size_t requested_alignment,
+    const RetainedBufferAllocation& allocation) {
+  if (allocation.data == nullptr || allocation.size < requested_size ||
+      allocation.cleanup.get() == nullptr) {
+    return Status::InvalidArgument(
+        "RetainedBlockBufferProvider returned an invalid lease");
+  }
+  if (requested_alignment > 1 && (reinterpret_cast<uintptr_t>(allocation.data) &
+                                  (requested_alignment - 1)) != 0) {
+    return Status::InvalidArgument(
+        "RetainedBlockBufferProvider returned a misaligned lease");
+  }
+  return Status::OK();
+}
+
+static Status AllocateRetainedBuffer(
+    size_t size, size_t alignment,
+    RetainedBlockBufferProvider* block_buffer_provider,
+    RetainedBufferAllocation* out) {
+  assert(block_buffer_provider != nullptr);
+  assert(out != nullptr);
+  RetainedBlockBufferProvider::Lease lease;
+  Status s = block_buffer_provider->Allocate(size, alignment, &lease);
+  if (!s.ok()) {
+    return s;
+  }
+
+  out->data = lease.data;
+  out->size = lease.size;
+  out->cleanup = std::move(lease.cleanup);
+  out->dedupe_token = lease.dedupe_token;
+  if (Status validate_status =
+          ValidateRetainedBufferAllocation(size, alignment, *out);
+      !validate_status.ok()) {
+    return validate_status;
+  }
+  return Status::OK();
+}
+
+static Status AllocateRetainedBufferForAlignedBuffer(
+    void* state, size_t size, size_t alignment, RetainedBufferAllocation* out) {
+  auto* block_buffer_provider =
+      static_cast<RetainedBlockBufferProvider*>(state);
+  assert(block_buffer_provider != nullptr);
+  return AllocateRetainedBuffer(size, alignment, block_buffer_provider, out);
+}
+
 // Helper function to create and pin a block from a buffer
 // Used by both ReadSet::PollAndProcessAsyncIO and IODispatcherImpl::Impl
 static Status CreateAndPinBlockFromBuffer(
     const std::shared_ptr<IOJob>& job, const BlockHandle& block,
     uint64_t buffer_start_offset, const Slice& buffer_data,
+    const SharedCleanablePtr& read_buffer_cleanup,
+    const void* read_buffer_cleanup_dedupe_token,
     CachableEntry<Block>& pinned_block_entry) {
   auto* rep = job->table->get_rep();
+  const bool use_block_cache_for_data_blocks =
+      ShouldUseBlockCacheForIteratorDataBlocks(rep->table_options,
+                                               job->job_options.read_options);
 
   // Get decompressor
   UnownedPtr<Decompressor> decompressor = rep->decompressor.get();
@@ -71,20 +124,59 @@ static Status CreateAndPinBlockFromBuffer(
   const auto block_size_with_trailer =
       BlockBasedTable::BlockSizeWithTrailer(block);
   const auto block_offset_in_buffer = block.offset() - buffer_start_offset;
+  const char* block_data = buffer_data.data() + block_offset_in_buffer;
 
-  CacheAllocationPtr data = AllocateBlock(
-      block_size_with_trailer, GetMemoryAllocator(rep->table_options));
-  memcpy(data.get(), buffer_data.data() + block_offset_in_buffer,
-         block_size_with_trailer);
-  BlockContents tmp_contents(std::move(data), block.size());
+  if (use_block_cache_for_data_blocks) {
+    CacheAllocationPtr data = AllocateBlock(
+        block_size_with_trailer, GetMemoryAllocator(rep->table_options));
+    memcpy(data.get(), block_data, block_size_with_trailer);
+    BlockContents tmp_contents(std::move(data), block.size());
 
 #ifndef NDEBUG
-  tmp_contents.has_trailer = rep->footer.GetBlockTrailerSize() > 0;
+    tmp_contents.has_trailer = rep->footer.GetBlockTrailerSize() > 0;
 #endif
 
-  return job->table->CreateAndPinBlockInCache<Block_kData>(
-      job->job_options.read_options, block, decompressor, &tmp_contents,
-      &pinned_block_entry.As<Block_kData>());
+    return job->table->CreateAndPinBlockInCache<Block_kData>(
+        job->job_options.read_options, block, decompressor, &tmp_contents,
+        &pinned_block_entry.As<Block_kData>());
+  }
+
+  BlockContents tmp_contents;
+  const CompressionType compression_type =
+      BlockBasedTable::GetBlockCompressionType(block_data, block.size());
+  RetainedBlockBufferProvider* block_buffer_provider =
+      GetRetainedBlockBufferProvider(rep->table_options,
+                                     job->job_options.read_options);
+  Status s;
+  if (compression_type == kNoCompression) {
+    if (read_buffer_cleanup.get() != nullptr) {
+      tmp_contents.data = Slice(block_data, block.size());
+      tmp_contents.SetRetainedBacking(SharedCleanablePtr(read_buffer_cleanup),
+                                      read_buffer_cleanup_dedupe_token,
+                                      block_size_with_trailer);
+#ifndef NDEBUG
+      tmp_contents.has_trailer = rep->footer.GetBlockTrailerSize() > 0;
+#endif
+    } else {
+      s = CopyBufferToOwnedBlockContents(
+          Slice(block_data, block_size_with_trailer), block.size(),
+          GetMemoryAllocator(rep->table_options), block_buffer_provider,
+          &tmp_contents);
+    }
+  } else {
+    s = DecompressSerializedBlock(block_data, block.size(), compression_type,
+                                  *decompressor, &tmp_contents, rep->ioptions,
+                                  GetMemoryAllocator(rep->table_options),
+                                  block_buffer_provider);
+  }
+  if (!s.ok()) {
+    return s;
+  }
+
+  std::unique_ptr<Block_kData> block_holder;
+  rep->create_context.Create(&block_holder, std::move(tmp_contents));
+  pinned_block_entry.As<Block_kData>().SetOwnedValue(std::move(block_holder));
+  return Status::OK();
 }
 
 // State for async IO operations (implementation detail)
@@ -97,6 +189,7 @@ struct AsyncIOState {
   AsyncIOState(AsyncIOState&&) = default;
   AsyncIOState& operator=(AsyncIOState&&) = default;
 
+  RetainedBufferAllocation retained_buf;
   std::unique_ptr<char[]> buf;
   AlignedBuf aligned_buf;
   void* io_handle = nullptr;
@@ -320,15 +413,22 @@ Status ReadSet::PollAndProcessAsyncIO(
   // Use the result slice from the callback which has been correctly set
   // with any necessary alignment adjustments for direct IO
   const Slice& buffer_data = async_state->read_req.result;
+  SharedCleanablePtr read_buffer_cleanup;
+  const void* read_buffer_cleanup_dedupe_token = nullptr;
+  if (async_state->retained_buf.cleanup.get() != nullptr) {
+    read_buffer_cleanup = std::move(async_state->retained_buf.cleanup);
+    read_buffer_cleanup_dedupe_token = async_state->retained_buf.dedupe_token;
+  }
 
   // Process all blocks in this async request
   for (size_t i = 0; i < async_state->block_indices.size(); ++i) {
     const size_t idx = async_state->block_indices[i];
     const auto& block_handle = async_state->blocks[i];
 
-    Status s =
-        CreateAndPinBlockFromBuffer(job_, block_handle, async_state->offset,
-                                    buffer_data, pinned_blocks_[idx]);
+    Status s = CreateAndPinBlockFromBuffer(
+        job_, block_handle, async_state->offset, buffer_data,
+        read_buffer_cleanup, read_buffer_cleanup_dedupe_token,
+        pinned_blocks_[idx]);
     if (!s.ok()) {
       return s;
     }
@@ -356,6 +456,9 @@ Status ReadSet::PollAndProcessAsyncIO(
 Status ReadSet::SyncRead(size_t block_index) {
   const auto& block_handle = job_->block_handles[block_index];
   auto* rep = job_->table->get_rep();
+  const bool use_block_cache_for_data_blocks =
+      ShouldUseBlockCacheForIteratorDataBlocks(rep->table_options,
+                                               job_->job_options.read_options);
 
   // Get dictionary-aware decompressor if available
   UnownedPtr<Decompressor> decompressor = rep->decompressor.get();
@@ -376,8 +479,9 @@ Status ReadSet::SyncRead(size_t block_index) {
       /*prefetch_buffer=*/nullptr, job_->job_options.read_options, block_handle,
       decompressor, &pinned_blocks_[block_index].As<Block_kData>(),
       /*get_context=*/nullptr, /*lookup_context=*/nullptr,
-      /*for_compaction=*/false, /*use_cache=*/true,
-      /*async_read=*/false, /*use_block_cache_for_lookup=*/true);
+      /*for_compaction=*/false, /*use_cache=*/use_block_cache_for_data_blocks,
+      /*async_read=*/false,
+      /*use_block_cache_for_lookup=*/use_block_cache_for_data_blocks);
 }
 
 // A pre-coalesced group of blocks for prefetching
@@ -705,9 +809,17 @@ Status IODispatcherImpl::Impl::SubmitJob(const std::shared_ptr<IOJob>& job,
 
   // Step 1: Check cache and pin cached blocks
   std::vector<size_t> block_indices_to_read;
+  const bool use_block_cache_for_data_blocks =
+      ShouldUseBlockCacheForIteratorDataBlocks(
+          job->table->get_rep()->table_options, job->job_options.read_options);
 
   for (size_t i = 0; i < job->block_handles.size(); ++i) {
     const auto& data_block_handle = job->block_handles[i];
+
+    if (!use_block_cache_for_data_blocks) {
+      block_indices_to_read.emplace_back(i);
+      continue;
+    }
 
     // Lookup and pin block in cache
     Status s = job->table->LookupAndPinBlocksInCache<Block_kData>(
@@ -951,6 +1063,25 @@ std::vector<size_t> IODispatcherImpl::Impl::ExecuteAsyncIO(
   }
 
   const bool direct_io = rep->file->use_direct_io();
+  const bool use_block_cache_for_data_blocks =
+      ShouldUseBlockCacheForIteratorDataBlocks(rep->table_options,
+                                               job->job_options.read_options);
+  RetainedBlockBufferProvider* block_buffer_provider =
+      GetRetainedBlockBufferProvider(rep->table_options,
+                                     job->job_options.read_options);
+  const bool use_retained_direct_io = direct_io &&
+                                      !use_block_cache_for_data_blocks &&
+                                      block_buffer_provider != nullptr;
+  const bool use_retained_scratch = !direct_io &&
+                                    !use_block_cache_for_data_blocks &&
+                                    block_buffer_provider != nullptr;
+  RetainedBufferAllocator retained_buffer_allocator;
+  const RetainedBufferAllocator* retained_buffer_allocator_ptr = nullptr;
+  if (use_retained_direct_io) {
+    retained_buffer_allocator = RetainedBufferAllocator(
+        block_buffer_provider, &AllocateRetainedBufferForAlignedBuffer);
+    retained_buffer_allocator_ptr = &retained_buffer_allocator;
+  }
 
   // Submit async read requests and store them in the ReadSet
   for (size_t i = 0; i < read_reqs.size(); ++i) {
@@ -966,6 +1097,15 @@ std::vector<size_t> IODispatcherImpl::Impl::ExecuteAsyncIO(
 
     if (direct_io) {
       async_state->read_req.scratch = nullptr;
+    } else if (use_retained_scratch) {
+      s = AllocateRetainedBuffer(async_state->read_req.len, 1,
+                                 block_buffer_provider,
+                                 &async_state->retained_buf);
+      if (!s.ok()) {
+        *out_status = s;
+        return fallback_block_indices;
+      }
+      async_state->read_req.scratch = async_state->retained_buf.data;
     } else {
       async_state->buf.reset(new char[async_state->read_req.len]);
       async_state->read_req.scratch = async_state->buf.get();
@@ -980,10 +1120,14 @@ std::vector<size_t> IODispatcherImpl::Impl::ExecuteAsyncIO(
       state->read_req.status = req.status;
     };
 
-    s = rep->file->ReadAsync(async_state->read_req, io_opts, cb,
-                             async_state.get(), &async_state->io_handle,
-                             &async_state->del_fn,
-                             direct_io ? &async_state->aligned_buf : nullptr);
+    s = rep->file->ReadAsync(
+        async_state->read_req, io_opts, cb, async_state.get(),
+        &async_state->io_handle, &async_state->del_fn,
+        use_retained_direct_io
+            ? nullptr
+            : (direct_io ? &async_state->aligned_buf : nullptr),
+        /*dbg=*/nullptr, /*direct_io_scratch=*/nullptr,
+        retained_buffer_allocator_ptr, &async_state->retained_buf);
 
     if (s.IsNotSupported()) {
       // Async IO may be compiled in but unavailable at runtime. Fall back to
@@ -1031,13 +1175,39 @@ Status IODispatcherImpl::Impl::ExecuteSyncIO(
   }
 
   const bool direct_io = rep->file->use_direct_io();
+  const bool use_block_cache_for_data_blocks =
+      ShouldUseBlockCacheForIteratorDataBlocks(rep->table_options,
+                                               job->job_options.read_options);
+  RetainedBlockBufferProvider* block_buffer_provider =
+      GetRetainedBlockBufferProvider(rep->table_options,
+                                     job->job_options.read_options);
+  const bool use_retained_scratch = !direct_io &&
+                                    !use_block_cache_for_data_blocks &&
+                                    block_buffer_provider != nullptr;
+  const bool use_retained_direct_io = direct_io &&
+                                      !use_block_cache_for_data_blocks &&
+                                      block_buffer_provider != nullptr;
+
+  std::vector<SharedCleanablePtr> read_req_cleanups;
+  std::vector<const void*> read_req_cleanup_dedupe_tokens;
 
   // Setup scratch buffers for MultiRead
   std::unique_ptr<char[]> buf;
+  std::vector<RetainedBufferAllocation> retained_buffers;
 
   if (direct_io) {
     for (auto& read_req : read_reqs) {
       read_req.scratch = nullptr;
+    }
+  } else if (use_retained_scratch) {
+    retained_buffers.resize(read_reqs.size());
+    for (size_t i = 0; i < read_reqs.size(); ++i) {
+      if (Status s = AllocateRetainedBuffer(
+              read_reqs[i].len, 1, block_buffer_provider, &retained_buffers[i]);
+          !s.ok()) {
+        return s;
+      }
+      read_reqs[i].scratch = retained_buffers[i].data;
     }
   } else {
     // Allocate a single contiguous buffer for all requests
@@ -1053,11 +1223,22 @@ Status IODispatcherImpl::Impl::ExecuteSyncIO(
     }
   }
 
+  RetainedBufferAllocator retained_buffer_allocator;
+  const RetainedBufferAllocator* retained_buffer_allocator_ptr = nullptr;
+  RetainedBufferAllocation multi_read_retained_buffer;
+  if (use_retained_direct_io) {
+    retained_buffer_allocator = RetainedBufferAllocator(
+        block_buffer_provider, &AllocateRetainedBufferForAlignedBuffer);
+    retained_buffer_allocator_ptr = &retained_buffer_allocator;
+  }
+
   // Execute MultiRead
   AlignedBuf aligned_buf;
   if (Status s =
           rep->file->MultiRead(io_opts, read_reqs.data(), read_reqs.size(),
-                               direct_io ? &aligned_buf : nullptr);
+                               direct_io ? &aligned_buf : nullptr,
+                               /*dbg=*/nullptr, retained_buffer_allocator_ptr,
+                               &multi_read_retained_buffer);
       !s.ok()) {
     return s;
   }
@@ -1065,6 +1246,23 @@ Status IODispatcherImpl::Impl::ExecuteSyncIO(
   for (const auto& rq : read_reqs) {
     if (!rq.status.ok()) {
       return rq.status;
+    }
+  }
+
+  if (use_retained_scratch) {
+    read_req_cleanups.resize(read_reqs.size());
+    read_req_cleanup_dedupe_tokens.resize(read_reqs.size(), nullptr);
+    for (size_t i = 0; i < retained_buffers.size(); ++i) {
+      read_req_cleanups[i] = std::move(retained_buffers[i].cleanup);
+      read_req_cleanup_dedupe_tokens[i] = retained_buffers[i].dedupe_token;
+    }
+  } else if (multi_read_retained_buffer.cleanup.get() != nullptr) {
+    read_req_cleanups.resize(read_reqs.size());
+    read_req_cleanup_dedupe_tokens.resize(read_reqs.size(), nullptr);
+    for (size_t i = 0; i < read_reqs.size(); ++i) {
+      read_req_cleanups[i] = multi_read_retained_buffer.cleanup;
+      read_req_cleanup_dedupe_tokens[i] =
+          multi_read_retained_buffer.dedupe_token;
     }
   }
 
@@ -1076,6 +1274,11 @@ Status IODispatcherImpl::Impl::ExecuteSyncIO(
 
       Status create_status = CreateAndPinBlockFromBuffer(
           job, block_handle, read_req.offset, read_req.result,
+          i < read_req_cleanups.size() ? read_req_cleanups[i]
+                                       : SharedCleanablePtr(),
+          i < read_req_cleanup_dedupe_tokens.size()
+              ? read_req_cleanup_dedupe_tokens[i]
+              : nullptr,
           read_set->pinned_blocks_[block_idx]);
       if (!create_status.ok()) {
         return create_status;


### PR DESCRIPTION
## Summary

- Add public `Iterator::PinCurrent()` and `Iterator::AppendPinnedCurrent()` APIs with `PinnableKeyValue` and `PinnableKeyValueBatch` result containers so callers can keep current key/value data valid after iterator movement or destruction.
- Add mutable iterator backing controls through `IteratorMutableOptions`, `PinnedBlockBackingPolicy`, and `Iterator::SetMutableOptions()` / `GetMutableOptions()`, including validation and invalidation when backing settings change.
- Add `RetainedBlockBufferProvider` and `BlockBasedTableOptions::block_buffer_provider` so block-based iterators can pin data blocks without block cache by retaining provider-owned block buffers.
- Plumb retained backing through block fetch/read paths, `BlockContents`, block iterators, random-access direct I/O helpers, async/multiread dispatch, and cache/provider selection logic while preserving the existing block-cache pin path.
- Add unit coverage for cache-backed, copy fallback, retained-provider, compressed-block, invalid-provider, reverse-iteration, blob, wide-column, timestamp, and batch-dedupe cases; add db_bench, db_stress, crash-test, docs, and release-note coverage for the new APIs.

## Test Plan

Not run by me; this pass only generated PR metadata from the already-pushed branch.
