### PR TITLE
Add listener_uri stress test flag for pluggable EventListener

### DIFF
--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -472,6 +472,8 @@ DECLARE_int32(compaction_on_deletion_window_size);
 DECLARE_double(compaction_on_deletion_ratio);
 DECLARE_double(read_triggered_compaction_threshold);
 
+DECLARE_string(listener_uri);
+
 constexpr long KB = 1024;
 constexpr int kRandomValueMaxFactor = 3;
 constexpr int kValueMaxLen = 100;

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -1664,6 +1664,10 @@ DEFINE_double(read_triggered_compaction_threshold,
               ROCKSDB_NAMESPACE::Options().read_triggered_compaction_threshold,
               "Sets CF option read_triggered_compaction_threshold.");
 
+DEFINE_string(listener_uri, "",
+              "URI for an additional EventListener to attach (e.g. "
+              "auto_tuner://). Empty means none.");
+
 DEFINE_bool(
     auto_refresh_iterator_with_snapshot,
     ROCKSDB_NAMESPACE::ReadOptions().auto_refresh_iterator_with_snapshot,

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -3962,6 +3962,19 @@ void StressTest::Open(SharedState* shared, bool reopen) {
         FLAGS_db, options_.db_paths, cf_descriptors, shared));
     RegisterAdditionalListeners();
 
+    if (!FLAGS_listener_uri.empty()) {
+      std::shared_ptr<EventListener> listener;
+      Status listener_status =
+          ObjectRegistry::Default()->NewSharedObject<EventListener>(
+              FLAGS_listener_uri, &listener);
+      if (!listener_status.ok()) {
+        fprintf(stderr, "Failed to create listener from URI '%s': %s\n",
+                FLAGS_listener_uri.c_str(), listener_status.ToString().c_str());
+        exit(1);
+      }
+      options_.listeners.emplace_back(std::move(listener));
+    }
+
     // If this is for DB reopen,  error injection may have been enabled.
     // Disable it here in case there is no open fault injection.
     if (fault_fs_guard) {


### PR DESCRIPTION
**Summary:** 
Adds a --listener_uri flag to db_stress that creates an EventListener via ObjectLibrary from the given URI and attaches it to the DB options.  

**Test:** 
- Compilation 
- e2e test will be done next internally with a customized listener
 


