### PR TITLE
Fix check-sources.sh non-ASCII check and remove non-ASCII from sources

### DIFF
--- a/build_tools/check-sources.sh
+++ b/build_tools/check-sources.sh
@@ -37,7 +37,7 @@ if [ "$?" != "1" ]; then
   BAD=1
 fi
 
-git grep -n -P "[\x80-\xFF]" -- ':!docs' ':!*.md'
+LC_ALL=C git grep -n $'[\x80-\xff]' -- ':!docs' ':!*.md' ':!.github'
 if [ "$?" != "1" ]; then
   echo '^^^^ Use only ASCII characters in source files'
   BAD=1

--- a/db/blob/blob_write_batch_transformer.cc
+++ b/db/blob/blob_write_batch_transformer.cc
@@ -278,7 +278,7 @@ Status BlobWriteBatchTransformer::MergeCF(uint32_t column_family_id,
 Status BlobWriteBatchTransformer::PutBlobIndexCF(uint32_t column_family_id,
                                                  const Slice& key,
                                                  const Slice& value) {
-  // Already a blob index — pass through unchanged.
+  // Already a blob index -- pass through unchanged.
   return WriteBatchInternal::PutBlobIndex(output_batch_, column_family_id, key,
                                           value);
 }

--- a/db/blob/blob_write_batch_transformer.h
+++ b/db/blob/blob_write_batch_transformer.h
@@ -35,7 +35,7 @@ struct BlobDirectWriteSettings {
   CompressionType compression_type = kNoCompression;
   // Compression options for newly written blob records.
   CompressionOptions compression_opts;
-  // Raw pointer — the Cache is owned by ColumnFamilyOptions and outlives all
+  // Raw pointer -- the Cache is owned by ColumnFamilyOptions and outlives all
   // settings snapshots. Using raw avoids 2 atomic ref-count ops per Put().
   Cache* blob_cache = nullptr;
   // Blob-cache prepopulation policy for direct-write records.

--- a/db/blob/db_blob_index_test.cc
+++ b/db/blob/db_blob_index_test.cc
@@ -2138,7 +2138,7 @@ TEST_F(DBBlobIndexTest, EntityBlobFilterV3Remove) {
       db_->PutEntity(WriteOptions(), db_->DefaultColumnFamily(), key, columns));
   ASSERT_OK(Flush());
 
-  // Compact to trigger the filter — entity should be removed
+  // Compact to trigger the filter -- entity should be removed
   ASSERT_OK(db_->CompactRange(CompactRangeOptions(), nullptr, nullptr));
 
   // Key should be gone

--- a/db/compaction/compaction_iterator.h
+++ b/db/compaction/compaction_iterator.h
@@ -75,7 +75,7 @@ class CompactionBlobResolver : public WideColumnBlobResolver {
   bool track_resolve_error_ = false;
 
   // Cache for resolved blob values to avoid re-fetching. Uses a vector of
-  // (column_index, PinnableSlice) pairs — typical entities have few blob
+  // (column_index, PinnableSlice) pairs -- typical entities have few blob
   // columns (<5), making linear scan cheaper than hash map overhead.
   std::vector<std::pair<size_t, std::unique_ptr<PinnableSlice>>>
       resolved_cache_;

--- a/db/compaction/compaction_picker_fifo.cc
+++ b/db/compaction/compaction_picker_fifo.cc
@@ -251,7 +251,7 @@ Compaction* FIFOCompactionPicker::PickSizeCompaction(
     // When using blob-aware sizing, use proportional estimation (same
     // principle as EstimateTotalDataForSST): each SST "owns"
     // effective_size / num_files of total data. This is an approximation
-    // — individual SSTs may reference different amounts of blob data,
+    // -- individual SSTs may reference different amounts of blob data,
     // but uniform distribution is a reasonable estimate for FIFO dropping.
     uint64_t remaining_size = effective_size;
     const uint64_t num_files = last_level_files.size();
@@ -477,12 +477,12 @@ Compaction* FIFOCompactionPicker::PickIntraL0Compaction(
     if (fifo_opts.max_data_files_size == 0) {
       ROCKS_LOG_BUFFER(
           log_buffer,
-          "[%s] FIFO kv-ratio compaction: skipping — "
+          "[%s] FIFO kv-ratio compaction: skipping -- "
           "max_data_files_size is 0, cannot compute target file size. ",
           cf_name.c_str());
     } else if (fifo_opts.max_data_files_size < fifo_opts.max_table_files_size) {
       ROCKS_LOG_BUFFER(log_buffer,
-                       "[%s] FIFO kv-ratio compaction: skipping — "
+                       "[%s] FIFO kv-ratio compaction: skipping -- "
                        "max_data_files_size (%" PRIu64
                        ") < max_table_files_size "
                        "(%" PRIu64 ").",
@@ -547,7 +547,7 @@ Compaction* FIFOCompactionPicker::PickRatioBasedIntraL0Compaction(
   for (int level = 1; level < vstorage->num_levels(); ++level) {
     if (!vstorage->LevelFiles(level).empty()) {
       ROCKS_LOG_BUFFER(log_buffer,
-                       "[%s] FIFO kv-ratio compaction: skipping — non-L0 "
+                       "[%s] FIFO kv-ratio compaction: skipping -- non-L0 "
                        "level %d still has %" ROCKSDB_PRIszt
                        " files (migration in progress)",
                        cf_name.c_str(), level,
@@ -587,7 +587,7 @@ Compaction* FIFOCompactionPicker::PickRatioBasedIntraL0Compaction(
   // once per flush or compaction completion, so no caching is needed.
   uint64_t target = 0;
   if (mutable_cf_options.max_compaction_bytes > 0) {
-    // User explicitly set max_compaction_bytes — use it as target
+    // User explicitly set max_compaction_bytes -- use it as target
     target = mutable_cf_options.max_compaction_bytes;
   } else {
     // Auto-calculate from capacity and observed SST/blob ratio
@@ -642,7 +642,7 @@ Compaction* FIFOCompactionPicker::PickRatioBasedIntraL0Compaction(
   //   of linear) write amplification.
 
   // Build tier boundaries from smallest to largest.
-  // Stop at 10KB minimum — SST files of most workloads are larger than
+  // Stop at 10KB minimum -- SST files of most workloads are larger than
   // this, so lower boundaries would only waste CPU scanning L0 files.
   // Files smaller than the lowest boundary simply merge at that boundary.
   static constexpr uint64_t kMinTierBoundary = 10 * 1024;  // 10KB
@@ -651,7 +651,7 @@ Compaction* FIFOCompactionPicker::PickRatioBasedIntraL0Compaction(
     boundaries.push_back(b);
   }
   if (boundaries.empty()) {
-    // target itself is below kMinTierBoundary — use target as the
+    // target itself is below kMinTierBoundary -- use target as the
     // sole boundary so we can still compact at the target size.
     boundaries.push_back(target);
   }
@@ -668,7 +668,7 @@ Compaction* FIFOCompactionPicker::PickRatioBasedIntraL0Compaction(
         continue;
       }
 
-      // Found a file < boundary — collect contiguous batch
+      // Found a file < boundary -- collect contiguous batch
       std::vector<FileMetaData*> batch;
       uint64_t accumulated = 0;
       size_t pos = scan;
@@ -713,7 +713,7 @@ Compaction* FIFOCompactionPicker::PickRatioBasedIntraL0Compaction(
         return c;
       }
 
-      // This batch wasn't enough — advance past it
+      // This batch wasn't enough -- advance past it
       scan = pos;
     }
   }

--- a/db/compaction/compaction_picker_test.cc
+++ b/db/compaction/compaction_picker_test.cc
@@ -1101,7 +1101,7 @@ TEST_F(CompactionPickerTest, ReadTriggeredSkipsLastLevel) {
   Add(0, 1U, "150", "200", kFileSize, 0, 500, 550);
   Add(4, 3U, "301", "350", kFileSize, 0, 101, 150);
 
-  // File 3 is at the last non-empty level — should NOT be marked for
+  // File 3 is at the last non-empty level -- should NOT be marked for
   // read-triggered compaction. Bottommost file cleanup is handled
   // separately by ComputeBottommostFilesMarkedForCompaction().
   file_map_[3U].first->stats.num_collapsible_entry_reads_sampled.store(

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -186,14 +186,14 @@ TEST_F(DBBasicTest,
 }
 
 // When the per-CF log_number actually advances, the per-CF skip must NOT
-// fire — the edit carries real information and must be emitted.
+// fire -- the edit carries real information and must be emitted.
 TEST_F(DBBasicTest, OptimizeManifestForRecoveryEmitsPerCFWhenLogAdvances) {
   Options options = CurrentOptions();
   options.create_if_missing = true;
   options.optimize_manifest_for_recovery = true;
   DestroyAndReopen(options);
   ASSERT_OK(Put("k", "v"));
-  // Write data and close WITHOUT flushing — the WAL has un-replayed
+  // Write data and close WITHOUT flushing -- the WAL has un-replayed
   // records, so on reopen recovery flushes the memtable and the per-CF
   // edit's log_number must advance past the prior WAL.
   Close();
@@ -230,7 +230,7 @@ TEST_F(DBBasicTest, OptimizeManifestForRecoveryPreservesWalTracking) {
 // best_efforts_recovery requires a fresh MANIFEST + CURRENT to be
 // produced on every open (the salvage contract). Even with the option
 // on, none of the SkippedNoopEdit branches must fire under
-// best_efforts_recovery — otherwise CURRENT can be left missing or
+// best_efforts_recovery -- otherwise CURRENT can be left missing or
 // stale (regression caught by DBBasicTest.RecoverWithNoCurrentFile and
 // DBTest2.BestEffortsRecoveryWithSstUniqueIdVerification under an
 // option-on default).
@@ -267,7 +267,7 @@ TEST_F(DBBasicTest, OptimizeManifestForRecoveryMultiCF) {
   ASSERT_OK(Put(1, "k", "v1"));
   ASSERT_OK(Put(2, "k", "v2"));
   ASSERT_OK(Flush(0));
-  // CF 1 and 2 keep dirty memtables — recovery must emit their per-CF
+  // CF 1 and 2 keep dirty memtables -- recovery must emit their per-CF
   // edits (log_number advance from WAL replay).
   Close();
 
@@ -662,7 +662,7 @@ TEST_F(DBBasicTest, ReuseManifestOnOpenStillRotatesOnSizeCap) {
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->ClearAllCallBacks();
 
   // The Flush after Reopen must have triggered a rotation given the
-  // tiny size cap — proves the size-driven rotation path still runs
+  // tiny size cap -- proves the size-driven rotation path still runs
   // when descriptor_log_ is bound by reuse.
   EXPECT_GT(rotations.load(), 0);
   EXPECT_EQ("v", Get("k"));
@@ -685,7 +685,7 @@ TEST_F(DBBasicTest, ReuseManifestOnOpenMultiCF) {
   Close();
 
   ReopenWithColumnFamilies({"default", "alpha", "beta"}, options);
-  // Trigger more writes post-reopen on each CF — these get appended to
+  // Trigger more writes post-reopen on each CF -- these get appended to
   // the reused MANIFEST.
   ASSERT_OK(Put(0, "k2", "v0b"));
   ASSERT_OK(Put(1, "k2", "v1b"));
@@ -777,7 +777,7 @@ TEST_F(DBBasicTest, WritableFileWriterInitialFileSizeAdoptsExistingSize) {
     ASSERT_OK(raw->Close());
   }
 
-  // Reopen and wrap in a WritableFileWriter without initial_file_size —
+  // Reopen and wrap in a WritableFileWriter without initial_file_size --
   // GetFileSize() should be 0 (the constructor's default).
   std::unique_ptr<FSWritableFile> fs_file;
   ASSERT_OK(env->GetFileSystem()->ReopenWritableFile(
@@ -805,7 +805,7 @@ TEST_F(DBBasicTest, WritableFileWriterInitialFileSizeAdoptsExistingSize) {
 }
 
 // Tail corruption: appending garbage bytes to the MANIFEST after a
-// clean close must prevent reuse — the physical size exceeds the
+// clean close must prevent reuse -- the physical size exceeds the
 // last valid record end.
 TEST_F(DBBasicTest, ReuseManifestOnOpenSkipsOnTailCorruption) {
   Options options = CurrentOptions();

--- a/db/db_block_cache_test.cc
+++ b/db/db_block_cache_test.cc
@@ -542,7 +542,7 @@ TEST_F(DBBlockCacheTest, WarmCacheWithDataBlocksDuringCompaction) {
   EXPECT_TRUE(tracking_cache->HasPriority(Cache::Priority::BOTTOM));
   EXPECT_FALSE(tracking_cache->HasPriority(Cache::Priority::LOW));
 
-  // Compaction output is in cache — reads should have zero misses.
+  // Compaction output is in cache -- reads should have zero misses.
   auto data_miss_before =
       options.statistics->getTickerCount(BLOCK_CACHE_DATA_MISS);
   ASSERT_EQ(value + "2", Get("key"));

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -11833,7 +11833,7 @@ TEST_F(DBCompactionTest, RoundRobinCleanCutWithSharedBoundary) {
 // 2. A post-verification step fails (injected here via sync point), setting
 //    compact_->status to error while each subcompaction's status stays OK.
 // 3. SubcompactionState::Cleanup checks individual status (OK) and skips
-//    ReleaseObsolete — the cache entries leak.
+//    ReleaseObsolete -- the cache entries leak.
 // 4. FaultInjectionTestFS injects metadata read errors, causing GetChildren
 //    to fail in FindObsoleteFiles.
 // 5. Close()'s FindObsoleteFiles also fails to find the orphan for the same
@@ -11864,7 +11864,7 @@ TEST_F(DBCompactionTest, LeakedTableCacheEntryOnCompactionFailure) {
   // fail while individual subcompaction statuses stay OK (so Cleanup skips
   // ReleaseObsolete). The filesystem deactivation makes GetChildren fail
   // in FindObsoleteFiles, preventing the backstop from evicting the leaked
-  // cache entries — matching the crash test's metadata read fault injection.
+  // cache entries -- matching the crash test's metadata read fault injection.
   std::atomic<bool> inject_error{true};
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
       "CompactionJob::Run():AfterVerifyOutputFiles", [&](void* arg) {
@@ -11876,7 +11876,7 @@ TEST_F(DBCompactionTest, LeakedTableCacheEntryOnCompactionFailure) {
   // Enable metadata read fault injection on the bg compaction thread after
   // the compaction job finishes but before FindObsoleteFiles runs. This
   // makes GetChildren fail (metadata read), matching crash test's
-  // --open_metadata_read_fault_one_in=8. Only metadata reads fail —
+  // --open_metadata_read_fault_one_in=8. Only metadata reads fail --
   // logging and other IO operations continue normally.
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
       "BackgroundCallCompaction:1", [&](void*) {
@@ -11889,7 +11889,7 @@ TEST_F(DBCompactionTest, LeakedTableCacheEntryOnCompactionFailure) {
 
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
 
-  // Trigger compaction — fails after VerifyOutputFiles.
+  // Trigger compaction -- fails after VerifyOutputFiles.
   Status s = dbfull()->TEST_CompactRange(0, nullptr, nullptr);
   ASSERT_NOK(s);
 
@@ -11971,7 +11971,7 @@ TEST_F(DBCompactionTest, LeakedTableCacheEntryOnInstallFailure) {
 
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
 
-  // Trigger compaction — Run() succeeds but Install() fails.
+  // Trigger compaction -- Run() succeeds but Install() fails.
   Status s = dbfull()->TEST_CompactRange(0, nullptr, nullptr);
   ASSERT_NOK(s);
 
@@ -12032,7 +12032,7 @@ TEST_F(DBCompactionTest, ObsoleteFileTableCacheEntryWithConcurrentRef) {
       TableCache::Lookup(table_cache, target_file_number);
   ASSERT_NE(concurrent_handle, nullptr);
 
-  // Call ReleaseObsolete directly — this is what PurgeObsoleteFiles calls
+  // Call ReleaseObsolete directly -- this is what PurgeObsoleteFiles calls
   // when a file becomes obsolete. Pass nullptr for the handle to make
   // ReleaseObsolete do its own Lookup internally.
   TableCache::ReleaseObsolete(table_cache, target_file_number,

--- a/db/db_flush_test.cc
+++ b/db/db_flush_test.cc
@@ -3883,7 +3883,7 @@ TEST_F(DBFlushTest, LeakedTableCacheEntryOnFlushInstallFailure) {
 
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
 
-  // Trigger flush — BuildTable succeeds but LogAndApply fails.
+  // Trigger flush -- BuildTable succeeds but LogAndApply fails.
   Status s = Flush();
   ASSERT_NOK(s);
 

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -7407,7 +7407,7 @@ Status DBImpl::GetCreationTimeOfOldestFile(uint64_t* creation_time) {
           // For modern DBs, manifest carries file_creation_time and the
           // first call returns the real value. We only need to wait for
           // BGWorkAsyncFileOpen on legacy DBs whose manifest lacks
-          // file_creation_time — those rely on the pinned reader, which is
+          // file_creation_time -- those rely on the pinned reader, which is
           // null until async file open completes.
           if (ctime == 0 && immutable_db_options_.open_files_async) {
             std::call_once(waited_for_async_open, [&]() {

--- a/db/db_impl/db_impl_files.cc
+++ b/db/db_impl/db_impl_files.cc
@@ -1206,7 +1206,7 @@ Status DBImpl::MaybeUpdateNextFileNumber(RecoveryContext* recovery_ctx) {
       normalized_fpath += kFilePathSeparator;
       normalized_fpath.append(fname);
       // Use >= so a crashed-mid-allocation file at exactly
-      // prev_next_file_number triggers the advance — otherwise the next
+      // prev_next_file_number triggers the advance -- otherwise the next
       // NewFileNumber() would collide with it.
       if (number >= prev_next_file_number) {
         on_disk_file_advanced_counter = true;

--- a/db/db_impl/db_impl_secondary.cc
+++ b/db/db_impl/db_impl_secondary.cc
@@ -1553,7 +1553,7 @@ Status DB::OpenAndCompact(
     }
   }
 
-  // 5. Open db As Secondary (skip WAL recovery — remote compaction only
+  // 5. Open db As Secondary (skip WAL recovery -- remote compaction only
   //    needs LSM state from MANIFEST, not memtable data from WAL replay)
   std::unique_ptr<DB> db;
   std::vector<ColumnFamilyHandle*> handles;

--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -623,7 +623,7 @@ bool DBIter::FindNextUserEntryInternal(bool skipping_saved_key) {
               PERF_COUNTER_ADD(internal_delete_skipped_count, 1);
               MarkMemtableForFlushForPerOpTrigger(mem_hidden_op_scanned);
               // Track contiguous tombstones for range conversion.
-              // Skip if outside seek prefix — the top-of-loop check
+              // Skip if outside seek prefix -- the top-of-loop check
               // flushed any pending run, but we must also avoid starting
               // a new run outside the prefix.
               if (min_tombstones_for_range_conversion_ > 0 &&
@@ -1097,7 +1097,7 @@ void DBIter::PrevInternal() {
     if (min_tombstones_for_range_conversion_ > 0 &&
         range_tomb_end_key_.Size() > 0 && timestamp_lb_ == nullptr) {
       if (!valid_ && found_visible && PrefixCheck(saved_key_without_ts)) {
-        // Key was deleted and is within the seek prefix — track it.
+        // Key was deleted and is within the seek prefix -- track it.
         TrackContiguousTombstone(saved_key_.GetUserKey(),
                                  /*always_update_first_key=*/true);
       } else if (valid_) {
@@ -1141,7 +1141,7 @@ void DBIter::PrevInternal() {
 // Sets ikey_ to the last visible entry's internal key.  When found_visible
 // is false, ikey_ is not updated and may contain stale data.
 // Sets found_visible to true if at least one entry passed the IsVisible()
-// check (seqno <= snapshot).  When false, no entry was visible — the key
+// check (seqno <= snapshot).  When false, no entry was visible -- the key
 // does not exist at this snapshot and should not be treated as a tombstone.
 // Returns false if an error occurred, and !status().ok() and !valid_.
 //
@@ -1196,7 +1196,7 @@ bool DBIter::FindValueForCurrentKey(bool& found_visible) {
       break;
     }
 
-    // Entry survived the visibility check — at least one visible version
+    // Entry survived the visibility check -- at least one visible version
     // exists for this user key.
     found_visible = true;
 

--- a/db/db_iter.h
+++ b/db/db_iter.h
@@ -589,7 +589,7 @@ class DBIter final : public Iterator {
 
   // If enough contiguous tombstones have been tracked, insert a range
   // tombstone [first_key, end_key) into the mutable memtable.
-  // end_key is the exclusive upper bound — typically the next live key.
+  // end_key is the exclusive upper bound -- typically the next live key.
   void MaybeInsertRangeTombstone(const Slice& end_key);
   void ResetContiguousTombstoneTracking() {
     contiguous_tombstone_count_ = 0;

--- a/db/db_iterator_test.cc
+++ b/db/db_iterator_test.cc
@@ -4151,7 +4151,7 @@ TEST_P(DBIteratorTest, PrefixSameAsStartSeekToNonInDomainKey) {
   ASSERT_OK(Put("abc2", "v2"));
   ASSERT_OK(Put("abc3", "v3"));
 
-  // Seek to "ab" (2 bytes) — out-of-domain for FixedPrefixTransform(3).
+  // Seek to "ab" (2 bytes) -- out-of-domain for FixedPrefixTransform(3).
   // ShouldSetPrefix returns false for out-of-domain targets, so no prefix
   // constraint is set. The seek should find "abc1" and iteration should
   // proceed without prefix_same_as_start enforcement.
@@ -5820,13 +5820,13 @@ TEST_P(ReadPathRangeTombstoneTest, ExhaustedIteratorWithBounds) {
   // Both directions encounter two tombstone runs (a-d and g-j).
   ASSERT_EQ(attempted_insert_ranges_.size(), 2);
   if (Forward()) {
-    // Forward: sees a-d tombstones first → live e terminates → [a, e).
-    // Then g-j → exhaustion past j, saved_key_="j" fallback → [g, j),
+    // Forward: sees a-d tombstones first -> live e terminates -> [a, e).
+    // Then g-j -> exhaustion past j, saved_key_="j" fallback -> [g, j),
     // covering g,h,i. j remains a point tombstone.
     AssertRange(0, "a", "e");
     AssertRange(1, "g", "j");
   } else {
-    // Reverse: sees j-g tombstones first, then f,e live, then d-a → exhausts.
+    // Reverse: sees j-g tombstones first, then f,e live, then d-a -> exhausts.
     AssertRange(0, "g", "z");
     AssertRange(1, "a", "e");
   }
@@ -5863,8 +5863,8 @@ TEST_P(ReadPathRangeTombstoneTest, ExhaustedIteratorNoBounds) {
   VerifyIteration({"e", "f"});
 
   if (Forward()) {
-    // Forward: a-d run terminates at live e → [a, e). g-j run exhausts
-    // past j → saved_key_ fallback → [g, j), covering g,h,i with j as a
+    // Forward: a-d run terminates at live e -> [a, e). g-j run exhausts
+    // past j -> saved_key_ fallback -> [g, j), covering g,h,i with j as a
     // point tombstone.
     ASSERT_EQ(attempted_insert_ranges_.size(), 2);
     AssertRange(0, "a", "e");
@@ -6061,7 +6061,7 @@ TEST_P(ReadPathRangeTombstoneTest, PrefixFilterDefaultReadOptions) {
 }
 
 TEST_P(ReadPathRangeTombstoneTest, PrefixFilterTotalOrderSeek) {
-  // total_order_seek=true disables prefix filtering — all files visible.
+  // total_order_seek=true disables prefix filtering -- all files visible.
   // The delete run spans from prefix 'b' into prefix 'c', terminated by
   // live key "cb" from L0. The tombstone [ba, cb) crosses prefix boundaries,
   // which is safe because total_order_seek makes all files visible.
@@ -6103,7 +6103,7 @@ TEST_P(ReadPathRangeTombstoneTest, PrefixFilterTotalOrderSeek) {
     ASSERT_OK(Flush());
 
     // Memtable: contiguous deletes spanning prefixes 'b' and 'c'.
-    // No live key between "bb" and "cb" — the run crosses prefix boundaries.
+    // No live key between "bb" and "cb" -- the run crosses prefix boundaries.
     ASSERT_OK(put("aa", "below"));
     ASSERT_OK(del("ba"));
     ASSERT_OK(del("bb"));
@@ -6311,7 +6311,7 @@ TEST_P(ReadPathRangeTombstoneTest, PrefixFilterOutOfDomainSeek) {
   ro.prefix_same_as_start = true;
   auto it = std::unique_ptr<Iterator>(db_->NewIterator(ro));
   if (Forward()) {
-    // Seek with a 1-byte key — out-of-domain for FixedPrefixTransform(4).
+    // Seek with a 1-byte key -- out-of-domain for FixedPrefixTransform(4).
     // prefix_same_as_start cannot set a prefix bound for this target.
     it->Seek("b");
     while (it->Valid()) {
@@ -6674,7 +6674,7 @@ TEST_P(ReadPathRangeTombstoneTest, ExhaustedWithUDT) {
 
   ASSERT_EQ(attempted_insert_ranges_.size(), 1);
   if (Forward()) {
-    // Forward exhaustion past h: saved_key_="h"+ts fallback → [e+ts, h+ts).
+    // Forward exhaustion past h: saved_key_="h"+ts fallback -> [e+ts, h+ts).
     AssertRange(0, std::string("e") + ts, std::string("h") + ts);
   } else {
     // Reverse exhaustion: range is [a+ts, e+ts).
@@ -6687,9 +6687,9 @@ TEST_P(ReadPathRangeTombstoneTest, ExhaustedWithUDT) {
 
 TEST_P(ReadPathRangeTombstoneTest, SeekForPrevTombstone) {
   // SeekForPrev lands directly on tombstones. No upper bound. Forward
-  // exhaustion past h falls back to saved_key_="h" → [e, h), covering
+  // exhaustion past h falls back to saved_key_="h" -> [e, h), covering
   // e,f,g with h as a point tombstone.
-  // Reverse: SeekForPrev("h") → Delete(h,g,f,e) → live "d" → range [e, h).
+  // Reverse: SeekForPrev("h") -> Delete(h,g,f,e) -> live "d" -> range [e, h).
   for (bool use_udt : {false, true}) {
     SCOPED_TRACE(use_udt ? "with UDT" : "without UDT");
     Options options = CurrentOptions();
@@ -6727,7 +6727,7 @@ TEST_P(ReadPathRangeTombstoneTest, SeekForPrevTombstone) {
         keys.push_back(iter->key().ToString());
       }
     } else {
-      // SeekForPrev("h") lands on Delete(h), traverses g,f,e → finds "d".
+      // SeekForPrev("h") lands on Delete(h), traverses g,f,e -> finds "d".
       for (iter->SeekForPrev("h"); iter->Valid(); iter->Prev()) {
         keys.push_back(iter->key().ToString());
       }
@@ -6738,7 +6738,7 @@ TEST_P(ReadPathRangeTombstoneTest, SeekForPrevTombstone) {
 
     ASSERT_EQ(attempted_insert_ranges_.size(), 1);
     if (Forward()) {
-      // Forward exhausts past h → saved_key_="h" fallback → [e, h),
+      // Forward exhausts past h -> saved_key_="h" fallback -> [e, h),
       // covering e,f,g with h as a point tombstone.
       if (use_udt) {
         AssertRange(0, std::string("e") + ts, std::string("h") + ts);
@@ -6761,11 +6761,11 @@ TEST_P(ReadPathRangeTombstoneTest, SeekForPrevTombstone) {
 
 TEST_P(ReadPathRangeTombstoneTest, UpperBoundTombstone) {
   // iterate_upper_bound lands past the data. Both directions see tombstones
-  // e-h. Forward exhausts naturally past h (no key in DB ≥ upper) so the
+  // e-h. Forward exhausts naturally past h (no key in DB >= upper) so the
   // forward path falls back to saved_key_ ("h") as the exclusive end_key,
-  // covering n-1 of n deletes — [e, h). The remaining tombstone for h
+  // covering n-1 of n deletes -- [e, h). The remaining tombstone for h
   // stays as a point delete. Reverse captures the live key "d" before the
-  // run and uses it via range_tomb_end_key_ — [e, i) when SeekToLast
+  // run and uses it via range_tomb_end_key_ -- [e, i) when SeekToLast
   // delegates to SeekForPrev("i").
   for (bool use_udt : {false, true}) {
     SCOPED_TRACE(use_udt ? "with UDT" : "without UDT");
@@ -6837,8 +6837,8 @@ TEST_P(ReadPathRangeTombstoneTest, UpperBoundTombstone) {
 
 TEST_P(ReadPathRangeTombstoneTest, LowerBoundTruncatesReverse) {
   // Keys a-j, delete a-h. Lower bound "e" truncates reverse iteration
-  // mid-tombstone-run. Forward: tombstones e-h ended by live key i → [e, i).
-  // Reverse: tombstones h,g,f,e then lower_bound hit → flush [e, i).
+  // mid-tombstone-run. Forward: tombstones e-h ended by live key i -> [e, i).
+  // Reverse: tombstones h,g,f,e then lower_bound hit -> flush [e, i).
   for (bool use_udt : {false, true}) {
     SCOPED_TRACE(use_udt ? "with UDT" : "without UDT");
     Options options = CurrentOptions();
@@ -6975,14 +6975,14 @@ TEST_P(ReadPathRangeTombstoneTest, InvisibleKeysDontBreakTombstoneRun) {
   ASSERT_OK(Put("f", "vf"));
   ASSERT_OK(Flush());
 
-  // Delete b, d — visible tombstones.
+  // Delete b, d -- visible tombstones.
   ASSERT_OK(Delete("b"));
   ASSERT_OK(Delete("d"));
 
   // Snapshot S.  At S: a(live), b(del), d(del), f(live).
   const Snapshot* snap = db_->GetSnapshot();
 
-  // Write c, e AFTER the snapshot — invisible at S.
+  // Write c, e AFTER the snapshot -- invisible at S.
   // At S the iterator sees: a(live), b(del), c(invis), d(del),
   //   e(invis), f(live).
   ASSERT_OK(Put("c", "vc"));
@@ -6994,7 +6994,7 @@ TEST_P(ReadPathRangeTombstoneTest, InvisibleKeysDontBreakTombstoneRun) {
   VerifyIteration({"a", "f"}, ro);
 
   // Invisible keys c and e should not break the tombstone run.
-  // 2 tombstones (b, d) ≥ threshold → range [b, f).
+  // 2 tombstones (b, d) >= threshold -> range [b, f).
   ASSERT_EQ(attempted_insert_ranges_.size(), 1);
   AssertRange(0, "b", "f");
 

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -8214,7 +8214,7 @@ TEST_P(OpenFilesAsyncTest, GetCreationTimeOfOldestFileSkipsWaitForModernDB) {
   Options options = CurrentOptions();
   ASSERT_NO_FATAL_FAILURE(SetupData(options));
 
-  // If WaitForAsyncFileOpen is entered, the test fails — modern DBs must
+  // If WaitForAsyncFileOpen is entered, the test fails -- modern DBs must
   // never need the wait.
   std::atomic<bool> waited{false};
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(

--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -107,7 +107,7 @@ TEST_F(DBTest2, ReadOnlyDBWalInDbPathInitialized) {
   ASSERT_OK(Put("key2", "value2"));
   Close();
 
-  // Reopen as read-only — wal_in_db_path_ must be properly initialized.
+  // Reopen as read-only -- wal_in_db_path_ must be properly initialized.
   // Before the fix, closing this DB would read an uninitialized bool in
   // DeleteObsoleteFileImpl, which UBSan catches as undefined behavior.
   std::unique_ptr<DB> db_ptr;
@@ -115,7 +115,7 @@ TEST_F(DBTest2, ReadOnlyDBWalInDbPathInitialized) {
   std::string value;
   ASSERT_OK(db_ptr->Get(ReadOptions(), "key1", &value));
   ASSERT_EQ("value1", value);
-  // Close the read-only DB — this triggers PurgeObsoleteFiles which reads
+  // Close the read-only DB -- this triggers PurgeObsoleteFiles which reads
   // wal_in_db_path_. Under UBSan, an uninitialized bool here would fail.
   db_ptr.reset();
 
@@ -8173,7 +8173,7 @@ TEST_F(DBTest2, FastSstOpenDisableAfterMetadataPersisted) {
   ASSERT_EQ(1, test_fs->GetMetadataRetrievedCount());
   db.reset();
 
-  // Reopen with fast_sst_open DISABLED — metadata is in the MANIFEST
+  // Reopen with fast_sst_open DISABLED -- metadata is in the MANIFEST
   // but should NOT be passed to the filesystem
   options.fast_sst_open = false;
   test_fs->ResetCounters();

--- a/db/dbformat_test.cc
+++ b/db/dbformat_test.cc
@@ -218,7 +218,7 @@ TEST_P(IterKeySwapTest, SwapAndDestroy) {
         b_use_secondary] = GetParam();
 
   std::string expected_a, expected_b;
-  // Storage for pinned keys — must outlive the IterKeys.
+  // Storage for pinned keys -- must outlive the IterKeys.
   std::string a_storage, b_storage;
   IterKey a;
   expected_a =
@@ -236,7 +236,7 @@ TEST_P(IterKeySwapTest, SwapAndDestroy) {
     // After swap: a has b's old data, b has a's old data.
     ASSERT_EQ(a.GetUserKey().ToString(), expected_b);
     ASSERT_EQ(b.GetUserKey().ToString(), expected_a);
-  }  // b destroyed here — must not corrupt a's data
+  }  // b destroyed here -- must not corrupt a's data
 
   // a must still hold valid data after b's destruction.
   ASSERT_EQ(a.GetUserKey().ToString(), expected_b);

--- a/db/listener_test.cc
+++ b/db/listener_test.cc
@@ -1696,7 +1696,7 @@ TEST_F(EventListenerTest, BackgroundJobPressure) {
                  Env::Priority::LOW);
   sleeping_task.WaitUntilSleeping();
 
-  // Phase 1: No pressure — 3 SST files (below slowdown trigger=4).
+  // Phase 1: No pressure -- 3 SST files (below slowdown trigger=4).
   for (int i = 0; i < 3; i++) {
     ASSERT_OK(Put("k" + std::to_string(i), std::string(100, 'x')));
     ASSERT_OK(Flush());
@@ -1714,7 +1714,7 @@ TEST_F(EventListenerTest, BackgroundJobPressure) {
   // MaybeScheduleFlushOrCompaction() runs before the pressure callback and
   // may schedule new flush work, making flush counts non-deterministic.
 
-  // Phase 2: Build pressure — flush past slowdown trigger (4 L0 SST files).
+  // Phase 2: Build pressure -- flush past slowdown trigger (4 L0 SST files).
   // Compaction is blocked, so L0 SST files pile up.
   listener->Reset();
   {
@@ -1750,7 +1750,7 @@ TEST_F(EventListenerTest, BackgroundJobPressure) {
   ASSERT_TRUE(found_compaction_scheduled);
   ASSERT_TRUE(found_high_proximity);
 
-  // Phase 3: Relieve pressure — unblock compaction, wait for completion.
+  // Phase 3: Relieve pressure -- unblock compaction, wait for completion.
   listener->Reset();
   sleeping_task.WakeUp();
   sleeping_task.WaitUntilDone();

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -320,7 +320,7 @@ class ReadOnlyMemTable {
   virtual uint64_t ApproximateOldestKeyTime() const = 0;
 
   // Inserts a range tombstone [start_key, end_key) that is logically redundant
-  // — it is derived from existing point tombstones observed during iteration
+  // -- it is derived from existing point tombstones observed during iteration
   // and does not delete any data that isn't already deleted. This is a
   // best-effort optimization. It allows future reads to skip iterating over
   // continuous single deletion tombstones.

--- a/db/version_edit.cc
+++ b/db/version_edit.cc
@@ -30,7 +30,7 @@ PinnedTableReader& PinnedTableReader::operator=(
   TableReader* r = other.reader_.load(std::memory_order_acquire);
   // Only read handle_ when reader_ is non-null. Pin() writes handle_ before
   // reader_ (with release), so a non-null reader_ guarantees handle_ is stable.
-  // If reader_ is null, Pin() may be in progress — avoid reading handle_.
+  // If reader_ is null, Pin() may be in progress -- avoid reading handle_.
   handle_ = (r != nullptr) ? other.handle_ : nullptr;
   reader_.store(r, std::memory_order_release);
   return *this;

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -4217,10 +4217,10 @@ void VersionStorageInfo::ComputeFilesMarkedForReadTriggeredCompaction(
     return;
   }
 
-  // Skip files at the last non-empty level — there is no lower level to
+  // Skip files at the last non-empty level -- there is no lower level to
   // compact into. Exception: L0 files are allowed even when L0 is the last
   // non-empty level, because in single-level universal or FIFO compaction, L0
-  // files can be compacted together (L0 → L0).
+  // files can be compacted together (L0 -> L0).
   int last_non_empty = num_non_empty_levels_ - 1;
 
   for (int level = 0; level < num_levels(); level++) {
@@ -5690,7 +5690,7 @@ Status VersionSet::Close(FSDirectory* db_dir, InstrumentedMutex* mu) {
           content_manifest_name, fs_->OptimizeForManifestRead(file_options_),
           &manifest_file, nullptr);
       if (!content_io_s.ok()) {
-        // Surface I/O errors to the caller — users who call DB::Close() and
+        // Surface I/O errors to the caller -- users who call DB::Close() and
         // check the status should know about filesystem problems.
         s = content_io_s;
         ROCKS_LOG_ERROR(db_options_->info_log,
@@ -5742,7 +5742,7 @@ Status VersionSet::Close(FSDirectory* db_dir, InstrumentedMutex* mu) {
       corrupt_io_s.PermitUncheckedError();
       io_error_info.io_status.PermitUncheckedError();
       if (content_check == 0) {
-        // First check failed — rewrite and verify again
+        // First check failed -- rewrite and verify again
         ROCKS_LOG_ERROR(db_options_->info_log,
                         "MANIFEST content verification on Close failed, "
                         "filename %s, rewriting manifest\n",
@@ -5753,7 +5753,7 @@ Status VersionSet::Close(FSDirectory* db_dir, InstrumentedMutex* mu) {
         s = LogAndApply(cfd, ReadOptions(), WriteOptions(), &recovery_edit, mu,
                         db_dir);
       } else {
-        // Rewritten manifest is also corrupt — likely a recurring filesystem
+        // Rewritten manifest is also corrupt -- likely a recurring filesystem
         // issue. Surface it so DB::Close() callers can detect the problem.
         ROCKS_LOG_ERROR(db_options_->info_log,
                         "MANIFEST content verification on Close failed again "
@@ -6715,7 +6715,7 @@ Status VersionSet::ReopenManifestForAppend(const std::string& manifest_path) {
   FileOptions opt_file_opts = GetFileOptionsForManifestWrite();
 
   // Bail if the on-disk size diverges from what Recover's Reader
-  // consumed — likely a torn tail from a prior crash; mid-block append
+  // consumed -- likely a torn tail from a prior crash; mid-block append
   // would mis-frame the record stream.
   uint64_t physical_size = 0;
   IOStatus stat_s = fs_->GetFileSize(manifest_path, IOOptions(), &physical_size,

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -1726,7 +1726,7 @@ class VersionSet {
   // MANIFEST as before) if ReopenWritableFile fails.
   Status ReopenManifestForAppend(const std::string& manifest_path);
 
-  // FileOptions for MANIFEST writes — applies the FS's
+  // FileOptions for MANIFEST writes -- applies the FS's
   // OptimizeForManifestWrite tuning, then re-applies the user-configured
   // temperature so a custom FS can't override it.
   FileOptions GetFileOptionsForManifestWrite() const;

--- a/db/version_set_test.cc
+++ b/db/version_set_test.cc
@@ -2440,7 +2440,7 @@ TEST_F(VersionSetTest, ManifestContentValidationOnCloseClean) {
   // Verify content validation actually ran
   ASSERT_TRUE(content_validation_ran);
 
-  // No corruption — counter should be zero
+  // No corruption -- counter should be zero
   ASSERT_EQ(0, stats->getTickerCount(MANIFEST_VALIDATION_FAILURE_COUNT));
 
   // Manifest path should be unchanged (no rotation)
@@ -2513,7 +2513,7 @@ TEST_F(VersionSetTest, ManifestContentValidationOnCloseCorruptRecord) {
 
 TEST_F(VersionSetTest, ManifestContentValidationOnCloseDisabled) {
   // Default (option disabled), corrupt manifest after writer close,
-  // verify no rotation occurred — corrupt manifest persists.
+  // verify no rotation occurred -- corrupt manifest persists.
   NewDB();
   auto stats = CreateDBStatistics();
   imm_db_options_.statistics = stats;
@@ -2538,7 +2538,7 @@ TEST_F(VersionSetTest, ManifestContentValidationOnCloseDisabled) {
 
   ASSERT_FALSE(content_validation_ran);
 
-  // Validation disabled — counter should be zero
+  // Validation disabled -- counter should be zero
   ASSERT_EQ(0, stats->getTickerCount(MANIFEST_VALIDATION_FAILURE_COUNT));
 
   // Manifest path should be unchanged (no rotation since validation is off)
@@ -2585,7 +2585,7 @@ TEST_F(VersionSetTest, ManifestContentValidationOnCloseSizeCheckFails) {
   SyncPoint::GetInstance()->DisableProcessing();
 
   // Size check caught the issue; content validation on rewritten manifest
-  // should pass — no content validation failure recorded
+  // should pass -- no content validation failure recorded
   ASSERT_EQ(0, stats->getTickerCount(MANIFEST_VALIDATION_FAILURE_COUNT));
 
   // Size check should have triggered rotation
@@ -2697,7 +2697,7 @@ TEST_F(VersionSetTest, ManifestContentValidationOnCloseOpenFails) {
 
   ASSERT_TRUE(close_s.IsIOError()) << close_s.ToString();
 
-  // File couldn't be opened — no content validation ran
+  // File couldn't be opened -- no content validation ran
   ASSERT_EQ(0, stats->getTickerCount(MANIFEST_VALIDATION_FAILURE_COUNT));
 }
 

--- a/db/wide/db_wide_basic_test.cc
+++ b/db/wide/db_wide_basic_test.cc
@@ -2776,7 +2776,7 @@ TEST_F(DBWideBasicTest, EntityBlobBlockCacheTierGet) {
   // Reopen to clear any caches
   Reopen(options);
 
-  // Read with kBlockCacheTier — blob is not in cache
+  // Read with kBlockCacheTier -- blob is not in cache
   ReadOptions read_opts;
   read_opts.read_tier = kBlockCacheTier;
   PinnableSlice result;
@@ -2998,7 +2998,7 @@ TEST_F(DBWideBasicTest, MergeEntityWithBlobColumnsBlockCacheTier) {
   // Reopen to clear caches
   Reopen(options);
 
-  // Read with kBlockCacheTier — blob not in cache, merge needs blob resolution
+  // Read with kBlockCacheTier -- blob not in cache, merge needs blob resolution
   ReadOptions read_opts;
   read_opts.read_tier = kBlockCacheTier;
   PinnableSlice result;

--- a/db/wide/read_path_blob_resolver.cc
+++ b/db/wide/read_path_blob_resolver.cc
@@ -59,7 +59,7 @@ Status ReadPathBlobResolver::ResolveColumn(size_t column_index,
         blob_resolver_util::FindBlobColumn(blob_columns_, column_index);
 
     if (blob_index_ptr == nullptr) {
-      // Inline column — return the value directly
+      // Inline column -- return the value directly
       *resolved_value = (*columns_)[column_index].value();
     } else {
       // Check if already resolved

--- a/db/wide/wide_column_serialization_test.cc
+++ b/db/wide/wide_column_serialization_test.cc
@@ -391,7 +391,7 @@ static BlobIndex MakeBlobIndex(uint64_t file_number, uint64_t offset,
   return bi;
 }
 
-// Helper: V2 serialize → DeserializeV2 round-trip, returning
+// Helper: V2 serialize -> DeserializeV2 round-trip, returning
 // deserialized columns and blob column info.
 static void V2SerializeAndDeserialize(
     const std::vector<std::pair<std::string, std::string>>& columns,
@@ -798,7 +798,7 @@ TEST_F(WideColumnSerializationTest, RandomizedSerializeDeserializeRoundTrip) {
       }
     }
 
-    // V2 serialize → DeserializeV2 round-trip
+    // V2 serialize -> DeserializeV2 round-trip
     std::string serialized;
     std::vector<WideColumn> deserialized;
     std::vector<std::pair<size_t, BlobIndex>> blob_out;

--- a/db_stress_tool/db_stress_env_wrapper.h
+++ b/db_stress_tool/db_stress_env_wrapper.h
@@ -197,10 +197,10 @@ class DbStressFSWrapper : public FileSystemWrapper {
       assert(!file_opts.file_checksum_func_name.empty());
       if (file_opts.file_checksum_func_name == kUnknownFileChecksumFuncName ||
           file_opts.file_checksum_func_name == kNoFileChecksumFuncName) {
-        // No checksum available — checksum value must be empty
+        // No checksum available -- checksum value must be empty
         assert(file_opts.file_checksum.empty());
       } else {
-        // A real checksum function — checksum value must be present
+        // A real checksum function -- checksum value must be present
         assert(!file_opts.file_checksum.empty());
       }
     }

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -2900,7 +2900,7 @@ class NonBatchedOpsStressTest : public StressTest {
       op_logs += "N";
     }
 
-    // backward scan — skip when backward iteration is not supported
+    // backward scan -- skip when backward iteration is not supported
     if (FLAGS_test_backward_scan) {
       key_str = Key(ub - 1);
       iter->SeekForPrev(key_str);

--- a/env/env_test.cc
+++ b/env/env_test.cc
@@ -1892,7 +1892,7 @@ TEST_F(EnvPosixTest, SupportedOpsNoAsyncIOOnIOUringInitFailure) {
   int64_t thread_supported_ops2 = 0;
   std::thread t([&]() {
     fs->SupportedOps(thread_supported_ops);
-    // Second call on the same thread — cached failure, no retry.
+    // Second call on the same thread -- cached failure, no retry.
     fs->SupportedOps(thread_supported_ops2);
   });
   t.join();
@@ -1903,7 +1903,7 @@ TEST_F(EnvPosixTest, SupportedOpsNoAsyncIOOnIOUringInitFailure) {
   // Second call should also lack kAsyncIO.
   ASSERT_EQ(thread_supported_ops2 & (1 << FSSupportedOps::kAsyncIO), 0);
   ASSERT_NE(thread_supported_ops2 & (1 << FSSupportedOps::kFSPrefetch), 0);
-  // CreateIOUring must have been called exactly once — not retried.
+  // CreateIOUring must have been called exactly once -- not retried.
   ASSERT_EQ(create_count, 1);
 
   SyncPoint::GetInstance()->DisableProcessing();

--- a/file/file_util.cc
+++ b/file/file_util.cc
@@ -221,7 +221,7 @@ IOStatus GenerateOneFileChecksum(
     std::unique_ptr<FSRandomAccessFile> r_file;
     FileOptions fopts = file_options;
     if (fopts.file_checksum.empty()) {
-      // No expected checksum is known — this is a from-scratch computation.
+      // No expected checksum is known -- this is a from-scratch computation.
       fopts.file_checksum_func_name = kNoFileChecksumFuncName;
     }
     io_s = fs->NewRandomAccessFile(file_path, fopts, &r_file, nullptr);

--- a/file/prefetch_test.cc
+++ b/file/prefetch_test.cc
@@ -3899,7 +3899,7 @@ TEST_P(FSBufferPrefetchTest, FSBufferPrefetchStatsInternals) {
                            &result, &s, for_compaction);
   // Platforms that don't have IO uring may not support async IO.
   // With the ReadAsync sync fallback, s will be OK even when async IO is
-  // unavailable — detect by checking if the second buffer has an async read
+  // unavailable -- detect by checking if the second buffer has an async read
   // in progress.
   if (use_async_prefetch && s.IsNotSupported()) {
     return;

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -946,7 +946,7 @@ struct AdvancedColumnFamilyOptions {
   // (estimated_reads / file_size) exceeds this threshold. This helps reduce
   // read amplification for hot keys by compacting frequently-read files.
   //
-  // Only "collapsible" reads are counted — lookups that return NotFound
+  // Only "collapsible" reads are counted -- lookups that return NotFound
   // (bloom filter false positive), Delete/SingleDeletion (tombstone), or
   // Merge (partial result). These are reads where the file contributed no
   // final value and compaction would eliminate the wasted work.
@@ -972,15 +972,15 @@ struct AdvancedColumnFamilyOptions {
   //     r * S * B = 2 * (1 + F) * S
   //     r = 2 * (1 + F) / B
   //
-  //   With F = 10, B = 4096:  r = 22 / 4096 ≈ 0.005.
+  //   With F = 10, B = 4096:  r = 22 / 4096 ~= 0.005.
   //
-  // With a block-cache hit rate h (0 ≤ h < 1), each collapsible read
+  // With a block-cache hit rate h (0 <= h < 1), each collapsible read
   // only costs (1 - h) * B bytes of actual disk IO, so:
   //     r = 2 * (1 + F) / ((1 - h) * B)
   //
-  //   h = 0   → r ≈ 0.005
-  //   h = 0.5 → r ≈ 0.01
-  //   h = 0.9 → r ≈ 0.05
+  //   h = 0   -> r ~= 0.005
+  //   h = 0.5 -> r ~= 0.01
+  //   h = 0.9 -> r ~= 0.05
   //
   // A recommended starting point is 0.01, which avoids triggering
   // compactions that cost more IO than they save for most cache-friendly

--- a/include/rocksdb/compaction_filter.h
+++ b/include/rocksdb/compaction_filter.h
@@ -420,7 +420,7 @@ class CompactionFilter : public Customizable {
 
   // Returns true if the filter overrides FilterV4 and can handle
   // WideColumnBlobResolver (lazy blob loading). When false (default),
-  // FilterV4 delegates to FilterV3 with fully resolved column values —
+  // FilterV4 delegates to FilterV3 with fully resolved column values --
   // blob columns are eagerly fetched before the filter is called, ensuring
   // backward compatibility with FilterV3-only filters.
   //

--- a/include/rocksdb/listener.h
+++ b/include/rocksdb/listener.h
@@ -556,7 +556,7 @@ struct IOErrorInfo {
   uint64_t offset;
 };
 
-// EXPERIMENTAL — under active development, fields may change.
+// EXPERIMENTAL -- under active development, fields may change.
 // Point-in-time snapshot of background job pressure for one DB: how busy
 // compaction and flush are, and how close the DB is to write-stalling.
 struct BackgroundJobPressure {

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -2952,7 +2952,7 @@ struct SizeApproximationOptions {
   // blob file data in the key range. When enabled, the total blob file size
   // is prorated by the ratio of SST data in the range to the total SST data:
   //
-  //   blob_size_in_range ≈ total_blob_size * (sst_in_range / total_sst)
+  //   blob_size_in_range ~= total_blob_size * (sst_in_range / total_sst)
   //
   // Limitations of this approximation:
   // - Assumes blob data is distributed proportionally to SST data, which

--- a/include/rocksdb/user_defined_index.h
+++ b/include/rocksdb/user_defined_index.h
@@ -43,7 +43,7 @@ class UserDefinedIndexBuilder {
     kOther = 3,   // Other types (e.g., blob reference, wide-column entity).
                   // The value format is type-specific and may not be the
                   // actual user data.
-    kTypeMax,     // Sentinel — must be last. Value may change across releases.
+    kTypeMax,     // Sentinel -- must be last. Value may change across releases.
   };
 
   // File offset and size of the data block
@@ -106,7 +106,7 @@ class UserDefinedIndexBuilder {
   // (e.g., trie-based indexes) can leave this as a no-op.
   //
   // @key:   The user key (without sequence number or type suffix).
-  // @type:  The entry type — kValue (Put), kDelete, kMerge, or kOther.
+  // @type:  The entry type -- kValue (Put), kDelete, kMerge, or kOther.
   //         For kDelete entries, the value may be empty. For kOther, the
   //         value format is type-specific and may not be actual user data.
   // @value: The associated value (may be empty for deletions).

--- a/memtable/inlineskiplist_test.cc
+++ b/memtable/inlineskiplist_test.cc
@@ -559,7 +559,7 @@ TEST_F(InlineSkipTest, MultiGetDuplicateKeysWithCallbackWalk) {
   }
 
   // Callback that walks forward through multiple entries before stopping.
-  // This simulates the Merge operand accumulation in SaveValue — the callback
+  // This simulates the Merge operand accumulation in SaveValue -- the callback
   // returns true for entries until it reaches one >= stop_at, simulating
   // walking through merge chain entries.
   struct WalkingCallbackArg {
@@ -1068,11 +1068,11 @@ static void ConcurrentMultiGetWorker(void* arg) {
     // Validate all results: each found result must equal its query key
     // (since all queried keys were inserted, an exact match is expected).
     // However, due to concurrent inserts, a key sampled from the ring
-    // might not yet be visible — so we only check that if a result is
+    // might not yet be visible -- so we only check that if a result is
     // found, it equals the query key (i.e., no wrong key returned).
     for (size_t j = 0; j < batch_size; j++) {
       if (results[j] != 0 && results[j] != query_keys[j]) {
-        // Got a result that doesn't match the query — either a bug or
+        // Got a result that doesn't match the query -- either a bug or
         // the exact key wasn't inserted and we got the next one. Since
         // all our query keys are inserted, this means the result should
         // be >= query. For the just-inserted key we already checked

--- a/port/stack_trace.cc
+++ b/port/stack_trace.cc
@@ -434,14 +434,14 @@ void InstallStackTraceHandler() {
   // Ignore SIGPIPE so that broken-pipe writes (e.g. to a closed stdout)
   // return EPIPE instead of killing the process.
   signal(SIGPIPE, SIG_IGN);
-  // Crash signals — invoke full stack trace + ring buffer
+  // Crash signals -- invoke full stack trace + ring buffer
   signal(SIGILL, StackTraceHandler);
   signal(SIGSEGV, StackTraceHandler);
   signal(SIGBUS, StackTraceHandler);
   signal(SIGABRT, StackTraceHandler);
   signal(SIGFPE, StackTraceHandler);
   signal(SIGQUIT, StackTraceHandler);
-  // Termination signals — print ring buffer only, no stack trace
+  // Termination signals -- print ring buffer only, no stack trace
   signal(SIGTERM, TerminationHandler);
   signal(SIGINT, TerminationHandler);
   atexit(AtExit);

--- a/table/block_based/block_based_table_iterator.cc
+++ b/table/block_based/block_based_table_iterator.cc
@@ -41,7 +41,7 @@ void BlockBasedTableIterator::SeekImpl(const Slice* target,
     return;
   }
 
-  // MultiScan requires an explicit seek key — SeekToFirst() is not supported
+  // MultiScan requires an explicit seek key -- SeekToFirst() is not supported
   if (multi_scan_read_set_ && !target) {
     multi_scan_status_ = Status::InvalidArgument("No seek key for MultiScan");
     RecordTick(table_->GetStatistics(), MULTISCAN_SEEK_ERRORS);
@@ -683,7 +683,7 @@ void BlockBasedTableIterator::FindBlockForward() {
         if (multi_scan_index_iter_ &&
             multi_scan_index_iter_->IsScanRangeExhausted()) {
           if (multi_scan_index_iter_->HasMoreScanRanges()) {
-            // More ranges remain — signal out-of-bound so DBIter/LevelIter
+            // More ranges remain -- signal out-of-bound so DBIter/LevelIter
             // will trigger the next Seek for the next scan range.
             is_out_of_bound_ = true;
           }

--- a/table/block_based/data_block_footer.h
+++ b/table/block_based/data_block_footer.h
@@ -52,7 +52,7 @@ struct DataBlockFooter {
   // limit is adequate because a 4GiB block (maximum due to 32-bit block size)
   // with restart_interval=1 and minimum entries (12 bytes: 3 varint bytes +
   // 9-byte internal key + empty value) plus 4-byte restart offsets = 16 bytes
-  // per restart, fits at most (2^32 - 4) / 16 ≈ 268 million restarts.
+  // per restart, fits at most (2^32 - 4) / 16 ~= 268 million restarts.
   static constexpr uint32_t kMaxNumRestarts = (1u << 28) - 1;
 
   // Maximum encoded length of a DataBlockFooter (for buffer sizing).

--- a/table/block_based/multi_scan_index_iterator.cc
+++ b/table/block_based/multi_scan_index_iterator.cc
@@ -65,7 +65,7 @@ void MultiScanIndexIterator::Seek(const Slice& target) {
 
   // Enforce forward-only seek
   if (!prev_seek_key_.empty() && icomp_.Compare(target, prev_seek_key_) <= 0) {
-    // Seek key is not moving forward — keep current position
+    // Seek key is not moving forward -- keep current position
     return;
   }
   prev_seek_key_ = target.ToString();
@@ -87,11 +87,12 @@ void MultiScanIndexIterator::Seek(const Slice& target) {
   // The following diagram explains different seek targets seeking at various
   // positions on the table, while the next_scan_idx_ points to PreparedRange 2.
   //
-  // next_scan_idx_: ------------------┐
-  //                                   ▼
+  // next_scan_idx_: ------------------+
+  //                                   |
+  //                                   v
   // table:     : __[PreparedRange 1]__[PreparedRange 2]__[PreparedRange 3]__
-  // Seek target: <----- Case 1 ------>▲<------------- Case 2 -------------->
-  //                                   │
+  // Seek target: <----- Case 1 ------>^<------------- Case 2 -------------->
+  //                                   |
   //                                 Case 3
   //
   // Case 1: seek before the start of next prepared range. This could happen
@@ -103,7 +104,7 @@ void MultiScanIndexIterator::Seek(const Slice& target) {
   if (compare_next_scan_start_result < 0) {
     // Case 1: Seek before the start of the next prepared range
     if (next_scan_idx_ == 0) {
-      // Should not happen — seek before first prepared range
+      // Should not happen -- seek before first prepared range
       assert(false && "Seek target before the first prepared range");
       valid_ = false;
       return;
@@ -122,7 +123,7 @@ void MultiScanIndexIterator::Seek(const Slice& target) {
       valid_ = false;
       return;
     }
-    // Seek within a gap — advance to the right scan range and find block
+    // Seek within a gap -- advance to the right scan range and find block
     SeekToBlock(&user_seek_target);
   } else if (compare_next_scan_start_result > 0) {
     // Case 2: Seek after the start of the next prepared range
@@ -220,7 +221,7 @@ void MultiScanIndexIterator::SeekToBlockIdx(size_t block_idx) {
 void MultiScanIndexIterator::SetExhausted() {
   scan_range_exhausted_ = true;
   if (next_scan_idx_ < block_index_ranges_per_scan_.size()) {
-    // More ranges remain — signal out-of-bound for current range.
+    // More ranges remain -- signal out-of-bound for current range.
     valid_ = true;
     // Position at the start of the next range so that the next Seek()
     // can find it. We need to be "valid" so that FindBlockForward sets
@@ -232,7 +233,7 @@ void MultiScanIndexIterator::SetExhausted() {
     }
     valid_ = false;
   } else {
-    // Last range — natural EOF. Don't set out-of-bound so LevelIterator
+    // Last range -- natural EOF. Don't set out-of-bound so LevelIterator
     // advances to the next file.
     valid_ = false;
   }

--- a/table/block_based/multi_scan_index_iterator.h
+++ b/table/block_based/multi_scan_index_iterator.h
@@ -58,7 +58,7 @@ class MultiScanIndexIterator : public InternalIteratorBase<IndexValue> {
   // Move to the first block of the first scan range.
   void SeekToFirst() override;
 
-  // Not supported — sets valid_ = false.
+  // Not supported -- sets valid_ = false.
   void SeekForPrev(const Slice& target) override;
   void SeekToLast() override;
   void Prev() override;

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -8633,7 +8633,7 @@ TEST_P(UserDefinedIndexTest, ValueTypeMappingViaDBFlush) {
   // ValueTypes by writing various operation types via the DB API, flushing,
   // and inspecting what the TestUserDefinedIndexBuilder received.
   if (is_reverse_comparator_) {
-    // Skip for reverse comparator — the key ordering makes this test
+    // Skip for reverse comparator -- the key ordering makes this test
     // unnecessarily complex and the mapping logic is comparator-independent.
     ROCKSDB_GTEST_BYPASS("Skipped for reverse comparator");
     return;
@@ -8735,7 +8735,7 @@ TEST_P(UserDefinedIndexTest, CompactionWithSnapshotsAndUDI) {
   ASSERT_OK(db->Delete(WriteOptions(), "key_bb"));
   ASSERT_OK(db->Flush(FlushOptions()));
 
-  // Compact L0 → L1. With the snapshot held, both versions of key_aa
+  // Compact L0 -> L1. With the snapshot held, both versions of key_aa
   // and the delete tombstone for key_bb must be preserved in the compaction
   // output. The UDI builder receives multiple entries for key_aa.
   ASSERT_OK(db->CompactRange(CompactRangeOptions(), nullptr, nullptr));
@@ -8747,7 +8747,7 @@ TEST_P(UserDefinedIndexTest, CompactionWithSnapshotsAndUDI) {
   const auto& log = user_defined_index_factory->key_type_log_;
   ASSERT_FALSE(log.empty());
 
-  // Count total occurrences of key_aa across all builders — at least 4:
+  // Count total occurrences of key_aa across all builders -- at least 4:
   // flush1 (v1) + flush2 (v2) + compaction (v2, v1).
   int key_aa_count = 0;
   int key_bb_count = 0;

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -1936,7 +1936,7 @@ def execute_cmd(cmd, timeout=None, timeout_pstack=False):
         hit_timeout = True
         if timeout_pstack:
             os.system("pstack %d" % pid)
-        child.terminate()  # SIGTERM — triggers TerminationHandler
+        child.terminate()  # SIGTERM -- triggers TerminationHandler
         try:
             outs, errs = child.communicate(timeout=3)
             print("TERMINATED %d\n" % child.pid)

--- a/tools/run_clang_tidy.py
+++ b/tools/run_clang_tidy.py
@@ -205,7 +205,7 @@ def collect_changed_lines(repo_root, diff_base_arg=None):
         )
         merge_into(all_changed, parse_diff_for_changed_lines(diff_staged))
 
-        # Untracked files — treat every line as changed
+        # Untracked files -- treat every line as changed
         untracked_out, _ = run_cmd(
             ["git", "ls-files", "--others", "--exclude-standard"], cwd=repo_root
         )
@@ -510,7 +510,7 @@ def main():
     jobs = args.jobs or os.cpu_count() or 4
 
     # ------------------------------------------------------------------
-    # Step 1 — detect changes
+    # Step 1 -- detect changes
     # ------------------------------------------------------------------
     log("=" * 70)
     log("Step 1: Detecting changes")
@@ -529,7 +529,7 @@ def main():
         log(f"    {f}  ({len(changed_lines[f])} lines)")
 
     # ------------------------------------------------------------------
-    # Step 2 — select compilable files present in compile_commands.json
+    # Step 2 -- select compilable files present in compile_commands.json
     # ------------------------------------------------------------------
     db_files = load_compile_db(compile_db_path, repo_root)
     cc_changed = sorted(
@@ -549,7 +549,7 @@ def main():
     log("=" * 70)
 
     # ------------------------------------------------------------------
-    # Step 3 — run clang-tidy in parallel via ThreadPoolExecutor
+    # Step 3 -- run clang-tidy in parallel via ThreadPoolExecutor
     # ------------------------------------------------------------------
     all_raw_output = []
     all_filtered = []
@@ -603,7 +603,7 @@ def main():
         log(f"\nFull clang-tidy output saved to {args.output}")
 
     # ------------------------------------------------------------------
-    # Step 4 — report filtered results
+    # Step 4 -- report filtered results
     # ------------------------------------------------------------------
     log(f"\n{'=' * 70}")
     log(f"Step 3: Results  (wall time {wall_time:.1f}s)")

--- a/util/dirty_tracked.h
+++ b/util/dirty_tracked.h
@@ -16,7 +16,7 @@
 namespace ROCKSDB_NAMESPACE {
 
 // Wraps a value of type T and tracks whether it has been mutated since the
-// last Reset(). Reset() short-circuits when the value is not dirty — useful
+// last Reset(). Reset() short-circuits when the value is not dirty -- useful
 // when T::Reset() is non-trivial (allocations, container clears) and the
 // value is rarely populated on a hot path.
 //
@@ -41,7 +41,7 @@ class DirtyTracked {
   const T* operator->() const { return &value_; }
   const T& operator*() const { return value_; }
 
-  // Explicit mutating access — marks dirty, returns a mutable pointer.
+  // Explicit mutating access -- marks dirty, returns a mutable pointer.
   T* mut() {
     dirty_ = true;
     return &value_;

--- a/util/io_dispatcher_imp.cc
+++ b/util/io_dispatcher_imp.cc
@@ -216,7 +216,7 @@ Status ReadSet::ReadIndex(size_t block_index, CachableEntry<Block>* out) {
 
   // Case 3: Block needs synchronous read (pending or never-dispatched blocks).
   // No ReleaseMemory() needed here because blocks reaching this path never had
-  // TryAcquireMemory() called — they were either pending prefetch or skipped
+  // TryAcquireMemory() called -- they were either pending prefetch or skipped
   // during SubmitJob. block_sizes_[block_index] may be > 0 (set during
   // SubmitJob for all uncached blocks) but that does not imply memory was
   // acquired.

--- a/util/io_dispatcher_test.cc
+++ b/util/io_dispatcher_test.cc
@@ -1830,7 +1830,7 @@ TEST_F(IODispatcherTest, MemoryReleasedAfterReadIndexThenReleaseBlock) {
     // Some memory should have been granted for prefetch
     ASSERT_GT(stats->getTickerCount(PREFETCH_MEMORY_BYTES_GRANTED), 0);
 
-    // Read all blocks — ReadIndex moves values out of pinned_blocks_.
+    // Read all blocks -- ReadIndex moves values out of pinned_blocks_.
     // This also triggers TryDispatchPendingPrefetches as memory is released,
     // which acquires more memory for pending groups. So granted grows during
     // this loop.
@@ -1840,7 +1840,7 @@ TEST_F(IODispatcherTest, MemoryReleasedAfterReadIndexThenReleaseBlock) {
       ASSERT_NE(block.GetValue(), nullptr);
     }
 
-    // Release all blocks — should be a no-op for memory accounting since
+    // Release all blocks -- should be a no-op for memory accounting since
     // ReadIndex already released memory when moving values out
     for (size_t i = 0; i < block_handles.size(); ++i) {
       read_set->ReleaseBlock(i);
@@ -1894,12 +1894,12 @@ TEST_F(IODispatcherTest, DestructorReleasesMemoryAfterReadIndex) {
       ASSERT_GT(granted, 0);
 
       // Read all blocks via ReadIndex (moves values out of pinned_blocks_)
-      // but do NOT call ReleaseBlock — let the destructor handle cleanup
+      // but do NOT call ReleaseBlock -- let the destructor handle cleanup
       for (size_t i = 0; i < block_handles.size(); ++i) {
         CachableEntry<Block> block;
         ASSERT_OK(read_set->ReadIndex(i, &block));
       }
-      // read_set goes out of scope — destructor should release all memory
+      // read_set goes out of scope -- destructor should release all memory
     }
 
     uint64_t granted = stats->getTickerCount(PREFETCH_MEMORY_BYTES_GRANTED);

--- a/utilities/backup/backup_engine_test.cc
+++ b/utilities/backup/backup_engine_test.cc
@@ -3436,7 +3436,7 @@ TEST_F(BackupEngineTest, FileDetailsHaveCorrectFileType) {
   bool found_options = false;
 
   for (const auto& file_info : backup_info.file_details) {
-    // No file should have the default kTempFile type — ParseFileName should
+    // No file should have the default kTempFile type -- ParseFileName should
     // have successfully identified all backup files.
     EXPECT_NE(file_info.file_type, kTempFile)
         << "Unexpected kTempFile for: " << file_info.relative_filename;

--- a/utilities/checkpoint/checkpoint_test.cc
+++ b/utilities/checkpoint/checkpoint_test.cc
@@ -443,7 +443,7 @@ TEST_F(CheckpointTest, ExportEmptyColumnFamily) {
   options.create_if_missing = true;
   CreateAndReopenWithCF({}, options);
 
-  // Do NOT put any data — the default CF has no levels.
+  // Do NOT put any data -- the default CF has no levels.
 
   Checkpoint* checkpoint;
   ASSERT_OK(Checkpoint::Create(db_.get(), &checkpoint));

--- a/utilities/sorted_run_builder/sorted_run_builder.cc
+++ b/utilities/sorted_run_builder/sorted_run_builder.cc
@@ -47,7 +47,7 @@ class SortedRunBuilderImpl : public SortedRunBuilder {
     // Universal compaction for merging all L0 files
     db_options.compaction_style = kCompactionStyleUniversal;
 
-    // Disable auto compaction — we compact manually at the end
+    // Disable auto compaction -- we compact manually at the end
     db_options.disable_auto_compactions = true;
 
     // Memory budget
@@ -75,7 +75,7 @@ class SortedRunBuilderImpl : public SortedRunBuilder {
       db_options.table_factory = options_.table_factory;
     }
 
-    // WAL is not needed — resumability comes from flushed SSTs
+    // WAL is not needed -- resumability comes from flushed SSTs
     db_options.manual_wal_flush = true;
     db_options.wal_bytes_per_sync = 0;
 

--- a/utilities/sorted_run_builder/sorted_run_builder_test.cc
+++ b/utilities/sorted_run_builder/sorted_run_builder_test.cc
@@ -309,7 +309,7 @@ TEST_F(SortedRunBuilderTest, NumEntriesAfterDedup) {
   std::unique_ptr<SortedRunBuilder> builder;
   ASSERT_OK(SortedRunBuilder::Create(opts, &builder));
 
-  // Add duplicate keys — pre-Finish count includes duplicates
+  // Add duplicate keys -- pre-Finish count includes duplicates
   ASSERT_OK(builder->Add("key1", "old_value"));
   ASSERT_OK(builder->Add("key1", "new_value"));
   ASSERT_OK(builder->Add("key2", "value2"));
@@ -317,7 +317,7 @@ TEST_F(SortedRunBuilderTest, NumEntriesAfterDedup) {
 
   ASSERT_OK(builder->Finish());
 
-  // After Finish(), duplicates are resolved — only 2 unique keys remain
+  // After Finish(), duplicates are resolved -- only 2 unique keys remain
   ASSERT_EQ(builder->GetNumEntries(), 2);
 }
 
@@ -412,7 +412,7 @@ TEST_F(SortedRunBuilderTest, DuplicateKeys) {
   std::unique_ptr<SortedRunBuilder> builder;
   ASSERT_OK(SortedRunBuilder::Create(opts, &builder));
 
-  // Add duplicate keys — later value should win (RocksDB semantics)
+  // Add duplicate keys -- later value should win (RocksDB semantics)
   ASSERT_OK(builder->Add("key1", "old_value"));
   ASSERT_OK(builder->Add("key1", "new_value"));
   ASSERT_OK(builder->Add("key2", "value2"));
@@ -510,7 +510,7 @@ TEST_F(SortedRunBuilderTest, DestructionWithoutFinish) {
     std::unique_ptr<SortedRunBuilder> builder;
     ASSERT_OK(SortedRunBuilder::Create(opts, &builder));
     ASSERT_OK(builder->Add("key1", "value1"));
-    // Intentionally not calling Finish() — destructor should clean up
+    // Intentionally not calling Finish() -- destructor should clean up
   }
 
   // Verify temp dir is cleaned up

--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -4118,7 +4118,7 @@ TEST_P(WritePreparedTransactionTest, RangeTombstoneInsertionWithWritePrepared) {
       ASSERT_OK(db->Delete(WriteOptions(), std::string(1, c)));
     }
 
-    // Begin a transaction and prepare it — the prepare_seq will be higher
+    // Begin a transaction and prepare it -- the prepare_seq will be higher
     // than the tombstone seqnos above.
     std::unique_ptr<Transaction> txn(db->BeginTransaction(WriteOptions()));
     ASSERT_NE(txn, nullptr);
@@ -4173,14 +4173,14 @@ TEST_P(WritePreparedTransactionTest,
     }
     ASSERT_OK(db->Flush(FlushOptions()));
 
-    // Prepare a transaction first — the prepare_seq will be low.
+    // Prepare a transaction first -- the prepare_seq will be low.
     std::unique_ptr<Transaction> txn(db->BeginTransaction(WriteOptions()));
     ASSERT_NE(txn, nullptr);
     ASSERT_OK(txn->SetName("txn1"));
     ASSERT_OK(txn->Put("z", "txn_val"));
     ASSERT_OK(txn->Prepare());
 
-    // Now delete 5 contiguous keys — these tombstones get seqnos AFTER
+    // Now delete 5 contiguous keys -- these tombstones get seqnos AFTER
     // the prepare_seq, so max_tombstone_seq >= min_uncommitted.
     for (char c = 'c'; c <= 'g'; c++) {
       ASSERT_OK(db->Delete(WriteOptions(), std::string(1, c)));

--- a/utilities/transactions/write_prepared_txn.h
+++ b/utilities/transactions/write_prepared_txn.h
@@ -53,7 +53,7 @@ class WritePreparedTxnDB;
 //   db_impl_->WriteImpl(write_options, GetWriteBatch(),
 //                       ..., !DISABLE_MEMTABLE, ...);
 //
-// !DISABLE_MEMTABLE is false — memtable is enabled. This is the defining
+// !DISABLE_MEMTABLE is false -- memtable is enabled. This is the defining
 // characteristic of "WritePrepared": the actual data (Put("key1", "value1"))
 // is written to the memtable at Prepare time.
 //
@@ -68,7 +68,7 @@ class WritePreparedTxnDB;
 //
 // The data is now durable (WAL) and in the memtable, but not yet visible
 // to readers. Readers use GetLastPublishedSequence() which consults a
-// commit map — since prepare_seq is in the PreparedHeap but not yet in the
+// commit map -- since prepare_seq is in the PreparedHeap but not yet in the
 // CommitCache, readers know this data is uncommitted and skip it.
 //
 // -- Phase 2: Commit (CommitInternal) --
@@ -92,7 +92,7 @@ class WritePreparedTxnDB;
 //   Destination | What gets written   | Sequence
 //   ------------|---------------------|-----------
 //   WAL         | Commit(txn1) marker | commit_seq
-//   Memtable    | Nothing             | —
+//   Memtable    | Nothing             | --
 //
 // The PreReleaseCallback (WritePreparedCommitEntryPreReleaseCallback)
 // updates the CommitCache to record that prepare_seq was committed at
@@ -101,7 +101,7 @@ class WritePreparedTxnDB;
 //
 // -- Why two queues help --
 //
-// The Commit phase doesn't touch the memtable — it only writes a small
+// The Commit phase doesn't touch the memtable -- it only writes a small
 // marker to WAL and updates an in-memory commit map. By routing this
 // through a separate queue, Commit writes don't have to wait behind other
 // transactions' Prepare writes (which do the expensive memtable insertion
@@ -119,7 +119,7 @@ class WritePreparedTxnDB;
 //     FetchAdd alloc seq             9      |        10          |        9
 //     Write WAL + memtable
 //     SetLastSequence               10      |        10          |        9
-//     (published_seq not advanced yet — data is uncommitted)
+//     (published_seq not advanced yet -- data is uncommitted)
 //
 //   Commit (2nd queue):
 //     FetchAdd alloc seq            10      |        11          |        9

--- a/utilities/transactions/write_unprepared_transaction_test.cc
+++ b/utilities/transactions/write_unprepared_transaction_test.cc
@@ -795,7 +795,7 @@ TEST_P(WriteUnpreparedTransactionTest, RangeTombstoneMultipleBatchesAndCommit) {
       ASSERT_OK(txn->Put("b", "txn_b"));  // batch 1, bounds start of run
       if (middle_tombstone) {
         // Txn Delete("e") fills the gap in the middle of committed deletes
-        // c, d, [e], f, g — making a contiguous run of 5 that contains an
+        // c, d, [e], f, g -- making a contiguous run of 5 that contains an
         // uncommitted seqno in the middle.
         ASSERT_OK(txn->Delete("e"));
       } else {
@@ -886,7 +886,7 @@ TEST_P(WriteUnpreparedTransactionTest,
     ASSERT_NE(txn, nullptr);
     txn->SetSnapshot();
 
-    // Multiple unprepared writes — these get seqnos beyond the snapshot.
+    // Multiple unprepared writes -- these get seqnos beyond the snapshot.
     // CalcMaxVisibleSeq returns max(last_unprep_seqno, snapshot_seq), so
     // the committed deletions (seqno between snap and unprep) are visible.
     ASSERT_OK(txn->Put("x", "txn_x"));
@@ -991,7 +991,7 @@ TEST_P(WriteUnpreparedTransactionTest, RangeTombstoneOwnDeletionsAndRollback) {
     SyncPoint::GetInstance()->DisableProcessing();
     SyncPoint::GetInstance()->ClearAllCallBacks();
 
-    // Rollback — own Deletes and Puts are undone.
+    // Rollback -- own Deletes and Puts are undone.
     ASSERT_OK(txn->Rollback());
 
     // After rollback: committed deletes c-g remain, own deletes j-n are

--- a/utilities/trie_index/bitvector.h
+++ b/utilities/trie_index/bitvector.h
@@ -247,7 +247,7 @@ class BitvectorBuilder {
 //
 // Created from serialized data (e.g., read from an SST file meta-block) or
 // from a BitvectorBuilder. The bitvector does NOT own the underlying memory
-// when created from a Slice — the caller must ensure the data outlives this
+// when created from a Slice -- the caller must ensure the data outlives this
 // object.
 //
 // Select acceleration: select hints store the rank LUT index where every
@@ -379,7 +379,7 @@ class Bitvector {
 
   // select1(i): Position of the i-th 1-bit (0-indexed).
   // Returns num_bits_ if there are fewer than (i+1) 1-bits.
-  // Inlined for hot-path performance — the hint lookup + linear scan is
+  // Inlined for hot-path performance -- the hint lookup + linear scan is
   // branch-predictor friendly and avoids function call overhead.
   inline uint64_t FindNthOneBit(uint64_t i) const {
     if (i >= num_ones_) {
@@ -422,7 +422,7 @@ class Bitvector {
 
   // Find the next set bit at or after position `pos`.
   // Returns num_bits_ if no set bit is found.
-  // Inlined for hot-path performance — called on every dense Seek, Advance,
+  // Inlined for hot-path performance -- called on every dense Seek, Advance,
   // and DescendToLeftmostLeaf.
   inline uint64_t NextSetBit(uint64_t pos) const {
     if (pos >= num_bits_) {
@@ -580,7 +580,7 @@ class EliasFano {
   // Custom move operations to re-seat low_words_ after moving owned_low_data_.
   // The default move would leave low_words_ pointing into the moved-from
   // object's owned_low_data_ buffer. For SSO-sized strings (owned_low_data_
-  // with <= ~22 bytes, e.g. count_=1 low_bits_=8 → 8 bytes), std::string
+  // with <= ~22 bytes, e.g. count_=1 low_bits_=8 -> 8 bytes), std::string
   // move copies the SSO buffer to a new address rather than transferring a
   // heap pointer, leaving low_words_ dangling. For heap-allocated strings
   // move transfers the pointer (address preserved), but we re-seat

--- a/utilities/trie_index/louds_trie.cc
+++ b/utilities/trie_index/louds_trie.cc
@@ -255,12 +255,12 @@ void LoudsTrieBuilder::Finish() {
     if (lcp > 0) {
       auto& pl = levels[lcp - 1];
       if (!pl.has_child.empty() && !pl.has_child.back()) {
-        // Leaf → internal transition.
+        // Leaf -> internal transition.
         pl.has_child.back() = true;
 
         // Handle migration: move the leaf's handle to a NEW child node at
         // level lcp as a prefix key. The child node is always new because
-        // this label just transitioned from leaf to internal — no child
+        // this label just transitioned from leaf to internal -- no child
         // node existed before for this branch.
         //
         // The leaf_handle must be valid (>= 0) because the label was marked
@@ -306,7 +306,7 @@ void LoudsTrieBuilder::Finish() {
   // created left-to-right as sorted keys are processed). We iterate by
   // level and by node within each level:
   //   - For each node: emit prefix key handle (if any), then for each label:
-  //     if leaf → emit handle; if internal → skip (child visited at next
+  //     if leaf -> emit handle; if internal -> skip (child visited at next
   //     level).
   //   - Build dense/sparse bitvectors from labels and has_child flags.
   // =========================================================================
@@ -393,7 +393,7 @@ void LoudsTrieBuilder::Finish() {
         emit_leaf(static_cast<size_t>(ld.prefix_handle[ni]));
       }
 
-      // Skip pure leaf nodes (no labels) — they are accounted for by
+      // Skip pure leaf nodes (no labels) -- they are accounted for by
       // has_child=0 in their parent. They don't produce LOUDS entries.
       if (label_start == label_end) {
         if (ld.is_prefix[ni]) {
@@ -640,7 +640,7 @@ void LoudsTrieBuilder::SerializeAll() {
         continue;
       }
 
-      // Check if the child node is a prefix key — if so, cannot skip it.
+      // Check if the child node is a prefix key -- if so, cannot skip it.
       {
         uint64_t child_sparse_node = bv_s_louds.Rank1(cs + 1) - 1;
         if (child_sparse_node < bv_s_is_prefix_key.NumBits() &&
@@ -674,7 +674,7 @@ void LoudsTrieBuilder::SerializeAll() {
           break;
         }
 
-        // Check if next node is a prefix key — stop chain here.
+        // Check if next node is a prefix key -- stop chain here.
         {
           uint64_t next_sparse_node = bv_s_louds.Rank1(next_cs + 1) - 1;
           if (next_sparse_node < bv_s_is_prefix_key.NumBits() &&
@@ -1118,7 +1118,7 @@ Status LoudsTrie::InitFromData(const Slice& data) {
   // Validate dense section counts against bitvector sizes. These counts
   // were read from the header (untrusted data) and will be used for leaf
   // ordinal computation during traversal. Inconsistent values would cause
-  // incorrect rank arithmetic leading to wrong leaf indices → wrong block
+  // incorrect rank arithmetic leading to wrong leaf indices -> wrong block
   // handles.
   if (dense_node_count_ > 0) {
     // Each dense node uses 256 bits in d_labels_.
@@ -2150,7 +2150,7 @@ bool LoudsTrieIterator::SeekImpl(const Slice& target) {
                     return DescendToLeftmostLeaf(false, SparseChildNodeNum(cs));
                   }
                 }  // if constexpr (kHasChains)
-                // No chain — normal child lookup.
+                // No chain -- normal child lookup.
                 sparse_start = trie_->s_child_start_pos_[child_idx];
                 sparse_end = trie_->s_child_end_pos_[child_idx];
                 have_sparse_bounds = true;
@@ -2386,7 +2386,7 @@ bool LoudsTrieIterator::SeekImpl(const Slice& target) {
               return DescendToLeftmostLeaf(false, SparseChildNodeNum(cs));
             }
           }  // if constexpr (kHasChains)
-          // No chain — normal child lookup.
+          // No chain -- normal child lookup.
           sparse_start = trie_->s_child_start_pos_[child_idx];
           sparse_end = trie_->s_child_end_pos_[child_idx];
           have_sparse_bounds = true;
@@ -2558,7 +2558,7 @@ bool LoudsTrieIterator::Advance() {
       }
     }
 
-    // No sibling found at this level — pop and continue backtracking.
+    // No sibling found at this level -- pop and continue backtracking.
     path_.pop_back();
     if (key_len_ > 0) {
       key_len_--;
@@ -2572,7 +2572,7 @@ bool LoudsTrieIterator::Advance() {
 bool LoudsTrieIterator::DescendToRightmostLeaf(bool in_dense,
                                                uint64_t node_num) {
   // Mirror of DescendToLeftmostLeaf: go to the rightmost (largest) child
-  // at each level. Does NOT check prefix keys — they are the smallest leaf
+  // at each level. Does NOT check prefix keys -- they are the smallest leaf
   // at a node, so they come last in reverse order and are handled by
   // Retreat() when backtracking past all children.
 
@@ -2595,7 +2595,7 @@ bool LoudsTrieIterator::DescendToRightmostLeaf(bool in_dense,
       }
       uint64_t last = trie_->d_labels_.PrevSetBit(node_end);
       if (last >= trie_->d_labels_.NumBits() || last < base) {
-        // Empty node — shouldn't happen in a valid trie, but guard anyway.
+        // Empty node -- shouldn't happen in a valid trie, but guard anyway.
         valid_ = false;
         return false;
       }
@@ -2705,13 +2705,13 @@ bool LoudsTrieIterator::Retreat() {
             cd, cd ? child : child - trie_->dense_node_count_);
       }
 
-      // No previous sibling — check prefix key at this node.
+      // No previous sibling -- check prefix key at this node.
       // Prefix keys are the smallest leaf at a node, so in reverse order
       // they come after all children.
       if (trie_->d_is_prefix_key_.NumBits() > 0 &&
           node_num < trie_->d_is_prefix_key_.NumBits() &&
           trie_->d_is_prefix_key_.GetBit(node_num)) {
-        // Pop the current level before returning the prefix key — the
+        // Pop the current level before returning the prefix key -- the
         // prefix key doesn't have its own path entry.
         path_.pop_back();
         if (key_len_ > 0) {
@@ -2743,7 +2743,7 @@ bool LoudsTrieIterator::Retreat() {
         return DescendToRightmostLeaf(false, SparseChildNodeNum(prev_pos));
       }
 
-      // At first label — no previous sibling. Check prefix key.
+      // At first label -- no previous sibling. Check prefix key.
       uint64_t sparse_node = SparseNodeNum(cur_sparse_pos);
       if (trie_->s_is_prefix_key_.NumBits() > 0 &&
           sparse_node < trie_->s_is_prefix_key_.NumBits() &&
@@ -2759,7 +2759,7 @@ bool LoudsTrieIterator::Retreat() {
       }
     }
 
-    // No sibling and no prefix key — pop and continue backtracking.
+    // No sibling and no prefix key -- pop and continue backtracking.
     path_.pop_back();
     if (key_len_ > 0) {
       key_len_--;

--- a/utilities/trie_index/louds_trie.h
+++ b/utilities/trie_index/louds_trie.h
@@ -350,7 +350,7 @@ class LoudsTrie {
   // plus compact arrays indexed by chain ordinal (Rank1 on the bitmap).
   //
   // Lookup during Seek:
-  //   1. s_chain_bitmap_.GetBit(child_idx) — has chain?
+  //   1. s_chain_bitmap_.GetBit(child_idx) -- has chain?
   //   2. chain_idx = s_chain_bitmap_.Rank1(child_idx + 1) - 1
   //   3. s_chain_lens_[chain_idx], s_chain_suffix_offsets_[chain_idx], etc.
   //
@@ -628,7 +628,7 @@ class LoudsTrieIterator {
   // Descend from the given node to the rightmost leaf in its subtree,
   // pushing entries onto path_ and building key_buf_. Sets
   // leaf_index_ and valid_. Returns true if a leaf was found.
-  // Unlike DescendToLeftmostLeaf, this does NOT check prefix keys —
+  // Unlike DescendToLeftmostLeaf, this does NOT check prefix keys --
   // prefix keys are the smallest leaf at a node, so in reverse order
   // they are visited last (handled by Retreat when backtracking).
   bool DescendToRightmostLeaf(bool in_dense, uint64_t node_num);
@@ -668,7 +668,7 @@ class LoudsTrieIterator {
   // sparse levels, the byte is s_labels_[pos].
   //
   // Key reconstruction appends one byte per trie level in the Seek/Next
-  // hot loop, so the append operation must be as cheap as possible — a
+  // hot loop, so the append operation must be as cheap as possible -- a
   // single inlined store + increment with no function call overhead. The
   // buffer is heap-allocated once in the constructor to MaxDepth()+1 bytes.
   //

--- a/utilities/trie_index/trie_index_db_test.cc
+++ b/utilities/trie_index/trie_index_db_test.cc
@@ -2971,7 +2971,7 @@ TEST_P(TrieIndexDBTest, EmptyDBOperations) {
     ASSERT_OK(iter->status());
   }
 
-  // Create an SST, delete its only key, compact → DB has no live data but
+  // Create an SST, delete its only key, compact -> DB has no live data but
   // the trie code path was exercised during flush.
   ASSERT_OK(db_->Put(WriteOptions(), "temp", "val"));
   ASSERT_OK(db_->Flush(FlushOptions()));
@@ -3019,7 +3019,7 @@ TEST_P(TrieIndexDBTest, SeekEdgeCases) {
     ASSERT_TRUE(iter->Valid());
     ASSERT_EQ(iter->key().ToString(), "ddd");
 
-    // Between keys (eee → fff).
+    // Between keys (eee -> fff).
     iter->Seek("eee");
     ASSERT_TRUE(iter->Valid());
     ASSERT_EQ(iter->key().ToString(), "fff");
@@ -3137,7 +3137,7 @@ TEST_P(TrieIndexDBTest, OverlappingL0SSTs) {
     }
   }
 
-  // Compact all L0 → L1, re-verify.
+  // Compact all L0 -> L1, re-verify.
   ASSERT_OK(db_->CompactRange(CompactRangeOptions(), nullptr, nullptr));
   for (const auto& ro : {StandardIndexReadOptions(), TrieIndexReadOptions()}) {
     SCOPED_TRACE(ro.table_index_factory ? "trie" : "standard");
@@ -3367,7 +3367,7 @@ TEST_P(TrieIndexDBTest, IteratorUpperBound) {
        {StandardIndexReadOptions(), TrieIndexReadOptions()}) {
     SCOPED_TRACE(base_ro.table_index_factory ? "trie" : "standard");
 
-    // Upper bound = "dd" → should see aa, bb, cc only.
+    // Upper bound = "dd" -> should see aa, bb, cc only.
     std::string ub_str = "dd";
     Slice ub(ub_str);
     ReadOptions ro = base_ro;
@@ -3380,7 +3380,7 @@ TEST_P(TrieIndexDBTest, IteratorUpperBound) {
     ASSERT_OK(iter->status());
     ASSERT_EQ(keys, (std::vector<std::string>{"aa", "bb", "cc"}));
 
-    // Upper bound = "aa" → should see nothing.
+    // Upper bound = "aa" -> should see nothing.
     std::string ub2_str = "aa";
     Slice ub2(ub2_str);
     ReadOptions ro2 = base_ro;
@@ -3390,7 +3390,7 @@ TEST_P(TrieIndexDBTest, IteratorUpperBound) {
     ASSERT_FALSE(iter2->Valid());
     ASSERT_OK(iter2->status());
 
-    // Upper bound after all data → should see everything.
+    // Upper bound after all data -> should see everything.
     std::string ub3_str = "zz";
     Slice ub3(ub3_str);
     ReadOptions ro3 = base_ro;
@@ -3471,7 +3471,7 @@ TEST_P(TrieIndexDBTest, ManySmallSSTs) {
   options_.disable_auto_compactions = true;
   ASSERT_OK(OpenDB());
 
-  // 50 flushes, 2 keys each → 50 SSTs.
+  // 50 flushes, 2 keys each -> 50 SSTs.
   for (int f = 0; f < 50; f++) {
     char k1[16];
     char k2[16];
@@ -3578,7 +3578,7 @@ TEST_P(TrieIndexDBTest, MixedSSTsWithAndWithoutUDI) {
   }
   options_.disable_auto_compactions = true;
 
-  // Phase 1: Write with UDI → SST1 has UDI + standard index.
+  // Phase 1: Write with UDI -> SST1 has UDI + standard index.
   ASSERT_OK(OpenDB());
   ASSERT_OK(db_->Put(WriteOptions(), "key_01", "udi_val1"));
   ASSERT_OK(db_->Put(WriteOptions(), "key_02", "udi_val2"));
@@ -3586,7 +3586,7 @@ TEST_P(TrieIndexDBTest, MixedSSTsWithAndWithoutUDI) {
   ASSERT_OK(db_->Close());
   db_.reset();
 
-  // Phase 2: Reopen WITHOUT UDI, write more → SST2 has only standard index.
+  // Phase 2: Reopen WITHOUT UDI, write more -> SST2 has only standard index.
   ASSERT_OK(OpenDBWithoutUDI());
   ASSERT_OK(db_->Put(WriteOptions(), "key_03", "noudi_val3"));
   ASSERT_OK(db_->Put(WriteOptions(), "key_04", "noudi_val4"));
@@ -3595,7 +3595,7 @@ TEST_P(TrieIndexDBTest, MixedSSTsWithAndWithoutUDI) {
   db_.reset();
 
   // Phase 3: Reopen WITH UDI again. SST1 uses trie, SST2 falls back to
-  // standard index (UDI block missing → logged warning, graceful fallback).
+  // standard index (UDI block missing -> logged warning, graceful fallback).
   options_.disable_auto_compactions = true;
   ASSERT_OK(OpenDB());
 
@@ -3608,7 +3608,7 @@ TEST_P(TrieIndexDBTest, MixedSSTsWithAndWithoutUDI) {
   ASSERT_NO_FATAL_FAILURE(
       VerifyScanBothIndexes({"key_01", "key_02", "key_03", "key_04"}));
 
-  // Compact: merges UDI + non-UDI SSTs → new SST has UDI.
+  // Compact: merges UDI + non-UDI SSTs -> new SST has UDI.
   ASSERT_OK(db_->CompactRange(CompactRangeOptions(), nullptr, nullptr));
   ASSERT_NO_FATAL_FAILURE(
       VerifyScanBothIndexes({"key_01", "key_02", "key_03", "key_04"}));
@@ -4236,7 +4236,7 @@ TEST_P(TrieIndexDBTest, PrimaryUDIBackwardCompatibility) {
 
 TEST_P(TrieIndexDBTest, MigrationFullPath) {
   // Tests the complete recommended migration path:
-  // Step 1: No UDI → Step 2: UDI secondary → Step 3: Compact all SSTs →
+  // Step 1: No UDI -> Step 2: UDI secondary -> Step 3: Compact all SSTs ->
   // Step 4: UDI primary
 
   // Step 1: Start without UDI. Write some data.
@@ -4317,7 +4317,7 @@ TEST_P(TrieIndexDBTest, MigrationPrimaryRejectsPreUDISSTs) {
 }
 
 TEST_P(TrieIndexDBTest, RollbackFromPrimaryToSecondary) {
-  // Tests the rollback path: primary → compact with secondary → remove UDI.
+  // Tests the rollback path: primary -> compact with secondary -> remove UDI.
 
   // Start in primary mode. Write data.
   ASSERT_OK(OpenDBPrimary(/*block_size=*/128));
@@ -4617,7 +4617,7 @@ TEST_P(TrieIndexDBTest, GetEntityWithExplicitSnapshotComparison) {
   ASSERT_OK(db_->Put(WriteOptions(), "regular_key", "regular_val_v2"));
   ASSERT_OK(db_->Flush(FlushOptions()));
 
-  // Read at snapshot through both indexes — should see v1 data.
+  // Read at snapshot through both indexes -- should see v1 data.
   for (auto base_ro : {StandardIndexReadOptions(), TrieIndexReadOptions()}) {
     SCOPED_TRACE(base_ro.table_index_factory ? "trie" : "standard");
     base_ro.snapshot = snap;
@@ -4644,7 +4644,7 @@ TEST_P(TrieIndexDBTest, GetEntityWithExplicitSnapshotComparison) {
                     .IsNotFound());
   }
 
-  // Read without snapshot — should see v2 data.
+  // Read without snapshot -- should see v2 data.
   for (auto base_ro : {StandardIndexReadOptions(), TrieIndexReadOptions()}) {
     SCOPED_TRACE(base_ro.table_index_factory ? "trie" : "standard");
 

--- a/utilities/trie_index/trie_index_factory.cc
+++ b/utilities/trie_index/trie_index_factory.cc
@@ -36,7 +36,7 @@ Slice TrieIndexBuilder::AddIndexEntry(const Slice& last_key_in_current_block,
   // comparator. FindShortestSeparator takes `*start` as both input and output:
   //   input:  *start == last_key_in_current_block
   //   output: *start modified to shortest string in [start, limit)
-  // If first_key_in_next_block is nullptr, this is the last block — use a
+  // If first_key_in_next_block is nullptr, this is the last block -- use a
   // short successor of the last key.
   Slice separator;
   // True when last_key and first_key_in_next_block are the same user key
@@ -85,7 +85,7 @@ Slice TrieIndexBuilder::AddIndexEntry(const Slice& last_key_in_current_block,
     // ":", but the data block only contains keys up to "9\xff\xff". A seek
     // targeting a key in that gap (e.g., "9\xff\xff\x01") would find a
     // block via the trie that contains no matching data, causing iterator
-    // desynchronization — the trie index returns a valid block while the
+    // desynchronization -- the trie index returns a valid block while the
     // standard index correctly reports no match.
     separator = last_key_in_current_block;
 
@@ -157,9 +157,9 @@ Status TrieIndexBuilder::Finish(Slice* index_contents) {
 
   if (use_seqno) {
     // Feed de-duplicated separators to the trie with seqno side-table metadata.
-    // Consecutive identical separators form a "run" — only the first occurrence
-    // goes into the trie (as the primary block). The remaining blocks in the
-    // run are stored as overflow blocks in the side-table.
+    // Consecutive identical separators form a "run" -- only the first
+    // occurrence goes into the trie (as the primary block). The remaining
+    // blocks in the run are stored as overflow blocks in the side-table.
     //
     // For non-boundary separators (different user keys), the tag is 0
     // (sentinel meaning "no seqno correction needed"), matching the standard
@@ -213,11 +213,11 @@ Status TrieIndexBuilder::Finish(Slice* index_contents) {
     assert(buffered_entries_.empty());
   }
 
-  // Release buffered entries — no longer needed after feeding to the trie.
+  // Release buffered entries -- no longer needed after feeding to the trie.
   buffered_entries_.clear();
   buffered_entries_.shrink_to_fit();
 
-  // Always finish the trie builder, even with 0 keys — this produces a valid
+  // Always finish the trie builder, even with 0 keys -- this produces a valid
   // serialized trie that can be parsed by NewReader. Without this, an empty
   // Slice would be returned, causing InitFromData to fail with "data too short
   // for header".
@@ -343,12 +343,12 @@ Status TrieIndexIterator::SeekAndGetResult(const Slice& target,
 
   ResetOverflowState();
 
-  // Always seek with user key only — the trie stores user-key separators.
+  // Always seek with user key only -- the trie stores user-key separators.
   // When seqno encoding is active, post-seek correction handles the seqno.
   if (!iter_.Seek(target)) {
     // No leaf has a key >= target: the target is past all blocks in this SST.
     // Return kUnknown (not kOutOfBound) because exhausting this SST's trie
-    // says nothing about the upper bound — the next SST on the level may
+    // says nothing about the upper bound -- the next SST on the level may
     // still contain in-bound keys. kOutOfBound would cause LevelIterator to
     // stop scanning the level prematurely.
     result->bound_check_result = IterBoundCheck::kUnknown;
@@ -357,7 +357,7 @@ Status TrieIndexIterator::SeekAndGetResult(const Slice& target,
   }
 
   // Set the result key (always a user key, no suffix stripping needed).
-  // Reuse current_key_scratch_ capacity — avoids heap allocation after warmup.
+  // Reuse current_key_scratch_ capacity -- avoids heap allocation after warmup.
   {
     Slice trie_key = iter_.Key();
     current_key_scratch_.assign(trie_key.data(), trie_key.size());
@@ -412,7 +412,7 @@ Status TrieIndexIterator::SeekAndGetResult(const Slice& target,
         // the next trie leaf (the block after the run).
         if (!iter_.Next()) {
           // Exhausted all blocks: target is past the end of this SST.
-          // Return kUnknown — see comment in Seek path above.
+          // Return kUnknown -- see comment in Seek path above.
           result->bound_check_result = IterBoundCheck::kUnknown;
           result->key = Slice();
           return Status::OK();
@@ -428,7 +428,7 @@ Status TrieIndexIterator::SeekAndGetResult(const Slice& target,
         overflow_base_idx_ = 0;
         // Check if the new leaf also has overflow (unlikely but possible
         // with adjacent same-key runs for different user keys).
-        // iter_.Valid() is guaranteed here — Next() returned true above.
+        // iter_.Valid() is guaranteed here -- Next() returned true above.
         if (has_seqno_encoding_) {
           uint64_t new_leaf = iter_.LeafIndex();
           overflow_run_size_ = trie_->GetLeafBlockCount(new_leaf);
@@ -480,11 +480,11 @@ Status TrieIndexIterator::NextAndGetResult(IterateResult* result) {
 
 UserDefinedIndexBuilder::BlockHandle TrieIndexIterator::value() {
   if (overflow_run_index_ == 0) {
-    // Primary block — use the trie leaf's handle.
+    // Primary block -- use the trie leaf's handle.
     auto handle = iter_.Value();
     return UserDefinedIndexBuilder::BlockHandle{handle.offset, handle.size};
   }
-  // Overflow block — use the side-table handle.
+  // Overflow block -- use the side-table handle.
   // overflow_run_index_ is 1-based, overflow array is 0-based.
   uint32_t overflow_idx = overflow_base_idx_ + overflow_run_index_ - 1;
   auto handle = trie_->GetOverflowHandle(overflow_idx);
@@ -494,7 +494,7 @@ UserDefinedIndexBuilder::BlockHandle TrieIndexIterator::value() {
 IterBoundCheck TrieIndexIterator::CheckBounds(
     const Slice& reference_key) const {
   if (!prepared_ || scan_opts_.empty()) {
-    // No bounds to check — always in-bound.
+    // No bounds to check -- always in-bound.
     return IterBoundCheck::kInbound;
   }
 
@@ -549,7 +549,7 @@ size_t TrieIndexReader::ApproximateMemoryUsage() const {
   // and handle arrays, so the base cost is the serialized data size. On top
   // of that, InitFromData() heap-allocates child position lookup tables
   // (s_child_start_pos_ and s_child_end_pos_) for Select-free sparse
-  // traversal — 8 bytes per sparse internal node.
+  // traversal -- 8 bytes per sparse internal node.
   return data_size_ + trie_.ApproximateAuxMemoryUsage();
 }
 

--- a/utilities/trie_index/trie_index_factory.h
+++ b/utilities/trie_index/trie_index_factory.h
@@ -71,7 +71,7 @@ class TrieIndexBuilder final : public UserDefinedIndexBuilder {
                       std::string* separator_scratch,
                       const IndexEntryContext& context) override;
 
-  // Called for each key added to the SST. Currently a no-op — the trie is
+  // Called for each key added to the SST. Currently a no-op -- the trie is
   // built entirely from separator keys provided via AddIndexEntry().
   void OnKeyAdded(const Slice& key, ValueType type,
                   const Slice& value) override;
@@ -100,7 +100,7 @@ class TrieIndexBuilder final : public UserDefinedIndexBuilder {
   // We buffer all separator entries during building, then at Finish() feed
   // them to the trie with seqno side-table metadata.
   //
-  // Always set to true in AddIndexEntry() — seqno encoding is
+  // Always set to true in AddIndexEntry() -- seqno encoding is
   // unconditionally enabled. The 8-byte per-leaf overhead is always incurred.
   bool must_use_separator_with_seq_;
 
@@ -172,7 +172,7 @@ class TrieIndexIterator final : public UserDefinedIndexIterator {
   // is the seek target, for Next this is the previous separator key.
   // The trie stores separator keys (upper bounds on block contents), not
   // first-in-block keys, so we cannot compare the current separator against
-  // the limit directly — see the UDI API contract in user_defined_index.h.
+  // the limit directly -- see the UDI API contract in user_defined_index.h.
   IterBoundCheck CheckBounds(const Slice& reference_key) const;
 
   const Comparator* comparator_;

--- a/utilities/trie_index/trie_index_test.cc
+++ b/utilities/trie_index/trie_index_test.cc
@@ -357,7 +357,7 @@ TEST_F(BitvectorTest, NextSetBit) {
   ASSERT_EQ(bv.NextSetBit(64), 64u);    // Exact position.
   ASSERT_EQ(bv.NextSetBit(65), 128u);   // Next one.
   ASSERT_EQ(bv.NextSetBit(128), 128u);  // Exact.
-  ASSERT_EQ(bv.NextSetBit(129), 129u);  // Past end → num_bits_.
+  ASSERT_EQ(bv.NextSetBit(129), 129u);  // Past end -> num_bits_.
 }
 
 TEST_F(BitvectorTest, NextSetBitAllZeros) {
@@ -384,10 +384,10 @@ TEST_F(BitvectorTest, DistanceToNextSetBit) {
   Bitvector bv;
   bv.BuildFrom(builder);
 
-  ASSERT_EQ(bv.DistanceToNextSetBit(0), 3u);  // 0 → 3
-  ASSERT_EQ(bv.DistanceToNextSetBit(3), 2u);  // 3 → 5
+  ASSERT_EQ(bv.DistanceToNextSetBit(0), 3u);  // 0 -> 3
+  ASSERT_EQ(bv.DistanceToNextSetBit(3), 2u);  // 3 -> 5
   // Last set bit: distance to next = num_bits_ - pos.
-  ASSERT_EQ(bv.DistanceToNextSetBit(5), 1u);  // 5 → 6 (num_bits_)
+  ASSERT_EQ(bv.DistanceToNextSetBit(5), 1u);  // 5 -> 6 (num_bits_)
 }
 
 TEST_F(BitvectorTest, MultipleRankSampleBoundaries) {
@@ -576,7 +576,7 @@ TEST_F(BitvectorTest, NumZeros) {
 }
 
 TEST_F(BitvectorTest, InitFromDataNumOnesExceedsNumBits) {
-  // Craft a header where num_ones > num_bits — should return Corruption.
+  // Craft a header where num_ones > num_bits -- should return Corruption.
   std::string buf(2 * sizeof(uint64_t), '\0');
   uint64_t num_bits = 64;
   uint64_t num_ones = 65;  // Invalid: more ones than bits.
@@ -590,7 +590,7 @@ TEST_F(BitvectorTest, InitFromDataNumOnesExceedsNumBits) {
 }
 
 TEST_F(BitvectorTest, InitFromDataNumBitsExceedsUint32) {
-  // Craft a header where num_bits > UINT32_MAX — should return Corruption.
+  // Craft a header where num_bits > UINT32_MAX -- should return Corruption.
   std::string buf(2 * sizeof(uint64_t), '\0');
   uint64_t num_bits = static_cast<uint64_t>(UINT32_MAX) + 1;
   uint64_t num_ones = 0;
@@ -656,7 +656,7 @@ TEST_F(BitvectorTest, InitFromDataTruncatedSelect1Hints) {
   // Build a bitvector with enough ones to have select1 hints, then truncate
   // after the rank LUT so select1 hints cannot be read.
   BitvectorBuilder builder;
-  // 600 bits, all ones → lots of select1 hints.
+  // 600 bits, all ones -> lots of select1 hints.
   for (int i = 0; i < 600; i++) {
     builder.Append(true);
   }
@@ -682,7 +682,7 @@ TEST_F(BitvectorTest, InitFromDataTruncatedSelect0Hints) {
   // Build a bitvector with enough zeros to have select0 hints, then truncate
   // so select0 hints cannot be fully read.
   BitvectorBuilder builder;
-  // 600 bits, all zeros → lots of select0 hints, zero select1 hints.
+  // 600 bits, all zeros -> lots of select0 hints, zero select1 hints.
   for (int i = 0; i < 600; i++) {
     builder.Append(false);
   }
@@ -1443,7 +1443,7 @@ TEST_F(LoudsTrieTest, MultipleKeys) {
 }
 
 TEST_F(LoudsTrieTest, SharedPrefixKeys) {
-  // Keys with long shared prefixes — this exercises the trie's prefix
+  // Keys with long shared prefixes -- this exercises the trie's prefix
   // compression.
   LoudsTrieBuilder builder;
   std::vector<std::string> keys;
@@ -1541,7 +1541,7 @@ TEST_F(LoudsTrieTest, PrefixKeyHandleReorderVerification) {
 
   LoudsTrieIterator iter(&trie);
 
-  // Seek to "a" — should find "a" with handle {100, 10}.
+  // Seek to "a" -- should find "a" with handle {100, 10}.
   ASSERT_TRUE(iter.Seek(Slice("a")));
   ASSERT_EQ(iter.Key().ToString(), "a");
   ASSERT_EQ(iter.Value().offset, 100u);
@@ -1576,7 +1576,7 @@ TEST_F(LoudsTrieTest, PrefixKeySeekBetween) {
   ASSERT_OK(trie.InitFromData(data));
   LoudsTrieIterator iter(&trie);
 
-  // "aa" is between "a" (prefix key) and "ab" → should land on "ab".
+  // "aa" is between "a" (prefix key) and "ab" -> should land on "ab".
   ASSERT_TRUE(iter.Seek(Slice("aa")));
   ASSERT_EQ(iter.Key().ToString(), "ab");
 
@@ -1604,7 +1604,7 @@ TEST_F(LoudsTrieTest, IteratorSeekExact) {
 TEST_F(LoudsTrieTest, IteratorSeekBetweenKeys) {
   auto bt = BuildTrieFromKeys({"aaa", "bbb", "ccc", "ddd"});
 
-  // Seek to a key between "aaa" and "bbb" — should land on "bbb".
+  // Seek to a key between "aaa" and "bbb" -- should land on "bbb".
   ASSERT_TRUE(bt.iter->Seek(Slice("ab")));
   ASSERT_TRUE(bt.iter->Valid());
   ASSERT_EQ(bt.iter->Value().offset, 100u);  // "bbb"'s handle.
@@ -2144,7 +2144,7 @@ TEST_F(LoudsTrieTest, SparseBinarySearchPath) {
 
   LoudsTrieIterator iter(&trie);
 
-  // Seek to each key — exercises binary search in the 20-label root node.
+  // Seek to each key -- exercises binary search in the 20-label root node.
   for (size_t i = 0; i < keys.size(); i++) {
     ASSERT_TRUE(iter.Seek(Slice(keys[i])))
         << "Seek failed for key[" << i << "]";
@@ -2153,9 +2153,9 @@ TEST_F(LoudsTrieTest, SparseBinarySearchPath) {
   }
 
   // Seek to a key between existing labels (binary search inexact match).
-  // 'A' + 0.5 doesn't exist — seek "AAx" which is between "Ax" and "Bx".
+  // 'A' + 0.5 doesn't exist -- seek "AAx" which is between "Ax" and "Bx".
   ASSERT_TRUE(iter.Seek(Slice("AAx")));
-  // Should land on "Ax" or "Bx" — the first key >= "AAx".
+  // Should land on "Ax" or "Bx" -- the first key >= "AAx".
   ASSERT_TRUE(iter.Valid());
   std::string result_key = iter.Key().ToString();
   ASSERT_GE(result_key, "AAx");
@@ -2222,7 +2222,7 @@ TEST_F(LoudsTrieTest, ChainSeekVariousTargets) {
   }
 
   // 2. Chain mismatch: target < chain suffix.
-  // Seek to prefix + "L" — 'L' < 'M', so chain mismatch with target < suffix.
+  // Seek to prefix + "L" -- 'L' < 'M', so chain mismatch with target < suffix.
   // Should land on the first key (prefix + "Ma").
   {
     std::string target = prefix + "La";
@@ -2232,7 +2232,7 @@ TEST_F(LoudsTrieTest, ChainSeekVariousTargets) {
   }
 
   // 3. Chain mismatch: target > chain suffix.
-  // Seek to prefix + "Md" — 'd' > 'c' after chain, should advance past "Mc".
+  // Seek to prefix + "Md" -- 'd' > 'c' after chain, should advance past "Mc".
   {
     std::string target = prefix + "Md";
     ASSERT_TRUE(iter.Seek(Slice(target)));
@@ -2241,7 +2241,7 @@ TEST_F(LoudsTrieTest, ChainSeekVariousTargets) {
   }
 
   // 4. Target runs out before chain (shorter target < chain prefix).
-  // Seek to prefix + "L" (shorter than chain). 'L' < 'M' → target < chain.
+  // Seek to prefix + "L" (shorter than chain). 'L' < 'M' -> target < chain.
   {
     std::string target = prefix + "L";
     ASSERT_TRUE(iter.Seek(Slice(target)));
@@ -2250,7 +2250,7 @@ TEST_F(LoudsTrieTest, ChainSeekVariousTargets) {
   }
 
   // 5. Target runs out before chain (shorter target > chain prefix character).
-  // Seek to prefix + "O" — 'O' > 'N' (the highest chain prefix). Should
+  // Seek to prefix + "O" -- 'O' > 'N' (the highest chain prefix). Should
   // advance past all keys.
   {
     std::string target = prefix + "O";
@@ -2259,7 +2259,7 @@ TEST_F(LoudsTrieTest, ChainSeekVariousTargets) {
   }
 
   // 6. Target consumed exactly at the parent of the chain (target_remaining
-  // == 0). Seek to just the prefix "AAAAAAAAA" — shorter than any key.
+  // == 0). Seek to just the prefix "AAAAAAAAA" -- shorter than any key.
   // All keys are > prefix, so should land on the first key.
   {
     ASSERT_TRUE(iter.Seek(Slice(prefix)));
@@ -2282,7 +2282,7 @@ TEST_F(LoudsTrieTest, ChainSeekVariousTargets) {
 TEST_F(LoudsTrieTest, ChainSeekEndAtLeaf) {
   // Test path compression chains that end at a leaf node (end_child_idx ==
   // UINT32_MAX). This requires a key whose suffix after the chain endpoint
-  // has no children — i.e., the chain is the entire remaining path.
+  // has no children -- i.e., the chain is the entire remaining path.
   //
   // Strategy: Create keys with a long shared prefix and a single-character
   // difference at the very end, so the chain covers most of the key and
@@ -2324,7 +2324,7 @@ TEST_F(LoudsTrieTest, ChainSeekEndAtLeaf) {
   ASSERT_TRUE(iter.Valid());
   ASSERT_EQ(iter.Key().ToString(), chain_key);
 
-  // Seek to a target longer than the chain key — target has more bytes but
+  // Seek to a target longer than the chain key -- target has more bytes but
   // trie key ends at leaf. Should Advance() past it.
   std::string longer_target = chain_key + "Z";
   ASSERT_TRUE(iter.Seek(Slice(longer_target)));
@@ -2484,7 +2484,7 @@ TEST_F(TrieIndexFactoryTest, BasicBuildAndRead) {
   auto iter = reader->NewIterator(ro);
   ASSERT_NE(iter, nullptr);
 
-  // Seek to "banana" — should find the separator for the second block.
+  // Seek to "banana" -- should find the separator for the second block.
   IterateResult result;
   ASSERT_OK(iter->SeekAndGetResult(Slice("banana"), &result,
                                    SeekCtx(kMaxSequenceNumber)));
@@ -2568,17 +2568,17 @@ TEST_F(TrieIndexFactoryTest, IteratorBoundsChecking) {
   ScanOptions scan_opts(Slice("key_00"), Slice("key_01z"));
   iter->Prepare(&scan_opts, 1);
 
-  // Seek to first key — should be in bound.
+  // Seek to first key -- should be in bound.
   IterateResult result;
   ASSERT_OK(iter->SeekAndGetResult(Slice("key_00"), &result,
                                    SeekCtx(kMaxSequenceNumber)));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
 
-  // Next — should be in bound (key_01 < key_01z).
+  // Next -- should be in bound (key_01 < key_01z).
   ASSERT_OK(iter->NextAndGetResult(&result));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
 
-  // Next — the previous separator is for block 1 (< "key_01z"), so
+  // Next -- the previous separator is for block 1 (< "key_01z"), so
   // CheckBounds conservatively returns kInbound. The data-level iterator
   // handles per-key filtering. This is correct per the UDI API contract:
   // since we don't store first-in-block keys, we cannot determine that
@@ -2609,7 +2609,7 @@ TEST_F(TrieIndexFactoryTest, IteratorNoBounds) {
   ReadOptions ro;
   auto iter = reader->NewIterator(ro);
 
-  // No Prepare() call — bounds should be kInbound.
+  // No Prepare() call -- bounds should be kInbound.
   IterateResult result;
   ASSERT_OK(iter->SeekAndGetResult(Slice("key"), &result,
                                    SeekCtx(kMaxSequenceNumber)));
@@ -2629,7 +2629,7 @@ TEST_F(TrieIndexFactoryTest, UpperBoundDoesNotDropValidBlocks) {
   std::unique_ptr<UserDefinedIndexBuilder> udi_builder;
   ASSERT_OK(factory_->NewBuilder(option, udi_builder));
 
-  // Block 0: last="az", next_first="c" → separator ≈ "b"
+  // Block 0: last="az", next_first="c" -> separator ~= "b"
   {
     UserDefinedIndexBuilder::BlockHandle handle{0, 1000};
     std::string scratch;
@@ -2637,7 +2637,7 @@ TEST_F(TrieIndexFactoryTest, UpperBoundDoesNotDropValidBlocks) {
     udi_builder->AddIndexEntry(Slice("az"), &next, handle, &scratch,
                                EntryCtx(100, 100));
   }
-  // Block 1: last="cz", next_first="e" → separator ≈ "d"
+  // Block 1: last="cz", next_first="e" -> separator ~= "d"
   {
     UserDefinedIndexBuilder::BlockHandle handle{1000, 1000};
     std::string scratch;
@@ -2645,7 +2645,7 @@ TEST_F(TrieIndexFactoryTest, UpperBoundDoesNotDropValidBlocks) {
     udi_builder->AddIndexEntry(Slice("cz"), &next, handle, &scratch,
                                EntryCtx(100, 100));
   }
-  // Block 2: last="ez", no next → separator ≈ "f"
+  // Block 2: last="ez", no next -> separator ~= "f"
   {
     UserDefinedIndexBuilder::BlockHandle handle{2000, 1000};
     std::string scratch;
@@ -2667,21 +2667,22 @@ TEST_F(TrieIndexFactoryTest, UpperBoundDoesNotDropValidBlocks) {
   iter->Prepare(&scan_opts, 1);
 
   IterateResult result;
-  // Seek("a") → lands on block 0 (separator "b"). target "a" < "d" → kInbound.
+  // Seek("a") -> lands on block 0 (separator "b"). target "a" < "d" ->
+  // kInbound.
   ASSERT_OK(
       iter->SeekAndGetResult(Slice("a"), &result, SeekCtx(kMaxSequenceNumber)));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
   ASSERT_EQ(iter->value().offset, 0u);
 
-  // Next() → lands on block 1 (separator "d"). Previous separator "b" < "d"
-  // → kInbound (conservative). Block 1 contains keys like "c".."cz", which
+  // Next() -> lands on block 1 (separator "d"). Previous separator "b" < "d"
+  // -> kInbound (conservative). Block 1 contains keys like "c".."cz", which
   // are < "d", so returning kInbound is correct.
   ASSERT_OK(iter->NextAndGetResult(&result));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
   ASSERT_EQ(iter->value().offset, 1000u);
 
-  // Next() → lands on block 2 (separator "f"). Previous separator "d" >= "d"
-  // → kOutOfBound. All keys in block 2 are >= "d", so this is correct.
+  // Next() -> lands on block 2 (separator "f"). Previous separator "d" >= "d"
+  // -> kOutOfBound. All keys in block 2 are >= "d", so this is correct.
   ASSERT_OK(iter->NextAndGetResult(&result));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kOutOfBound);
 }
@@ -2738,17 +2739,18 @@ TEST_F(TrieIndexFactoryTest, MultiScanBoundsAdvanceCorrectly) {
   IterateResult result;
 
   // --- Scan 0 ---
-  // Seek("a") → block 0 (separator "b"). target "a" < limit "c" → kInbound.
+  // Seek("a") -> block 0 (separator "b"). target "a" < limit "c" -> kInbound.
   ASSERT_OK(
       iter->SeekAndGetResult(Slice("a"), &result, SeekCtx(kMaxSequenceNumber)));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
   ASSERT_EQ(iter->value().offset, 0u);
 
-  // Next() → block 1 (separator "d"). prev "b" < "c" → kInbound (conservative).
+  // Next() -> block 1 (separator "d"). prev "b" < "c" -> kInbound
+  // (conservative).
   ASSERT_OK(iter->NextAndGetResult(&result));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
 
-  // Next() → block 2 (separator "f"). prev "d" >= "c" → kOutOfBound.
+  // Next() -> block 2 (separator "f"). prev "d" >= "c" -> kOutOfBound.
   // Scan 0 is done.
   ASSERT_OK(iter->NextAndGetResult(&result));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kOutOfBound);
@@ -2756,17 +2758,18 @@ TEST_F(TrieIndexFactoryTest, MultiScanBoundsAdvanceCorrectly) {
   // --- Scan 1 ---
   // Seek("e") should advance current_scan_idx_ to 1 (target "e" >= scan 0
   // limit "c"), then check against scan 1's limit "g".
-  // Lands on block 2 (separator "f"). target "e" < "g" → kInbound.
+  // Lands on block 2 (separator "f"). target "e" < "g" -> kInbound.
   ASSERT_OK(
       iter->SeekAndGetResult(Slice("e"), &result, SeekCtx(kMaxSequenceNumber)));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
   ASSERT_EQ(iter->value().offset, 2000u);
 
-  // Next() → block 3 (separator "h"). prev "f" < "g" → kInbound (conservative).
+  // Next() -> block 3 (separator "h"). prev "f" < "g" -> kInbound
+  // (conservative).
   ASSERT_OK(iter->NextAndGetResult(&result));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
 
-  // Next() → block 4 (separator "j"). prev "h" >= "g" → kOutOfBound.
+  // Next() -> block 4 (separator "j"). prev "h" >= "g" -> kOutOfBound.
   // Scan 1 is done.
   ASSERT_OK(iter->NextAndGetResult(&result));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kOutOfBound);
@@ -2867,13 +2870,13 @@ TEST_F(TrieIndexFactoryTest, EmptyTrieIterator) {
                                    SeekCtx(kMaxSequenceNumber)));
   // kUnknown: no leaf has a key >= target, so the target is past all blocks
   // in this SST. We return kUnknown (not kOutOfBound) because exhausting
-  // this SST says nothing about the upper bound — the next SST on the level
+  // this SST says nothing about the upper bound -- the next SST on the level
   // may still have in-bound keys.
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kUnknown);
 }
 
 TEST_F(TrieIndexFactoryTest, PrepareWithZeroScans) {
-  // Prepare with 0 scan ranges, then seek — should behave as no bounds.
+  // Prepare with 0 scan ranges, then seek -- should behave as no bounds.
   auto ctx = BuildTrieAndGetIterator({
       {"az", "c", 0, 500, 0, 0},
       {"cz", "e", 1000, 500, 0, 0},
@@ -2890,7 +2893,7 @@ TEST_F(TrieIndexFactoryTest, PrepareWithZeroScans) {
 }
 
 TEST_F(TrieIndexFactoryTest, RePrepareResetsScanState) {
-  // Call Prepare twice — second Prepare should reset scan state.
+  // Call Prepare twice -- second Prepare should reset scan state.
   auto ctx = BuildTrieAndGetIterator({
       {"az", "c", 0, 500, 0, 0},
       {"cz", "e", 1000, 500, 0, 0},
@@ -2940,7 +2943,7 @@ TEST_F(TrieIndexFactoryTest, ScanWithNoLimit) {
   ASSERT_OK(ctx.iter->NextAndGetResult(&result));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
 
-  // No more blocks — kUnknown because exhausting this SST doesn't imply
+  // No more blocks -- kUnknown because exhausting this SST doesn't imply
   // the upper bound was reached.
   ASSERT_OK(ctx.iter->NextAndGetResult(&result));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kUnknown);
@@ -2967,7 +2970,7 @@ TEST_F(TrieIndexFactoryTest, OnKeyAddedNoOp) {
   std::unique_ptr<UserDefinedIndexBuilder> builder;
   ASSERT_OK(factory_->NewBuilder(option, builder));
 
-  // Call OnKeyAdded with all ValueType variants — all should be no-ops.
+  // Call OnKeyAdded with all ValueType variants -- all should be no-ops.
   builder->OnKeyAdded(Slice("key1"), UserDefinedIndexBuilder::kValue,
                       Slice("value1"));
   builder->OnKeyAdded(Slice("key2"), UserDefinedIndexBuilder::kDelete,
@@ -3002,7 +3005,7 @@ TEST_F(TrieIndexFactoryTest, NullComparator) {
   ASSERT_OK(factory_->NewBuilder(option, builder));
   ASSERT_NE(builder, nullptr);
 
-  // Add some entries — AddIndexEntry uses the defaulted comparator internally.
+  // Add some entries -- AddIndexEntry uses the defaulted comparator internally.
   std::string scratch;
   {
     UserDefinedIndexBuilder::BlockHandle h{0, 100};
@@ -3025,7 +3028,7 @@ TEST_F(TrieIndexFactoryTest, NullComparator) {
   ASSERT_OK(factory_->NewReader(option, index_contents, reader));
   ASSERT_NE(reader, nullptr);
 
-  // Verify the reader works — Seek uses the comparator for bounds checking.
+  // Verify the reader works -- Seek uses the comparator for bounds checking.
   ReadOptions ro;
   auto iter = reader->NewIterator(ro);
   IterateResult result;
@@ -3053,13 +3056,13 @@ TEST_F(TrieIndexFactoryTest, SeekSucceedsButTargetPastLimit) {
   ScanOptions scan(Slice("a"), Slice("c"));
   ctx.iter->Prepare(&scan, 1);
 
-  // Seek to "c" — target == limit, so CheckBounds returns kOutOfBound.
+  // Seek to "c" -- target == limit, so CheckBounds returns kOutOfBound.
   IterateResult result;
   ASSERT_OK(ctx.iter->SeekAndGetResult(Slice("c"), &result,
                                        SeekCtx(kMaxSequenceNumber)));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kOutOfBound);
 
-  // Seek to "d" — target > limit, also kOutOfBound.
+  // Seek to "d" -- target > limit, also kOutOfBound.
   ASSERT_OK(ctx.iter->SeekAndGetResult(Slice("d"), &result,
                                        SeekCtx(kMaxSequenceNumber)));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kOutOfBound);
@@ -3082,7 +3085,7 @@ TEST_F(TrieIndexFactoryTest, SameUserKeyBoundaryTriggersSeqnoEncoding) {
   // trie cannot distinguish the two blocks, causing incorrect Seek.
   auto ctx = BuildTrieAndGetIterator({
       // Block 0: last_key="foo" seq=100, next_first="foo" seq=50.
-      // Same user key at boundary — triggers must_use_separator_with_seq_.
+      // Same user key at boundary -- triggers must_use_separator_with_seq_.
       {"foo", "foo", 0, 1000, 100, 50},
       // Block 1: last_key="foo" seq=50, next_first="goo" seq=1.
       {"foo", "goo", 1000, 1000, 50, 1},
@@ -3092,7 +3095,7 @@ TEST_F(TrieIndexFactoryTest, SameUserKeyBoundaryTriggersSeqnoEncoding) {
 
   IterateResult result;
 
-  // Seek for "foo" with seq=100 (highest seqno — should find Block 0).
+  // Seek for "foo" with seq=100 (highest seqno -- should find Block 0).
   ASSERT_NO_FATAL_FAILURE(
       AssertSeekOffset(ctx.iter.get(), Slice("foo"), 100, 0));
 
@@ -3107,17 +3110,17 @@ TEST_F(TrieIndexFactoryTest, SameUserKeyBoundaryTriggersSeqnoEncoding) {
   ASSERT_NO_FATAL_FAILURE(
       AssertSeekOffset(ctx.iter.get(), Slice("foo"), 75, 1000));
 
-  // Seek for "foo" with seq=50 (exact seqno of Block 1's first key —
+  // Seek for "foo" with seq=50 (exact seqno of Block 1's first key --
   // should find Block 1).
   ASSERT_NO_FATAL_FAILURE(
       AssertSeekOffset(ctx.iter.get(), Slice("foo"), 50, 1000));
 
-  // Seek for "foo" with seq=1 (lower than any foo seqno — should find
+  // Seek for "foo" with seq=1 (lower than any foo seqno -- should find
   // Block 1, because in descending seqno order seq=1 comes after seq=50).
   ASSERT_NO_FATAL_FAILURE(
       AssertSeekOffset(ctx.iter.get(), Slice("foo"), 1, 1000));
 
-  // Seek for "goo" with kMaxSequenceNumber — should find Block 2.
+  // Seek for "goo" with kMaxSequenceNumber -- should find Block 2.
   ASSERT_NO_FATAL_FAILURE(
       AssertSeekOffset(ctx.iter.get(), Slice("goo"), kMaxSequenceNumber, 2000));
 
@@ -3160,42 +3163,42 @@ TEST_F(TrieIndexFactoryTest, MultipleSameUserKeyBoundaries) {
       {"other", "", 3000, 1000, 50, 0},
   });
 
-  // Seek "key"|seq=300 → Block 0
+  // Seek "key"|seq=300 -> Block 0
   ASSERT_NO_FATAL_FAILURE(
       AssertSeekOffset(ctx.iter.get(), Slice("key"), 300, 0));
 
-  // Seek "key"|seq=250 → Block 1. In internal key order, higher seqno is
+  // Seek "key"|seq=250 -> Block 1. In internal key order, higher seqno is
   // "smaller", so "key"|300 < "key"|250. Block 0's separator "key"+enc(300)
-  // is less than the target → skip. Block 1's separator "key"+enc(200)
-  // is >= target because enc(200) > enc(250) (lower seqno → larger encoded
+  // is less than the target -> skip. Block 1's separator "key"+enc(200)
+  // is >= target because enc(200) > enc(250) (lower seqno -> larger encoded
   // bytes). So the first separator >= target is Block 1.
   ASSERT_NO_FATAL_FAILURE(
       AssertSeekOffset(ctx.iter.get(), Slice("key"), 250, 1000));
 
-  // Seek "key"|seq=200 → Block 1
+  // Seek "key"|seq=200 -> Block 1
   ASSERT_NO_FATAL_FAILURE(
       AssertSeekOffset(ctx.iter.get(), Slice("key"), 200, 1000));
 
-  // Seek "key"|seq=150 → Block 2. "key"+enc(300) < target (skip Block 0),
+  // Seek "key"|seq=150 -> Block 2. "key"+enc(300) < target (skip Block 0),
   // "key"+enc(200) < target (skip Block 1, because enc(200) < enc(150):
-  // 200 > 150 → higher seqno → smaller encoding). The next separator is
-  // Block 2's separator which is >= target → Block 2.
+  // 200 > 150 -> higher seqno -> smaller encoding). The next separator is
+  // Block 2's separator which is >= target -> Block 2.
   ASSERT_NO_FATAL_FAILURE(
       AssertSeekOffset(ctx.iter.get(), Slice("key"), 150, 2000));
 
-  // Seek "key"|seq=100 → Block 2
+  // Seek "key"|seq=100 -> Block 2
   ASSERT_NO_FATAL_FAILURE(
       AssertSeekOffset(ctx.iter.get(), Slice("key"), 100, 2000));
 
-  // Seek "key"|seq=1 → Block 2 (below all key seqnos)
+  // Seek "key"|seq=1 -> Block 2 (below all key seqnos)
   ASSERT_NO_FATAL_FAILURE(
       AssertSeekOffset(ctx.iter.get(), Slice("key"), 1, 2000));
 
-  // Seek "other"|kMaxSequenceNumber → Block 3
+  // Seek "other"|kMaxSequenceNumber -> Block 3
   ASSERT_NO_FATAL_FAILURE(AssertSeekOffset(ctx.iter.get(), Slice("other"),
                                            kMaxSequenceNumber, 3000));
 
-  // Full forward scan: Block 0 → 1 → 2 → 3
+  // Full forward scan: Block 0 -> 1 -> 2 -> 3
   ASSERT_NO_FATAL_FAILURE(AssertFullForwardScan(ctx.iter.get(), Slice("key"),
                                                 {0, 1000, 2000, 3000}));
 }
@@ -3204,7 +3207,7 @@ TEST_F(TrieIndexFactoryTest, SameUserKeyWithZeroSeqnos) {
   // During bottommost compaction, RocksDB zeroes sequence numbers for keys
   // that no longer need version discrimination. When the same user key spans
   // multiple data blocks and all versions have seqno=0, the overflow entries
-  // in the same-key run also have seqno=0. This is valid — the reader's
+  // in the same-key run also have seqno=0. This is valid -- the reader's
   // post-seek correction handles it correctly:
   //   - Primary leaf seqno=0, and target_packed >= 0 so no advancement
   //   - Next() iterates overflow blocks by index, not seqno
@@ -3215,7 +3218,7 @@ TEST_F(TrieIndexFactoryTest, SameUserKeyWithZeroSeqnos) {
       {"zzz", "", 3000, 1000, 0, 0},
   });
 
-  // Seek "key"|kMaxSequenceNumber → Block 0 (primary, seqno=0 guard prevents
+  // Seek "key"|kMaxSequenceNumber -> Block 0 (primary, seqno=0 guard prevents
   // advancement through overflow blocks).
   ASSERT_NO_FATAL_FAILURE(
       AssertSeekOffset(ctx.iter.get(), Slice("key"), kMaxSequenceNumber, 0));
@@ -3223,11 +3226,11 @@ TEST_F(TrieIndexFactoryTest, SameUserKeyWithZeroSeqnos) {
   // Seek "key"|seq=0 -> Block 0 (primary, target_packed=0 >= leaf_packed=0).
   ASSERT_NO_FATAL_FAILURE(AssertSeekOffset(ctx.iter.get(), Slice("key"), 0, 0));
 
-  // Full forward scan: Block 0 → 1 → 2 → 3
+  // Full forward scan: Block 0 -> 1 -> 2 -> 3
   ASSERT_NO_FATAL_FAILURE(AssertFullForwardScan(ctx.iter.get(), Slice("key"),
                                                 {0, 1000, 2000, 3000}));
 
-  // SeekToFirst → Block 0, then full scan.
+  // SeekToFirst -> Block 0, then full scan.
   IterateResult result;
   ASSERT_OK(ctx.iter->SeekToFirstAndGetResult(&result));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
@@ -3249,17 +3252,17 @@ TEST_F(TrieIndexFactoryTest, SameUserKeyLastBlockZeroSeqno) {
       {"key", "", 1000, 1000, 0, 0},  // last block
   });
 
-  // Seek → Block 0 (primary).
+  // Seek -> Block 0 (primary).
   ASSERT_NO_FATAL_FAILURE(
       AssertSeekOffset(ctx.iter.get(), Slice("key"), kMaxSequenceNumber, 0));
 
-  // Next → Block 1 (overflow).
+  // Next -> Block 1 (overflow).
   IterateResult result;
   ASSERT_OK(ctx.iter->NextAndGetResult(&result));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
   ASSERT_EQ(ctx.iter->value().offset, 1000u);
 
-  // Next → exhausted.
+  // Next -> exhausted.
   ASSERT_OK(ctx.iter->NextAndGetResult(&result));
   ASSERT_NE(result.bound_check_result, IterBoundCheck::kInbound);
 }
@@ -3273,10 +3276,10 @@ TEST_F(TrieIndexFactoryTest, SeqnoEncodingRoundTripSerialization) {
       {"x", "", 500, 500, 5, 0},
   });
 
-  // Seek "x"|seq=10 → Block 0
+  // Seek "x"|seq=10 -> Block 0
   ASSERT_NO_FATAL_FAILURE(AssertSeekOffset(ctx.iter.get(), Slice("x"), 10, 0));
 
-  // Seek "x"|seq=5 → Block 1
+  // Seek "x"|seq=5 -> Block 1
   ASSERT_NO_FATAL_FAILURE(AssertSeekOffset(ctx.iter.get(), Slice("x"), 5, 500));
 }
 
@@ -3296,12 +3299,12 @@ TEST_F(TrieIndexFactoryTest, SeqnoEncodingWithBoundsChecking) {
 
   IterateResult result;
 
-  // Seek "key"|seq=100 → Block 0, within bounds.
+  // Seek "key"|seq=100 -> Block 0, within bounds.
   ASSERT_OK(ctx.iter->SeekAndGetResult(Slice("key"), &result, SeekCtx(100)));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
   ASSERT_EQ(ctx.iter->value().offset, 0u);
 
-  // Next → Block 1, previous separator "key" < "zzz" → kInbound.
+  // Next -> Block 1, previous separator "key" < "zzz" -> kInbound.
   ASSERT_OK(ctx.iter->NextAndGetResult(&result));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
   ASSERT_EQ(ctx.iter->value().offset, 1000u);
@@ -3326,7 +3329,7 @@ TEST_F(TrieIndexFactoryTest, SeqnoEncodingWithBoundsChecking) {
 //   - Seeking non-existent keys when seqno encoding is active
 //   - Seeking past all keys / Next() past last block with seqno encoding
 //   - kUnknown on exhaustion with seqno encoding and overflow
-//   - Next() transitions: overflow→next leaf, overflow→next overflow run
+//   - Next() transitions: overflow->next leaf, overflow->next overflow run
 //   - Bounds checking during overflow run iteration
 //   - Size comparison: seqno-free trie same size as without the feature
 //   - Re-seeking after being positioned in an overflow run
@@ -3336,7 +3339,7 @@ TEST_F(TrieIndexFactoryTest, LargeOverflowRun) {
   // 12 blocks all with user key "key", seqnos descending from 1200 to 100.
   // The last "key" block transitions to "zzz", so
   // FindShortestSeparator("key", "zzz") = "l". The trie has:
-  //   "key" (11-block run, seqnos 1200..200) → "l" (block 11) → "zzz" (block
+  //   "key" (11-block run, seqnos 1200..200) -> "l" (block 11) -> "zzz" (block
   //   12)
   // The overflow run for "key" has 10 overflow entries (blocks 1-10).
   UserDefinedIndexOption option;
@@ -3353,7 +3356,7 @@ TEST_F(TrieIndexFactoryTest, LargeOverflowRun) {
     SequenceNumber seq = static_cast<SequenceNumber>((kNumKeyBlocks - i) * 100);
 
     if (i < kNumKeyBlocks - 1) {
-      // Same-user-key boundary: "key" → "key".
+      // Same-user-key boundary: "key" -> "key".
       Slice next("key");
       SequenceNumber next_seq =
           static_cast<SequenceNumber>((kNumKeyBlocks - i - 1) * 100);
@@ -3386,35 +3389,35 @@ TEST_F(TrieIndexFactoryTest, LargeOverflowRun) {
   auto iter = reader->NewIterator(ro);
   IterateResult result;
 
-  // Seek "key"|kMax → Block 0.
+  // Seek "key"|kMax -> Block 0.
   ASSERT_OK(iter->SeekAndGetResult(Slice("key"), &result,
                                    SeekCtx(kMaxSequenceNumber)));
   ASSERT_EQ(iter->value().offset, 0u);
 
-  // Seek "key"|1100 → leaf_seqno=1200, 1100<1200 → advance.
-  // overflow[0]=1100, 1100>=1100 → Block 1.
+  // Seek "key"|1100 -> leaf_seqno=1200, 1100<1200 -> advance.
+  // overflow[0]=1100, 1100>=1100 -> Block 1.
   ASSERT_OK(iter->SeekAndGetResult(Slice("key"), &result, SeekCtx(1100)));
   ASSERT_EQ(iter->value().offset, 1000u);
 
-  // Seek "key"|550 → advance through overflow:
+  // Seek "key"|550 -> advance through overflow:
   //   overflow seqnos: 1100,1000,900,800,700,600,500,400,300,200
   //   550 < 1100..600, 550 >= 500? No, 550 is not < 600:
   //   Actually: 550<1100 skip, 550<1000 skip, 550<900 skip, 550<800 skip,
-  //   550<700 skip, 550<600 skip, 550>=500 → found at overflow index 6.
-  //   overflow_run_index_ = 7 (1-based) → Block 7, offset 7000.
+  //   550<700 skip, 550<600 skip, 550>=500 -> found at overflow index 6.
+  //   overflow_run_index_ = 7 (1-based) -> Block 7, offset 7000.
   ASSERT_OK(iter->SeekAndGetResult(Slice("key"), &result, SeekCtx(550)));
   ASSERT_EQ(iter->value().offset, 7000u);
 
-  // Seek "key"|50 → below all "key" overflow seqnos (minimum is 200).
-  // All 10 overflow seqnos exhausted → advance to next leaf "l" (block 11).
+  // Seek "key"|50 -> below all "key" overflow seqnos (minimum is 200).
+  // All 10 overflow seqnos exhausted -> advance to next leaf "l" (block 11).
   ASSERT_OK(iter->SeekAndGetResult(Slice("key"), &result, SeekCtx(50)));
   ASSERT_EQ(iter->value().offset, 11000u);
 
-  // Seek "key"|0 → same: advance past run → "l" (block 11).
+  // Seek "key"|0 -> same: advance past run -> "l" (block 11).
   ASSERT_OK(iter->SeekAndGetResult(Slice("key"), &result, SeekCtx(0)));
   ASSERT_EQ(iter->value().offset, 11000u);
 
-  // Full forward scan: blocks 0..10 ("key" run) → 11 ("l") → 12 ("zzz").
+  // Full forward scan: blocks 0..10 ("key" run) -> 11 ("l") -> 12 ("zzz").
   ASSERT_OK(iter->SeekAndGetResult(Slice("key"), &result,
                                    SeekCtx(kMaxSequenceNumber)));
   ASSERT_EQ(iter->value().offset, 0u);
@@ -3423,7 +3426,7 @@ TEST_F(TrieIndexFactoryTest, LargeOverflowRun) {
     ASSERT_EQ(iter->value().offset, static_cast<uint64_t>(i) * 1000)
         << "Next failed at block " << i;
   }
-  // Past end — kUnknown (exhaustion doesn't imply upper bound reached).
+  // Past end -- kUnknown (exhaustion doesn't imply upper bound reached).
   ASSERT_OK(iter->NextAndGetResult(&result));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kUnknown);
 }
@@ -3432,14 +3435,14 @@ TEST_F(TrieIndexFactoryTest, MixedSameKeyRuns) {
   // Two different user keys each with multi-block runs, plus distinct blocks.
   //
   // The trie structure (after FindShortestSeparator shortening):
-  //   "aaa" (2-block run, seqnos 300, 200) → "b" (block 2) →
-  //   "mmm" (1-block, seqno 60) → "n" (block 4) → "zzz" (block 5)
+  //   "aaa" (2-block run, seqnos 300, 200) -> "b" (block 2) ->
+  //   "mmm" (1-block, seqno 60) -> "n" (block 4) -> "zzz" (block 5)
   //
-  // Block 0: "aaa"|300 → next "aaa"|200 (same-key → separator "aaa")
-  // Block 1: "aaa"|200 → next "mmm"    (diff-key → separator "b")
-  // Block 2: "mmm"|60  → next "mmm"|30 (same-key → separator "mmm")
-  // Block 3: "mmm"|30  → next "zzz"    (diff-key → separator "n")
-  // Block 4: "zzz"|10  → null          (last → separator "zzz")
+  // Block 0: "aaa"|300 -> next "aaa"|200 (same-key -> separator "aaa")
+  // Block 1: "aaa"|200 -> next "mmm"    (diff-key -> separator "b")
+  // Block 2: "mmm"|60  -> next "mmm"|30 (same-key -> separator "mmm")
+  // Block 3: "mmm"|30  -> next "zzz"    (diff-key -> separator "n")
+  // Block 4: "zzz"|10  -> null          (last -> separator "zzz")
   //
   // "aaa" run: blocks 0-1 (2 entries, run of 2 in trie)
   // block 2 gets separator "b" (separate trie leaf)
@@ -3447,12 +3450,12 @@ TEST_F(TrieIndexFactoryTest, MixedSameKeyRuns) {
   // block 4 gets separator "n" (separate trie leaf)
   // block 5 gets separator "zzz" (separate trie leaf, no shortening)
   //
-  // Wait — let me recount. We have 6 AddIndexEntry calls:
-  //   Entry 0: "aaa" 300 next="aaa" → sep="aaa"
-  //   Entry 1: "aaa" 200 next="mmm" → sep="b"
-  //   Entry 2: "mmm"  60 next="mmm" → sep="mmm"
-  //   Entry 3: "mmm"  30 next="zzz" → sep="n"
-  //   Entry 4: "zzz"  10 next=null  → sep="zzz"
+  // Wait -- let me recount. We have 6 AddIndexEntry calls:
+  //   Entry 0: "aaa" 300 next="aaa" -> sep="aaa"
+  //   Entry 1: "aaa" 200 next="mmm" -> sep="b"
+  //   Entry 2: "mmm"  60 next="mmm" -> sep="mmm"
+  //   Entry 3: "mmm"  30 next="zzz" -> sep="n"
+  //   Entry 4: "zzz"  10 next=null  -> sep="zzz"
   //
   // De-duplicated separators: "aaa" appears once (run=1), "b", "mmm" appears
   // once (run=1), "n", "zzz". So actually there are no overflow runs here!
@@ -3460,7 +3463,7 @@ TEST_F(TrieIndexFactoryTest, MixedSameKeyRuns) {
   // The "mmm" run is only block 2, and block 3 gets separator "n".
   //
   // For a true multi-block overflow run for "aaa", we need 3+ consecutive
-  // blocks ALL with "aaa" → "aaa" boundaries.
+  // blocks ALL with "aaa" -> "aaa" boundaries.
   UserDefinedIndexOption option;
   option.comparator = BytewiseComparator();
 
@@ -3482,7 +3485,7 @@ TEST_F(TrieIndexFactoryTest, MixedSameKeyRuns) {
     builder->AddIndexEntry(Slice("aaa"), &next, h, &scratch,
                            EntryCtx(200, 100));
   }
-  // Last "aaa" block transitions to "mmm" → separator "b".
+  // Last "aaa" block transitions to "mmm" -> separator "b".
   {
     UserDefinedIndexBuilder::BlockHandle h{2000, 1000};
     std::string scratch;
@@ -3496,14 +3499,14 @@ TEST_F(TrieIndexFactoryTest, MixedSameKeyRuns) {
     Slice next("mmm");
     builder->AddIndexEntry(Slice("mmm"), &next, h, &scratch, EntryCtx(60, 30));
   }
-  // Last "mmm" block transitions to "zzz" → separator "n".
+  // Last "mmm" block transitions to "zzz" -> separator "n".
   {
     UserDefinedIndexBuilder::BlockHandle h{4000, 1000};
     std::string scratch;
     Slice next("zzz");
     builder->AddIndexEntry(Slice("mmm"), &next, h, &scratch, EntryCtx(30, 10));
   }
-  // "zzz": 1 block (last → separator "zzz", no shortening).
+  // "zzz": 1 block (last -> separator "zzz", no shortening).
   {
     UserDefinedIndexBuilder::BlockHandle h{5000, 1000};
     std::string scratch;
@@ -3520,37 +3523,37 @@ TEST_F(TrieIndexFactoryTest, MixedSameKeyRuns) {
   auto iter = reader->NewIterator(ro);
   IterateResult result;
 
-  // Trie structure: "aaa"(run=2) → "b" → "mmm"(run=1) → "n" → "zzz"
+  // Trie structure: "aaa"(run=2) -> "b" -> "mmm"(run=1) -> "n" -> "zzz"
   //
-  // Seek "aaa"|kMax → Block 0.
+  // Seek "aaa"|kMax -> Block 0.
   ASSERT_OK(iter->SeekAndGetResult(Slice("aaa"), &result,
                                    SeekCtx(kMaxSequenceNumber)));
   ASSERT_EQ(iter->value().offset, 0u);
 
-  // Seek "aaa"|250 → leaf_seqno=300, 250<300 → advance.
-  // overflow[0]=200, 250>=200 → Block 1.
+  // Seek "aaa"|250 -> leaf_seqno=300, 250<300 -> advance.
+  // overflow[0]=200, 250>=200 -> Block 1.
   ASSERT_OK(iter->SeekAndGetResult(Slice("aaa"), &result, SeekCtx(250)));
   ASSERT_EQ(iter->value().offset, 1000u);
 
-  // Seek "aaa"|50 → leaf_seqno=300, 50<300 → advance.
-  // overflow[0]=200, 50<200 → skip. All exhausted → next leaf "b" (block 2).
+  // Seek "aaa"|50 -> leaf_seqno=300, 50<300 -> advance.
+  // overflow[0]=200, 50<200 -> skip. All exhausted -> next leaf "b" (block 2).
   ASSERT_OK(iter->SeekAndGetResult(Slice("aaa"), &result, SeekCtx(50)));
   ASSERT_EQ(iter->value().offset, 2000u);
 
-  // Seek "mmm"|kMax → Block 3 (the "mmm" trie leaf).
+  // Seek "mmm"|kMax -> Block 3 (the "mmm" trie leaf).
   ASSERT_OK(iter->SeekAndGetResult(Slice("mmm"), &result,
                                    SeekCtx(kMaxSequenceNumber)));
   ASSERT_EQ(iter->value().offset, 3000u);
 
-  // Seek "mmm"|45 → leaf_seqno=60, 45<60 → advance.
-  // "mmm" has run_size=1 (only 1 block in trie), no overflow → next leaf "n".
-  // Wait — "mmm" appears only once in the separator list (entry 2), because
+  // Seek "mmm"|45 -> leaf_seqno=60, 45<60 -> advance.
+  // "mmm" has run_size=1 (only 1 block in trie), no overflow -> next leaf "n".
+  // Wait -- "mmm" appears only once in the separator list (entry 2), because
   // entry 3 has separator "n". So "mmm" trie leaf has block_count=1.
-  // 45 < 60, no overflow → advance to "n" (block 4).
+  // 45 < 60, no overflow -> advance to "n" (block 4).
   ASSERT_OK(iter->SeekAndGetResult(Slice("mmm"), &result, SeekCtx(45)));
   ASSERT_EQ(iter->value().offset, 4000u);
 
-  // Full forward scan: 0 → 1 → 2 → 3 → 4 → 5.
+  // Full forward scan: 0 -> 1 -> 2 -> 3 -> 4 -> 5.
   ASSERT_OK(iter->SeekAndGetResult(Slice("aaa"), &result,
                                    SeekCtx(kMaxSequenceNumber)));
   ASSERT_EQ(iter->value().offset, 0u);
@@ -3561,7 +3564,7 @@ TEST_F(TrieIndexFactoryTest, MixedSameKeyRuns) {
     ASSERT_EQ(iter->value().offset, expected_offsets[i])
         << "Next failed at i=" << i;
   }
-  // Past end — kUnknown (exhaustion doesn't imply upper bound reached).
+  // Past end -- kUnknown (exhaustion doesn't imply upper bound reached).
   ASSERT_OK(iter->NextAndGetResult(&result));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kUnknown);
 }
@@ -3571,15 +3574,15 @@ TEST_F(TrieIndexFactoryTest, AdjacentSameKeyRuns) {
   // the first run has a different-key boundary, creating a non-run trie leaf
   // between the two runs. To get true adjacency we make ALL "aaa" blocks
   // transition to "aaa", and ALL "bbb" blocks transition to "bbb", with
-  // the boundary between runs being "aaa"→"bbb".
+  // the boundary between runs being "aaa"->"bbb".
   //
   // Entries (separator after FindShortestSeparator):
-  //   Entry 0: "aaa" 200 next="aaa" → sep="aaa" (same-key)
-  //   Entry 1: "aaa" 100 next="bbb" → sep="b"   (diff-key)
-  //   Entry 2: "bbb"  80 next="bbb" → sep="bbb"  (same-key)
-  //   Entry 3: "bbb"  40 next=null  → sep="bbb"  (last block, no shortening)
+  //   Entry 0: "aaa" 200 next="aaa" -> sep="aaa" (same-key)
+  //   Entry 1: "aaa" 100 next="bbb" -> sep="b"   (diff-key)
+  //   Entry 2: "bbb"  80 next="bbb" -> sep="bbb"  (same-key)
+  //   Entry 3: "bbb"  40 next=null  -> sep="bbb"  (last block, no shortening)
   //
-  // Trie: "aaa"(run=1, seq=200) → "b"(1 block) → "bbb"(run=2, seqnos 80,40)
+  // Trie: "aaa"(run=1, seq=200) -> "b"(1 block) -> "bbb"(run=2, seqnos 80,40)
   // Note: the last block joins the "bbb" run since its separator also is "bbb".
   auto ctx = BuildTrieAndGetIterator({
       {"aaa", "aaa", 0, 1000, 200, 100},
@@ -3590,7 +3593,7 @@ TEST_F(TrieIndexFactoryTest, AdjacentSameKeyRuns) {
 
   IterateResult result;
 
-  // Full scan: "aaa" (block 0) → "b" (block 1) → "bbb" (block 2) → "bbb"
+  // Full scan: "aaa" (block 0) -> "b" (block 1) -> "bbb" (block 2) -> "bbb"
   // overflow (block 3).
   ASSERT_OK(ctx.iter->SeekAndGetResult(Slice("aaa"), &result,
                                        SeekCtx(kMaxSequenceNumber)));
@@ -3609,7 +3612,7 @@ TEST_F(TrieIndexFactoryTest, AdjacentSameKeyRuns) {
   ASSERT_EQ(ctx.iter->value().offset, 3000u);
   ASSERT_EQ(result.key.ToString(), "bbb");
 
-  // Past end — kUnknown (exhaustion doesn't imply upper bound reached).
+  // Past end -- kUnknown (exhaustion doesn't imply upper bound reached).
   ASSERT_OK(ctx.iter->NextAndGetResult(&result));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kUnknown);
 }
@@ -3621,9 +3624,9 @@ TEST_F(TrieIndexFactoryTest, SeqnoEncodingResultKeyIsUserKey) {
   // is shortened.
   //
   // Entries:
-  //   "foo" 100 next="foo" → sep="foo" (same-key, run of 2)
-  //   "foo"  50 next="zoo" → sep="g"   (FindShortestSeparator("foo","zoo"))
-  //   "zoo"   1 next=null  → sep="zoo" (last block, no successor shortening)
+  //   "foo" 100 next="foo" -> sep="foo" (same-key, run of 2)
+  //   "foo"  50 next="zoo" -> sep="g"   (FindShortestSeparator("foo","zoo"))
+  //   "zoo"   1 next=null  -> sep="zoo" (last block, no successor shortening)
   auto ctx = BuildTrieAndGetIterator({
       {"foo", "foo", 0, 500, 100, 50},
       {"foo", "zoo", 500, 500, 50, 1},
@@ -3632,12 +3635,12 @@ TEST_F(TrieIndexFactoryTest, SeqnoEncodingResultKeyIsUserKey) {
 
   IterateResult result;
 
-  // Seek to "foo"|100 → "foo" leaf. result.key = "foo" (3 bytes, no suffix).
+  // Seek to "foo"|100 -> "foo" leaf. result.key = "foo" (3 bytes, no suffix).
   ASSERT_OK(ctx.iter->SeekAndGetResult(Slice("foo"), &result, SeekCtx(100)));
   ASSERT_EQ(result.key.ToString(), "foo");
   ASSERT_EQ(result.key.size(), 3u);
 
-  // Next → "g" leaf (FindShortestSeparator("foo", "zoo") = "g").
+  // Next -> "g" leaf (FindShortestSeparator("foo", "zoo") = "g").
   // result.key = "g" (1 byte).
   ASSERT_OK(ctx.iter->NextAndGetResult(&result));
   ASSERT_EQ(result.key.size(), 1u);
@@ -3649,7 +3652,7 @@ TEST_F(TrieIndexFactoryTest, SeqnoEncodingResultKeyIsUserKey) {
 TEST_F(TrieIndexFactoryTest, SeekNonExistentKeyWithSeqnoEncoding) {
   // Seeking for keys not in the trie when seqno encoding is active.
   //
-  // Trie: "mmm"(run=1, seq=100) → "n" → "zzz"
+  // Trie: "mmm"(run=1, seq=100) -> "n" -> "zzz"
   auto ctx = BuildTrieAndGetIterator({
       {"mmm", "mmm", 0, 1000, 100, 50},
       {"mmm", "zzz", 1000, 1000, 50, 1},
@@ -3657,14 +3660,14 @@ TEST_F(TrieIndexFactoryTest, SeekNonExistentKeyWithSeqnoEncoding) {
   });
   auto* iter = ctx.iter.get();
 
-  // Seek "aaa" (before all keys) → lands on "mmm" leaf, Block 0.
+  // Seek "aaa" (before all keys) -> lands on "mmm" leaf, Block 0.
   ASSERT_NO_FATAL_FAILURE(
       AssertSeekOffset(iter, Slice("aaa"), kMaxSequenceNumber, 0u));
-  // Seek "nnn" (between "n" and "zzz") → lands on "zzz" leaf, Block 2.
+  // Seek "nnn" (between "n" and "zzz") -> lands on "zzz" leaf, Block 2.
   ASSERT_NO_FATAL_FAILURE(
       AssertSeekOffset(iter, Slice("nnn"), kMaxSequenceNumber, 2000u));
 
-  // Seek "|" (past all keys, "|" > "zzz") → kUnknown.
+  // Seek "|" (past all keys, "|" > "zzz") -> kUnknown.
   IterateResult result;
   ASSERT_OK(
       iter->SeekAndGetResult(Slice("|"), &result, SeekCtx(kMaxSequenceNumber)));
@@ -3683,20 +3686,20 @@ TEST_F(TrieIndexFactoryTest, SeqnoEncodingPastEndAndNextPastEnd) {
   auto* iter = ctx.iter.get();
   IterateResult result;
 
-  // Seek past all keys → kUnknown (exhaustion doesn't imply upper bound).
+  // Seek past all keys -> kUnknown (exhaustion doesn't imply upper bound).
   ASSERT_OK(iter->SeekAndGetResult(Slice("zzz"), &result,
                                    SeekCtx(kMaxSequenceNumber)));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kUnknown);
 
-  // Seek "key"|5 → seqno=10 on primary, 5<10 → overflow seqno=5, 5>=5 →
+  // Seek "key"|5 -> seqno=10 on primary, 5<10 -> overflow seqno=5, 5>=5 ->
   // overflow block 1.
   ASSERT_NO_FATAL_FAILURE(AssertSeekOffset(iter, Slice("key"), 5, 500u));
 
-  // Next from last block in run → past end.
+  // Next from last block in run -> past end.
   ASSERT_OK(iter->NextAndGetResult(&result));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kUnknown);
 
-  // Full forward scan: block 0 → block 1 → past end.
+  // Full forward scan: block 0 -> block 1 -> past end.
   ASSERT_NO_FATAL_FAILURE(AssertFullForwardScan(iter, Slice("key"), {0, 500}));
 }
 
@@ -3705,12 +3708,12 @@ TEST_F(TrieIndexFactoryTest, SeqnoEncodingOutOfBoundWithOverflow) {
   // overflow blocks.
   //
   // Entries:
-  //   "key" 300 next="key" → sep="key" (same-key)
-  //   "key" 200 next="key" → sep="key" (same-key)
-  //   "key" 100 next="zzz" → sep="l"
-  //   "zzz"   1 next=null  → sep="zzz" (last block, no shortening)
+  //   "key" 300 next="key" -> sep="key" (same-key)
+  //   "key" 200 next="key" -> sep="key" (same-key)
+  //   "key" 100 next="zzz" -> sep="l"
+  //   "zzz"   1 next=null  -> sep="zzz" (last block, no shortening)
   //
-  // Trie: "key"(run=2, seqnos 300,200) → "l" → "zzz"
+  // Trie: "key"(run=2, seqnos 300,200) -> "l" -> "zzz"
   auto ctx = BuildTrieAndGetIterator({
       {"key", "key", 0, 1000, 300, 200},
       {"key", "key", 1000, 1000, 200, 100},
@@ -3724,22 +3727,23 @@ TEST_F(TrieIndexFactoryTest, SeqnoEncodingOutOfBoundWithOverflow) {
 
   IterateResult result;
 
-  // Seek "key"|300 → Block 0, target "key" < "zzz" → kInbound.
+  // Seek "key"|300 -> Block 0, target "key" < "zzz" -> kInbound.
   ASSERT_OK(ctx.iter->SeekAndGetResult(Slice("key"), &result, SeekCtx(300)));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
   ASSERT_EQ(ctx.iter->value().offset, 0u);
 
-  // Next → Block 1 (overflow within "key" run), prev "key" < "zzz" → kInbound.
+  // Next -> Block 1 (overflow within "key" run), prev "key" < "zzz" ->
+  // kInbound.
   ASSERT_OK(ctx.iter->NextAndGetResult(&result));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
   ASSERT_EQ(ctx.iter->value().offset, 1000u);
 
-  // Next → "l" leaf (block 2), prev "key" < "zzz" → kInbound.
+  // Next -> "l" leaf (block 2), prev "key" < "zzz" -> kInbound.
   ASSERT_OK(ctx.iter->NextAndGetResult(&result));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
   ASSERT_EQ(ctx.iter->value().offset, 2000u);
 
-  // Next → "zzz" leaf (block 3). prev key is "l", "l" < "zzz" → kInbound.
+  // Next -> "zzz" leaf (block 3). prev key is "l", "l" < "zzz" -> kInbound.
   ASSERT_OK(ctx.iter->NextAndGetResult(&result));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
   ASSERT_EQ(ctx.iter->value().offset, 3000u);
@@ -3750,19 +3754,19 @@ TEST_F(TrieIndexFactoryTest, SeqnoEncodingOutOfBoundWithOverflow) {
   ScanOptions scan2(Slice("key"), Slice("l"));
   ctx.iter->Prepare(&scan2, 1);
 
-  // Seek "key"|300 → Block 0, target "key" < "l" → kInbound.
+  // Seek "key"|300 -> Block 0, target "key" < "l" -> kInbound.
   ASSERT_OK(ctx.iter->SeekAndGetResult(Slice("key"), &result, SeekCtx(300)));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
 
-  // Next → Block 1 (overflow), prev "key" < "l" → kInbound.
+  // Next -> Block 1 (overflow), prev "key" < "l" -> kInbound.
   ASSERT_OK(ctx.iter->NextAndGetResult(&result));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
 
-  // Next → "l" leaf (block 2). prev "key" < "l" → kInbound (conservative).
+  // Next -> "l" leaf (block 2). prev "key" < "l" -> kInbound (conservative).
   ASSERT_OK(ctx.iter->NextAndGetResult(&result));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
 
-  // Next → "zzz" leaf (block 3). prev "l" >= "l" → kOutOfBound.
+  // Next -> "zzz" leaf (block 3). prev "l" >= "l" -> kOutOfBound.
   ASSERT_OK(ctx.iter->NextAndGetResult(&result));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kOutOfBound);
 }
@@ -3798,7 +3802,7 @@ TEST_F(TrieIndexFactoryTest, SeqnoEncodingConsistentSize) {
   ASSERT_OK(builder_no_seq->Finish(&contents_no_seq));
   size_t size_no_seq = contents_no_seq.size();
 
-  // Same keys but with nonzero seqnos (still distinct → no seqno encoding).
+  // Same keys but with nonzero seqnos (still distinct -> no seqno encoding).
   std::unique_ptr<UserDefinedIndexBuilder> builder_with_seq;
   ASSERT_OK(factory_->NewBuilder(option, builder_with_seq));
   for (int i = 0; i < 50; i++) {
@@ -3829,7 +3833,7 @@ TEST_F(TrieIndexFactoryTest, SeqnoEncodingConsistentSize) {
 TEST_F(TrieIndexFactoryTest, SeekWithMaxSeqOnSameKeyBlocks) {
   // kMaxSequenceNumber should always land on Block 0 of a same-key run.
   //
-  // Trie: "key"(run=3, seqnos 400,300,200) → "l"
+  // Trie: "key"(run=3, seqnos 400,300,200) -> "l"
   auto ctx = BuildTrieAndGetIterator({
       {"key", "key", 0, 1000, 400, 300},
       {"key", "key", 1000, 1000, 300, 200},
@@ -3841,10 +3845,10 @@ TEST_F(TrieIndexFactoryTest, SeekWithMaxSeqOnSameKeyBlocks) {
 }
 
 TEST_F(TrieIndexFactoryTest, SeekWithZeroSeqOnSameKeyBlocks) {
-  // seq=0 is below all overflow seqnos → advance past the entire run.
+  // seq=0 is below all overflow seqnos -> advance past the entire run.
   //
-  // Trie: "key"(run=2, seqnos 300,200) → "l" → "zzz"
-  // seq=0 < all overflow seqnos → advance past run → lands on "l" (block 2).
+  // Trie: "key"(run=2, seqnos 300,200) -> "l" -> "zzz"
+  // seq=0 < all overflow seqnos -> advance past run -> lands on "l" (block 2).
   auto ctx = BuildTrieAndGetIterator({
       {"key", "key", 0, 1000, 300, 200},
       {"key", "key", 1000, 1000, 200, 100},
@@ -3885,14 +3889,14 @@ TEST_F(TrieIndexFactoryTest, NextTransitionOverflowToOverflow) {
   // same-key boundaries. We need a 3rd user key to separate them in the trie.
   //
   // Entries:
-  //   "aaa" 200 next="aaa" → sep="aaa" (same-key)
-  //   "aaa" 100 next="aaa" → sep="aaa" (same-key)
-  //   "aaa"  50 next="bbb" → sep="b"   (diff-key)
-  //   "bbb"  90 next="bbb" → sep="bbb" (same-key)
-  //   "bbb"  60 next="bbb" → sep="bbb" (same-key)
-  //   "bbb"  30 next=null  → sep="bbb" (last block, no successor shortening)
+  //   "aaa" 200 next="aaa" -> sep="aaa" (same-key)
+  //   "aaa" 100 next="aaa" -> sep="aaa" (same-key)
+  //   "aaa"  50 next="bbb" -> sep="b"   (diff-key)
+  //   "bbb"  90 next="bbb" -> sep="bbb" (same-key)
+  //   "bbb"  60 next="bbb" -> sep="bbb" (same-key)
+  //   "bbb"  30 next=null  -> sep="bbb" (last block, no successor shortening)
   //
-  // Trie: "aaa"(run=2, seqnos 200,100) → "b" → "bbb"(run=3, seqnos 90,60,30)
+  // Trie: "aaa"(run=2, seqnos 200,100) -> "b" -> "bbb"(run=3, seqnos 90,60,30)
   // Note: the last block's separator is "bbb" (not "c"), matching the standard
   // index builder's behavior with kShortenSeparators (the default). This means
   // the last block joins the "bbb" run, making it a 3-block run.
@@ -3959,11 +3963,11 @@ TEST_F(TrieIndexFactoryTest, NextTransitionOverflowToOverflow) {
   ASSERT_EQ(iter->value().offset, 1000u);
   ASSERT_EQ(result.key.ToString(), "aaa");
 
-  ASSERT_OK(iter->NextAndGetResult(&result));  // → "b" leaf (block 2)
+  ASSERT_OK(iter->NextAndGetResult(&result));  // -> "b" leaf (block 2)
   ASSERT_EQ(iter->value().offset, 2000u);
   ASSERT_EQ(result.key.ToString(), "b");
 
-  ASSERT_OK(iter->NextAndGetResult(&result));  // → "bbb" leaf (block 3)
+  ASSERT_OK(iter->NextAndGetResult(&result));  // -> "bbb" leaf (block 3)
   ASSERT_EQ(iter->value().offset, 3000u);
   ASSERT_EQ(result.key.ToString(), "bbb");
 
@@ -3975,7 +3979,7 @@ TEST_F(TrieIndexFactoryTest, NextTransitionOverflowToOverflow) {
   ASSERT_EQ(iter->value().offset, 5000u);
   ASSERT_EQ(result.key.ToString(), "bbb");
 
-  // Past end — kUnknown (exhaustion doesn't imply upper bound reached).
+  // Past end -- kUnknown (exhaustion doesn't imply upper bound reached).
   ASSERT_OK(iter->NextAndGetResult(&result));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kUnknown);
 }
@@ -3990,13 +3994,13 @@ TEST_F(TrieIndexFactoryTest, SingleBlockWithSeqnoActive) {
   });
   auto* iter = ctx.iter.get();
 
-  // Seek "x"|10 ��� leaf_seqno=10, 10>=10 → Block 0.
+  // Seek "x"|10 -> leaf_seqno=10, 10>=10 -> Block 0.
   ASSERT_NO_FATAL_FAILURE(AssertSeekOffset(iter, Slice("x"), 10, 0u));
-  // Seek "x"|7 → 7<10 → advance through overflow. overflow seqno=5, 7>=5 →
+  // Seek "x"|7 -> 7<10 -> advance through overflow. overflow seqno=5, 7>=5 ->
   // overflow block 1.
   ASSERT_NO_FATAL_FAILURE(AssertSeekOffset(iter, Slice("x"), 7, 500u));
-  // Seek "x"|3 → 3<10 → advance. overflow seqno=5, 3<5 → not found. Advance
-  // past run. No more leaves → invalid. This matches the standard index
+  // Seek "x"|3 -> 3<10 -> advance. overflow seqno=5, 3<5 -> not found. Advance
+  // past run. No more leaves -> invalid. This matches the standard index
   // behavior: seeking for internal key "x"|3 is past the standard index's
   // last separator "x"|5.
   {
@@ -4017,12 +4021,12 @@ TEST_F(TrieIndexFactoryTest, TagDistinguishesSameSeqDifferentType) {
   // (kTypeValue) In internal key order, higher tag = smaller key, so
   // target (12801) < separator (12800). The trie should stay on Block 0.
   //
-  // With seqno-only comparison: 50 < 50 is false → stay. Same result.
+  // With seqno-only comparison: 50 < 50 is false -> stay. Same result.
   // But the reverse case matters:
   // Separator tag (50 << 8) | 1 = 12801 (kTypeValue)
   // Target tag (50 << 8) | 0 = 12800 (kTypeDeletion)
-  // target (12800) < separator (12801) → advance to Block 1.
-  // With seqno-only: 50 < 50 is false → stay (WRONG — should advance).
+  // target (12800) < separator (12801) -> advance to Block 1.
+  // With seqno-only: 50 < 50 is false -> stay (WRONG -- should advance).
 
   UserDefinedIndexOption option;
   option.comparator = BytewiseComparator();
@@ -4048,14 +4052,14 @@ TEST_F(TrieIndexFactoryTest, TagDistinguishesSameSeqDifferentType) {
   IterateResult result;
 
   // Target: ("x", seqno=50, kTypeValue=1), packed=12801.
-  // Separator packed=12801. 12801 >= 12801 → stay on Block 0. Correct.
+  // Separator packed=12801. 12801 >= 12801 -> stay on Block 0. Correct.
   ASSERT_OK(iter->SeekAndGetResult(Slice("x"), &result, {(50ULL << 8) | 1}));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
   ASSERT_EQ(iter->value().offset, 0u);
 
   // Target: ("x", seqno=50, kTypeDeletion=0), packed=12800.
-  // Separator packed=12801. 12800 < 12801 → advance to Block 1. Correct.
-  // With seqno-only comparison (without tag): 50 < 50 → false →
+  // Separator packed=12801. 12800 < 12801 -> advance to Block 1. Correct.
+  // With seqno-only comparison (without tag): 50 < 50 -> false ->
   // stay on Block 0 (WRONG).
   ASSERT_OK(iter->SeekAndGetResult(Slice("x"), &result, {(50ULL << 8) | 0}));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
@@ -4066,7 +4070,7 @@ TEST_F(TrieIndexFactoryTest, SeqnoEncodingReSeekAfterOverflow) {
   // Verify that re-seeking after being positioned in an overflow run
   // correctly resets the overflow state.
   //
-  // Trie: "key"(run=2, seqnos 300,200) → "l" → "zzz"
+  // Trie: "key"(run=2, seqnos 300,200) -> "l" -> "zzz"
   auto ctx = BuildTrieAndGetIterator({
       {"key", "key", 0, 1000, 300, 200},
       {"key", "key", 1000, 1000, 200, 100},
@@ -4075,11 +4079,11 @@ TEST_F(TrieIndexFactoryTest, SeqnoEncodingReSeekAfterOverflow) {
   });
   auto* iter = ctx.iter.get();
 
-  // Position in overflow: 150 < all run seqnos → advance to "l" (block 2).
+  // Position in overflow: 150 < all run seqnos -> advance to "l" (block 2).
   ASSERT_NO_FATAL_FAILURE(AssertSeekOffset(iter, Slice("key"), 150, 2000u));
-  // Re-seek to "key"|300 → should reset to Block 0.
+  // Re-seek to "key"|300 -> should reset to Block 0.
   ASSERT_NO_FATAL_FAILURE(AssertSeekOffset(iter, Slice("key"), 300, 0u));
-  // Re-seek to "zzz" → "zzz" leaf (block 3), overflow state should be clean.
+  // Re-seek to "zzz" -> "zzz" leaf (block 3), overflow state should be clean.
   ASSERT_NO_FATAL_FAILURE(
       AssertSeekOffset(iter, Slice("zzz"), kMaxSequenceNumber, 3000u));
 
@@ -4101,12 +4105,12 @@ TEST_F(TrieIndexFactoryTest, AllFfLastKeyWithSameKeyBoundary) {
   });
   auto* iter = ctx.iter.get();
 
-  // Seek "\xff\xff"|200 → Block 0.
+  // Seek "\xff\xff"|200 -> Block 0.
   ASSERT_NO_FATAL_FAILURE(AssertSeekOffset(iter, Slice(ff), 200, 0u));
-  // Seek "\xff\xff"|100 → advance to overflow Block 1.
+  // Seek "\xff\xff"|100 -> advance to overflow Block 1.
   ASSERT_NO_FATAL_FAILURE(AssertSeekOffset(iter, Slice(ff), 100, 500u));
 
-  // Seek "\xff\xff"|50 → past entire run → exhausted → kUnknown.
+  // Seek "\xff\xff"|50 -> past entire run -> exhausted -> kUnknown.
   IterateResult result;
   ASSERT_OK(iter->SeekAndGetResult(Slice(ff), &result, SeekCtx(50)));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kUnknown);
@@ -4300,7 +4304,7 @@ TEST_F(TrieIndexSSTTest, WriteAndReadWithTrieUDI) {
   auto kvs = GenerateKVs(100);
   ASSERT_OK(WriteSST(kvs));
 
-  // Read without UDI (native index) — should work since native index is
+  // Read without UDI (native index) -- should work since native index is
   // always present alongside the UDI.
   {
     Options options;
@@ -4325,7 +4329,7 @@ TEST_F(TrieIndexSSTTest, WriteAndReadWithTrieUDI) {
     ASSERT_EQ(count, 100);
   }
 
-  // Read WITH trie UDI — use table_index_factory in ReadOptions.
+  // Read WITH trie UDI -- use table_index_factory in ReadOptions.
   {
     Options options;
     BlockBasedTableOptions table_options;
@@ -4544,7 +4548,7 @@ TEST_F(TrieIndexSSTTest, MixedKeyTypesWithCompressionDict) {
 // Compares the trie data structure against the actual RocksDB binary search
 // index (IndexBlockIter) which is used in production. The IndexBlockIter
 // operates on a prefix-compressed block with InternalKeys, varint decoding,
-// and the InternalKeyComparator abstraction — making it a realistic baseline.
+// and the InternalKeyComparator abstraction -- making it a realistic baseline.
 // ============================================================================
 
 class TrieSeekBenchmark : public testing::Test {
@@ -4607,14 +4611,14 @@ class TrieSeekBenchmark : public testing::Test {
 // their full production code paths:
 //
 // Trie (via UDI wrapper):
-//   ParseInternalKey → Seek(user_key) → Key().ToString() (string copy) →
-//   CheckBounds (no-op without Prepare) → Value() → BlockHandle
+//   ParseInternalKey -> Seek(user_key) -> Key().ToString() (string copy) ->
+//   CheckBounds (no-op without Prepare) -> Value() -> BlockHandle
 //
 // IndexBlockIter:
-//   Seek(internal_key) → value() → IndexValue with BlockHandle
+//   Seek(internal_key) -> value() -> IndexValue with BlockHandle
 //
 // The IndexBlockIter operates on a prefix-compressed block with InternalKeys,
-// varint decoding, and the InternalKeyComparator — matching production
+// varint decoding, and the InternalKeyComparator -- matching production
 // exactly.
 TEST_F(TrieSeekBenchmark, TrieVsRealIndexBlockIter) {
   static constexpr size_t kNumLookups = 200000;
@@ -4671,7 +4675,7 @@ TEST_F(TrieSeekBenchmark, TrieVsRealIndexBlockIter) {
     auto indices = GenerateRandomIndices(kNumLookups, num_keys);
 
     // Pre-build InternalKey seek targets (user_key + kMaxSequenceNumber).
-    // Both sides use the same InternalKey targets — the trie path parses
+    // Both sides use the same InternalKey targets -- the trie path parses
     // them to extract the user key (matching production), while
     // IndexBlockIter uses them directly.
     std::vector<std::string> seek_ikeys;
@@ -4688,18 +4692,18 @@ TEST_F(TrieSeekBenchmark, TrieVsRealIndexBlockIter) {
     }
 
     // ---- Benchmark: Trie Seek (full production path) ----
-    // Replicates UserDefinedIndexIteratorWrapper::Seek() →
+    // Replicates UserDefinedIndexIteratorWrapper::Seek() ->
     //   TrieIndexIterator::SeekAndGetResult():
     //   1. ParseInternalKey to extract user_key
     //   2. trie_iter.Seek(user_key)
-    //   3. trie_iter.Key().ToString() — string copy (result must outlive
+    //   3. trie_iter.Key().ToString() -- string copy (result must outlive
     //   call)
-    //   4. trie_iter.Value() — look up BlockHandle from packed arrays
+    //   4. trie_iter.Value() -- look up BlockHandle from packed arrays
     volatile uint64_t trie_checksum = 0;
     std::string key_scratch;  // Reused scratch, like current_key_scratch_
     auto t0 = std::chrono::high_resolution_clock::now();
     for (size_t i = 0; i < kNumLookups; i++) {
-      // Step 1: Parse InternalKey → user key (same as wrapper)
+      // Step 1: Parse InternalKey -> user key (same as wrapper)
       ParsedInternalKey pkey;
       ASSERT_OK(ParseInternalKey(seek_ikey_slices[i], &pkey,
                                  /*log_err_key=*/false));
@@ -4724,7 +4728,7 @@ TEST_F(TrieSeekBenchmark, TrieVsRealIndexBlockIter) {
         static_cast<double>(kNumLookups);
 
     // ---- Benchmark: Real IndexBlockIter Seek ----
-    // This is exactly what production does: Seek(InternalKey) → value().
+    // This is exactly what production does: Seek(InternalKey) -> value().
     std::unique_ptr<IndexBlockIter> ibi_iter(index_block.NewIndexIterator(
         BytewiseComparator(), kDisableGlobalSequenceNumber,
         /*iter=*/nullptr, /*stats=*/nullptr,
@@ -4757,7 +4761,7 @@ TEST_F(TrieSeekBenchmark, TrieVsRealIndexBlockIter) {
 }
 
 // ============================================================================
-// Mixed key type tests — verifies UDI works with Delete, Merge, etc.
+// Mixed key type tests -- verifies UDI works with Delete, Merge, etc.
 // ============================================================================
 
 TEST_F(TrieIndexSSTTest, MixedKeyTypesWithTrieUDI) {
@@ -4830,7 +4834,7 @@ TEST_F(TrieIndexSSTTest, MixedKeyTypesWithTrieUDI) {
     ro.table_index_factory = trie_factory_.get();
     std::unique_ptr<Iterator> iter(reader.NewIterator(ro));
 
-    // Full forward scan — expect 6 logically visible entries.
+    // Full forward scan -- expect 6 logically visible entries.
     iter->SeekToFirst();
     ASSERT_OK(iter->status());
     ASSERT_TRUE(iter->Valid())
@@ -4850,17 +4854,17 @@ TEST_F(TrieIndexSSTTest, MixedKeyTypesWithTrieUDI) {
     };
     ASSERT_EQ(visible_keys, expected_visible);
 
-    // Point seek to a merged key — should find it.
+    // Point seek to a merged key -- should find it.
     iter->Seek("key_0002");
     ASSERT_TRUE(iter->Valid());
     ASSERT_EQ(iter->key().ToString(), "key_0002");
 
-    // Point seek to a deleted key — should advance past the tombstone.
+    // Point seek to a deleted key -- should advance past the tombstone.
     iter->Seek("key_0004");
     ASSERT_TRUE(iter->Valid());
     ASSERT_EQ(iter->key().ToString(), "key_0005");
 
-    // Point seek to the last deleted key — should advance to key_0008.
+    // Point seek to the last deleted key -- should advance to key_0008.
     iter->Seek("key_0007");
     ASSERT_TRUE(iter->Valid());
     ASSERT_EQ(iter->key().ToString(), "key_0008");
@@ -4897,7 +4901,7 @@ TEST_F(TrieIndexSSTTest, LargeMixedKeyTypesWithTrieUDI) {
     if (i % 5 == 0) {
       ASSERT_OK(writer.Delete(key));
       all_entries.emplace_back(key, 'D');
-      // Deletes are hidden by DBIter — not added to visible_keys.
+      // Deletes are hidden by DBIter -- not added to visible_keys.
     } else if (i % 5 == 1) {
       char val_buf[32];
       snprintf(val_buf, sizeof(val_buf), "merge_%06d", i);
@@ -4957,7 +4961,7 @@ TEST_F(TrieIndexSSTTest, LargeMixedKeyTypesWithTrieUDI) {
     ro.table_index_factory = trie_factory_.get();
     std::unique_ptr<Iterator> iter(reader.NewIterator(ro));
 
-    // Full forward scan — only visible keys should appear.
+    // Full forward scan -- only visible keys should appear.
     iter->SeekToFirst();
     ASSERT_OK(iter->status());
     ASSERT_TRUE(iter->Valid());
@@ -4979,7 +4983,7 @@ TEST_F(TrieIndexSSTTest, LargeMixedKeyTypesWithTrieUDI) {
       ASSERT_EQ(iter->key().ToString(), visible_keys[i]);
     }
 
-    // Point seek to deleted keys — should advance past the tombstone.
+    // Point seek to deleted keys -- should advance past the tombstone.
     for (int i = 0; i < kNumKeys; i++) {
       if (all_entries[i].second == 'D') {
         iter->Seek(all_entries[i].first);
@@ -5032,7 +5036,7 @@ TEST_F(TrieIndexFactoryTest, WrapperNextAndGetResultReturnsInternalKey) {
   // Wrap the UDI iterator in the adapter that converts to InternalIterator.
   UserDefinedIndexIteratorWrapper wrapper(std::move(udi_iter));
 
-  // Seek to "a" — constructs an internal key from user key "a".
+  // Seek to "a" -- constructs an internal key from user key "a".
   InternalKey seek_ikey;
   seek_ikey.Set(Slice("a"), kMaxSequenceNumber, kValueTypeForSeek);
   wrapper.Seek(Slice(*seek_ikey.const_rep()));
@@ -5048,7 +5052,7 @@ TEST_F(TrieIndexFactoryTest, WrapperNextAndGetResultReturnsInternalKey) {
   EXPECT_EQ(parsed.user_key.ToString(), "a");
   EXPECT_EQ(parsed.type, ValueType::kTypeValue);
 
-  // Now test NextAndGetResult — this is the method we fixed.
+  // Now test NextAndGetResult -- this is the method we fixed.
   IterateResult result;
   bool valid = wrapper.NextAndGetResult(&result);
   ASSERT_TRUE(valid);
@@ -5065,7 +5069,7 @@ TEST_F(TrieIndexFactoryTest, WrapperNextAndGetResultReturnsInternalKey) {
   EXPECT_EQ(parsed.user_key.ToString(), "b");
   EXPECT_EQ(parsed.type, ValueType::kTypeValue);
 
-  // result.key must match wrapper.key() — both views of the current key.
+  // result.key must match wrapper.key() -- both views of the current key.
   EXPECT_EQ(result.key, wrapper.key());
 
   // Advance again and verify. The last block's separator is "c"
@@ -5078,7 +5082,7 @@ TEST_F(TrieIndexFactoryTest, WrapperNextAndGetResultReturnsInternalKey) {
   EXPECT_EQ(parsed.user_key.ToString(), "c");
   EXPECT_EQ(result.key, wrapper.key());
 
-  // One more advance — past end.
+  // One more advance -- past end.
   valid = wrapper.NextAndGetResult(&result);
   EXPECT_FALSE(valid);
 }
@@ -5115,7 +5119,7 @@ TEST_F(TrieIndexFactoryTest, OverflowBfsReordering) {
   Slice sep;
 
   // Block 0: last="ab", next="ab" (same-key boundary)
-  // → sep="ab", same_user_key=true, seqno=500
+  // -> sep="ab", same_user_key=true, seqno=500
   {
     UserDefinedIndexBuilder::BlockHandle h{0, 100};
     Slice next("ab");
@@ -5123,8 +5127,8 @@ TEST_F(TrieIndexFactoryTest, OverflowBfsReordering) {
                                  EntryCtx(500, 0));
     ASSERT_EQ(scratch, "ab") << "Block 0 separator";
   }
-  // Block 1: last="ab", next="abc" (prefix — FindShortestSeparator no-op)
-  // → sep="ab", edge-case match with prev sep, same_user_key=true, seqno=400
+  // Block 1: last="ab", next="abc" (prefix -- FindShortestSeparator no-op)
+  // -> sep="ab", edge-case match with prev sep, same_user_key=true, seqno=400
   {
     UserDefinedIndexBuilder::BlockHandle h{100, 100};
     Slice next("abc");
@@ -5134,8 +5138,8 @@ TEST_F(TrieIndexFactoryTest, OverflowBfsReordering) {
   }
   // Block 2: last="abc", next="b"
   // FindShortestSeparator("abc","b"): diff_index=0, 'a' vs 'b',
-  // limit.size()-1=0 so fallback: increment start[1] 'b'→'c' → "ac"
-  // → sep="ac", different key, seqno=kMax→0
+  // limit.size()-1=0 so fallback: increment start[1] 'b'->'c' -> "ac"
+  // -> sep="ac", different key, seqno=kMax->0
   {
     UserDefinedIndexBuilder::BlockHandle h{200, 100};
     Slice next("b");
@@ -5144,7 +5148,7 @@ TEST_F(TrieIndexFactoryTest, OverflowBfsReordering) {
     ASSERT_EQ(scratch, "ac") << "Block 2 separator";
   }
   // Block 3: last="b", next="b" (same-key boundary)
-  // → sep="b", same_user_key=true, seqno=300
+  // -> sep="b", same_user_key=true, seqno=300
   {
     UserDefinedIndexBuilder::BlockHandle h{300, 100};
     Slice next("b");
@@ -5152,8 +5156,8 @@ TEST_F(TrieIndexFactoryTest, OverflowBfsReordering) {
                                  EntryCtx(300, 0));
     ASSERT_EQ(scratch, "b") << "Block 3 separator";
   }
-  // Block 4: last="b", next="ba" (prefix — FindShortestSeparator no-op)
-  // → sep="b", edge-case match with prev sep, same_user_key=true, seqno=200
+  // Block 4: last="b", next="ba" (prefix -- FindShortestSeparator no-op)
+  // -> sep="b", edge-case match with prev sep, same_user_key=true, seqno=200
   {
     UserDefinedIndexBuilder::BlockHandle h{400, 100};
     Slice next("ba");
@@ -5163,8 +5167,8 @@ TEST_F(TrieIndexFactoryTest, OverflowBfsReordering) {
   }
   // Block 5: last="ba", next="d"
   // FindShortestSeparator("ba","d"): diff_index=0, 'b' vs 'd',
-  // start_byte+1='c' < 'd' → increment and truncate → "c"
-  // → sep="c", different key, seqno=kMax→0
+  // start_byte+1='c' < 'd' -> increment and truncate -> "c"
+  // -> sep="c", different key, seqno=kMax->0
   {
     UserDefinedIndexBuilder::BlockHandle h{500, 100};
     Slice next("d");
@@ -5173,7 +5177,7 @@ TEST_F(TrieIndexFactoryTest, OverflowBfsReordering) {
     ASSERT_EQ(scratch, "c") << "Block 5 separator";
   }
   // Block 6: last="d", next=null (last block, no successor shortening)
-  // → sep="d", different from prev "c", seqno=kMax→0
+  // -> sep="d", different from prev "c", seqno=kMax->0
   {
     UserDefinedIndexBuilder::BlockHandle h{600, 100};
     sep = builder->AddIndexEntry(Slice("d"), nullptr, h, &scratch,
@@ -5239,36 +5243,36 @@ TEST_F(TrieIndexFactoryTest, OverflowBfsReordering) {
 
   // --- Seek-based tests: verify overflow data is correctly associated ---
 
-  // "ab" primary: Seek("ab", kMax) → offset=0
+  // "ab" primary: Seek("ab", kMax) -> offset=0
   ASSERT_OK(iter->SeekAndGetResult(Slice("ab"), &result,
                                    SeekCtx(kMaxSequenceNumber)));
   EXPECT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
   EXPECT_EQ(iter->value().offset, 0u) << "Seek(ab,kMax): ab primary";
 
-  // "ab" overflow: Seek("ab", 400) → offset=100
-  // Primary seqno=500, 400<500 → advance to overflow. Overflow seqno=400,
-  // 400>=400 → match.
+  // "ab" overflow: Seek("ab", 400) -> offset=100
+  // Primary seqno=500, 400<500 -> advance to overflow. Overflow seqno=400,
+  // 400>=400 -> match.
   ASSERT_OK(iter->SeekAndGetResult(Slice("ab"), &result, SeekCtx(400)));
   EXPECT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
   EXPECT_EQ(iter->value().offset, 100u) << "Seek(ab,400): ab overflow";
 
-  // "ab" advance past run: Seek("ab", 50) → advances to "ac" at offset=200
-  // Primary seqno=500, 50<500 → overflow seqno=400, 50<400 → exhaust run →
+  // "ab" advance past run: Seek("ab", 50) -> advances to "ac" at offset=200
+  // Primary seqno=500, 50<500 -> overflow seqno=400, 50<400 -> exhaust run ->
   // advance to next trie leaf "ac".
   ASSERT_OK(iter->SeekAndGetResult(Slice("ab"), &result, SeekCtx(50)));
   EXPECT_EQ(result.key.ToString(), "ac")
       << "Seek(ab,50): should advance past ab run";
   EXPECT_EQ(iter->value().offset, 200u) << "Seek(ab,50): expected ac (200)";
 
-  // "b" primary: Seek("b", kMax) → offset=300
+  // "b" primary: Seek("b", kMax) -> offset=300
   ASSERT_OK(
       iter->SeekAndGetResult(Slice("b"), &result, SeekCtx(kMaxSequenceNumber)));
   EXPECT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
   EXPECT_EQ(iter->value().offset, 300u) << "Seek(b,kMax): b primary";
 
-  // "b" overflow: Seek("b", 200) → offset=400
-  // Primary seqno=300, 200<300 → advance to overflow. Overflow seqno=200,
-  // 200>=200 → match.
+  // "b" overflow: Seek("b", 200) -> offset=400
+  // Primary seqno=300, 200<300 -> advance to overflow. Overflow seqno=200,
+  // 200>=200 -> match.
   // If overflow blocks were NOT BFS-reordered, overflow[0] would contain
   // ab's data {offset=100,seqno=400}, and 200<400 would fail to match,
   // incorrectly advancing to "c".
@@ -5278,7 +5282,7 @@ TEST_F(TrieIndexFactoryTest, OverflowBfsReordering) {
       << "Seek(b,200): must stay on b, not advance";
   EXPECT_EQ(iter->value().offset, 400u) << "Seek(b,200): b overflow";
 
-  // "b" advance past run: Seek("b", 50) → advances to "c" at offset=500
+  // "b" advance past run: Seek("b", 50) -> advances to "c" at offset=500
   ASSERT_OK(iter->SeekAndGetResult(Slice("b"), &result, SeekCtx(50)));
   EXPECT_EQ(result.key.ToString(), "c")
       << "Seek(b,50): should advance past b run";
@@ -5370,23 +5374,23 @@ TEST_F(TrieIndexFactoryTest, LastBlockSeekWithRealSeqno) {
       {"cherry", "", 1000, 1000, 50, 0},
   });
 
-  // Seek "cherry" with kMaxSequenceNumber — should find block at offset 1000.
+  // Seek "cherry" with kMaxSequenceNumber -- should find block at offset 1000.
   ASSERT_NO_FATAL_FAILURE(AssertSeekOffset(ctx.iter.get(), Slice("cherry"),
                                            kMaxSequenceNumber, 1000));
 
-  // Seek "cherry" with a real seqno (200) — the last block's separator has
+  // Seek "cherry" with a real seqno (200) -- the last block's separator has
   // seqno=50. In internal key order, 200 > 50 means target is SMALLER (higher
-  // seqno = smaller key). So target <= separator → should stay on this block.
+  // seqno = smaller key). So target <= separator -> should stay on this block.
   ASSERT_NO_FATAL_FAILURE(
       AssertSeekOffset(ctx.iter.get(), Slice("cherry"), 200, 1000));
 
-  // Seek "cherry" with seqno=50 (equal to separator) — should stay.
+  // Seek "cherry" with seqno=50 (equal to separator) -- should stay.
   ASSERT_NO_FATAL_FAILURE(
       AssertSeekOffset(ctx.iter.get(), Slice("cherry"), 50, 1000));
 
-  // Seek "cherry" with seqno=10 (less than separator seqno=50) — target is
-  // LARGER in internal key order. target > separator → should advance past.
-  // But this is the last block — no next block → past end.
+  // Seek "cherry" with seqno=10 (less than separator seqno=50) -- target is
+  // LARGER in internal key order. target > separator -> should advance past.
+  // But this is the last block -- no next block -> past end.
   IterateResult result;
   ASSERT_OK(ctx.iter->SeekAndGetResult(Slice("cherry"), &result, SeekCtx(10)));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kUnknown);
@@ -5395,7 +5399,7 @@ TEST_F(TrieIndexFactoryTest, LastBlockSeekWithRealSeqno) {
 TEST_F(TrieIndexFactoryTest, IntermediateNonBoundarySeparatorNoAdvance) {
   // Verifies that seeking with any seqno on an intermediate non-boundary
   // separator does NOT advance past it. Intermediate non-boundary separators
-  // store tag=0 (sentinel), making target_tag < 0 always false → stays.
+  // store tag=0 (sentinel), making target_tag < 0 always false -> stays.
   // This matches the standard index's index_key_is_user_key=true mode where
   // equal user keys always match without seqno comparison.
   auto ctx = BuildTrieAndGetIterator({
@@ -5415,7 +5419,7 @@ TEST_F(TrieIndexFactoryTest, IntermediateNonBoundarySeparatorNoAdvance) {
 
   // Seeking for "cherry" should find block 1 regardless of seqno.
   // The separator between block 0 and 1 is a shortened key (non-boundary).
-  // "cherry" matches block 1's separator — should stay with any seqno.
+  // "cherry" matches block 1's separator -- should stay with any seqno.
   ASSERT_NO_FATAL_FAILURE(AssertSeekOffset(ctx.iter.get(), Slice("cherry"),
                                            kMaxSequenceNumber, 1000));
   ASSERT_NO_FATAL_FAILURE(
@@ -5442,7 +5446,7 @@ TEST_F(TrieIndexFactoryTest, NonBoundarySeparatorSeekWhenShorteningFails) {
 
   // Seek for "acc" with any seqno should find block 1 at offset 1000.
   // The separator "acc" has tag=0 (non-boundary sentinel), so
-  // target_packed < 0 is always false → no advancement occurs.
+  // target_packed < 0 is always false -> no advancement occurs.
   //
   // Non-boundary separators use tag=0 (sentinel). For unsigned uint64_t,
   // target_packed < 0 is always false, so no advancement occurs. This
@@ -5476,7 +5480,7 @@ TEST_F(TrieIndexFactoryTest, PrevWithinOverflowRun) {
 
   IterateResult result;
 
-  // Seek to "key"|100 — should land on the last block in the "key" overflow
+  // Seek to "key"|100 -- should land on the last block in the "key" overflow
   // run (offset 2000) since seqno=100 matches that block's tag.
   ASSERT_OK(ctx.iter->SeekAndGetResult(Slice("key"), &result, SeekCtx(100)));
   ASSERT_EQ(ctx.iter->value().offset, 2000u);
@@ -5502,7 +5506,8 @@ TEST_F(TrieIndexFactoryTest, SeekToLastWithOverflowRun) {
   auto ctx = BuildTrieAndGetIterator({
       // Block 0: "aaa" standalone.
       {"aaa", "zzz", 0, 1000, 100, 50},
-      // Block 1-3: "zzz" spans 3 blocks (overflow run) — this is the last leaf.
+      // Block 1-3: "zzz" spans 3 blocks (overflow run) -- this is the last
+      // leaf.
       {"zzz", "zzz", 1000, 1000, 50, 30},
       {"zzz", "zzz", 2000, 1000, 30, 10},
       {"zzz", "", 3000, 1000, 10, 0},
@@ -5560,7 +5565,7 @@ TEST_F(TrieIndexFactoryTest, PrevLandsOnLeafWithOverflow) {
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
   ASSERT_EQ(ctx.iter->value().offset, 2000u);
 
-  // Prev to "aaa" — should land on the LAST block in the overflow run
+  // Prev to "aaa" -- should land on the LAST block in the overflow run
   // (offset 1000), not the primary block (offset 0).
   ASSERT_OK(ctx.iter->PrevAndGetResult(&result));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
@@ -5631,7 +5636,7 @@ TEST_F(TrieIndexFactoryTest, OverflowExhaustionThenForwardScanThroughOverflow) {
 
   IterateResult result;
 
-  // Seek "key"|1 — seqno=1 is below all overflow tags in the "key" run
+  // Seek "key"|1 -- seqno=1 is below all overflow tags in the "key" run
   // (300, 200), so it exhausts the run and advances to the next leaf.
   // FindShortestSeparator("key", "zzz") = "l", so the next leaf is "l".
   ASSERT_OK(ctx.iter->SeekAndGetResult(Slice("key"), &result, SeekCtx(1)));
@@ -5670,17 +5675,17 @@ TEST_F(TrieIndexFactoryTest, AllScansExhaustedThenSeek) {
 
   IterateResult result;
 
-  // Seek "a" — within first scan range, kInbound.
+  // Seek "a" -- within first scan range, kInbound.
   ASSERT_OK(ctx.iter->SeekAndGetResult(Slice("a"), &result,
                                        SeekCtx(kMaxSequenceNumber)));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
 
-  // Seek "c" — advances to second scan range, kInbound.
+  // Seek "c" -- advances to second scan range, kInbound.
   ASSERT_OK(ctx.iter->SeekAndGetResult(Slice("c"), &result,
                                        SeekCtx(kMaxSequenceNumber)));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
 
-  // Seek "e" — past both scan ranges, kOutOfBound.
+  // Seek "e" -- past both scan ranges, kOutOfBound.
   ASSERT_OK(ctx.iter->SeekAndGetResult(Slice("e"), &result,
                                        SeekCtx(kMaxSequenceNumber)));
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kOutOfBound);


### PR DESCRIPTION
Summary:
The non-ASCII character check in check-sources.sh used git grep -P (Perl regex), which requires git compiled with PCRE support. On systems without it, the command fails with exit code 128, which is != 1 (no match), so the check always reported a violation -- effectively dead.

Even in CI where git has PCRE2 support, the check was silently broken: git grep -P uses PCRE2 in UTF mode by default, which interprets [\x80-\xFF] as a Unicode codepoint range (U+0080 to U+00FF). Characters like em-dash (U+2014), arrows (U+2192), and math symbols (U+2248, etc.) fall outside that range and were not detected. Only Latin-1 Supplement characters (U+0080-U+00FF) would have been caught.

Replace with LC_ALL=C git grep using bash $'[\x80-\xff]' literal byte range, which works with basic regex in the C locale, and replace all non-ASCII characters in non-excluded source files:
- em-dash to --
- arrow to ->
- math symbols to ASCII equivalents (~=, <=, >=)
- box-drawing characters to ASCII art

Also exclude .github/ from the check, as scripts there can use non-ascii without disrupting RocksDB builds on non-UTF-8 systems.

Test Plan: manual / CI (make check-sources passes clean)