### PR TITLE
Add FileSystem SyncFile API (#14739)

### DIFF
--- a/db/external_sst_file_basic_test.cc
+++ b/db/external_sst_file_basic_test.cc
@@ -1311,7 +1311,7 @@ TEST_F(ExternalSSTFileBasicTest, SyncFailure) {
     });
     if (i == 0) {
       SyncPoint::GetInstance()->SetCallBack(
-          "ExternalSstFileIngestionJob::Prepare:Reopen", [&](void* s) {
+          "ExternalSstFileIngestionJob::CheckSyncReturnCode", [&](void* s) {
             Status* status = static_cast<Status*>(s);
             if (status->IsNotSupported()) {
               no_sync = true;
@@ -1367,13 +1367,13 @@ TEST_F(ExternalSSTFileBasicTest, SyncFailure) {
   }
 }
 
-TEST_F(ExternalSSTFileBasicTest, ReopenNotSupported) {
+TEST_F(ExternalSSTFileBasicTest, SyncFileNotSupported) {
   Options options;
   options.create_if_missing = true;
   options.env = env_;
 
   SyncPoint::GetInstance()->SetCallBack(
-      "ExternalSstFileIngestionJob::Prepare:Reopen", [&](void* arg) {
+      "ExternalSstFileIngestionJob::CheckSyncReturnCode", [&](void* arg) {
         Status* s = static_cast<Status*>(arg);
         *s = Status::NotSupported();
       });
@@ -1386,7 +1386,7 @@ TEST_F(ExternalSSTFileBasicTest, ReopenNotSupported) {
   std::unique_ptr<SstFileWriter> sst_file_writer(
       new SstFileWriter(EnvOptions(), sst_file_writer_options));
   std::string file_name =
-      sst_files_dir_ + "reopen_not_supported_test_" + ".sst";
+      sst_files_dir_ + "sync_file_not_supported_test_" + ".sst";
   ASSERT_OK(sst_file_writer->Open(file_name));
   ASSERT_OK(sst_file_writer->Put("bar", "v2"));
   ASSERT_OK(sst_file_writer->Finish());

--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -165,35 +165,21 @@ Status ExternalSstFileIngestionJob::Prepare(
         // It is unsafe to assume application had sync the file and file
         // directory before ingest the file. For integrity of RocksDB we need
         // to sync the file.
-
-        // TODO(xingbo), We should in general be moving away from production
-        // uses of ReuseWritableFile (except explicitly for WAL recycling),
-        // ReopenWritableFile, and NewRandomRWFile. We should create a
-        // FileSystem::SyncFile/FsyncFile API that by default does the
-        // re-open+sync+close combo but can (a) be reused easily, and (b) be
-        // overridden to do that more cleanly, e.g. in EncryptedEnv.
-        // https://github.com/facebook/rocksdb/issues/13741
-        std::unique_ptr<FSWritableFile> file_to_sync;
-        Status s = fs_->ReopenWritableFile(path_inside_db, env_options_,
-                                           &file_to_sync, nullptr);
-        TEST_SYNC_POINT_CALLBACK("ExternalSstFileIngestionJob::Prepare:Reopen",
-                                 &s);
+        TEST_SYNC_POINT("ExternalSstFileIngestionJob::BeforeSyncIngestedFile");
+        Status s = fs_->SyncFile(path_inside_db, env_options_, IOOptions(),
+                                 db_options_.use_fsync, nullptr);
+        TEST_SYNC_POINT("ExternalSstFileIngestionJob::AfterSyncIngestedFile");
+        TEST_SYNC_POINT_CALLBACK(
+            "ExternalSstFileIngestionJob::CheckSyncReturnCode", &s);
         // Some file systems (especially remote/distributed) don't support
-        // reopening a file for writing and don't require reopening and
-        // syncing the file. Ignore the NotSupported error in that case.
+        // explicitly syncing the file and don't require it. Ignore the
+        // NotSupported error in that case.
         if (!s.IsNotSupported()) {
           status = s;
-          if (status.ok()) {
-            TEST_SYNC_POINT(
-                "ExternalSstFileIngestionJob::BeforeSyncIngestedFile");
-            status = SyncIngestedFile(file_to_sync.get());
-            TEST_SYNC_POINT(
-                "ExternalSstFileIngestionJob::AfterSyncIngestedFile");
-            if (!status.ok()) {
-              ROCKS_LOG_WARN(db_options_.info_log,
-                             "Failed to sync ingested file %s: %s",
-                             path_inside_db.c_str(), status.ToString().c_str());
-            }
+          if (!status.ok()) {
+            ROCKS_LOG_WARN(db_options_.info_log,
+                           "Failed to sync ingested file %s: %s",
+                           path_inside_db.c_str(), status.ToString().c_str());
           }
         }
       } else if (status.IsNotSupported() &&

--- a/env/composite_env_wrapper.h
+++ b/env/composite_env_wrapper.h
@@ -142,6 +142,13 @@ class CompositeEnv : public Env {
     return file_system_->LinkFile(s, t, io_opts, &dbg);
   }
 
+  Status SyncFile(const std::string& fname, const EnvOptions& env_options,
+                  bool use_fsync) override {
+    IODebugContext dbg;
+    return file_system_->SyncFile(fname, FileOptions(env_options), IOOptions(),
+                                  use_fsync, &dbg);
+  }
+
   Status NumFileLinks(const std::string& fname, uint64_t* count) override {
     IOOptions io_opts;
     IODebugContext dbg;

--- a/env/env.cc
+++ b/env/env.cc
@@ -26,6 +26,7 @@
 #include "rocksdb/utilities/customizable_util.h"
 #include "rocksdb/utilities/object_registry.h"
 #include "rocksdb/utilities/options_type.h"
+#include "test_util/sync_point.h"
 #include "util/autovector.h"
 #include "util/string_util.h"
 
@@ -530,6 +531,13 @@ class LegacyFileSystemWrapper : public FileSystem {
     return status_to_io_status(target_->LinkFile(s, t));
   }
 
+  IOStatus SyncFile(const std::string& fname, const FileOptions& file_options,
+                    const IOOptions& /*io_options*/, bool use_fsync,
+                    IODebugContext* /*dbg*/) override {
+    return status_to_io_status(
+        target_->SyncFile(fname, file_options, use_fsync));
+  }
+
   IOStatus NumFileLinks(const std::string& fname, const IOOptions& /*options*/,
                         uint64_t* count, IODebugContext* /*dbg*/) override {
     return status_to_io_status(target_->NumFileLinks(fname, count));
@@ -794,6 +802,23 @@ Status Env::ReuseWritableFile(const std::string& fname,
     return s;
   }
   return NewWritableFile(fname, result, options);
+}
+
+Status Env::SyncFile(const std::string& fname, const EnvOptions& options,
+                     bool use_fsync) {
+  std::unique_ptr<WritableFile> file_to_sync;
+  Status status = ReopenWritableFile(fname, &file_to_sync, options);
+  TEST_SYNC_POINT_CALLBACK("Env::SyncFile:Open", &status);
+  if (status.ok()) {
+    status = use_fsync ? file_to_sync->Fsync() : file_to_sync->Sync();
+    Status close_status = file_to_sync->Close();
+    if (status.ok()) {
+      status = close_status;
+    } else {
+      close_status.PermitUncheckedError();
+    }
+  }
+  return status;
 }
 
 Status Env::GetChildrenFileAttributes(const std::string& dir,

--- a/env/env_encryption.cc
+++ b/env/env_encryption.cc
@@ -814,6 +814,16 @@ class EncryptedFileSystemImpl : public EncryptedFileSystem {
     return status;
   }
 
+  IOStatus SyncFile(const std::string& fname, const FileOptions& file_opts,
+                    const IOOptions& io_opts, bool use_fsync,
+                    IODebugContext* dbg) override {
+    // SyncFile does not read or write file contents, so it can delegate
+    // directly to the underlying filesystem without constructing an encrypted
+    // writable wrapper.
+    return FileSystemWrapper::SyncFile(fname, file_opts, io_opts, use_fsync,
+                                       dbg);
+  }
+
  private:
   std::shared_ptr<EncryptionProvider> provider_;
 };

--- a/env/env_test.cc
+++ b/env/env_test.cc
@@ -4613,6 +4613,344 @@ TEST_F(EnvTest, WriteStringToFileClosesFile) {
   ASSERT_OK(counted_fs->DeleteFile(fname, IOOptions(), nullptr));
 }
 
+enum class SyncFileTestResult {
+  kOk,
+  kNotSupported,
+  kSyncError,
+  kFsyncError,
+  kCloseError,
+};
+
+Status MakeSyncFileTestStatus(SyncFileTestResult result) {
+  switch (result) {
+    case SyncFileTestResult::kOk:
+      return Status::OK();
+    case SyncFileTestResult::kNotSupported:
+      return Status::NotSupported("injected reopen failure");
+    case SyncFileTestResult::kSyncError:
+      return Status::IOError("injected sync failure");
+    case SyncFileTestResult::kFsyncError:
+      return Status::IOError("injected fsync failure");
+    case SyncFileTestResult::kCloseError:
+      return Status::IOError("injected close failure");
+  }
+  assert(false);
+  return Status::Corruption("unexpected sync file test result");
+}
+
+IOStatus MakeSyncFileTestIOStatus(SyncFileTestResult result) {
+  switch (result) {
+    case SyncFileTestResult::kOk:
+      return IOStatus::OK();
+    case SyncFileTestResult::kNotSupported:
+      return IOStatus::NotSupported("injected reopen failure");
+    case SyncFileTestResult::kSyncError:
+      return IOStatus::IOError("injected sync failure");
+    case SyncFileTestResult::kFsyncError:
+      return IOStatus::IOError("injected fsync failure");
+    case SyncFileTestResult::kCloseError:
+      return IOStatus::IOError("injected close failure");
+  }
+  assert(false);
+  return IOStatus::Corruption("unexpected sync file test result");
+}
+
+struct SyncFileTestState {
+  SyncFileTestResult reopen_result = SyncFileTestResult::kOk;
+  SyncFileTestResult sync_result = SyncFileTestResult::kOk;
+  SyncFileTestResult fsync_result = SyncFileTestResult::kOk;
+  SyncFileTestResult close_result = SyncFileTestResult::kOk;
+  int reopen_count = 0;
+  int sync_count = 0;
+  int fsync_count = 0;
+  int close_count = 0;
+};
+
+class SyncFileTestWritableFile : public WritableFileWrapper {
+ public:
+  SyncFileTestWritableFile(std::unique_ptr<WritableFile>&& target,
+                           SyncFileTestState* state)
+      : WritableFileWrapper(target.get()),
+        target_guard_(std::move(target)),
+        state_(state) {}
+
+  Status Sync() override {
+    ++state_->sync_count;
+    return MakeSyncFileTestStatus(state_->sync_result);
+  }
+
+  Status Fsync() override {
+    ++state_->fsync_count;
+    return MakeSyncFileTestStatus(state_->fsync_result);
+  }
+
+  Status Close() override {
+    ++state_->close_count;
+    if (state_->close_result == SyncFileTestResult::kOk) {
+      return WritableFileWrapper::Close();
+    }
+    Status status = WritableFileWrapper::Close();
+    status.PermitUncheckedError();
+    return MakeSyncFileTestStatus(state_->close_result);
+  }
+
+ private:
+  std::unique_ptr<WritableFile> target_guard_;
+  SyncFileTestState* state_;
+};
+
+class SyncFileTestEnv : public EnvWrapper {
+ public:
+  SyncFileTestEnv(Env* target, SyncFileTestState* state)
+      : EnvWrapper(target), state_(state) {}
+
+  Status ReopenWritableFile(const std::string& fname,
+                            std::unique_ptr<WritableFile>* result,
+                            const EnvOptions& options) override {
+    ++state_->reopen_count;
+    Status status = MakeSyncFileTestStatus(state_->reopen_result);
+    if (!status.ok()) {
+      return status;
+    }
+    status = target()->ReopenWritableFile(fname, result, options);
+    if (status.ok()) {
+      result->reset(new SyncFileTestWritableFile(std::move(*result), state_));
+    }
+    return status;
+  }
+
+  Status SyncFile(const std::string& fname, const EnvOptions& options,
+                  bool use_fsync) override {
+    return Env::SyncFile(fname, options, use_fsync);
+  }
+
+ private:
+  SyncFileTestState* state_;
+};
+
+class SyncFileTestFSWritableFile : public FSWritableFileOwnerWrapper {
+ public:
+  SyncFileTestFSWritableFile(std::unique_ptr<FSWritableFile>&& target,
+                             SyncFileTestState* state)
+      : FSWritableFileOwnerWrapper(std::move(target)), state_(state) {}
+
+  IOStatus Sync(const IOOptions& /*options*/,
+                IODebugContext* /*dbg*/) override {
+    ++state_->sync_count;
+    return MakeSyncFileTestIOStatus(state_->sync_result);
+  }
+
+  IOStatus Fsync(const IOOptions& /*options*/,
+                 IODebugContext* /*dbg*/) override {
+    ++state_->fsync_count;
+    return MakeSyncFileTestIOStatus(state_->fsync_result);
+  }
+
+  IOStatus Close(const IOOptions& options, IODebugContext* dbg) override {
+    ++state_->close_count;
+    if (state_->close_result == SyncFileTestResult::kOk) {
+      return FSWritableFileOwnerWrapper::Close(options, dbg);
+    }
+    IOStatus status = FSWritableFileOwnerWrapper::Close(options, dbg);
+    status.PermitUncheckedError();
+    return MakeSyncFileTestIOStatus(state_->close_result);
+  }
+
+ private:
+  SyncFileTestState* state_;
+};
+
+class SyncFileTestFileSystem : public FileSystemWrapper {
+ public:
+  SyncFileTestFileSystem(const std::shared_ptr<FileSystem>& target,
+                         SyncFileTestState* state)
+      : FileSystemWrapper(target), state_(state) {}
+
+  const char* Name() const override { return "SyncFileTestFileSystem"; }
+
+  IOStatus ReopenWritableFile(const std::string& fname,
+                              const FileOptions& file_opts,
+                              std::unique_ptr<FSWritableFile>* result,
+                              IODebugContext* dbg) override {
+    ++state_->reopen_count;
+    IOStatus status = MakeSyncFileTestIOStatus(state_->reopen_result);
+    if (!status.ok()) {
+      return status;
+    }
+    status = target()->ReopenWritableFile(fname, file_opts, result, dbg);
+    if (status.ok()) {
+      result->reset(new SyncFileTestFSWritableFile(std::move(*result), state_));
+    }
+    return status;
+  }
+
+  IOStatus SyncFile(const std::string& fname, const FileOptions& file_opts,
+                    const IOOptions& io_opts, bool use_fsync,
+                    IODebugContext* dbg) override {
+    return FileSystem::SyncFile(fname, file_opts, io_opts, use_fsync, dbg);
+  }
+
+ private:
+  SyncFileTestState* state_;
+};
+
+TEST_F(EnvTest, EnvSyncFileDefaultUsesSyncAndFsync) {
+  const std::string fname = test::PerThreadDBPath("env_sync_file_default");
+  ASSERT_OK(WriteStringToFile(Env::Default(), "sync-file-test", fname));
+
+  SyncFileTestState state;
+  SyncFileTestEnv env(Env::Default(), &state);
+
+  ASSERT_OK(env.SyncFile(fname, EnvOptions(), /*use_fsync=*/false));
+  ASSERT_EQ(state.reopen_count, 1);
+  ASSERT_EQ(state.sync_count, 1);
+  ASSERT_EQ(state.fsync_count, 0);
+  ASSERT_EQ(state.close_count, 1);
+
+  ASSERT_OK(env.SyncFile(fname, EnvOptions(), /*use_fsync=*/true));
+  ASSERT_EQ(state.reopen_count, 2);
+  ASSERT_EQ(state.sync_count, 1);
+  ASSERT_EQ(state.fsync_count, 1);
+  ASSERT_EQ(state.close_count, 2);
+
+  ASSERT_OK(Env::Default()->DeleteFile(fname));
+}
+
+TEST_F(EnvTest, EnvSyncFileDefaultReturnsReopenError) {
+  SyncFileTestState state;
+  state.reopen_result = SyncFileTestResult::kNotSupported;
+  SyncFileTestEnv env(Env::Default(), &state);
+
+  const Status status =
+      env.SyncFile("unused", EnvOptions(), /*use_fsync=*/false);
+  ASSERT_TRUE(status.IsNotSupported()) << status.ToString();
+  ASSERT_EQ(state.reopen_count, 1);
+  ASSERT_EQ(state.sync_count, 0);
+  ASSERT_EQ(state.fsync_count, 0);
+  ASSERT_EQ(state.close_count, 0);
+}
+
+TEST_F(EnvTest, EnvSyncFileDefaultReturnsCloseErrorAfterSuccessfulSync) {
+  const std::string fname = test::PerThreadDBPath("env_sync_file_close_error");
+  ASSERT_OK(WriteStringToFile(Env::Default(), "sync-file-test", fname));
+
+  SyncFileTestState state;
+  state.close_result = SyncFileTestResult::kCloseError;
+  SyncFileTestEnv env(Env::Default(), &state);
+
+  const Status status = env.SyncFile(fname, EnvOptions(), /*use_fsync=*/false);
+  ASSERT_TRUE(status.IsIOError()) << status.ToString();
+  ASSERT_NE(status.ToString().find("close failure"), std::string::npos)
+      << status.ToString();
+  ASSERT_EQ(state.reopen_count, 1);
+  ASSERT_EQ(state.sync_count, 1);
+  ASSERT_EQ(state.close_count, 1);
+
+  ASSERT_OK(Env::Default()->DeleteFile(fname));
+}
+
+TEST_F(EnvTest, EnvSyncFileDefaultReturnsSyncErrorBeforeCloseError) {
+  const std::string fname = test::PerThreadDBPath("env_sync_file_sync_error");
+  ASSERT_OK(WriteStringToFile(Env::Default(), "sync-file-test", fname));
+
+  SyncFileTestState state;
+  state.sync_result = SyncFileTestResult::kSyncError;
+  state.close_result = SyncFileTestResult::kCloseError;
+  SyncFileTestEnv env(Env::Default(), &state);
+
+  const Status status = env.SyncFile(fname, EnvOptions(), /*use_fsync=*/false);
+  ASSERT_TRUE(status.IsIOError()) << status.ToString();
+  ASSERT_NE(status.ToString().find("sync failure"), std::string::npos)
+      << status.ToString();
+  ASSERT_EQ(state.reopen_count, 1);
+  ASSERT_EQ(state.sync_count, 1);
+  ASSERT_EQ(state.close_count, 1);
+
+  ASSERT_OK(Env::Default()->DeleteFile(fname));
+}
+
+TEST_F(EnvTest, FileSystemSyncFileDefaultUsesSyncAndFsync) {
+  const std::string fname = test::PerThreadDBPath("fs_sync_file_default");
+  ASSERT_OK(
+      WriteStringToFile(FileSystem::Default().get(), "sync-file-test", fname));
+
+  SyncFileTestState state;
+  SyncFileTestFileSystem fs(FileSystem::Default(), &state);
+
+  ASSERT_OK(fs.SyncFile(fname, FileOptions(), IOOptions(), /*use_fsync=*/false,
+                        nullptr));
+  ASSERT_EQ(state.reopen_count, 1);
+  ASSERT_EQ(state.sync_count, 1);
+  ASSERT_EQ(state.fsync_count, 0);
+  ASSERT_EQ(state.close_count, 1);
+
+  ASSERT_OK(fs.SyncFile(fname, FileOptions(), IOOptions(), /*use_fsync=*/true,
+                        nullptr));
+  ASSERT_EQ(state.reopen_count, 2);
+  ASSERT_EQ(state.sync_count, 1);
+  ASSERT_EQ(state.fsync_count, 1);
+  ASSERT_EQ(state.close_count, 2);
+
+  ASSERT_OK(FileSystem::Default()->DeleteFile(fname, IOOptions(), nullptr));
+}
+
+TEST_F(EnvTest, FileSystemSyncFileDefaultReturnsReopenError) {
+  SyncFileTestState state;
+  state.reopen_result = SyncFileTestResult::kNotSupported;
+  SyncFileTestFileSystem fs(FileSystem::Default(), &state);
+
+  const IOStatus status = fs.SyncFile("unused", FileOptions(), IOOptions(),
+                                      /*use_fsync=*/false, nullptr);
+  ASSERT_TRUE(status.IsNotSupported()) << status.ToString();
+  ASSERT_EQ(state.reopen_count, 1);
+  ASSERT_EQ(state.sync_count, 0);
+  ASSERT_EQ(state.fsync_count, 0);
+  ASSERT_EQ(state.close_count, 0);
+}
+
+TEST_F(EnvTest, FileSystemSyncFileDefaultReturnsCloseErrorAfterSuccessfulSync) {
+  const std::string fname = test::PerThreadDBPath("fs_sync_file_close_error");
+  ASSERT_OK(
+      WriteStringToFile(FileSystem::Default().get(), "sync-file-test", fname));
+
+  SyncFileTestState state;
+  state.close_result = SyncFileTestResult::kCloseError;
+  SyncFileTestFileSystem fs(FileSystem::Default(), &state);
+
+  const IOStatus status = fs.SyncFile(fname, FileOptions(), IOOptions(),
+                                      /*use_fsync=*/false, nullptr);
+  ASSERT_TRUE(status.IsIOError()) << status.ToString();
+  ASSERT_NE(status.ToString().find("close failure"), std::string::npos)
+      << status.ToString();
+  ASSERT_EQ(state.reopen_count, 1);
+  ASSERT_EQ(state.sync_count, 1);
+  ASSERT_EQ(state.close_count, 1);
+
+  ASSERT_OK(FileSystem::Default()->DeleteFile(fname, IOOptions(), nullptr));
+}
+
+TEST_F(EnvTest, FileSystemSyncFileDefaultReturnsSyncErrorBeforeCloseError) {
+  const std::string fname = test::PerThreadDBPath("fs_sync_file_sync_error");
+  ASSERT_OK(
+      WriteStringToFile(FileSystem::Default().get(), "sync-file-test", fname));
+
+  SyncFileTestState state;
+  state.sync_result = SyncFileTestResult::kSyncError;
+  state.close_result = SyncFileTestResult::kCloseError;
+  SyncFileTestFileSystem fs(FileSystem::Default(), &state);
+
+  const IOStatus status = fs.SyncFile(fname, FileOptions(), IOOptions(),
+                                      /*use_fsync=*/false, nullptr);
+  ASSERT_TRUE(status.IsIOError()) << status.ToString();
+  ASSERT_NE(status.ToString().find("sync failure"), std::string::npos)
+      << status.ToString();
+  ASSERT_EQ(state.reopen_count, 1);
+  ASSERT_EQ(state.sync_count, 1);
+  ASSERT_EQ(state.close_count, 1);
+
+  ASSERT_OK(FileSystem::Default()->DeleteFile(fname, IOOptions(), nullptr));
+}
+
 // Writable file wrapper that injects a Close() failure.
 // Uses FSWritableFileOwnerWrapper to properly take ownership of the wrapped
 // file.

--- a/env/file_system.cc
+++ b/env/file_system.cc
@@ -16,6 +16,7 @@
 #include "rocksdb/utilities/customizable_util.h"
 #include "rocksdb/utilities/object_registry.h"
 #include "rocksdb/utilities/options_type.h"
+#include "test_util/sync_point.h"
 #include "util/string_util.h"
 #include "utilities/counted_fs.h"
 #include "utilities/env_timed.h"
@@ -105,6 +106,26 @@ IOStatus FileSystem::ReuseWritableFile(const std::string& fname,
     return s;
   }
   return NewWritableFile(fname, opts, result, dbg);
+}
+
+IOStatus FileSystem::SyncFile(const std::string& fname,
+                              const FileOptions& file_opts,
+                              const IOOptions& io_opts, bool use_fsync,
+                              IODebugContext* dbg) {
+  std::unique_ptr<FSWritableFile> file_to_sync;
+  IOStatus status = ReopenWritableFile(fname, file_opts, &file_to_sync, dbg);
+  TEST_SYNC_POINT_CALLBACK("FileSystem::SyncFile:Open", &status);
+  if (status.ok()) {
+    status = use_fsync ? file_to_sync->Fsync(io_opts, dbg)
+                       : file_to_sync->Sync(io_opts, dbg);
+    IOStatus close_status = file_to_sync->Close(io_opts, dbg);
+    if (status.ok()) {
+      status = close_status;
+    } else {
+      close_status.PermitUncheckedError();
+    }
+  }
+  return status;
 }
 
 IOStatus FileSystem::NewLogger(const std::string& fname,

--- a/env/fs_readonly.h
+++ b/env/fs_readonly.h
@@ -89,6 +89,12 @@ class ReadOnlyFileSystem : public FileSystemWrapper {
                     IODebugContext* /*dbg*/) override {
     return FailReadOnly();
   }
+  IOStatus SyncFile(const std::string& /*fname*/,
+                    const FileOptions& /*file_opts*/,
+                    const IOOptions& /*io_opts*/, bool /*use_fsync*/,
+                    IODebugContext* /*dbg*/) override {
+    return FailReadOnly();
+  }
   IOStatus LockFile(const std::string& /*fname*/, const IOOptions& /*options*/,
                     FileLock** /*lock*/, IODebugContext* /*dbg*/) override {
     return FailReadOnly();

--- a/env/fs_remap.cc
+++ b/env/fs_remap.cc
@@ -309,6 +309,18 @@ IOStatus RemapFileSystem::LinkFile(const std::string& src,
                                      dbg);
 }
 
+IOStatus RemapFileSystem::SyncFile(const std::string& fname,
+                                   const FileOptions& file_opts,
+                                   const IOOptions& io_opts, bool use_fsync,
+                                   IODebugContext* dbg) {
+  auto status_and_enc_path = EncodePathWithNewBasename(fname);
+  if (!status_and_enc_path.first.ok()) {
+    return status_and_enc_path.first;
+  }
+  return FileSystemWrapper::SyncFile(status_and_enc_path.second, file_opts,
+                                     io_opts, use_fsync, dbg);
+}
+
 IOStatus RemapFileSystem::LockFile(const std::string& fname,
                                    const IOOptions& options, FileLock** lock,
                                    IODebugContext* dbg) {

--- a/env/fs_remap.h
+++ b/env/fs_remap.h
@@ -125,6 +125,10 @@ class RemapFileSystem : public FileSystemWrapper {
   IOStatus LinkFile(const std::string& src, const std::string& dest,
                     const IOOptions& options, IODebugContext* dbg) override;
 
+  IOStatus SyncFile(const std::string& fname, const FileOptions& file_opts,
+                    const IOOptions& io_opts, bool use_fsync,
+                    IODebugContext* dbg) override;
+
   IOStatus LockFile(const std::string& fname, const IOOptions& options,
                     FileLock** lock, IODebugContext* dbg) override;
 

--- a/env/mock_env.cc
+++ b/env/mock_env.cc
@@ -957,6 +957,13 @@ IOStatus MockFileSystem::LinkFile(const std::string& src,
   return IOStatus::OK();
 }
 
+IOStatus MockFileSystem::SyncFile(const std::string& /*fname*/,
+                                  const FileOptions& /*file_opts*/,
+                                  const IOOptions& /*io_opts*/,
+                                  bool /*use_fsync*/, IODebugContext* /*dbg*/) {
+  return IOStatus::OK();
+}
+
 IOStatus MockFileSystem::NewLogger(const std::string& fname,
                                    const IOOptions& io_opts,
                                    std::shared_ptr<Logger>* result,

--- a/env/mock_env.h
+++ b/env/mock_env.h
@@ -86,6 +86,10 @@ class MockFileSystem : public FileSystem {
   IOStatus LinkFile(const std::string& /*src*/, const std::string& /*target*/,
                     const IOOptions& /*options*/,
                     IODebugContext* /*dbg*/) override;
+  IOStatus SyncFile(const std::string& /*fname*/,
+                    const FileOptions& /*file_opts*/,
+                    const IOOptions& /*io_opts*/, bool /*use_fsync*/,
+                    IODebugContext* /*dbg*/) override;
   IOStatus LockFile(const std::string& fname, const IOOptions& options,
                     FileLock** lock, IODebugContext* dbg) override;
   IOStatus UnlockFile(FileLock* lock, const IOOptions& options,

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -385,6 +385,14 @@ class Env : public Customizable {
     return Status::NotSupported("LinkFile is not supported for this Env");
   }
 
+  // Syncs file data and, when requested, file metadata for `fname`.
+  //
+  // See FileSystem::SyncFile() for the corresponding path-level sync contract.
+  // The default implementation reopens the file as writable, calls Sync() or
+  // Fsync(), then closes it.
+  virtual Status SyncFile(const std::string& fname, const EnvOptions& options,
+                          bool use_fsync);
+
   virtual Status NumFileLinks(const std::string& /*fname*/,
                               uint64_t* /*count*/) {
     return Status::NotSupported(
@@ -1692,6 +1700,11 @@ class EnvWrapper : public Env {
 
   Status LinkFile(const std::string& s, const std::string& t) override {
     return target_.env->LinkFile(s, t);
+  }
+
+  Status SyncFile(const std::string& fname, const EnvOptions& options,
+                  bool use_fsync) override {
+    return target_.env->SyncFile(fname, options, use_fsync);
   }
 
   Status NumFileLinks(const std::string& fname, uint64_t* count) override {

--- a/include/rocksdb/file_system.h
+++ b/include/rocksdb/file_system.h
@@ -625,6 +625,22 @@ class FileSystem : public Customizable {
         "LinkFile is not supported for this FileSystem");
   }
 
+  // Syncs file data and, when requested, file metadata for `fname`.
+  //
+  // The default implementation reopens the file as writable, calls Sync() or
+  // Fsync(), then closes it. Filesystems that already make file contents
+  // durable on file flush/close can override this as a no-op to avoid the
+  // reopen overhead.
+  //
+  // RocksDB code that needs to sync a named file should use this API instead of
+  // hand-rolling ReopenWritableFile()+Sync()/Fsync(). This lets filesystems
+  // reject ReopenWritableFile() for post-close data writes while still
+  // providing a cleaner path-level sync implementation.
+  virtual IOStatus SyncFile(const std::string& fname,
+                            const FileOptions& file_opts,
+                            const IOOptions& io_opts, bool use_fsync,
+                            IODebugContext* dbg);
+
   virtual IOStatus NumFileLinks(const std::string& /*fname*/,
                                 const IOOptions& /*options*/,
                                 uint64_t* /*count*/, IODebugContext* /*dbg*/) {
@@ -1640,6 +1656,12 @@ class FileSystemWrapper : public FileSystem {
   IOStatus LinkFile(const std::string& s, const std::string& t,
                     const IOOptions& options, IODebugContext* dbg) override {
     return target_->LinkFile(s, t, options, dbg);
+  }
+
+  IOStatus SyncFile(const std::string& fname, const FileOptions& file_opts,
+                    const IOOptions& io_opts, bool use_fsync,
+                    IODebugContext* dbg) override {
+    return target_->SyncFile(fname, file_opts, io_opts, use_fsync, dbg);
   }
 
   IOStatus NumFileLinks(const std::string& fname, const IOOptions& options,

--- a/unreleased_history/public_api_changes/sync_file_api.md
+++ b/unreleased_history/public_api_changes/sync_file_api.md
@@ -1,0 +1,1 @@
+Added `FileSystem::SyncFile()` and `Env::SyncFile()` public APIs for syncing or fsyncing a file by name without requiring callers to reopen it as writable.

--- a/utilities/fault_injection_env.cc
+++ b/utilities/fault_injection_env.cc
@@ -361,6 +361,15 @@ Status FaultInjectionTestEnv::ReopenWritableFile(
   return s;
 }
 
+Status FaultInjectionTestEnv::SyncFile(const std::string& fname,
+                                       const EnvOptions& options,
+                                       bool use_fsync) {
+  // Call Env's default implementation instead of EnvWrapper forwarding so
+  // SyncFile exercises this wrapper's ReopenWritableFile hook and the wrapped
+  // file's Sync, Fsync, and Close hooks.
+  return Env::SyncFile(fname, options, use_fsync);
+}
+
 Status FaultInjectionTestEnv::NewRandomRWFile(
     const std::string& fname, std::unique_ptr<RandomRWFile>* result,
     const EnvOptions& soptions) {

--- a/utilities/fault_injection_env.h
+++ b/utilities/fault_injection_env.h
@@ -163,6 +163,9 @@ class FaultInjectionTestEnv : public EnvWrapper {
                             std::unique_ptr<WritableFile>* result,
                             const EnvOptions& soptions) override;
 
+  Status SyncFile(const std::string& fname, const EnvOptions& options,
+                  bool use_fsync) override;
+
   Status NewRandomRWFile(const std::string& fname,
                          std::unique_ptr<RandomRWFile>* result,
                          const EnvOptions& soptions) override;

--- a/utilities/fault_injection_fs.cc
+++ b/utilities/fault_injection_fs.cc
@@ -1020,6 +1020,16 @@ IOStatus FaultInjectionTestFS::ReopenWritableFile(
   return io_s;
 }
 
+IOStatus FaultInjectionTestFS::SyncFile(const std::string& fname,
+                                        const FileOptions& file_opts,
+                                        const IOOptions& io_opts,
+                                        bool use_fsync, IODebugContext* dbg) {
+  // Call FileSystem's default implementation instead of FileSystemWrapper
+  // forwarding so SyncFile exercises this wrapper's ReopenWritableFile hook and
+  // the wrapped file's Sync, Fsync, and Close hooks.
+  return FileSystem::SyncFile(fname, file_opts, io_opts, use_fsync, dbg);
+}
+
 IOStatus FaultInjectionTestFS::ReuseWritableFile(
     const std::string& fname, const std::string& old_fname,
     const FileOptions& file_opts, std::unique_ptr<FSWritableFile>* result,

--- a/utilities/fault_injection_fs.h
+++ b/utilities/fault_injection_fs.h
@@ -573,6 +573,10 @@ class FaultInjectionTestFS : public FileSystemWrapper {
   IOStatus LinkFile(const std::string& src, const std::string& target,
                     const IOOptions& options, IODebugContext* dbg) override;
 
+  IOStatus SyncFile(const std::string& fname, const FileOptions& file_opts,
+                    const IOOptions& io_opts, bool use_fsync,
+                    IODebugContext* dbg) override;
+
   IOStatus NumFileLinks(const std::string& fname, const IOOptions& options,
                         uint64_t* count, IODebugContext* dbg) override;
 


### PR DESCRIPTION
Summary:

Adds public path-level file sync APIs to RocksDB so callers can ask `Env` or `FileSystem` to sync a named file without hand-rolled reopen logic.

This diff:

- Adds public `Env::SyncFile` and `FileSystem::SyncFile` APIs for syncing or fsyncing a file by name without requiring callers to reopen it directly.
- Documents the `SyncFile` contract: filesystems may override it as a no-op when flush/close already provides durability, and RocksDB callers should use it instead of hand-rolled `ReopenWritableFile()+Sync()/Fsync()` so filesystems can reject post-close data-write reopen paths.
- Implements the default `Env` and `FileSystem` behavior by reopening the file as writable, calling `Sync` or `Fsync`, closing the handle, returning the sync/fsync error ahead of a close error when both fail, and explicitly consuming the close status on the sync-failure path.
- Wires `SyncFile` through the Env/FileSystem bridge and wrapper layers, including `EnvWrapper`, `FileSystemWrapper`, `CompositeEnvWrapper`, `EncryptedFileSystem`, `RemapFileSystem`, read-only file systems, mock file systems, and fault-injection wrappers.
- Keeps fault-injection `SyncFile` overrides on the base default implementation so the operation still exercises the wrapper's `ReopenWritableFile`, wrapped-file `Sync`/`Fsync`, and `Close` hooks instead of bypassing them through target forwarding.
- Updates external SST ingestion to call `FileSystem::SyncFile` instead of manually reopening an ingested file as writable, while preserving the `NotSupported` skip behavior and failure logging.
- Adds release-note coverage for the new public API and unit coverage for default `Env`/`FileSystem` success, reopen failure, close failure, sync-versus-close failure precedence, and external SST sync behavior.

There was an earlier version of this API which got reverted (PR #13987) due to internal change broken. Re-apply the change. The internal issue will be resolved in next release.

Reviewed By: pdillinger

Differential Revision: D104918547


