### PR TITLE
Clarify ldb unsupported compaction style error

### DIFF
--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -2847,8 +2847,8 @@ ChangeCompactionStyleCommand::ChangeCompactionStyleCommand(
   if (old_compaction_style_ == kCompactionStyleUniversal &&
       new_compaction_style_ == kCompactionStyleLevel) {
     exec_state_ = LDBCommandExecuteResult::Failed(
-        "Convert from universal compaction to level compaction. "
-        "Nothing to do.\n");
+        "Changing from universal compaction to level compaction is not "
+        "supported by ldb.\n");
     return;
   }
 }


### PR DESCRIPTION
Summary:
Clarifies the ldb error message shown when attempting to convert from universal compaction to level compaction. The previous message made it sound like there was simply nothing to do, while the operation is actually unsupported by ldb.

Fixes #10596

Test Plan:
make ldb -j8
git diff --check
./ldb --db=/tmp/rocksdb_ldb_dummy change_compaction_style --old_compaction_style=1 --new_compaction_style=0
