### PR TITLE
Fix secondary WAL tailing with precreated future WAL

### DIFF
--- a/db/db_impl/db_impl_secondary.cc
+++ b/db/db_impl/db_impl_secondary.cc
@@ -105,10 +105,22 @@ Status DBImplSecondary::FindNewLogNumbers(std::vector<uint64_t>* logs) {
     return s;
   }
 
-  // if log_readers_ is non-empty, it means we have applied all logs with log
-  // numbers smaller than the smallest log in log_readers_, so there is no
-  // need to pass these logs to RecoverLogFiles
-  uint64_t log_number_min = 0;
+  // Drop readers only after MANIFEST replay says the WAL is obsolete. The
+  // primary can create a higher-number empty WAL before it stops appending to a
+  // lower-number current WAL, so seeing a higher-number WAL is not sufficient.
+  const uint64_t min_log_number_to_keep = versions_->min_log_number_to_keep();
+  for (auto iter = log_readers_.begin(); iter != log_readers_.end();) {
+    if (iter->first < min_log_number_to_keep) {
+      iter = log_readers_.erase(iter);
+    } else {
+      break;
+    }
+  }
+
+  // If log_readers_ is non-empty, it means we have applied all logs with log
+  // numbers smaller than the smallest retained log reader. Otherwise, manifest
+  // recovery tells us which older logs can be skipped.
+  uint64_t log_number_min = min_log_number_to_keep;
   if (!log_readers_.empty()) {
     log_number_min = log_readers_.begin()->first;
   }
@@ -320,12 +332,6 @@ Status DBImplSecondary::RecoverLogFiles(
       wal_read_status->PermitUncheckedError();
       return status;
     }
-  }
-  // remove logreaders from map after successfully recovering the WAL
-  if (log_readers_.size() > 1) {
-    auto erase_iter = log_readers_.begin();
-    std::advance(erase_iter, log_readers_.size() - 1);
-    log_readers_.erase(log_readers_.begin(), erase_iter);
   }
   return status;
 }

--- a/db/db_secondary_test.cc
+++ b/db/db_secondary_test.cc
@@ -13,6 +13,7 @@
 #include "db/db_with_timestamp_test_util.h"
 #include "db/wide/wide_column_test_util.h"
 #include "db/write_batch_internal.h"
+#include "file/filename.h"
 #include "port/stack_trace.h"
 #include "rocksdb/utilities/transaction_db.h"
 #include "test_util/sync_point.h"
@@ -920,6 +921,48 @@ TEST_F(DBSecondaryTest, OpenAsSecondaryWALTailing) {
   ASSERT_OK(Put("foo", "new_foo_value_1"));
   ASSERT_OK(db_secondary_->TryCatchUpWithPrimary());
   verify_db_func("new_foo_value_1", "new_bar_value");
+}
+
+TEST_F(DBSecondaryTest, CatchUpTailsCurrentWalWhenFutureWalExists) {
+  // Goal: secondary catch-up must keep tailing the current WAL even when a
+  // higher-number empty WAL is present. This reproduces the async WAL
+  // precreation shape by creating a future WAL before opening the secondary,
+  // then appending another write to the current WAL and catching up again.
+  Options options;
+  options.env = env_;
+  Reopen(options);
+
+  ASSERT_OK(Put("foo", "value0"));
+  ASSERT_OK(Flush());
+  ASSERT_OK(Put("foo", "value1"));
+  ASSERT_OK(db_->FlushWAL(/*sync=*/true));
+
+  std::unique_ptr<WalFile> current_wal;
+  ASSERT_OK(db_->GetCurrentWalFile(&current_wal));
+  ASSERT_NE(nullptr, current_wal);
+
+  const uint64_t future_wal_number = current_wal->LogNumber() + 1000;
+  std::unique_ptr<WritableFile> future_wal_file;
+  ASSERT_OK(env_->NewWritableFile(LogFileName(dbname_, future_wal_number),
+                                  &future_wal_file, EnvOptions()));
+  ASSERT_OK(future_wal_file->Close());
+
+  Options secondary_options;
+  secondary_options.env = env_;
+  secondary_options.max_open_files = -1;
+  OpenSecondary(secondary_options);
+
+  ReadOptions read_options;
+  std::string value;
+  ASSERT_OK(db_secondary_->Get(read_options, "foo", &value));
+  ASSERT_EQ("value1", value);
+
+  ASSERT_OK(Put("foo", "value2"));
+  ASSERT_OK(db_->FlushWAL(/*sync=*/true));
+
+  ASSERT_OK(db_secondary_->TryCatchUpWithPrimary());
+  ASSERT_OK(db_secondary_->Get(read_options, "foo", &value));
+  ASSERT_EQ("value2", value);
 }
 
 TEST_F(DBSecondaryTest, SecondaryTailingBug_ISSUE_8467) {


### PR DESCRIPTION
Summary:
- Fix secondary catch-up WAL discovery to retain existing WAL readers until MANIFEST replay advances min_log_number_to_keep past them.
- Do not treat a higher-number WAL appearing in the directory as proof that a lower-number current WAL is obsolete; async WAL precreation can expose that shape while the lower-number WAL is still growing.
- Continue scanning from the smallest retained reader so later appends to the current WAL are replayed, and add a regression test that precreates an empty future WAL before secondary catch-up.

Test Plan:
- make -j128 db_secondary_test
- ./db_secondary_test --gtest_filter=DBSecondaryTest.CatchUpTailsCurrentWalWhenFutureWalExists
- ./db_secondary_test
- make check-sources
