### PR TITLE
Document WriteBatchWithIndex prefix iterator behavior

### DIFF
--- a/include/rocksdb/utilities/write_batch_with_index.h
+++ b/include/rocksdb/utilities/write_batch_with_index.h
@@ -226,6 +226,10 @@ class WriteBatchWithIndex : public WriteBatchBase {
   // The returned iterator should be deleted by the caller.
   // The base_iterator is now 'owned' by the returned iterator. Deleting the
   // returned iterator will also delete the base_iterator.
+  // The returned iterator does not infer the ReadOptions or prefix extractor
+  // used to create base_iterator. In particular, prefix_same_as_start on
+  // base_iterator is not applied to keys from this write batch; callers that
+  // need prefix-bounded iteration must enforce the prefix boundary themselves.
   //
   // Updating write batch with the current key of the iterator is not safe.
   // We strongly recommend users not to do it. It will invalidate the current

--- a/utilities/write_batch_with_index/write_batch_with_index_test.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_test.cc
@@ -1978,6 +1978,44 @@ TEST_P(WriteBatchWithIndexTest, TestNewIteratorWithBaseFromWbwi) {
   ASSERT_OK(iter->status());
 }
 
+TEST_P(WriteBatchWithIndexTest,
+       NewIteratorWithBasePrefixSameAsStartAppliesOnlyToBase) {
+  options_.prefix_extractor.reset(NewFixedPrefixTransform(4));
+  ASSERT_OK(OpenDB());
+
+  ASSERT_OK(db_->Put(write_opts_, "foo:base", "db_value"));
+  ASSERT_OK(db_->Put(write_opts_, "goo:base", "db_value"));
+
+  ASSERT_OK(batch_->Put("foo:key1", "v1"));
+  ASSERT_OK(batch_->Put("foo:key2", "v2"));
+  ASSERT_OK(batch_->Put("goo:key1", "v3"));
+
+  ReadOptions ro;
+  ro.prefix_same_as_start = true;
+
+  std::unique_ptr<Iterator> db_iter(db_->NewIterator(ro));
+  db_iter->Seek("foo:");
+  ASSERT_TRUE(db_iter->Valid());
+  ASSERT_EQ(db_iter->key(), "foo:base");
+  db_iter->Next();
+  ASSERT_FALSE(db_iter->Valid());
+  ASSERT_OK(db_iter->status());
+
+  // NewIteratorWithBase cannot infer prefix_same_as_start or the prefix
+  // extractor from base_iterator, so the write batch portion is not
+  // prefix-bounded by the base iterator's ReadOptions.
+  std::unique_ptr<Iterator> iter(
+      batch_->NewIteratorWithBase(db_->NewIterator(ro)));
+  std::vector<std::string> keys;
+  for (iter->Seek("foo:"); iter->Valid(); iter->Next()) {
+    keys.push_back(iter->key().ToString());
+  }
+  ASSERT_OK(iter->status());
+  ASSERT_EQ(keys,
+            (std::vector<std::string>{"foo:base", "foo:key1", "foo:key2",
+                                      "goo:key1"}));
+}
+
 TEST_P(WriteBatchWithIndexTest, NewIteratorWithBasePrepareValue) {
   // BaseDeltaIterator by default should call PrepareValue if it lands on the
   // base iterator in case it was created with allow_unprepared_value=true.


### PR DESCRIPTION
Summary:
Documents that WriteBatchWithIndex::NewIteratorWithBase cannot infer the ReadOptions or prefix extractor used to create the base iterator. In particular, prefix_same_as_start on the base iterator is not applied to keys from the write batch, so callers that need prefix-bounded iteration must enforce the prefix boundary themselves.

Adds a focused test showing that a plain DB iterator respects prefix_same_as_start while the merged WriteBatchWithIndex iterator can still return in-batch keys outside the seek prefix.

Refs #14610

Test Plan:
make write_batch_with_index_test -j8
./write_batch_with_index_test --gtest_filter='*Prefix*'
git diff --check
make check-sources
