### PR TITLE
Fix tiered compaction incorrectly moving range tombstones upwards

### DIFF
--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -2065,10 +2065,18 @@ Status CompactionJob::FinishCompactionOutputFile(
     std::pair<SequenceNumber, SequenceNumber> keep_seqno_range{
         0, kMaxSequenceNumber};
     if (sub_compact->compaction->SupportsPerKeyPlacement()) {
+      // Point entries are routed to proximal output only when their seqno is
+      // strictly greater than `proximal_after_seqno_`. Range tombstones use a
+      // [lower, upper) filter, so split them at the next seqno to preserve the
+      // same boundary.
+      SequenceNumber range_del_split_seqno = proximal_after_seqno_;
+      if (range_del_split_seqno < kMaxSequenceNumber) {
+        range_del_split_seqno++;
+      }
       if (outputs.IsProximalLevel()) {
-        keep_seqno_range.first = proximal_after_seqno_;
+        keep_seqno_range.first = range_del_split_seqno;
       } else {
-        keep_seqno_range.second = proximal_after_seqno_;
+        keep_seqno_range.second = range_del_split_seqno;
       }
     }
     CompactionIterationStats range_del_out_stats;

--- a/db/compaction/tiered_compaction_test.cc
+++ b/db/compaction/tiered_compaction_test.cc
@@ -2897,6 +2897,61 @@ TEST_P(PrecludeLastLevelTest, RangeDelsCauseFileEndpointsToOverlap) {
   Close();
 }
 
+TEST_F(PrecludeLastLevelTestBase,
+       RangeDelAtProximalSeqnoBoundaryStaysInLastLevel) {
+  constexpr int kNumLevels = 7;
+
+  Options options = CurrentOptions();
+  options.env = mock_env_.get();
+  options.num_levels = kNumLevels;
+  options.disable_auto_compactions = true;
+  DestroyAndReopen(options);
+  Defer close_db([&] { Close(); });
+
+  ASSERT_OK(Put(Key(2), "old"));
+  ASSERT_OK(Put(Key(12), "old"));
+  ManagedSnapshot snapshot(db_.get());
+  ASSERT_OK(db_->DeleteRange(WriteOptions(), db_->DefaultColumnFamily(), Key(2),
+                             Key(12)));
+  ASSERT_OK(Flush());
+  MoveFilesToLevel(6);
+
+  const int l5_file_keys[][2] = {{0, 4}, {5, 9}};
+  for (const auto& l5_file : l5_file_keys) {
+    ASSERT_OK(Put(Key(l5_file[0]), "hot"));
+    ASSERT_OK(Put(Key(l5_file[1]), "hot"));
+    ASSERT_OK(Flush());
+    MoveFilesToLevel(5);
+  }
+  ASSERT_EQ("0,0,0,0,0,2,1", FilesPerLevel());
+
+  SyncPoint::GetInstance()->SetCallBack(
+      "CompactionJob::PrepareTimes():preclude_last_level_min_seqno",
+      [](void* arg) { *static_cast<SequenceNumber*>(arg) = 0; });
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  ASSERT_OK(db_->SetOptions({{"preclude_last_level_data_seconds", "10000"}}));
+
+  auto l5_files = GetLevelFileMetadatas(5);
+  auto l6_files = GetLevelFileMetadatas(6);
+  ASSERT_EQ(2, l5_files.size());
+  ASSERT_EQ(1, l6_files.size());
+
+  ASSERT_OK(db_->CompactFiles(CompactionOptions(),
+                              {MakeTableFileName(l5_files[1]->fd.GetNumber()),
+                               MakeTableFileName(l6_files[0]->fd.GetNumber())},
+                              6));
+
+  uint64_t l6_range_deletions = 0;
+  for (auto* f : GetLevelFileMetadatas(5)) {
+    ASSERT_EQ(0, f->num_range_deletions);
+  }
+  for (auto* f : GetLevelFileMetadatas(6)) {
+    l6_range_deletions += f->num_range_deletions;
+  }
+  ASSERT_GT(l6_range_deletions, 0);
+}
+
 // Tests DBIter::GetProperty("rocksdb.iterator.write-time") return a data's
 // approximate write unix time.
 class IteratorWriteTimeTest

--- a/unreleased_history/bug_fixes/proximal_compaction_range_tombstone
+++ b/unreleased_history/bug_fixes/proximal_compaction_range_tombstone
@@ -1,0 +1,1 @@
+Fix a rare corruption bug for tiered compaction that incorrectly moved last level range tombstones into proximal level.

--- a/unreleased_history/bug_fixes/proximal_compaction_range_tombstone
+++ b/unreleased_history/bug_fixes/proximal_compaction_range_tombstone
@@ -1,1 +1,1 @@
-Fix a rare corruption bug for tiered compaction that incorrectly moved last level range tombstones into proximal level.
+Fix a rare corruption bug for tiered compaction that incorrectly moved last level range tombstones into proximal level. This corruption error is surfaced when force_consistency_checks is enabled.


### PR DESCRIPTION
## Summary

Fixes an off-by-one bug in how sequence numbers are handled when splitting range tombstones across output levels in per-key-placement (tiered) compaction. The bug was either introduced or propagated in #13256.

Point entries move to proximal output only when their sequence number is strictly greater than `proximal_after_seqno_`, but range tombstones were previously split using an inclusive lower bound at that same seqno. That allowed a range tombstone at the boundary to be emitted to the proximal level while point keys at the same seqno stayed in the last level, which could create overlapping files in the proximal level (caught by `force_consistency_checks` as `L<n> has overlapping ranges`).

This matters when `proximal_output_range_type_` is `kNonLastRange`: the compaction only owns the selected proximal-level input range, so existing last-level data at the split boundary must stay in the last level. In `kFullRange`, the compaction owns the relevant proximal-level range, so newer last-level data can be safely emitted to proximal output.

The fix splits range tombstones at `proximal_after_seqno_ + 1` (saturating at `kMaxSequenceNumber`), so the half-open `[lower, upper)` tombstone filter lands on the same boundary as the strict `seqno > proximal_after_seqno_` rule used for point keys.

## Test Plan

New regression test `PrecludeLastLevelTestBase.RangeDelAtProximalSeqnoBoundaryStaysInLastLevel` uses a targeted manual compaction to exercise the `kNonLastRange` case directly, verifying a boundary range tombstone stays in the last level instead of widening the proximal output range.

Worked example:

```text
Initial state:

  L6 (last level):   Put(Key 2)@s1,  Put(Key 12)@s2,  RangeDel[Key 2, Key 12)@s3
  L5 (proximal):     file A [Key 0 .. Key 4]@s4-s5     file B [Key 5 .. Key 9]@s6-s7

  preclude_last_level_min_seqno is forced to 0 via sync point.

Manual CompactFiles selects only L5 file B + the L6 file (output level 6).
Only part of the proximal level is selected, so this is the kNonLastRange case:

  max_last_level_seqno  = 3
  proximal_after_seqno_ = max(0, 3) = 3

  Point keys Key 5 (s6) and Key 9 (s7): both seqno > 3 -> proximal output (L5)   OK

  Range tombstone @s3:
    Old (buggy):  proximal keep range [3, MAX) includes s3, so the tombstone is
                  emitted to the proximal output. The output is built from L5 input
                  file B [Key 5 .. Key 9], but the tombstone covers [Key 2, Key 12),
                  so the proximal output file starts at Key 2 and spills past Key 5
                  into the existing, untouched L5 file A [Key 0 .. Key 4].
                  Two overlapping files in L5 -> Corruption.

    New (fixed):  split at proximal_after_seqno_ + 1 = 4.
                  proximal keep [4, MAX) excludes s3; last-level keep [0, 4) includes
                  s3 -> tombstone stays in the last level (L6).   OK
```

Verification (debug build, `make -j64 tiered_compaction_test`):

- Without the fix, the test fails at the `CompactFiles` call:
  ```
  tiered_compaction_test.cc:2940: Failure
  Corruption: force_consistency_checks(DEBUG): VersionBuilder: L5 has overlapping ranges:
    file #11 largest key: Key(4) seq:5, type:1 (Put) vs.
    file #17 smallest key: Key(2) seq:3, type:15 (range deletion)
  ```
- With the fix, the test passes (range deletions absent from L5, still present in L6).
