### PR TITLE
Cap Claude thinking budget

### DIFF
--- a/.github/workflows/ai-review-analysis.yml
+++ b/.github/workflows/ai-review-analysis.yml
@@ -531,7 +531,9 @@ jobs:
               core.warning(
                 `Could not parse classifier output: ${error.message}`);
             }
-            const budget = label === 'simple' ? '16000' : '32000';
+            // Keep Claude's thinking budget below the action's effective
+            // max_tokens so the API has room for the final review text.
+            const budget = label === 'simple' ? '16000' : '24000';
             core.info(
               `Complexity classified as: ${label} ` +
               `-> MAX_THINKING_TOKENS=${budget}`
@@ -1102,9 +1104,19 @@ jobs:
             }
             const override = (process.env.OVERRIDE || '').trim();
             if (override && /^\d+$/.test(override)) {
-              core.info(`Using thinking_budget override: ${override}`);
+              const maxSafeBudget = 24000;
+              const requested = parseInt(override, 10);
+              const budget = Math.min(requested, maxSafeBudget).toString();
+              if (budget !== override) {
+                core.info(
+                  `Clamping thinking_budget override from ${override} ` +
+                  `to ${budget} so max_tokens can exceed thinking tokens.`
+                );
+              } else {
+                core.info(`Using thinking_budget override: ${budget}`);
+              }
               core.setOutput('label', 'override');
-              core.setOutput('tokens', override);
+              core.setOutput('tokens', budget);
               return;
             }
             let label = 'complex';
@@ -1122,7 +1134,9 @@ jobs:
               core.warning(
                 `Could not parse classifier output: ${error.message}`);
             }
-            const budget = label === 'simple' ? '16000' : '32000';
+            // Keep Claude's thinking budget below the action's effective
+            // max_tokens so the API has room for the final review text.
+            const budget = label === 'simple' ? '16000' : '24000';
             core.info(
               `Complexity classified as: ${label} ` +
               `-> MAX_THINKING_TOKENS=${budget}`

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -34,7 +34,7 @@ on:
           - claude-sonnet-4-6
         default: claude-opus-4-6
       thinking_budget:
-        description: Override MAX_THINKING_TOKENS (blank = auto-classify)
+        description: Override MAX_THINKING_TOKENS (blank = auto-classify, capped at 24000)
         required: false
         type: string
         default: ""


### PR DESCRIPTION
### Motivation
Claude's auto review workflow classifies the PR as complex and sets `MAX_THINKING_TOKENS`=**32000** in `.github/workflows/ai-review-analysis.yml:534`. The Claude action then sends a request where `thinking.budget_tokens` is **32000**, but the request `max_tokens` is not greater than that, so Anthropic rejects it before the review starts ([example](https://github.com/facebook/rocksdb/actions/runs/25691112276/job/75427435133)).

### Fix
Reduce the "complex" thinking budget from **32000** to **24000** tokens and clamp manual overrides to the same ceiling, preventing the thinking budget from exceeding or equalling the action's effective `max_tokens`. 24k is still generous — enough for deep reasoning on complex PRs while guaranteeing the model can emit the formatted review.