### PR TITLE
Narrow a race in BlobFile::UnlinkSstFile

### DIFF
--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -460,14 +460,22 @@ void BlobDBImpl::UnlinkSstFromBlobFile(uint64_t sst_file_number,
   BlobFile* const blob_file = it->second.get();
   assert(blob_file);
 
+  bool unlinked;
   {
     WriteLock file_lock(&blob_file->mutex_);
-    blob_file->UnlinkSstFile(sst_file_number);
+    unlinked = blob_file->UnlinkSstFile(sst_file_number);
   }
 
-  ROCKS_LOG_INFO(db_options_.info_log,
-                 "Blob file %" PRIu64 " unlinked from SST file %" PRIu64,
-                 blob_file_number, sst_file_number);
+  if (unlinked) {
+    ROCKS_LOG_INFO(db_options_.info_log,
+                   "Blob file %" PRIu64 " unlinked from SST file %" PRIu64,
+                   blob_file_number, sst_file_number);
+  } else {
+    ROCKS_LOG_WARN(db_options_.info_log,
+                   "SST file %" PRIu64 " not found in blob file %" PRIu64
+                   " while trying to unlink",
+                   sst_file_number, blob_file_number);
+  }
 }
 
 void BlobDBImpl::InitializeBlobFileToSstMapping(
@@ -1184,6 +1192,7 @@ void BlobDBImpl::GetCompactionContext(BlobCompactionContext* context,
 }
 
 void BlobDBImpl::UpdateLiveSSTSize() {
+  TEST_SYNC_POINT("BlobDBImpl::UpdateLiveSSTSize:Begin");
   uint64_t live_sst_size = 0;
   bool ok = GetIntProperty(DB::Properties::kLiveSstFilesSize, &live_sst_size);
   if (ok) {

--- a/utilities/blob_db/blob_db_listener.h
+++ b/utilities/blob_db/blob_db_listener.h
@@ -8,6 +8,7 @@
 #include <atomic>
 
 #include "rocksdb/listener.h"
+#include "test_util/sync_point.h"
 #include "util/mutexlock.h"
 #include "utilities/blob_db/blob_db_impl.h"
 
@@ -51,17 +52,23 @@ class BlobDBListenerGC : public BlobDBListener {
   const char* Name() const override { return kClassName(); }
   static const char* kClassName() { return "BlobDBListenerGC"; }
   void OnFlushCompleted(DB* db, const FlushJobInfo& info) override {
-    BlobDBListener::OnFlushCompleted(db, info);
-
     assert(blob_db_impl_);
+    TEST_SYNC_POINT_CALLBACK("BlobDBListenerGC::OnFlushCompleted:BeforeProcess",
+                             const_cast<FlushJobInfo*>(&info));
+    // Keep GC bookkeeping ahead of any DB property queries in the base
+    // listener; later compactions can rely on these mappings.
     blob_db_impl_->ProcessFlushJobInfo(info);
+
+    BlobDBListener::OnFlushCompleted(db, info);
   }
 
   void OnCompactionCompleted(DB* db, const CompactionJobInfo& info) override {
-    BlobDBListener::OnCompactionCompleted(db, info);
-
     assert(blob_db_impl_);
+    // Keep GC bookkeeping ahead of any DB property queries in the base
+    // listener; later compactions can rely on these mappings.
     blob_db_impl_->ProcessCompactionJobInfo(info);
+
+    BlobDBListener::OnCompactionCompleted(db, info);
   }
 };
 

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -6,6 +6,7 @@
 #include "utilities/blob_db/blob_db.h"
 
 #include <algorithm>
+#include <atomic>
 #include <chrono>
 #include <cstdlib>
 #include <iomanip>
@@ -1717,6 +1718,72 @@ TEST_F(BlobDBTest, MaintainBlobFileToSstMapping) {
     ASSERT_EQ(obsolete_files[0]->BlobFileNumber(), 1);
     ASSERT_EQ(obsolete_files[1]->BlobFileNumber(), 2);
   }
+}
+
+TEST_F(BlobDBTest, ProcessFlushJobInfoBeforeUpdateLiveSSTSize) {
+  BlobDBOptions bdb_options;
+  bdb_options.enable_garbage_collection = true;
+  bdb_options.disable_background_tasks = true;
+
+  Options options;
+  options.disable_auto_compactions = true;
+  Open(bdb_options, options);
+
+  ASSERT_OK(Put("key", "value"));
+
+  std::atomic<bool> checked{false};
+  SyncPoint::GetInstance()->SetCallBack(
+      "BlobDBImpl::UpdateLiveSSTSize:Begin", [&](void* /* arg */) {
+        if (checked.exchange(true)) {
+          return;
+        }
+        auto blob_files = blob_db_impl()->TEST_GetBlobFiles();
+        EXPECT_EQ(blob_files.size(), 1);
+        if (blob_files.size() == 1) {
+          EXPECT_EQ(blob_files[0]->GetLinkedSstFiles().size(), 1);
+        }
+      });
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  ASSERT_OK(blob_db_->Flush(FlushOptions()));
+
+  SyncPoint::GetInstance()->DisableProcessing();
+
+  ASSERT_TRUE(checked.load());
+}
+
+TEST_F(BlobDBTest, UnlinkSstBeforeFlushLink) {
+  BlobDBOptions bdb_options;
+  bdb_options.enable_garbage_collection = true;
+  bdb_options.disable_background_tasks = true;
+
+  Options options;
+  options.disable_auto_compactions = true;
+  Open(bdb_options, options);
+
+  ASSERT_OK(Put("key", "value"));
+
+  SyncPoint::GetInstance()->SetCallBack(
+      "BlobDBListenerGC::OnFlushCompleted:BeforeProcess", [&](void* arg) {
+        auto* info = static_cast<FlushJobInfo*>(arg);
+        if (info->oldest_blob_file_number == kInvalidBlobFileNumber) {
+          return;
+        }
+        // Simulate a compaction that consumed this SST before the flush
+        // listener had a chance to link it. This is the race window that
+        // exists between version install and listener notification.
+        CompactionJobInfo cinfo{};
+        cinfo.input_file_infos.emplace_back(CompactionFileInfo{
+            0, info->file_number, info->oldest_blob_file_number});
+        cinfo.output_file_infos.emplace_back(CompactionFileInfo{
+            1, info->file_number + 1, info->oldest_blob_file_number});
+        blob_db_impl()->TEST_ProcessCompactionJobInfo(cinfo);
+      });
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  ASSERT_OK(blob_db_->Flush(FlushOptions()));
+
+  SyncPoint::GetInstance()->DisableProcessing();
 }
 
 TEST_F(BlobDBTest, ShutdownWait) {

--- a/utilities/blob_db/blob_file.h
+++ b/utilities/blob_db/blob_file.h
@@ -130,10 +130,14 @@ class BlobFile {
   }
 
   // Unlink an SST file whose oldest blob file reference points to this file.
-  void UnlinkSstFile(uint64_t sst_file_number) {
+  // Returns true if the SST was found and unlinked, false otherwise.
+  bool UnlinkSstFile(uint64_t sst_file_number) {
     auto it = linked_sst_files_.find(sst_file_number);
-    assert(it != linked_sst_files_.end());
+    if (it == linked_sst_files_.end()) {
+      return false;
+    }
     linked_sst_files_.erase(it);
+    return true;
   }
 
   // the following functions are atomic, and don't need


### PR DESCRIPTION
### Motivation

Make `BlobFile::UnlinkSstFile` best-effort to fix a race between flush listener notification and compaction scheduling. When `NotifyOnFlushCompleted` releases the DB mutex to call the listener, there is a window where a compaction can start on the flushed SST before `ProcessFlushJobInfo` links it to its blob file. Under `ASAN`/`UBSAN` slowdown this window widens enough for `ProcessCompactionJobInfo` to attempt unlinking an SST that was never linked, crashing on the  assert. The fix makes `UnlinkSstFile` return a bool and log a warning on miss, consistent with `UnlinkSstFromBlobFile` which already handles missing blob files gracefully.

### Test Plan
`./blob_db_test --gtest_filter="*UnlinkSstBeforeFlushLink*"` — deterministic repro: hooks the flush listener before `ProcessFlushJobInfo` and fires `ProcessCompactionJobInfo` on the unlinked SST; crashes without the fix, passes with it.