### PR TITLE
Expose missing options for GetApproximateSizes and CompactRange in the C API

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -6426,6 +6426,16 @@ void rocksdb_compactoptions_set_full_history_ts_low(
   }
 }
 
+void rocksdb_compactoptions_set_blob_garbage_collection_age_cutoff(
+    rocksdb_compactoptions_t* opt, double n) {
+  opt->rep.blob_garbage_collection_age_cutoff = n;
+}
+
+double rocksdb_compactoptions_get_blob_garbage_collection_age_cutoff(
+    rocksdb_compactoptions_t* opt) {
+  return opt->rep.blob_garbage_collection_age_cutoff;
+}
+
 rocksdb_flushoptions_t* rocksdb_flushoptions_create() {
   return new rocksdb_flushoptions_t;
 }

--- a/db/c.cc
+++ b/db/c.cc
@@ -130,6 +130,7 @@ using ROCKSDB_NAMESPACE::RateLimiter;
 using ROCKSDB_NAMESPACE::ReadOptions;
 using ROCKSDB_NAMESPACE::RestoreOptions;
 using ROCKSDB_NAMESPACE::SequentialFile;
+using ROCKSDB_NAMESPACE::SizeApproximationOptions;
 using ROCKSDB_NAMESPACE::Slice;
 using ROCKSDB_NAMESPACE::SliceParts;
 using ROCKSDB_NAMESPACE::SliceTransform;
@@ -337,6 +338,10 @@ struct rocksdb_optimistictransaction_options_t {
 };
 struct rocksdb_wait_for_compact_options_t {
   WaitForCompactOptions rep;
+};
+
+struct rocksdb_sizeapproximationoptions_t {
+  SizeApproximationOptions rep;
 };
 
 struct rocksdb_compactionfiltercontext_t {
@@ -2565,6 +2570,26 @@ void rocksdb_approximate_sizes_cf(
   delete[] ranges;
 }
 
+void rocksdb_approximate_sizes_cf_opt(
+    rocksdb_t* db, rocksdb_column_family_handle_t* column_family,
+    int num_ranges, const char* const* range_start_key,
+    const size_t* range_start_key_len, const char* const* range_limit_key,
+    const size_t* range_limit_key_len,
+    const rocksdb_sizeapproximationoptions_t* options, uint64_t* sizes,
+    char** errptr) {
+  Range* ranges = new Range[num_ranges];
+  for (int i = 0; i < num_ranges; i++) {
+    ranges[i].start = Slice(range_start_key[i], range_start_key_len[i]);
+    ranges[i].limit = Slice(range_limit_key[i], range_limit_key_len[i]);
+  }
+  Status s = db->rep->GetApproximateSizes(options->rep, column_family->rep,
+                                          ranges, num_ranges, sizes);
+  if (!s.ok()) {
+    SaveError(errptr, s);
+  }
+  delete[] ranges;
+}
+
 extern ROCKSDB_LIBRARY_API void rocksdb_approximate_sizes_cf_with_flags(
     rocksdb_t* db, rocksdb_column_family_handle_t* column_family,
     int num_ranges, const char* const* range_start_key,
@@ -2583,6 +2608,56 @@ extern ROCKSDB_LIBRARY_API void rocksdb_approximate_sizes_cf_with_flags(
     SaveError(errptr, s);
   }
   delete[] ranges;
+}
+
+rocksdb_sizeapproximationoptions_t* rocksdb_sizeapproximationoptions_create(
+    void) {
+  return new rocksdb_sizeapproximationoptions_t;
+}
+
+void rocksdb_sizeapproximationoptions_destroy(
+    rocksdb_sizeapproximationoptions_t* opts) {
+  delete opts;
+}
+
+void rocksdb_sizeapproximationoptions_set_include_memtables(
+    rocksdb_sizeapproximationoptions_t* opts, bool v) {
+  opts->rep.include_memtables = v;
+}
+
+bool rocksdb_sizeapproximationoptions_get_include_memtables(
+    const rocksdb_sizeapproximationoptions_t* opts) {
+  return opts->rep.include_memtables;
+}
+
+void rocksdb_sizeapproximationoptions_set_include_files(
+    rocksdb_sizeapproximationoptions_t* opts, bool v) {
+  opts->rep.include_files = v;
+}
+
+bool rocksdb_sizeapproximationoptions_get_include_files(
+    const rocksdb_sizeapproximationoptions_t* opts) {
+  return opts->rep.include_files;
+}
+
+void rocksdb_sizeapproximationoptions_set_include_blob_files(
+    rocksdb_sizeapproximationoptions_t* opts, bool v) {
+  opts->rep.include_blob_files = v;
+}
+
+bool rocksdb_sizeapproximationoptions_get_include_blob_files(
+    const rocksdb_sizeapproximationoptions_t* opts) {
+  return opts->rep.include_blob_files;
+}
+
+void rocksdb_sizeapproximationoptions_set_files_size_error_margin(
+    rocksdb_sizeapproximationoptions_t* opts, double v) {
+  opts->rep.files_size_error_margin = v;
+}
+
+double rocksdb_sizeapproximationoptions_get_files_size_error_margin(
+    const rocksdb_sizeapproximationoptions_t* opts) {
+  return opts->rep.files_size_error_margin;
 }
 
 const rocksdb_livefiles_t* rocksdb_livefiles(rocksdb_t* db) {

--- a/db/c_test.c
+++ b/db/c_test.c
@@ -1763,6 +1763,29 @@ int main(int argc, char** argv) {
     CheckPinGet(db, roptions, "notfound", NULL);
   }
 
+  StartPhase("SizeApproximationOptions");
+  {
+    rocksdb_sizeapproximationoptions_t* opts =
+        rocksdb_sizeapproximationoptions_create();
+
+    rocksdb_sizeapproximationoptions_set_include_memtables(opts, true);
+    CheckCondition(
+        rocksdb_sizeapproximationoptions_get_include_memtables(opts));
+
+    rocksdb_sizeapproximationoptions_set_include_files(opts, true);
+    CheckCondition(rocksdb_sizeapproximationoptions_get_include_files(opts));
+
+    rocksdb_sizeapproximationoptions_set_include_blob_files(opts, true);
+    CheckCondition(
+        rocksdb_sizeapproximationoptions_get_include_blob_files(opts));
+
+    rocksdb_sizeapproximationoptions_set_files_size_error_margin(opts, 0.1);
+    CheckCondition(rocksdb_sizeapproximationoptions_get_files_size_error_margin(
+                       opts) == 0.1);
+
+    rocksdb_sizeapproximationoptions_destroy(opts);
+  }
+
   StartPhase("approximate_sizes");
   {
     int i;

--- a/db/c_test.c
+++ b/db/c_test.c
@@ -3491,6 +3491,9 @@ int main(int argc, char** argv) {
     rocksdb_compactoptions_set_max_subcompactions(co, 1);
     CheckCondition(1 == rocksdb_compactoptions_get_max_subcompactions(co));
 
+    rocksdb_compactoptions_set_blob_garbage_collection_age_cutoff(co, 1.0);
+    CheckCondition(1.0 == rocksdb_compactoptions_get_blob_garbage_collection_age_cutoff(co));
+
     rocksdb_compactoptions_destroy(co);
   }
 

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -2477,6 +2477,10 @@ extern ROCKSDB_LIBRARY_API int rocksdb_compactoptions_get_max_subcompactions(
     rocksdb_compactoptions_t*);
 extern ROCKSDB_LIBRARY_API void rocksdb_compactoptions_set_full_history_ts_low(
     rocksdb_compactoptions_t*, char* ts, size_t tslen);
+extern ROCKSDB_LIBRARY_API void rocksdb_compactoptions_set_blob_garbage_collection_age_cutoff(
+    rocksdb_compactoptions_t*, double);
+extern ROCKSDB_LIBRARY_API double rocksdb_compactoptions_get_blob_garbage_collection_age_cutoff(
+    rocksdb_compactoptions_t*);
 
 /* Flush options */
 

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -154,6 +154,8 @@ typedef struct rocksdb_statistics_histogram_data_t
     rocksdb_statistics_histogram_data_t;
 typedef struct rocksdb_wait_for_compact_options_t
     rocksdb_wait_for_compact_options_t;
+typedef struct rocksdb_sizeapproximationoptions_t
+    rocksdb_sizeapproximationoptions_t;
 
 /* rocksdb_slice_t: Optimized slice type for high-performance C API operations
  * This struct is ABI-compatible with rocksdb::Slice for zero-copy interop.
@@ -731,6 +733,14 @@ extern ROCKSDB_LIBRARY_API void rocksdb_approximate_sizes_cf(
     int num_ranges, const char* const* range_start_key,
     const size_t* range_start_key_len, const char* const* range_limit_key,
     const size_t* range_limit_key_len, uint64_t* sizes, char** errptr);
+
+extern ROCKSDB_LIBRARY_API void rocksdb_approximate_sizes_cf_opt(
+    rocksdb_t* db, rocksdb_column_family_handle_t* column_family,
+    int num_ranges, const char* const* range_start_key,
+    const size_t* range_start_key_len, const char* const* range_limit_key,
+    const size_t* range_limit_key_len,
+    const rocksdb_sizeapproximationoptions_t* options, uint64_t* sizes,
+    char** errptr);
 
 enum {
   rocksdb_size_approximation_flags_none = 0,
@@ -3598,6 +3608,37 @@ extern ROCKSDB_LIBRARY_API void rocksdb_wait_for_compact_options_set_timeout(
 extern ROCKSDB_LIBRARY_API uint64_t
 rocksdb_wait_for_compact_options_get_timeout(
     rocksdb_wait_for_compact_options_t* opt);
+
+/* SizeApproximationOptions */
+
+extern ROCKSDB_LIBRARY_API rocksdb_sizeapproximationoptions_t*
+rocksdb_sizeapproximationoptions_create(void);
+extern ROCKSDB_LIBRARY_API void rocksdb_sizeapproximationoptions_destroy(
+    rocksdb_sizeapproximationoptions_t* opts);
+extern ROCKSDB_LIBRARY_API void
+rocksdb_sizeapproximationoptions_set_include_memtables(
+    rocksdb_sizeapproximationoptions_t* opts, bool v);
+extern ROCKSDB_LIBRARY_API bool
+rocksdb_sizeapproximationoptions_get_include_memtables(
+    const rocksdb_sizeapproximationoptions_t* opts);
+extern ROCKSDB_LIBRARY_API void
+rocksdb_sizeapproximationoptions_set_include_files(
+    rocksdb_sizeapproximationoptions_t* opts, bool v);
+extern ROCKSDB_LIBRARY_API bool
+rocksdb_sizeapproximationoptions_get_include_files(
+    const rocksdb_sizeapproximationoptions_t* opts);
+extern ROCKSDB_LIBRARY_API void
+rocksdb_sizeapproximationoptions_set_include_blob_files(
+    rocksdb_sizeapproximationoptions_t* opts, bool v);
+extern ROCKSDB_LIBRARY_API bool
+rocksdb_sizeapproximationoptions_get_include_blob_files(
+    const rocksdb_sizeapproximationoptions_t* opts);
+extern ROCKSDB_LIBRARY_API void
+rocksdb_sizeapproximationoptions_set_files_size_error_margin(
+    rocksdb_sizeapproximationoptions_t* opts, double v);
+extern ROCKSDB_LIBRARY_API double
+rocksdb_sizeapproximationoptions_get_files_size_error_margin(
+    const rocksdb_sizeapproximationoptions_t* opts);
 
 /* High-performance zero-copy Get variants
    These functions avoid unnecessary memory allocations and copies.


### PR DESCRIPTION
* Exposes the `GetApproximateSizes` variant that takes an options struct in the C API
* Exposes the `blob_garbage_collection_age_cutoff` parameter on the `CompactRangeOptions` struct in the C API

Let me know if you'd like me to split these into separate PRs.