### PR TITLE
[rocksdb] Add blob_cache_read_byte perf context counter

### DIFF
--- a/db/blob/blob_source.cc
+++ b/db/blob/blob_source.cc
@@ -74,6 +74,7 @@ Status BlobSource::GetBlobFromCache(
     assert(cached_blob->GetValue());
 
     PERF_COUNTER_ADD(blob_cache_hit_count, 1);
+    PERF_COUNTER_ADD(blob_cache_read_byte, cached_blob->GetValue()->size());
     RecordTick(statistics_, BLOB_DB_CACHE_HIT);
     RecordTick(statistics_, BLOB_DB_CACHE_BYTES_READ,
                cached_blob->GetValue()->size());

--- a/db/blob/blob_source_test.cc
+++ b/db/blob/blob_source_test.cc
@@ -229,6 +229,7 @@ TEST_F(BlobSourceTest, GetBlobsFromCache) {
     // Retrieved the blob cache num_blobs * 3 times via TEST_BlobInCache,
     // GetBlob, and TEST_BlobInCache.
     ASSERT_EQ((int)get_perf_context()->blob_cache_hit_count, 0);
+    ASSERT_EQ((int)get_perf_context()->blob_cache_read_byte, 0);
     ASSERT_EQ((int)get_perf_context()->blob_read_count, num_blobs);
     ASSERT_EQ((int)get_perf_context()->blob_read_byte, total_bytes);
     ASSERT_GE((int)get_perf_context()->blob_checksum_time, 0);
@@ -262,6 +263,8 @@ TEST_F(BlobSourceTest, GetBlobsFromCache) {
       blob_bytes += blob_sizes[i];
       total_bytes += bytes_read;
       ASSERT_EQ((int)get_perf_context()->blob_cache_hit_count, i);
+      ASSERT_EQ((int)get_perf_context()->blob_cache_read_byte,
+                blob_bytes - blob_sizes[i]);
       ASSERT_EQ((int)get_perf_context()->blob_read_count, i + 1);
       ASSERT_EQ((int)get_perf_context()->blob_read_byte, total_bytes);
 
@@ -269,11 +272,13 @@ TEST_F(BlobSourceTest, GetBlobsFromCache) {
                                                blob_offsets[i]));
 
       ASSERT_EQ((int)get_perf_context()->blob_cache_hit_count, i + 1);
+      ASSERT_EQ((int)get_perf_context()->blob_cache_read_byte, blob_bytes);
       ASSERT_EQ((int)get_perf_context()->blob_read_count, i + 1);
       ASSERT_EQ((int)get_perf_context()->blob_read_byte, total_bytes);
     }
 
     ASSERT_EQ((int)get_perf_context()->blob_cache_hit_count, num_blobs);
+    ASSERT_EQ((int)get_perf_context()->blob_cache_read_byte, blob_bytes);
     ASSERT_EQ((int)get_perf_context()->blob_read_count, num_blobs);
     ASSERT_EQ((int)get_perf_context()->blob_read_byte, total_bytes);
 
@@ -312,6 +317,7 @@ TEST_F(BlobSourceTest, GetBlobsFromCache) {
     // Retrieved the blob cache num_blobs * 3 times via TEST_BlobInCache,
     // GetBlob, and TEST_BlobInCache.
     ASSERT_EQ((int)get_perf_context()->blob_cache_hit_count, num_blobs * 3);
+    ASSERT_EQ((int)get_perf_context()->blob_cache_read_byte, blob_bytes * 3);
     ASSERT_EQ((int)get_perf_context()->blob_read_count, 0);  // without i/o
     ASSERT_EQ((int)get_perf_context()->blob_read_byte, 0);   // without i/o
 
@@ -690,6 +696,8 @@ TEST_F(BlobSourceTest, MultiGetBlobsFromMultiFiles) {
     // TEST_BlobInCache.
     ASSERT_EQ((int)get_perf_context()->blob_cache_hit_count,
               num_blobs * blob_files);
+    ASSERT_EQ((int)get_perf_context()->blob_cache_read_byte,
+              blob_value_bytes * blob_files);
     ASSERT_EQ((int)get_perf_context()->blob_read_count,
               num_blobs * blob_files);  // blocking i/o
     ASSERT_EQ((int)get_perf_context()->blob_read_byte,
@@ -750,6 +758,8 @@ TEST_F(BlobSourceTest, MultiGetBlobsFromMultiFiles) {
     // via MultiGetBlob and TEST_BlobInCache.
     ASSERT_EQ((int)get_perf_context()->blob_cache_hit_count,
               num_blobs * blob_files * 2);
+    ASSERT_EQ((int)get_perf_context()->blob_cache_read_byte,
+              blob_value_bytes * blob_files * 2);
     ASSERT_EQ((int)get_perf_context()->blob_read_count,
               0);  // blocking i/o
     ASSERT_EQ((int)get_perf_context()->blob_read_byte,

--- a/db/c.cc
+++ b/db/c.cc
@@ -5844,6 +5844,8 @@ uint64_t rocksdb_perfcontext_metric(rocksdb_perfcontext_t* context,
       return rep->number_async_seek;
     case rocksdb_blob_cache_hit_count:
       return rep->blob_cache_hit_count;
+    case rocksdb_blob_cache_read_byte:
+      return rep->blob_cache_read_byte;
     case rocksdb_blob_read_count:
       return rep->blob_read_count;
     case rocksdb_blob_read_byte:

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -2225,7 +2225,8 @@ enum {
   rocksdb_filter_block_read_byte,
   rocksdb_compression_dict_block_read_byte,
   rocksdb_metadata_block_read_byte,
-  rocksdb_total_metric_count = 85
+  rocksdb_blob_cache_read_byte,
+  rocksdb_total_metric_count = 86
 };
 
 extern ROCKSDB_LIBRARY_API void rocksdb_set_perf_level(int);

--- a/include/rocksdb/perf_context.h
+++ b/include/rocksdb/perf_context.h
@@ -114,6 +114,7 @@ struct PerfContextBase {
   uint64_t iter_read_bytes;      // bytes for keys/vals decoded by iterator
 
   uint64_t blob_cache_hit_count;  // total number of blob cache hits
+  uint64_t blob_cache_read_byte;  // total bytes read from blob cache
   uint64_t blob_read_count;       // total number of blob reads (with IO)
   uint64_t blob_read_byte;        // total number of bytes from blob reads
   uint64_t blob_read_time;        // total nanos spent on blob reads

--- a/java/rocksjni/jni_perf_context.cc
+++ b/java/rocksjni/jni_perf_context.cc
@@ -350,6 +350,18 @@ jlong Java_org_rocksdb_PerfContext_getBlobCacheHitCount(JNIEnv*, jobject,
 
 /*
  * Class:     org_rocksdb_PerfContext
+ * Method:    getBlobCacheReadByte
+ * Signature: (J)J
+ */
+jlong Java_org_rocksdb_PerfContext_getBlobCacheReadByte(JNIEnv*, jobject,
+                                                        jlong jpc_handle) {
+  ROCKSDB_NAMESPACE::PerfContext* perf_context =
+      reinterpret_cast<ROCKSDB_NAMESPACE::PerfContext*>(jpc_handle);
+  return perf_context->blob_cache_read_byte;
+}
+
+/*
+ * Class:     org_rocksdb_PerfContext
  * Method:    getBlobReadCount
  * Signature: (J)J
  */

--- a/java/src/main/java/org/rocksdb/PerfContext.java
+++ b/java/src/main/java/org/rocksdb/PerfContext.java
@@ -185,6 +185,13 @@ public class PerfContext extends RocksObject {
   }
 
   /**
+   * @return total number of bytes read from blob cache
+   */
+  public long getBlobCacheReadByte() {
+    return getBlobCacheReadByte(nativeHandle_);
+  }
+
+  /**
    * @return total number of blob reads (with IO)
    */
   public long getBlobReadCount() {
@@ -693,6 +700,7 @@ public class PerfContext extends RocksObject {
   private native long getMultigetReadBytes(final long handle);
   private native long getIterReadBytes(final long handle);
   private native long getBlobCacheHitCount(final long handle);
+  private native long getBlobCacheReadByte(final long handle);
   private native long getBlobReadCount(final long handle);
   private native long getBlobReadByte(final long handle);
   private native long getBlobReadTime(final long handle);

--- a/monitoring/perf_context.cc
+++ b/monitoring/perf_context.cc
@@ -78,6 +78,7 @@ struct PerfContextByLevelInt {
   defCmd(multiget_read_bytes)                      \
   defCmd(iter_read_bytes)                          \
   defCmd(blob_cache_hit_count)                     \
+  defCmd(blob_cache_read_byte)                     \
   defCmd(blob_read_count)                          \
   defCmd(blob_read_byte)                           \
   defCmd(blob_read_time)                           \

--- a/unreleased_history/public_api_changes/perf_context_captured.md
+++ b/unreleased_history/public_api_changes/perf_context_captured.md
@@ -1,0 +1,1 @@
+Added a new PerfContext counter `blob_cache_read_byte` for blob cache bytes read.


### PR DESCRIPTION
Added blob_cache_read_byte in the rocksdb::PerContextBase to expose the blob cache read bytes when blob cache is enabled.