### PR TITLE
env/posix: improve io_uring init failure diagnostics in ReadAsync

### DIFF
--- a/env/io_posix.cc
+++ b/env/io_posix.cc
@@ -1081,22 +1081,45 @@ IOStatus PosixRandomAccessFile::ReadAsync(
   }
 
 #if defined(ROCKSDB_IOURING_PRESENT)
-  // io_uring_queue_init.
+  // Attempt to get (or lazily create) the per-thread io_uring ring.
+  int io_uring_init_err = 0;
   struct io_uring* iu = nullptr;
   if (thread_local_async_read_io_urings_) {
     iu = static_cast<struct io_uring*>(
         thread_local_async_read_io_urings_->Get());
     if (iu == nullptr) {
-      iu = CreateIOUring();
+      iu = CreateIOUring(&io_uring_init_err);
       if (iu != nullptr) {
         thread_local_async_read_io_urings_->Reset(iu);
       }
     }
   }
 
-  // Init failed, platform doesn't support io_uring.
+  // io_uring ring unavailable.  Return a descriptive error so callers can
+  // distinguish resource-exhaustion (ENOMEM) from "not supported by kernel"
+  // (ENOSYS/EPERM).
   if (iu == nullptr) {
-    return IOStatus::NotSupported("ReadAsync: failed to init io_uring");
+    if (io_uring_init_err == ENOMEM) {
+      return IOStatus::IOError(
+          "ReadAsync: io_uring_queue_init failed with ENOMEM — memlock limit "
+          "exhausted. Raise RLIMIT_MEMLOCK or reduce concurrent io_uring "
+          "usage. See CreateIOUring log for details.");
+    } else if (io_uring_init_err == ENOSYS || io_uring_init_err == EPERM) {
+      return IOStatus::NotSupported(
+          "ReadAsync: io_uring not available on this system (errno=" +
+          std::to_string(io_uring_init_err) + ": " +
+          errnoStr(io_uring_init_err) + ")");
+    } else if (io_uring_init_err != 0) {
+      return IOStatus::IOError(
+          "ReadAsync: io_uring_queue_init failed (errno=" +
+          std::to_string(io_uring_init_err) + ": " +
+          errnoStr(io_uring_init_err) + ")");
+    } else {
+      // thread_local_async_read_io_urings_ was null — io_uring disabled at
+      // file-open time.
+      return IOStatus::NotSupported(
+          "ReadAsync: io_uring not enabled for this file");
+    }
   }
 
   *io_handle = nullptr;

--- a/env/io_posix.h
+++ b/env/io_posix.h
@@ -377,16 +377,41 @@ inline void DeleteIOUring(void* p) {
   delete iu;
 }
 
-inline struct io_uring* CreateIOUring() {
+// Creates a new io_uring instance for the calling thread.
+//
+// On failure, returns nullptr and, if err_out is non-null, sets *err_out to
+// the positive errno value returned by io_uring_queue_init.  Callers can use
+// this to distinguish resource-exhaustion failures (ENOMEM — memlock limit
+// hit) from "not supported by kernel" failures (ENOSYS/EPERM).
+//
+// Common failure reasons:
+//   ENOMEM  — the process has exhausted its locked-memory quota
+//             (RLIMIT_MEMLOCK).  Raise the limit or reduce the number of
+//             concurrent io_uring rings.
+//   ENOSYS  — the kernel does not support io_uring.
+//   EPERM   — the process lacks the required capability.
+inline struct io_uring* CreateIOUring(int* err_out = nullptr) {
   struct io_uring* new_io_uring = new struct io_uring;
   unsigned int flags = 0;
   flags |= IORING_SETUP_SINGLE_ISSUER;
   flags |= IORING_SETUP_DEFER_TASKRUN;
   int ret = io_uring_queue_init(kIoUringDepth, new_io_uring, flags);
   if (ret) {
-    fprintf(stdout, "CreateIOUring failed: %s (errno=%d), thread=%lu\n",
-            errnoStr(-ret).c_str(), -ret,
-            static_cast<unsigned long>(pthread_self()));
+    int err = -ret;  // liburing returns negative errno
+    if (err_out) {
+      *err_out = err;
+    }
+    if (err == ENOMEM) {
+      fprintf(stderr,
+              "CreateIOUring failed: %s (errno=%d) — memlock limit may be too"
+              " low; consider raising RLIMIT_MEMLOCK. thread=%lu\n",
+              errnoStr(err).c_str(), err,
+              static_cast<unsigned long>(pthread_self()));
+    } else {
+      fprintf(stderr, "CreateIOUring failed: %s (errno=%d), thread=%lu\n",
+              errnoStr(err).c_str(), err,
+              static_cast<unsigned long>(pthread_self()));
+    }
     delete new_io_uring;
     new_io_uring = nullptr;
   } else {


### PR DESCRIPTION
# Problem

When io_uring_queue_init fails with ENOMEM (memlock limit exhausted — common on systems running many concurrent threads), CreateIOUring returns
nullptr and ReadAsync propagates a generic IOStatus::NotSupported("ReadAsync") with no indication of why the ring creation failed. This makes the failure opaque and hard to diagnose.

# Root Cause Chain
```
 MultiGet(async_io=true)
   → MultiGetFromSSTCoroutine (per SST file)
     → FilePrefetchBuffer::ReadAsync
       → PosixRandomAccessFile::ReadAsync
         → CreateIOUring() → io_uring_queue_init(256, ring, flags)
           ← ENOMEM (memlock exhausted)
         ← returns null
       ← returns IOStatus::NotSupported("ReadAsync")   ← opaque, no errno
     ← per-key error propagated to caller
```
# Fix
 - CreateIOUring now accepts an optional int* err_out parameter. On failure it captures the errno from io_uring_queue_init, logs a diagnostic to stderr
(with a memlock-specific hint when errno is ENOMEM), and — if the caller passes a pointer — fills it with the raw errno so the caller can respond
appropriately.
 - PosixRandomAccessFile::ReadAsync now uses err_out to return a typed IOStatus:
 - ENOMEM → IOStatus::IOError(...) with a message explaining the memlock limit
 - ENOSYS / EPERM → IOStatus::NotSupported(...) (kernel doesn't support io_uring)
 - Other errno → IOStatus::IOError(...) with the raw errno string
 - PosixRandomAccessFile::MultiRead is unchanged in behavior — it already falls back to synchronous reads when ring init fails. It calls CreateIOUring()
 with no argument (default nullptr), relying on the internal stderr logging.