### PR TITLE
Per-StressTest fault injection with env/fs cleanup (#14750)

### DIFF
--- a/db_stress_tool/cf_consistency_stress.cc
+++ b/db_stress_tool/cf_consistency_stress.cc
@@ -227,10 +227,10 @@ class CfConsistencyStressTest : public StressTest {
                    key, &value0);
 
       // Temporarily disable error injection for verification
-      if (fault_fs_guard) {
-        fault_fs_guard->DisableThreadLocalErrorInjection(
+      if (db_fault_injection_fs_) {
+        db_fault_injection_fs_->DisableThreadLocalErrorInjection(
             FaultInjectionIOType::kRead);
-        fault_fs_guard->DisableThreadLocalErrorInjection(
+        db_fault_injection_fs_->DisableThreadLocalErrorInjection(
             FaultInjectionIOType::kMetadataRead);
       }
 
@@ -279,10 +279,10 @@ class CfConsistencyStressTest : public StressTest {
       }
 
       //  Enable back error injection disabled for verification
-      if (fault_fs_guard) {
-        fault_fs_guard->EnableThreadLocalErrorInjection(
+      if (db_fault_injection_fs_) {
+        db_fault_injection_fs_->EnableThreadLocalErrorInjection(
             FaultInjectionIOType::kRead);
-        fault_fs_guard->EnableThreadLocalErrorInjection(
+        db_fault_injection_fs_->EnableThreadLocalErrorInjection(
             FaultInjectionIOType::kMetadataRead);
       }
       db_->ReleaseSnapshot(snapshot);
@@ -397,10 +397,10 @@ class CfConsistencyStressTest : public StressTest {
                          &cmp_result);
 
       //  Temporarily disable error injection for verification
-      if (fault_fs_guard) {
-        fault_fs_guard->DisableThreadLocalErrorInjection(
+      if (db_fault_injection_fs_) {
+        db_fault_injection_fs_->DisableThreadLocalErrorInjection(
             FaultInjectionIOType::kRead);
-        fault_fs_guard->DisableThreadLocalErrorInjection(
+        db_fault_injection_fs_->DisableThreadLocalErrorInjection(
             FaultInjectionIOType::kMetadataRead);
       }
 
@@ -559,10 +559,10 @@ class CfConsistencyStressTest : public StressTest {
       }
 
       //  Enable back error injection disabled for verification
-      if (fault_fs_guard) {
-        fault_fs_guard->EnableThreadLocalErrorInjection(
+      if (db_fault_injection_fs_) {
+        db_fault_injection_fs_->EnableThreadLocalErrorInjection(
             FaultInjectionIOType::kRead);
-        fault_fs_guard->EnableThreadLocalErrorInjection(
+        db_fault_injection_fs_->EnableThreadLocalErrorInjection(
             FaultInjectionIOType::kMetadataRead);
       }
     }

--- a/db_stress_tool/db_stress_common.cc
+++ b/db_stress_tool/db_stress_common.cc
@@ -13,14 +13,13 @@
 
 #include <cmath>
 
+#include "db_stress_tool/db_stress_test_base.h"
 #include "file/file_util.h"
 #include "rocksdb/secondary_cache.h"
 #include "util/file_checksum_helper.h"
 #include "util/xxhash.h"
 
-ROCKSDB_NAMESPACE::Env* db_stress_listener_env = nullptr;
-ROCKSDB_NAMESPACE::Env* db_stress_env = nullptr;
-std::shared_ptr<ROCKSDB_NAMESPACE::FaultInjectionTestFS> fault_fs_guard;
+ROCKSDB_NAMESPACE::Env* raw_env = nullptr;
 std::shared_ptr<ROCKSDB_NAMESPACE::SecondaryCache> compressed_secondary_cache;
 std::shared_ptr<ROCKSDB_NAMESPACE::Cache> block_cache;
 enum ROCKSDB_NAMESPACE::CompressionType compression_type_e =
@@ -114,10 +113,10 @@ void PoolSizeChangeThread(void* v) {
     if (new_thread_pool_size < 1) {
       new_thread_pool_size = 1;
     }
-    db_stress_env->SetBackgroundThreads(new_thread_pool_size,
-                                        ROCKSDB_NAMESPACE::Env::Priority::LOW);
+    raw_env->SetBackgroundThreads(new_thread_pool_size,
+                                  ROCKSDB_NAMESPACE::Env::Priority::LOW);
     // Sleep up to 3 seconds
-    db_stress_env->SleepForMicroseconds(
+    raw_env->SleepForMicroseconds(
         thread->rand.Next() % FLAGS_compaction_thread_pool_adjust_interval *
             1000 +
         1);
@@ -144,7 +143,7 @@ void DbVerificationThread(void* v) {
     if (!shared->HasVerificationFailedYet()) {
       stress_test->ContinuouslyVerifyDb(thread);
     }
-    db_stress_env->SleepForMicroseconds(
+    raw_env->SleepForMicroseconds(
         thread->rand.Next() % FLAGS_continuous_verification_interval * 1000 +
         1);
   }
@@ -166,7 +165,7 @@ void CompressedCacheSetCapacityThread(void* v) {
         return;
       }
     }
-    db_stress_env->SleepForMicroseconds(FLAGS_secondary_cache_update_interval);
+    raw_env->SleepForMicroseconds(FLAGS_secondary_cache_update_interval);
     if (FLAGS_compressed_secondary_cache_size > 0) {
       Status s = compressed_secondary_cache->SetCapacity(0);
       size_t capacity;
@@ -174,7 +173,7 @@ void CompressedCacheSetCapacityThread(void* v) {
         s = compressed_secondary_cache->GetCapacity(capacity);
         assert(capacity == 0);
       }
-      db_stress_env->SleepForMicroseconds(10 * 1000 * 1000);
+      raw_env->SleepForMicroseconds(10 * 1000 * 1000);
       if (s.ok()) {
         s = compressed_secondary_cache->SetCapacity(
             FLAGS_compressed_secondary_cache_size);
@@ -201,7 +200,7 @@ void CompressedCacheSetCapacityThread(void* v) {
         block_cache->SetCapacity(capacity - adjustment);
         fprintf(stdout, "New cache capacity = %zu\n",
                 block_cache->GetCapacity());
-        db_stress_env->SleepForMicroseconds(10 * 1000 * 1000);
+        raw_env->SleepForMicroseconds(10 * 1000 * 1000);
         block_cache->SetCapacity(capacity);
       } else {
         Status s;
@@ -214,7 +213,7 @@ void CompressedCacheSetCapacityThread(void* v) {
         s = UpdateTieredCache(block_cache, /*capacity*/ -1,
                               new_comp_cache_ratio);
         if (s.ok()) {
-          db_stress_env->SleepForMicroseconds(10 * 1000 * 1000);
+          raw_env->SleepForMicroseconds(10 * 1000 * 1000);
         }
         if (s.ok()) {
           s = UpdateTieredCache(block_cache, /*capacity*/ -1,
@@ -231,36 +230,37 @@ void CompressedCacheSetCapacityThread(void* v) {
 
 #ifndef NDEBUG
 static void SetupFaultInjectionForRemoteCompaction(SharedState* shared) {
-  if (!fault_fs_guard) {
+  auto fault_fs = shared->GetStressTest()->GetDbFaultInjectionFs();
+  if (!fault_fs) {
     return;
   }
 
-  fault_fs_guard->SetThreadLocalErrorContext(
+  fault_fs->SetThreadLocalErrorContext(
       FaultInjectionIOType::kRead, shared->GetSeed(), FLAGS_read_fault_one_in,
       FLAGS_inject_error_severity == 1 /* retryable */,
       FLAGS_inject_error_severity == 2 /* has_data_loss*/);
-  fault_fs_guard->EnableThreadLocalErrorInjection(FaultInjectionIOType::kRead);
+  fault_fs->EnableThreadLocalErrorInjection(FaultInjectionIOType::kRead);
 
-  fault_fs_guard->SetThreadLocalErrorContext(
+  fault_fs->SetThreadLocalErrorContext(
       FaultInjectionIOType::kWrite, shared->GetSeed(), FLAGS_write_fault_one_in,
       FLAGS_inject_error_severity == 1 /* retryable */,
       FLAGS_inject_error_severity == 2 /* has_data_loss*/);
-  fault_fs_guard->EnableThreadLocalErrorInjection(FaultInjectionIOType::kWrite);
+  fault_fs->EnableThreadLocalErrorInjection(FaultInjectionIOType::kWrite);
 
-  fault_fs_guard->SetThreadLocalErrorContext(
+  fault_fs->SetThreadLocalErrorContext(
       FaultInjectionIOType::kMetadataRead, shared->GetSeed(),
       FLAGS_metadata_read_fault_one_in,
       FLAGS_inject_error_severity == 1 /* retryable */,
       FLAGS_inject_error_severity == 2 /* has_data_loss*/);
-  fault_fs_guard->EnableThreadLocalErrorInjection(
+  fault_fs->EnableThreadLocalErrorInjection(
       FaultInjectionIOType::kMetadataRead);
 
-  fault_fs_guard->SetThreadLocalErrorContext(
+  fault_fs->SetThreadLocalErrorContext(
       FaultInjectionIOType::kMetadataWrite, shared->GetSeed(),
       FLAGS_metadata_write_fault_one_in,
       FLAGS_inject_error_severity == 1 /* retryable */,
       FLAGS_inject_error_severity == 2 /* has_data_loss*/);
-  fault_fs_guard->EnableThreadLocalErrorInjection(
+  fault_fs->EnableThreadLocalErrorInjection(
       FaultInjectionIOType::kMetadataWrite);
 }
 #endif  // NDEBUG
@@ -268,7 +268,7 @@ static void SetupFaultInjectionForRemoteCompaction(SharedState* shared) {
 static CompactionServiceOptionsOverride CreateOverrideOptions(
     const Options& options, const CompactionServiceJobInfo& job_info) {
   CompactionServiceOptionsOverride override_options{
-      .env = db_stress_env,
+      .env = options.env,
       .file_checksum_gen_factory = options.file_checksum_gen_factory,
       .merge_operator = options.merge_operator,
       .compaction_filter = options.compaction_filter,
@@ -311,14 +311,8 @@ static CompactionServiceOptionsOverride CreateOverrideOptions(
 }
 
 static Status CleanupOutputDirectory(const std::string& output_directory) {
-#ifndef NDEBUG
-  // Temporarily disable fault injection to ensure deletion always succeeds
-  if (fault_fs_guard) {
-    fault_fs_guard->DisableAllThreadLocalErrorInjection();
-  }
-#endif  // NDEBUG
-
-  Status s = DestroyDir(db_stress_env, output_directory);
+  // Uses raw_env (no fault injection); cleanup must always succeed.
+  Status s = DestroyDir(raw_env, output_directory);
   if (!s.ok()) {
     fprintf(stderr,
             "Failed to destroy output directory %s when allow_resumption is "
@@ -327,7 +321,7 @@ static Status CleanupOutputDirectory(const std::string& output_directory) {
   }
 
   if (s.ok()) {
-    s = db_stress_env->CreateDir(output_directory);
+    s = raw_env->CreateDir(output_directory);
     if (!s.ok()) {
       fprintf(stderr,
               "Failed to recreate output directory %s when allow_resumption is "
@@ -335,13 +329,6 @@ static Status CleanupOutputDirectory(const std::string& output_directory) {
               output_directory.c_str(), s.ToString().c_str());
     }
   }
-
-#ifndef NDEBUG
-  // Re-enable fault injection after deletion
-  if (fault_fs_guard) {
-    fault_fs_guard->EnableAllThreadLocalErrorInjection();
-  }
-#endif  // NDEBUG
 
   return s;
 }
@@ -497,7 +484,7 @@ void RemoteCompactionWorkerThread(void* v) {
           shared, stress_test, rand, successful_compaction_end_to_end_micros);
     }
 
-    db_stress_env->SleepForMicroseconds(
+    raw_env->SleepForMicroseconds(
         thread->rand.Next() % FLAGS_remote_compaction_worker_interval * 1000 +
         1);
   }
@@ -679,7 +666,7 @@ bool VerifyIteratorAttributeGroups(
 }
 
 std::string GetNowNanos() {
-  uint64_t t = db_stress_env->NowNanos();
+  uint64_t t = raw_env->NowNanos();
   std::string ret;
   PutFixed64(&ret, t);
   return ret;
@@ -691,7 +678,7 @@ uint64_t GetWriteUnixTime(ThreadState* thread) {
                FLAGS_preclude_last_level_data_seconds);
   static uint64_t kFallbackTime = std::numeric_limits<uint64_t>::max();
   int64_t write_time = 0;
-  Status s = db_stress_env->GetCurrentTime(&write_time);
+  Status s = raw_env->GetCurrentTime(&write_time);
   uint32_t write_time_mode = thread->rand.Uniform(3);
   if (write_time_mode == 0 || !s.ok()) {
     return kFallbackTime;
@@ -806,6 +793,8 @@ std::shared_ptr<FileChecksumGenFactory> GetFileChecksumImpl(
   return std::make_shared<DbStressChecksumGenFactory>(internal_name);
 }
 
+// Expected values state files are always on local filesystem (Python owns
+// this dir), so use Env::Default() (PosixEnv) even when raw_env is remote.
 Status DeleteFilesInDirectory(const std::string& dirname) {
   std::vector<std::string> filenames;
   Status s = Env::Default()->GetChildren(dirname, &filenames);
@@ -880,8 +869,12 @@ Status DestroyUnverifiedSubdir(const std::string& dirname) {
 Status DbStressDestroyDb(const std::string& db_path) {
   Status s;
   Options options;
-  // NOTE: using db_stress_listener_env in order to see obsolete MANIFEST files
-  options.env = db_stress_listener_env;
+  // Use raw_env (no DbStressFSWrapper) because DbStressFSWrapper renames
+  // MANIFEST files to MANIFEST-xxx_renamed_ instead of deleting them during
+  // normal DB operation (to preserve history for debugging). Using raw_env
+  // here ensures DestroyDB actually deletes these files. DestroyDir below
+  // catches any remaining files not known to DestroyDB.
+  options.env = raw_env;
   // Remove DB files in a principled way to avoid issues
   if (FLAGS_use_blob_db) {
     s = blob_db::DestroyBlobDB(db_path, options, blob_db::BlobDBOptions());
@@ -893,7 +886,7 @@ Status DbStressDestroyDb(const std::string& db_path) {
   }
   // Remove everything else recursively, only reporting success if able to
   // delete everything
-  return DestroyDir(db_stress_listener_env, db_path);
+  return DestroyDir(raw_env, db_path);
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -480,10 +480,11 @@ constexpr int kRandomValueMaxFactor = 3;
 constexpr int kValueMaxLen = 100;
 constexpr uint32_t kLargePrimeForCommonFactorSkew = 1872439133;
 
-// wrapped posix environment
-extern ROCKSDB_NAMESPACE::Env* db_stress_env;
-extern ROCKSDB_NAMESPACE::Env* db_stress_listener_env;
-extern std::shared_ptr<ROCKSDB_NAMESPACE::FaultInjectionTestFS> fault_fs_guard;
+// Base env from --env_uri/--fs_uri. No wrappers (no DbStressFSWrapper, no
+// fault injection). Could be PosixEnv or remote. Used for infrastructure ops
+// (threads, time, dirs, cleanup). Per-StressTest env adds fault injection +
+// DbStressFSWrapper on top for DB I/O.
+extern ROCKSDB_NAMESPACE::Env* raw_env;
 extern std::shared_ptr<ROCKSDB_NAMESPACE::SecondaryCache>
     compressed_secondary_cache;
 extern std::shared_ptr<ROCKSDB_NAMESPACE::Cache> block_cache;

--- a/db_stress_tool/db_stress_driver.cc
+++ b/db_stress_tool/db_stress_driver.cc
@@ -15,7 +15,7 @@
 
 namespace ROCKSDB_NAMESPACE {
 void ThreadBody(void* v) {
-  ThreadStatusUtil::RegisterThread(db_stress_env, ThreadStatus::USER);
+  ThreadStatusUtil::RegisterThread(raw_env, ThreadStatus::USER);
   ThreadState* thread = static_cast<ThreadState*>(v);
   SharedState* shared = thread->shared;
 
@@ -64,7 +64,7 @@ void ThreadBody(void* v) {
   ThreadStatusUtil::UnregisterThread();
 }
 bool RunStressTestImpl(SharedState* shared) {
-  SystemClock* clock = db_stress_env->GetSystemClock().get();
+  SystemClock* clock = raw_env->GetSystemClock().get();
   StressTest* stress = shared->GetStressTest();
 
   if (shared->ShouldVerifyAtBeginning() && FLAGS_preserve_unverified_changes) {
@@ -115,25 +115,24 @@ bool RunStressTestImpl(SharedState* shared) {
   std::vector<ThreadState*> threads(n);
   for (uint32_t i = 0; i < n; i++) {
     threads[i] = new ThreadState(i, shared);
-    db_stress_env->StartThread(ThreadBody, threads[i]);
+    raw_env->StartThread(ThreadBody, threads[i]);
   }
 
   ThreadState bg_thread(0, shared);
   if (FLAGS_compaction_thread_pool_adjust_interval > 0) {
-    db_stress_env->StartThread(PoolSizeChangeThread, &bg_thread);
+    raw_env->StartThread(PoolSizeChangeThread, &bg_thread);
   }
 
   ThreadState continuous_verification_thread(0, shared);
   if (FLAGS_continuous_verification_interval > 0) {
-    db_stress_env->StartThread(DbVerificationThread,
-                               &continuous_verification_thread);
+    raw_env->StartThread(DbVerificationThread, &continuous_verification_thread);
   }
 
   ThreadState compressed_cache_set_capacity_thread(0, shared);
   if (FLAGS_compressed_secondary_cache_size > 0 ||
       FLAGS_compressed_secondary_cache_ratio > 0.0) {
-    db_stress_env->StartThread(CompressedCacheSetCapacityThread,
-                               &compressed_cache_set_capacity_thread);
+    raw_env->StartThread(CompressedCacheSetCapacityThread,
+                         &compressed_cache_set_capacity_thread);
   }
 
   std::vector<ThreadState*> remote_compaction_worker_threads;
@@ -143,7 +142,7 @@ bool RunStressTestImpl(SharedState* shared) {
     for (uint32_t i = 0; i < remote_compaction_worker_thread_count; i++) {
       ThreadState* ts = new ThreadState(i, shared);
       remote_compaction_worker_threads.push_back(ts);
-      db_stress_env->StartThread(RemoteCompactionWorkerThread, ts);
+      raw_env->StartThread(RemoteCompactionWorkerThread, ts);
     }
   }
 
@@ -182,10 +181,11 @@ bool RunStressTestImpl(SharedState* shared) {
       }
 
       if (FLAGS_sync_fault_injection || FLAGS_write_fault_one_in > 0) {
-        fault_fs_guard->SetFilesystemDirectWritable(false);
-        fault_fs_guard->SetInjectUnsyncedDataLoss(FLAGS_sync_fault_injection);
+        auto fault_fs = stress->GetDbFaultInjectionFs();
+        fault_fs->SetFilesystemDirectWritable(false);
+        fault_fs->SetInjectUnsyncedDataLoss(FLAGS_sync_fault_injection);
         if (FLAGS_exclude_wal_from_write_fault_injection) {
-          fault_fs_guard->SetFileTypesExcludedFromWriteFaultInjection(
+          fault_fs->SetFileTypesExcludedFromWriteFaultInjection(
               {FileType::kWalFile});
         }
       }
@@ -280,7 +280,7 @@ bool RunStressTestImpl(SharedState* shared) {
   return true;
 }
 bool RunStressTest(SharedState* shared) {
-  ThreadStatusUtil::RegisterThread(db_stress_env, ThreadStatus::USER);
+  ThreadStatusUtil::RegisterThread(raw_env, ThreadStatus::USER);
   bool result = RunStressTestImpl(shared);
   ThreadStatusUtil::UnregisterThread();
   return result;

--- a/db_stress_tool/db_stress_listener.cc
+++ b/db_stress_tool/db_stress_listener.cc
@@ -27,7 +27,9 @@ DbStressListener::DbStressListener(
       unique_ids_(shared->GetStressTest()->GetExpectedValuesDir().empty()
                       ? db_name
                       : shared->GetStressTest()->GetExpectedValuesDir()),
-      shared_(shared) {}
+      shared_(shared),
+      db_fault_injection_fs_(shared->GetStressTest()->GetDbFaultInjectionFs()) {
+}
 
 UniqueIdVerifier::UniqueIdVerifier(const std::string& dir)
     : path_(dir + "/.unique_ids") {

--- a/db_stress_tool/db_stress_listener.h
+++ b/db_stress_tool/db_stress_listener.h
@@ -27,8 +27,6 @@
 #include "utilities/fault_injection_fs.h"
 DECLARE_int32(compact_files_one_in);
 
-extern std::shared_ptr<ROCKSDB_NAMESPACE::FaultInjectionTestFS> fault_fs_guard;
-
 namespace ROCKSDB_NAMESPACE {
 
 // Verify across process executions that all seen IDs are unique
@@ -76,8 +74,8 @@ class DbStressListener : public EventListener {
     VerifyFilePath(info.file_path);
     // pretending doing some work here
     RandomSleep();
-    if (fault_fs_guard) {
-      fault_fs_guard->DisableAllThreadLocalErrorInjection();
+    if (db_fault_injection_fs_) {
+      db_fault_injection_fs_->DisableAllThreadLocalErrorInjection();
     }
     shared_->SetPersistedSeqno(info.largest_seqno);
   }
@@ -85,37 +83,37 @@ class DbStressListener : public EventListener {
   void OnFlushBegin(DB* /*db*/,
                     const FlushJobInfo& /*flush_job_info*/) override {
     RandomSleep();
-    if (fault_fs_guard) {
-      fault_fs_guard->SetThreadLocalErrorContext(
+    if (db_fault_injection_fs_) {
+      db_fault_injection_fs_->SetThreadLocalErrorContext(
           FaultInjectionIOType::kRead, static_cast<uint32_t>(FLAGS_seed),
           FLAGS_read_fault_one_in,
           FLAGS_inject_error_severity == 1 /* retryable */,
           FLAGS_inject_error_severity == 2 /* has_data_loss*/);
-      fault_fs_guard->EnableThreadLocalErrorInjection(
+      db_fault_injection_fs_->EnableThreadLocalErrorInjection(
           FaultInjectionIOType::kRead);
 
-      fault_fs_guard->SetThreadLocalErrorContext(
+      db_fault_injection_fs_->SetThreadLocalErrorContext(
           FaultInjectionIOType::kWrite, static_cast<uint32_t>(FLAGS_seed),
           FLAGS_write_fault_one_in,
           FLAGS_inject_error_severity == 1 /* retryable */,
           FLAGS_inject_error_severity == 2 /* has_data_loss*/);
-      fault_fs_guard->EnableThreadLocalErrorInjection(
+      db_fault_injection_fs_->EnableThreadLocalErrorInjection(
           FaultInjectionIOType::kWrite);
 
-      fault_fs_guard->SetThreadLocalErrorContext(
+      db_fault_injection_fs_->SetThreadLocalErrorContext(
           FaultInjectionIOType::kMetadataRead,
           static_cast<uint32_t>(FLAGS_seed), FLAGS_metadata_read_fault_one_in,
           FLAGS_inject_error_severity == 1 /* retryable */,
           FLAGS_inject_error_severity == 2 /* has_data_loss*/);
-      fault_fs_guard->EnableThreadLocalErrorInjection(
+      db_fault_injection_fs_->EnableThreadLocalErrorInjection(
           FaultInjectionIOType::kMetadataRead);
 
-      fault_fs_guard->SetThreadLocalErrorContext(
+      db_fault_injection_fs_->SetThreadLocalErrorContext(
           FaultInjectionIOType::kMetadataWrite,
           static_cast<uint32_t>(FLAGS_seed), FLAGS_metadata_write_fault_one_in,
           FLAGS_inject_error_severity == 1 /* retryable */,
           FLAGS_inject_error_severity == 2 /* has_data_loss*/);
-      fault_fs_guard->EnableThreadLocalErrorInjection(
+      db_fault_injection_fs_->EnableThreadLocalErrorInjection(
           FaultInjectionIOType::kMetadataWrite);
     }
   }
@@ -242,44 +240,44 @@ class DbStressListener : public EventListener {
   }
 
   void OnSubcompactionBegin(const SubcompactionJobInfo& /* si */) override {
-    if (fault_fs_guard) {
-      fault_fs_guard->SetThreadLocalErrorContext(
+    if (db_fault_injection_fs_) {
+      db_fault_injection_fs_->SetThreadLocalErrorContext(
           FaultInjectionIOType::kRead, static_cast<uint32_t>(FLAGS_seed),
           FLAGS_read_fault_one_in,
           FLAGS_inject_error_severity == 1 /* retryable */,
           FLAGS_inject_error_severity == 2 /* has_data_loss*/);
-      fault_fs_guard->EnableThreadLocalErrorInjection(
+      db_fault_injection_fs_->EnableThreadLocalErrorInjection(
           FaultInjectionIOType::kRead);
 
-      fault_fs_guard->SetThreadLocalErrorContext(
+      db_fault_injection_fs_->SetThreadLocalErrorContext(
           FaultInjectionIOType::kWrite, static_cast<uint32_t>(FLAGS_seed),
           FLAGS_write_fault_one_in,
           FLAGS_inject_error_severity == 1 /* retryable */,
           FLAGS_inject_error_severity == 2 /* has_data_loss*/);
-      fault_fs_guard->EnableThreadLocalErrorInjection(
+      db_fault_injection_fs_->EnableThreadLocalErrorInjection(
           FaultInjectionIOType::kWrite);
 
-      fault_fs_guard->SetThreadLocalErrorContext(
+      db_fault_injection_fs_->SetThreadLocalErrorContext(
           FaultInjectionIOType::kMetadataRead,
           static_cast<uint32_t>(FLAGS_seed), FLAGS_metadata_read_fault_one_in,
           FLAGS_inject_error_severity == 1 /* retryable */,
           FLAGS_inject_error_severity == 2 /* has_data_loss*/);
-      fault_fs_guard->EnableThreadLocalErrorInjection(
+      db_fault_injection_fs_->EnableThreadLocalErrorInjection(
           FaultInjectionIOType::kMetadataRead);
 
-      fault_fs_guard->SetThreadLocalErrorContext(
+      db_fault_injection_fs_->SetThreadLocalErrorContext(
           FaultInjectionIOType::kMetadataWrite,
           static_cast<uint32_t>(FLAGS_seed), FLAGS_metadata_write_fault_one_in,
           FLAGS_inject_error_severity == 1 /* retryable */,
           FLAGS_inject_error_severity == 2 /* has_data_loss*/);
-      fault_fs_guard->EnableThreadLocalErrorInjection(
+      db_fault_injection_fs_->EnableThreadLocalErrorInjection(
           FaultInjectionIOType::kMetadataWrite);
     }
   }
 
   void OnSubcompactionCompleted(const SubcompactionJobInfo& /* si */) override {
-    if (fault_fs_guard) {
-      fault_fs_guard->DisableAllThreadLocalErrorInjection();
+    if (db_fault_injection_fs_) {
+      db_fault_injection_fs_->DisableAllThreadLocalErrorInjection();
     }
   }
 
@@ -372,11 +370,12 @@ class DbStressListener : public EventListener {
                             Status /* bg_error */,
                             bool* /* auto_recovery */) override {
     RandomSleep();
-    if (FLAGS_error_recovery_with_no_fault_injection && fault_fs_guard) {
-      fault_fs_guard->DisableAllThreadLocalErrorInjection();
+    if (FLAGS_error_recovery_with_no_fault_injection &&
+        db_fault_injection_fs_) {
+      db_fault_injection_fs_->DisableAllThreadLocalErrorInjection();
       // TODO(hx235): only exempt the flush thread during error recovery instead
       // of all the flush threads from error injection
-      fault_fs_guard->SetIOActivitiesExcludedFromFaultInjection(
+      db_fault_injection_fs_->SetIOActivitiesExcludedFromFaultInjection(
           {Env::IOActivity::kFlush});
     }
   }
@@ -384,9 +383,10 @@ class DbStressListener : public EventListener {
   void OnErrorRecoveryEnd(
       const BackgroundErrorRecoveryInfo& /*info*/) override {
     RandomSleep();
-    if (FLAGS_error_recovery_with_no_fault_injection && fault_fs_guard) {
-      fault_fs_guard->EnableAllThreadLocalErrorInjection();
-      fault_fs_guard->SetIOActivitiesExcludedFromFaultInjection({});
+    if (FLAGS_error_recovery_with_no_fault_injection &&
+        db_fault_injection_fs_) {
+      db_fault_injection_fs_->EnableAllThreadLocalErrorInjection();
+      db_fault_injection_fs_->SetIOActivitiesExcludedFromFaultInjection({});
     }
   }
 
@@ -477,6 +477,7 @@ class DbStressListener : public EventListener {
   std::atomic<int> num_pending_file_creations_;
   UniqueIdVerifier unique_ids_;
   SharedState* shared_;
+  std::shared_ptr<FaultInjectionTestFS> db_fault_injection_fs_;
   mutable std::mutex bg_pressure_mu_;
   BackgroundJobPressure last_bg_pressure_;
   // Files (by file_number) currently in flight from OnCompactionBegin to

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -63,6 +63,15 @@ std::shared_ptr<const FilterPolicy> CreateFilterPolicy() {
   return std::shared_ptr<const FilterPolicy>(new_policy);
 }
 
+static bool NeedsFaultInjection() {
+  return FLAGS_open_metadata_read_fault_one_in ||
+         FLAGS_open_metadata_write_fault_one_in ||
+         FLAGS_open_read_fault_one_in || FLAGS_open_write_fault_one_in ||
+         FLAGS_metadata_read_fault_one_in ||
+         FLAGS_metadata_write_fault_one_in || FLAGS_read_fault_one_in ||
+         FLAGS_write_fault_one_in || FLAGS_sync_fault_injection;
+}
+
 }  // namespace
 
 const std::string& StressTest::GetDbPath() const { return FLAGS_db; }
@@ -75,14 +84,26 @@ const std::string& StressTest::GetSecondariesBase() const {
   return FLAGS_secondaries_base;
 }
 
+Env* StressTest::GetDbEnv() const { return db_env_.get(); }
+
 StressTest::StressTest()
-    : cache_(NewCache(FLAGS_cache_size, FLAGS_cache_numshardbits)),
+    : db_stress_fs_(
+          std::make_shared<DbStressFSWrapper>(raw_env->GetFileSystem())),
+      db_fault_injection_fs_(
+          NeedsFaultInjection()
+              ? std::make_shared<FaultInjectionTestFS>(db_stress_fs_)
+              : nullptr),
+      db_env_(std::make_unique<CompositeEnvWrapper>(
+          raw_env, db_fault_injection_fs_
+                       ? std::shared_ptr<FileSystem>(db_fault_injection_fs_)
+                       : std::shared_ptr<FileSystem>(db_stress_fs_))),
+      cache_(NewCache(FLAGS_cache_size, FLAGS_cache_numshardbits)),
       filter_policy_(CreateFilterPolicy()),
       db_(nullptr),
       txn_db_(nullptr),
       optimistic_txn_db_(nullptr),
       db_aptr_(nullptr),
-      clock_(db_stress_env->GetSystemClock().get()),
+      clock_(raw_env->GetSystemClock().get()),
       new_column_family_name_(1),
       num_times_reopened_(0),
       db_preload_finished_(false),
@@ -90,6 +111,34 @@ StressTest::StressTest()
       manifest_verify_mode_(MANIFEST_VERIFY_NONE),
       manifest_file_number_before_reopen_(0),
       manifest_file_size_before_reopen_(0) {
+  if (db_fault_injection_fs_) {
+    // Info logs are debugging artifacts, so exclude them from fault injection
+    // and keep error accounting focused on DB data and metadata.
+    db_fault_injection_fs_->SetFileTypesExcludedFromFaultInjection(
+        {FileType::kInfoLogFile});
+    // Set it to direct writable here to initially bypass any fault injection
+    // during DB open. This will correspondingly be overwritten in
+    // StressTest::Open() for open fault injection and in RunStressTestImpl()
+    // for proper fault injection setup.
+    db_fault_injection_fs_->SetFilesystemDirectWritable(true);
+
+    // Set the fault injection log file path so that PrintAll() writes to a
+    // file instead of stderr (signal-safe). PrintAll() opens this path with
+    // plain POSIX open(), not through raw_env, so the log path must stay on
+    // the local filesystem. Store it in the local test directory (TEST_TMPDIR
+    // via Env::Default()) outside the DB directory so it survives DB reopen
+    // and gets included in the sandcastle db.tar.gz artifact for post-failure
+    // analysis.
+    std::string log_dir;
+    if (!Env::Default()->GetTestDirectory(&log_dir).ok() || log_dir.empty()) {
+      log_dir = "/tmp";
+    }
+    std::string log_path = log_dir + "/fault_injection_" +
+                           std::to_string(getpid()) + "_" +
+                           std::to_string(Env::Default()->NowMicros()) + ".log";
+    db_fault_injection_fs_->SetInjectedErrorLogPath(log_path);
+  }
+
   if (FLAGS_destroy_db_initially) {
     const Status s = DbStressDestroyDb(GetDbPath());
     if (!s.ok()) {
@@ -945,13 +994,13 @@ Status StressTest::CommitTxn(Transaction& txn, ThreadState* thread) {
     if (s.ok()) {
       if (thread && FLAGS_create_timestamped_snapshot_one_in &&
           thread->rand.OneIn(FLAGS_create_timestamped_snapshot_one_in)) {
-        uint64_t ts = db_stress_env->NowNanos();
+        uint64_t ts = raw_env->NowNanos();
         s = txn.CommitAndTryCreateSnapshot(/*notifier=*/nullptr, ts,
                                            &timestamped_snapshot);
 
         std::pair<Status, std::shared_ptr<const Snapshot>> res;
         if (thread->tid == 0) {
-          uint64_t now = db_stress_env->NowNanos();
+          uint64_t now = raw_env->NowNanos();
           res = txn_db_->CreateTimestampedSnapshot(now);
           if (res.first.ok()) {
             assert(res.second);
@@ -970,7 +1019,7 @@ Status StressTest::CommitTxn(Transaction& txn, ThreadState* thread) {
     }
     if (thread && FLAGS_create_timestamped_snapshot_one_in > 0 &&
         thread->rand.OneInOpt(50000)) {
-      uint64_t now = db_stress_env->NowNanos();
+      uint64_t now = raw_env->NowNanos();
       constexpr uint64_t time_diff = static_cast<uint64_t>(1000) * 1000 * 1000;
       txn_db_->ReleaseTimestampedSnapshotsOlderThan(now - time_diff);
     }
@@ -1107,37 +1156,37 @@ void StressTest::OperateDb(ThreadState* thread) {
     }
 
 #ifndef NDEBUG
-    if (fault_fs_guard) {
-      fault_fs_guard->SetThreadLocalErrorContext(
+    if (db_fault_injection_fs_) {
+      db_fault_injection_fs_->SetThreadLocalErrorContext(
           FaultInjectionIOType::kRead, thread->shared->GetSeed(),
           FLAGS_read_fault_one_in,
           FLAGS_inject_error_severity == 1 /* retryable */,
           FLAGS_inject_error_severity == 2 /* has_data_loss*/);
-      fault_fs_guard->EnableThreadLocalErrorInjection(
+      db_fault_injection_fs_->EnableThreadLocalErrorInjection(
           FaultInjectionIOType::kRead);
 
-      fault_fs_guard->SetThreadLocalErrorContext(
+      db_fault_injection_fs_->SetThreadLocalErrorContext(
           FaultInjectionIOType::kWrite, thread->shared->GetSeed(),
           FLAGS_write_fault_one_in,
           FLAGS_inject_error_severity == 1 /* retryable */,
           FLAGS_inject_error_severity == 2 /* has_data_loss*/);
-      fault_fs_guard->EnableThreadLocalErrorInjection(
+      db_fault_injection_fs_->EnableThreadLocalErrorInjection(
           FaultInjectionIOType::kWrite);
 
-      fault_fs_guard->SetThreadLocalErrorContext(
+      db_fault_injection_fs_->SetThreadLocalErrorContext(
           FaultInjectionIOType::kMetadataRead, thread->shared->GetSeed(),
           FLAGS_metadata_read_fault_one_in,
           FLAGS_inject_error_severity == 1 /* retryable */,
           FLAGS_inject_error_severity == 2 /* has_data_loss*/);
-      fault_fs_guard->EnableThreadLocalErrorInjection(
+      db_fault_injection_fs_->EnableThreadLocalErrorInjection(
           FaultInjectionIOType::kMetadataRead);
 
-      fault_fs_guard->SetThreadLocalErrorContext(
+      db_fault_injection_fs_->SetThreadLocalErrorContext(
           FaultInjectionIOType::kMetadataWrite, thread->shared->GetSeed(),
           FLAGS_metadata_write_fault_one_in,
           FLAGS_inject_error_severity == 1 /* retryable */,
           FLAGS_inject_error_severity == 2 /* has_data_loss*/);
-      fault_fs_guard->EnableThreadLocalErrorInjection(
+      db_fault_injection_fs_->EnableThreadLocalErrorInjection(
           FaultInjectionIOType::kMetadataWrite);
     }
 #endif  // NDEBUG
@@ -1160,13 +1209,13 @@ void StressTest::OperateDb(ThreadState* thread) {
       if (thread->tid == 0 && FLAGS_verify_db_one_in > 0 &&
           thread->rand.OneIn(FLAGS_verify_db_one_in)) {
         //  Temporarily disable error injection for verification
-        if (fault_fs_guard) {
-          fault_fs_guard->DisableAllThreadLocalErrorInjection();
+        if (db_fault_injection_fs_) {
+          db_fault_injection_fs_->DisableAllThreadLocalErrorInjection();
         }
         ContinuouslyVerifyDb(thread);
         //  Enable back error injection disabled for verification
-        if (fault_fs_guard) {
-          fault_fs_guard->EnableAllThreadLocalErrorInjection();
+        if (db_fault_injection_fs_) {
+          db_fault_injection_fs_->EnableAllThreadLocalErrorInjection();
         }
         if (thread->shared->ShouldStopTest()) {
           break;
@@ -1191,8 +1240,8 @@ void StressTest::OperateDb(ThreadState* thread) {
           fprintf(stderr, "LockWAL() failed: %s\n", s.ToString().c_str());
         } else if (s.ok()) {
           //  Temporarily disable error injection for verification
-          if (fault_fs_guard) {
-            fault_fs_guard->DisableAllThreadLocalErrorInjection();
+          if (db_fault_injection_fs_) {
+            db_fault_injection_fs_->DisableAllThreadLocalErrorInjection();
           }
 
           // Verify no writes during LockWAL
@@ -1246,8 +1295,8 @@ void StressTest::OperateDb(ThreadState* thread) {
           }
 
           //  Enable back error injection disabled for verification
-          if (fault_fs_guard) {
-            fault_fs_guard->EnableAllThreadLocalErrorInjection();
+          if (db_fault_injection_fs_) {
+            db_fault_injection_fs_->EnableAllThreadLocalErrorInjection();
           }
         }
       }
@@ -1364,14 +1413,14 @@ void StressTest::OperateDb(ThreadState* thread) {
         // TestGetProperty doesn't return status for us to tell whether it has
         // failed due to injected error. So we disable fault injection to avoid
         // false positive
-        if (fault_fs_guard) {
-          fault_fs_guard->DisableAllThreadLocalErrorInjection();
+        if (db_fault_injection_fs_) {
+          db_fault_injection_fs_->DisableAllThreadLocalErrorInjection();
         }
 
         TestGetProperty(thread);
 
-        if (fault_fs_guard) {
-          fault_fs_guard->EnableAllThreadLocalErrorInjection();
+        if (db_fault_injection_fs_) {
+          db_fault_injection_fs_->EnableAllThreadLocalErrorInjection();
         }
       }
 
@@ -1392,7 +1441,7 @@ void StressTest::OperateDb(ThreadState* thread) {
         uint64_t total_size = 0;
         if (FLAGS_backup_max_size > 0) {
           std::vector<FileAttributes> files;
-          db_stress_env->GetChildrenFileAttributes(GetDbPath(), &files);
+          GetDbEnv()->GetChildrenFileAttributes(GetDbPath(), &files);
           for (auto& file : files) {
             total_size += file.size_bytes;
           }
@@ -1401,12 +1450,12 @@ void StressTest::OperateDb(ThreadState* thread) {
         if (total_size <= FLAGS_backup_max_size) {
           // TODO(hx235): enable error injection with
           // backup/restore after fixing the various issues it surfaces
-          if (fault_fs_guard) {
-            fault_fs_guard->DisableAllThreadLocalErrorInjection();
+          if (db_fault_injection_fs_) {
+            db_fault_injection_fs_->DisableAllThreadLocalErrorInjection();
           }
           Status s = TestBackupRestore(thread, rand_column_families, rand_keys);
-          if (fault_fs_guard) {
-            fault_fs_guard->EnableAllThreadLocalErrorInjection();
+          if (db_fault_injection_fs_) {
+            db_fault_injection_fs_->EnableAllThreadLocalErrorInjection();
           }
           ProcessStatus(shared, "Backup/restore", s);
         }
@@ -1449,7 +1498,7 @@ void StressTest::OperateDb(ThreadState* thread) {
       // tolerated. Keep fault injection disabled during user writes until each
       // injected failure mode is audited against that contract.
       bool disable_fault_injection_during_user_write =
-          fault_fs_guard && MightHaveUnsyncedDataLoss();
+          db_fault_injection_fs_ && MightHaveUnsyncedDataLoss();
       int prob_op = thread->rand.Uniform(100);
       // Reset this in case we pick something other than a read op. We don't
       // want to use a stale value when deciding at the beginning of the loop
@@ -1509,32 +1558,32 @@ void StressTest::OperateDb(ThreadState* thread) {
         assert(prefix_bound <= prob_op);
         // OPERATION write
         if (disable_fault_injection_during_user_write) {
-          fault_fs_guard->DisableAllThreadLocalErrorInjection();
+          db_fault_injection_fs_->DisableAllThreadLocalErrorInjection();
         }
         TestPut(thread, write_opts, read_opts, rand_column_families, rand_keys,
                 value);
         if (disable_fault_injection_during_user_write) {
-          fault_fs_guard->EnableAllThreadLocalErrorInjection();
+          db_fault_injection_fs_->EnableAllThreadLocalErrorInjection();
         }
       } else if (prob_op < del_bound) {
         assert(write_bound <= prob_op);
         // OPERATION delete
         if (disable_fault_injection_during_user_write) {
-          fault_fs_guard->DisableAllThreadLocalErrorInjection();
+          db_fault_injection_fs_->DisableAllThreadLocalErrorInjection();
         }
         TestDelete(thread, write_opts, rand_column_families, rand_keys);
         if (disable_fault_injection_during_user_write) {
-          fault_fs_guard->EnableAllThreadLocalErrorInjection();
+          db_fault_injection_fs_->EnableAllThreadLocalErrorInjection();
         }
       } else if (prob_op < delrange_bound) {
         assert(del_bound <= prob_op);
         // OPERATION delete range
         if (disable_fault_injection_during_user_write) {
-          fault_fs_guard->DisableAllThreadLocalErrorInjection();
+          db_fault_injection_fs_->DisableAllThreadLocalErrorInjection();
         }
         TestDeleteRange(thread, write_opts, rand_column_families, rand_keys);
         if (disable_fault_injection_during_user_write) {
-          fault_fs_guard->EnableAllThreadLocalErrorInjection();
+          db_fault_injection_fs_->EnableAllThreadLocalErrorInjection();
         }
       } else if (prob_op < iterate_bound) {
         assert(delrange_bound <= prob_op);
@@ -1592,8 +1641,8 @@ void StressTest::OperateDb(ThreadState* thread) {
     }
 
 #ifndef NDEBUG
-    if (fault_fs_guard) {
-      fault_fs_guard->DisableAllThreadLocalErrorInjection();
+    if (db_fault_injection_fs_) {
+      db_fault_injection_fs_->DisableAllThreadLocalErrorInjection();
     }
 #endif  // NDEBUG
   }
@@ -2586,7 +2635,7 @@ Status StressTest::TestBackupRestore(
   std::ostringstream restore_opts_oss;
   BackupEngine* backup_engine = nullptr;
   std::string from = "a backup/restore operation";
-  Status s = BackupEngine::Open(db_stress_env, backup_opts, &backup_engine);
+  Status s = BackupEngine::Open(GetDbEnv(), backup_opts, &backup_engine);
   if (!s.ok()) {
     from = "BackupEngine::Open";
   }
@@ -2646,7 +2695,7 @@ Status StressTest::TestBackupRestore(
   if (s.ok()) {
     delete backup_engine;
     backup_engine = nullptr;
-    s = BackupEngine::Open(db_stress_env, backup_opts, &backup_engine);
+    s = BackupEngine::Open(GetDbEnv(), backup_opts, &backup_engine);
     if (!s.ok()) {
       from = "BackupEngine::Open (again)";
     }
@@ -2816,14 +2865,14 @@ Status StressTest::TestBackupRestore(
   }
 
   // Temporarily disable error injection for clean up
-  if (fault_fs_guard) {
-    fault_fs_guard->DisableAllThreadLocalErrorInjection();
+  if (db_fault_injection_fs_) {
+    db_fault_injection_fs_->DisableAllThreadLocalErrorInjection();
   }
 
   if (s.ok() || IsErrorInjectedAndRetryable(s)) {
     // Preserve directories on failure, or allowed persistent backup
     if (!allow_persistent) {
-      s = DestroyDir(db_stress_env, backup_dir);
+      s = DestroyDir(GetDbEnv(), backup_dir);
       if (!s.ok()) {
         from = "Destroy backup dir";
       }
@@ -2831,15 +2880,15 @@ Status StressTest::TestBackupRestore(
   }
 
   if (s.ok() || IsErrorInjectedAndRetryable(s)) {
-    s = DestroyDir(db_stress_env, restore_dir);
+    s = DestroyDir(GetDbEnv(), restore_dir);
     if (!s.ok()) {
       from = "Destroy restore dir";
     }
   }
 
   // Enable back error injection disabled for clean up
-  if (fault_fs_guard) {
-    fault_fs_guard->EnableAllThreadLocalErrorInjection();
+  if (db_fault_injection_fs_) {
+    db_fault_injection_fs_->EnableAllThreadLocalErrorInjection();
   }
 
   if (!s.ok() && !IsErrorInjectedAndRetryable(s)) {
@@ -2984,17 +3033,17 @@ Status StressTest::TestCheckpoint(ThreadState* thread,
       GetDbPath() + "/.checkpoint" + std::to_string(thread->tid);
   Options tmp_opts(options_);
   tmp_opts.listeners.clear();
-  tmp_opts.env = db_stress_env;
+  tmp_opts.env = GetDbEnv();
   // Avoid delayed deletion so whole directory can be deleted
   tmp_opts.sst_file_manager.reset();
   //  Temporarily disable error injection for clean-up
-  if (fault_fs_guard) {
-    fault_fs_guard->DisableAllThreadLocalErrorInjection();
+  if (db_fault_injection_fs_) {
+    db_fault_injection_fs_->DisableAllThreadLocalErrorInjection();
   }
   DestroyDB(checkpoint_dir, tmp_opts);
   // Enable back error injection disabled for clean-up
-  if (fault_fs_guard) {
-    fault_fs_guard->EnableAllThreadLocalErrorInjection();
+  if (db_fault_injection_fs_) {
+    db_fault_injection_fs_->EnableAllThreadLocalErrorInjection();
   }
   Checkpoint* checkpoint = nullptr;
   Status s = Checkpoint::Create(db_, &checkpoint);
@@ -3006,17 +3055,17 @@ Status StressTest::TestCheckpoint(ThreadState* thread,
       std::vector<std::string> files;
 
       // Temporarily disable error injection to print debugging information
-      if (fault_fs_guard) {
-        fault_fs_guard->DisableThreadLocalErrorInjection(
+      if (db_fault_injection_fs_) {
+        db_fault_injection_fs_->DisableThreadLocalErrorInjection(
             FaultInjectionIOType::kMetadataRead);
       }
 
-      Status my_s = db_stress_env->GetChildren(checkpoint_dir, &files);
+      Status my_s = GetDbEnv()->GetChildren(checkpoint_dir, &files);
 
       // Enable back disable error injection disabled for printing debugging
       // information
-      if (fault_fs_guard) {
-        fault_fs_guard->EnableThreadLocalErrorInjection(
+      if (db_fault_injection_fs_) {
+        db_fault_injection_fs_->EnableThreadLocalErrorInjection(
             FaultInjectionIOType::kMetadataRead);
       }
       if (!my_s.ok()) {
@@ -3100,8 +3149,8 @@ Status StressTest::TestCheckpoint(ThreadState* thread,
   }
 
   //  Temporarily disable error injection for clean-up
-  if (fault_fs_guard) {
-    fault_fs_guard->DisableAllThreadLocalErrorInjection();
+  if (db_fault_injection_fs_) {
+    db_fault_injection_fs_->DisableAllThreadLocalErrorInjection();
   }
 
   if (!s.ok() && !IsErrorInjectedAndRetryable(s)) {
@@ -3112,8 +3161,8 @@ Status StressTest::TestCheckpoint(ThreadState* thread,
   }
 
   // Enable back error injection disabled for clean-up
-  if (fault_fs_guard) {
-    fault_fs_guard->EnableAllThreadLocalErrorInjection();
+  if (db_fault_injection_fs_) {
+    db_fault_injection_fs_->EnableAllThreadLocalErrorInjection();
   }
   return s;
 }
@@ -3504,8 +3553,8 @@ void StressTest::TestCompactRange(ThreadState* thread, int64_t rand_key,
   uint32_t pre_hash = 0;
   if (thread->rand.OneIn(2)) {
     // Temporarily disable error injection to for validation
-    if (fault_fs_guard) {
-      fault_fs_guard->DisableAllThreadLocalErrorInjection();
+    if (db_fault_injection_fs_) {
+      db_fault_injection_fs_->DisableAllThreadLocalErrorInjection();
     }
 
     // Declare a snapshot and compare the data before and after the compaction
@@ -3514,8 +3563,8 @@ void StressTest::TestCompactRange(ThreadState* thread, int64_t rand_key,
         GetRangeHash(thread, pre_snapshot, column_family, start_key, end_key);
 
     // Enable back error injection disabled for validation
-    if (fault_fs_guard) {
-      fault_fs_guard->EnableAllThreadLocalErrorInjection();
+    if (db_fault_injection_fs_) {
+      db_fault_injection_fs_->EnableAllThreadLocalErrorInjection();
     }
   }
   std::ostringstream compact_range_opt_oss;
@@ -3552,8 +3601,8 @@ void StressTest::TestCompactRange(ThreadState* thread, int64_t rand_key,
 
   if (pre_snapshot != nullptr) {
     // Temporarily disable error injection for validation
-    if (fault_fs_guard) {
-      fault_fs_guard->DisableAllThreadLocalErrorInjection();
+    if (db_fault_injection_fs_) {
+      db_fault_injection_fs_->DisableAllThreadLocalErrorInjection();
     }
     uint32_t post_hash =
         GetRangeHash(thread, pre_snapshot, column_family, start_key, end_key);
@@ -3570,9 +3619,9 @@ void StressTest::TestCompactRange(ThreadState* thread, int64_t rand_key,
       thread->shared->SetVerificationFailure();
     }
     db_->ReleaseSnapshot(pre_snapshot);
-    if (fault_fs_guard) {
+    if (db_fault_injection_fs_) {
       // Enable back error injection disabled for validation
-      fault_fs_guard->EnableAllThreadLocalErrorInjection();
+      db_fault_injection_fs_->EnableAllThreadLocalErrorInjection();
     }
   }
 }
@@ -3850,6 +3899,26 @@ void StressTest::Open(SharedState* shared, bool reopen) {
     InitializeOptionsFromFlags(cache_, filter_policy_, udi_factory_, options_);
   }
   InitializeOptionsGeneral(cache_, filter_policy_, sqfc_factory_, options_);
+  // InitializeOptions* helpers set options_.env = raw_env (no fault injection).
+  // Override with per-StressTest env that includes FaultInjectionTestFS +
+  // DbStressFSWrapper for all DB I/O.
+  options_.env = GetDbEnv();
+  // InitializeOptionsGeneral creates SstFileManager with raw_env. Override
+  // with per-StressTest env so file deletions go through DbStressFSWrapper.
+  if (options_.sst_file_manager) {
+    Status status;
+    options_.sst_file_manager.reset(NewSstFileManager(
+        GetDbEnv(), options_.info_log, "" /* trash_dir */,
+        static_cast<int64_t>(FLAGS_sst_file_manager_bytes_per_sec),
+        true /* delete_existing_trash */, &status,
+        0.25 /* max_trash_db_ratio */,
+        FLAGS_sst_file_manager_bytes_per_truncate));
+    if (!status.ok()) {
+      fprintf(stderr, "SstFileManager creation failed: %s\n",
+              status.ToString().c_str());
+      exit(1);
+    }
+  }
   DbStressCustomCompressionManager::Register();
 
   if (!strcasecmp(FLAGS_compression_manager.c_str(), "custom")) {
@@ -4009,8 +4078,8 @@ void StressTest::Open(SharedState* shared, bool reopen) {
 
     // If this is for DB reopen,  error injection may have been enabled.
     // Disable it here in case there is no open fault injection.
-    if (fault_fs_guard) {
-      fault_fs_guard->DisableAllThreadLocalErrorInjection();
+    if (db_fault_injection_fs_) {
+      db_fault_injection_fs_->DisableAllThreadLocalErrorInjection();
     }
     // TODO; test transaction DB Open with fault injection
     if (!FLAGS_use_txn) {
@@ -4024,40 +4093,41 @@ void StressTest::Open(SharedState* shared, bool reopen) {
       if ((inject_sync_fault || inject_open_meta_read_error ||
            inject_open_meta_write_error || inject_open_read_error ||
            inject_open_write_error) &&
-          fault_fs_guard->FileExists(db_path + "/CURRENT", IOOptions(), nullptr)
+          db_fault_injection_fs_
+              ->FileExists(db_path + "/CURRENT", IOOptions(), nullptr)
               .ok()) {
         if (inject_sync_fault || inject_open_write_error) {
-          fault_fs_guard->SetFilesystemDirectWritable(false);
-          fault_fs_guard->SetInjectUnsyncedDataLoss(inject_sync_fault);
+          db_fault_injection_fs_->SetFilesystemDirectWritable(false);
+          db_fault_injection_fs_->SetInjectUnsyncedDataLoss(inject_sync_fault);
         }
-        fault_fs_guard->SetThreadLocalErrorContext(
+        db_fault_injection_fs_->SetThreadLocalErrorContext(
             FaultInjectionIOType::kMetadataRead,
             static_cast<uint32_t>(FLAGS_seed),
             FLAGS_open_metadata_read_fault_one_in, false /* retryable */,
             false /* has_data_loss */);
-        fault_fs_guard->EnableThreadLocalErrorInjection(
+        db_fault_injection_fs_->EnableThreadLocalErrorInjection(
             FaultInjectionIOType::kMetadataRead);
 
-        fault_fs_guard->SetThreadLocalErrorContext(
+        db_fault_injection_fs_->SetThreadLocalErrorContext(
             FaultInjectionIOType::kMetadataWrite,
             static_cast<uint32_t>(FLAGS_seed),
             FLAGS_open_metadata_write_fault_one_in, false /* retryable */,
             false /* has_data_loss */);
-        fault_fs_guard->EnableThreadLocalErrorInjection(
+        db_fault_injection_fs_->EnableThreadLocalErrorInjection(
             FaultInjectionIOType::kMetadataWrite);
 
-        fault_fs_guard->SetThreadLocalErrorContext(
+        db_fault_injection_fs_->SetThreadLocalErrorContext(
             FaultInjectionIOType::kRead, static_cast<uint32_t>(FLAGS_seed),
             FLAGS_open_read_fault_one_in, false /* retryable */,
             false /* has_data_loss */);
-        fault_fs_guard->EnableThreadLocalErrorInjection(
+        db_fault_injection_fs_->EnableThreadLocalErrorInjection(
             FaultInjectionIOType::kRead);
 
-        fault_fs_guard->SetThreadLocalErrorContext(
+        db_fault_injection_fs_->SetThreadLocalErrorContext(
             FaultInjectionIOType::kWrite, static_cast<uint32_t>(FLAGS_seed),
             FLAGS_open_write_fault_one_in, false /* retryable */,
             false /* has_data_loss */);
-        fault_fs_guard->EnableThreadLocalErrorInjection(
+        db_fault_injection_fs_->EnableThreadLocalErrorInjection(
             FaultInjectionIOType::kWrite);
       }
       while (true) {
@@ -4092,7 +4162,7 @@ void StressTest::Open(SharedState* shared, bool reopen) {
         if (inject_sync_fault || inject_open_meta_read_error ||
             inject_open_meta_write_error || inject_open_read_error ||
             inject_open_write_error) {
-          fault_fs_guard->DisableAllThreadLocalErrorInjection();
+          db_fault_injection_fs_->DisableAllThreadLocalErrorInjection();
 
           if (s.ok()) {
             // Injected errors might happen in background compactions. We
@@ -4122,13 +4192,13 @@ void StressTest::Open(SharedState* shared, bool reopen) {
             if (!reopen) {
               Random rand(static_cast<uint32_t>(FLAGS_seed));
               if (rand.OneIn(2)) {
-                fault_fs_guard->DeleteFilesCreatedAfterLastDirSync(IOOptions(),
-                                                                   nullptr);
+                db_fault_injection_fs_->DeleteFilesCreatedAfterLastDirSync(
+                    IOOptions(), nullptr);
               }
               if (rand.OneIn(3)) {
-                fault_fs_guard->DropUnsyncedFileData();
+                db_fault_injection_fs_->DropUnsyncedFileData();
               } else if (rand.OneIn(2)) {
-                fault_fs_guard->DropRandomUnsyncedFileData(&rand);
+                db_fault_injection_fs_->DropRandomUnsyncedFileData(&rand);
               }
             }
             // DB::Open() can fail after scheduling background compaction. Use
@@ -4232,7 +4302,7 @@ void StressTest::Open(SharedState* shared, bool reopen) {
       Options tmp_opts;
       // TODO(yanqin) support max_open_files != -1 for secondary instance.
       tmp_opts.max_open_files = -1;
-      tmp_opts.env = db_stress_env;
+      tmp_opts.env = GetDbEnv();
       const std::string& secondary_path = GetSecondariesBase();
       s = DB::OpenAsSecondary(tmp_opts, db_path, secondary_path, cf_descriptors,
                               &secondary_cfhs_, &secondary_db_);
@@ -4622,7 +4692,7 @@ bool StressTest::MaybeUseOlderTimestampForPointLookup(ThreadState* thread,
   assert(shared);
   const uint64_t start_ts = shared->GetStartTimestamp();
 
-  uint64_t now = db_stress_env->NowNanos();
+  uint64_t now = raw_env->NowNanos();
 
   assert(now > start_ts);
   uint64_t time_diff = now - start_ts;
@@ -4659,7 +4729,7 @@ void StressTest::MaybeUseOlderTimestampForRangeScan(ThreadState* thread,
   assert(shared);
   const uint64_t start_ts = shared->GetStartTimestamp();
 
-  uint64_t now = db_stress_env->NowNanos();
+  uint64_t now = raw_env->NowNanos();
 
   assert(now > start_ts);
   uint64_t time_diff = now - start_ts;
@@ -4719,7 +4789,7 @@ bool InitializeOptionsFromFile(Options& options) {
   ConfigOptions config_options;
   config_options.ignore_unknown_options = false;
   config_options.input_strings_escaped = true;
-  config_options.env = db_stress_env;
+  config_options.env = raw_env;
   std::vector<ColumnFamilyDescriptor> cf_descriptors;
   if (!FLAGS_options_file.empty()) {
     Status s = LoadOptionsFromFile(config_options, FLAGS_options_file,
@@ -4729,7 +4799,7 @@ bool InitializeOptionsFromFile(Options& options) {
               FLAGS_options_file.c_str(), s.ToString().c_str());
       exit(1);
     }
-    db_options.env = new CompositeEnvWrapper(db_stress_env);
+    db_options.env = new CompositeEnvWrapper(raw_env);
     options = Options(db_options, cf_descriptors[0].options);
     return true;
   }
@@ -4901,7 +4971,7 @@ void InitializeOptionsFromFlags(
   if (FLAGS_statistics) {
     options.statistics = ROCKSDB_NAMESPACE::CreateDBStatistics();
   }
-  options.env = db_stress_env;
+  options.env = raw_env;
   options.use_fsync = FLAGS_use_fsync;
   options.compaction_readahead_size = FLAGS_compaction_readahead_size;
   options.allow_mmap_reads = FLAGS_mmap_read;
@@ -5178,7 +5248,7 @@ void InitializeOptionsGeneral(
   }
 
   if (options.env == Options().env) {
-    options.env = db_stress_env;
+    options.env = raw_env;
   }
 
   assert(options.table_factory);
@@ -5210,22 +5280,6 @@ void InitializeOptionsGeneral(
         GetFileChecksumImpl(FLAGS_file_checksum_impl);
   }
 
-  if (FLAGS_sst_file_manager_bytes_per_sec > 0 ||
-      FLAGS_sst_file_manager_bytes_per_truncate > 0) {
-    Status status;
-    options.sst_file_manager.reset(NewSstFileManager(
-        db_stress_env, options.info_log, "" /* trash_dir */,
-        static_cast<int64_t>(FLAGS_sst_file_manager_bytes_per_sec),
-        true /* delete_existing_trash */, &status,
-        0.25 /* max_trash_db_ratio */,
-        FLAGS_sst_file_manager_bytes_per_truncate));
-    if (!status.ok()) {
-      fprintf(stderr, "SstFileManager creation failed: %s\n",
-              status.ToString().c_str());
-      exit(1);
-    }
-  }
-
   if (FLAGS_preserve_unverified_changes) {
     if (!options.avoid_flush_during_recovery) {
       fprintf(stderr,
@@ -5246,6 +5300,22 @@ void InitializeOptionsGeneral(
     // `DB::Open()` and `DisableFileDeletions()` due to flush or compaction.
     // We do not need to warn the user since we will reenable compaction soon.
     options.disable_auto_compactions = true;
+  }
+
+  if (FLAGS_sst_file_manager_bytes_per_sec > 0 ||
+      FLAGS_sst_file_manager_bytes_per_truncate > 0) {
+    Status status;
+    options.sst_file_manager.reset(NewSstFileManager(
+        raw_env, options.info_log, "" /* trash_dir */,
+        static_cast<int64_t>(FLAGS_sst_file_manager_bytes_per_sec),
+        true /* delete_existing_trash */, &status,
+        0.25 /* max_trash_db_ratio */,
+        FLAGS_sst_file_manager_bytes_per_truncate));
+    if (!status.ok()) {
+      fprintf(stderr, "SstFileManager creation failed: %s\n",
+              status.ToString().c_str());
+      exit(1);
+    }
   }
 
   options.table_properties_collector_factories.clear();

--- a/db_stress_tool/db_stress_test_base.h
+++ b/db_stress_tool/db_stress_test_base.h
@@ -13,6 +13,7 @@
 
 #include "db_stress_tool/db_stress_common.h"
 #include "db_stress_tool/db_stress_shared_state.h"
+#include "env/composite_env_wrapper.h"
 #include "rocksdb/experimental.h"
 #include "rocksdb/user_defined_index.h"
 #include "utilities/fault_injection_fs.h"
@@ -22,6 +23,7 @@ class SystemClock;
 class Transaction;
 class TransactionDB;
 class OptimisticTransactionDB;
+class DbStressFSWrapper;
 struct TransactionDBOptions;
 using experimental::SstQueryFilterConfigsManager;
 
@@ -47,6 +49,14 @@ class StressTest {
   const std::string& GetDbPath() const;
   const std::string& GetExpectedValuesDir() const;
   const std::string& GetSecondariesBase() const;
+
+  // See db_fault_injection_fs_ member.
+  std::shared_ptr<FaultInjectionTestFS> GetDbFaultInjectionFs() const {
+    return db_fault_injection_fs_;
+  }
+
+  // See db_env_ member.
+  Env* GetDbEnv() const;
 
   std::shared_ptr<Cache> NewCache(size_t capacity, int32_t num_shard_bits);
 
@@ -94,39 +104,34 @@ class StressTest {
     }
   }
 
-  void UpdateIfInitialWriteFails(Env* db_stress_env, const Status& write_s,
+  void UpdateIfInitialWriteFails(Env* env, const Status& write_s,
                                  Status* initial_write_s,
                                  bool* initial_wal_write_may_succeed,
                                  uint64_t* wait_for_recover_start_time,
                                  bool commit_bypass_memtable = false) {
-    assert(db_stress_env && initial_write_s && initial_wal_write_may_succeed &&
+    assert(env && initial_write_s && initial_wal_write_may_succeed &&
            wait_for_recover_start_time);
-    // Only update `initial_write_s`, `initial_wal_write_may_succeed` when the
-    // first write fails
     if (!write_s.ok() && (*initial_write_s).ok()) {
       *initial_write_s = write_s;
-      // With commit_bypass_memtable, we create a new WAL after WAL write
-      // succeeds, that wal creation may fail due to injected error. So the
-      // initial wal write may succeed even if status is failed to write to wal
       *initial_wal_write_may_succeed =
           commit_bypass_memtable ||
           !FaultInjectionTestFS::IsFailedToWriteToWALError(*initial_write_s);
-      *wait_for_recover_start_time = db_stress_env->NowMicros();
+      *wait_for_recover_start_time = env->NowMicros();
     }
   }
 
-  void PrintWriteRecoveryWaitTimeIfNeeded(Env* db_stress_env,
+  void PrintWriteRecoveryWaitTimeIfNeeded(Env* env,
                                           const Status& initial_write_s,
                                           bool initial_wal_write_may_succeed,
                                           uint64_t wait_for_recover_start_time,
                                           const std::string& thread_name) {
-    assert(db_stress_env);
+    assert(env);
     bool waited_for_recovery = !initial_write_s.ok() &&
                                IsErrorInjectedAndRetryable(initial_write_s) &&
                                initial_wal_write_may_succeed;
     if (waited_for_recovery) {
       uint64_t elapsed_sec =
-          (db_stress_env->NowMicros() - wait_for_recover_start_time) / 1000000;
+          (env->NowMicros() - wait_for_recover_start_time) / 1000000;
       if (elapsed_sec > 10) {
         fprintf(stdout,
                 "%s thread slept to wait for write recovery for "
@@ -455,6 +460,12 @@ class StressTest {
   void RecordManifestStateBeforeReopen();
   void VerifyManifestNotRewritten();
 
+  // Wraps raw_env->GetFileSystem(). See DbStressFSWrapper.
+  std::shared_ptr<DbStressFSWrapper> db_stress_fs_;
+  // Wraps db_stress_fs_ when NeedsFaultInjection(). Null otherwise.
+  std::shared_ptr<FaultInjectionTestFS> db_fault_injection_fs_;
+  // Wraps the outermost FS above. Set as options_.env for all DB I/O.
+  std::unique_ptr<CompositeEnvWrapper> db_env_;
   std::shared_ptr<Cache> cache_;
   std::shared_ptr<Cache> compressed_cache_;
   std::shared_ptr<const FilterPolicy> filter_policy_;

--- a/db_stress_tool/db_stress_tool.cc
+++ b/db_stress_tool/db_stress_tool.cc
@@ -33,11 +33,11 @@
 namespace ROCKSDB_NAMESPACE {
 namespace {
 static std::shared_ptr<ROCKSDB_NAMESPACE::Env> env_guard;
-static std::shared_ptr<ROCKSDB_NAMESPACE::Env> env_wrapper_guard;
 static std::shared_ptr<ROCKSDB_NAMESPACE::Env> legacy_env_wrapper_guard;
-static std::shared_ptr<ROCKSDB_NAMESPACE::CompositeEnvWrapper>
-    dbsl_env_wrapper_guard;
-static std::shared_ptr<CompositeEnvWrapper> fault_env_guard;
+// Raw pointer for signal-safe crash callback. Signal handlers can only access
+// file-static/global variables -- they can't capture StressTest instance.
+static ROCKSDB_NAMESPACE::FaultInjectionTestFS* fault_fs_for_crash_report =
+    nullptr;
 
 int ReturnFlagValidationError(const char* message) {
   std::cerr << "Error: " << message << '\n';
@@ -67,8 +67,6 @@ int db_stress_tool(int argc, char** argv) {
       StringToCompressionType(FLAGS_bottommost_compression_type.c_str());
   checksum_type_e = StringToChecksumType(FLAGS_checksum_type.c_str());
 
-  Env* raw_env;
-
   int env_opts = !FLAGS_env_uri.empty() + !FLAGS_fs_uri.empty();
   if (env_opts > 1) {
     fprintf(stderr, "Error: --env_uri and --fs_uri are mutually exclusive\n");
@@ -82,45 +80,6 @@ int db_stress_tool(int argc, char** argv) {
             s.ToString().c_str());
     exit(1);
   }
-  dbsl_env_wrapper_guard = std::make_shared<CompositeEnvWrapper>(raw_env);
-  db_stress_listener_env = dbsl_env_wrapper_guard.get();
-
-  if (FLAGS_open_metadata_read_fault_one_in ||
-      FLAGS_open_metadata_write_fault_one_in || FLAGS_open_read_fault_one_in ||
-      FLAGS_open_write_fault_one_in || FLAGS_metadata_read_fault_one_in ||
-      FLAGS_metadata_write_fault_one_in || FLAGS_read_fault_one_in ||
-      FLAGS_write_fault_one_in || FLAGS_sync_fault_injection) {
-    FaultInjectionTestFS* fs =
-        new FaultInjectionTestFS(raw_env->GetFileSystem());
-    fault_fs_guard.reset(fs);
-    // Info logs are debugging artifacts, so exclude them from fault injection
-    // and keep error accounting focused on DB data and metadata.
-    fault_fs_guard->SetFileTypesExcludedFromFaultInjection(
-        {FileType::kInfoLogFile});
-    // Set it to direct writable here to initially bypass any fault injection
-    // during DB open This will correspondingly be overwritten in
-    // StressTest::Open() for open fault injection and in RunStressTestImpl()
-    // for proper fault injection setup.
-    fault_fs_guard->SetFilesystemDirectWritable(true);
-    fault_env_guard =
-        std::make_shared<CompositeEnvWrapper>(raw_env, fault_fs_guard);
-    raw_env = fault_env_guard.get();
-
-    // Register a crash callback so that recently injected errors are
-    // printed to stderr when the process crashes (SIGABRT, SIGSEGV, etc.).
-    // This helps diagnose stress test failures caused by fault injection.
-    port::RegisterCrashCallback([]() {
-      if (fault_fs_guard) {
-        fault_fs_guard->PrintRecentInjectedErrors();
-      }
-    });
-  }
-
-  auto db_stress_fs =
-      std::make_shared<DbStressFSWrapper>(raw_env->GetFileSystem());
-  env_wrapper_guard =
-      std::make_shared<CompositeEnvWrapper>(raw_env, db_stress_fs);
-  db_stress_env = env_wrapper_guard.get();
 
   // Handle --destroy_db_and_exit early, before other option validation
   if (FLAGS_destroy_db_and_exit) {
@@ -153,10 +112,10 @@ int db_stress_tool(int argc, char** argv) {
 
   // The number of background threads should be at least as much the
   // max number of concurrent compactions.
-  db_stress_env->SetBackgroundThreads(FLAGS_max_background_compactions,
-                                      ROCKSDB_NAMESPACE::Env::Priority::LOW);
-  db_stress_env->SetBackgroundThreads(FLAGS_num_bottom_pri_threads,
-                                      ROCKSDB_NAMESPACE::Env::Priority::BOTTOM);
+  raw_env->SetBackgroundThreads(FLAGS_max_background_compactions,
+                                ROCKSDB_NAMESPACE::Env::Priority::LOW);
+  raw_env->SetBackgroundThreads(FLAGS_num_bottom_pri_threads,
+                                ROCKSDB_NAMESPACE::Env::Priority::BOTTOM);
   if (FLAGS_prefixpercent > 0 && FLAGS_prefix_size < 0) {
     fprintf(stderr,
             "Error: prefixpercent is non-zero while prefix_size is "
@@ -356,36 +315,17 @@ int db_stress_tool(int argc, char** argv) {
   // Choose a location for the test database if none given with --db=<path>
   if (FLAGS_db.empty()) {
     std::string default_db_path;
-    db_stress_env->GetTestDirectory(&default_db_path);
+    raw_env->GetTestDirectory(&default_db_path);
     default_db_path += "/dbstress";
     FLAGS_db = default_db_path;
-  }
-
-  // Now that FLAGS_db is resolved, set the fault injection log file path
-  // so that PrintAll() writes to a file instead of stderr (signal-safe).
-  // Store the log in TEST_TMPDIR (outside the DB directory) so it survives
-  // DB reopen (which cleans untracked files) and gets included in the
-  // sandcastle db.tar.gz artifact for post-failure analysis.
-  if (fault_fs_guard) {
-    std::string log_dir;
-    const char* test_tmpdir = getenv("TEST_TMPDIR");
-    if (test_tmpdir && test_tmpdir[0] != '\0') {
-      log_dir = test_tmpdir;
-    } else {
-      log_dir = "/tmp";
-    }
-    std::string log_path = log_dir + "/fault_injection_" +
-                           std::to_string(getpid()) + "_" +
-                           std::to_string(time(nullptr)) + ".log";
-    fault_fs_guard->SetInjectedErrorLogPath(log_path);
   }
 
   if ((FLAGS_test_secondary || FLAGS_continuous_verification_interval > 0) &&
       FLAGS_secondaries_base.empty()) {
     std::string default_secondaries_path;
-    db_stress_env->GetTestDirectory(&default_secondaries_path);
+    raw_env->GetTestDirectory(&default_secondaries_path);
     default_secondaries_path += "/dbstress_secondaries";
-    s = db_stress_env->CreateDirIfMissing(default_secondaries_path);
+    s = raw_env->CreateDirIfMissing(default_secondaries_path);
     if (!s.ok()) {
       fprintf(stderr, "Failed to create directory %s: %s\n",
               default_secondaries_path.c_str(), s.ToString().c_str());
@@ -524,11 +464,23 @@ int db_stress_tool(int argc, char** argv) {
   }
   // Initialize the Zipfian pre-calculated array
   InitializeHotKeyGenerator(FLAGS_hot_key_alpha);
-  shared.reset(new SharedState(db_stress_env, stress.get()));
+
+  // Register a crash callback so that recently injected errors are printed
+  // to stderr when the process crashes (SIGABRT, SIGSEGV, etc.). This helps
+  // diagnose stress test failures caused by fault injection.
+  fault_fs_for_crash_report = stress->GetDbFaultInjectionFs().get();
+  port::RegisterCrashCallback([]() {
+    if (fault_fs_for_crash_report) {
+      fault_fs_for_crash_report->PrintRecentInjectedErrors();
+    }
+  });
+
+  shared.reset(new SharedState(raw_env, stress.get()));
   bool run_stress_test = RunStressTest(shared.get());
   // Close DB in CleanUp() before destructor to prevent race between destructor
   // and operations in listener callbacks (e.g. MultiOpsTxnsStressListener).
   stress->CleanUp();
+  fault_fs_for_crash_report = nullptr;
   return run_stress_test ? 0 : 1;
 }
 

--- a/db_stress_tool/multi_ops_txns_stress.cc
+++ b/db_stress_tool/multi_ops_txns_stress.cc
@@ -40,7 +40,7 @@ DEFINE_int32(clear_wp_commit_cache_one_in, 0,
              "write-unprepared transactions.");
 
 extern "C" bool rocksdb_write_prepared_TEST_ShouldClearCommitCache(void) {
-  static Random rand(static_cast<uint32_t>(db_stress_env->NowMicros()));
+  static Random rand(static_cast<uint32_t>(raw_env->NowMicros()));
   return FLAGS_clear_wp_commit_cache_one_in > 0 &&
          rand.OneIn(FLAGS_clear_wp_commit_cache_one_in);
 }
@@ -1413,7 +1413,7 @@ Status MultiOpsTxnsStressTest::CommitAndCreateTimestampedSnapshotIfNeeded(
   Status s;
   if (FLAGS_create_timestamped_snapshot_one_in > 0 &&
       thread->rand.OneInOpt(FLAGS_create_timestamped_snapshot_one_in)) {
-    uint64_t ts = db_stress_env->NowNanos();
+    uint64_t ts = raw_env->NowNanos();
     std::shared_ptr<const Snapshot> snapshot;
     s = txn.CommitAndTryCreateSnapshot(/*notifier=*/nullptr, ts, &snapshot);
   } else {
@@ -1428,7 +1428,7 @@ Status MultiOpsTxnsStressTest::CommitAndCreateTimestampedSnapshotIfNeeded(
   assert(txn_db_);
   if (FLAGS_create_timestamped_snapshot_one_in > 0 &&
       thread->rand.OneInOpt(50000)) {
-    uint64_t now = db_stress_env->NowNanos();
+    uint64_t now = raw_env->NowNanos();
     constexpr uint64_t time_diff = static_cast<uint64_t>(1000) * 1000 * 1000;
     txn_db_->ReleaseTimestampedSnapshotsOlderThan(now - time_diff);
   }

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -265,20 +265,20 @@ class NonBatchedOpsStressTest : public StressTest {
             std::string from_db;
 
             // Temporarily disable error injection to verify the secondary
-            if (fault_fs_guard) {
-              fault_fs_guard->DisableThreadLocalErrorInjection(
+            if (db_fault_injection_fs_) {
+              db_fault_injection_fs_->DisableThreadLocalErrorInjection(
                   FaultInjectionIOType::kRead);
-              fault_fs_guard->DisableThreadLocalErrorInjection(
+              db_fault_injection_fs_->DisableThreadLocalErrorInjection(
                   FaultInjectionIOType::kMetadataRead);
             }
 
             s = secondary_db_->Get(options, secondary_cfhs_[cf], key, &from_db);
 
             // Re-enable error injection after verifying the secondary
-            if (fault_fs_guard) {
-              fault_fs_guard->EnableThreadLocalErrorInjection(
+            if (db_fault_injection_fs_) {
+              db_fault_injection_fs_->EnableThreadLocalErrorInjection(
                   FaultInjectionIOType::kRead);
-              fault_fs_guard->EnableThreadLocalErrorInjection(
+              db_fault_injection_fs_->EnableThreadLocalErrorInjection(
                   FaultInjectionIOType::kMetadataRead);
             }
 
@@ -688,10 +688,10 @@ class NonBatchedOpsStressTest : public StressTest {
     bool read_older_ts = MaybeUseOlderTimestampForPointLookup(
         thread, read_ts_str, read_ts_slice, read_opts_copy);
 
-    if (fault_fs_guard) {
-      fault_fs_guard->GetAndResetInjectedThreadLocalErrorCount(
+    if (db_fault_injection_fs_) {
+      db_fault_injection_fs_->GetAndResetInjectedThreadLocalErrorCount(
           FaultInjectionIOType::kRead);
-      fault_fs_guard->GetAndResetInjectedThreadLocalErrorCount(
+      db_fault_injection_fs_->GetAndResetInjectedThreadLocalErrorCount(
           FaultInjectionIOType::kMetadataRead);
       SharedState::ignore_read_error = false;
     }
@@ -703,11 +703,11 @@ class NonBatchedOpsStressTest : public StressTest {
         thread->shared->Get(rand_column_families[0], rand_keys[0]);
 
     int injected_error_count = 0;
-    if (fault_fs_guard) {
+    if (db_fault_injection_fs_) {
       injected_error_count = GetMinInjectedErrorCount(
-          fault_fs_guard->GetAndResetInjectedThreadLocalErrorCount(
+          db_fault_injection_fs_->GetAndResetInjectedThreadLocalErrorCount(
               FaultInjectionIOType::kRead),
-          fault_fs_guard->GetAndResetInjectedThreadLocalErrorCount(
+          db_fault_injection_fs_->GetAndResetInjectedThreadLocalErrorCount(
               FaultInjectionIOType::kMetadataRead));
       if (!SharedState::ignore_read_error && injected_error_count > 0 &&
           (s.ok() || s.IsNotFound())) {
@@ -716,9 +716,9 @@ class NonBatchedOpsStressTest : public StressTest {
         MutexLock l(thread->shared->GetMutex());
         fprintf(stderr, "Didn't get expected error from Get\n");
         fprintf(stderr, "Callstack that injected the fault\n");
-        fault_fs_guard->PrintInjectedThreadLocalErrorBacktrace(
+        db_fault_injection_fs_->PrintInjectedThreadLocalErrorBacktrace(
             FaultInjectionIOType::kRead);
-        fault_fs_guard->PrintInjectedThreadLocalErrorBacktrace(
+        db_fault_injection_fs_->PrintInjectedThreadLocalErrorBacktrace(
             FaultInjectionIOType::kMetadataRead);
         std::terminate();
       }
@@ -821,10 +821,10 @@ class NonBatchedOpsStressTest : public StressTest {
     std::unique_ptr<Transaction> txn;
     if (use_txn) {
       // TODO(hx235): test fault injection with MultiGet() with transactions
-      if (fault_fs_guard) {
-        fault_fs_guard->DisableThreadLocalErrorInjection(
+      if (db_fault_injection_fs_) {
+        db_fault_injection_fs_->DisableThreadLocalErrorInjection(
             FaultInjectionIOType::kRead);
-        fault_fs_guard->DisableThreadLocalErrorInjection(
+        db_fault_injection_fs_->DisableThreadLocalErrorInjection(
             FaultInjectionIOType::kMetadataRead);
       }
       WriteOptions wo;
@@ -850,20 +850,20 @@ class NonBatchedOpsStressTest : public StressTest {
     int injected_error_count = 0;
 
     if (!use_txn) {
-      if (fault_fs_guard) {
-        fault_fs_guard->GetAndResetInjectedThreadLocalErrorCount(
+      if (db_fault_injection_fs_) {
+        db_fault_injection_fs_->GetAndResetInjectedThreadLocalErrorCount(
             FaultInjectionIOType::kRead);
-        fault_fs_guard->GetAndResetInjectedThreadLocalErrorCount(
+        db_fault_injection_fs_->GetAndResetInjectedThreadLocalErrorCount(
             FaultInjectionIOType::kMetadataRead);
         SharedState::ignore_read_error = false;
       }
       db_->MultiGet(readoptionscopy, cfh, num_keys, keys.data(), values.data(),
                     statuses.data());
-      if (fault_fs_guard) {
+      if (db_fault_injection_fs_) {
         injected_error_count = GetMinInjectedErrorCount(
-            fault_fs_guard->GetAndResetInjectedThreadLocalErrorCount(
+            db_fault_injection_fs_->GetAndResetInjectedThreadLocalErrorCount(
                 FaultInjectionIOType::kRead),
-            fault_fs_guard->GetAndResetInjectedThreadLocalErrorCount(
+            db_fault_injection_fs_->GetAndResetInjectedThreadLocalErrorCount(
                 FaultInjectionIOType::kMetadataRead));
 
         if (injected_error_count > 0) {
@@ -883,9 +883,9 @@ class NonBatchedOpsStressTest : public StressTest {
                     "num_keys %zu Expected %d errors, seen at least %d\n",
                     num_keys, injected_error_count, stat_nok_nfound);
             fprintf(stderr, "Callstack that injected the fault\n");
-            fault_fs_guard->PrintInjectedThreadLocalErrorBacktrace(
+            db_fault_injection_fs_->PrintInjectedThreadLocalErrorBacktrace(
                 FaultInjectionIOType::kRead);
-            fault_fs_guard->PrintInjectedThreadLocalErrorBacktrace(
+            db_fault_injection_fs_->PrintInjectedThreadLocalErrorBacktrace(
                 FaultInjectionIOType::kMetadataRead);
             std::terminate();
           }
@@ -952,10 +952,10 @@ class NonBatchedOpsStressTest : public StressTest {
             const Status& s,
             const std::optional<ExpectedValue>& ryw_expected_value) -> bool {
       //  Temporarily disable error injection for verification
-      if (fault_fs_guard) {
-        fault_fs_guard->DisableThreadLocalErrorInjection(
+      if (db_fault_injection_fs_) {
+        db_fault_injection_fs_->DisableThreadLocalErrorInjection(
             FaultInjectionIOType::kRead);
-        fault_fs_guard->DisableThreadLocalErrorInjection(
+        db_fault_injection_fs_->DisableThreadLocalErrorInjection(
             FaultInjectionIOType::kMetadataRead);
       }
 
@@ -1049,10 +1049,10 @@ class NonBatchedOpsStressTest : public StressTest {
       }
 
       // Enable back error injection disbled for checking results
-      if (fault_fs_guard) {
-        fault_fs_guard->DisableThreadLocalErrorInjection(
+      if (db_fault_injection_fs_) {
+        db_fault_injection_fs_->DisableThreadLocalErrorInjection(
             FaultInjectionIOType::kRead);
-        fault_fs_guard->DisableThreadLocalErrorInjection(
+        db_fault_injection_fs_->DisableThreadLocalErrorInjection(
             FaultInjectionIOType::kMetadataRead);
       }
       return check_multiget_res;
@@ -1091,10 +1091,10 @@ class NonBatchedOpsStressTest : public StressTest {
     if (use_txn) {
       txn->Rollback().PermitUncheckedError();
       // Enable back error injection disbled for transactions
-      if (fault_fs_guard) {
-        fault_fs_guard->EnableThreadLocalErrorInjection(
+      if (db_fault_injection_fs_) {
+        db_fault_injection_fs_->EnableThreadLocalErrorInjection(
             FaultInjectionIOType::kRead);
-        fault_fs_guard->EnableThreadLocalErrorInjection(
+        db_fault_injection_fs_->EnableThreadLocalErrorInjection(
             FaultInjectionIOType::kMetadataRead);
       }
     }
@@ -1141,10 +1141,10 @@ class NonBatchedOpsStressTest : public StressTest {
     const ExpectedValue pre_read_expected_value =
         thread->shared->Get(column_family, key);
 
-    if (fault_fs_guard) {
-      fault_fs_guard->GetAndResetInjectedThreadLocalErrorCount(
+    if (db_fault_injection_fs_) {
+      db_fault_injection_fs_->GetAndResetInjectedThreadLocalErrorCount(
           FaultInjectionIOType::kRead);
-      fault_fs_guard->GetAndResetInjectedThreadLocalErrorCount(
+      db_fault_injection_fs_->GetAndResetInjectedThreadLocalErrorCount(
           FaultInjectionIOType::kMetadataRead);
       SharedState::ignore_read_error = false;
     }
@@ -1164,11 +1164,11 @@ class NonBatchedOpsStressTest : public StressTest {
         thread->shared->Get(column_family, key);
 
     int injected_error_count = 0;
-    if (fault_fs_guard) {
+    if (db_fault_injection_fs_) {
       injected_error_count = GetMinInjectedErrorCount(
-          fault_fs_guard->GetAndResetInjectedThreadLocalErrorCount(
+          db_fault_injection_fs_->GetAndResetInjectedThreadLocalErrorCount(
               FaultInjectionIOType::kRead),
-          fault_fs_guard->GetAndResetInjectedThreadLocalErrorCount(
+          db_fault_injection_fs_->GetAndResetInjectedThreadLocalErrorCount(
               FaultInjectionIOType::kMetadataRead));
       if (!SharedState::ignore_read_error && injected_error_count > 0 &&
           (s.ok() || s.IsNotFound())) {
@@ -1177,9 +1177,9 @@ class NonBatchedOpsStressTest : public StressTest {
         MutexLock l(thread->shared->GetMutex());
         fprintf(stderr, "Didn't get expected error from GetEntity\n");
         fprintf(stderr, "Callstack that injected the fault\n");
-        fault_fs_guard->PrintInjectedThreadLocalErrorBacktrace(
+        db_fault_injection_fs_->PrintInjectedThreadLocalErrorBacktrace(
             FaultInjectionIOType::kRead);
-        fault_fs_guard->PrintInjectedThreadLocalErrorBacktrace(
+        db_fault_injection_fs_->PrintInjectedThreadLocalErrorBacktrace(
             FaultInjectionIOType::kMetadataRead);
         std::terminate();
       }
@@ -1281,10 +1281,10 @@ class NonBatchedOpsStressTest : public StressTest {
     if (FLAGS_use_txn) {
       // TODO(hx235): test fault injection with MultiGetEntity() with
       // transactions
-      if (fault_fs_guard) {
-        fault_fs_guard->DisableThreadLocalErrorInjection(
+      if (db_fault_injection_fs_) {
+        db_fault_injection_fs_->DisableThreadLocalErrorInjection(
             FaultInjectionIOType::kRead);
-        fault_fs_guard->DisableThreadLocalErrorInjection(
+        db_fault_injection_fs_->DisableThreadLocalErrorInjection(
             FaultInjectionIOType::kMetadataRead);
       }
       WriteOptions write_options;
@@ -1318,11 +1318,11 @@ class NonBatchedOpsStressTest : public StressTest {
     int injected_error_count = 0;
 
     auto verify_expected_errors = [&](auto get_status) {
-      assert(fault_fs_guard);
+      assert(db_fault_injection_fs_);
       injected_error_count = GetMinInjectedErrorCount(
-          fault_fs_guard->GetAndResetInjectedThreadLocalErrorCount(
+          db_fault_injection_fs_->GetAndResetInjectedThreadLocalErrorCount(
               FaultInjectionIOType::kRead),
-          fault_fs_guard->GetAndResetInjectedThreadLocalErrorCount(
+          db_fault_injection_fs_->GetAndResetInjectedThreadLocalErrorCount(
               FaultInjectionIOType::kMetadataRead));
       if (injected_error_count) {
         int stat_nok_nfound = 0;
@@ -1344,9 +1344,9 @@ class NonBatchedOpsStressTest : public StressTest {
           fprintf(stderr, "num_keys %zu Expected %d errors, seen %d\n",
                   num_keys, injected_error_count, stat_nok_nfound);
           fprintf(stderr, "Call stack that injected the fault\n");
-          fault_fs_guard->PrintInjectedThreadLocalErrorBacktrace(
+          db_fault_injection_fs_->PrintInjectedThreadLocalErrorBacktrace(
               FaultInjectionIOType::kRead);
-          fault_fs_guard->PrintInjectedThreadLocalErrorBacktrace(
+          db_fault_injection_fs_->PrintInjectedThreadLocalErrorBacktrace(
               FaultInjectionIOType::kMetadataRead);
           std::terminate();
         }
@@ -1356,10 +1356,10 @@ class NonBatchedOpsStressTest : public StressTest {
     auto check_results = [&](auto get_columns, auto get_status,
                              auto do_extra_check, auto call_get_entity) {
       // Temporarily disable error injection for checking results
-      if (fault_fs_guard) {
-        fault_fs_guard->DisableThreadLocalErrorInjection(
+      if (db_fault_injection_fs_) {
+        db_fault_injection_fs_->DisableThreadLocalErrorInjection(
             FaultInjectionIOType::kRead);
-        fault_fs_guard->DisableThreadLocalErrorInjection(
+        db_fault_injection_fs_->DisableThreadLocalErrorInjection(
             FaultInjectionIOType::kMetadataRead);
       }
       const bool check_get_entity =
@@ -1538,10 +1538,10 @@ class NonBatchedOpsStressTest : public StressTest {
         }
       }
       // Enable back error injection disbled for checking results
-      if (fault_fs_guard) {
-        fault_fs_guard->EnableThreadLocalErrorInjection(
+      if (db_fault_injection_fs_) {
+        db_fault_injection_fs_->EnableThreadLocalErrorInjection(
             FaultInjectionIOType::kRead);
-        fault_fs_guard->EnableThreadLocalErrorInjection(
+        db_fault_injection_fs_->EnableThreadLocalErrorInjection(
             FaultInjectionIOType::kMetadataRead);
       }
     };
@@ -1624,19 +1624,19 @@ class NonBatchedOpsStressTest : public StressTest {
 
       txn->Rollback().PermitUncheckedError();
       // Enable back error injection disbled for transactions
-      if (fault_fs_guard) {
-        fault_fs_guard->EnableThreadLocalErrorInjection(
+      if (db_fault_injection_fs_) {
+        db_fault_injection_fs_->EnableThreadLocalErrorInjection(
             FaultInjectionIOType::kRead);
-        fault_fs_guard->EnableThreadLocalErrorInjection(
+        db_fault_injection_fs_->EnableThreadLocalErrorInjection(
             FaultInjectionIOType::kMetadataRead);
       }
     } else if (FLAGS_use_attribute_group) {
       // AttributeGroup MultiGetEntity verification
 
-      if (fault_fs_guard) {
-        fault_fs_guard->GetAndResetInjectedThreadLocalErrorCount(
+      if (db_fault_injection_fs_) {
+        db_fault_injection_fs_->GetAndResetInjectedThreadLocalErrorCount(
             FaultInjectionIOType::kRead);
-        fault_fs_guard->GetAndResetInjectedThreadLocalErrorCount(
+        db_fault_injection_fs_->GetAndResetInjectedThreadLocalErrorCount(
             FaultInjectionIOType::kMetadataRead);
         SharedState::ignore_read_error = false;
       }
@@ -1652,7 +1652,7 @@ class NonBatchedOpsStressTest : public StressTest {
       db_->MultiGetEntity(read_opts_copy, num_keys, key_slices.data(),
                           results.data());
 
-      if (fault_fs_guard) {
+      if (db_fault_injection_fs_) {
         verify_expected_errors(
             [&](size_t i) { return results[i][0].status(); });
       }
@@ -1668,10 +1668,10 @@ class NonBatchedOpsStressTest : public StressTest {
     } else {
       // Non-AttributeGroup MultiGetEntity verification
 
-      if (fault_fs_guard) {
-        fault_fs_guard->GetAndResetInjectedThreadLocalErrorCount(
+      if (db_fault_injection_fs_) {
+        db_fault_injection_fs_->GetAndResetInjectedThreadLocalErrorCount(
             FaultInjectionIOType::kRead);
-        fault_fs_guard->GetAndResetInjectedThreadLocalErrorCount(
+        db_fault_injection_fs_->GetAndResetInjectedThreadLocalErrorCount(
             FaultInjectionIOType::kMetadataRead);
         SharedState::ignore_read_error = false;
       }
@@ -1682,7 +1682,7 @@ class NonBatchedOpsStressTest : public StressTest {
       db_->MultiGetEntity(read_opts_copy, cfh, num_keys, key_slices.data(),
                           results.data(), statuses.data());
 
-      if (fault_fs_guard) {
+      if (db_fault_injection_fs_) {
         verify_expected_errors([&](size_t i) { return statuses[i]; });
       }
 
@@ -1733,10 +1733,10 @@ class NonBatchedOpsStressTest : public StressTest {
     MaybeUseOlderTimestampForRangeScan(thread, read_ts_str, read_ts_slice,
                                        ro_copy);
 
-    if (fault_fs_guard) {
-      fault_fs_guard->GetAndResetInjectedThreadLocalErrorCount(
+    if (db_fault_injection_fs_) {
+      db_fault_injection_fs_->GetAndResetInjectedThreadLocalErrorCount(
           FaultInjectionIOType::kRead);
-      fault_fs_guard->GetAndResetInjectedThreadLocalErrorCount(
+      db_fault_injection_fs_->GetAndResetInjectedThreadLocalErrorCount(
           FaultInjectionIOType::kMetadataRead);
       SharedState::ignore_read_error = false;
     }
@@ -1798,11 +1798,11 @@ class NonBatchedOpsStressTest : public StressTest {
     }
 
     int injected_error_count = 0;
-    if (fault_fs_guard) {
+    if (db_fault_injection_fs_) {
       injected_error_count = GetMinInjectedErrorCount(
-          fault_fs_guard->GetAndResetInjectedThreadLocalErrorCount(
+          db_fault_injection_fs_->GetAndResetInjectedThreadLocalErrorCount(
               FaultInjectionIOType::kRead),
-          fault_fs_guard->GetAndResetInjectedThreadLocalErrorCount(
+          db_fault_injection_fs_->GetAndResetInjectedThreadLocalErrorCount(
               FaultInjectionIOType::kMetadataRead));
       if (!SharedState::ignore_read_error && injected_error_count > 0 &&
           s.ok()) {
@@ -1811,9 +1811,9 @@ class NonBatchedOpsStressTest : public StressTest {
         MutexLock l(thread->shared->GetMutex());
         fprintf(stderr, "Didn't get expected error from PrefixScan\n");
         fprintf(stderr, "Callstack that injected the fault\n");
-        fault_fs_guard->PrintInjectedThreadLocalErrorBacktrace(
+        db_fault_injection_fs_->PrintInjectedThreadLocalErrorBacktrace(
             FaultInjectionIOType::kRead);
-        fault_fs_guard->PrintInjectedThreadLocalErrorBacktrace(
+        db_fault_injection_fs_->PrintInjectedThreadLocalErrorBacktrace(
             FaultInjectionIOType::kMetadataRead);
         std::terminate();
       }
@@ -1880,10 +1880,10 @@ class NonBatchedOpsStressTest : public StressTest {
 
     if (FLAGS_verify_before_write) {
       // Temporarily disable error injection for preparation
-      if (fault_fs_guard) {
-        fault_fs_guard->DisableThreadLocalErrorInjection(
+      if (db_fault_injection_fs_) {
+        db_fault_injection_fs_->DisableThreadLocalErrorInjection(
             FaultInjectionIOType::kRead);
-        fault_fs_guard->DisableThreadLocalErrorInjection(
+        db_fault_injection_fs_->DisableThreadLocalErrorInjection(
             FaultInjectionIOType::kMetadataRead);
       }
 
@@ -1894,10 +1894,10 @@ class NonBatchedOpsStressTest : public StressTest {
           /* msg_prefix */ "Pre-Put Get verification", from_db, s);
 
       // Enable back error injection disabled for preparation
-      if (fault_fs_guard) {
-        fault_fs_guard->EnableThreadLocalErrorInjection(
+      if (db_fault_injection_fs_) {
+        db_fault_injection_fs_->EnableThreadLocalErrorInjection(
             FaultInjectionIOType::kRead);
-        fault_fs_guard->EnableThreadLocalErrorInjection(
+        db_fault_injection_fs_->EnableThreadLocalErrorInjection(
             FaultInjectionIOType::kMetadataRead);
       }
       if (!res) {
@@ -2000,7 +2000,7 @@ class NonBatchedOpsStressTest : public StressTest {
               &commit_bypass_memtable);
         }
       }
-      UpdateIfInitialWriteFails(db_stress_env, s, &initial_write_s,
+      UpdateIfInitialWriteFails(raw_env, s, &initial_write_s,
                                 &initial_wal_write_may_succeed,
                                 &wait_for_recover_start_time);
 
@@ -2031,7 +2031,7 @@ class NonBatchedOpsStressTest : public StressTest {
       }
     } else {
       PrintWriteRecoveryWaitTimeIfNeeded(
-          db_stress_env, initial_write_s, initial_wal_write_may_succeed,
+          raw_env, initial_write_s, initial_wal_write_may_succeed,
           wait_for_recover_start_time, "TestPut");
       pending_expected_value.Commit();
       thread->stats.AddBytesForWrites(1, sz);
@@ -2107,7 +2107,7 @@ class NonBatchedOpsStressTest : public StressTest {
               &commit_bypass_memtable);
         }
         UpdateIfInitialWriteFails(
-            db_stress_env, s, &initial_write_s, &initial_wal_write_may_succeed,
+            raw_env, s, &initial_write_s, &initial_wal_write_may_succeed,
             &wait_for_recover_start_time, commit_bypass_memtable);
       } while (!s.ok() && IsErrorInjectedAndRetryable(s) &&
                initial_wal_write_may_succeed);
@@ -2137,7 +2137,7 @@ class NonBatchedOpsStressTest : public StressTest {
         }
       } else {
         PrintWriteRecoveryWaitTimeIfNeeded(
-            db_stress_env, initial_write_s, initial_wal_write_may_succeed,
+            raw_env, initial_write_s, initial_wal_write_may_succeed,
             wait_for_recover_start_time, "TestDelete");
         pending_expected_value.Commit();
         thread->stats.AddDeletes(1);
@@ -2179,7 +2179,7 @@ class NonBatchedOpsStressTest : public StressTest {
               &commit_bypass_memtable);
         }
         UpdateIfInitialWriteFails(
-            db_stress_env, s, &initial_write_s, &initial_wal_write_may_succeed,
+            raw_env, s, &initial_write_s, &initial_wal_write_may_succeed,
             &wait_for_recover_start_time, commit_bypass_memtable);
       } while (!s.ok() && IsErrorInjectedAndRetryable(s) &&
                initial_wal_write_may_succeed);
@@ -2209,7 +2209,7 @@ class NonBatchedOpsStressTest : public StressTest {
         }
       } else {
         PrintWriteRecoveryWaitTimeIfNeeded(
-            db_stress_env, initial_write_s, initial_wal_write_may_succeed,
+            raw_env, initial_write_s, initial_wal_write_may_succeed,
             wait_for_recover_start_time, "TestDelete");
         pending_expected_value.Commit();
         thread->stats.AddSingleDeletes(1);
@@ -2274,7 +2274,7 @@ class NonBatchedOpsStressTest : public StressTest {
       } else {
         s = db_->DeleteRange(write_opts, cfh, key, end_key);
       }
-      UpdateIfInitialWriteFails(db_stress_env, s, &initial_write_s,
+      UpdateIfInitialWriteFails(raw_env, s, &initial_write_s,
                                 &initial_wal_write_may_succeed,
                                 &wait_for_recover_start_time);
     } while (!s.ok() && IsErrorInjectedAndRetryable(s) &&
@@ -2302,7 +2302,7 @@ class NonBatchedOpsStressTest : public StressTest {
       }
     } else {
       PrintWriteRecoveryWaitTimeIfNeeded(
-          db_stress_env, initial_write_s, initial_wal_write_may_succeed,
+          raw_env, initial_write_s, initial_wal_write_may_succeed,
           wait_for_recover_start_time, "TestDeleteRange");
       for (PendingExpectedValue& pending_expected_value :
            pending_expected_values) {
@@ -2338,28 +2338,28 @@ class NonBatchedOpsStressTest : public StressTest {
     std::ostringstream ingest_options_oss;
 
     // Temporarily disable error injection for preparation
-    if (fault_fs_guard) {
-      fault_fs_guard->DisableThreadLocalErrorInjection(
+    if (db_fault_injection_fs_) {
+      db_fault_injection_fs_->DisableThreadLocalErrorInjection(
           FaultInjectionIOType::kMetadataRead);
-      fault_fs_guard->DisableThreadLocalErrorInjection(
+      db_fault_injection_fs_->DisableThreadLocalErrorInjection(
           FaultInjectionIOType::kMetadataWrite);
     }
 
     for (const auto& filename : external_files) {
-      if (db_stress_env->FileExists(filename).ok()) {
+      if (raw_env->FileExists(filename).ok()) {
         // Maybe we terminated abnormally before, so cleanup to give this file
         // ingestion a clean slate
-        s = db_stress_env->DeleteFile(filename);
+        s = raw_env->DeleteFile(filename);
       }
       if (!s.ok()) {
         return;
       }
     }
 
-    if (fault_fs_guard) {
-      fault_fs_guard->EnableThreadLocalErrorInjection(
+    if (db_fault_injection_fs_) {
+      db_fault_injection_fs_->EnableThreadLocalErrorInjection(
           FaultInjectionIOType::kMetadataRead);
-      fault_fs_guard->EnableThreadLocalErrorInjection(
+      db_fault_injection_fs_->EnableThreadLocalErrorInjection(
           FaultInjectionIOType::kMetadataWrite);
     }
 

--- a/utilities/fault_injection_fs.cc
+++ b/utilities/fault_injection_fs.cc
@@ -22,6 +22,7 @@
 #include <utility>
 
 #include "env/composite_env_wrapper.h"
+#include "monitoring/thread_status_util.h"
 #include "port/lang.h"
 #include "port/stack_trace.h"
 #include "rocksdb/env.h"
@@ -177,7 +178,7 @@ TestFSWritableFile::TestFSWritableFile(const std::string& fname,
     : state_(fname),
       file_opts_(file_opts),
       target_(std::move(f)),
-      writable_file_opened_(true),
+      should_forward_close_(true),
       fs_(fs),
       unsync_data_loss_(fs_->InjectUnsyncedDataLoss()) {
   assert(target_ != nullptr);
@@ -186,8 +187,15 @@ TestFSWritableFile::TestFSWritableFile(const std::string& fname,
 }
 
 TestFSWritableFile::~TestFSWritableFile() {
-  if (writable_file_opened_) {
-    Close(IOOptions(), nullptr).PermitUncheckedError();
+  const ThreadStatus::OperationType thread_op =
+      ThreadStatusUtil::GetThreadOperation();
+  if (thread_op != ThreadStatus::OperationType::OP_UNKNOWN) {
+    ThreadStatusUtil::SetThreadOperation(
+        ThreadStatus::OperationType::OP_UNKNOWN);
+  }
+  CloseImpl(IOOptions(), nullptr).PermitUncheckedError();
+  if (thread_op != ThreadStatus::OperationType::OP_UNKNOWN) {
+    ThreadStatusUtil::SetThreadOperation(thread_op);
   }
 }
 
@@ -361,7 +369,24 @@ IOStatus TestFSWritableFile::PositionedAppend(
 
 IOStatus TestFSWritableFile::Close(const IOOptions& options,
                                    IODebugContext* dbg) {
+  return CloseImpl(options, dbg);
+}
+
+IOStatus TestFSWritableFile::CloseImpl(const IOOptions& options,
+                                       IODebugContext* dbg) {
   MutexLock l(&mutex_);
+  if (!should_forward_close_) {
+    return IOStatus::OK();
+  }
+  // Mirror the production FSWritableFile close boundary here: the first
+  // Close() attempt is this wrapper's one chance to forward Close() to
+  // target_. Later Close() calls, including the destructor path, are
+  // wrapper-level no-ops.
+  should_forward_close_ = false;
+  // Publish the path-level close transition before injection. FSWritableFile
+  // considers the file closed after the first Close() attempt regardless of
+  // returned status, so crash/recovery bookkeeping must observe that first
+  // close attempt even if fault injection aborts the metadata close path.
   fs_->WritableFileClosed(state_);
   if (!fs_->IsFilesystemActive()) {
     return fs_->GetError();
@@ -371,7 +396,6 @@ IOStatus TestFSWritableFile::Close(const IOOptions& options,
   if (!io_s.ok()) {
     return io_s;
   }
-  writable_file_opened_ = false;
 
   // Drop buffered data that was never synced because close is not a syncing
   // mechanism in POSIX file semantics.

--- a/utilities/fault_injection_fs.h
+++ b/utilities/fault_injection_fs.h
@@ -305,8 +305,9 @@ struct FSFileState {
   IOStatus DropRandomUnsyncedData(Random* rand);
 };
 
-// A wrapper around WritableFileWriter* file
-// is written to or sync'ed.
+// A per-file fault-injection wrapper around FSWritableFile. It injects
+// write/metadata faults while reporting path-level state transitions back to
+// FaultInjectionTestFS.
 class TestFSWritableFile : public FSWritableFile {
  public:
   explicit TestFSWritableFile(const std::string& fname,
@@ -345,17 +346,23 @@ class TestFSWritableFile : public FSWritableFile {
   }
 
  private:
+  IOStatus CloseImpl(const IOOptions& options, IODebugContext* dbg);
+
   FSFileState state_;  // Need protection by mutex_
   FileOptions file_opts_;
   std::unique_ptr<FSWritableFile> target_;
-  bool writable_file_opened_;
+  // Whether this wrapper may still forward Close() to target_. The
+  // FSWritableFile contract treats the file as closed after the first Close()
+  // attempt regardless of returned status, so later Close() calls are
+  // wrapper-level no-ops here.
+  bool should_forward_close_;
   FaultInjectionTestFS* fs_;
   port::Mutex mutex_;
   const bool unsync_data_loss_;
 };
 
-// A wrapper around FSRandomRWFile* file
-// is read from/write to or sync'ed.
+// A per-file fault-injection wrapper around FSRandomRWFile that reports
+// path-level close transitions back to FaultInjectionTestFS.
 class TestFSRandomRWFile : public FSRandomRWFile {
  public:
   explicit TestFSRandomRWFile(const std::string& fname,
@@ -415,6 +422,9 @@ class TestFSRandomAccessFile : public FSRandomAccessFile {
   const bool is_sst_;
 };
 
+// A per-file fault-injection wrapper around FSSequentialFile that can surface
+// injected read faults and simulated unsynced data through
+// FaultInjectionTestFS.
 class TestFSSequentialFile : public FSSequentialFileOwnerWrapper {
  public:
   explicit TestFSSequentialFile(std::unique_ptr<FSSequentialFile>&& f,
@@ -435,6 +445,8 @@ class TestFSSequentialFile : public FSSequentialFileOwnerWrapper {
   uint64_t target_read_pos_ = 0;
 };
 
+// A fault-injection wrapper around FSDirectory that surfaces metadata faults
+// through FaultInjectionTestFS.
 class TestFSDirectory : public FSDirectory {
  public:
   explicit TestFSDirectory(FaultInjectionTestFS* fs, std::string dirname,

--- a/utilities/fault_injection_fs_test.cc
+++ b/utilities/fault_injection_fs_test.cc
@@ -5,7 +5,6 @@
 
 #include "utilities/fault_injection_fs.h"
 
-#include <atomic>
 #include <thread>
 #include <vector>
 
@@ -28,6 +27,22 @@ std::shared_ptr<FaultInjectionTestFS> NewFaultFsExcludingInfoLogs(
   fault_fs->EnableThreadLocalErrorInjection(type);
   return fault_fs;
 }
+
+class CloseCountingWritableFile : public FSWritableFileOwnerWrapper {
+ public:
+  CloseCountingWritableFile(std::unique_ptr<FSWritableFile>&& target,
+                            int* close_calls)
+      : FSWritableFileOwnerWrapper(std::move(target)),
+        close_calls_(close_calls) {}
+
+  IOStatus Close(const IOOptions& options, IODebugContext* dbg) override {
+    ++(*close_calls_);
+    return target()->Close(options, dbg);
+  }
+
+ private:
+  int* close_calls_;
+};
 
 }  // namespace
 
@@ -194,6 +209,48 @@ TEST_F(FaultInjectionTestFSTest, FaultInjectionExcludesInfoLogFiles) {
     ASSERT_EQ(1, fault_fs->GetAndResetInjectedThreadLocalErrorCount(
                      FaultInjectionIOType::kMetadataWrite));
   }
+}
+
+TEST_F(FaultInjectionTestFSTest,
+       InjectedMetadataCloseErrorDoesNotRetryInnerClose) {
+  Env* env = Env::Default();
+  const std::string dbname =
+      test::PerThreadDBPath("fault_injection_fs_test_close_retry");
+  ASSERT_OK(env->CreateDirIfMissing(dbname));
+
+  auto fault_fs = std::make_shared<FaultInjectionTestFS>(env->GetFileSystem());
+  fault_fs->SetThreadLocalErrorContext(
+      FaultInjectionIOType::kMetadataWrite, /*seed=*/0, /*one_in=*/1,
+      /*retryable=*/false, /*has_data_loss=*/false);
+  fault_fs->EnableThreadLocalErrorInjection(
+      FaultInjectionIOType::kMetadataWrite);
+
+  int inner_close_calls = 0;
+  std::unique_ptr<FSWritableFile> file;
+  ASSERT_OK(fault_fs->NewWritableFile(dbname + "/CURRENT.tmp", FileOptions(),
+                                      &file, nullptr /* dbg */));
+  file.reset(new TestFSWritableFile(dbname + "/CURRENT.tmp", FileOptions(),
+                                    std::make_unique<CloseCountingWritableFile>(
+                                        std::move(file), &inner_close_calls),
+                                    fault_fs.get()));
+
+  ASSERT_OK(file->Append("test", IOOptions(), nullptr));
+
+  IOStatus s = file->Close(IOOptions(), nullptr);
+  ASSERT_NOK(s);
+  ASSERT_TRUE(s.IsIOError()) << s.ToString();
+  ASSERT_EQ(0, inner_close_calls);
+
+  // Mirror production layering: after Close() has already been attempted on
+  // this wrapper, later Close() calls are wrapper-level no-ops rather than a
+  // second raw Close() forwarded to the same owned file.
+  ASSERT_OK(file->Close(IOOptions(), nullptr));
+  ASSERT_EQ(0, inner_close_calls);
+
+  // Destruction may still release the owned file object, but it must not
+  // forward another raw Close().
+  file.reset();
+  ASSERT_EQ(0, inner_close_calls);
 }
 
 }  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
**Summary:**

Prerequisite for multi-DB stress test support where each StressTest instance owns one DB. Moves fault injection from a single global to per-StressTest instance so each DB gets isolated fault injection; errors injected into one DB do not leak to others.

FS/Env architecture change:

  Before (upstream):
    raw_fs → FaultInjectionTestFS (global) → DbStressFSWrapper → db_stress_env → DB::Open

  After (this diff):
    Global: raw_env (no wrappers)
      Used outside StressTest: non-FS ops (threads, time, sleep), test framework FS setup (dirs), DB destruction
      Used inside StressTest: cleanup ops that must succeed (external file delete)

    Per StressTest:
      raw_fs → DbStressFSWrapper (db_stress_fs_, always)
                → FaultInjectionTestFS (db_fault_injection_fs_, optional)
                      → CompositeEnvWrapper (db_env_, always) → DB::Open

    Expected values state: Env::Default() (always local PosixEnv even when raw_env is remote)

FS layer order swapped (DbStressFSWrapper now innermost). Safe because:
- Error injection returns early; inner wrapper never executes (same behavior)
- DbStressFSWrapper assertions do not modify data (checksum validation, IOActivity checks)
- MANIFEST rename tracking slightly better for crash simulation in new order

Stored members (per StressTest):
- db_stress_fs_: DbStressFSWrapper. Always active regardless of fault injection flags.
- db_fault_injection_fs_: FaultInjectionTestFS. Only when fault injection flags set. Direct access for Enable/Disable/SetThreadLocal.
- db_env_: CompositeEnvWrapper. Always present. THE env for all DB I/O (options_.env).

Eliminated globals: db_stress_env → renamed to raw_env (no wrappers, DbStressFSWrapper moved to per-StressTest); db_stress_listener_env, db_stress_raw_fs removed; fault_fs_guard, fault_env_guard moved to per-StressTest.

Other changes:
- CleanupOutputDirectory simplified (uses raw_env, no disable/enable needed)
- SstFileManager recreated with per-StressTest env in Open()
- Remote compaction override env uses options.env directly (fixes pre-existing silent bug)
- Comments added: Env::Default() always local, DbStressDestroyDb MANIFEST explanation, fault injection log path in TEST_TMPDIR
- TestFSWritableFile::Close() now mirrors the production FSWritableFile close boundary. After the first Close() attempt, later explicit or destructor Close() calls are wrapper-level no-ops, while FaultInjectionTestFS still records the first close attempt for crash/recovery simulation.
- Added targeted fault_injection_fs_test coverage for injected metadata-close failures to ensure FaultInjectionTestFS does not retry the inner Close() path.

**Test plan:**

TEST 2: Smoke test without fault injection
  $ db_stress --db=/tmp/v2_final/1/db --expected_values_dir=/tmp/v2_final/1/ev --destroy_db_initially --max_key=1000 --ops_per_thread=500 --threads=4 --clear_column_family_one_in=0 --reopen=0
  Verification successful

TEST 3: Fault injection smoke
  $ db_stress --db=/tmp/v2_final/2/db --expected_values_dir=/tmp/v2_final/2/ev --destroy_db_initially --max_key=100 --ops_per_thread=200 --threads=2 --clear_column_family_one_in=0 --write_fault_one_in=1 --sync_fault_injection=1 --open_write_fault_one_in=16 --reopen=3
  Verification successful
  DB LOG: [ERROR] OpenCompactionOutputFiles for table #50 fails at NewWritableFile with status IO error: injected write error
  DB LOG: ErrorHandler: Set background retryable IO error

TEST 4: MANIFEST preservation with swapped FS order
  $ db_stress --db=/tmp/v2_final/3/db ... --reopen=3
  Verification successful
  $ ls /tmp/v2_final/3/db/MANIFEST*_renamed_
  MANIFEST-000001_renamed_  MANIFEST-000005_renamed_  MANIFEST-000019_renamed_

TEST 5: DestroyDB cleans MANIFEST*_renamed_ files
  $ db_stress --destroy_db_and_exit=1 --db=/tmp/v2_final/3/db
  Successfully destroyed db
  $ ls /tmp/v2_final/3/db
  No such file or directory

TEST 6: Instrumented wrapper-order validation in db_stress_env_wrapper.h
  Temporary instrumentation added to db_stress_env_wrapper.h:
    static std::atomic<uint64_t> io_activity_check_count{0};
    static std::atomic<uint64_t> sst_checksum_verify_count{0};
  Printed at StressTest::CleanUp().

  Test A: without fault injection
  $ ./db_stress --db=/tmp/d2_inst_final/db --expected_values_dir=/tmp/d2_inst_final/ev --destroy_db_initially --max_key=500 --ops_per_thread=200 --threads=2 --clear_column_family_one_in=0 --reopen=3 --continuous_verification_interval=0 --test_secondary=0 --enable_checksum_handoff=1 --file_checksum_impl=crc32c
  Verification successful
  DbStressFSWrapper instrumentation: IOActivity checks=942, SST checksum verifications=66
  MANIFEST-000001_renamed_ MANIFEST-000005_renamed_ MANIFEST-000019_renamed_ MANIFEST-000033_renamed_

  Test B: with fault injection
  $ ./db_stress --db=/tmp/d2_inst_final2/db --expected_values_dir=/tmp/d2_inst_final2/ev --destroy_db_initially --max_key=500 --ops_per_thread=200 --threads=2 --clear_column_family_one_in=0 --reopen=3 --continuous_verification_interval=0 --test_secondary=0 --write_fault_one_in=100 --sync_fault_injection=1 --open_write_fault_one_in=16 --enable_checksum_handoff=1 --file_checksum_impl=crc32c
  Verification successful
  DbStressFSWrapper instrumentation: IOActivity checks=318, SST checksum verifications=94
  MANIFEST-000001_renamed_ MANIFEST-000005_renamed_ MANIFEST-000019_renamed_ MANIFEST-000037_renamed_
  LOG.old.1778909841646222: 4 injected errors
  LOG.old.1778909841886623: 4 injected errors
  LOG.old.1778909842158291: 4 injected errors

  Proves: after FS order swap, IOActivity assertion checks and SST checksum verifications are still executing, and MANIFEST preservation and fault injection still work together.
  
Reviewed By: anand1976

Differential Revision: D104959945


