### PR TITLE
Guard db_bench DB lifetime with RWMutex against shutdown race (#14754)

### DIFF
--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -2912,6 +2912,44 @@ class Benchmark {
   std::shared_ptr<const SliceTransform> prefix_extractor_;
   DBWithColumnFamilies db_;
   std::vector<DBWithColumnFamilies> multi_dbs_;
+  //
+  // === DB lifetime protocol ===
+  //
+  // Two RAII guards protect db_, multi_dbs_, and secondary_update_thread_:
+  //
+  //  - DbUseGuard:           held by any thread that reads or holds a raw
+  //                          DBWithColumnFamilies* derived from db_ /
+  //                          multi_dbs_, for the entire scope of use. Takes a
+  //                          read lock on db_lifecycle_rwlock_.
+  //                          STRICT enforcement at the SelectDBWithCfh entry
+  //                          point (assert on holds_db_use_guard_).
+  //                          Direct field accesses elsewhere (e.g.
+  //                          db_.db->NewIterator) are protected by the outer
+  //                          DbUseGuard that ThreadBody installs for workers,
+  //                          or by main-thread serialization -- but are not
+  //                          mechanically asserted per-site.
+  //
+  //  - DbStateMutationGuard: held by any thread that mutates db_, multi_dbs_,
+  //                          or secondary_update_thread_. Takes a write lock
+  //                          on db_lifecycle_rwlock_, then stops the secondary
+  //                          update thread before mutation may proceed.
+  //                          STRICT enforcement at DeleteDBs (assert on
+  //                          holds_db_state_mutation_guard_). Direct calls
+  //                          to DBWithColumnFamilies::DeleteDBs() and
+  //                          multi_dbs_.clear() in the fresh-DB reopen branch
+  //                          are protected by being inside the same guard
+  //                          scope, but not mechanically asserted.
+  //
+  // Three thread-locals, each with a single meaning:
+  //  - holds_db_use_guard_            : in DbUseGuard scope
+  //  - holds_db_state_mutation_guard_ : in DbStateMutationGuard scope
+  //  - is_secondary_update_thread_    : this thread is the secondary updater
+  //
+  // ErrorExit consults the first and third: a thread in *either* state
+  // cannot safely run the mutation cleanup path (self-wait or self-join
+  // respectively), so it takes std::_Exit(1) instead.
+  //
+  port::RWMutex db_lifecycle_rwlock_;
   int64_t num_;
   int key_size_;
   int user_timestamp_size_;
@@ -3502,6 +3540,11 @@ class Benchmark {
   }
 
   void DeleteDBs() {
+    // Caller MUST hold DbStateMutationGuard (proven by ownership flag).
+    // Note: direct calls to db_.DeleteDBs() / multi_dbs_[i].DeleteDBs() in
+    // the fresh-DB reopen branch bypass this wrapper; they're protected by
+    // being inside DbStateMutationGuard but are not mechanically asserted.
+    assert(holds_db_state_mutation_guard_);
     db_.DeleteDBs();
     for (auto& dbwcf : multi_dbs_) {
       dbwcf.DeleteDBs();
@@ -3509,7 +3552,10 @@ class Benchmark {
   }
 
   ~Benchmark() {
-    DeleteDBs();
+    {
+      DbStateMutationGuard mutation(this);
+      DeleteDBs();
+    }
     if (cache_.get() != nullptr) {
       // Clear cache reference first
       open_options_.write_buffer_manager.reset();
@@ -3643,7 +3689,19 @@ class Benchmark {
   }
 
   void ErrorExit() {
-    DeleteDBs();
+    if (holds_db_use_guard_ || is_secondary_update_thread_) {
+      // Neither kind of DB-user context can safely run the mutation cleanup
+      // path:
+      //   - DbUseGuard holder would self-wait on the write lock
+      //   - secondary update thread would self-join via
+      //     StopSecondaryUpdateThread()
+      // Terminate immediately and let the OS reclaim resources.
+      std::_Exit(1);
+    }
+    {
+      DbStateMutationGuard mutation(this);
+      DeleteDBs();
+    }
     db_bench_exit(1);
   }
 
@@ -4010,6 +4068,7 @@ class Benchmark {
       }
 
       if (fresh_db) {
+        DbStateMutationGuard mutation(this);
         if (FLAGS_use_existing_db) {
           fprintf(stdout, "%-12s : skipped (--use_existing_db is true)\n",
                   name.c_str());
@@ -4137,11 +4196,7 @@ class Benchmark {
       }
     }
 
-    if (secondary_update_thread_) {
-      secondary_update_stopped_.store(1, std::memory_order_relaxed);
-      secondary_update_thread_->join();
-      secondary_update_thread_.reset();
-    }
+    StopSecondaryUpdateThread();
 
     if (name != "replay" && FLAGS_trace_file != "") {
       Status s = db_.db->EndTrace();
@@ -4179,6 +4234,83 @@ class Benchmark {
   std::unique_ptr<port::Thread> secondary_update_thread_;
   std::atomic<int> secondary_update_stopped_{0};
   uint64_t secondary_db_updates_ = 0;
+  void StopSecondaryUpdateThread() {
+    if (secondary_update_thread_) {
+      secondary_update_stopped_.store(1, std::memory_order_relaxed);
+      secondary_update_thread_->join();
+      secondary_update_thread_.reset();
+      secondary_update_stopped_.store(0, std::memory_order_relaxed);
+    }
+  }
+
+  // True iff the current thread is inside a DbUseGuard scope.
+  // Set/cleared only by DbUseGuard. Strict guard ownership.
+  static thread_local bool holds_db_use_guard_;
+
+  // True iff the current thread is inside a DbStateMutationGuard scope.
+  // Set/cleared only by DbStateMutationGuard.
+  static thread_local bool holds_db_state_mutation_guard_;
+
+  // True iff the current thread is the secondary update thread.
+  // The secondary thread reads its captured DBWithColumnFamilies* without
+  // going through DbUseGuard or SelectDBWithCfh. This flag exists so
+  // ErrorExit can route it to _Exit(1) without self-joining via
+  // StopSecondaryUpdateThread.
+  static thread_local bool is_secondary_update_thread_;
+
+  class DbUseGuard {
+   public:
+    explicit DbUseGuard(Benchmark* bm)
+        : lock_(CheckDbUsePreconditionsAndGetLock(bm)) {
+      holds_db_use_guard_ = true;
+    }
+    ~DbUseGuard() {
+      assert(holds_db_use_guard_);
+      holds_db_use_guard_ = false;
+    }
+    DbUseGuard(const DbUseGuard&) = delete;
+    DbUseGuard& operator=(const DbUseGuard&) = delete;
+    DbUseGuard(DbUseGuard&&) = delete;
+    DbUseGuard& operator=(DbUseGuard&&) = delete;
+
+   private:
+    static port::RWMutex* CheckDbUsePreconditionsAndGetLock(Benchmark* bm) {
+      assert(!holds_db_use_guard_);
+      return &bm->db_lifecycle_rwlock_;
+    }
+
+    ReadLock lock_;
+  };
+
+  class DbStateMutationGuard {
+   public:
+    explicit DbStateMutationGuard(Benchmark* bm)
+        : bm_(bm), lock_(CheckDbMutationPreconditionsAndGetLock(bm)) {
+      bm_->StopSecondaryUpdateThread();
+      holds_db_state_mutation_guard_ = true;
+    }
+    ~DbStateMutationGuard() {
+      assert(holds_db_state_mutation_guard_);
+      holds_db_state_mutation_guard_ = false;
+    }
+    DbStateMutationGuard(const DbStateMutationGuard&) = delete;
+    DbStateMutationGuard& operator=(const DbStateMutationGuard&) = delete;
+    DbStateMutationGuard(DbStateMutationGuard&&) = delete;
+    DbStateMutationGuard& operator=(DbStateMutationGuard&&) = delete;
+
+   private:
+    static port::RWMutex* CheckDbMutationPreconditionsAndGetLock(
+        Benchmark* bm) {
+      assert(!holds_db_state_mutation_guard_);
+      assert(!holds_db_use_guard_);
+      assert(!is_secondary_update_thread_);
+      return &bm->db_lifecycle_rwlock_;
+    }
+
+    Benchmark* bm_;
+    WriteLock lock_;
+  };
+
   struct ThreadArg {
     Benchmark* bm;
     SharedState* shared;
@@ -4204,7 +4336,10 @@ class Benchmark {
     SetPerfLevel(static_cast<PerfLevel>(shared->perf_level));
     perf_context.EnablePerLevelPerfContext();
     thread->stats.Start(thread->tid);
-    (arg->bm->*(arg->method))(thread);
+    {
+      DbUseGuard db_guard(arg->bm);
+      (arg->bm->*(arg->method))(thread);
+    }
     if (FLAGS_perf_level > ROCKSDB_NAMESPACE::PerfLevel::kDisable) {
       thread->stats.AddMessage(std::string("PERF_CONTEXT:\n") +
                                get_perf_context()->ToString());
@@ -5382,6 +5517,7 @@ class Benchmark {
       if (s.ok() && FLAGS_secondary_update_interval > 0) {
         secondary_update_thread_.reset(new port::Thread(
             [this](int interval, DBWithColumnFamilies* _db) {
+              is_secondary_update_thread_ = true;
               while (0 == secondary_update_stopped_.load(
                               std::memory_order_relaxed)) {
                 Status secondary_update_status =
@@ -5694,6 +5830,10 @@ class Benchmark {
   }
 
   DBWithColumnFamilies* SelectDBWithCfh(uint64_t rand_int) {
+    // Caller MUST hold DbUseGuard (proven by ownership flag). The secondary
+    // update thread does not call this function; it uses its captured
+    // DBWithColumnFamilies* directly.
+    assert(holds_db_use_guard_);
     if (db_.db != nullptr) {
       return &db_;
     } else {
@@ -9484,6 +9624,10 @@ class Benchmark {
     delete backup_engine;
   }
 };
+
+thread_local bool Benchmark::holds_db_use_guard_ = false;
+thread_local bool Benchmark::holds_db_state_mutation_guard_ = false;
+thread_local bool Benchmark::is_secondary_update_thread_ = false;
 
 int db_bench_tool(int argc, char** argv, ToolHooks& hooks) {
   ROCKSDB_NAMESPACE::port::InstallStackTraceHandler();


### PR DESCRIPTION
### Problem

When db_bench shuts down (fatal IO error, unknown benchmark name, etc.), ErrorExit() or ~Benchmark() destroys db_/multi_dbs_ while worker threads may still be inside benchmark methods holding raw DBWithColumnFamilies pointers returned by SelectDBWithCfh(). In single-DB mode, db_.db becomes nullptr and multi_dbs_ is empty, so workers evaluate rand_int % 0 and SIGFPE. The cascade across all workers masks whatever originally triggered the shutdown. Observed in the reliable_volumes crash-fault test at ~5 SIGFPE events per hour.

### Approach

Guard DB lifetime at the worker-thread boundary with a reader-writer lock (port::RWMutex): workers acquire a read lock for the duration of their benchmark method; mutators acquire the write lock (which waits for active readers to drain) before destroying DBs. This ensures raw pointers returned by SelectDBWithCfh() remain valid for their entire usage scope.

### Fix

- Workers hold a DbUseGuard (RAII wrapper over a read lock on db_lifecycle_rwlock_) for the entire benchmark method in ThreadBody. Cost: one rdlock/unlock pair per worker lifetime, zero hot-path overhead.

- Every DB mutation path (ErrorExit, ~Benchmark, fresh-DB reopen) takes DbStateMutationGuard, which acquires the write lock and then stops the secondary update thread before mutation may proceed.

- ErrorExit() routes to std::_Exit(1) when called from any thread that cannot safely run the mutation cleanup path: a DbUseGuard holder (would self-wait on the write lock) or the secondary update thread (would self-join via StopSecondaryUpdateThread). Tracked via two thread-locals: holds_db_use_guard_ and is_secondary_update_thread_. Main thread takes DbStateMutationGuard, cleans up, dispatches through db_bench_exit() / ToolHooks::Exit.

- StopSecondaryUpdateThread() resets secondary_update_stopped_ to 0 after joining, so a replacement thread created by a subsequent Open() is not immediately killed.

- Protocol is mechanically enforced in debug builds:
    * SelectDBWithCfh asserts holds_db_use_guard_  (read-side ownership)
    * DeleteDBs        asserts holds_db_state_mutation_guard_ (write-side ownership)
    * DbUseGuard and DbStateMutationGuard ctor/dtor assert correct imbalance (no nested or stray release).
    * DbStateMutationGuard ctor additionally asserts !holds_db_use_guard_ and !is_secondary_update_thread_, catching the new deadlock modes the single-lock design makes reachable (WriteLock while holding ReadLock; secondary thread self-joining via StopSecondaryUpdateThread).
  These convert "trust me" invariants into "the assert fires if you break it." Direct field accesses (e.g. db_.db->NewIterator inside a benchmark method, multi_dbs_.clear() in the reopen branch) are protected by the enclosing guard scope but are not per-site asserted.

### Caveat

port::RWMutex is pthread_rwlock_t with default attrs -> reader-preferred on Linux/glibc. The current call graph has no concurrent worker spawn during mutator wait (mutator paths run only from the main thread, not concurrently with RunBenchmark spawning workers), so writer starvation is not reachable. Documented as a constraint; revisit if that invariant changes. The port layer doesn't expose pthread_rwlockattr_setkind_np cross-platform.

### Alternatives considered

- std::_Exit(1) on every shutdown path, skip cleanup entirely. Loses ToolHooks::Exit dispatch, flushed traces, and end-of-run stats -- those matter for the RV crash-fault test image which consumes db_bench output. Rejected.

- shared_ptr<DBWithColumnFamilies> from SelectDBWithCfh, let DB lifetime extend naturally to the last reader. Adds a per-call atomic refcount bump in the hot path; the RWMutex approach is per-method-call instead of per-op, making the hot-path cost zero. Rejected for hot-path neutrality.

Reviewed By: xingbowang

Differential Revision: D104974784


