### PR TITLE
Avoid reusing db_stress listeners across open retries

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -130,6 +130,28 @@ void StressTest::NotifyListenerShuttingDown() {
   }
 }
 
+void StressTest::InitializeListenersForOpen(
+    SharedState* shared,
+    const std::vector<ColumnFamilyDescriptor>& cf_descriptors) {
+  options_.listeners.clear();
+  options_.listeners.emplace_back(new DbStressListener(
+      GetDbPath(), options_.db_paths, cf_descriptors, shared));
+  RegisterAdditionalListeners();
+
+  if (!FLAGS_listener_uri.empty()) {
+    std::shared_ptr<EventListener> listener;
+    Status listener_status =
+        ObjectRegistry::Default()->NewSharedObject<EventListener>(
+            FLAGS_listener_uri, &listener);
+    if (!listener_status.ok()) {
+      fprintf(stderr, "Failed to create listener from URI '%s': %s\n",
+              FLAGS_listener_uri.c_str(), listener_status.ToString().c_str());
+      exit(1);
+    }
+    options_.listeners.emplace_back(std::move(listener));
+  }
+}
+
 void StressTest::CleanUpColumnFamilies() {
   for (auto cf : column_families_) {
     delete cf;
@@ -3983,23 +4005,7 @@ void StressTest::Open(SharedState* shared, bool reopen) {
       column_family_names_.push_back(name);
     }
 
-    options_.listeners.clear();
-    options_.listeners.emplace_back(new DbStressListener(
-        db_path, options_.db_paths, cf_descriptors, shared));
-    RegisterAdditionalListeners();
-
-    if (!FLAGS_listener_uri.empty()) {
-      std::shared_ptr<EventListener> listener;
-      Status listener_status =
-          ObjectRegistry::Default()->NewSharedObject<EventListener>(
-              FLAGS_listener_uri, &listener);
-      if (!listener_status.ok()) {
-        fprintf(stderr, "Failed to create listener from URI '%s': %s\n",
-                FLAGS_listener_uri.c_str(), listener_status.ToString().c_str());
-        exit(1);
-      }
-      options_.listeners.emplace_back(std::move(listener));
-    }
+    InitializeListenersForOpen(shared, cf_descriptors);
 
     // If this is for DB reopen,  error injection may have been enabled.
     // Disable it here in case there is no open fault injection.
@@ -4125,6 +4131,10 @@ void StressTest::Open(SharedState* shared, bool reopen) {
                 fault_fs_guard->DropRandomUnsyncedFileData(&rand);
               }
             }
+            // DB::Open() can fail after scheduling background compaction. Use
+            // fresh listeners on retry so per-DBImpl listener state is not
+            // carried across failed open attempts.
+            InitializeListenersForOpen(shared, cf_descriptors);
             continue;
           }
         }

--- a/db_stress_tool/db_stress_test_base.h
+++ b/db_stress_tool/db_stress_test_base.h
@@ -77,6 +77,9 @@ class StressTest {
 
  private:
   void NotifyListenerShuttingDown();
+  void InitializeListenersForOpen(
+      SharedState* shared,
+      const std::vector<ColumnFamilyDescriptor>& cf_descriptors);
 
  protected:
   static int GetMinInjectedErrorCount(int error_count_1, int error_count_2) {


### PR DESCRIPTION
## Summary

- Rebuild db_stress event listeners through a shared `InitializeListenersForOpen()` helper.
- Reinitialize listeners before retrying `DB::Open()` after injected open or open-compaction failures.

## Context
- A stress test failed with "Concurrent compaction of SST file detected".
- Root cause: StressTest::Open() built DbStressListener once before its DB::Open() retry loop. With open fault injection, a DB::Open() attempt can create a DBImpl, schedule background compaction, and then fail during late open work such as persisting OPTIONS. During teardown of that failed DBImpl, DBImpl's shutdown flag can suppress later compaction callbacks, leaving listener-local compaction bookkeeping stale.
- Diagnosis: Sandcastle DB LOGs showed file 16821 flushed, then a failed open attempt with an injected read error and a background compaction picking 16821. The crash was in DbStressListener::OnCompactionBegin, so this was stale db_stress listener state across open attempts rather than DBImpl allowing a real concurrent compaction of the same SST.
- Fix: factor listener construction into InitializeListenersForOpen() and call it before each DB::Open() attempt, including the retry path after open/open-compaction failure. Each DBImpl open attempt now gets fresh listener state.
- Verification: make clean; make db_stress -j192; make check-sources; git diff --check.

## Test Plan

- `make clean`
- `make db_stress -j192`
- `make check-sources`
- `git diff --check`
