### PR TITLE
Clarify tailing iterator late insert behavior

### DIFF
--- a/db/db_tailing_iter_test.cc
+++ b/db/db_tailing_iter_test.cc
@@ -55,6 +55,40 @@ TEST_P(DBTestTailingIterator, TailingIteratorSingle) {
   ASSERT_OK(iter->status());
 }
 
+TEST_P(DBTestTailingIterator, TailingIteratorNextDoesNotRefreshMutableMemtable) {
+  ReadOptions read_options;
+  read_options.tailing = true;
+  if (GetParam()) {
+    read_options.async_io = true;
+  }
+
+  ASSERT_OK(db_->Put(WriteOptions(), "A", "va"));
+  ASSERT_OK(db_->Put(WriteOptions(), "C", "vc"));
+  ASSERT_OK(Flush());
+
+  std::unique_ptr<Iterator> iter(db_->NewIterator(read_options));
+  ASSERT_OK(iter->status());
+
+  iter->SeekToFirst();
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ("A", iter->key().ToString());
+
+  ASSERT_OK(db_->Put(WriteOptions(), "B", "vb"));
+
+  // Next() advances the child iterators positioned by SeekToFirst(). It does
+  // not refresh the mutable memtable iterator to discover keys inserted behind
+  // the current cursor after that seek.
+  iter->Next();
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ("C", iter->key().ToString());
+  ASSERT_OK(iter->status());
+
+  iter->Seek("B");
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ("B", iter->key().ToString());
+  ASSERT_OK(iter->status());
+}
+
 TEST_P(DBTestTailingIterator, TailingIteratorKeepAdding) {
   if (mem_env_ || encrypted_env_) {
     ROCKSDB_GTEST_BYPASS("Test requires non-mem or non-encrypted environment");

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -2358,6 +2358,9 @@ extern ROCKSDB_LIBRARY_API void rocksdb_readoptions_set_read_tier(
     rocksdb_readoptions_t*, int);
 extern ROCKSDB_LIBRARY_API int rocksdb_readoptions_get_read_tier(
     rocksdb_readoptions_t*);
+// Sets whether iterators are tailing. Tailing iterators can read newly added
+// data after a seek refresh, but Next() is not guaranteed to observe keys
+// inserted after the most recent seek that sort before the next visible key.
 extern ROCKSDB_LIBRARY_API void rocksdb_readoptions_set_tailing(
     rocksdb_readoptions_t*, unsigned char);
 extern ROCKSDB_LIBRARY_API unsigned char rocksdb_readoptions_get_tailing(

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -2218,10 +2218,12 @@ struct ReadOptions {
   // point to key without timestamp part.
   const Slice* iterate_upper_bound = nullptr;
 
-  // Specify to create a tailing iterator -- a special iterator that has a
-  // view of the complete database (i.e. it can also be used to read newly
-  // added data) and is optimized for sequential reads. It will return records
-  // that were inserted into the database after the creation of the iterator.
+  // Specify to create a tailing iterator -- a special iterator that is
+  // optimized for sequential reads and can also be used to read newly added
+  // data. The view is refreshed on Seek(), SeekToFirst(), and after internal
+  // iterator renewal, but not on every Next(). In particular, Next() is not
+  // guaranteed to observe keys inserted after the most recent Seek() that sort
+  // before the next key visible to that Seek().
   bool tailing = false;
 
   // Enable a total order seek regardless of index format (e.g. hash index)


### PR DESCRIPTION
Summary:
Clarifies tailing iterator documentation around the view refreshed by Seek()/SeekToFirst() and the fact that Next() is not guaranteed to observe keys inserted after the most recent seek, even when those keys sort after the last key returned.

Adds a focused test covering the case where a key is inserted into the mutable memtable after the iterator has already sought, but is skipped by Next() because the mutable memtable iterator is not refreshed until a later seek/renewal.

Refs #14677

Test Plan:
make db_tailing_iter_test -j8
./db_tailing_iter_test --gtest_filter='*Tailing*'
git diff --check
make check-sources