### PR TITLE
Avoid retryable io_uring wait_cqe stderr in crash tests

### DIFF
--- a/env/fs_posix.cc
+++ b/env/fs_posix.cc
@@ -1114,10 +1114,10 @@ class PosixFileSystem : public FileSystem {
         struct io_uring_cqe* cqe = nullptr;
         ssize_t ret = io_uring_wait_cqe(iu, &cqe);
         if (ret) {
-          fprintf(stderr, "Poll: io_uring_wait_cqe failed: %ld", (long)ret);
           if (ret == -EINTR || ret == -EAGAIN) {
             continue;  // Retry
           }
+          fprintf(stderr, "Poll: io_uring_wait_cqe failed: %ld\n", (long)ret);
           abort();
         }
 
@@ -1207,10 +1207,11 @@ class PosixFileSystem : public FileSystem {
         struct io_uring_cqe* cqe = nullptr;
         ssize_t ret = io_uring_wait_cqe(iu, &cqe);
         if (ret) {
-          fprintf(stderr, "AbortIO: io_uring_wait_cqe failed: %ld", (long)ret);
           if (ret == -EINTR || ret == -EAGAIN) {
             continue;  // Retry
           }
+          fprintf(stderr, "AbortIO: io_uring_wait_cqe failed: %ld\n",
+                  (long)ret);
           abort();
         }
         assert(cqe != nullptr);

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -19,9 +19,12 @@ remain_argv = None
 is_remote_db = False
 
 _SIGTERM_STDOUT_MARKER = "Received signal 15 (Terminated)"
+# Keep this timeout filter narrow: Poll/AbortIO only retry Linux
+# -EINTR (-4) and -EAGAIN (-11), so terminal wait_cqe errors still fail.
 _IGNORED_SIGTERM_STDERR_RE = re.compile(
-    r"^PosixRandomAccessFile::MultiRead: io_uring_submit_and_wait "
-    r"returned terminal error: -9\.$"
+    r"^(?:PosixRandomAccessFile::MultiRead: io_uring_submit_and_wait "
+    r"returned terminal error: -9\."
+    r"|(?:Poll|AbortIO): io_uring_wait_cqe failed: -(?:4|11))$"
 )
 _NO_SPACE_SUBSTRINGS = (
     "no space left on device",

--- a/tools/db_crashtest_test.py
+++ b/tools/db_crashtest_test.py
@@ -190,6 +190,41 @@ class DBCrashTestTest(unittest.TestCase):
             filtered_stdout,
         )
 
+    def test_strip_expected_sigterm_stderr_suppresses_retryable_wait_cqe(self):
+        db_crashtest = self.load_db_crashtest()
+        stdout = "Received signal 15 (Terminated)\n"
+
+        # This models blackbox crash test SIGTERM interrupting wait_cqe before
+        # the C++ retry path can avoid stderr; only retryable codes are expected.
+        for caller in ("Poll", "AbortIO"):
+            for err in (-4, -11):
+                stderr = f"{caller}: io_uring_wait_cqe failed: {err}\n"
+                filtered_stdout, filtered_stderr = (
+                    db_crashtest.strip_expected_sigterm_stderr(stdout, stderr, True)
+                )
+
+                self.assertEqual("", filtered_stderr)
+                self.assertEqual(
+                    stdout
+                    + "Ignored expected post-SIGTERM stderr while handling timeout:\n"
+                    + stderr,
+                    filtered_stdout,
+                )
+
+    def test_strip_expected_sigterm_stderr_preserves_terminal_wait_cqe(self):
+        db_crashtest = self.load_db_crashtest()
+        stdout = "Received signal 15 (Terminated)\n"
+        stderr = "Poll: io_uring_wait_cqe failed: -5\n"
+
+        # This guards against hiding real io_uring failures: even after SIGTERM,
+        # non-retryable wait_cqe errors must remain visible on stderr.
+        filtered_stdout, filtered_stderr = db_crashtest.strip_expected_sigterm_stderr(
+            stdout, stderr, True
+        )
+
+        self.assertEqual(stderr, filtered_stderr)
+        self.assertEqual(stdout, filtered_stdout)
+
     def test_strip_expected_sigterm_stderr_preserves_other_stderr(self):
         db_crashtest = self.load_db_crashtest()
         stdout = "Received signal 15 (Terminated)\n"


### PR DESCRIPTION
## Summary
- Suppress retryable `io_uring_wait_cqe()` errors in `PosixFileSystem::Poll()` and `AbortIO()` before they reach stderr during crash-test SIGTERM timeout handling.
- Keep terminal `wait_cqe` failures logged and fatal.
- Extend the `db_crashtest.py` SIGTERM stderr filter only for retryable `Poll`/`AbortIO` wait_cqe errors and add regression coverage.

## Test Plan
CI

## Related
- T272682963
