### PR TITLE
Add listener_uri gflag for pluggable EventListener

### DIFF
--- a/db_stress_tool/batched_ops_stress.cc
+++ b/db_stress_tool/batched_ops_stress.cc
@@ -13,7 +13,8 @@
 namespace ROCKSDB_NAMESPACE {
 class BatchedOpsStressTest : public StressTest {
  public:
-  BatchedOpsStressTest() = default;
+  explicit BatchedOpsStressTest(int db_index)
+      : StressTest(db_index) {}
   virtual ~BatchedOpsStressTest() = default;
 
   bool IsStateTracked() const override { return false; }
@@ -722,7 +723,9 @@ class BatchedOpsStressTest : public StressTest {
   }
 };
 
-StressTest* CreateBatchedOpsStressTest() { return new BatchedOpsStressTest(); }
+StressTest* CreateBatchedOpsStressTest(int db_index) {
+  return new BatchedOpsStressTest(db_index);
+}
 
 }  // namespace ROCKSDB_NAMESPACE
 #endif  // GFLAGS

--- a/db_stress_tool/cf_consistency_stress.cc
+++ b/db_stress_tool/cf_consistency_stress.cc
@@ -21,7 +21,8 @@
 namespace ROCKSDB_NAMESPACE {
 class CfConsistencyStressTest : public StressTest {
  public:
-  CfConsistencyStressTest() : batch_id_(0) {}
+  explicit CfConsistencyStressTest(int db_index)
+      : StressTest(db_index), batch_id_(0) {}
 
   ~CfConsistencyStressTest() override = default;
 
@@ -1543,8 +1544,8 @@ class CfConsistencyStressTest : public StressTest {
   std::deque<DebugEvent> recent_debug_events_;
 };
 
-StressTest* CreateCfConsistencyStressTest() {
-  return new CfConsistencyStressTest();
+StressTest* CreateCfConsistencyStressTest(int db_index) {
+  return new CfConsistencyStressTest(db_index);
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db_stress_tool/cf_consistency_stress.cc
+++ b/db_stress_tool/cf_consistency_stress.cc
@@ -228,10 +228,10 @@ class CfConsistencyStressTest : public StressTest {
                    key, &value0);
 
       // Temporarily disable error injection for verification
-      if (fault_fs_guard) {
-        fault_fs_guard->DisableThreadLocalErrorInjection(
+      if (db_fault_injection_fs_) {
+        db_fault_injection_fs_->DisableThreadLocalErrorInjection(
             FaultInjectionIOType::kRead);
-        fault_fs_guard->DisableThreadLocalErrorInjection(
+        db_fault_injection_fs_->DisableThreadLocalErrorInjection(
             FaultInjectionIOType::kMetadataRead);
       }
 
@@ -280,10 +280,10 @@ class CfConsistencyStressTest : public StressTest {
       }
 
       //  Enable back error injection disabled for verification
-      if (fault_fs_guard) {
-        fault_fs_guard->EnableThreadLocalErrorInjection(
+      if (db_fault_injection_fs_) {
+        db_fault_injection_fs_->EnableThreadLocalErrorInjection(
             FaultInjectionIOType::kRead);
-        fault_fs_guard->EnableThreadLocalErrorInjection(
+        db_fault_injection_fs_->EnableThreadLocalErrorInjection(
             FaultInjectionIOType::kMetadataRead);
       }
       db_->ReleaseSnapshot(snapshot);
@@ -398,10 +398,10 @@ class CfConsistencyStressTest : public StressTest {
                          &cmp_result);
 
       //  Temporarily disable error injection for verification
-      if (fault_fs_guard) {
-        fault_fs_guard->DisableThreadLocalErrorInjection(
+      if (db_fault_injection_fs_) {
+        db_fault_injection_fs_->DisableThreadLocalErrorInjection(
             FaultInjectionIOType::kRead);
-        fault_fs_guard->DisableThreadLocalErrorInjection(
+        db_fault_injection_fs_->DisableThreadLocalErrorInjection(
             FaultInjectionIOType::kMetadataRead);
       }
 
@@ -560,10 +560,10 @@ class CfConsistencyStressTest : public StressTest {
       }
 
       //  Enable back error injection disabled for verification
-      if (fault_fs_guard) {
-        fault_fs_guard->EnableThreadLocalErrorInjection(
+      if (db_fault_injection_fs_) {
+        db_fault_injection_fs_->EnableThreadLocalErrorInjection(
             FaultInjectionIOType::kRead);
-        fault_fs_guard->EnableThreadLocalErrorInjection(
+        db_fault_injection_fs_->EnableThreadLocalErrorInjection(
             FaultInjectionIOType::kMetadataRead);
       }
     }

--- a/db_stress_tool/db_stress_common.cc
+++ b/db_stress_tool/db_stress_common.cc
@@ -20,7 +20,7 @@
 
 ROCKSDB_NAMESPACE::Env* db_stress_listener_env = nullptr;
 ROCKSDB_NAMESPACE::Env* db_stress_env = nullptr;
-std::shared_ptr<ROCKSDB_NAMESPACE::FaultInjectionTestFS> fault_fs_guard;
+std::shared_ptr<ROCKSDB_NAMESPACE::FileSystem> db_stress_raw_fs;
 std::shared_ptr<ROCKSDB_NAMESPACE::SecondaryCache> compressed_secondary_cache;
 std::shared_ptr<ROCKSDB_NAMESPACE::Cache> block_cache;
 enum ROCKSDB_NAMESPACE::CompressionType compression_type_e =
@@ -230,37 +230,39 @@ void CompressedCacheSetCapacityThread(void* v) {
 }
 
 #ifndef NDEBUG
-static void SetupFaultInjectionForRemoteCompaction(SharedState* shared) {
-  if (!fault_fs_guard) {
+static void SetupFaultInjectionForRemoteCompaction(
+    const std::shared_ptr<FaultInjectionTestFS>& fault_fs,
+    SharedState* shared) {
+  if (!fault_fs) {
     return;
   }
 
-  fault_fs_guard->SetThreadLocalErrorContext(
+  fault_fs->SetThreadLocalErrorContext(
       FaultInjectionIOType::kRead, shared->GetSeed(), FLAGS_read_fault_one_in,
       FLAGS_inject_error_severity == 1 /* retryable */,
       FLAGS_inject_error_severity == 2 /* has_data_loss*/);
-  fault_fs_guard->EnableThreadLocalErrorInjection(FaultInjectionIOType::kRead);
+  fault_fs->EnableThreadLocalErrorInjection(FaultInjectionIOType::kRead);
 
-  fault_fs_guard->SetThreadLocalErrorContext(
+  fault_fs->SetThreadLocalErrorContext(
       FaultInjectionIOType::kWrite, shared->GetSeed(), FLAGS_write_fault_one_in,
       FLAGS_inject_error_severity == 1 /* retryable */,
       FLAGS_inject_error_severity == 2 /* has_data_loss*/);
-  fault_fs_guard->EnableThreadLocalErrorInjection(FaultInjectionIOType::kWrite);
+  fault_fs->EnableThreadLocalErrorInjection(FaultInjectionIOType::kWrite);
 
-  fault_fs_guard->SetThreadLocalErrorContext(
+  fault_fs->SetThreadLocalErrorContext(
       FaultInjectionIOType::kMetadataRead, shared->GetSeed(),
       FLAGS_metadata_read_fault_one_in,
       FLAGS_inject_error_severity == 1 /* retryable */,
       FLAGS_inject_error_severity == 2 /* has_data_loss*/);
-  fault_fs_guard->EnableThreadLocalErrorInjection(
+  fault_fs->EnableThreadLocalErrorInjection(
       FaultInjectionIOType::kMetadataRead);
 
-  fault_fs_guard->SetThreadLocalErrorContext(
+  fault_fs->SetThreadLocalErrorContext(
       FaultInjectionIOType::kMetadataWrite, shared->GetSeed(),
       FLAGS_metadata_write_fault_one_in,
       FLAGS_inject_error_severity == 1 /* retryable */,
       FLAGS_inject_error_severity == 2 /* has_data_loss*/);
-  fault_fs_guard->EnableThreadLocalErrorInjection(
+  fault_fs->EnableThreadLocalErrorInjection(
       FaultInjectionIOType::kMetadataWrite);
 }
 #endif  // NDEBUG
@@ -268,7 +270,7 @@ static void SetupFaultInjectionForRemoteCompaction(SharedState* shared) {
 static CompactionServiceOptionsOverride CreateOverrideOptions(
     const Options& options, const CompactionServiceJobInfo& job_info) {
   CompactionServiceOptionsOverride override_options{
-      .env = db_stress_env,
+      .env = options.env,
       .file_checksum_gen_factory = options.file_checksum_gen_factory,
       .merge_operator = options.merge_operator,
       .compaction_filter = options.compaction_filter,
@@ -310,11 +312,13 @@ static CompactionServiceOptionsOverride CreateOverrideOptions(
   return override_options;
 }
 
-static Status CleanupOutputDirectory(const std::string& output_directory) {
+static Status CleanupOutputDirectory(
+    const std::string& output_directory,
+    [[maybe_unused]] const std::shared_ptr<FaultInjectionTestFS>& fault_fs) {
 #ifndef NDEBUG
   // Temporarily disable fault injection to ensure deletion always succeeds
-  if (fault_fs_guard) {
-    fault_fs_guard->DisableAllThreadLocalErrorInjection();
+  if (fault_fs) {
+    fault_fs->DisableAllThreadLocalErrorInjection();
   }
 #endif  // NDEBUG
 
@@ -338,8 +342,8 @@ static Status CleanupOutputDirectory(const std::string& output_directory) {
 
 #ifndef NDEBUG
   // Re-enable fault injection after deletion
-  if (fault_fs_guard) {
-    fault_fs_guard->EnableAllThreadLocalErrorInjection();
+  if (fault_fs) {
+    fault_fs->EnableAllThreadLocalErrorInjection();
   }
 #endif  // NDEBUG
 
@@ -428,7 +432,8 @@ static void ProcessRemoteCompactionJob(
   }
 
   if (!open_compact_options.allow_resumption) {
-    CleanupOutputDirectory(output_directory);
+    CleanupOutputDirectory(output_directory,
+                           stress_test->GetDbFaultInjectionFs());
   }
 
   std::shared_ptr<std::atomic<bool>> canceled = nullptr;
@@ -460,7 +465,8 @@ void RemoteCompactionWorkerThread(void* v) {
   assert(stress_test != nullptr);
 
 #ifndef NDEBUG
-  SetupFaultInjectionForRemoteCompaction(shared);
+  SetupFaultInjectionForRemoteCompaction(
+      stress_test->GetDbFaultInjectionFs(), shared);
 #endif  // NDEBUG
 
   // Tracks the duration (in microseconds) of the most recent successfully

--- a/db_stress_tool/db_stress_common.cc
+++ b/db_stress_tool/db_stress_common.cc
@@ -23,6 +23,10 @@ ROCKSDB_NAMESPACE::Env* db_stress_env = nullptr;
 std::shared_ptr<ROCKSDB_NAMESPACE::FileSystem> db_stress_raw_fs;
 std::shared_ptr<ROCKSDB_NAMESPACE::SecondaryCache> compressed_secondary_cache;
 std::shared_ptr<ROCKSDB_NAMESPACE::Cache> block_cache;
+// NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
+std::shared_ptr<ROCKSDB_NAMESPACE::WriteBufferManager> wbm;
+std::shared_ptr<ROCKSDB_NAMESPACE::RateLimiter> rate_limiter;
+// NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
 enum ROCKSDB_NAMESPACE::CompressionType compression_type_e =
     ROCKSDB_NAMESPACE::kSnappyCompression;
 enum ROCKSDB_NAMESPACE::CompressionType bottommost_compression_type_e =

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -186,10 +186,10 @@ DECLARE_double(uniform_cv_threshold);
 DECLARE_bool(use_trie_index);
 DECLARE_bool(use_udi_as_primary_index);
 DECLARE_bool(test_backward_scan);
-DECLARE_string(db);
-DECLARE_string(secondaries_base);
+DECLARE_string(db_root);
+DECLARE_string(secondary_dbs_root);
 DECLARE_bool(test_secondary);
-DECLARE_string(expected_values_dir);
+DECLARE_string(expected_states_root);
 DECLARE_bool(expected_state_trace_debug);
 DECLARE_int64(expected_state_trace_debug_key);
 DECLARE_int32(expected_state_trace_debug_max_logs);
@@ -828,10 +828,10 @@ AttributeGroups GenerateAttributeGroups(
     const std::vector<ColumnFamilyHandle*>& cfhs, uint32_t value_base,
     const Slice& slice);
 
-StressTest* CreateCfConsistencyStressTest();
-StressTest* CreateBatchedOpsStressTest();
-StressTest* CreateNonBatchedOpsStressTest();
-StressTest* CreateMultiOpsTxnsStressTest();
+StressTest* CreateCfConsistencyStressTest(int db_index);
+StressTest* CreateBatchedOpsStressTest(int db_index);
+StressTest* CreateNonBatchedOpsStressTest(int db_index);
+StressTest* CreateMultiOpsTxnsStressTest(int db_index);
 void CheckAndSetOptionsForMultiOpsTxnStressTest();
 void InitializeHotKeyGenerator(double alpha);
 int64_t GetOneHotKeyID(double rand_seed, int64_t max_key);

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -484,6 +484,11 @@ extern std::shared_ptr<ROCKSDB_NAMESPACE::FileSystem> db_stress_raw_fs;
 extern std::shared_ptr<ROCKSDB_NAMESPACE::SecondaryCache>
     compressed_secondary_cache;
 extern std::shared_ptr<ROCKSDB_NAMESPACE::Cache> block_cache;
+DECLARE_int32(num_dbs);
+// NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
+extern std::shared_ptr<ROCKSDB_NAMESPACE::WriteBufferManager> wbm;
+extern std::shared_ptr<ROCKSDB_NAMESPACE::RateLimiter> rate_limiter;
+// NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
 
 extern enum ROCKSDB_NAMESPACE::CompressionType compression_type_e;
 extern enum ROCKSDB_NAMESPACE::CompressionType bottommost_compression_type_e;

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -472,6 +472,8 @@ DECLARE_int32(compaction_on_deletion_window_size);
 DECLARE_double(compaction_on_deletion_ratio);
 DECLARE_double(read_triggered_compaction_threshold);
 
+DECLARE_string(listener_uri);
+
 constexpr long KB = 1024;
 constexpr int kRandomValueMaxFactor = 3;
 constexpr int kValueMaxLen = 100;

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -480,7 +480,7 @@ constexpr uint32_t kLargePrimeForCommonFactorSkew = 1872439133;
 // wrapped posix environment
 extern ROCKSDB_NAMESPACE::Env* db_stress_env;
 extern ROCKSDB_NAMESPACE::Env* db_stress_listener_env;
-extern std::shared_ptr<ROCKSDB_NAMESPACE::FaultInjectionTestFS> fault_fs_guard;
+extern std::shared_ptr<ROCKSDB_NAMESPACE::FileSystem> db_stress_raw_fs;
 extern std::shared_ptr<ROCKSDB_NAMESPACE::SecondaryCache>
     compressed_secondary_cache;
 extern std::shared_ptr<ROCKSDB_NAMESPACE::Cache> block_cache;

--- a/db_stress_tool/db_stress_driver.cc
+++ b/db_stress_tool/db_stress_driver.cc
@@ -66,6 +66,7 @@ void ThreadBody(void* v) {
 bool RunStressTestImpl(SharedState* shared) {
   SystemClock* clock = db_stress_env->GetSystemClock().get();
   StressTest* stress = shared->GetStressTest();
+  const std::string label = "[" + stress->GetDbLabel() + "] ";
 
   if (shared->ShouldVerifyAtBeginning() && FLAGS_preserve_unverified_changes) {
     const std::string db_path = stress->GetDbPath();
@@ -75,8 +76,8 @@ bool RunStressTestImpl(SharedState* shared) {
       s = InitUnverifiedSubdir(expected_values_dir);
     }
     if (!s.ok()) {
-      fprintf(stderr, "Failed to setup unverified state dir: %s\n",
-              s.ToString().c_str());
+      fprintf(stderr, "%sFailed to setup unverified state dir: %s\n",
+              label.c_str(), s.ToString().c_str());
       exit(1);
     }
   }
@@ -86,8 +87,8 @@ bool RunStressTestImpl(SharedState* shared) {
 
   uint32_t n = FLAGS_threads;
   uint64_t now = clock->NowMicros();
-  fprintf(stdout, "%s Initializing worker threads\n",
-          clock->TimeToString(now / 1000000).c_str());
+  fprintf(stdout, "%s %sInitializing worker threads\n",
+          clock->TimeToString(now / 1000000).c_str(), label.c_str());
 
   shared->SetThreads(n);
 
@@ -158,17 +159,19 @@ bool RunStressTestImpl(SharedState* shared) {
     }
     if (shared->ShouldVerifyAtBeginning()) {
       if (shared->HasVerificationFailedYet()) {
-        fprintf(stderr, "Crash-recovery verification failed :(\n");
+        fprintf(stderr, "%sCrash-recovery verification failed :(\n",
+                label.c_str());
       } else {
-        fprintf(stdout, "Crash-recovery verification passed :)\n");
+        fprintf(stdout, "%sCrash-recovery verification passed :)\n",
+                label.c_str());
         const std::string ev_dir = stress->GetExpectedValuesDir();
         Status s = DestroyUnverifiedSubdir(stress->GetDbPath());
         if (s.ok() && !ev_dir.empty()) {
           s = DestroyUnverifiedSubdir(ev_dir);
         }
         if (!s.ok()) {
-          fprintf(stderr, "Failed to cleanup unverified state dir: %s\n",
-                  s.ToString().c_str());
+          fprintf(stderr, "%sFailed to cleanup unverified state dir: %s\n",
+                  label.c_str(), s.ToString().c_str());
           exit(1);
         }
       }
@@ -194,8 +197,8 @@ bool RunStressTestImpl(SharedState* shared) {
         Status s = stress->EnableAutoCompaction();
         assert(s.ok());
       }
-      fprintf(stdout, "%s Starting database operations\n",
-              clock->TimeToString(now / 1000000).c_str());
+      fprintf(stdout, "%s %sStarting database operations\n",
+              clock->TimeToString(now / 1000000).c_str(), label.c_str());
 
       shared->SetStart();
       shared->GetCondVar()->SignalAll();
@@ -205,14 +208,17 @@ bool RunStressTestImpl(SharedState* shared) {
 
       now = clock->NowMicros();
       if (FLAGS_test_batches_snapshots) {
-        fprintf(stdout, "%s Limited verification already done during gets\n",
-                clock->TimeToString((uint64_t)now / 1000000).c_str());
+        fprintf(stdout, "%s %sLimited verification already done during gets\n",
+                clock->TimeToString((uint64_t)now / 1000000).c_str(),
+                label.c_str());
       } else if (FLAGS_skip_verifydb) {
-        fprintf(stdout, "%s Verification skipped\n",
-                clock->TimeToString((uint64_t)now / 1000000).c_str());
+        fprintf(stdout, "%s %sVerification skipped\n",
+                clock->TimeToString((uint64_t)now / 1000000).c_str(),
+                label.c_str());
       } else {
-        fprintf(stdout, "%s Starting verification\n",
-                clock->TimeToString((uint64_t)now / 1000000).c_str());
+        fprintf(stdout, "%s %sStarting verification\n",
+                clock->TimeToString((uint64_t)now / 1000000).c_str(),
+                label.c_str());
       }
 
       shared->SetStartVerify();
@@ -234,7 +240,7 @@ bool RunStressTestImpl(SharedState* shared) {
     for (unsigned int i = 1; i < n; i++) {
       threads[0]->stats.Merge(threads[i]->stats);
     }
-    threads[0]->stats.Report("Stress Test");
+    threads[0]->stats.Report((label + "Stress Test").c_str());
   }
 
   for (unsigned int i = 0; i < n; i++) {
@@ -245,8 +251,8 @@ bool RunStressTestImpl(SharedState* shared) {
   now = clock->NowMicros();
   if (!FLAGS_skip_verifydb && !FLAGS_test_batches_snapshots &&
       !shared->HasVerificationFailedYet()) {
-    fprintf(stdout, "%s Verification successful\n",
-            clock->TimeToString(now / 1000000).c_str());
+    fprintf(stdout, "%s %sVerification successful\n",
+            clock->TimeToString(now / 1000000).c_str(), label.c_str());
   }
 
   if (!FLAGS_verification_only) {
@@ -275,7 +281,7 @@ bool RunStressTestImpl(SharedState* shared) {
   }
 
   if (shared->HasVerificationFailedYet()) {
-    fprintf(stderr, "Verification failed :(\n");
+    fprintf(stderr, "%sVerification failed :(\n", label.c_str());
     return false;
   }
   return true;

--- a/db_stress_tool/db_stress_driver.cc
+++ b/db_stress_tool/db_stress_driver.cc
@@ -182,10 +182,11 @@ bool RunStressTestImpl(SharedState* shared) {
       }
 
       if (FLAGS_sync_fault_injection || FLAGS_write_fault_one_in > 0) {
-        fault_fs_guard->SetFilesystemDirectWritable(false);
-        fault_fs_guard->SetInjectUnsyncedDataLoss(FLAGS_sync_fault_injection);
+        auto fault_fs = stress->GetDbFaultInjectionFs();
+        fault_fs->SetFilesystemDirectWritable(false);
+        fault_fs->SetInjectUnsyncedDataLoss(FLAGS_sync_fault_injection);
         if (FLAGS_exclude_wal_from_write_fault_injection) {
-          fault_fs_guard->SetFileTypesExcludedFromWriteFaultInjection(
+          fault_fs->SetFileTypesExcludedFromWriteFaultInjection(
               {FileType::kWalFile});
         }
       }

--- a/db_stress_tool/db_stress_driver.cc
+++ b/db_stress_tool/db_stress_driver.cc
@@ -68,9 +68,11 @@ bool RunStressTestImpl(SharedState* shared) {
   StressTest* stress = shared->GetStressTest();
 
   if (shared->ShouldVerifyAtBeginning() && FLAGS_preserve_unverified_changes) {
-    Status s = InitUnverifiedSubdir(FLAGS_db);
-    if (s.ok() && !FLAGS_expected_values_dir.empty()) {
-      s = InitUnverifiedSubdir(FLAGS_expected_values_dir);
+    const std::string db_path = stress->GetDbPath();
+    const std::string expected_values_dir = stress->GetExpectedValuesDir();
+    Status s = InitUnverifiedSubdir(db_path);
+    if (s.ok() && !expected_values_dir.empty()) {
+      s = InitUnverifiedSubdir(expected_values_dir);
     }
     if (!s.ok()) {
       fprintf(stderr, "Failed to setup unverified state dir: %s\n",
@@ -159,9 +161,10 @@ bool RunStressTestImpl(SharedState* shared) {
         fprintf(stderr, "Crash-recovery verification failed :(\n");
       } else {
         fprintf(stdout, "Crash-recovery verification passed :)\n");
-        Status s = DestroyUnverifiedSubdir(FLAGS_db);
-        if (s.ok() && !FLAGS_expected_values_dir.empty()) {
-          s = DestroyUnverifiedSubdir(FLAGS_expected_values_dir);
+        const std::string ev_dir = stress->GetExpectedValuesDir();
+        Status s = DestroyUnverifiedSubdir(stress->GetDbPath());
+        if (s.ok() && !ev_dir.empty()) {
+          s = DestroyUnverifiedSubdir(ev_dir);
         }
         if (!s.ok()) {
           fprintf(stderr, "Failed to cleanup unverified state dir: %s\n",
@@ -174,7 +177,7 @@ bool RunStressTestImpl(SharedState* shared) {
     if (!FLAGS_verification_only) {
       // This is after the verification step to avoid making all those `Get()`s
       // and `MultiGet()`s contend on the DB-wide trace mutex.
-      if (!FLAGS_expected_values_dir.empty()) {
+      if (!stress->GetExpectedValuesDir().empty()) {
         stress->TrackExpectedState(shared);
       }
 

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -24,7 +24,7 @@ static bool ValidateUint32Range(const char* flagname, uint64_t value) {
 
 DEFINE_uint64(seed, 2341234,
               "Seed for PRNG. When --nooverwritepercent is "
-              "nonzero and --expected_values_dir is nonempty, this value "
+              "nonzero and --expected_states_root is nonempty, this value "
               "must be fixed across invocations.");
 static const bool FLAGS_seed_dummy __attribute__((__unused__)) =
     RegisterFlagValidator(&FLAGS_seed, &ValidateUint32Range);
@@ -683,23 +683,27 @@ DEFINE_bool(use_udi_as_primary_index, false,
 DEFINE_bool(test_backward_scan, true,
             "Test backward iteration (Prev, SeekForPrev) in stress tests.");
 
-DEFINE_string(db, "", "Use the db with the following name.");
+DEFINE_string(db_root, "",
+              "Use this path as the root directory for primary DB instances. "
+              "Each DB instance is resolved under this root as db_<i>.");
 
-DEFINE_string(secondaries_base, "",
-              "Use this path as the base path for secondary instances.");
+DEFINE_string(secondary_dbs_root, "",
+              "Use this path as the root directory for secondary DB "
+              "instances. Each primary DB at db_root/db_<i> has exactly one "
+              "secondary instance at secondary_dbs_root/db_<i>.");
 
 DEFINE_bool(test_secondary, false,
             "If true, start an additional secondary instance which can be used "
             "for verification.");
 
 DEFINE_string(
-    expected_values_dir, "",
-    "Dir where files containing info about the latest/historical values will "
-    "be stored. If provided and non-empty, the DB state will be verified "
-    "against values from these files after recovery. --max_key and "
+    expected_states_root, "",
+    "Root directory where expected-state files for each DB instance will be "
+    "stored under db_<i>. If provided and non-empty, the DB state will be "
+    "verified against values from these files after recovery. --max_key and "
     "--column_family must be kept the same across invocations of this program "
-    "that use the same --expected_values_dir. Currently historical values are "
-    "only tracked when --sync_fault_injection is set. See --seed and "
+    "that use the same --expected_states_root. Currently historical values "
+    "are only tracked when --sync_fault_injection is set. See --seed and "
     "--nooverwritepercent for further requirements.");
 
 DEFINE_bool(expected_state_trace_debug, true,
@@ -1006,7 +1010,7 @@ static const bool FLAGS_delrangepercent_dummy __attribute__((__unused__)) =
 
 DEFINE_int32(nooverwritepercent, 60,
              "Ratio of keys without overwrite to total workload (expressed as "
-             "a percentage). When --expected_values_dir is nonempty, must "
+             "a percentage). When --expected_states_root is nonempty, must "
              "keep this value constant across invocations.");
 static const bool FLAGS_nooverwritepercent_dummy __attribute__((__unused__)) =
     RegisterFlagValidator(&FLAGS_nooverwritepercent, &ValidateInt32Percent);
@@ -1214,7 +1218,7 @@ DEFINE_bool(sync_fault_injection, false,
             "If true, FaultInjectionTestFS will be used for write operations, "
             "and unsynced data in DB will lost after crash. In such a case we "
             "track DB changes in a trace file (\"*.trace\") in "
-            "--expected_values_dir for verifying there are no holes in the "
+            "--expected_states_root for verifying there are no holes in the "
             "recovered data.");
 
 DEFINE_bool(best_efforts_recovery, false,
@@ -1369,11 +1373,12 @@ DEFINE_uint64(
 
 DEFINE_bool(
     preserve_unverified_changes, false,
-    "DB files of the current run will all be preserved in `FLAGS_db`. DB files "
-    "from the last run will be preserved in `FLAGS_db/unverified` until the "
-    "first verification succeeds. Expected state files from the last run will "
-    "be preserved similarly under `FLAGS_expected_values_dir/unverified` when "
-    "`--expected_values_dir` is nonempty.");
+    "DB files of the current run will all be preserved under "
+    "`FLAGS_db_root/db_<i>`. DB files from the last run will be preserved in "
+    "`FLAGS_db_root/db_<i>/unverified` until the first verification succeeds. "
+    "Expected state files from the last run will be preserved similarly under "
+    "`FLAGS_expected_states_root/db_<i>/unverified` when "
+    "`--expected_states_root` is nonempty.");
 
 DEFINE_uint64(stats_dump_period_sec,
               ROCKSDB_NAMESPACE::Options().stats_dump_period_sec,

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -1669,6 +1669,10 @@ DEFINE_double(read_triggered_compaction_threshold,
               ROCKSDB_NAMESPACE::Options().read_triggered_compaction_threshold,
               "Sets CF option read_triggered_compaction_threshold.");
 
+DEFINE_string(listener_uri, "",
+              "URI for an additional EventListener to attach (e.g. "
+              "auto_tuner://). Empty means none.");
+
 DEFINE_bool(
     auto_refresh_iterator_with_snapshot,
     ROCKSDB_NAMESPACE::ReadOptions().auto_refresh_iterator_with_snapshot,

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -1708,4 +1708,7 @@ DEFINE_uint64(multiscan_max_prefetch_memory_bytes, 0,
               "used for prefetching data blocks across all concurrent "
               "MultiScan ReadSets.");
 
+DEFINE_int32(num_dbs, 1,
+             "Number of DB instances to run in parallel.");
+
 #endif  // GFLAGS

--- a/db_stress_tool/db_stress_listener.cc
+++ b/db_stress_tool/db_stress_listener.cc
@@ -7,6 +7,7 @@
 
 #include <cstdint>
 
+#include "db_stress_tool/db_stress_test_base.h"
 #include "file/file_util.h"
 #include "rocksdb/file_system.h"
 #include "util/coding_lean.h"
@@ -14,6 +15,19 @@
 namespace ROCKSDB_NAMESPACE {
 
 #ifdef GFLAGS
+
+DbStressListener::DbStressListener(
+    const std::string& db_name, const std::vector<DbPath>& db_paths,
+    const std::vector<ColumnFamilyDescriptor>& column_families,
+    SharedState* shared)
+    : db_name_(db_name),
+      db_paths_(db_paths),
+      column_families_(column_families),
+      num_pending_file_creations_(0),
+      unique_ids_(shared->GetStressTest()->GetExpectedValuesDir().empty()
+                      ? db_name
+                      : shared->GetStressTest()->GetExpectedValuesDir()),
+      shared_(shared) {}
 
 UniqueIdVerifier::UniqueIdVerifier(const std::string& dir)
     : path_(dir + "/.unique_ids") {

--- a/db_stress_tool/db_stress_listener.cc
+++ b/db_stress_tool/db_stress_listener.cc
@@ -120,7 +120,8 @@ UniqueIdVerifier::UniqueIdVerifier(const std::string& dir)
       size = 0;
     }
   }
-  fprintf(stdout, "(Re-)verified %zu unique IDs\n", id_set_.size());
+  fprintf(stdout, "(Re-)verified %zu unique IDs in %s\n", id_set_.size(),
+          dir.c_str());
 
   std::unique_ptr<FSWritableFile> file_writer;
   st = fs->NewWritableFile(path_, FileOptions(), &file_writer, /*dbg*/ nullptr);

--- a/db_stress_tool/db_stress_listener.cc
+++ b/db_stress_tool/db_stress_listener.cc
@@ -27,7 +27,9 @@ DbStressListener::DbStressListener(
       unique_ids_(shared->GetStressTest()->GetExpectedValuesDir().empty()
                       ? db_name
                       : shared->GetStressTest()->GetExpectedValuesDir()),
-      shared_(shared) {}
+      shared_(shared),
+      db_fault_injection_fs_(
+          shared->GetStressTest()->GetDbFaultInjectionFs()) {}
 
 UniqueIdVerifier::UniqueIdVerifier(const std::string& dir)
     : path_(dir + "/.unique_ids") {

--- a/db_stress_tool/db_stress_listener.h
+++ b/db_stress_tool/db_stress_listener.h
@@ -24,8 +24,6 @@
 #include "utilities/fault_injection_fs.h"
 DECLARE_int32(compact_files_one_in);
 
-extern std::shared_ptr<ROCKSDB_NAMESPACE::FaultInjectionTestFS> fault_fs_guard;
-
 namespace ROCKSDB_NAMESPACE {
 
 // Verify across process executions that all seen IDs are unique
@@ -66,8 +64,8 @@ class DbStressListener : public EventListener {
     VerifyFilePath(info.file_path);
     // pretending doing some work here
     RandomSleep();
-    if (fault_fs_guard) {
-      fault_fs_guard->DisableAllThreadLocalErrorInjection();
+    if (db_fault_injection_fs_) {
+      db_fault_injection_fs_->DisableAllThreadLocalErrorInjection();
     }
     shared_->SetPersistedSeqno(info.largest_seqno);
   }
@@ -75,37 +73,37 @@ class DbStressListener : public EventListener {
   void OnFlushBegin(DB* /*db*/,
                     const FlushJobInfo& /*flush_job_info*/) override {
     RandomSleep();
-    if (fault_fs_guard) {
-      fault_fs_guard->SetThreadLocalErrorContext(
+    if (db_fault_injection_fs_) {
+      db_fault_injection_fs_->SetThreadLocalErrorContext(
           FaultInjectionIOType::kRead, static_cast<uint32_t>(FLAGS_seed),
           FLAGS_read_fault_one_in,
           FLAGS_inject_error_severity == 1 /* retryable */,
           FLAGS_inject_error_severity == 2 /* has_data_loss*/);
-      fault_fs_guard->EnableThreadLocalErrorInjection(
+      db_fault_injection_fs_->EnableThreadLocalErrorInjection(
           FaultInjectionIOType::kRead);
 
-      fault_fs_guard->SetThreadLocalErrorContext(
+      db_fault_injection_fs_->SetThreadLocalErrorContext(
           FaultInjectionIOType::kWrite, static_cast<uint32_t>(FLAGS_seed),
           FLAGS_write_fault_one_in,
           FLAGS_inject_error_severity == 1 /* retryable */,
           FLAGS_inject_error_severity == 2 /* has_data_loss*/);
-      fault_fs_guard->EnableThreadLocalErrorInjection(
+      db_fault_injection_fs_->EnableThreadLocalErrorInjection(
           FaultInjectionIOType::kWrite);
 
-      fault_fs_guard->SetThreadLocalErrorContext(
+      db_fault_injection_fs_->SetThreadLocalErrorContext(
           FaultInjectionIOType::kMetadataRead,
           static_cast<uint32_t>(FLAGS_seed), FLAGS_metadata_read_fault_one_in,
           FLAGS_inject_error_severity == 1 /* retryable */,
           FLAGS_inject_error_severity == 2 /* has_data_loss*/);
-      fault_fs_guard->EnableThreadLocalErrorInjection(
+      db_fault_injection_fs_->EnableThreadLocalErrorInjection(
           FaultInjectionIOType::kMetadataRead);
 
-      fault_fs_guard->SetThreadLocalErrorContext(
+      db_fault_injection_fs_->SetThreadLocalErrorContext(
           FaultInjectionIOType::kMetadataWrite,
           static_cast<uint32_t>(FLAGS_seed), FLAGS_metadata_write_fault_one_in,
           FLAGS_inject_error_severity == 1 /* retryable */,
           FLAGS_inject_error_severity == 2 /* has_data_loss*/);
-      fault_fs_guard->EnableThreadLocalErrorInjection(
+      db_fault_injection_fs_->EnableThreadLocalErrorInjection(
           FaultInjectionIOType::kMetadataWrite);
     }
   }
@@ -132,44 +130,44 @@ class DbStressListener : public EventListener {
   }
 
   void OnSubcompactionBegin(const SubcompactionJobInfo& /* si */) override {
-    if (fault_fs_guard) {
-      fault_fs_guard->SetThreadLocalErrorContext(
+    if (db_fault_injection_fs_) {
+      db_fault_injection_fs_->SetThreadLocalErrorContext(
           FaultInjectionIOType::kRead, static_cast<uint32_t>(FLAGS_seed),
           FLAGS_read_fault_one_in,
           FLAGS_inject_error_severity == 1 /* retryable */,
           FLAGS_inject_error_severity == 2 /* has_data_loss*/);
-      fault_fs_guard->EnableThreadLocalErrorInjection(
+      db_fault_injection_fs_->EnableThreadLocalErrorInjection(
           FaultInjectionIOType::kRead);
 
-      fault_fs_guard->SetThreadLocalErrorContext(
+      db_fault_injection_fs_->SetThreadLocalErrorContext(
           FaultInjectionIOType::kWrite, static_cast<uint32_t>(FLAGS_seed),
           FLAGS_write_fault_one_in,
           FLAGS_inject_error_severity == 1 /* retryable */,
           FLAGS_inject_error_severity == 2 /* has_data_loss*/);
-      fault_fs_guard->EnableThreadLocalErrorInjection(
+      db_fault_injection_fs_->EnableThreadLocalErrorInjection(
           FaultInjectionIOType::kWrite);
 
-      fault_fs_guard->SetThreadLocalErrorContext(
+      db_fault_injection_fs_->SetThreadLocalErrorContext(
           FaultInjectionIOType::kMetadataRead,
           static_cast<uint32_t>(FLAGS_seed), FLAGS_metadata_read_fault_one_in,
           FLAGS_inject_error_severity == 1 /* retryable */,
           FLAGS_inject_error_severity == 2 /* has_data_loss*/);
-      fault_fs_guard->EnableThreadLocalErrorInjection(
+      db_fault_injection_fs_->EnableThreadLocalErrorInjection(
           FaultInjectionIOType::kMetadataRead);
 
-      fault_fs_guard->SetThreadLocalErrorContext(
+      db_fault_injection_fs_->SetThreadLocalErrorContext(
           FaultInjectionIOType::kMetadataWrite,
           static_cast<uint32_t>(FLAGS_seed), FLAGS_metadata_write_fault_one_in,
           FLAGS_inject_error_severity == 1 /* retryable */,
           FLAGS_inject_error_severity == 2 /* has_data_loss*/);
-      fault_fs_guard->EnableThreadLocalErrorInjection(
+      db_fault_injection_fs_->EnableThreadLocalErrorInjection(
           FaultInjectionIOType::kMetadataWrite);
     }
   }
 
   void OnSubcompactionCompleted(const SubcompactionJobInfo& /* si */) override {
-    if (fault_fs_guard) {
-      fault_fs_guard->DisableAllThreadLocalErrorInjection();
+    if (db_fault_injection_fs_) {
+      db_fault_injection_fs_->DisableAllThreadLocalErrorInjection();
     }
   }
 
@@ -262,11 +260,11 @@ class DbStressListener : public EventListener {
                             Status /* bg_error */,
                             bool* /* auto_recovery */) override {
     RandomSleep();
-    if (FLAGS_error_recovery_with_no_fault_injection && fault_fs_guard) {
-      fault_fs_guard->DisableAllThreadLocalErrorInjection();
+    if (FLAGS_error_recovery_with_no_fault_injection && db_fault_injection_fs_) {
+      db_fault_injection_fs_->DisableAllThreadLocalErrorInjection();
       // TODO(hx235): only exempt the flush thread during error recovery instead
       // of all the flush threads from error injection
-      fault_fs_guard->SetIOActivitiesExcludedFromFaultInjection(
+      db_fault_injection_fs_->SetIOActivitiesExcludedFromFaultInjection(
           {Env::IOActivity::kFlush});
     }
   }
@@ -274,9 +272,9 @@ class DbStressListener : public EventListener {
   void OnErrorRecoveryEnd(
       const BackgroundErrorRecoveryInfo& /*info*/) override {
     RandomSleep();
-    if (FLAGS_error_recovery_with_no_fault_injection && fault_fs_guard) {
-      fault_fs_guard->EnableAllThreadLocalErrorInjection();
-      fault_fs_guard->SetIOActivitiesExcludedFromFaultInjection({});
+    if (FLAGS_error_recovery_with_no_fault_injection && db_fault_injection_fs_) {
+      db_fault_injection_fs_->EnableAllThreadLocalErrorInjection();
+      db_fault_injection_fs_->SetIOActivitiesExcludedFromFaultInjection({});
     }
   }
 
@@ -367,6 +365,7 @@ class DbStressListener : public EventListener {
   std::atomic<int> num_pending_file_creations_;
   UniqueIdVerifier unique_ids_;
   SharedState* shared_;
+  std::shared_ptr<FaultInjectionTestFS> db_fault_injection_fs_;
   mutable std::mutex bg_pressure_mu_;
   BackgroundJobPressure last_bg_pressure_;
 };

--- a/db_stress_tool/db_stress_listener.h
+++ b/db_stress_tool/db_stress_listener.h
@@ -55,15 +55,7 @@ class DbStressListener : public EventListener {
   DbStressListener(const std::string& db_name,
                    const std::vector<DbPath>& db_paths,
                    const std::vector<ColumnFamilyDescriptor>& column_families,
-                   SharedState* shared)
-      : db_name_(db_name),
-        db_paths_(db_paths),
-        column_families_(column_families),
-        num_pending_file_creations_(0),
-        unique_ids_(FLAGS_expected_values_dir.empty()
-                        ? db_name
-                        : FLAGS_expected_values_dir),
-        shared_(shared) {}
+                   SharedState* shared);
 
   const char* Name() const override { return kClassName(); }
   static const char* kClassName() { return "DBStressListener"; }

--- a/db_stress_tool/db_stress_shared_state.cc
+++ b/db_stress_tool/db_stress_shared_state.cc
@@ -80,7 +80,8 @@ SharedState::SharedState(Env* /*env*/, StressTest* stress_test)
   }
 
   if (FLAGS_test_batches_snapshots) {
-    fprintf(stdout, "No lock creation because test_batches_snapshots set\n");
+    fprintf(stdout, "[%s] No lock creation because test_batches_snapshots set\n",
+            stress_test_->GetDbLabel().c_str());
     return;
   }
 
@@ -88,7 +89,6 @@ SharedState::SharedState(Env* /*env*/, StressTest* stress_test)
   if (max_key_ & ((1 << log2_keys_per_lock_) - 1)) {
     num_locks++;
   }
-  fprintf(stdout, "Creating %ld locks\n", num_locks * FLAGS_column_families);
   key_locks_.resize(FLAGS_column_families);
 
   for (int i = 0; i < FLAGS_column_families; ++i) {

--- a/db_stress_tool/db_stress_shared_state.cc
+++ b/db_stress_tool/db_stress_shared_state.cc
@@ -11,7 +11,109 @@
 #ifdef GFLAGS
 #include "db_stress_tool/db_stress_shared_state.h"
 
+#include "db_stress_tool/db_stress_test_base.h"
+
 namespace ROCKSDB_NAMESPACE {
 thread_local bool SharedState::ignore_read_error;
+
+SharedState::SharedState(Env* /*env*/, StressTest* stress_test)
+    : cv_(&mu_),
+      seed_(static_cast<uint32_t>(FLAGS_seed)),
+      max_key_(FLAGS_max_key),
+      log2_keys_per_lock_(static_cast<uint32_t>(FLAGS_log2_keys_per_lock)),
+      num_threads_(0),
+      num_initialized_(0),
+      num_populated_(0),
+      vote_reopen_(0),
+      num_done_(0),
+      start_(false),
+      start_verify_(false),
+      num_bg_threads_(0),
+      should_stop_bg_thread_(false),
+      bg_thread_finished_(0),
+      stress_test_(stress_test),
+      verification_failure_(false),
+      should_stop_test_(false),
+      no_overwrite_ids_(GenerateNoOverwriteIds()),
+      expected_state_manager_(nullptr),
+      printing_verification_results_(false),
+      start_timestamp_(Env::Default()->NowNanos()) {
+  const std::string expected_values_dir = stress_test_->GetExpectedValuesDir();
+  Status status;
+  // TODO: We should introduce a way to explicitly disable verification
+  // during shutdown. When that is disabled and expected_states_root
+  // is empty (disabling verification at startup), we can skip tracking
+  // expected state. Only then should we permit bypassing the below feature
+  // compatibility checks.
+  if (!expected_values_dir.empty()) {
+    if (!std::atomic<uint32_t>{}.is_lock_free() ||
+        !std::atomic<uint64_t>{}.is_lock_free()) {
+      std::ostringstream status_s;
+      status_s << "Cannot use --expected_states_root on platforms without "
+                  "lock-free "
+               << (!std::atomic<uint32_t>{}.is_lock_free()
+                       ? "std::atomic<uint32_t>"
+                       : "std::atomic<uint64_t>");
+      status = Status::InvalidArgument(status_s.str());
+    }
+
+    if (status.ok() && FLAGS_clear_column_family_one_in > 0) {
+      status = Status::InvalidArgument(
+          "Cannot use --expected_states_root when "
+          "--clear_column_family_one_in is greater than zero.");
+    }
+  }
+  if (status.ok()) {
+    if (expected_values_dir.empty()) {
+      expected_state_manager_.reset(
+          new AnonExpectedStateManager(FLAGS_max_key, FLAGS_column_families));
+    } else {
+      expected_state_manager_.reset(new FileExpectedStateManager(
+          FLAGS_max_key, FLAGS_column_families, expected_values_dir));
+    }
+    status = expected_state_manager_->Open();
+  }
+  if (!status.ok()) {
+    fprintf(stderr, "Failed setting up expected state with error: %s\n",
+            status.ToString().c_str());
+    exit(1);  // NOLINT(concurrency-mt-unsafe)
+  }
+
+  if (FLAGS_test_batches_snapshots) {
+    fprintf(stdout, "No lock creation because test_batches_snapshots set\n");
+    return;
+  }
+
+  long num_locks = static_cast<long>(max_key_ >> log2_keys_per_lock_);
+  if (max_key_ & ((1 << log2_keys_per_lock_) - 1)) {
+    num_locks++;
+  }
+  fprintf(stdout, "Creating %ld locks\n", num_locks * FLAGS_column_families);
+  key_locks_.resize(FLAGS_column_families);
+
+  for (int i = 0; i < FLAGS_column_families; ++i) {
+    key_locks_[i].reset(new port::Mutex[num_locks]);
+  }
+  if (FLAGS_read_fault_one_in || FLAGS_metadata_read_fault_one_in) {
+#ifdef NDEBUG
+    // Unsupported in release mode because it relies on
+    // `IGNORE_STATUS_IF_ERROR` to distinguish faults not expected to lead to
+    // failure.
+    fprintf(stderr,
+            "Cannot set nonzero value for --read_fault_one_in in "
+            "release mode.");
+    exit(1);  // NOLINT(concurrency-mt-unsafe)
+#else   // NDEBUG
+    SyncPoint::GetInstance()->SetCallBack("FaultInjectionIgnoreError",
+                                          IgnoreReadErrorCallback);
+    SyncPoint::GetInstance()->EnableProcessing();
+#endif  // NDEBUG
+  }
+}
+
+bool SharedState::ShouldVerifyAtBeginning() const {
+  return !stress_test_->GetExpectedValuesDir().empty();
+}
+
 }  // namespace ROCKSDB_NAMESPACE
 #endif  // GFLAGS

--- a/db_stress_tool/db_stress_shared_state.h
+++ b/db_stress_tool/db_stress_shared_state.h
@@ -363,7 +363,6 @@ class SharedState {
 
   // Pick random keys in each column family that will not experience overwrite.
   std::unordered_set<int64_t> GenerateNoOverwriteIds() const {
-    fprintf(stdout, "Choosing random keys with no overwrite\n");
     // Start with the identity permutation. Subsequent iterations of
     // for loop below will start with perm of previous for loop
     std::vector<int64_t> permutation(max_key_);

--- a/db_stress_tool/db_stress_shared_state.h
+++ b/db_stress_tool/db_stress_shared_state.h
@@ -24,7 +24,6 @@ DECLARE_uint64(log2_keys_per_lock);
 DECLARE_int32(threads);
 DECLARE_int32(column_families);
 DECLARE_int32(nooverwritepercent);
-DECLARE_string(expected_values_dir);
 DECLARE_int32(clear_column_family_one_in);
 DECLARE_bool(test_batches_snapshots);
 DECLARE_int32(compaction_thread_pool_adjust_interval);
@@ -78,99 +77,7 @@ class SharedState {
   // for those calls
   static thread_local bool ignore_read_error;
 
-  SharedState(Env* /*env*/, StressTest* stress_test)
-      : cv_(&mu_),
-        seed_(static_cast<uint32_t>(FLAGS_seed)),
-        max_key_(FLAGS_max_key),
-        log2_keys_per_lock_(static_cast<uint32_t>(FLAGS_log2_keys_per_lock)),
-        num_threads_(0),
-        num_initialized_(0),
-        num_populated_(0),
-        vote_reopen_(0),
-        num_done_(0),
-        start_(false),
-        start_verify_(false),
-        num_bg_threads_(0),
-        should_stop_bg_thread_(false),
-        bg_thread_finished_(0),
-        stress_test_(stress_test),
-        verification_failure_(false),
-        should_stop_test_(false),
-        no_overwrite_ids_(GenerateNoOverwriteIds()),
-        expected_state_manager_(nullptr),
-        printing_verification_results_(false),
-        start_timestamp_(Env::Default()->NowNanos()) {
-    Status status;
-    // TODO: We should introduce a way to explicitly disable verification
-    // during shutdown. When that is disabled and FLAGS_expected_values_dir
-    // is empty (disabling verification at startup), we can skip tracking
-    // expected state. Only then should we permit bypassing the below feature
-    // compatibility checks.
-    if (!FLAGS_expected_values_dir.empty()) {
-      if (!std::atomic<uint32_t>{}.is_lock_free() ||
-          !std::atomic<uint64_t>{}.is_lock_free()) {
-        std::ostringstream status_s;
-        status_s << "Cannot use --expected_values_dir on platforms without "
-                    "lock-free "
-                 << (!std::atomic<uint32_t>{}.is_lock_free()
-                         ? "std::atomic<uint32_t>"
-                         : "std::atomic<uint64_t>");
-        status = Status::InvalidArgument(status_s.str());
-      }
-
-      if (status.ok() && FLAGS_clear_column_family_one_in > 0) {
-        status = Status::InvalidArgument(
-            "Cannot use --expected_values_dir on when "
-            "--clear_column_family_one_in is greater than zero.");
-      }
-    }
-    if (status.ok()) {
-      if (FLAGS_expected_values_dir.empty()) {
-        expected_state_manager_.reset(
-            new AnonExpectedStateManager(FLAGS_max_key, FLAGS_column_families));
-      } else {
-        expected_state_manager_.reset(new FileExpectedStateManager(
-            FLAGS_max_key, FLAGS_column_families, FLAGS_expected_values_dir));
-      }
-      status = expected_state_manager_->Open();
-    }
-    if (!status.ok()) {
-      fprintf(stderr, "Failed setting up expected state with error: %s\n",
-              status.ToString().c_str());
-      exit(1);
-    }
-
-    if (FLAGS_test_batches_snapshots) {
-      fprintf(stdout, "No lock creation because test_batches_snapshots set\n");
-      return;
-    }
-
-    long num_locks = static_cast<long>(max_key_ >> log2_keys_per_lock_);
-    if (max_key_ & ((1 << log2_keys_per_lock_) - 1)) {
-      num_locks++;
-    }
-    fprintf(stdout, "Creating %ld locks\n", num_locks * FLAGS_column_families);
-    key_locks_.resize(FLAGS_column_families);
-
-    for (int i = 0; i < FLAGS_column_families; ++i) {
-      key_locks_[i].reset(new port::Mutex[num_locks]);
-    }
-    if (FLAGS_read_fault_one_in || FLAGS_metadata_read_fault_one_in) {
-#ifdef NDEBUG
-      // Unsupported in release mode because it relies on
-      // `IGNORE_STATUS_IF_ERROR` to distinguish faults not expected to lead to
-      // failure.
-      fprintf(stderr,
-              "Cannot set nonzero value for --read_fault_one_in in "
-              "release mode.");
-      exit(1);
-#else   // NDEBUG
-      SyncPoint::GetInstance()->SetCallBack("FaultInjectionIgnoreError",
-                                            IgnoreReadErrorCallback);
-      SyncPoint::GetInstance()->EnableProcessing();
-#endif  // NDEBUG
-    }
-  }
+  SharedState(Env* env, StressTest* stress_test);
 
   ~SharedState() {
 #ifndef NDEBUG
@@ -430,9 +337,7 @@ class SharedState {
     return bg_thread_finished_ == num_bg_threads_;
   }
 
-  bool ShouldVerifyAtBeginning() const {
-    return !FLAGS_expected_values_dir.empty();
-  }
+  bool ShouldVerifyAtBeginning() const;
 
   bool PrintingVerificationResults() {
     bool tmp = false;

--- a/db_stress_tool/db_stress_stat.h
+++ b/db_stress_tool/db_stress_stat.h
@@ -181,6 +181,8 @@ class Stats {
     double rate = bytes_mb / elapsed;
     double throughput = (double)done_ / elapsed;
 
+    // Lock stdout to prevent interleaving with other DBs' stats output.
+    flockfile(stdout);
     fprintf(stdout, "%-12s: ", name);
     fprintf(stdout, "%.3f micros/op %ld ops/sec\n", seconds_ * 1e6 / done_,
             (long)throughput);
@@ -199,17 +201,16 @@ class Stats {
     fprintf(stdout, "%-12s: Deleted %ld key-ranges\n", "", range_deletions_);
     fprintf(stdout, "%-12s: Range deletions covered %ld keys\n", "",
             covered_by_range_deletions_);
-
     fprintf(stdout, "%-12s: Got errors %ld times\n", "", errors_);
     fprintf(stdout, "%-12s: %ld CompactFiles() succeed\n", "",
             num_compact_files_succeed_);
     fprintf(stdout, "%-12s: %ld CompactFiles() did not succeed\n", "",
             num_compact_files_failed_);
-
     if (FLAGS_histogram) {
       fprintf(stdout, "Microseconds per op:\n%s\n", hist_.ToString().c_str());
     }
     fflush(stdout);
+    funlockfile(stdout);
   }
 };
 }  // namespace ROCKSDB_NAMESPACE

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -65,8 +65,29 @@ std::shared_ptr<const FilterPolicy> CreateFilterPolicy() {
 
 }  // namespace
 
-StressTest::StressTest()
-    : cache_(NewCache(FLAGS_cache_size, FLAGS_cache_numshardbits)),
+std::string StressTest::GetDbLabel() const {
+  return "db_" + std::to_string(db_index_);
+}
+
+std::string StressTest::GetDbPath() const {
+  return FLAGS_db_root + "/" + GetDbLabel();
+}
+
+std::string StressTest::GetExpectedValuesDir() const {
+  return FLAGS_expected_states_root.empty()
+             ? std::string()
+             : FLAGS_expected_states_root + "/" + GetDbLabel();
+}
+
+std::string StressTest::GetSecondariesBase() const {
+  return FLAGS_secondary_dbs_root.empty()
+             ? std::string()
+             : FLAGS_secondary_dbs_root + "/" + GetDbLabel();
+}
+
+StressTest::StressTest(int db_index)
+    : db_index_(db_index),
+      cache_(NewCache(FLAGS_cache_size, FLAGS_cache_numshardbits)),
       filter_policy_(CreateFilterPolicy()),
       db_(nullptr),
       txn_db_(nullptr),
@@ -78,7 +99,7 @@ StressTest::StressTest()
       db_preload_finished_(false),
       is_db_stopped_(false) {
   if (FLAGS_destroy_db_initially) {
-    const Status s = DbStressDestroyDb(FLAGS_db);
+    const Status s = DbStressDestroyDb(GetDbPath());
     if (!s.ok()) {
       fprintf(stderr, "Cannot destroy original db: %s\n", s.ToString().c_str());
       exit(1);
@@ -1345,7 +1366,7 @@ void StressTest::OperateDb(ThreadState* thread) {
         uint64_t total_size = 0;
         if (FLAGS_backup_max_size > 0) {
           std::vector<FileAttributes> files;
-          db_stress_env->GetChildrenFileAttributes(FLAGS_db, &files);
+          db_stress_env->GetChildrenFileAttributes(GetDbPath(), &files);
           for (auto& file : files) {
             total_size += file.size_bytes;
           }
@@ -2468,9 +2489,9 @@ Status StressTest::TestBackupRestore(
   }
 
   const std::string backup_dir =
-      FLAGS_db + "/.backup" + std::to_string(thread->tid);
+      GetDbPath() + "/.backup" + std::to_string(thread->tid);
   const std::string restore_dir =
-      FLAGS_db + "/.restore" + std::to_string(thread->tid);
+      GetDbPath() + "/.restore" + std::to_string(thread->tid);
   BackupEngineOptions backup_opts(backup_dir);
   // For debugging, get info_log from live options
   backup_opts.info_log = db_->GetDBOptions().info_log.get();
@@ -2934,7 +2955,7 @@ Status StressTest::TestCheckpoint(ThreadState* thread,
   }
 
   std::string checkpoint_dir =
-      FLAGS_db + "/.checkpoint" + std::to_string(thread->tid);
+      GetDbPath() + "/.checkpoint" + std::to_string(thread->tid);
   Options tmp_opts(options_);
   tmp_opts.listeners.clear();
   tmp_opts.env = db_stress_env;
@@ -3904,13 +3925,21 @@ void StressTest::Open(SharedState* shared, bool reopen) {
     fprintf(stdout, "Integrated BlobDB: blob cache disabled\n");
   }
 
-  fprintf(stdout, "DB path: [%s]\n", FLAGS_db.c_str());
+  fprintf(stdout, "DB path: [%s]\n", GetDbPath().c_str());
+  if (!GetExpectedValuesDir().empty()) {
+    fprintf(stdout, "Expected states path: [%s]\n",
+            GetExpectedValuesDir().c_str());
+  }
+  if (!GetSecondariesBase().empty()) {
+    fprintf(stdout, "Secondary DB path: [%s]\n",
+            GetSecondariesBase().c_str());
+  }
 
   Status s;
 
   if (FLAGS_ttl == -1) {
     std::vector<std::string> existing_column_families;
-    s = DB::ListColumnFamilies(DBOptions(options_), FLAGS_db,
+    s = DB::ListColumnFamilies(DBOptions(options_), GetDbPath(),
                                &existing_column_families);  // ignore errors
     if (!s.ok()) {
       // DB doesn't exist
@@ -3959,7 +3988,7 @@ void StressTest::Open(SharedState* shared, bool reopen) {
 
     options_.listeners.clear();
     options_.listeners.emplace_back(new DbStressListener(
-        FLAGS_db, options_.db_paths, cf_descriptors, shared));
+        GetDbPath(), options_.db_paths, cf_descriptors, shared));
     RegisterAdditionalListeners();
 
     // If this is for DB reopen,  error injection may have been enabled.
@@ -3980,7 +4009,7 @@ void StressTest::Open(SharedState* shared, bool reopen) {
            inject_open_meta_write_error || inject_open_read_error ||
            inject_open_write_error) &&
           fault_fs_guard
-              ->FileExists(FLAGS_db + "/CURRENT", IOOptions(), nullptr)
+              ->FileExists(GetDbPath() + "/CURRENT", IOOptions(), nullptr)
               .ok()) {
         if (inject_sync_fault || inject_open_write_error) {
           fault_fs_guard->SetFilesystemDirectWritable(false);
@@ -4024,7 +4053,7 @@ void StressTest::Open(SharedState* shared, bool reopen) {
           blob_db_options.enable_garbage_collection = FLAGS_blob_db_enable_gc;
 
           blob_db::BlobDB* blob_db = nullptr;
-          s = blob_db::BlobDB::Open(options_, blob_db_options, FLAGS_db,
+          s = blob_db::BlobDB::Open(options_, blob_db_options, GetDbPath(),
                                     cf_descriptors, &column_families_,
                                     &blob_db);
           if (s.ok()) {
@@ -4033,11 +4062,11 @@ void StressTest::Open(SharedState* shared, bool reopen) {
           }
         } else {
           if (db_preload_finished_.load() && FLAGS_read_only) {
-            s = DB::OpenForReadOnly(DBOptions(options_), FLAGS_db,
+            s = DB::OpenForReadOnly(DBOptions(options_), GetDbPath(),
                                     cf_descriptors, &column_families_,
                                     &db_owner_);
           } else {
-            s = DB::Open(DBOptions(options_), FLAGS_db, cf_descriptors,
+            s = DB::Open(DBOptions(options_), GetDbPath(), cf_descriptors,
                          &column_families_, &db_owner_);
           }
           if (s.ok()) {
@@ -4107,7 +4136,7 @@ void StressTest::Open(SharedState* shared, bool reopen) {
           optimistic_txn_db_options.shared_lock_buckets = nullptr;
         }
         s = OptimisticTransactionDB::Open(
-            options_, optimistic_txn_db_options, FLAGS_db, cf_descriptors,
+            options_, optimistic_txn_db_options, GetDbPath(), cf_descriptors,
             &column_families_, &optimistic_txn_db_);
         if (!s.ok()) {
           fprintf(stderr, "Error in opening the OptimisticTransactionDB [%s]\n",
@@ -4145,7 +4174,7 @@ void StressTest::Open(SharedState* shared, bool reopen) {
         txn_db_options.use_per_key_point_lock_mgr =
             FLAGS_use_per_key_point_lock_mgr;
         PrepareTxnDbOptions(shared, txn_db_options);
-        s = TransactionDB::Open(options_, txn_db_options, FLAGS_db,
+        s = TransactionDB::Open(options_, txn_db_options, GetDbPath(),
                                 cf_descriptors, &column_families_, &txn_db_);
         if (!s.ok()) {
           fprintf(stderr, "Error in opening the TransactionDB [%s]\n",
@@ -4185,8 +4214,8 @@ void StressTest::Open(SharedState* shared, bool reopen) {
       // TODO(yanqin) support max_open_files != -1 for secondary instance.
       tmp_opts.max_open_files = -1;
       tmp_opts.env = db_stress_env;
-      const std::string& secondary_path = FLAGS_secondaries_base;
-      s = DB::OpenAsSecondary(tmp_opts, FLAGS_db, secondary_path,
+      const std::string& secondary_path = GetSecondariesBase();
+      s = DB::OpenAsSecondary(tmp_opts, GetDbPath(), secondary_path,
                               cf_descriptors, &secondary_cfhs_, &secondary_db_);
       assert(s.ok());
       assert(secondary_cfhs_.size() ==
@@ -4194,7 +4223,7 @@ void StressTest::Open(SharedState* shared, bool reopen) {
     }
   } else {
     DBWithTTL* db_with_ttl;
-    s = DBWithTTL::Open(options_, FLAGS_db, &db_with_ttl, FLAGS_ttl);
+    s = DBWithTTL::Open(options_, GetDbPath(), &db_with_ttl, FLAGS_ttl);
     db_owner_.reset(db_with_ttl);
     db_ = db_with_ttl;
   }

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -109,7 +109,7 @@ StressTest::StressTest(int db_index)
                     db_stress_env,
                     std::make_shared<DbStressFSWrapper>(db_fault_injection_fs_))
               : nullptr),
-      cache_(NewCache(FLAGS_cache_size, FLAGS_cache_numshardbits)),
+      cache_(block_cache),
       filter_policy_(CreateFilterPolicy()),
       db_(nullptr),
       txn_db_(nullptr),
@@ -146,7 +146,8 @@ StressTest::StressTest(int db_index)
   if (FLAGS_destroy_db_initially) {
     const Status s = DbStressDestroyDb(GetDbPath());
     if (!s.ok()) {
-      fprintf(stderr, "Cannot destroy original db: %s\n", s.ToString().c_str());
+      fprintf(stderr, "[%s] Cannot destroy original db: %s\n",
+              GetDbLabel().c_str(), s.ToString().c_str());
       exit(1);
     }
   }
@@ -516,9 +517,15 @@ bool StressTest::BuildOptionsTable() {
 
 void StressTest::InitDb(SharedState* shared) {
   uint64_t now = clock_->NowMicros();
-  fprintf(stdout, "%s Initializing db_stress\n",
-          clock_->TimeToString(now / 1000000).c_str());
-  PrintEnv();
+  fprintf(stdout, "%s [%s] Initializing db_stress\n",
+          clock_->TimeToString(now / 1000000).c_str(),
+          GetDbLabel().c_str());
+  if (db_index_ == 0) {
+    // Print shared configuration once -- all DBs use the same options.
+    // Per-DB paths are printed separately below.
+    fprintf(stdout, "=== Shared configuration (all DBs) ===\n");
+    PrintEnv();
+  }
   Open(shared);
   BuildOptionsTable();
 }
@@ -538,8 +545,8 @@ void StressTest::FinishInitDb(SharedState* shared) {
     // `db_`'s current seqno.
     Status s = shared->Restore(db_);
     if (!s.ok()) {
-      fprintf(stderr, "Error restoring historical expected values: %s\n",
-              s.ToString().c_str());
+      fprintf(stderr, "[%s] Error restoring historical expected values: %s\n",
+              GetDbLabel().c_str(), s.ToString().c_str());
       exit(1);
     }
   }
@@ -718,15 +725,16 @@ void StressTest::PrintStatistics() {
   if (db_) {
     auto stats = db_->GetOptions().statistics;
     if (stats) {
-      fprintf(stdout, "STATISTICS:\n%s\n", stats->ToString().c_str());
+      fprintf(stdout, "[%s] STATISTICS:\n%s\n", GetDbLabel().c_str(),
+              stats->ToString().c_str());
     }
   }
   // Print statistics from secondary DB instance if it exists
   if (secondary_db_) {
     auto stats = secondary_db_->GetOptions().statistics;
     if (stats) {
-      fprintf(stdout, "Secondary instance STATISTICS:\n%s\n",
-              stats->ToString().c_str());
+      fprintf(stdout, "[%s] Secondary instance STATISTICS:\n%s\n",
+              GetDbLabel().c_str(), stats->ToString().c_str());
     }
   }
 }
@@ -3889,19 +3897,23 @@ void StressTest::Open(SharedState* shared, bool reopen) {
   } else if (!strcasecmp(FLAGS_compression_manager.c_str(), "none")) {
     // Nothing to do using default compression manager
   } else {
-    fprintf(stderr, "Unknown compression manager: %s\n",
-            FLAGS_compression_manager.c_str());
+    fprintf(stderr, "[%s] Unknown compression manager: %s\n",
+            GetDbLabel().c_str(), FLAGS_compression_manager.c_str());
     exit(1);
   }
   if (FLAGS_prefix_size == 0 && FLAGS_rep_factory == kHashSkipList) {
     fprintf(stderr,
-            "prefeix_size cannot be zero if memtablerep == prefix_hash\n");
+            "[%s] prefeix_size cannot be zero if memtablerep == prefix_hash\n",
+            GetDbLabel().c_str());
     exit(1);
   }
   if (FLAGS_prefix_size != 0 && FLAGS_rep_factory != kHashSkipList) {
-    fprintf(stdout,
-            "WARNING: prefix_size is non-zero but "
-            "memtablerep != prefix_hash\n");
+    // Print once -- shared across all DBs
+    if (db_index_ == 0) {
+      fprintf(stdout,
+              "WARNING: prefix_size is non-zero but "
+              "memtablerep != prefix_hash\n");
+    }
   }
 
   // Remote Compaction
@@ -3910,8 +3922,9 @@ void StressTest::Open(SharedState* shared, bool reopen) {
          options_.enable_blob_garbage_collection ||
          FLAGS_allow_setting_blob_options_dynamically)) {
       fprintf(stderr,
-              "Integrated BlobDB is currently incompatible with Remote "
-              "Compaction\n");
+              "[%s] Integrated BlobDB is currently incompatible with Remote "
+              "Compaction\n",
+              GetDbLabel().c_str());
       exit(1);
     }
     // Each DB open/reopen gets a fresh compaction service instance with a clean
@@ -3925,8 +3938,9 @@ void StressTest::Open(SharedState* shared, bool reopen) {
   if (FLAGS_allow_resumption_one_in > 0) {
     if (FLAGS_remote_compaction_worker_threads == 0) {
       fprintf(stderr,
-              "allow_resumption or randomize_allow_resumption requires "
-              "remote_compaction_worker_threads > 0\n");
+              "[%s] allow_resumption or randomize_allow_resumption requires "
+              "remote_compaction_worker_threads > 0\n",
+              GetDbLabel().c_str());
       exit(1);
     }
   }
@@ -3935,51 +3949,57 @@ void StressTest::Open(SharedState* shared, bool reopen) {
        FLAGS_allow_setting_blob_options_dynamically) &&
       FLAGS_best_efforts_recovery) {
     fprintf(stderr,
-            "Integrated BlobDB is currently incompatible with best-effort "
-            "recovery\n");
+            "[%s] Integrated BlobDB is currently incompatible with best-effort "
+            "recovery\n",
+            GetDbLabel().c_str());
     exit(1);
   }
 
-  fprintf(stdout,
-          "Integrated BlobDB: blob files enabled %d, min blob size %" PRIu64
-          ", direct write enabled %d, direct write partitions %" PRIu32
-          ", blob file size %" PRIu64
-          ", blob compression type %s, blob GC enabled %d, cutoff %f, force "
-          "threshold %f, blob compaction readahead size %" PRIu64
-          ", blob file starting level %d\n",
-          options_.enable_blob_files, options_.min_blob_size,
-          options_.enable_blob_direct_write,
-          options_.blob_direct_write_partitions, options_.blob_file_size,
-          CompressionTypeToString(options_.blob_compression_type).c_str(),
-          options_.enable_blob_garbage_collection,
-          options_.blob_garbage_collection_age_cutoff,
-          options_.blob_garbage_collection_force_threshold,
-          options_.blob_compaction_readahead_size,
-          options_.blob_file_starting_level);
-
-  if (FLAGS_use_blob_cache) {
+  // Print once -- shared across all DBs
+  if (db_index_ == 0) {
     fprintf(stdout,
-            "Integrated BlobDB: blob cache enabled"
-            ", block and blob caches shared: %d",
-            FLAGS_use_shared_block_and_blob_cache);
-    if (!FLAGS_use_shared_block_and_blob_cache) {
+            "Integrated BlobDB: blob files enabled %d, min blob size %" PRIu64
+            ", direct write enabled %d, direct write partitions %" PRIu32
+            ", blob file size %" PRIu64
+            ", blob compression type %s, blob GC enabled %d, cutoff %f, force "
+            "threshold %f, blob compaction readahead size %" PRIu64
+            ", blob file starting level %d\n",
+            options_.enable_blob_files, options_.min_blob_size,
+            options_.enable_blob_direct_write,
+            options_.blob_direct_write_partitions, options_.blob_file_size,
+            CompressionTypeToString(options_.blob_compression_type).c_str(),
+            options_.enable_blob_garbage_collection,
+            options_.blob_garbage_collection_age_cutoff,
+            options_.blob_garbage_collection_force_threshold,
+            options_.blob_compaction_readahead_size,
+            options_.blob_file_starting_level);
+
+    if (FLAGS_use_blob_cache) {
       fprintf(stdout,
-              ", blob cache size %" PRIu64 ", blob cache num shard bits: %d",
-              FLAGS_blob_cache_size, FLAGS_blob_cache_numshardbits);
+              "Integrated BlobDB: blob cache enabled"
+              ", block and blob caches shared: %d",
+              FLAGS_use_shared_block_and_blob_cache);
+      if (!FLAGS_use_shared_block_and_blob_cache) {
+        fprintf(stdout,
+                ", blob cache size %" PRIu64 ", blob cache num shard bits: %d",
+                FLAGS_blob_cache_size, FLAGS_blob_cache_numshardbits);
+      }
+      fprintf(stdout, ", blob cache prepopulated: %d\n",
+              FLAGS_prepopulate_blob_cache);
+    } else {
+      fprintf(stdout, "Integrated BlobDB: blob cache disabled\n");
     }
-    fprintf(stdout, ", blob cache prepopulated: %d\n",
-            FLAGS_prepopulate_blob_cache);
-  } else {
-    fprintf(stdout, "Integrated BlobDB: blob cache disabled\n");
+    fprintf(stdout, "=== End shared configuration ===\n");
   }
 
-  fprintf(stdout, "DB path: [%s]\n", GetDbPath().c_str());
+  fprintf(stdout, "[%s] DB path: [%s]\n", GetDbLabel().c_str(),
+          GetDbPath().c_str());
   if (!GetExpectedValuesDir().empty()) {
-    fprintf(stdout, "Expected states path: [%s]\n",
-            GetExpectedValuesDir().c_str());
+    fprintf(stdout, "[%s] Expected states path: [%s]\n",
+            GetDbLabel().c_str(), GetExpectedValuesDir().c_str());
   }
   if (!GetSecondariesBase().empty()) {
-    fprintf(stdout, "Secondary DB path: [%s]\n",
+    fprintf(stdout, "[%s] Secondary DB path: [%s]\n", GetDbLabel().c_str(),
             GetSecondariesBase().c_str());
   }
 
@@ -4291,15 +4311,17 @@ void StressTest::Open(SharedState* shared, bool reopen) {
   }
 
   if (!s.ok()) {
-    fprintf(stderr, "open error: %s\n", s.ToString().c_str());
+    fprintf(stderr, "[%s] open error: %s\n", GetDbLabel().c_str(),
+            s.ToString().c_str());
     exit(1);
   }
 
   if (db_->GetLatestSequenceNumber() < shared->GetPersistedSeqno()) {
     fprintf(stderr,
-            "DB of latest sequence number %" PRIu64
-            "did not recover to the persisted "
+            "[%s] DB of latest sequence number %" PRIu64
+            " did not recover to the persisted "
             "sequence number %" PRIu64 " from last DB session\n",
+            GetDbLabel().c_str(),
             db_->GetLatestSequenceNumber(), shared->GetPersistedSeqno());
     exit(1);
   }
@@ -4360,8 +4382,9 @@ void StressTest::Reopen(ThreadState* thread) {
 
   num_times_reopened_++;
   auto now = clock_->NowMicros();
-  fprintf(stdout, "%s Reopening database for the %dth time\n",
-          clock_->TimeToString(now / 1000000).c_str(), num_times_reopened_);
+  fprintf(stdout, "%s [%s] Reopening database for the %dth time\n",
+          clock_->TimeToString(now / 1000000).c_str(),
+          GetDbLabel().c_str(), num_times_reopened_);
   Open(thread->shared, /*reopen=*/true);
 
   if (thread->shared->GetStressTest()->MightHaveUnsyncedDataLoss() &&
@@ -4625,9 +4648,8 @@ void InitializeOptionsFromFlags(
       FLAGS_max_write_buffer_size_to_maintain;
   options.memtable_prefix_bloom_size_ratio =
       FLAGS_memtable_prefix_bloom_size_ratio;
-  if (FLAGS_use_write_buffer_manager) {
-    options.write_buffer_manager.reset(
-        new WriteBufferManager(FLAGS_db_write_buffer_size, block_cache));
+  if (wbm) {
+    options.write_buffer_manager = wbm;
   }
   options.memtable_whole_key_filtering = FLAGS_memtable_whole_key_filtering;
   if (ShouldDisableAutoCompactionsBeforeVerifyDb()) {
@@ -4969,14 +4991,8 @@ void InitializeOptionsGeneral(
 
   // TODO: row_cache, thread-pool IO priority, CPU priority.
 
-  if (!options.rate_limiter) {
-    if (FLAGS_rate_limiter_bytes_per_sec > 0) {
-      options.rate_limiter.reset(NewGenericRateLimiter(
-          FLAGS_rate_limiter_bytes_per_sec, 1000 /* refill_period_us */,
-          10 /* fairness */,
-          FLAGS_rate_limit_bg_reads ? RateLimiter::Mode::kReadsOnly
-                                    : RateLimiter::Mode::kWritesOnly));
-    }
+  if (rate_limiter) {
+    options.rate_limiter = rate_limiter;
   }
 
   if (!options.file_checksum_gen_factory) {

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -8,8 +8,11 @@
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 //
 
+#include <ctime>
 #include <ios>
 #include <thread>
+
+#include <unistd.h>
 
 #include "db_stress_tool/db_stress_compression_manager.h"
 #include "db_stress_tool/db_stress_listener.h"
@@ -85,8 +88,27 @@ std::string StressTest::GetSecondariesBase() const {
              : FLAGS_secondary_dbs_root + "/" + GetDbLabel();
 }
 
+static bool NeedsFaultInjection() {
+  return FLAGS_open_metadata_read_fault_one_in ||
+         FLAGS_open_metadata_write_fault_one_in ||
+         FLAGS_open_read_fault_one_in || FLAGS_open_write_fault_one_in ||
+         FLAGS_metadata_read_fault_one_in || FLAGS_metadata_write_fault_one_in ||
+         FLAGS_read_fault_one_in || FLAGS_write_fault_one_in ||
+         FLAGS_sync_fault_injection;
+}
+
 StressTest::StressTest(int db_index)
     : db_index_(db_index),
+      db_fault_injection_fs_(
+          NeedsFaultInjection()
+              ? std::make_shared<FaultInjectionTestFS>(db_stress_raw_fs)
+              : nullptr),
+      db_fault_injection_env_wrapper_(
+          db_fault_injection_fs_
+              ? std::make_unique<CompositeEnvWrapper>(
+                    db_stress_env,
+                    std::make_shared<DbStressFSWrapper>(db_fault_injection_fs_))
+              : nullptr),
       cache_(NewCache(FLAGS_cache_size, FLAGS_cache_numshardbits)),
       filter_policy_(CreateFilterPolicy()),
       db_(nullptr),
@@ -98,6 +120,29 @@ StressTest::StressTest(int db_index)
       num_times_reopened_(0),
       db_preload_finished_(false),
       is_db_stopped_(false) {
+  if (db_fault_injection_fs_) {
+    // Info logs are debugging artifacts, so exclude them from fault injection
+    // and keep error accounting focused on DB data and metadata.
+    db_fault_injection_fs_->SetFileTypesExcludedFromFaultInjection(
+        {FileType::kInfoLogFile});
+    // Set it to direct writable here to initially bypass any fault injection
+    // during DB open. This will correspondingly be overwritten in
+    // StressTest::Open() for open fault injection and in RunStressTestImpl()
+    // for proper fault injection setup.
+    db_fault_injection_fs_->SetFilesystemDirectWritable(true);
+
+    // Set fault injection log path for crash diagnostics
+    std::string log_dir;
+    Status log_s = db_stress_env->GetTestDirectory(&log_dir);
+    if (!log_s.ok()) {
+      log_dir = "/tmp";
+    }
+    std::string log_path =
+        log_dir + "/fault_injection_" + std::to_string(getpid()) + "_" +
+        std::to_string(db_stress_env->GetSystemClock()->NowMicros()) + "_" +
+        GetDbLabel() + ".log";
+    db_fault_injection_fs_->SetInjectedErrorLogPath(log_path);
+  }
   if (FLAGS_destroy_db_initially) {
     const Status s = DbStressDestroyDb(GetDbPath());
     if (!s.ok()) {
@@ -1081,37 +1126,37 @@ void StressTest::OperateDb(ThreadState* thread) {
     }
 
 #ifndef NDEBUG
-    if (fault_fs_guard) {
-      fault_fs_guard->SetThreadLocalErrorContext(
+    if (db_fault_injection_fs_) {
+      db_fault_injection_fs_->SetThreadLocalErrorContext(
           FaultInjectionIOType::kRead, thread->shared->GetSeed(),
           FLAGS_read_fault_one_in,
           FLAGS_inject_error_severity == 1 /* retryable */,
           FLAGS_inject_error_severity == 2 /* has_data_loss*/);
-      fault_fs_guard->EnableThreadLocalErrorInjection(
+      db_fault_injection_fs_->EnableThreadLocalErrorInjection(
           FaultInjectionIOType::kRead);
 
-      fault_fs_guard->SetThreadLocalErrorContext(
+      db_fault_injection_fs_->SetThreadLocalErrorContext(
           FaultInjectionIOType::kWrite, thread->shared->GetSeed(),
           FLAGS_write_fault_one_in,
           FLAGS_inject_error_severity == 1 /* retryable */,
           FLAGS_inject_error_severity == 2 /* has_data_loss*/);
-      fault_fs_guard->EnableThreadLocalErrorInjection(
+      db_fault_injection_fs_->EnableThreadLocalErrorInjection(
           FaultInjectionIOType::kWrite);
 
-      fault_fs_guard->SetThreadLocalErrorContext(
+      db_fault_injection_fs_->SetThreadLocalErrorContext(
           FaultInjectionIOType::kMetadataRead, thread->shared->GetSeed(),
           FLAGS_metadata_read_fault_one_in,
           FLAGS_inject_error_severity == 1 /* retryable */,
           FLAGS_inject_error_severity == 2 /* has_data_loss*/);
-      fault_fs_guard->EnableThreadLocalErrorInjection(
+      db_fault_injection_fs_->EnableThreadLocalErrorInjection(
           FaultInjectionIOType::kMetadataRead);
 
-      fault_fs_guard->SetThreadLocalErrorContext(
+      db_fault_injection_fs_->SetThreadLocalErrorContext(
           FaultInjectionIOType::kMetadataWrite, thread->shared->GetSeed(),
           FLAGS_metadata_write_fault_one_in,
           FLAGS_inject_error_severity == 1 /* retryable */,
           FLAGS_inject_error_severity == 2 /* has_data_loss*/);
-      fault_fs_guard->EnableThreadLocalErrorInjection(
+      db_fault_injection_fs_->EnableThreadLocalErrorInjection(
           FaultInjectionIOType::kMetadataWrite);
     }
 #endif  // NDEBUG
@@ -1134,13 +1179,13 @@ void StressTest::OperateDb(ThreadState* thread) {
       if (thread->tid == 0 && FLAGS_verify_db_one_in > 0 &&
           thread->rand.OneIn(FLAGS_verify_db_one_in)) {
         //  Temporarily disable error injection for verification
-        if (fault_fs_guard) {
-          fault_fs_guard->DisableAllThreadLocalErrorInjection();
+        if (db_fault_injection_fs_) {
+          db_fault_injection_fs_->DisableAllThreadLocalErrorInjection();
         }
         ContinuouslyVerifyDb(thread);
         //  Enable back error injection disabled for verification
-        if (fault_fs_guard) {
-          fault_fs_guard->EnableAllThreadLocalErrorInjection();
+        if (db_fault_injection_fs_) {
+          db_fault_injection_fs_->EnableAllThreadLocalErrorInjection();
         }
         if (thread->shared->ShouldStopTest()) {
           break;
@@ -1165,8 +1210,8 @@ void StressTest::OperateDb(ThreadState* thread) {
           fprintf(stderr, "LockWAL() failed: %s\n", s.ToString().c_str());
         } else if (s.ok()) {
           //  Temporarily disable error injection for verification
-          if (fault_fs_guard) {
-            fault_fs_guard->DisableAllThreadLocalErrorInjection();
+          if (db_fault_injection_fs_) {
+            db_fault_injection_fs_->DisableAllThreadLocalErrorInjection();
           }
 
           // Verify no writes during LockWAL
@@ -1220,8 +1265,8 @@ void StressTest::OperateDb(ThreadState* thread) {
           }
 
           //  Enable back error injection disabled for verification
-          if (fault_fs_guard) {
-            fault_fs_guard->EnableAllThreadLocalErrorInjection();
+          if (db_fault_injection_fs_) {
+            db_fault_injection_fs_->EnableAllThreadLocalErrorInjection();
           }
         }
       }
@@ -1338,14 +1383,14 @@ void StressTest::OperateDb(ThreadState* thread) {
         // TestGetProperty doesn't return status for us to tell whether it has
         // failed due to injected error. So we disable fault injection to avoid
         // false positive
-        if (fault_fs_guard) {
-          fault_fs_guard->DisableAllThreadLocalErrorInjection();
+        if (db_fault_injection_fs_) {
+          db_fault_injection_fs_->DisableAllThreadLocalErrorInjection();
         }
 
         TestGetProperty(thread);
 
-        if (fault_fs_guard) {
-          fault_fs_guard->EnableAllThreadLocalErrorInjection();
+        if (db_fault_injection_fs_) {
+          db_fault_injection_fs_->EnableAllThreadLocalErrorInjection();
         }
       }
 
@@ -1375,12 +1420,12 @@ void StressTest::OperateDb(ThreadState* thread) {
         if (total_size <= FLAGS_backup_max_size) {
           // TODO(hx235): enable error injection with
           // backup/restore after fixing the various issues it surfaces
-          if (fault_fs_guard) {
-            fault_fs_guard->DisableAllThreadLocalErrorInjection();
+          if (db_fault_injection_fs_) {
+            db_fault_injection_fs_->DisableAllThreadLocalErrorInjection();
           }
           Status s = TestBackupRestore(thread, rand_column_families, rand_keys);
-          if (fault_fs_guard) {
-            fault_fs_guard->EnableAllThreadLocalErrorInjection();
+          if (db_fault_injection_fs_) {
+            db_fault_injection_fs_->EnableAllThreadLocalErrorInjection();
           }
           ProcessStatus(shared, "Backup/restore", s);
         }
@@ -1423,7 +1468,7 @@ void StressTest::OperateDb(ThreadState* thread) {
       // tolerated. Keep fault injection disabled during user writes until each
       // injected failure mode is audited against that contract.
       bool disable_fault_injection_during_user_write =
-          fault_fs_guard && MightHaveUnsyncedDataLoss();
+          db_fault_injection_fs_ && MightHaveUnsyncedDataLoss();
       int prob_op = thread->rand.Uniform(100);
       // Reset this in case we pick something other than a read op. We don't
       // want to use a stale value when deciding at the beginning of the loop
@@ -1483,32 +1528,32 @@ void StressTest::OperateDb(ThreadState* thread) {
         assert(prefix_bound <= prob_op);
         // OPERATION write
         if (disable_fault_injection_during_user_write) {
-          fault_fs_guard->DisableAllThreadLocalErrorInjection();
+          db_fault_injection_fs_->DisableAllThreadLocalErrorInjection();
         }
         TestPut(thread, write_opts, read_opts, rand_column_families, rand_keys,
                 value);
         if (disable_fault_injection_during_user_write) {
-          fault_fs_guard->EnableAllThreadLocalErrorInjection();
+          db_fault_injection_fs_->EnableAllThreadLocalErrorInjection();
         }
       } else if (prob_op < del_bound) {
         assert(write_bound <= prob_op);
         // OPERATION delete
         if (disable_fault_injection_during_user_write) {
-          fault_fs_guard->DisableAllThreadLocalErrorInjection();
+          db_fault_injection_fs_->DisableAllThreadLocalErrorInjection();
         }
         TestDelete(thread, write_opts, rand_column_families, rand_keys);
         if (disable_fault_injection_during_user_write) {
-          fault_fs_guard->EnableAllThreadLocalErrorInjection();
+          db_fault_injection_fs_->EnableAllThreadLocalErrorInjection();
         }
       } else if (prob_op < delrange_bound) {
         assert(del_bound <= prob_op);
         // OPERATION delete range
         if (disable_fault_injection_during_user_write) {
-          fault_fs_guard->DisableAllThreadLocalErrorInjection();
+          db_fault_injection_fs_->DisableAllThreadLocalErrorInjection();
         }
         TestDeleteRange(thread, write_opts, rand_column_families, rand_keys);
         if (disable_fault_injection_during_user_write) {
-          fault_fs_guard->EnableAllThreadLocalErrorInjection();
+          db_fault_injection_fs_->EnableAllThreadLocalErrorInjection();
         }
       } else if (prob_op < iterate_bound) {
         assert(delrange_bound <= prob_op);
@@ -1566,8 +1611,8 @@ void StressTest::OperateDb(ThreadState* thread) {
     }
 
 #ifndef NDEBUG
-    if (fault_fs_guard) {
-      fault_fs_guard->DisableAllThreadLocalErrorInjection();
+    if (db_fault_injection_fs_) {
+      db_fault_injection_fs_->DisableAllThreadLocalErrorInjection();
     }
 #endif  // NDEBUG
   }
@@ -2560,7 +2605,7 @@ Status StressTest::TestBackupRestore(
   std::ostringstream restore_opts_oss;
   BackupEngine* backup_engine = nullptr;
   std::string from = "a backup/restore operation";
-  Status s = BackupEngine::Open(db_stress_env, backup_opts, &backup_engine);
+  Status s = BackupEngine::Open(options_.env, backup_opts, &backup_engine);
   if (!s.ok()) {
     from = "BackupEngine::Open";
   }
@@ -2620,7 +2665,7 @@ Status StressTest::TestBackupRestore(
   if (s.ok()) {
     delete backup_engine;
     backup_engine = nullptr;
-    s = BackupEngine::Open(db_stress_env, backup_opts, &backup_engine);
+    s = BackupEngine::Open(options_.env, backup_opts, &backup_engine);
     if (!s.ok()) {
       from = "BackupEngine::Open (again)";
     }
@@ -2790,8 +2835,8 @@ Status StressTest::TestBackupRestore(
   }
 
   // Temporarily disable error injection for clean up
-  if (fault_fs_guard) {
-    fault_fs_guard->DisableAllThreadLocalErrorInjection();
+  if (db_fault_injection_fs_) {
+    db_fault_injection_fs_->DisableAllThreadLocalErrorInjection();
   }
 
   if (s.ok() || IsErrorInjectedAndRetryable(s)) {
@@ -2812,8 +2857,8 @@ Status StressTest::TestBackupRestore(
   }
 
   // Enable back error injection disabled for clean up
-  if (fault_fs_guard) {
-    fault_fs_guard->EnableAllThreadLocalErrorInjection();
+  if (db_fault_injection_fs_) {
+    db_fault_injection_fs_->EnableAllThreadLocalErrorInjection();
   }
 
   if (!s.ok() && !IsErrorInjectedAndRetryable(s)) {
@@ -2958,17 +3003,17 @@ Status StressTest::TestCheckpoint(ThreadState* thread,
       GetDbPath() + "/.checkpoint" + std::to_string(thread->tid);
   Options tmp_opts(options_);
   tmp_opts.listeners.clear();
-  tmp_opts.env = db_stress_env;
+  tmp_opts.env = options_.env;
   // Avoid delayed deletion so whole directory can be deleted
   tmp_opts.sst_file_manager.reset();
   //  Temporarily disable error injection for clean-up
-  if (fault_fs_guard) {
-    fault_fs_guard->DisableAllThreadLocalErrorInjection();
+  if (db_fault_injection_fs_) {
+    db_fault_injection_fs_->DisableAllThreadLocalErrorInjection();
   }
   DestroyDB(checkpoint_dir, tmp_opts);
   // Enable back error injection disabled for clean-up
-  if (fault_fs_guard) {
-    fault_fs_guard->EnableAllThreadLocalErrorInjection();
+  if (db_fault_injection_fs_) {
+    db_fault_injection_fs_->EnableAllThreadLocalErrorInjection();
   }
   Checkpoint* checkpoint = nullptr;
   Status s = Checkpoint::Create(db_, &checkpoint);
@@ -2980,8 +3025,8 @@ Status StressTest::TestCheckpoint(ThreadState* thread,
       std::vector<std::string> files;
 
       // Temporarily disable error injection to print debugging information
-      if (fault_fs_guard) {
-        fault_fs_guard->DisableThreadLocalErrorInjection(
+      if (db_fault_injection_fs_) {
+        db_fault_injection_fs_->DisableThreadLocalErrorInjection(
             FaultInjectionIOType::kMetadataRead);
       }
 
@@ -2989,8 +3034,8 @@ Status StressTest::TestCheckpoint(ThreadState* thread,
 
       // Enable back disable error injection disabled for printing debugging
       // information
-      if (fault_fs_guard) {
-        fault_fs_guard->EnableThreadLocalErrorInjection(
+      if (db_fault_injection_fs_) {
+        db_fault_injection_fs_->EnableThreadLocalErrorInjection(
             FaultInjectionIOType::kMetadataRead);
       }
       if (!my_s.ok()) {
@@ -3074,8 +3119,8 @@ Status StressTest::TestCheckpoint(ThreadState* thread,
   }
 
   //  Temporarily disable error injection for clean-up
-  if (fault_fs_guard) {
-    fault_fs_guard->DisableAllThreadLocalErrorInjection();
+  if (db_fault_injection_fs_) {
+    db_fault_injection_fs_->DisableAllThreadLocalErrorInjection();
   }
 
   if (!s.ok() && !IsErrorInjectedAndRetryable(s)) {
@@ -3086,8 +3131,8 @@ Status StressTest::TestCheckpoint(ThreadState* thread,
   }
 
   // Enable back error injection disabled for clean-up
-  if (fault_fs_guard) {
-    fault_fs_guard->EnableAllThreadLocalErrorInjection();
+  if (db_fault_injection_fs_) {
+    db_fault_injection_fs_->EnableAllThreadLocalErrorInjection();
   }
   return s;
 }
@@ -3478,8 +3523,8 @@ void StressTest::TestCompactRange(ThreadState* thread, int64_t rand_key,
   uint32_t pre_hash = 0;
   if (thread->rand.OneIn(2)) {
     // Temporarily disable error injection to for validation
-    if (fault_fs_guard) {
-      fault_fs_guard->DisableAllThreadLocalErrorInjection();
+    if (db_fault_injection_fs_) {
+      db_fault_injection_fs_->DisableAllThreadLocalErrorInjection();
     }
 
     // Declare a snapshot and compare the data before and after the compaction
@@ -3488,8 +3533,8 @@ void StressTest::TestCompactRange(ThreadState* thread, int64_t rand_key,
         GetRangeHash(thread, pre_snapshot, column_family, start_key, end_key);
 
     // Enable back error injection disabled for validation
-    if (fault_fs_guard) {
-      fault_fs_guard->EnableAllThreadLocalErrorInjection();
+    if (db_fault_injection_fs_) {
+      db_fault_injection_fs_->EnableAllThreadLocalErrorInjection();
     }
   }
   std::ostringstream compact_range_opt_oss;
@@ -3526,8 +3571,8 @@ void StressTest::TestCompactRange(ThreadState* thread, int64_t rand_key,
 
   if (pre_snapshot != nullptr) {
     // Temporarily disable error injection for validation
-    if (fault_fs_guard) {
-      fault_fs_guard->DisableAllThreadLocalErrorInjection();
+    if (db_fault_injection_fs_) {
+      db_fault_injection_fs_->DisableAllThreadLocalErrorInjection();
     }
     uint32_t post_hash =
         GetRangeHash(thread, pre_snapshot, column_family, start_key, end_key);
@@ -3544,9 +3589,9 @@ void StressTest::TestCompactRange(ThreadState* thread, int64_t rand_key,
       thread->shared->SetVerificationFailure();
     }
     db_->ReleaseSnapshot(pre_snapshot);
-    if (fault_fs_guard) {
+    if (db_fault_injection_fs_) {
       // Enable back error injection disabled for validation
-      fault_fs_guard->EnableAllThreadLocalErrorInjection();
+      db_fault_injection_fs_->EnableAllThreadLocalErrorInjection();
     }
   }
 }
@@ -3823,6 +3868,9 @@ void StressTest::Open(SharedState* shared, bool reopen) {
     InitializeOptionsFromFlags(cache_, filter_policy_, udi_factory_, options_);
   }
   InitializeOptionsGeneral(cache_, filter_policy_, sqfc_factory_, options_);
+  options_.env = db_fault_injection_env_wrapper_
+                     ? db_fault_injection_env_wrapper_.get()
+                     : db_stress_env;
   DbStressCustomCompressionManager::Register();
 
   if (!strcasecmp(FLAGS_compression_manager.c_str(), "custom")) {
@@ -3993,8 +4041,8 @@ void StressTest::Open(SharedState* shared, bool reopen) {
 
     // If this is for DB reopen,  error injection may have been enabled.
     // Disable it here in case there is no open fault injection.
-    if (fault_fs_guard) {
-      fault_fs_guard->DisableAllThreadLocalErrorInjection();
+    if (db_fault_injection_fs_) {
+      db_fault_injection_fs_->DisableAllThreadLocalErrorInjection();
     }
     // TODO; test transaction DB Open with fault injection
     if (!FLAGS_use_txn) {
@@ -4008,41 +4056,41 @@ void StressTest::Open(SharedState* shared, bool reopen) {
       if ((inject_sync_fault || inject_open_meta_read_error ||
            inject_open_meta_write_error || inject_open_read_error ||
            inject_open_write_error) &&
-          fault_fs_guard
+          db_fault_injection_fs_
               ->FileExists(GetDbPath() + "/CURRENT", IOOptions(), nullptr)
               .ok()) {
         if (inject_sync_fault || inject_open_write_error) {
-          fault_fs_guard->SetFilesystemDirectWritable(false);
-          fault_fs_guard->SetInjectUnsyncedDataLoss(inject_sync_fault);
+          db_fault_injection_fs_->SetFilesystemDirectWritable(false);
+          db_fault_injection_fs_->SetInjectUnsyncedDataLoss(inject_sync_fault);
         }
-        fault_fs_guard->SetThreadLocalErrorContext(
+        db_fault_injection_fs_->SetThreadLocalErrorContext(
             FaultInjectionIOType::kMetadataRead,
             static_cast<uint32_t>(FLAGS_seed),
             FLAGS_open_metadata_read_fault_one_in, false /* retryable */,
             false /* has_data_loss */);
-        fault_fs_guard->EnableThreadLocalErrorInjection(
+        db_fault_injection_fs_->EnableThreadLocalErrorInjection(
             FaultInjectionIOType::kMetadataRead);
 
-        fault_fs_guard->SetThreadLocalErrorContext(
+        db_fault_injection_fs_->SetThreadLocalErrorContext(
             FaultInjectionIOType::kMetadataWrite,
             static_cast<uint32_t>(FLAGS_seed),
             FLAGS_open_metadata_write_fault_one_in, false /* retryable */,
             false /* has_data_loss */);
-        fault_fs_guard->EnableThreadLocalErrorInjection(
+        db_fault_injection_fs_->EnableThreadLocalErrorInjection(
             FaultInjectionIOType::kMetadataWrite);
 
-        fault_fs_guard->SetThreadLocalErrorContext(
+        db_fault_injection_fs_->SetThreadLocalErrorContext(
             FaultInjectionIOType::kRead, static_cast<uint32_t>(FLAGS_seed),
             FLAGS_open_read_fault_one_in, false /* retryable */,
             false /* has_data_loss */);
-        fault_fs_guard->EnableThreadLocalErrorInjection(
+        db_fault_injection_fs_->EnableThreadLocalErrorInjection(
             FaultInjectionIOType::kRead);
 
-        fault_fs_guard->SetThreadLocalErrorContext(
+        db_fault_injection_fs_->SetThreadLocalErrorContext(
             FaultInjectionIOType::kWrite, static_cast<uint32_t>(FLAGS_seed),
             FLAGS_open_write_fault_one_in, false /* retryable */,
             false /* has_data_loss */);
-        fault_fs_guard->EnableThreadLocalErrorInjection(
+        db_fault_injection_fs_->EnableThreadLocalErrorInjection(
             FaultInjectionIOType::kWrite);
       }
       while (true) {
@@ -4077,7 +4125,7 @@ void StressTest::Open(SharedState* shared, bool reopen) {
         if (inject_sync_fault || inject_open_meta_read_error ||
             inject_open_meta_write_error || inject_open_read_error ||
             inject_open_write_error) {
-          fault_fs_guard->DisableAllThreadLocalErrorInjection();
+          db_fault_injection_fs_->DisableAllThreadLocalErrorInjection();
 
           if (s.ok()) {
             // Injected errors might happen in background compactions. We
@@ -4107,13 +4155,13 @@ void StressTest::Open(SharedState* shared, bool reopen) {
             if (!reopen) {
               Random rand(static_cast<uint32_t>(FLAGS_seed));
               if (rand.OneIn(2)) {
-                fault_fs_guard->DeleteFilesCreatedAfterLastDirSync(IOOptions(),
+                db_fault_injection_fs_->DeleteFilesCreatedAfterLastDirSync(IOOptions(),
                                                                    nullptr);
               }
               if (rand.OneIn(3)) {
-                fault_fs_guard->DropUnsyncedFileData();
+                db_fault_injection_fs_->DropUnsyncedFileData();
               } else if (rand.OneIn(2)) {
-                fault_fs_guard->DropRandomUnsyncedFileData(&rand);
+                db_fault_injection_fs_->DropRandomUnsyncedFileData(&rand);
               }
             }
             continue;
@@ -4213,7 +4261,7 @@ void StressTest::Open(SharedState* shared, bool reopen) {
       Options tmp_opts;
       // TODO(yanqin) support max_open_files != -1 for secondary instance.
       tmp_opts.max_open_files = -1;
-      tmp_opts.env = db_stress_env;
+      tmp_opts.env = options_.env;
       const std::string& secondary_path = GetSecondariesBase();
       s = DB::OpenAsSecondary(tmp_opts, GetDbPath(), secondary_path,
                               cf_descriptors, &secondary_cfhs_, &secondary_db_);

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -4059,6 +4059,19 @@ void StressTest::Open(SharedState* shared, bool reopen) {
         GetDbPath(), options_.db_paths, cf_descriptors, shared));
     RegisterAdditionalListeners();
 
+    if (!FLAGS_listener_uri.empty()) {
+      std::shared_ptr<EventListener> listener;
+      Status listener_status =
+          ObjectRegistry::Default()->NewSharedObject<EventListener>(
+              FLAGS_listener_uri, &listener);
+      if (!listener_status.ok()) {
+        fprintf(stderr, "Failed to create listener from URI '%s': %s\n",
+                FLAGS_listener_uri.c_str(), listener_status.ToString().c_str());
+        _exit(1);
+      }
+      options_.listeners.emplace_back(std::move(listener));
+    }
+
     // If this is for DB reopen,  error injection may have been enabled.
     // Disable it here in case there is no open fault injection.
     if (db_fault_injection_fs_) {

--- a/db_stress_tool/db_stress_test_base.h
+++ b/db_stress_tool/db_stress_test_base.h
@@ -40,11 +40,17 @@ class StressTest {
   // from optimistic transactions when conflict detection retries are exhausted.
   static bool IsExpectedTxnError(const Status& s);
 
-  StressTest();
+  explicit StressTest(int db_index);
 
   virtual ~StressTest() {}
 
-  std::shared_ptr<Cache> NewCache(size_t capacity, int32_t num_shard_bits);
+  std::string GetDbLabel() const;
+  std::string GetDbPath() const;
+  std::string GetExpectedValuesDir() const;
+  std::string GetSecondariesBase() const;
+
+  static std::shared_ptr<Cache> NewCache(size_t capacity,
+                                         int32_t num_shard_bits);
 
   static std::vector<std::string> GetBlobCompressionTags();
 
@@ -391,7 +397,6 @@ class StressTest {
                                  const WideColumns& columns);
 
   void PrintEnv() const;
-
   void Open(SharedState* shared, bool reopen = false);
 
   void Reopen(ThreadState* thread);
@@ -412,6 +417,8 @@ class StressTest {
                                           ReadOptions& read_opts);
 
   void CleanUpColumnFamilies();
+
+  int db_index_;
 
   std::shared_ptr<Cache> cache_;
   std::shared_ptr<Cache> compressed_cache_;

--- a/db_stress_tool/db_stress_test_base.h
+++ b/db_stress_tool/db_stress_test_base.h
@@ -13,6 +13,7 @@
 
 #include "db_stress_tool/db_stress_common.h"
 #include "db_stress_tool/db_stress_shared_state.h"
+#include "env/composite_env_wrapper.h"
 #include "rocksdb/experimental.h"
 #include "rocksdb/user_defined_index.h"
 #include "utilities/fault_injection_fs.h"
@@ -76,6 +77,9 @@ class StressTest {
   }
   Options GetOptions(int cf_id);
   void CleanUp();
+  std::shared_ptr<FaultInjectionTestFS> GetDbFaultInjectionFs() const {
+    return db_fault_injection_fs_;
+  }
 
  protected:
   static int GetMinInjectedErrorCount(int error_count_1, int error_count_2) {
@@ -419,6 +423,9 @@ class StressTest {
   void CleanUpColumnFamilies();
 
   int db_index_;
+
+  std::shared_ptr<FaultInjectionTestFS> db_fault_injection_fs_;
+  std::unique_ptr<CompositeEnvWrapper> db_fault_injection_env_wrapper_;
 
   std::shared_ptr<Cache> cache_;
   std::shared_ptr<Cache> compressed_cache_;

--- a/db_stress_tool/db_stress_tool.cc
+++ b/db_stress_tool/db_stress_tool.cc
@@ -22,16 +22,24 @@
 
 #ifdef GFLAGS
 #include <iostream>
+#include <thread>
 
 #include "db_stress_tool/db_stress_common.h"
 #include "db_stress_tool/db_stress_driver.h"
 #include "db_stress_tool/db_stress_shared_state.h"
 #include "port/stack_trace.h"
 #include "rocksdb/convenience.h"
+#include "rocksdb/rate_limiter.h"
 #include "utilities/fault_injection_fs.h"
 
 namespace ROCKSDB_NAMESPACE {
 namespace {
+static constexpr int kMaxDbsForCrash = 16;
+// NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
+static FaultInjectionTestFS* fault_fs_for_crash[kMaxDbsForCrash] = {};
+static int num_dbs_for_crash = 0;
+// NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
+
 static std::shared_ptr<ROCKSDB_NAMESPACE::Env> env_guard;
 static std::shared_ptr<ROCKSDB_NAMESPACE::Env> env_wrapper_guard;
 static std::shared_ptr<ROCKSDB_NAMESPACE::Env> legacy_env_wrapper_guard;
@@ -45,6 +53,53 @@ int ReturnFlagValidationError(const char* message) {
 }  // namespace
 
 KeyGenContext key_gen_ctx;
+
+void InitSharedResources() {
+  InitializeHotKeyGenerator(FLAGS_hot_key_alpha);
+  block_cache = StressTest::NewCache(FLAGS_cache_size, FLAGS_cache_numshardbits);
+  if (FLAGS_use_write_buffer_manager) {
+    wbm = std::make_shared<WriteBufferManager>(FLAGS_db_write_buffer_size,
+                                               block_cache);
+  }
+  if (FLAGS_rate_limiter_bytes_per_sec > 0) {
+    rate_limiter.reset(NewGenericRateLimiter(
+        FLAGS_rate_limiter_bytes_per_sec, 1000 /* refill_period_us */,
+        10 /* fairness */,
+        FLAGS_rate_limit_bg_reads ? RateLimiter::Mode::kReadsOnly
+                                  : RateLimiter::Mode::kWritesOnly));
+  }
+}
+
+void SetupCrashCallback(
+    const std::vector<std::unique_ptr<StressTest>>& stress_tests,
+    int num_dbs) {
+  assert(num_dbs <= kMaxDbsForCrash);
+  for (int i = 0; i < num_dbs; i++) {
+    fault_fs_for_crash[i] = stress_tests[i]->GetDbFaultInjectionFs().get();
+  }
+  num_dbs_for_crash = num_dbs;
+  port::RegisterCrashCallback([]() {
+    for (int i = 0; i < num_dbs_for_crash; i++) {
+      if (fault_fs_for_crash[i]) {
+        fault_fs_for_crash[i]->PrintRecentInjectedErrors();
+      }
+    }
+  });
+}
+
+void CleanupSharedResources() {
+  wbm.reset();
+  rate_limiter.reset();
+  block_cache.reset();
+}
+
+void ClearCrashCallback(int num_dbs) {
+  port::RegisterCrashCallback(nullptr);
+  for (int i = 0; i < num_dbs; i++) {
+    fault_fs_for_crash[i] = nullptr;
+  }
+  num_dbs_for_crash = 0;
+}
 
 int db_stress_tool(int argc, char** argv) {
   SetUsageMessage(std::string("\nUSAGE:\n") + std::string(argv[0]) +
@@ -90,18 +145,26 @@ int db_stress_tool(int argc, char** argv) {
       std::make_shared<CompositeEnvWrapper>(raw_env, db_stress_fs);
   db_stress_env = env_wrapper_guard.get();
 
-  // Handle --destroy_db_and_exit early, before other option validation
+  if (FLAGS_num_dbs < 1 || FLAGS_num_dbs > kMaxDbsForCrash) {
+    fprintf(stderr, "Error: --num_dbs must be in [1, %d]\n", kMaxDbsForCrash);
+    return 1;
+  }
+  const int num_dbs = FLAGS_num_dbs;
+
+  // Handle --destroy_db_and_exit early, before multi-DB guards and other
+  // option validation. The cleanup command only needs num_dbs and db_root.
   if (FLAGS_destroy_db_and_exit) {
-    const std::string db_path = FLAGS_db_root + "/db_0";
-    s = DbStressDestroyDb(db_path);
-    if (s.ok()) {
+    for (int i = 0; i < num_dbs; i++) {
+      std::string db_path = FLAGS_db_root + "/db_" + std::to_string(i);
+      s = DbStressDestroyDb(db_path);
+      if (!s.ok()) {
+        fprintf(stderr, "Failed to destroy db at %s: %s\n",
+                db_path.c_str(), s.ToString().c_str());
+        return 1;
+      }
       fprintf(stdout, "Successfully destroyed db at %s\n", db_path.c_str());
-      return 0;
-    } else {
-      fprintf(stderr, "Failed to destroy db at %s: %s\n", db_path.c_str(),
-              s.ToString().c_str());
-      return 1;
     }
+    return 0;
   }
 
   // Handle --delete_dir_and_exit early, before other option validation
@@ -114,6 +177,35 @@ int db_stress_tool(int argc, char** argv) {
     } else {
       fprintf(stderr, "Failed to delete directory %s: %s\n",
               FLAGS_delete_dir_and_exit.c_str(), s.ToString().c_str());
+      return 1;
+    }
+  }
+
+  // Multi-DB guards — see db_crashtest.py finalize_and_sanitize for details
+  if (num_dbs > 1) {
+    if (FLAGS_clear_column_family_one_in > 0) {
+      fprintf(stderr,
+              "Error: --num_dbs > 1 incompatible with "
+              "--clear_column_family_one_in\n");
+      return 1;
+    }
+    if (FLAGS_test_multi_ops_txns) {
+      fprintf(stderr,
+              "Error: --num_dbs > 1 incompatible with "
+              "--test_multi_ops_txns\n");
+      return 1;
+    }
+    if (FLAGS_compaction_thread_pool_adjust_interval > 0) {
+      fprintf(stderr,
+              "Error: --num_dbs > 1 incompatible with "
+              "--compaction_thread_pool_adjust_interval\n");
+      return 1;
+    }
+    if (FLAGS_compressed_secondary_cache_size > 0 ||
+        FLAGS_compressed_secondary_cache_ratio > 0.0) {
+      fprintf(stderr,
+              "Error: --num_dbs > 1 incompatible with compressed secondary "
+              "cache\n");
       return 1;
     }
   }
@@ -461,85 +553,97 @@ int db_stress_tool(int argc, char** argv) {
     key_gen_ctx.weights.emplace_back(key_gen_ctx.window -
                                      keys_per_level * (levels - 1));
   }
-  // Create per-DB subdirectories (db_root/db_0, expected_states_root/db_0, etc.)
-  // These don't exist yet because paths changed from e.g. FLAGS_db to
-  // FLAGS_db_root/db_0.
-  const int db_index = 0;
-  const std::string db_label = "db_" + std::to_string(db_index);
-  s = db_stress_env->CreateDirIfMissing(FLAGS_db_root);
-  if (s.ok()) {
-    s = db_stress_env->CreateDirIfMissing(FLAGS_db_root + "/" + db_label);
-  }
-  if (!s.ok()) {
-    fprintf(stderr, "Failed to create directory %s: %s\n",
-            (FLAGS_db_root + "/" + db_label).c_str(), s.ToString().c_str());
-    return 1;
-  }
-  if (!FLAGS_expected_states_root.empty()) {
-    // Use Env::Default() because expected states are always on the local
-    // filesystem (created by Python's tempfile.mkdtemp), even when the DB
-    // itself is on a remote/custom filesystem.
-    s = Env::Default()->CreateDirIfMissing(FLAGS_expected_states_root);
+  // --- Shared initialization ---
+  InitSharedResources();
+
+  // --- Per-DB setup ---
+  std::vector<std::unique_ptr<StressTest>> stress_tests(num_dbs);
+  std::vector<std::unique_ptr<SharedState>> shared_states(num_dbs);
+  std::vector<int> results(num_dbs, 0);
+  std::vector<std::thread> db_runners(num_dbs);
+
+  for (int i = 0; i < num_dbs; i++) {
+    const std::string db_label = "db_" + std::to_string(i);
+    const std::string db_path = FLAGS_db_root + "/" + db_label;
+    const std::string expected_path =
+        FLAGS_expected_states_root.empty()
+            ? ""
+            : FLAGS_expected_states_root + "/" + db_label;
+    const std::string secondary_path =
+        FLAGS_secondary_dbs_root.empty()
+            ? ""
+            : FLAGS_secondary_dbs_root + "/" + db_label;
+
+    s = db_stress_env->CreateDirIfMissing(FLAGS_db_root);
     if (s.ok()) {
-      s = Env::Default()->CreateDirIfMissing(FLAGS_expected_states_root + "/" +
-                                             db_label);
+      s = db_stress_env->CreateDirIfMissing(db_path);
     }
     if (!s.ok()) {
       fprintf(stderr, "Failed to create directory %s: %s\n",
-              (FLAGS_expected_states_root + "/" + db_label).c_str(),
-              s.ToString().c_str());
+              db_path.c_str(), s.ToString().c_str());
       return 1;
     }
-  }
-  if (!FLAGS_secondary_dbs_root.empty()) {
-    s = db_stress_env->CreateDirIfMissing(FLAGS_secondary_dbs_root);
-    if (s.ok()) {
-      s = db_stress_env->CreateDirIfMissing(FLAGS_secondary_dbs_root + "/" +
-                                            db_label);
-    }
-    if (!s.ok()) {
-      fprintf(stderr, "Failed to create directory %s: %s\n",
-              (FLAGS_secondary_dbs_root + "/" + db_label).c_str(),
-              s.ToString().c_str());
-      return 1;
-    }
-  }
-
-  std::unique_ptr<ROCKSDB_NAMESPACE::SharedState> shared;
-  std::unique_ptr<ROCKSDB_NAMESPACE::StressTest> stress;
-  if (FLAGS_test_cf_consistency) {
-    stress.reset(CreateCfConsistencyStressTest(db_index));
-  } else if (FLAGS_test_batches_snapshots) {
-    stress.reset(CreateBatchedOpsStressTest(db_index));
-  } else if (FLAGS_test_multi_ops_txns) {
-    stress.reset(CreateMultiOpsTxnsStressTest(db_index));
-  } else {
-    stress.reset(CreateNonBatchedOpsStressTest(db_index));
-  }
-
-  // Register a crash callback so that recently injected errors are
-  // printed to stderr when the process crashes (SIGABRT, SIGSEGV, etc.).
-  // This helps diagnose stress test failures caused by fault injection.
-  static std::shared_ptr<FaultInjectionTestFS> g_db_fault_fs_for_crash;
-  g_db_fault_fs_for_crash = stress->GetDbFaultInjectionFs();
-  if (g_db_fault_fs_for_crash) {
-    port::RegisterCrashCallback([]() {
-      if (g_db_fault_fs_for_crash) {
-        g_db_fault_fs_for_crash->PrintRecentInjectedErrors();
+    if (!expected_path.empty()) {
+      // Use Env::Default() because expected states are always on the local
+      // filesystem (created by Python's tempfile.mkdtemp), even when the DB
+      // itself is on a remote/custom filesystem.
+      s = Env::Default()->CreateDirIfMissing(FLAGS_expected_states_root);
+      if (s.ok()) {
+        s = Env::Default()->CreateDirIfMissing(expected_path);
       }
+      if (!s.ok()) {
+        fprintf(stderr, "Failed to create directory %s: %s\n",
+                expected_path.c_str(), s.ToString().c_str());
+        return 1;
+      }
+    }
+    if (!secondary_path.empty()) {
+      s = db_stress_env->CreateDirIfMissing(FLAGS_secondary_dbs_root);
+      if (s.ok()) {
+        s = db_stress_env->CreateDirIfMissing(secondary_path);
+      }
+      if (!s.ok()) {
+        fprintf(stderr, "Failed to create directory %s: %s\n",
+                secondary_path.c_str(), s.ToString().c_str());
+        return 1;
+      }
+    }
+
+    if (FLAGS_test_cf_consistency) {
+      stress_tests[i].reset(CreateCfConsistencyStressTest(i));
+    } else if (FLAGS_test_batches_snapshots) {
+      stress_tests[i].reset(CreateBatchedOpsStressTest(i));
+    } else if (FLAGS_test_multi_ops_txns) {
+      stress_tests[i].reset(CreateMultiOpsTxnsStressTest(i));
+    } else {
+      stress_tests[i].reset(CreateNonBatchedOpsStressTest(i));
+    }
+
+    shared_states[i].reset(new SharedState(db_stress_env, stress_tests[i].get()));
+    db_runners[i] = std::thread([i, &results, &shared_states]() {
+      results[i] = RunStressTest(shared_states[i].get());
     });
   }
 
-  // Initialize the Zipfian pre-calculated array
-  InitializeHotKeyGenerator(FLAGS_hot_key_alpha);
-  shared.reset(new SharedState(db_stress_env, stress.get()));
-  bool run_stress_test = RunStressTest(shared.get());
-  // Close DB in CleanUp() before destructor to prevent race between destructor
-  // and operations in listener callbacks (e.g. MultiOpsTxnsStressListener).
-  stress->CleanUp();
-  port::RegisterCrashCallback(nullptr);
-  g_db_fault_fs_for_crash.reset();
-  return run_stress_test ? 0 : 1;
+  SetupCrashCallback(stress_tests, num_dbs);
+
+  // --- Join per-DB runners and cleanup ---
+  bool all_passed = true;
+  for (int i = 0; i < num_dbs; i++) {
+    db_runners[i].join();
+    if (!results[i]) {
+      all_passed = false;
+    }
+    // Close DB in CleanUp() before destructor to prevent race between
+    // destructor and operations in listener callbacks.
+    stress_tests[i]->CleanUp();
+  }
+
+  ClearCrashCallback(num_dbs);
+  CleanupSharedResources();
+
+  // Exit 0 if all DBs passed, 1 if any failed
+  return all_passed ? 0 : 1;
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db_stress_tool/db_stress_tool.cc
+++ b/db_stress_tool/db_stress_tool.cc
@@ -124,12 +124,13 @@ int db_stress_tool(int argc, char** argv) {
 
   // Handle --destroy_db_and_exit early, before other option validation
   if (FLAGS_destroy_db_and_exit) {
-    s = DbStressDestroyDb(FLAGS_db);
+    const std::string db_path = FLAGS_db_root + "/db_0";
+    s = DbStressDestroyDb(db_path);
     if (s.ok()) {
-      fprintf(stdout, "Successfully destroyed db at %s\n", FLAGS_db.c_str());
+      fprintf(stdout, "Successfully destroyed db at %s\n", db_path.c_str());
       return 0;
     } else {
-      fprintf(stderr, "Failed to destroy db at %s: %s\n", FLAGS_db.c_str(),
+      fprintf(stderr, "Failed to destroy db at %s: %s\n", db_path.c_str(),
               s.ToString().c_str());
       return 1;
     }
@@ -353,35 +354,16 @@ int db_stress_tool(int argc, char** argv) {
     }
   }
 
-  // Choose a location for the test database if none given with --db=<path>
-  if (FLAGS_db.empty()) {
+  // Choose a location for the test database if none given with --db_root=<path>
+  if (FLAGS_db_root.empty()) {
     std::string default_db_path;
     db_stress_env->GetTestDirectory(&default_db_path);
     default_db_path += "/dbstress";
-    FLAGS_db = default_db_path;
-  }
-
-  // Now that FLAGS_db is resolved, set the fault injection log file path
-  // so that PrintAll() writes to a file instead of stderr (signal-safe).
-  // Store the log in TEST_TMPDIR (outside the DB directory) so it survives
-  // DB reopen (which cleans untracked files) and gets included in the
-  // sandcastle db.tar.gz artifact for post-failure analysis.
-  if (fault_fs_guard) {
-    std::string log_dir;
-    const char* test_tmpdir = getenv("TEST_TMPDIR");
-    if (test_tmpdir && test_tmpdir[0] != '\0') {
-      log_dir = test_tmpdir;
-    } else {
-      log_dir = "/tmp";
-    }
-    std::string log_path = log_dir + "/fault_injection_" +
-                           std::to_string(getpid()) + "_" +
-                           std::to_string(time(nullptr)) + ".log";
-    fault_fs_guard->SetInjectedErrorLogPath(log_path);
+    FLAGS_db_root = default_db_path;
   }
 
   if ((FLAGS_test_secondary || FLAGS_continuous_verification_interval > 0) &&
-      FLAGS_secondaries_base.empty()) {
+      FLAGS_secondary_dbs_root.empty()) {
     std::string default_secondaries_path;
     db_stress_env->GetTestDirectory(&default_secondaries_path);
     default_secondaries_path += "/dbstress_secondaries";
@@ -391,7 +373,24 @@ int db_stress_tool(int argc, char** argv) {
               default_secondaries_path.c_str(), s.ToString().c_str());
       exit(1);
     }
-    FLAGS_secondaries_base = default_secondaries_path;
+    FLAGS_secondary_dbs_root = default_secondaries_path;
+  }
+
+  // Now that root flags are resolved, set the fault injection log file path
+  // so that PrintAll() writes to a file instead of stderr (signal-safe).
+  // Store the log in TEST_TMPDIR (outside the DB directory) so it survives
+  // DB reopen (which cleans untracked files) and gets included in the
+  // sandcastle db.tar.gz artifact for post-failure analysis.
+  if (fault_fs_guard) {
+    std::string log_dir;
+    s = db_stress_env->GetTestDirectory(&log_dir);
+    if (!s.ok()) {
+      log_dir = "/tmp";
+    }
+    std::string log_path =
+        log_dir + "/fault_injection_" + std::to_string(getpid()) + "_" +
+        std::to_string(db_stress_env->GetSystemClock()->NowMicros()) + ".log";
+    fault_fs_guard->SetInjectedErrorLogPath(log_path);
   }
 
   if (FLAGS_best_efforts_recovery &&
@@ -511,16 +510,60 @@ int db_stress_tool(int argc, char** argv) {
     key_gen_ctx.weights.emplace_back(key_gen_ctx.window -
                                      keys_per_level * (levels - 1));
   }
+  // Create per-DB subdirectories (db_root/db_0, expected_states_root/db_0, etc.)
+  // These don't exist yet because paths changed from e.g. FLAGS_db to
+  // FLAGS_db_root/db_0.
+  const int db_index = 0;
+  const std::string db_label = "db_" + std::to_string(db_index);
+  s = db_stress_env->CreateDirIfMissing(FLAGS_db_root);
+  if (s.ok()) {
+    s = db_stress_env->CreateDirIfMissing(FLAGS_db_root + "/" + db_label);
+  }
+  if (!s.ok()) {
+    fprintf(stderr, "Failed to create directory %s: %s\n",
+            (FLAGS_db_root + "/" + db_label).c_str(), s.ToString().c_str());
+    return 1;
+  }
+  if (!FLAGS_expected_states_root.empty()) {
+    // Use Env::Default() because expected states are always on the local
+    // filesystem (created by Python's tempfile.mkdtemp), even when the DB
+    // itself is on a remote/custom filesystem.
+    s = Env::Default()->CreateDirIfMissing(FLAGS_expected_states_root);
+    if (s.ok()) {
+      s = Env::Default()->CreateDirIfMissing(FLAGS_expected_states_root + "/" +
+                                             db_label);
+    }
+    if (!s.ok()) {
+      fprintf(stderr, "Failed to create directory %s: %s\n",
+              (FLAGS_expected_states_root + "/" + db_label).c_str(),
+              s.ToString().c_str());
+      return 1;
+    }
+  }
+  if (!FLAGS_secondary_dbs_root.empty()) {
+    s = db_stress_env->CreateDirIfMissing(FLAGS_secondary_dbs_root);
+    if (s.ok()) {
+      s = db_stress_env->CreateDirIfMissing(FLAGS_secondary_dbs_root + "/" +
+                                            db_label);
+    }
+    if (!s.ok()) {
+      fprintf(stderr, "Failed to create directory %s: %s\n",
+              (FLAGS_secondary_dbs_root + "/" + db_label).c_str(),
+              s.ToString().c_str());
+      return 1;
+    }
+  }
+
   std::unique_ptr<ROCKSDB_NAMESPACE::SharedState> shared;
   std::unique_ptr<ROCKSDB_NAMESPACE::StressTest> stress;
   if (FLAGS_test_cf_consistency) {
-    stress.reset(CreateCfConsistencyStressTest());
+    stress.reset(CreateCfConsistencyStressTest(db_index));
   } else if (FLAGS_test_batches_snapshots) {
-    stress.reset(CreateBatchedOpsStressTest());
+    stress.reset(CreateBatchedOpsStressTest(db_index));
   } else if (FLAGS_test_multi_ops_txns) {
-    stress.reset(CreateMultiOpsTxnsStressTest());
+    stress.reset(CreateMultiOpsTxnsStressTest(db_index));
   } else {
-    stress.reset(CreateNonBatchedOpsStressTest());
+    stress.reset(CreateNonBatchedOpsStressTest(db_index));
   }
   // Initialize the Zipfian pre-calculated array
   InitializeHotKeyGenerator(FLAGS_hot_key_alpha);

--- a/db_stress_tool/db_stress_tool.cc
+++ b/db_stress_tool/db_stress_tool.cc
@@ -37,7 +37,6 @@ static std::shared_ptr<ROCKSDB_NAMESPACE::Env> env_wrapper_guard;
 static std::shared_ptr<ROCKSDB_NAMESPACE::Env> legacy_env_wrapper_guard;
 static std::shared_ptr<ROCKSDB_NAMESPACE::CompositeEnvWrapper>
     dbsl_env_wrapper_guard;
-static std::shared_ptr<CompositeEnvWrapper> fault_env_guard;
 
 int ReturnFlagValidationError(const char* message) {
   std::cerr << "Error: " << message << '\n';
@@ -85,39 +84,8 @@ int db_stress_tool(int argc, char** argv) {
   dbsl_env_wrapper_guard = std::make_shared<CompositeEnvWrapper>(raw_env);
   db_stress_listener_env = dbsl_env_wrapper_guard.get();
 
-  if (FLAGS_open_metadata_read_fault_one_in ||
-      FLAGS_open_metadata_write_fault_one_in || FLAGS_open_read_fault_one_in ||
-      FLAGS_open_write_fault_one_in || FLAGS_metadata_read_fault_one_in ||
-      FLAGS_metadata_write_fault_one_in || FLAGS_read_fault_one_in ||
-      FLAGS_write_fault_one_in || FLAGS_sync_fault_injection) {
-    FaultInjectionTestFS* fs =
-        new FaultInjectionTestFS(raw_env->GetFileSystem());
-    fault_fs_guard.reset(fs);
-    // Info logs are debugging artifacts, so exclude them from fault injection
-    // and keep error accounting focused on DB data and metadata.
-    fault_fs_guard->SetFileTypesExcludedFromFaultInjection(
-        {FileType::kInfoLogFile});
-    // Set it to direct writable here to initially bypass any fault injection
-    // during DB open This will correspondingly be overwritten in
-    // StressTest::Open() for open fault injection and in RunStressTestImpl()
-    // for proper fault injection setup.
-    fault_fs_guard->SetFilesystemDirectWritable(true);
-    fault_env_guard =
-        std::make_shared<CompositeEnvWrapper>(raw_env, fault_fs_guard);
-    raw_env = fault_env_guard.get();
-
-    // Register a crash callback so that recently injected errors are
-    // printed to stderr when the process crashes (SIGABRT, SIGSEGV, etc.).
-    // This helps diagnose stress test failures caused by fault injection.
-    port::RegisterCrashCallback([]() {
-      if (fault_fs_guard) {
-        fault_fs_guard->PrintRecentInjectedErrors();
-      }
-    });
-  }
-
-  auto db_stress_fs =
-      std::make_shared<DbStressFSWrapper>(raw_env->GetFileSystem());
+  db_stress_raw_fs = raw_env->GetFileSystem();
+  auto db_stress_fs = std::make_shared<DbStressFSWrapper>(db_stress_raw_fs);
   env_wrapper_guard =
       std::make_shared<CompositeEnvWrapper>(raw_env, db_stress_fs);
   db_stress_env = env_wrapper_guard.get();
@@ -376,23 +344,6 @@ int db_stress_tool(int argc, char** argv) {
     FLAGS_secondary_dbs_root = default_secondaries_path;
   }
 
-  // Now that root flags are resolved, set the fault injection log file path
-  // so that PrintAll() writes to a file instead of stderr (signal-safe).
-  // Store the log in TEST_TMPDIR (outside the DB directory) so it survives
-  // DB reopen (which cleans untracked files) and gets included in the
-  // sandcastle db.tar.gz artifact for post-failure analysis.
-  if (fault_fs_guard) {
-    std::string log_dir;
-    s = db_stress_env->GetTestDirectory(&log_dir);
-    if (!s.ok()) {
-      log_dir = "/tmp";
-    }
-    std::string log_path =
-        log_dir + "/fault_injection_" + std::to_string(getpid()) + "_" +
-        std::to_string(db_stress_env->GetSystemClock()->NowMicros()) + ".log";
-    fault_fs_guard->SetInjectedErrorLogPath(log_path);
-  }
-
   if (FLAGS_best_efforts_recovery &&
       !(FLAGS_skip_verifydb && FLAGS_disable_wal)) {
     fprintf(stderr,
@@ -565,6 +516,20 @@ int db_stress_tool(int argc, char** argv) {
   } else {
     stress.reset(CreateNonBatchedOpsStressTest(db_index));
   }
+
+  // Register a crash callback so that recently injected errors are
+  // printed to stderr when the process crashes (SIGABRT, SIGSEGV, etc.).
+  // This helps diagnose stress test failures caused by fault injection.
+  static std::shared_ptr<FaultInjectionTestFS> g_db_fault_fs_for_crash;
+  g_db_fault_fs_for_crash = stress->GetDbFaultInjectionFs();
+  if (g_db_fault_fs_for_crash) {
+    port::RegisterCrashCallback([]() {
+      if (g_db_fault_fs_for_crash) {
+        g_db_fault_fs_for_crash->PrintRecentInjectedErrors();
+      }
+    });
+  }
+
   // Initialize the Zipfian pre-calculated array
   InitializeHotKeyGenerator(FLAGS_hot_key_alpha);
   shared.reset(new SharedState(db_stress_env, stress.get()));
@@ -572,6 +537,8 @@ int db_stress_tool(int argc, char** argv) {
   // Close DB in CleanUp() before destructor to prevent race between destructor
   // and operations in listener callbacks (e.g. MultiOpsTxnsStressListener).
   stress->CleanUp();
+  port::RegisterCrashCallback(nullptr);
+  g_db_fault_fs_for_crash.reset();
   return run_stress_test ? 0 : 1;
 }
 

--- a/db_stress_tool/multi_ops_txns_stress.cc
+++ b/db_stress_tool/multi_ops_txns_stress.cc
@@ -1767,8 +1767,8 @@ void MultiOpsTxnsStressTest::ScanExistingDb(SharedState* shared, int threads) {
   }
 }
 
-StressTest* CreateMultiOpsTxnsStressTest() {
-  return new MultiOpsTxnsStressTest();
+StressTest* CreateMultiOpsTxnsStressTest(int db_index) {
+  return new MultiOpsTxnsStressTest(db_index);
 }
 
 void CheckAndSetOptionsForMultiOpsTxnStressTest() {

--- a/db_stress_tool/multi_ops_txns_stress.h
+++ b/db_stress_tool/multi_ops_txns_stress.h
@@ -191,7 +191,8 @@ class MultiOpsTxnsStressTest : public StressTest {
     uint32_t c_{0};
   };
 
-  MultiOpsTxnsStressTest() {}
+  explicit MultiOpsTxnsStressTest(int db_index)
+      : StressTest(db_index) {}
 
   ~MultiOpsTxnsStressTest() override {}
 

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -24,7 +24,8 @@
 namespace ROCKSDB_NAMESPACE {
 class NonBatchedOpsStressTest : public StressTest {
  public:
-  NonBatchedOpsStressTest() = default;
+  explicit NonBatchedOpsStressTest(int db_index)
+      : StressTest(db_index) {}
 
   virtual ~NonBatchedOpsStressTest() = default;
 
@@ -2325,11 +2326,11 @@ class NonBatchedOpsStressTest : public StressTest {
         FLAGS_test_ingest_standalone_range_deletion_one_in);
     std::vector<std::string> external_files;
     const std::string sst_filename =
-        FLAGS_db + "/." + std::to_string(thread->tid) + ".sst";
+        GetDbPath() + "/." + std::to_string(thread->tid) + ".sst";
     external_files.push_back(sst_filename);
     std::string standalone_rangedel_filename;
     if (test_standalone_range_deletion) {
-      standalone_rangedel_filename = FLAGS_db + "/." +
+      standalone_rangedel_filename = GetDbPath() + "/." +
                                      std::to_string(thread->tid) +
                                      "_standalone_rangedel.sst";
       external_files.push_back(standalone_rangedel_filename);
@@ -3485,8 +3486,8 @@ class NonBatchedOpsStressTest : public StressTest {
   }
 };
 
-StressTest* CreateNonBatchedOpsStressTest() {
-  return new NonBatchedOpsStressTest();
+StressTest* CreateNonBatchedOpsStressTest(int db_index) {
+  return new NonBatchedOpsStressTest(db_index);
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -266,20 +266,20 @@ class NonBatchedOpsStressTest : public StressTest {
             std::string from_db;
 
             // Temporarily disable error injection to verify the secondary
-            if (fault_fs_guard) {
-              fault_fs_guard->DisableThreadLocalErrorInjection(
+            if (db_fault_injection_fs_) {
+              db_fault_injection_fs_->DisableThreadLocalErrorInjection(
                   FaultInjectionIOType::kRead);
-              fault_fs_guard->DisableThreadLocalErrorInjection(
+              db_fault_injection_fs_->DisableThreadLocalErrorInjection(
                   FaultInjectionIOType::kMetadataRead);
             }
 
             s = secondary_db_->Get(options, secondary_cfhs_[cf], key, &from_db);
 
             // Re-enable error injection after verifying the secondary
-            if (fault_fs_guard) {
-              fault_fs_guard->EnableThreadLocalErrorInjection(
+            if (db_fault_injection_fs_) {
+              db_fault_injection_fs_->EnableThreadLocalErrorInjection(
                   FaultInjectionIOType::kRead);
-              fault_fs_guard->EnableThreadLocalErrorInjection(
+              db_fault_injection_fs_->EnableThreadLocalErrorInjection(
                   FaultInjectionIOType::kMetadataRead);
             }
 
@@ -689,10 +689,10 @@ class NonBatchedOpsStressTest : public StressTest {
     bool read_older_ts = MaybeUseOlderTimestampForPointLookup(
         thread, read_ts_str, read_ts_slice, read_opts_copy);
 
-    if (fault_fs_guard) {
-      fault_fs_guard->GetAndResetInjectedThreadLocalErrorCount(
+    if (db_fault_injection_fs_) {
+      db_fault_injection_fs_->GetAndResetInjectedThreadLocalErrorCount(
           FaultInjectionIOType::kRead);
-      fault_fs_guard->GetAndResetInjectedThreadLocalErrorCount(
+      db_fault_injection_fs_->GetAndResetInjectedThreadLocalErrorCount(
           FaultInjectionIOType::kMetadataRead);
       SharedState::ignore_read_error = false;
     }
@@ -704,11 +704,11 @@ class NonBatchedOpsStressTest : public StressTest {
         thread->shared->Get(rand_column_families[0], rand_keys[0]);
 
     int injected_error_count = 0;
-    if (fault_fs_guard) {
+    if (db_fault_injection_fs_) {
       injected_error_count = GetMinInjectedErrorCount(
-          fault_fs_guard->GetAndResetInjectedThreadLocalErrorCount(
+          db_fault_injection_fs_->GetAndResetInjectedThreadLocalErrorCount(
               FaultInjectionIOType::kRead),
-          fault_fs_guard->GetAndResetInjectedThreadLocalErrorCount(
+          db_fault_injection_fs_->GetAndResetInjectedThreadLocalErrorCount(
               FaultInjectionIOType::kMetadataRead));
       if (!SharedState::ignore_read_error && injected_error_count > 0 &&
           (s.ok() || s.IsNotFound())) {
@@ -717,9 +717,9 @@ class NonBatchedOpsStressTest : public StressTest {
         MutexLock l(thread->shared->GetMutex());
         fprintf(stderr, "Didn't get expected error from Get\n");
         fprintf(stderr, "Callstack that injected the fault\n");
-        fault_fs_guard->PrintInjectedThreadLocalErrorBacktrace(
+        db_fault_injection_fs_->PrintInjectedThreadLocalErrorBacktrace(
             FaultInjectionIOType::kRead);
-        fault_fs_guard->PrintInjectedThreadLocalErrorBacktrace(
+        db_fault_injection_fs_->PrintInjectedThreadLocalErrorBacktrace(
             FaultInjectionIOType::kMetadataRead);
         std::terminate();
       }
@@ -822,10 +822,10 @@ class NonBatchedOpsStressTest : public StressTest {
     std::unique_ptr<Transaction> txn;
     if (use_txn) {
       // TODO(hx235): test fault injection with MultiGet() with transactions
-      if (fault_fs_guard) {
-        fault_fs_guard->DisableThreadLocalErrorInjection(
+      if (db_fault_injection_fs_) {
+        db_fault_injection_fs_->DisableThreadLocalErrorInjection(
             FaultInjectionIOType::kRead);
-        fault_fs_guard->DisableThreadLocalErrorInjection(
+        db_fault_injection_fs_->DisableThreadLocalErrorInjection(
             FaultInjectionIOType::kMetadataRead);
       }
       WriteOptions wo;
@@ -851,20 +851,20 @@ class NonBatchedOpsStressTest : public StressTest {
     int injected_error_count = 0;
 
     if (!use_txn) {
-      if (fault_fs_guard) {
-        fault_fs_guard->GetAndResetInjectedThreadLocalErrorCount(
+      if (db_fault_injection_fs_) {
+        db_fault_injection_fs_->GetAndResetInjectedThreadLocalErrorCount(
             FaultInjectionIOType::kRead);
-        fault_fs_guard->GetAndResetInjectedThreadLocalErrorCount(
+        db_fault_injection_fs_->GetAndResetInjectedThreadLocalErrorCount(
             FaultInjectionIOType::kMetadataRead);
         SharedState::ignore_read_error = false;
       }
       db_->MultiGet(readoptionscopy, cfh, num_keys, keys.data(), values.data(),
                     statuses.data());
-      if (fault_fs_guard) {
+      if (db_fault_injection_fs_) {
         injected_error_count = GetMinInjectedErrorCount(
-            fault_fs_guard->GetAndResetInjectedThreadLocalErrorCount(
+            db_fault_injection_fs_->GetAndResetInjectedThreadLocalErrorCount(
                 FaultInjectionIOType::kRead),
-            fault_fs_guard->GetAndResetInjectedThreadLocalErrorCount(
+            db_fault_injection_fs_->GetAndResetInjectedThreadLocalErrorCount(
                 FaultInjectionIOType::kMetadataRead));
 
         if (injected_error_count > 0) {
@@ -884,9 +884,9 @@ class NonBatchedOpsStressTest : public StressTest {
                     "num_keys %zu Expected %d errors, seen at least %d\n",
                     num_keys, injected_error_count, stat_nok_nfound);
             fprintf(stderr, "Callstack that injected the fault\n");
-            fault_fs_guard->PrintInjectedThreadLocalErrorBacktrace(
+            db_fault_injection_fs_->PrintInjectedThreadLocalErrorBacktrace(
                 FaultInjectionIOType::kRead);
-            fault_fs_guard->PrintInjectedThreadLocalErrorBacktrace(
+            db_fault_injection_fs_->PrintInjectedThreadLocalErrorBacktrace(
                 FaultInjectionIOType::kMetadataRead);
             std::terminate();
           }
@@ -953,10 +953,10 @@ class NonBatchedOpsStressTest : public StressTest {
             const Status& s,
             const std::optional<ExpectedValue>& ryw_expected_value) -> bool {
       //  Temporarily disable error injection for verification
-      if (fault_fs_guard) {
-        fault_fs_guard->DisableThreadLocalErrorInjection(
+      if (db_fault_injection_fs_) {
+        db_fault_injection_fs_->DisableThreadLocalErrorInjection(
             FaultInjectionIOType::kRead);
-        fault_fs_guard->DisableThreadLocalErrorInjection(
+        db_fault_injection_fs_->DisableThreadLocalErrorInjection(
             FaultInjectionIOType::kMetadataRead);
       }
 
@@ -1050,10 +1050,10 @@ class NonBatchedOpsStressTest : public StressTest {
       }
 
       // Enable back error injection disbled for checking results
-      if (fault_fs_guard) {
-        fault_fs_guard->DisableThreadLocalErrorInjection(
+      if (db_fault_injection_fs_) {
+        db_fault_injection_fs_->DisableThreadLocalErrorInjection(
             FaultInjectionIOType::kRead);
-        fault_fs_guard->DisableThreadLocalErrorInjection(
+        db_fault_injection_fs_->DisableThreadLocalErrorInjection(
             FaultInjectionIOType::kMetadataRead);
       }
       return check_multiget_res;
@@ -1092,10 +1092,10 @@ class NonBatchedOpsStressTest : public StressTest {
     if (use_txn) {
       txn->Rollback().PermitUncheckedError();
       // Enable back error injection disbled for transactions
-      if (fault_fs_guard) {
-        fault_fs_guard->EnableThreadLocalErrorInjection(
+      if (db_fault_injection_fs_) {
+        db_fault_injection_fs_->EnableThreadLocalErrorInjection(
             FaultInjectionIOType::kRead);
-        fault_fs_guard->EnableThreadLocalErrorInjection(
+        db_fault_injection_fs_->EnableThreadLocalErrorInjection(
             FaultInjectionIOType::kMetadataRead);
       }
     }
@@ -1142,10 +1142,10 @@ class NonBatchedOpsStressTest : public StressTest {
     const ExpectedValue pre_read_expected_value =
         thread->shared->Get(column_family, key);
 
-    if (fault_fs_guard) {
-      fault_fs_guard->GetAndResetInjectedThreadLocalErrorCount(
+    if (db_fault_injection_fs_) {
+      db_fault_injection_fs_->GetAndResetInjectedThreadLocalErrorCount(
           FaultInjectionIOType::kRead);
-      fault_fs_guard->GetAndResetInjectedThreadLocalErrorCount(
+      db_fault_injection_fs_->GetAndResetInjectedThreadLocalErrorCount(
           FaultInjectionIOType::kMetadataRead);
       SharedState::ignore_read_error = false;
     }
@@ -1165,11 +1165,11 @@ class NonBatchedOpsStressTest : public StressTest {
         thread->shared->Get(column_family, key);
 
     int injected_error_count = 0;
-    if (fault_fs_guard) {
+    if (db_fault_injection_fs_) {
       injected_error_count = GetMinInjectedErrorCount(
-          fault_fs_guard->GetAndResetInjectedThreadLocalErrorCount(
+          db_fault_injection_fs_->GetAndResetInjectedThreadLocalErrorCount(
               FaultInjectionIOType::kRead),
-          fault_fs_guard->GetAndResetInjectedThreadLocalErrorCount(
+          db_fault_injection_fs_->GetAndResetInjectedThreadLocalErrorCount(
               FaultInjectionIOType::kMetadataRead));
       if (!SharedState::ignore_read_error && injected_error_count > 0 &&
           (s.ok() || s.IsNotFound())) {
@@ -1178,9 +1178,9 @@ class NonBatchedOpsStressTest : public StressTest {
         MutexLock l(thread->shared->GetMutex());
         fprintf(stderr, "Didn't get expected error from GetEntity\n");
         fprintf(stderr, "Callstack that injected the fault\n");
-        fault_fs_guard->PrintInjectedThreadLocalErrorBacktrace(
+        db_fault_injection_fs_->PrintInjectedThreadLocalErrorBacktrace(
             FaultInjectionIOType::kRead);
-        fault_fs_guard->PrintInjectedThreadLocalErrorBacktrace(
+        db_fault_injection_fs_->PrintInjectedThreadLocalErrorBacktrace(
             FaultInjectionIOType::kMetadataRead);
         std::terminate();
       }
@@ -1282,10 +1282,10 @@ class NonBatchedOpsStressTest : public StressTest {
     if (FLAGS_use_txn) {
       // TODO(hx235): test fault injection with MultiGetEntity() with
       // transactions
-      if (fault_fs_guard) {
-        fault_fs_guard->DisableThreadLocalErrorInjection(
+      if (db_fault_injection_fs_) {
+        db_fault_injection_fs_->DisableThreadLocalErrorInjection(
             FaultInjectionIOType::kRead);
-        fault_fs_guard->DisableThreadLocalErrorInjection(
+        db_fault_injection_fs_->DisableThreadLocalErrorInjection(
             FaultInjectionIOType::kMetadataRead);
       }
       WriteOptions write_options;
@@ -1319,11 +1319,11 @@ class NonBatchedOpsStressTest : public StressTest {
     int injected_error_count = 0;
 
     auto verify_expected_errors = [&](auto get_status) {
-      assert(fault_fs_guard);
+      assert(db_fault_injection_fs_);
       injected_error_count = GetMinInjectedErrorCount(
-          fault_fs_guard->GetAndResetInjectedThreadLocalErrorCount(
+          db_fault_injection_fs_->GetAndResetInjectedThreadLocalErrorCount(
               FaultInjectionIOType::kRead),
-          fault_fs_guard->GetAndResetInjectedThreadLocalErrorCount(
+          db_fault_injection_fs_->GetAndResetInjectedThreadLocalErrorCount(
               FaultInjectionIOType::kMetadataRead));
       if (injected_error_count) {
         int stat_nok_nfound = 0;
@@ -1345,9 +1345,9 @@ class NonBatchedOpsStressTest : public StressTest {
           fprintf(stderr, "num_keys %zu Expected %d errors, seen %d\n",
                   num_keys, injected_error_count, stat_nok_nfound);
           fprintf(stderr, "Call stack that injected the fault\n");
-          fault_fs_guard->PrintInjectedThreadLocalErrorBacktrace(
+          db_fault_injection_fs_->PrintInjectedThreadLocalErrorBacktrace(
               FaultInjectionIOType::kRead);
-          fault_fs_guard->PrintInjectedThreadLocalErrorBacktrace(
+          db_fault_injection_fs_->PrintInjectedThreadLocalErrorBacktrace(
               FaultInjectionIOType::kMetadataRead);
           std::terminate();
         }
@@ -1357,10 +1357,10 @@ class NonBatchedOpsStressTest : public StressTest {
     auto check_results = [&](auto get_columns, auto get_status,
                              auto do_extra_check, auto call_get_entity) {
       // Temporarily disable error injection for checking results
-      if (fault_fs_guard) {
-        fault_fs_guard->DisableThreadLocalErrorInjection(
+      if (db_fault_injection_fs_) {
+        db_fault_injection_fs_->DisableThreadLocalErrorInjection(
             FaultInjectionIOType::kRead);
-        fault_fs_guard->DisableThreadLocalErrorInjection(
+        db_fault_injection_fs_->DisableThreadLocalErrorInjection(
             FaultInjectionIOType::kMetadataRead);
       }
       const bool check_get_entity =
@@ -1539,10 +1539,10 @@ class NonBatchedOpsStressTest : public StressTest {
         }
       }
       // Enable back error injection disbled for checking results
-      if (fault_fs_guard) {
-        fault_fs_guard->EnableThreadLocalErrorInjection(
+      if (db_fault_injection_fs_) {
+        db_fault_injection_fs_->EnableThreadLocalErrorInjection(
             FaultInjectionIOType::kRead);
-        fault_fs_guard->EnableThreadLocalErrorInjection(
+        db_fault_injection_fs_->EnableThreadLocalErrorInjection(
             FaultInjectionIOType::kMetadataRead);
       }
     };
@@ -1625,19 +1625,19 @@ class NonBatchedOpsStressTest : public StressTest {
 
       txn->Rollback().PermitUncheckedError();
       // Enable back error injection disbled for transactions
-      if (fault_fs_guard) {
-        fault_fs_guard->EnableThreadLocalErrorInjection(
+      if (db_fault_injection_fs_) {
+        db_fault_injection_fs_->EnableThreadLocalErrorInjection(
             FaultInjectionIOType::kRead);
-        fault_fs_guard->EnableThreadLocalErrorInjection(
+        db_fault_injection_fs_->EnableThreadLocalErrorInjection(
             FaultInjectionIOType::kMetadataRead);
       }
     } else if (FLAGS_use_attribute_group) {
       // AttributeGroup MultiGetEntity verification
 
-      if (fault_fs_guard) {
-        fault_fs_guard->GetAndResetInjectedThreadLocalErrorCount(
+      if (db_fault_injection_fs_) {
+        db_fault_injection_fs_->GetAndResetInjectedThreadLocalErrorCount(
             FaultInjectionIOType::kRead);
-        fault_fs_guard->GetAndResetInjectedThreadLocalErrorCount(
+        db_fault_injection_fs_->GetAndResetInjectedThreadLocalErrorCount(
             FaultInjectionIOType::kMetadataRead);
         SharedState::ignore_read_error = false;
       }
@@ -1653,7 +1653,7 @@ class NonBatchedOpsStressTest : public StressTest {
       db_->MultiGetEntity(read_opts_copy, num_keys, key_slices.data(),
                           results.data());
 
-      if (fault_fs_guard) {
+      if (db_fault_injection_fs_) {
         verify_expected_errors(
             [&](size_t i) { return results[i][0].status(); });
       }
@@ -1669,10 +1669,10 @@ class NonBatchedOpsStressTest : public StressTest {
     } else {
       // Non-AttributeGroup MultiGetEntity verification
 
-      if (fault_fs_guard) {
-        fault_fs_guard->GetAndResetInjectedThreadLocalErrorCount(
+      if (db_fault_injection_fs_) {
+        db_fault_injection_fs_->GetAndResetInjectedThreadLocalErrorCount(
             FaultInjectionIOType::kRead);
-        fault_fs_guard->GetAndResetInjectedThreadLocalErrorCount(
+        db_fault_injection_fs_->GetAndResetInjectedThreadLocalErrorCount(
             FaultInjectionIOType::kMetadataRead);
         SharedState::ignore_read_error = false;
       }
@@ -1683,7 +1683,7 @@ class NonBatchedOpsStressTest : public StressTest {
       db_->MultiGetEntity(read_opts_copy, cfh, num_keys, key_slices.data(),
                           results.data(), statuses.data());
 
-      if (fault_fs_guard) {
+      if (db_fault_injection_fs_) {
         verify_expected_errors([&](size_t i) { return statuses[i]; });
       }
 
@@ -1734,10 +1734,10 @@ class NonBatchedOpsStressTest : public StressTest {
     MaybeUseOlderTimestampForRangeScan(thread, read_ts_str, read_ts_slice,
                                        ro_copy);
 
-    if (fault_fs_guard) {
-      fault_fs_guard->GetAndResetInjectedThreadLocalErrorCount(
+    if (db_fault_injection_fs_) {
+      db_fault_injection_fs_->GetAndResetInjectedThreadLocalErrorCount(
           FaultInjectionIOType::kRead);
-      fault_fs_guard->GetAndResetInjectedThreadLocalErrorCount(
+      db_fault_injection_fs_->GetAndResetInjectedThreadLocalErrorCount(
           FaultInjectionIOType::kMetadataRead);
       SharedState::ignore_read_error = false;
     }
@@ -1799,11 +1799,11 @@ class NonBatchedOpsStressTest : public StressTest {
     }
 
     int injected_error_count = 0;
-    if (fault_fs_guard) {
+    if (db_fault_injection_fs_) {
       injected_error_count = GetMinInjectedErrorCount(
-          fault_fs_guard->GetAndResetInjectedThreadLocalErrorCount(
+          db_fault_injection_fs_->GetAndResetInjectedThreadLocalErrorCount(
               FaultInjectionIOType::kRead),
-          fault_fs_guard->GetAndResetInjectedThreadLocalErrorCount(
+          db_fault_injection_fs_->GetAndResetInjectedThreadLocalErrorCount(
               FaultInjectionIOType::kMetadataRead));
       if (!SharedState::ignore_read_error && injected_error_count > 0 &&
           s.ok()) {
@@ -1812,9 +1812,9 @@ class NonBatchedOpsStressTest : public StressTest {
         MutexLock l(thread->shared->GetMutex());
         fprintf(stderr, "Didn't get expected error from PrefixScan\n");
         fprintf(stderr, "Callstack that injected the fault\n");
-        fault_fs_guard->PrintInjectedThreadLocalErrorBacktrace(
+        db_fault_injection_fs_->PrintInjectedThreadLocalErrorBacktrace(
             FaultInjectionIOType::kRead);
-        fault_fs_guard->PrintInjectedThreadLocalErrorBacktrace(
+        db_fault_injection_fs_->PrintInjectedThreadLocalErrorBacktrace(
             FaultInjectionIOType::kMetadataRead);
         std::terminate();
       }
@@ -1881,10 +1881,10 @@ class NonBatchedOpsStressTest : public StressTest {
 
     if (FLAGS_verify_before_write) {
       // Temporarily disable error injection for preparation
-      if (fault_fs_guard) {
-        fault_fs_guard->DisableThreadLocalErrorInjection(
+      if (db_fault_injection_fs_) {
+        db_fault_injection_fs_->DisableThreadLocalErrorInjection(
             FaultInjectionIOType::kRead);
-        fault_fs_guard->DisableThreadLocalErrorInjection(
+        db_fault_injection_fs_->DisableThreadLocalErrorInjection(
             FaultInjectionIOType::kMetadataRead);
       }
 
@@ -1895,10 +1895,10 @@ class NonBatchedOpsStressTest : public StressTest {
           /* msg_prefix */ "Pre-Put Get verification", from_db, s);
 
       // Enable back error injection disabled for preparation
-      if (fault_fs_guard) {
-        fault_fs_guard->EnableThreadLocalErrorInjection(
+      if (db_fault_injection_fs_) {
+        db_fault_injection_fs_->EnableThreadLocalErrorInjection(
             FaultInjectionIOType::kRead);
-        fault_fs_guard->EnableThreadLocalErrorInjection(
+        db_fault_injection_fs_->EnableThreadLocalErrorInjection(
             FaultInjectionIOType::kMetadataRead);
       }
       if (!res) {
@@ -2339,10 +2339,10 @@ class NonBatchedOpsStressTest : public StressTest {
     std::ostringstream ingest_options_oss;
 
     // Temporarily disable error injection for preparation
-    if (fault_fs_guard) {
-      fault_fs_guard->DisableThreadLocalErrorInjection(
+    if (db_fault_injection_fs_) {
+      db_fault_injection_fs_->DisableThreadLocalErrorInjection(
           FaultInjectionIOType::kMetadataRead);
-      fault_fs_guard->DisableThreadLocalErrorInjection(
+      db_fault_injection_fs_->DisableThreadLocalErrorInjection(
           FaultInjectionIOType::kMetadataWrite);
     }
 
@@ -2357,10 +2357,10 @@ class NonBatchedOpsStressTest : public StressTest {
       }
     }
 
-    if (fault_fs_guard) {
-      fault_fs_guard->EnableThreadLocalErrorInjection(
+    if (db_fault_injection_fs_) {
+      db_fault_injection_fs_->EnableThreadLocalErrorInjection(
           FaultInjectionIOType::kMetadataRead);
-      fault_fs_guard->EnableThreadLocalErrorInjection(
+      db_fault_injection_fs_->EnableThreadLocalErrorInjection(
           FaultInjectionIOType::kMetadataWrite);
     }
 

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -508,6 +508,7 @@ default_params = {
         + ["randommixed"] * 2
         + ["custom"] * 3
     ),
+    "num_dbs": 1,
     # fixed within a run for easier debugging
     # actual frequency is lower after option sanitization
     "use_multiscan": random.choice([1] + [0] * 3),
@@ -1570,6 +1571,36 @@ def finalize_and_sanitize(src_params):
     if dest_params.get("disable_wal", 0) == 1:
         dest_params["test_batches_snapshots"] = 0
 
+    # Multi-DB mode: disable features that are unsafe with multiple DB
+    # instances sharing one process.
+    if dest_params.get("num_dbs", 1) > 1:
+        # CF handle can be accessed by one thread after another drops and
+        # recreates it — more likely with multi-DB thread count.
+        # TODO: fix CF handle lifetime, then remove this guard.
+        dest_params["clear_column_family_one_in"] = 0
+        # MultiOpsTxnsStressTest uses a single global key_spaces_path —
+        # multiple DBs would corrupt each other's range descriptors.
+        # TODO: make key_spaces_path per-DB, then remove this guard.
+        dest_params["test_multi_ops_txns"] = 0
+        # SetBackgroundThreads and SetCapacity are thread-safe (use
+        # internal mutexes), so no data race. But each DB launches its
+        # own PoolSizeChangeThread that randomly resizes the shared Env
+        # thread pool — multiple DBs overwriting each other's pool size
+        # makes the stress test results unpredictable.
+        # TODO: run one PoolSizeChangeThread globally, then remove.
+        dest_params["compaction_thread_pool_adjust_interval"] = 0
+        # Same issue: each DB's CompressedCacheSetCapacityThread toggles
+        # the shared compressed_secondary_cache capacity between 0 and
+        # the configured size. One DB zeroing the cache while another
+        # expects it available makes the test results unpredictable.
+        # TODO: isolate cache capacity thread per-DB, then remove.
+        dest_params["compressed_secondary_cache_size"] = 0
+        dest_params["compressed_secondary_cache_ratio"] = 0.0
+        if dest_params.get("secondary_cache_uri", "").find(
+            "compressed_secondary_cache"
+        ) >= 0:
+            dest_params["secondary_cache_uri"] = ""
+
     return dest_params
 
 
@@ -2016,9 +2047,10 @@ def strip_expected_sigterm_stderr(stdout, stderr, hit_timeout):
     return stdout, stderr
 
 
-def cleanup_after_success(dbname):
+def cleanup_after_success(dbname, num_dbs=1):
     # Use db_stress --destroy_db_and_exit, which simplifies remote DB cleanup
-    cleanup_cmd_parts = [stress_cmd, "--destroy_db_and_exit=1", "--db_root=" + dbname]
+    cleanup_cmd_parts = [stress_cmd, "--destroy_db_and_exit=1", "--db_root=" + dbname,
+                         "--num_dbs=" + str(num_dbs)]
     # Pass through relevant arguments for remote DB access
     for arg in remain_args:
         parts = arg.split("=", 1)
@@ -2143,7 +2175,7 @@ def blackbox_crash_main(args, unknown_args):
     print_run_output_and_exit_on_error(args, finalized_params, outs, errs)
 
     # we need to clean up after ourselves -- only do this on test success
-    cleanup_after_success(dbname)
+    cleanup_after_success(dbname, cmd_params.get("num_dbs", 1))
 
 
 # This python script runs db_stress multiple times. Some runs with
@@ -2325,7 +2357,7 @@ def whitebox_crash_main(args, unknown_args):
     # If successfully finished or timed out (we currently treat timed out test as passing)
     # Clean up after ourselves
     if succeeded or hit_timeout:
-        cleanup_after_success(dbname)
+        cleanup_after_success(dbname, cmd_params.get("num_dbs", 1))
 
 
 def main():

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -210,7 +210,7 @@ default_params = {
     "index_block_search_type": lambda: random.choice([0, 1, 2]),
     "uniform_cv_threshold": lambda: random.choice([-1, 0.2, 1000]),
     "ingest_external_file_one_in": lambda: random.choice([1000, 1000000]),
-    "test_ingest_standalone_range_deletion_one_in": lambda: random.choice([0, 5, 10]),
+    "test_ingest_standalone_range_deletion_one_in": 0,
     "iterpercent": 10,
     "lock_wal_one_in": lambda: random.choice([10000, 1000000]),
     "mark_for_compaction_one_file_in": lambda: 10 * random.randint(0, 1),
@@ -277,7 +277,7 @@ default_params = {
     "use_merge": lambda: random.randint(0, 1),
     # use_trie_index must be the same across invocations so that all SSTs
     # in a DB are opened with matching table options.
-    "use_trie_index": random.choice([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
+    "use_trie_index": 0,
     # use_udi_as_primary_index must be the same across invocations (like
     # use_trie_index) so that SSTs written in primary mode can be read on
     # reopen.

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -193,7 +193,7 @@ default_params = {
     # causing stress test failures. Temporarily disabled until the
     # sanitization can account for cross-run incompatibility.
     "inplace_update_support": 0,
-    "expected_values_dir": lambda: setup_expected_values_dir(),
+    "expected_states_root": lambda: setup_expected_states_root(),
     "flush_one_in": lambda: random.choice([1000, 1000000]),
     "manual_wal_flush_one_in": lambda: random.choice([0, 1000]),
     "sync_wal_one_in": 0,
@@ -542,13 +542,13 @@ def get_dbname(test_name):
     return dbname
 
 
-expected_values_dir = None
+expected_states_root = None
 
 
-def setup_expected_values_dir():
-    global expected_values_dir
-    if expected_values_dir is not None:
-        return expected_values_dir
+def setup_expected_states_root():
+    global expected_states_root
+    if expected_states_root is not None:
+        return expected_states_root
     expected_dir_prefix = "rocksdb_crashtest_expected_"
     test_exp_tmpdir = os.environ.get(_TEST_EXPECTED_DIR_ENV_VAR)
 
@@ -556,22 +556,23 @@ def setup_expected_values_dir():
         test_exp_tmpdir = os.environ.get(_TEST_DIR_ENV_VAR)
 
     if test_exp_tmpdir is None or test_exp_tmpdir == "":
-        expected_values_dir = tempfile.mkdtemp(prefix=expected_dir_prefix)
+        expected_states_root = tempfile.mkdtemp(prefix=expected_dir_prefix)
     else:
-        # if tmpdir is specified, store the expected_values_dir under that dir
-        expected_values_dir = test_exp_tmpdir + "/rocksdb_crashtest_expected"
-        os.makedirs(expected_values_dir, exist_ok=True)
-    return expected_values_dir
+        # If tmpdir is specified, store the expected-states root under that
+        # directory and let db_stress resolve per-DB subdirectories beneath it.
+        expected_states_root = test_exp_tmpdir + "/rocksdb_crashtest_expected"
+        os.makedirs(expected_states_root, exist_ok=True)
+    return expected_states_root
 
 
-def prepare_expected_values_dir(expected_dir, destroy_db_initially):
-    if expected_dir is None or expected_dir == "":
+def prepare_expected_states_root(expected_root, destroy_db_initially):
+    if expected_root is None or expected_root == "":
         return
 
-    if destroy_db_initially and os.path.exists(expected_dir):
-        shutil.rmtree(expected_dir, True)
+    if destroy_db_initially and os.path.exists(expected_root):
+        shutil.rmtree(expected_root, True)
 
-    os.makedirs(expected_dir, exist_ok=True)
+    os.makedirs(expected_root, exist_ok=True)
 
 
 multiops_txn_key_spaces_file = None
@@ -950,11 +951,13 @@ def finalize_and_sanitize(src_params):
     if (
         dest_params["use_direct_io_for_flush_and_compaction"] == 1
         or dest_params["use_direct_reads"] == 1
-    ) and not is_direct_io_supported(dest_params["db"]):
+    ) and not is_direct_io_supported(dest_params["db_root"]):
         if is_release_mode():
             print(
                 "{} does not support direct IO. Disabling use_direct_reads and "
-                "use_direct_io_for_flush_and_compaction.\n".format(dest_params["db"])
+                "use_direct_io_for_flush_and_compaction.\n".format(
+                    dest_params["db_root"]
+                )
             )
             dest_params["use_direct_reads"] = 0
             dest_params["use_direct_io_for_flush_and_compaction"] = 0
@@ -1636,8 +1639,8 @@ def gen_cmd_params(args):
 
 def gen_cmd(params, unknown_params):
     finalzied_params = finalize_and_sanitize(params)
-    prepare_expected_values_dir(
-        finalzied_params.get("expected_values_dir"),
+    prepare_expected_states_root(
+        finalzied_params.get("expected_states_root"),
         finalzied_params.get("destroy_db_initially", 0),
     )
     cmd = (
@@ -1913,8 +1916,8 @@ def build_out_of_space_diagnostics(
 
 def diagnostic_paths(finalized_params):
     return [
-        finalized_params.get("db"),
-        finalized_params.get("expected_values_dir"),
+        finalized_params.get("db_root"),
+        finalized_params.get("expected_states_root"),
     ]
 
 
@@ -2015,7 +2018,7 @@ def strip_expected_sigterm_stderr(stdout, stderr, hit_timeout):
 
 def cleanup_after_success(dbname):
     # Use db_stress --destroy_db_and_exit, which simplifies remote DB cleanup
-    cleanup_cmd_parts = [stress_cmd, "--destroy_db_and_exit=1", "--db=" + dbname]
+    cleanup_cmd_parts = [stress_cmd, "--destroy_db_and_exit=1", "--db_root=" + dbname]
     # Pass through relevant arguments for remote DB access
     for arg in remain_args:
         parts = arg.split("=", 1)
@@ -2096,7 +2099,8 @@ def blackbox_crash_main(args, unknown_args):
     while time.time() < exit_time:
         apply_random_seed_per_iteration()
         cmd, finalized_params = gen_cmd(
-            dict(list(cmd_params.items()) + list({"db": dbname}.items())), unknown_args
+            dict(list(cmd_params.items()) + list({"db_root": dbname}.items())),
+            unknown_args,
         )
 
         hit_timeout, retcode, outs, errs, pid = execute_cmd(cmd, cmd_params["interval"])
@@ -2126,7 +2130,8 @@ def blackbox_crash_main(args, unknown_args):
     cmd_params.update({"skip_verifydb": 0})
 
     cmd, finalized_params = gen_cmd(
-        dict(list(cmd_params.items()) + list({"db": dbname}.items())), unknown_args
+        dict(list(cmd_params.items()) + list({"db_root": dbname}.items())),
+        unknown_args,
     )
     hit_timeout, retcode, outs, errs, pid = execute_cmd(
         cmd, cmd_params["verify_timeout"], True
@@ -2259,7 +2264,7 @@ def whitebox_crash_main(args, unknown_args):
             dict(
                 list(cmd_params.items())
                 + list(additional_opts.items())
-                + list({"db": dbname}.items())
+                + list({"db_root": dbname}.items())
             ),
             unknown_args,
         )
@@ -2388,9 +2393,9 @@ def main():
         blackbox_crash_main(args, unknown_args)
     if args.test_type == "whitebox":
         whitebox_crash_main(args, unknown_args)
-    # Only delete the `expected_values_dir` if test passes
-    if expected_values_dir is not None:
-        shutil.rmtree(expected_values_dir)
+    # Only delete the expected-states root if the test passes.
+    if expected_states_root is not None:
+        shutil.rmtree(expected_states_root)
     if multiops_txn_key_spaces_file is not None:
         os.remove(multiops_txn_key_spaces_file)
 


### PR DESCRIPTION
Summary: Adds a --listener_uri gflag to db_stress that creates an EventListener via ObjectLibrary from the given URI and attaches it to the DB options. This is the upstream repo change in internal_repo_rocksdb: the gflag declaration, definition, and the ObjectRegistry lookup in Open().

Differential Revision: D104750476
