### PR TITLE
Clean up failed regression test workdirs (#14751)

### DIFF
--- a/tools/regression_test.sh
+++ b/tools/regression_test.sh
@@ -122,6 +122,7 @@ PERC_PATTERN+="P99: ([0-9\.]+) P99.9: ([0-9\.]+) P99.99: ([0-9\.]+)"
 function main {
   TEST_ROOT_DIR=${TEST_PATH:-"/tmp/rocksdb/regression_test"}
   init_arguments $TEST_ROOT_DIR
+  arm_cleanup_trap $TEST_ROOT_DIR
 
   build_db_bench_and_ldb
 
@@ -147,9 +148,22 @@ function main {
       run_db_bench "multireadrandom"
   fi
 
-  cleanup_test_directory $TEST_ROOT_DIR
+  finalize_cleanup $TEST_ROOT_DIR
   echo ""
   echo "Benchmark completed!  Results are available in $RESULT_PATH"
+}
+
+############################################################################
+function arm_cleanup_trap {
+  CLEANUP_DONE=0
+  trap 'finalize_cleanup "$TEST_ROOT_DIR"' EXIT
+}
+
+function finalize_cleanup {
+  if [ "${CLEANUP_DONE:-0}" -eq 0 ]; then
+    cleanup_test_directory "$1"
+    CLEANUP_DONE=1
+  fi
 }
 
 ############################################################################


### PR DESCRIPTION
Summary:

`regression_test.sh` already cleans the current run's `TEST_PATH` on normal success and on the early-exit path when a recent `db_bench` is still running. But a hard benchmark failure goes through `exit_on_error`, which exits before the end-of-`main()` cleanup runs.

This change adds an `EXIT` trap and a single-shot finalizer so the current invocation still cleans its own `TEST_PATH` on hard failure. It does not reintroduce any sibling-directory cleanup, and it preserves the existing success-path cleanup, early-exit cleanup, and debug preservation behavior.

| Scenario | Previous code | New code |
| --- | --- | --- |
| Normal success | Cleans current `TEST_PATH` at end of `main()` | Still cleans current `TEST_PATH` |
| Hard benchmark failure via `exit_on_error` | Can leave current `TEST_PATH` behind | `EXIT` trap cleans current `TEST_PATH` |
| Early exit because recent `db_bench` exists | Cleans current `TEST_PATH`, exits `2` | Same behavior |
| Debug mode / `DELETE_TEST_PATH=0` | Preserves artifacts | Same behavior |

Differential Revision: D105411220


