### PR TITLE
Expose OptimisticTransactionDBOptions in C API

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -102,6 +102,7 @@ using ROCKSDB_NAMESPACE::ImportColumnFamilyOptions;
 using ROCKSDB_NAMESPACE::InfoLogLevel;
 using ROCKSDB_NAMESPACE::IngestExternalFileOptions;
 using ROCKSDB_NAMESPACE::Iterator;
+using ROCKSDB_NAMESPACE::kDefaultColumnFamilyName;
 using ROCKSDB_NAMESPACE::LevelMetaData;
 using ROCKSDB_NAMESPACE::LiveFileMetaData;
 using ROCKSDB_NAMESPACE::Logger;
@@ -117,7 +118,9 @@ using ROCKSDB_NAMESPACE::NewLRUCache;
 using ROCKSDB_NAMESPACE::NewRibbonFilterPolicy;
 using ROCKSDB_NAMESPACE::NewSstPartitionerFixedPrefixFactory;
 using ROCKSDB_NAMESPACE::OpenAndCompactOptions;
+using ROCKSDB_NAMESPACE::OccValidationPolicy;
 using ROCKSDB_NAMESPACE::OptimisticTransactionDB;
+using ROCKSDB_NAMESPACE::OptimisticTransactionDBOptions;
 using ROCKSDB_NAMESPACE::OptimisticTransactionOptions;
 using ROCKSDB_NAMESPACE::Options;
 using ROCKSDB_NAMESPACE::PerfContext;
@@ -319,6 +322,9 @@ struct rocksdb_transactiondb_t {
 };
 struct rocksdb_transaction_options_t {
   TransactionOptions rep;
+};
+struct rocksdb_optimistictransactiondb_options_t {
+  OptimisticTransactionDBOptions rep;
 };
 struct rocksdb_transaction_t {
   Transaction* rep;
@@ -7480,6 +7486,37 @@ void rocksdb_transactiondb_options_destroy(
   delete opt;
 }
 
+rocksdb_optimistictransactiondb_options_t*
+rocksdb_optimistictransactiondb_options_create() {
+  return new rocksdb_optimistictransactiondb_options_t;
+}
+
+void rocksdb_optimistictransactiondb_options_destroy(
+    rocksdb_optimistictransactiondb_options_t* opt) {
+  delete opt;
+}
+
+void rocksdb_optimistictransactiondb_options_set_occ_lock_buckets(
+    rocksdb_optimistictransactiondb_options_t* opt, uint32_t occ_lock_buckets) {
+  opt->rep.occ_lock_buckets = occ_lock_buckets;
+}
+
+uint32_t rocksdb_optimistictransactiondb_options_get_occ_lock_buckets(
+    rocksdb_optimistictransactiondb_options_t* opt) {
+  return opt->rep.occ_lock_buckets;
+}
+
+void rocksdb_optimistictransactiondb_options_set_validate_policy(
+    rocksdb_optimistictransactiondb_options_t* opt, int validate_policy) {
+  opt->rep.validate_policy =
+      static_cast<OccValidationPolicy>(validate_policy);
+}
+
+int rocksdb_optimistictransactiondb_options_get_validate_policy(
+    rocksdb_optimistictransactiondb_options_t* opt) {
+  return static_cast<int>(opt->rep.validate_policy);
+}
+
 void rocksdb_transactiondb_options_set_max_num_locks(
     rocksdb_transactiondb_options_t* opt, int64_t max_num_locks) {
   opt->rep.max_num_locks = max_num_locks;
@@ -8429,6 +8466,32 @@ rocksdb_optimistictransactiondb_t* rocksdb_optimistictransactiondb_open(
   if (SaveError(errptr, OptimisticTransactionDB::Open(
                             options->rep, std::string(name), &otxn_db))) {
     return nullptr;
+  }
+  rocksdb_optimistictransactiondb_t* result =
+      new rocksdb_optimistictransactiondb_t;
+  result->rep = otxn_db;
+  return result;
+}
+
+rocksdb_optimistictransactiondb_t*
+rocksdb_optimistictransactiondb_open_with_options(
+    const rocksdb_options_t* options,
+    const rocksdb_optimistictransactiondb_options_t* otxn_db_options,
+    const char* name, char** errptr) {
+  std::vector<ColumnFamilyDescriptor> column_families;
+  column_families.emplace_back(kDefaultColumnFamilyName,
+                               ColumnFamilyOptions(options->rep));
+
+  OptimisticTransactionDB* otxn_db;
+  std::vector<ColumnFamilyHandle*> handles;
+  if (SaveError(errptr, OptimisticTransactionDB::Open(
+                            DBOptions(options->rep), otxn_db_options->rep,
+                            std::string(name), column_families, &handles,
+                            &otxn_db))) {
+    return nullptr;
+  }
+  for (auto* handle : handles) {
+    delete handle;
   }
   rocksdb_optimistictransactiondb_t* result =
       new rocksdb_optimistictransactiondb_t;

--- a/db/c_test.c
+++ b/db/c_test.c
@@ -844,6 +844,7 @@ int main(int argc, char** argv) {
   rocksdb_transaction_t* txn;
   rocksdb_transaction_options_t* txn_options;
   rocksdb_optimistictransactiondb_t* otxn_db;
+  rocksdb_optimistictransactiondb_options_t* otxn_db_options;
   rocksdb_optimistictransaction_options_t* otxn_options;
   char* err = NULL;
   int run = -1;
@@ -4270,7 +4271,27 @@ int main(int argc, char** argv) {
     rocksdb_options_t* db_options = rocksdb_options_create();
     rocksdb_options_set_create_if_missing(db_options, 1);
     rocksdb_options_set_allow_concurrent_memtable_write(db_options, 1);
-    otxn_db = rocksdb_optimistictransactiondb_open(db_options, dbname, &err);
+    otxn_db_options = rocksdb_optimistictransactiondb_options_create();
+    CheckCondition(
+        rocksdb_optimistictransactiondb_options_get_occ_lock_buckets(
+            otxn_db_options) == (1 << 20));
+    rocksdb_optimistictransactiondb_options_set_occ_lock_buckets(
+        otxn_db_options, 128);
+    CheckCondition(
+        rocksdb_optimistictransactiondb_options_get_occ_lock_buckets(
+            otxn_db_options) == 128);
+    rocksdb_optimistictransactiondb_options_set_validate_policy(
+        otxn_db_options,
+        rocksdb_optimistictransactiondb_validate_policy_serial);
+    CheckCondition(
+        rocksdb_optimistictransactiondb_options_get_validate_policy(
+            otxn_db_options) ==
+        rocksdb_optimistictransactiondb_validate_policy_serial);
+    rocksdb_optimistictransactiondb_options_set_validate_policy(
+        otxn_db_options,
+        rocksdb_optimistictransactiondb_validate_policy_parallel);
+    otxn_db = rocksdb_optimistictransactiondb_open_with_options(
+        db_options, otxn_db_options, dbname, &err);
     otxn_options = rocksdb_optimistictransaction_options_create();
     rocksdb_transaction_t* txn1 = rocksdb_optimistictransaction_begin(
         otxn_db, woptions, otxn_options, NULL);
@@ -4388,6 +4409,7 @@ int main(int argc, char** argv) {
     rocksdb_optimistictransactiondb_close(otxn_db);
     rocksdb_destroy_db(db_options, dbname, &err);
     rocksdb_options_destroy(db_options);
+    rocksdb_optimistictransactiondb_options_destroy(otxn_db_options);
     rocksdb_optimistictransaction_options_destroy(otxn_options);
     CheckNoError(err);
   }

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -140,6 +140,8 @@ typedef struct rocksdb_pinnableslice_t rocksdb_pinnableslice_t;
 typedef struct rocksdb_transactiondb_options_t rocksdb_transactiondb_options_t;
 typedef struct rocksdb_transactiondb_t rocksdb_transactiondb_t;
 typedef struct rocksdb_transaction_options_t rocksdb_transaction_options_t;
+typedef struct rocksdb_optimistictransactiondb_options_t
+    rocksdb_optimistictransactiondb_options_t;
 typedef struct rocksdb_optimistictransactiondb_t
     rocksdb_optimistictransactiondb_t;
 typedef struct rocksdb_optimistictransaction_options_t
@@ -3376,6 +3378,12 @@ rocksdb_optimistictransactiondb_open(const rocksdb_options_t* options,
                                      const char* name, char** errptr);
 
 extern ROCKSDB_LIBRARY_API rocksdb_optimistictransactiondb_t*
+rocksdb_optimistictransactiondb_open_with_options(
+    const rocksdb_options_t* options,
+    const rocksdb_optimistictransactiondb_options_t* otxn_db_options,
+    const char* name, char** errptr);
+
+extern ROCKSDB_LIBRARY_API rocksdb_optimistictransactiondb_t*
 rocksdb_optimistictransactiondb_open_column_families(
     const rocksdb_options_t* options, const char* name, int num_column_families,
     const char* const* column_family_names,
@@ -3415,6 +3423,33 @@ rocksdb_transactiondb_options_create(void);
 
 extern ROCKSDB_LIBRARY_API void rocksdb_transactiondb_options_destroy(
     rocksdb_transactiondb_options_t* opt);
+
+enum {
+  rocksdb_optimistictransactiondb_validate_policy_serial = 0,
+  rocksdb_optimistictransactiondb_validate_policy_parallel = 1
+};
+
+extern ROCKSDB_LIBRARY_API rocksdb_optimistictransactiondb_options_t*
+rocksdb_optimistictransactiondb_options_create(void);
+
+extern ROCKSDB_LIBRARY_API void rocksdb_optimistictransactiondb_options_destroy(
+    rocksdb_optimistictransactiondb_options_t* opt);
+
+extern ROCKSDB_LIBRARY_API void
+rocksdb_optimistictransactiondb_options_set_occ_lock_buckets(
+    rocksdb_optimistictransactiondb_options_t* opt, uint32_t occ_lock_buckets);
+
+extern ROCKSDB_LIBRARY_API uint32_t
+rocksdb_optimistictransactiondb_options_get_occ_lock_buckets(
+    rocksdb_optimistictransactiondb_options_t* opt);
+
+extern ROCKSDB_LIBRARY_API void
+rocksdb_optimistictransactiondb_options_set_validate_policy(
+    rocksdb_optimistictransactiondb_options_t* opt, int validate_policy);
+
+extern ROCKSDB_LIBRARY_API int
+rocksdb_optimistictransactiondb_options_get_validate_policy(
+    rocksdb_optimistictransactiondb_options_t* opt);
 
 extern ROCKSDB_LIBRARY_API void rocksdb_transactiondb_options_set_max_num_locks(
     rocksdb_transactiondb_options_t* opt, int64_t max_num_locks);


### PR DESCRIPTION
Summary:
Exposes OptimisticTransactionDBOptions through the C API so C API users can configure optimistic transaction validation options such as the OCC lock bucket count.

Fixes #11703

Test Plan:
make c_test -j8
./c_test
git diff --check
make check-sources
