### PR TITLE
Fix "too many open files" failures in GitHub CI

### DIFF
--- a/.github/actions/pre-steps/action.yml
+++ b/.github/actions/pre-steps/action.yml
@@ -2,6 +2,13 @@ name: pre-steps
 runs:
   using: composite
   steps:
+  - name: Dump ulimits for diagnostics
+    run: |
+      echo "=== ulimits (soft) ==="
+      ulimit -a -S || true
+      echo "=== ulimits (hard) ==="
+      ulimit -a -H || true
+    shell: bash
   - name: Install lld linker for faster builds
     run: apt-get update -y && apt-get install -y lld 2>/dev/null || true
     shell: bash

--- a/.github/workflows/pr-jobs.yml
+++ b/.github/workflows/pr-jobs.yml
@@ -373,14 +373,17 @@ jobs:
           crash_duration: 240
     container:
       image: ghcr.io/facebook/rocksdb_ubuntu:22.1
-      options: --shm-size=16gb
+      options: --shm-size=16gb --ulimit nofile=1048576:1048576
     steps:
     - uses: actions/checkout@v4.1.0
     - uses: "./.github/actions/pre-steps"
     - uses: "./.github/actions/setup-ccache"
       with:
         cache-key-prefix: mini-crashtest
-    - run: ulimit -S -n `ulimit -H -n` && make V=1 -j8 CRASH_TEST_EXT_ARGS='--duration=${{ matrix.crash_duration }} --max_key=2500000' ${{ matrix.crash_test_target }}
+    - run: |
+        ulimit -S -n $(ulimit -Hn) # Raise open files soft limit to hard limit
+        echo "Updated ulimit -Hn: $(ulimit -Hn) -Sn: $(ulimit -Sn)"
+        make V=1 -j8 CRASH_TEST_EXT_ARGS='--duration=${{ matrix.crash_duration }} --max_key=2500000' ${{ matrix.crash_test_target }}
     - uses: "./.github/actions/teardown-ccache"
       if: always()
     - uses: "./.github/actions/post-steps"


### PR DESCRIPTION
Summary: seen several times in the build-linux-mini-crashtest job. Raise ulimit in container spec.

Task: T271298423

Test Plan: look at reported ulimits, watch CI