### PR TITLE
Add iterator key/value pinning APIs

### DIFF
--- a/db/arena_wrapped_db_iter.h
+++ b/db/arena_wrapped_db_iter.h
@@ -102,6 +102,14 @@ class ArenaWrappedDBIter : public Iterator {
     db_iter_->Prepare(scan_opts);
   }
 
+  Status PinCurrent(PinnableKeyValue* out) override {
+    return db_iter_->PinCurrent(out);
+  }
+
+  Status AppendPinnedCurrent(PinnableKeyValueBatch* batch) override {
+    return db_iter_->AppendPinnedCurrent(batch);
+  }
+
   // FIXME: we could just pass SV in for mutable cf option, version and version
   // number, but this is used by SstFileReader which does not have a SV.
   void Init(Env* env, const ReadOptions& read_options,

--- a/db/blob/blob_counting_iterator.h
+++ b/db/blob/blob_counting_iterator.h
@@ -119,6 +119,11 @@ class BlobCountingIterator : public InternalIterator {
     return iter_->IsValuePinned();
   }
 
+  Status PinCurrentKeyValue(PinnedIterKeyValue* out) override {
+    assert(Valid());
+    return iter_->PinCurrentKeyValue(out);
+  }
+
   Status GetProperty(std::string prop_name, std::string* prop) override {
     return iter_->GetProperty(prop_name, prop);
   }

--- a/db/compaction/clipping_iterator.h
+++ b/db/compaction/clipping_iterator.h
@@ -184,6 +184,11 @@ class ClippingIterator : public InternalIterator {
     return iter_->IsValuePinned();
   }
 
+  Status PinCurrentKeyValue(PinnedIterKeyValue* out) override {
+    assert(valid_);
+    return iter_->PinCurrentKeyValue(out);
+  }
+
   Status GetProperty(std::string prop_name, std::string* prop) override {
     return iter_->GetProperty(prop_name, prop);
   }

--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -194,6 +194,128 @@ Status DBIter::GetProperty(std::string prop_name, std::string* prop) {
   return Status::InvalidArgument("Unidentified property.");
 }
 
+Status DBIter::PrepareForPinCurrent() {
+  if (!Valid()) {
+    return Status::InvalidArgument("Iterator is not valid");
+  }
+  if (direction_ != kForward) {
+    return Status::NotSupported(
+        "Pinning the current row is only supported during forward iteration");
+  }
+  if (timestamp_size_ != 0 || timestamp_lb_ != nullptr) {
+    return Status::NotSupported(
+        "Pinning the current row does not yet support user-defined timestamps");
+  }
+  if (current_entry_is_merged_) {
+    return Status::NotSupported(
+        "Pinning the current row does not support merge results");
+  }
+  if (!iter_.Valid()) {
+    return Status::NotSupported(
+        "Pinning the current row requires the current internal entry to "
+        "remain positioned");
+  }
+  if (!iter_.IsValuePrepared() && !PrepareValue()) {
+    return status();
+  }
+  if (ikey_.type != kTypeValue) {
+    return Status::NotSupported(
+        "Pinning the current row only supports kTypeValue rows");
+  }
+  return Status::OK();
+}
+
+Status DBIter::TryPinCurrentKeyValue(Slice* current_key, Slice* current_value,
+                                     PinnedIterKeyValue* pinned_kv) {
+  assert(current_key != nullptr);
+  assert(current_value != nullptr);
+  assert(pinned_kv != nullptr);
+
+  *current_key = key();
+  *current_value = value();
+  pinned_kv->Reset();
+  return iter_.PinCurrentKeyValue(pinned_kv);
+}
+
+Status DBIter::PinCurrent(PinnableKeyValue* out) {
+  if (out == nullptr) {
+    return Status::InvalidArgument("PinnableKeyValue is nullptr");
+  }
+  out->Reset();
+  Status prepare_status = PrepareForPinCurrent();
+  if (!prepare_status.ok()) {
+    return prepare_status;
+  }
+
+  Slice current_key;
+  Slice current_value;
+  PinnedIterKeyValue pinned_kv;
+  Status pin_status =
+      TryPinCurrentKeyValue(&current_key, &current_value, &pinned_kv);
+  if (!pin_status.ok()) {
+    if (!pin_status.IsNotSupported()) {
+      return pin_status;
+    }
+    out->CopyKey(current_key);
+    out->CopyValue(current_value);
+    return Status::OK();
+  }
+
+  out->SetCleanup(std::move(pinned_kv.cleanup));
+  out->SetPinnedBlockCacheUsage(pinned_kv.pinned_block_cache_usage);
+  if (pinned_kv.value_pinned) {
+    out->PinValue(pinned_kv.value);
+  } else {
+    out->CopyValue(current_value);
+  }
+
+  if (!pinned_kv.key_pinned) {
+    out->CopyKey(current_key);
+    return Status::OK();
+  }
+
+  out->PinKey(pinned_kv.user_key);
+  return Status::OK();
+}
+
+Status DBIter::AppendPinnedCurrent(PinnableKeyValueBatch* batch) {
+  if (batch == nullptr) {
+    return Status::InvalidArgument("PinnableKeyValueBatch is nullptr");
+  }
+
+  Status prepare_status = PrepareForPinCurrent();
+  if (!prepare_status.ok()) {
+    return prepare_status;
+  }
+
+  Slice current_key;
+  Slice current_value;
+  PinnedIterKeyValue pinned_kv;
+  Status pin_status =
+      TryPinCurrentKeyValue(&current_key, &current_value, &pinned_kv);
+  if (!pin_status.ok()) {
+    if (!pin_status.IsNotSupported()) {
+      return pin_status;
+    }
+    batch->Append(current_key, false /* pin_key */, current_value,
+                  false /* pin_value */, SharedCleanablePtr(),
+                  nullptr /* cleanup_dedupe_token */,
+                  0 /* pinned_block_cache_usage */);
+    return Status::OK();
+  }
+
+  const Slice key_slice =
+      pinned_kv.key_pinned ? pinned_kv.user_key : current_key;
+  const Slice value_slice =
+      pinned_kv.value_pinned ? pinned_kv.value : current_value;
+
+  batch->Append(key_slice, pinned_kv.key_pinned, value_slice,
+                pinned_kv.value_pinned, std::move(pinned_kv.cleanup),
+                pinned_kv.cleanup_dedupe_token,
+                pinned_kv.pinned_block_cache_usage);
+  return Status::OK();
+}
+
 bool DBIter::ParseKey(ParsedInternalKey* ikey) {
   Status s = ParseInternalKey(iter_.key(), ikey, false /* log_err_key */);
   if (!s.ok()) {

--- a/db/db_iter.h
+++ b/db/db_iter.h
@@ -252,6 +252,8 @@ class DBIter final : public Iterator {
   bool PrepareValue() override;
 
   void Prepare(const MultiScanArgs& scan_opts) override;
+  Status PinCurrent(PinnableKeyValue* out) override;
+  Status AppendPinnedCurrent(PinnableKeyValueBatch* batch) override;
   Status ValidateScanOptions(const MultiScanArgs& multiscan_opts) const;
 
  private:
@@ -532,6 +534,9 @@ class DBIter final : public Iterator {
                                       const Slice& blob_index);
   bool SetValueAndColumnsFromBlob(const Slice& user_key,
                                   const Slice& blob_index);
+  Status PrepareForPinCurrent();
+  Status TryPinCurrentKeyValue(Slice* current_key, Slice* current_value,
+                               PinnedIterKeyValue* pinned_kv);
 
   bool SetValueAndColumnsFromEntity(Slice slice);
   bool MaterializeLazyEntityColumns() const;

--- a/db/db_iter_test.cc
+++ b/db/db_iter_test.cc
@@ -1424,6 +1424,45 @@ TEST_F(DBIteratorTest, DBIteratorTimedPutBasic) {
   ASSERT_OK(db_iter->status());
 }
 
+// Verifies the new row-pinning APIs explicitly reject
+// kTypeValuePreferredSeqno rows. This injects a TimedPut directly into the
+// internal iterator so DBIter sees the unsupported value type without relying
+// on flush or compaction setup, then checks both PinCurrent() and
+// AppendPinnedCurrent() leave caller-owned outputs empty on failure.
+TEST_F(DBIteratorTest, DBIteratorPinAPIsRejectTimedPutRows) {
+  ReadOptions ro;
+  Options options;
+
+  TestIterator* internal_iter = new TestIterator(BytewiseComparator());
+  internal_iter->AddTimedPut("a", "value", /*write_unix_time=*/0);
+  internal_iter->Finish();
+
+  std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
+      env_, ro, ImmutableOptions(options), MutableCFOptions(options),
+      BytewiseComparator(), internal_iter, nullptr /* version */,
+      7 /* sequence */, nullptr /* read_callback */, /*active_mem=*/nullptr));
+  db_iter->SeekToFirst();
+  ASSERT_TRUE(db_iter->Valid());
+  ASSERT_EQ("a", db_iter->key().ToString());
+  ASSERT_EQ("value", db_iter->value().ToString());
+
+  PinnableKeyValue pinned_kv;
+  PinnableKeyValueBatch batch;
+
+  Status pin_status = db_iter->PinCurrent(&pinned_kv);
+  ASSERT_TRUE(pin_status.IsNotSupported());
+  ASSERT_TRUE(pinned_kv.key().empty());
+  ASSERT_TRUE(pinned_kv.value().empty());
+  ASSERT_EQ(0U, pinned_kv.GetCopiedBytes());
+  ASSERT_EQ(0U, pinned_kv.GetPinnedBlockCacheUsage());
+
+  Status append_status = db_iter->AppendPinnedCurrent(&batch);
+  ASSERT_TRUE(append_status.IsNotSupported());
+  ASSERT_EQ(0U, batch.size());
+  ASSERT_EQ(0U, batch.GetCopiedBytes());
+  ASSERT_EQ(0U, batch.GetPinnedBlockCacheUsage());
+}
+
 TEST_F(DBIteratorTest, DBIterator1) {
   ReadOptions ro;
   Options options;

--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -36,6 +36,125 @@ namespace ROCKSDB_NAMESPACE {
 class DBTest2 : public DBTestBase {
  public:
   DBTest2() : DBTestBase("db_test2", /*env_do_fsync=*/true) {}
+
+ protected:
+  struct PinnedKVBatchSnapshot {
+    std::vector<std::string> keys;
+    std::vector<std::string> values;
+    std::vector<bool> key_pinned;
+    std::vector<bool> value_pinned;
+    size_t pinned_block_cache_usage = 0;
+    size_t copied_bytes = 0;
+  };
+
+  static std::string PinnedKVTestKey(int index) {
+    return "prefix" + std::to_string(100000 + index);
+  }
+
+  Options CurrentPinnedKVOptions(size_t block_size, bool use_block_cache,
+                                 std::shared_ptr<Cache>* block_cache,
+                                 bool use_delta_encoding = true) const {
+    Options options = CurrentOptions();
+    options.compression = kNoCompression;
+    BlockBasedTableOptions bbto;
+    if (use_block_cache) {
+      bbto.block_cache = NewLRUCache(1 << 20);
+      if (block_cache != nullptr) {
+        *block_cache = bbto.block_cache;
+      }
+    } else {
+      bbto.no_block_cache = true;
+    }
+    bbto.block_size = block_size;
+    bbto.block_restart_interval = 16;
+    bbto.use_delta_encoding = use_delta_encoding;
+    options.table_factory.reset(NewBlockBasedTableFactory(bbto));
+    return options;
+  }
+
+  void PutPinnedKVRows(int count, size_t value_size,
+                       std::vector<std::string>* values) {
+    assert(values != nullptr);
+    values->clear();
+    values->reserve(count);
+    for (int i = 0; i < count; ++i) {
+      values->emplace_back(value_size, static_cast<char>('a' + (i % 26)));
+      ASSERT_OK(Put(PinnedKVTestKey(i), values->back()));
+    }
+  }
+
+  void AssertPinnedBatchEntry(const PinnableKeyValueBatch& batch, size_t index,
+                              const std::string& expected_key,
+                              const std::string& expected_value,
+                              bool expect_key_pinned,
+                              bool expect_value_pinned) {
+    ASSERT_LT(index, batch.size());
+    ASSERT_EQ(expected_key, batch.key(index).ToString());
+    ASSERT_EQ(expected_value, batch.value(index).ToString());
+    ASSERT_EQ(expect_key_pinned, batch.IsKeyPinned(index));
+    ASSERT_EQ(expect_value_pinned, batch.IsValuePinned(index));
+  }
+
+  void AssertEmptyPinnedKeyValue(const PinnableKeyValue& pinned_kv) {
+    ASSERT_TRUE(pinned_kv.key().empty());
+    ASSERT_TRUE(pinned_kv.value().empty());
+    ASSERT_FALSE(pinned_kv.IsKeyPinned());
+    ASSERT_FALSE(pinned_kv.IsValuePinned());
+    ASSERT_EQ(0U, pinned_kv.GetPinnedBlockCacheUsage());
+    ASSERT_EQ(0U, pinned_kv.GetCopiedBytes());
+  }
+
+  void AssertEmptyPinnedKeyValueBatch(const PinnableKeyValueBatch& batch) {
+    ASSERT_TRUE(batch.empty());
+    ASSERT_EQ(0U, batch.GetPinnedBlockCacheUsage());
+    ASSERT_EQ(0U, batch.GetCopiedBytes());
+  }
+
+  void AssertPinAPIsNotSupportedForCurrentRow(Iterator* iter) {
+    assert(iter != nullptr);
+    assert(iter->Valid());
+
+    PinnableKeyValue pinned_kv;
+    PinnableKeyValueBatch batch;
+
+    Status pin_status = iter->PinCurrent(&pinned_kv);
+    ASSERT_TRUE(pin_status.IsNotSupported());
+    AssertEmptyPinnedKeyValue(pinned_kv);
+
+    Status append_status = iter->AppendPinnedCurrent(&batch);
+    ASSERT_TRUE(append_status.IsNotSupported());
+    AssertEmptyPinnedKeyValueBatch(batch);
+  }
+
+  PinnedKVBatchSnapshot CaptureBatchSnapshot(
+      const PinnableKeyValueBatch& batch) {
+    PinnedKVBatchSnapshot snapshot;
+    snapshot.pinned_block_cache_usage = batch.GetPinnedBlockCacheUsage();
+    snapshot.copied_bytes = batch.GetCopiedBytes();
+    snapshot.keys.reserve(batch.size());
+    snapshot.values.reserve(batch.size());
+    snapshot.key_pinned.reserve(batch.size());
+    snapshot.value_pinned.reserve(batch.size());
+    for (size_t i = 0; i < batch.size(); ++i) {
+      snapshot.keys.push_back(batch.key(i).ToString());
+      snapshot.values.push_back(batch.value(i).ToString());
+      snapshot.key_pinned.push_back(batch.IsKeyPinned(i));
+      snapshot.value_pinned.push_back(batch.IsValuePinned(i));
+    }
+    return snapshot;
+  }
+
+  void AssertBatchMatchesSnapshot(const PinnableKeyValueBatch& batch,
+                                  const PinnedKVBatchSnapshot& snapshot) {
+    ASSERT_EQ(snapshot.keys.size(), batch.size());
+    ASSERT_EQ(snapshot.pinned_block_cache_usage,
+              batch.GetPinnedBlockCacheUsage());
+    ASSERT_EQ(snapshot.copied_bytes, batch.GetCopiedBytes());
+    for (size_t i = 0; i < snapshot.keys.size(); ++i) {
+      AssertPinnedBatchEntry(batch, i, snapshot.keys[i], snapshot.values[i],
+                             snapshot.key_pinned[i], snapshot.value_pinned[i]);
+    }
+  }
 };
 
 TEST_F(DBTest2, OpenForReadOnly) {
@@ -4542,6 +4661,435 @@ TEST_F(DBTest2, PinnableSliceAndMmapReads) {
   ASSERT_EQ(Get("foo", &pinned_value), Status::OK());
   ASSERT_TRUE(pinned_value.IsPinned());
   ASSERT_EQ(pinned_value.ToString(), "bar");
+}
+
+TEST_F(DBTest2, IteratorPinCurrentDeltaEncodedKeyAndPinnedValue) {
+  std::shared_ptr<Cache> block_cache;
+  Options options = CurrentPinnedKVOptions(
+      160 /* block_size */, true /* use_block_cache */, &block_cache);
+  Reopen(options);
+
+  std::vector<std::string> values;
+  PutPinnedKVRows(20, 48, &values);
+  ASSERT_OK(Flush());
+  const size_t baseline_pinned_usage = block_cache->GetPinnedUsage();
+
+  PinnableKeyValue pinned_kv;
+  {
+    ReadOptions read_options;
+    std::unique_ptr<Iterator> iter(db_->NewIterator(read_options));
+    iter->Seek(PinnedKVTestKey(1));
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_OK(iter->PinCurrent(&pinned_kv));
+    ASSERT_EQ(PinnedKVTestKey(1), pinned_kv.key().ToString());
+    ASSERT_EQ(values[1], pinned_kv.value().ToString());
+    ASSERT_FALSE(pinned_kv.IsKeyPinned());
+    ASSERT_TRUE(pinned_kv.IsValuePinned());
+    ASSERT_EQ(pinned_kv.GetCopiedBytes(), pinned_kv.key().size());
+    ASSERT_GT(pinned_kv.GetPinnedBlockCacheUsage(), 0);
+    ASSERT_GE(block_cache->GetPinnedUsage(),
+              pinned_kv.GetPinnedBlockCacheUsage());
+
+    iter->Seek(PinnedKVTestKey(10));
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_EQ(PinnedKVTestKey(1), pinned_kv.key().ToString());
+    ASSERT_EQ(values[1], pinned_kv.value().ToString());
+  }
+
+  ASSERT_EQ(PinnedKVTestKey(1), pinned_kv.key().ToString());
+  ASSERT_EQ(values[1], pinned_kv.value().ToString());
+  const size_t row_pinned_usage = pinned_kv.GetPinnedBlockCacheUsage();
+  const size_t pinned_usage_before_reset = block_cache->GetPinnedUsage();
+  ASSERT_GE(pinned_usage_before_reset,
+            baseline_pinned_usage + row_pinned_usage);
+
+  pinned_kv.Reset();
+  ASSERT_EQ(baseline_pinned_usage, block_cache->GetPinnedUsage());
+}
+
+TEST_F(DBTest2, IteratorPinAPIsPinNonDeltaEncodedKeyAndValue) {
+  std::shared_ptr<Cache> block_cache;
+  Options options =
+      CurrentPinnedKVOptions(160 /* block_size */, true /* use_block_cache */,
+                             &block_cache, false /* use_delta_encoding */);
+  Reopen(options);
+
+  std::vector<std::string> values;
+  PutPinnedKVRows(3, 48, &values);
+  ASSERT_OK(Flush());
+
+  PinnableKeyValue pinned_kv;
+  PinnableKeyValueBatch batch;
+  const size_t baseline_pinned_usage = block_cache->GetPinnedUsage();
+  {
+    std::unique_ptr<Iterator> iter(db_->NewIterator(ReadOptions()));
+    iter->Seek(PinnedKVTestKey(1));
+    ASSERT_TRUE(iter->Valid());
+
+    ASSERT_OK(iter->PinCurrent(&pinned_kv));
+    ASSERT_EQ(PinnedKVTestKey(1), pinned_kv.key().ToString());
+    ASSERT_EQ(values[1], pinned_kv.value().ToString());
+    ASSERT_TRUE(pinned_kv.IsKeyPinned());
+    ASSERT_TRUE(pinned_kv.IsValuePinned());
+    ASSERT_EQ(0U, pinned_kv.GetCopiedBytes());
+    ASSERT_GT(pinned_kv.GetPinnedBlockCacheUsage(), 0);
+
+    ASSERT_OK(iter->AppendPinnedCurrent(&batch));
+    ASSERT_EQ(1U, batch.size());
+    AssertPinnedBatchEntry(batch, 0, PinnedKVTestKey(1), values[1],
+                           true /* expect_key_pinned */,
+                           true /* expect_value_pinned */);
+    ASSERT_EQ(0U, batch.GetCopiedBytes());
+
+    iter->Seek(PinnedKVTestKey(2));
+    ASSERT_TRUE(iter->Valid());
+  }
+
+  ASSERT_EQ(PinnedKVTestKey(1), pinned_kv.key().ToString());
+  ASSERT_EQ(values[1], pinned_kv.value().ToString());
+  AssertPinnedBatchEntry(batch, 0, PinnedKVTestKey(1), values[1],
+                         true /* expect_key_pinned */,
+                         true /* expect_value_pinned */);
+
+  pinned_kv.Reset();
+  batch.Reset();
+  ASSERT_EQ(baseline_pinned_usage, block_cache->GetPinnedUsage());
+}
+
+TEST_F(DBTest2, IteratorPinCurrentFallsBackToCopyWithoutBlockCache) {
+  Options options =
+      CurrentPinnedKVOptions(160 /* block_size */, false /* use_block_cache */,
+                             nullptr /* block_cache */);
+  Reopen(options);
+
+  std::vector<std::string> values;
+  PutPinnedKVRows(3, 48, &values);
+  ASSERT_OK(Flush());
+
+  PinnableKeyValue pinned_kv;
+  {
+    std::unique_ptr<Iterator> iter(db_->NewIterator(ReadOptions()));
+    iter->Seek(PinnedKVTestKey(1));
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_OK(iter->PinCurrent(&pinned_kv));
+    ASSERT_EQ(PinnedKVTestKey(1), pinned_kv.key().ToString());
+    ASSERT_EQ(values[1], pinned_kv.value().ToString());
+    ASSERT_FALSE(pinned_kv.IsKeyPinned());
+    ASSERT_FALSE(pinned_kv.IsValuePinned());
+    ASSERT_EQ(pinned_kv.GetCopiedBytes(),
+              pinned_kv.key().size() + pinned_kv.value().size());
+    ASSERT_EQ(0, pinned_kv.GetPinnedBlockCacheUsage());
+  }
+
+  ASSERT_EQ(PinnedKVTestKey(1), pinned_kv.key().ToString());
+  ASSERT_EQ(values[1], pinned_kv.value().ToString());
+}
+
+TEST_F(DBTest2, IteratorAppendPinnedCurrentDedupesSameBlockLease) {
+  std::shared_ptr<Cache> block_cache;
+  Options options = CurrentPinnedKVOptions(
+      4096 /* block_size */, true /* use_block_cache */, &block_cache);
+  Reopen(options);
+
+  std::vector<std::string> values;
+  PutPinnedKVRows(3, 32, &values);
+  ASSERT_OK(Flush());
+  const size_t baseline_pinned_usage = block_cache->GetPinnedUsage();
+
+  PinnableKeyValueBatch batch;
+  size_t first_row_pinned_usage = 0;
+  {
+    std::unique_ptr<Iterator> iter(db_->NewIterator(ReadOptions()));
+    iter->Seek(PinnedKVTestKey(1));
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_OK(iter->AppendPinnedCurrent(&batch));
+    first_row_pinned_usage = batch.GetPinnedBlockCacheUsage();
+    ASSERT_GT(first_row_pinned_usage, 0);
+    AssertPinnedBatchEntry(batch, 0, PinnedKVTestKey(1), values[1],
+                           false /* expect_key_pinned */,
+                           true /* expect_value_pinned */);
+
+    iter->Next();
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_OK(iter->AppendPinnedCurrent(&batch));
+    ASSERT_EQ(2U, batch.size());
+    AssertPinnedBatchEntry(batch, 1, PinnedKVTestKey(2), values[2],
+                           false /* expect_key_pinned */,
+                           true /* expect_value_pinned */);
+    ASSERT_EQ(first_row_pinned_usage, batch.GetPinnedBlockCacheUsage());
+    ASSERT_EQ(batch.key(0).size() + batch.key(1).size(),
+              batch.GetCopiedBytes());
+
+    iter->Seek(PinnedKVTestKey(0));
+    ASSERT_TRUE(iter->Valid());
+  }
+
+  AssertPinnedBatchEntry(batch, 0, PinnedKVTestKey(1), values[1],
+                         false /* expect_key_pinned */,
+                         true /* expect_value_pinned */);
+  AssertPinnedBatchEntry(batch, 1, PinnedKVTestKey(2), values[2],
+                         false /* expect_key_pinned */,
+                         true /* expect_value_pinned */);
+  const size_t batch_pinned_usage = batch.GetPinnedBlockCacheUsage();
+  const size_t pinned_usage_before_reset = block_cache->GetPinnedUsage();
+  ASSERT_GE(pinned_usage_before_reset,
+            baseline_pinned_usage + batch_pinned_usage);
+
+  batch.Reset();
+  ASSERT_EQ(baseline_pinned_usage, block_cache->GetPinnedUsage());
+}
+
+TEST_F(DBTest2, IteratorAppendPinnedCurrentTracksDistinctBlockUsage) {
+  std::shared_ptr<Cache> block_cache;
+  Options options = CurrentPinnedKVOptions(
+      160 /* block_size */, true /* use_block_cache */, &block_cache);
+  Reopen(options);
+
+  std::vector<std::string> values;
+  PutPinnedKVRows(20, 48, &values);
+  ASSERT_OK(Flush());
+  const size_t baseline_pinned_usage = block_cache->GetPinnedUsage();
+
+  PinnableKeyValueBatch batch;
+  {
+    std::unique_ptr<Iterator> iter(db_->NewIterator(ReadOptions()));
+    iter->Seek(PinnedKVTestKey(1));
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_OK(iter->AppendPinnedCurrent(&batch));
+    const size_t first_block_usage = batch.GetPinnedBlockCacheUsage();
+    ASSERT_GT(first_block_usage, 0);
+
+    iter->Seek(PinnedKVTestKey(10));
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_OK(iter->AppendPinnedCurrent(&batch));
+    ASSERT_EQ(2U, batch.size());
+    ASSERT_GT(batch.GetPinnedBlockCacheUsage(), first_block_usage);
+  }
+
+  ASSERT_EQ(PinnedKVTestKey(1), batch.key(0).ToString());
+  ASSERT_EQ(values[1], batch.value(0).ToString());
+  ASSERT_TRUE(batch.IsValuePinned(0));
+  ASSERT_EQ(PinnedKVTestKey(10), batch.key(1).ToString());
+  ASSERT_EQ(values[10], batch.value(1).ToString());
+  ASSERT_TRUE(batch.IsValuePinned(1));
+  const size_t batch_pinned_usage = batch.GetPinnedBlockCacheUsage();
+  const size_t pinned_usage_before_reset = block_cache->GetPinnedUsage();
+  ASSERT_GE(pinned_usage_before_reset,
+            baseline_pinned_usage + batch_pinned_usage);
+
+  batch.Reset();
+  ASSERT_EQ(baseline_pinned_usage, block_cache->GetPinnedUsage());
+}
+
+TEST_F(DBTest2, IteratorAppendPinnedCurrentFallsBackToCopyWithoutBlockCache) {
+  Options options =
+      CurrentPinnedKVOptions(160 /* block_size */, false /* use_block_cache */,
+                             nullptr /* block_cache */);
+  Reopen(options);
+
+  std::vector<std::string> values;
+  PutPinnedKVRows(3, 48, &values);
+  ASSERT_OK(Flush());
+
+  PinnableKeyValueBatch batch;
+  {
+    std::unique_ptr<Iterator> iter(db_->NewIterator(ReadOptions()));
+    iter->Seek(PinnedKVTestKey(0));
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_OK(iter->AppendPinnedCurrent(&batch));
+    iter->Next();
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_OK(iter->AppendPinnedCurrent(&batch));
+  }
+
+  ASSERT_EQ(2U, batch.size());
+  AssertPinnedBatchEntry(batch, 0, PinnedKVTestKey(0), values[0],
+                         false /* expect_key_pinned */,
+                         false /* expect_value_pinned */);
+  AssertPinnedBatchEntry(batch, 1, PinnedKVTestKey(1), values[1],
+                         false /* expect_key_pinned */,
+                         false /* expect_value_pinned */);
+  ASSERT_EQ(batch.key(0).size() + batch.value(0).size() + batch.key(1).size() +
+                batch.value(1).size(),
+            batch.GetCopiedBytes());
+  ASSERT_EQ(0, batch.GetPinnedBlockCacheUsage());
+}
+
+TEST_F(DBTest2, IteratorPinCurrentClearsOutputOnReverseIterationNotSupported) {
+  Options options =
+      CurrentPinnedKVOptions(160 /* block_size */, true /* use_block_cache */,
+                             nullptr /* block_cache */);
+  Reopen(options);
+
+  std::vector<std::string> values;
+  PutPinnedKVRows(3, 48, &values);
+  ASSERT_OK(Flush());
+
+  PinnableKeyValue pinned_kv;
+  std::unique_ptr<Iterator> iter(db_->NewIterator(ReadOptions()));
+  iter->Seek(PinnedKVTestKey(0));
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_OK(iter->PinCurrent(&pinned_kv));
+  ASSERT_EQ(PinnedKVTestKey(0), pinned_kv.key().ToString());
+  ASSERT_EQ(values[0], pinned_kv.value().ToString());
+
+  iter->SeekToLast();
+  ASSERT_TRUE(iter->Valid());
+  Status status = iter->PinCurrent(&pinned_kv);
+  ASSERT_TRUE(status.IsNotSupported());
+  AssertEmptyPinnedKeyValue(pinned_kv);
+}
+
+TEST_F(DBTest2, IteratorPinAPIsHandleReverseIterationSafely) {
+  Options options =
+      CurrentPinnedKVOptions(160 /* block_size */, true /* use_block_cache */,
+                             nullptr /* block_cache */);
+  Reopen(options);
+
+  std::vector<std::string> values;
+  PutPinnedKVRows(3, 48, &values);
+  ASSERT_OK(Flush());
+
+  PinnableKeyValue pinned_kv;
+  PinnableKeyValueBatch batch;
+  std::unique_ptr<Iterator> iter(db_->NewIterator(ReadOptions()));
+
+  iter->Seek(PinnedKVTestKey(0));
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_OK(iter->PinCurrent(&pinned_kv));
+  ASSERT_OK(iter->AppendPinnedCurrent(&batch));
+  const PinnedKVBatchSnapshot snapshot = CaptureBatchSnapshot(batch);
+
+  iter->SeekToLast();
+  ASSERT_TRUE(iter->Valid());
+  Status pin_status = iter->PinCurrent(&pinned_kv);
+  ASSERT_TRUE(pin_status.IsNotSupported());
+  AssertEmptyPinnedKeyValue(pinned_kv);
+
+  Status append_status = iter->AppendPinnedCurrent(&batch);
+  ASSERT_TRUE(append_status.IsNotSupported());
+  AssertBatchMatchesSnapshot(batch, snapshot);
+}
+
+TEST_F(DBTest2, IteratorAppendPinnedCurrentResetReleasesAndReusesBatch) {
+  std::shared_ptr<Cache> block_cache;
+  Options options = CurrentPinnedKVOptions(
+      160 /* block_size */, true /* use_block_cache */, &block_cache);
+  Reopen(options);
+
+  std::vector<std::string> values;
+  PutPinnedKVRows(20, 48, &values);
+  ASSERT_OK(Flush());
+  const size_t baseline_pinned_usage = block_cache->GetPinnedUsage();
+
+  PinnableKeyValueBatch batch;
+  std::unique_ptr<Iterator> iter(db_->NewIterator(ReadOptions()));
+  iter->Seek(PinnedKVTestKey(1));
+  ASSERT_TRUE(iter->Valid());
+  const size_t pinned_usage_before_first_append = block_cache->GetPinnedUsage();
+  ASSERT_OK(iter->AppendPinnedCurrent(&batch));
+  const size_t first_batch_pinned_usage = batch.GetPinnedBlockCacheUsage();
+  ASSERT_GT(first_batch_pinned_usage, 0);
+
+  batch.Reset();
+  ASSERT_TRUE(batch.empty());
+  ASSERT_EQ(0U, batch.GetPinnedBlockCacheUsage());
+  ASSERT_EQ(0U, batch.GetCopiedBytes());
+  ASSERT_EQ(pinned_usage_before_first_append, block_cache->GetPinnedUsage());
+
+  iter->Seek(PinnedKVTestKey(10));
+  ASSERT_TRUE(iter->Valid());
+  const size_t pinned_usage_before_second_append =
+      block_cache->GetPinnedUsage();
+  ASSERT_OK(iter->AppendPinnedCurrent(&batch));
+  ASSERT_EQ(1U, batch.size());
+  AssertPinnedBatchEntry(batch, 0, PinnedKVTestKey(10), values[10],
+                         false /* expect_key_pinned */,
+                         true /* expect_value_pinned */);
+  ASSERT_GT(batch.GetPinnedBlockCacheUsage(), 0);
+  ASSERT_EQ(batch.key(0).size(), batch.GetCopiedBytes());
+
+  const size_t second_batch_pinned_usage = batch.GetPinnedBlockCacheUsage();
+  batch.Reset();
+  ASSERT_GT(second_batch_pinned_usage, 0);
+  ASSERT_EQ(pinned_usage_before_second_append, block_cache->GetPinnedUsage());
+
+  iter.reset();
+  ASSERT_EQ(baseline_pinned_usage, block_cache->GetPinnedUsage());
+}
+
+TEST_F(DBTest2, IteratorPinAPIsRejectNullOutputPointers) {
+  Options options =
+      CurrentPinnedKVOptions(160 /* block_size */, true /* use_block_cache */,
+                             nullptr /* block_cache */);
+  Reopen(options);
+
+  std::vector<std::string> values;
+  PutPinnedKVRows(1, 48, &values);
+  ASSERT_OK(Flush());
+
+  std::unique_ptr<Iterator> iter(db_->NewIterator(ReadOptions()));
+  iter->Seek(PinnedKVTestKey(0));
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_TRUE(iter->PinCurrent(nullptr).IsInvalidArgument());
+  ASSERT_TRUE(iter->AppendPinnedCurrent(nullptr).IsInvalidArgument());
+}
+
+TEST_F(DBTest2, IteratorPinAPIsRejectBlobRowsAfterPrepareValue) {
+  Options options = CurrentOptions();
+  options.enable_blob_files = true;
+  options.min_blob_size = 0;
+  DestroyAndReopen(options);
+
+  const std::string blob_value(128, 'b');
+  ASSERT_OK(Put("blob-key", blob_value));
+  ASSERT_OK(Flush());
+
+  ReadOptions read_options;
+  read_options.allow_unprepared_value = true;
+  std::unique_ptr<Iterator> iter(db_->NewIterator(read_options));
+  iter->Seek("blob-key");
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_TRUE(iter->PrepareValue());
+  ASSERT_EQ(blob_value, iter->value().ToString());
+  AssertPinAPIsNotSupportedForCurrentRow(iter.get());
+}
+
+TEST_F(DBTest2, IteratorPinAPIsRejectWideColumnEntityRows) {
+  Options options = CurrentOptions();
+  DestroyAndReopen(options);
+
+  const WideColumns columns{{kDefaultWideColumnName, "default"},
+                            {"attr", "value"}};
+  ASSERT_OK(db_->PutEntity(WriteOptions(), db_->DefaultColumnFamily(),
+                           "wide-key", columns));
+  ASSERT_OK(Flush());
+
+  std::unique_ptr<Iterator> iter(db_->NewIterator(ReadOptions()));
+  iter->Seek("wide-key");
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ("default", iter->value().ToString());
+  AssertPinAPIsNotSupportedForCurrentRow(iter.get());
+}
+
+TEST_F(DBTest2, IteratorPinAPIsRejectUserDefinedTimestampRows) {
+  Options options = CurrentOptions();
+  options.comparator = test::BytewiseComparatorWithU64TsWrapper();
+  DestroyAndReopen(options);
+
+  std::string ts;
+  PutFixed64(&ts, 7);
+  ASSERT_OK(db_->Put(WriteOptions(), "ts-key", ts, "value"));
+  ASSERT_OK(Flush());
+
+  const Slice read_ts_slice(ts);
+  ReadOptions read_options;
+  read_options.timestamp = &read_ts_slice;
+  std::unique_ptr<Iterator> iter(db_->NewIterator(read_options));
+  iter->Seek("ts-key");
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ("value", iter->value().ToString());
+  AssertPinAPIsNotSupportedForCurrentRow(iter.get());
 }
 
 TEST_F(DBTest2, DISABLED_IteratorPinnedMemory) {

--- a/db/forward_iterator.cc
+++ b/db/forward_iterator.cc
@@ -195,6 +195,16 @@ class ForwardLevelIterator : public InternalIterator {
     return pinned_iters_mgr_ && pinned_iters_mgr_->PinningEnabled() &&
            file_iter_->IsValuePinned();
   }
+  Status PinCurrentKeyValue(PinnedIterKeyValue* out) override {
+    if (out == nullptr) {
+      return Status::InvalidArgument("PinnedIterKeyValue is nullptr");
+    }
+    out->Reset();
+    if (!valid_) {
+      return Status::InvalidArgument("Iterator is not valid");
+    }
+    return file_iter_->PinCurrentKeyValue(out);
+  }
   void SetPinnedItersMgr(PinnedIteratorsManager* pinned_iters_mgr) override {
     pinned_iters_mgr_ = pinned_iters_mgr;
     if (file_iter_) {
@@ -699,6 +709,17 @@ bool ForwardIterator::IsKeyPinned() const {
 bool ForwardIterator::IsValuePinned() const {
   return pinned_iters_mgr_ && pinned_iters_mgr_->PinningEnabled() &&
          current_->IsValuePinned();
+}
+
+Status ForwardIterator::PinCurrentKeyValue(PinnedIterKeyValue* out) {
+  if (out == nullptr) {
+    return Status::InvalidArgument("PinnedIterKeyValue is nullptr");
+  }
+  out->Reset();
+  if (!valid_ || current_ == nullptr) {
+    return Status::InvalidArgument("Iterator is not valid");
+  }
+  return current_->PinCurrentKeyValue(out);
 }
 
 void ForwardIterator::RebuildIterators(bool refresh_sv) {

--- a/db/forward_iterator.h
+++ b/db/forward_iterator.h
@@ -83,6 +83,7 @@ class ForwardIterator : public InternalIterator {
   void SetPinnedItersMgr(PinnedIteratorsManager* pinned_iters_mgr) override;
   bool IsKeyPinned() const override;
   bool IsValuePinned() const override;
+  Status PinCurrentKeyValue(PinnedIterKeyValue* out) override;
 
   bool TEST_CheckDeletedIters(int* deleted_iters, int* num_iters);
 

--- a/db/history_trimming_iterator.h
+++ b/db/history_trimming_iterator.h
@@ -82,6 +82,10 @@ class HistoryTrimmingIterator : public InternalIterator {
 
   bool IsValuePinned() const override { return input_->IsValuePinned(); }
 
+  Status PinCurrentKeyValue(PinnedIterKeyValue* out) override {
+    return input_->PinCurrentKeyValue(out);
+  }
+
   bool IsDeleteRangeSentinelKey() const override {
     return input_->IsDeleteRangeSentinelKey();
   }

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1105,6 +1105,20 @@ class LevelIterator final : public InternalIterator {
            file_iter_.iter() && file_iter_.IsValuePinned();
   }
 
+  Status PinCurrentKeyValue(PinnedIterKeyValue* out) override {
+    if (out == nullptr) {
+      return Status::InvalidArgument("PinnedIterKeyValue is nullptr");
+    }
+    out->Reset();
+    if (to_return_sentinel_) {
+      return Status::NotSupported("Current entry is a file boundary sentinel");
+    }
+    if (!Valid()) {
+      return Status::InvalidArgument("Iterator is not valid");
+    }
+    return file_iter_.PinCurrentKeyValue(out);
+  }
+
   bool IsDeleteRangeSentinelKey() const override { return to_return_sentinel_; }
 
   void SetRangeDelReadSeqno(SequenceNumber read_seq) override {

--- a/include/rocksdb/iterator.h
+++ b/include/rocksdb/iterator.h
@@ -19,12 +19,168 @@
 #pragma once
 
 #include <string>
+#include <unordered_set>
+#include <utility>
+#include <vector>
 
 #include "rocksdb/iterator_base.h"
 #include "rocksdb/options.h"
+#include "rocksdb/slice.h"
 #include "rocksdb/wide_columns.h"
 
 namespace ROCKSDB_NAMESPACE {
+
+// A self-contained key-value pair returned by Iterator::PinCurrent(). The
+// slices remain valid until Reset() or object destruction, regardless of
+// subsequent iterator movement.
+class PinnableKeyValue {
+ public:
+  PinnableKeyValue() = default;
+  PinnableKeyValue(PinnableKeyValue&&) = default;
+  PinnableKeyValue& operator=(PinnableKeyValue&&) = default;
+
+  PinnableKeyValue(const PinnableKeyValue&) = delete;
+  PinnableKeyValue& operator=(const PinnableKeyValue&) = delete;
+
+  Slice key() const { return key_; }
+  Slice value() const { return value_; }
+
+  bool IsKeyPinned() const { return key_.IsPinned(); }
+  bool IsValuePinned() const { return value_.IsPinned(); }
+
+  size_t GetPinnedBlockCacheUsage() const { return pinned_block_cache_usage_; }
+  size_t GetCopiedBytes() const { return copied_bytes_; }
+
+  void Reset() {
+    key_.Reset();
+    value_.Reset();
+    cleanup_.Reset();
+    pinned_block_cache_usage_ = 0;
+    copied_bytes_ = 0;
+  }
+
+ private:
+  friend class DBIter;
+
+  void PinKey(const Slice& key) { key_.PinSlice(key, nullptr); }
+  void CopyKey(const Slice& key) {
+    key_.PinSelf(key);
+    copied_bytes_ += key.size();
+  }
+
+  void PinValue(const Slice& value) { value_.PinSlice(value, nullptr); }
+  void CopyValue(const Slice& value) {
+    value_.PinSelf(value);
+    copied_bytes_ += value.size();
+  }
+
+  void SetCleanup(SharedCleanablePtr&& cleanup) {
+    cleanup_ = std::move(cleanup);
+  }
+
+  void SetPinnedBlockCacheUsage(size_t pinned_block_cache_usage) {
+    pinned_block_cache_usage_ = pinned_block_cache_usage;
+  }
+
+  PinnableSlice key_;
+  PinnableSlice value_;
+  SharedCleanablePtr cleanup_;
+  size_t pinned_block_cache_usage_ = 0;
+  size_t copied_bytes_ = 0;
+};
+
+// A self-contained batch of key-value pairs returned by
+// Iterator::AppendPinnedCurrent(). Each appended row remains valid until
+// Reset() or object destruction, regardless of subsequent iterator movement.
+class PinnableKeyValueBatch {
+ public:
+  PinnableKeyValueBatch() = default;
+  PinnableKeyValueBatch(PinnableKeyValueBatch&&) = default;
+  PinnableKeyValueBatch& operator=(PinnableKeyValueBatch&&) = default;
+
+  PinnableKeyValueBatch(const PinnableKeyValueBatch&) = delete;
+  PinnableKeyValueBatch& operator=(const PinnableKeyValueBatch&) = delete;
+
+  size_t size() const { return entries_.size(); }
+  bool empty() const { return entries_.empty(); }
+
+  Slice key(size_t index) const {
+    assert(index < entries_.size());
+    return entries_[index].key;
+  }
+
+  Slice value(size_t index) const {
+    assert(index < entries_.size());
+    return entries_[index].value;
+  }
+
+  bool IsKeyPinned(size_t index) const {
+    assert(index < entries_.size());
+    return entries_[index].key.IsPinned();
+  }
+
+  bool IsValuePinned(size_t index) const {
+    assert(index < entries_.size());
+    return entries_[index].value.IsPinned();
+  }
+
+  size_t GetPinnedBlockCacheUsage() const { return pinned_block_cache_usage_; }
+  size_t GetCopiedBytes() const { return copied_bytes_; }
+
+  void Reset() {
+    entries_.clear();
+    cleanups_.clear();
+    cleanup_dedupe_tokens_.clear();
+    pinned_block_cache_usage_ = 0;
+    copied_bytes_ = 0;
+  }
+
+ private:
+  friend class DBIter;
+
+  struct Entry {
+    PinnableSlice key;
+    PinnableSlice value;
+  };
+
+  void Append(const Slice& key, bool pin_key, const Slice& value,
+              bool pin_value, SharedCleanablePtr&& cleanup,
+              const void* cleanup_dedupe_token,
+              size_t pinned_block_cache_usage) {
+    if (cleanup.get() != nullptr) {
+      bool retain_cleanup = true;
+      if (cleanup_dedupe_token != nullptr) {
+        retain_cleanup =
+            cleanup_dedupe_tokens_.insert(cleanup_dedupe_token).second;
+      }
+      if (retain_cleanup) {
+        cleanups_.push_back(std::move(cleanup));
+        pinned_block_cache_usage_ += pinned_block_cache_usage;
+      }
+    }
+
+    entries_.emplace_back();
+    Entry& entry = entries_.back();
+    if (pin_key) {
+      entry.key.PinSlice(key, nullptr);
+    } else {
+      entry.key.PinSelf(key);
+      copied_bytes_ += key.size();
+    }
+    if (pin_value) {
+      entry.value.PinSlice(value, nullptr);
+    } else {
+      entry.value.PinSelf(value);
+      copied_bytes_ += value.size();
+    }
+  }
+
+  std::vector<Entry> entries_;
+  std::vector<SharedCleanablePtr> cleanups_;
+  std::unordered_set<const void*> cleanup_dedupe_tokens_;
+  size_t pinned_block_cache_usage_ = 0;
+  size_t copied_bytes_ = 0;
+};
 
 class Iterator : public IteratorBase {
  public:
@@ -110,6 +266,27 @@ class Iterator : public IteratorBase {
   // If Prepare() is called, it overrides the iterate_upper_bound in
   // ReadOptions
   virtual void Prepare(const MultiScanArgs& /*scan_opts*/) {}
+
+  // Populate `out` with the current key-value pair. Implementations may pin the
+  // underlying storage or copy into `out` as needed. The result remains valid
+  // until `out->Reset()` or object destruction. On any error, `out` is cleared.
+  //
+  // The DB iterator implementation currently supports valid forward-iteration
+  // positions over plain kTypeValue rows only. It returns NotSupported for
+  // reverse iteration, merge results, user-defined timestamps, wide-column
+  // entities, blobs, deletion markers, and other internal value types.
+  //
+  // GetPinnedBlockCacheUsage() reports the block cache entry charge held by the
+  // returned object. It might not include cache-implementation metadata.
+  virtual Status PinCurrent(PinnableKeyValue* out);
+
+  // Append the current key-value pair to `batch`. Implementations may pin the
+  // underlying storage or copy into `batch` as needed. Appended rows remain
+  // valid until `batch->Reset()` or object destruction.
+  //
+  // Same support limitations and pinned block cache usage semantics as
+  // PinCurrent().
+  virtual Status AppendPinnedCurrent(PinnableKeyValueBatch* batch);
 };
 
 // Return an empty iterator (yields nothing).

--- a/table/block_based/block_based_table_iterator.cc
+++ b/table/block_based/block_based_table_iterator.cc
@@ -10,10 +10,65 @@
 
 namespace ROCKSDB_NAMESPACE {
 
+namespace {
+
+void ReleasePinnedBlockCacheHandle(void* arg1, void* arg2) {
+  auto* cache = static_cast<Cache*>(arg1);
+  auto* cache_handle = static_cast<Cache::Handle*>(arg2);
+  assert(cache != nullptr);
+  assert(cache_handle != nullptr);
+  cache->Release(cache_handle);
+}
+
+}  // namespace
+
 void BlockBasedTableIterator::SeekToFirst() { SeekImpl(nullptr, false); }
 
 void BlockBasedTableIterator::Seek(const Slice& target) {
   SeekImpl(&target, true);
+}
+
+Status BlockBasedTableIterator::PinCurrentKeyValue(PinnedIterKeyValue* out) {
+  if (out == nullptr) {
+    return Status::InvalidArgument("PinnedIterKeyValue is nullptr");
+  }
+  out->Reset();
+  if (!Valid()) {
+    return Status::InvalidArgument("Iterator is not valid");
+  }
+  if (!PrepareValue()) {
+    return status();
+  }
+  if (!block_iter_points_to_real_block_ || !block_iter_.Valid()) {
+    return Status::NotSupported("Current entry is not backed by a data block");
+  }
+  if (!block_iter_.IsValuePinned()) {
+    return Status::NotSupported(
+        "Current entry is not backed by pinned block contents");
+  }
+
+  Cache* block_cache = table_->get_rep()->table_options.block_cache.get();
+  Cache::Handle* cache_handle = block_iter_.cache_handle();
+  if (block_cache == nullptr || cache_handle == nullptr) {
+    return Status::NotSupported(
+        "Current entry is not backed by a block cache entry");
+  }
+  if (!block_cache->Ref(cache_handle)) {
+    return Status::TryAgain(
+        "Failed to reference current data block cache entry");
+  }
+
+  out->cleanup.Allocate();
+  out->cleanup->RegisterCleanup(&ReleasePinnedBlockCacheHandle, block_cache,
+                                cache_handle);
+  out->cleanup_dedupe_token = cache_handle;
+  out->key = block_iter_.key();
+  out->user_key = block_iter_.user_key();
+  out->value = block_iter_.value();
+  out->key_pinned = block_iter_.IsKeyPinned();
+  out->value_pinned = true;
+  out->pinned_block_cache_usage = block_cache->GetCharge(cache_handle);
+  return Status::OK();
 }
 
 void BlockBasedTableIterator::SeekSecondPass(const Slice* target) {

--- a/table/block_based/block_based_table_iterator.h
+++ b/table/block_based/block_based_table_iterator.h
@@ -99,6 +99,8 @@ class BlockBasedTableIterator : public InternalIteratorBase<Slice> {
         ->MaterializeCurrentBlock();
   }
 
+  Status PinCurrentKeyValue(PinnedIterKeyValue* out) override;
+
   uint64_t write_unix_time() const override {
     assert(Valid());
     ParsedInternalKey pikey;

--- a/table/internal_iterator.h
+++ b/table/internal_iterator.h
@@ -20,6 +20,28 @@ namespace ROCKSDB_NAMESPACE {
 
 class PinnedIteratorsManager;
 
+struct PinnedIterKeyValue {
+  Slice key;
+  Slice user_key;
+  Slice value;
+  SharedCleanablePtr cleanup;
+  const void* cleanup_dedupe_token = nullptr;
+  bool key_pinned = false;
+  bool value_pinned = false;
+  size_t pinned_block_cache_usage = 0;
+
+  void Reset() {
+    key.clear();
+    user_key.clear();
+    value.clear();
+    cleanup.Reset();
+    cleanup_dedupe_token = nullptr;
+    key_pinned = false;
+    value_pinned = false;
+    pinned_block_cache_usage = 0;
+  }
+};
+
 template <class TValue>
 class InternalIteratorBase : public Cleanable {
  public:
@@ -176,6 +198,13 @@ class InternalIteratorBase : public Cleanable {
   // Iterator is not deleted.
   // REQUIRES: Same as for value().
   virtual bool IsValuePinned() const { return false; }
+
+  virtual Status PinCurrentKeyValue(PinnedIterKeyValue* out) {
+    if (out != nullptr) {
+      out->Reset();
+    }
+    return Status::NotSupported("PinCurrentKeyValue is not supported");
+  }
 
   virtual Status GetProperty(std::string /*prop_name*/, std::string* /*prop*/) {
     return Status::NotSupported("");

--- a/table/iterator.cc
+++ b/table/iterator.cc
@@ -30,6 +30,21 @@ Status Iterator::GetProperty(std::string prop_name, std::string* prop) {
   return Status::InvalidArgument("Unidentified property.");
 }
 
+Status Iterator::PinCurrent(PinnableKeyValue* out) {
+  if (out == nullptr) {
+    return Status::InvalidArgument("PinnableKeyValue is nullptr");
+  }
+  out->Reset();
+  return Status::NotSupported("PinCurrent is not supported");
+}
+
+Status Iterator::AppendPinnedCurrent(PinnableKeyValueBatch* batch) {
+  if (batch == nullptr) {
+    return Status::InvalidArgument("PinnableKeyValueBatch is nullptr");
+  }
+  return Status::NotSupported("AppendPinnedCurrent is not supported");
+}
+
 namespace {
 class EmptyIterator : public Iterator {
  public:

--- a/table/iterator_wrapper.h
+++ b/table/iterator_wrapper.h
@@ -176,6 +176,11 @@ class IteratorWrapperBase {
     return iter_->IsValuePinned();
   }
 
+  Status PinCurrentKeyValue(PinnedIterKeyValue* out) {
+    assert(Valid());
+    return iter_->PinCurrentKeyValue(out);
+  }
+
   bool IsValuePrepared() const { return result_.value_prepared; }
 
   Slice user_key() const {

--- a/table/merging_iterator.cc
+++ b/table/merging_iterator.cc
@@ -483,6 +483,11 @@ class MergingIterator : public InternalIterator {
            current_->IsValuePinned();
   }
 
+  Status PinCurrentKeyValue(PinnedIterKeyValue* out) override {
+    assert(Valid());
+    return current_->PinCurrentKeyValue(out);
+  }
+
   void Prepare(const MultiScanArgs* scan_opts) override {
     for (auto& child : children_) {
       child.iter.Prepare(scan_opts);

--- a/util/slice.cc
+++ b/util/slice.cc
@@ -322,7 +322,7 @@ bool Slice::DecodeHex(std::string* result) const {
   return true;
 }
 
-PinnableSlice::PinnableSlice(PinnableSlice&& other) {
+PinnableSlice::PinnableSlice(PinnableSlice&& other) : PinnableSlice() {
   *this = std::move(other);
 }
 

--- a/util/slice_test.cc
+++ b/util/slice_test.cc
@@ -92,6 +92,19 @@ TEST_F(PinnableSliceTest, Move) {
   ASSERT_EQ(2, res);
 
   {
+    // Test that a move-constructed pinned slice can be reset and reused.
+    res = 1;
+    PinnableSlice v1;
+    v1.PinSlice(slice1, Multiplier, &res, &n2);
+    PinnableSlice v2(std::move(v1));
+    v2.Reset();
+    ASSERT_EQ(2, res);
+    v2.PinSelf(slice2);
+
+    AssertSameData(const_str2, v2);
+  }
+
+  {
     // Test move constructor on an unpinned slice.
     PinnableSlice v1;
     v1.PinSelf(slice1);


### PR DESCRIPTION
## Summary

- Add `PinnableKeyValue`, `PinnableKeyValueBatch`, `Iterator::PinCurrent()`, and `Iterator::AppendPinnedCurrent()` so callers can keep the current key/value valid after iterator movement.
- Plumb an internal `PinCurrentKeyValue()` hook through DB, forward, merging, level, and wrapper iterators to block-based table iterators.
- Retain block-cache entries for pinned data-block values, track pinned cache charge and copied bytes, dedupe batch leases for rows from the same data block, and fall back to copying when pinning is unavailable.
- Document and enforce the initial support boundary: forward iteration over plain `kTypeValue` rows only; reverse iteration, merge results, timestamps, blobs, wide-column entities, timed puts, and other value types return `NotSupported`.
- Fix `PinnableSlice` move construction so moved pinned slices can be reset and reused safely.

## Test Plan

- `git diff --check upstream/main...kv_pinning`
- `timeout 60s ./db_test2 --gtest_filter='DBTest2.IteratorPinCurrentDeltaEncodedKeyAndPinnedValue:DBTest2.IteratorPinAPIsPinNonDeltaEncodedKeyAndValue:DBTest2.IteratorPinCurrentFallsBackToCopyWithoutBlockCache:DBTest2.IteratorAppendPinnedCurrentDedupesSameBlockLease:DBTest2.IteratorAppendPinnedCurrentTracksDistinctBlockUsage:DBTest2.IteratorAppendPinnedCurrentFallsBackToCopyWithoutBlockCache:DBTest2.IteratorPinCurrentClearsOutputOnReverseIterationNotSupported:DBTest2.IteratorPinAPIsHandleReverseIterationSafely:DBTest2.IteratorAppendPinnedCurrentResetReleasesAndReusesBatch:DBTest2.IteratorPinAPIsRejectNullOutputPointers:DBTest2.IteratorPinAPIsRejectBlobRowsAfterPrepareValue:DBTest2.IteratorPinAPIsRejectWideColumnEntityRows:DBTest2.IteratorPinAPIsRejectUserDefinedTimestampRows'`
- `timeout 60s ./db_iter_test --gtest_filter='DBIteratorTest.DBIteratorPinAPIsRejectTimedPutRows'`
- `timeout 60s ./slice_test --gtest_filter='PinnableSliceTest.Move'`
