### PR TITLE
Clarify MemTableInfo sequence number docs

### DIFF
--- a/db/memtable.h
+++ b/db/memtable.h
@@ -276,8 +276,8 @@ class ReadOnlyMemTable {
 
   virtual uint64_t GetDataSize() const = 0;
 
-  // Returns the sequence number of the first element that was inserted
-  // into the memtable.
+  // Returns the smallest sequence number of any element inserted into the
+  // memtable, or 0 if the memtable is empty.
   // REQUIRES: external synchronization to prevent simultaneous
   // operations on the same MemTable (unless this Memtable is immutable).
   virtual SequenceNumber GetFirstSequenceNumber() = 0;
@@ -287,10 +287,9 @@ class ReadOnlyMemTable {
   // operations on the same MemTable (unless this Memtable is immutable).
   virtual bool IsEmpty() const = 0;
 
-  // Returns the sequence number that is guaranteed to be smaller than or equal
-  // to the sequence number of any key that could be inserted into this
-  // memtable. It can then be assumed that any write with a larger(or equal)
-  // sequence number will be present in this memtable or a later memtable.
+  // Returns a lower bound on the sequence numbers that may be present in the
+  // memtable. This can be smaller than the first sequence number, and does not
+  // necessarily correspond to an entry in the memtable.
   //
   // If the earliest sequence number could not be determined,
   // kMaxSequenceNumber will be returned.
@@ -783,8 +782,8 @@ class MemTable final : public ReadOnlyMemTable {
     return first_seqno_.load(std::memory_order_relaxed);
   }
 
-  // Returns the sequence number of the first element that was inserted
-  // into the memtable.
+  // Sets the smallest sequence number of any element inserted into the
+  // memtable.
   // REQUIRES: external synchronization to prevent simultaneous
   // operations on the same MemTable (unless this Memtable is immutable).
   void SetFirstSequenceNumber(SequenceNumber first_seqno) {
@@ -796,10 +795,9 @@ class MemTable final : public ReadOnlyMemTable {
     return earliest_seqno_.load(std::memory_order_relaxed);
   }
 
-  // Sets the sequence number that is guaranteed to be smaller than or equal
-  // to the sequence number of any key that could be inserted into this
-  // memtable. It can then be assumed that any write with a larger(or equal)
-  // sequence number will be present in this memtable or a later memtable.
+  // Sets the lower bound on the sequence numbers that may be present in the
+  // memtable. This can be smaller than the first sequence number, and does not
+  // necessarily correspond to an entry in the memtable.
   // Used only for MemPurge operation
   void SetEarliestSequenceNumber(SequenceNumber earliest_seqno) {
     return earliest_seqno_.store(earliest_seqno, std::memory_order_relaxed);

--- a/include/rocksdb/listener.h
+++ b/include/rocksdb/listener.h
@@ -499,13 +499,12 @@ struct CompactionJobInfo {
 struct MemTableInfo {
   // the name of the column family to which memtable belongs
   std::string cf_name;
-  // Sequence number of the first element that was inserted
-  // into the memtable.
+  // Smallest sequence number of any element inserted into the memtable, or 0
+  // if the memtable is empty.
   SequenceNumber first_seqno;
-  // Sequence number that is guaranteed to be smaller than or equal
-  // to the sequence number of any key that could be inserted into this
-  // memtable. It can then be assumed that any write with a larger(or equal)
-  // sequence number will be present in this memtable or a later memtable.
+  // Lower bound on the sequence numbers that may be present in the memtable.
+  // This can be smaller than first_seqno, and does not necessarily correspond
+  // to an entry in the memtable.
   SequenceNumber earliest_seqno;
   // Total number of entries in memtable
   uint64_t num_entries;


### PR DESCRIPTION
Summary:
Clarifies the MemTableInfo API documentation for first_seqno and earliest_seqno to match the current implementation and avoid confusion about their sequence number semantics.

Fixes #11278

Test Plan:
git diff --check
make check-sources
