### PR TITLE
Expose fill_cache in RocksJava ingest options

### DIFF
--- a/db/db_tailing_iter_test.cc
+++ b/db/db_tailing_iter_test.cc
@@ -55,6 +55,40 @@ TEST_P(DBTestTailingIterator, TailingIteratorSingle) {
   ASSERT_OK(iter->status());
 }
 
+TEST_P(DBTestTailingIterator, TailingIteratorNextDoesNotRefreshMutableMemtable) {
+  ReadOptions read_options;
+  read_options.tailing = true;
+  if (GetParam()) {
+    read_options.async_io = true;
+  }
+
+  ASSERT_OK(db_->Put(WriteOptions(), "A", "va"));
+  ASSERT_OK(db_->Put(WriteOptions(), "C", "vc"));
+  ASSERT_OK(Flush());
+
+  std::unique_ptr<Iterator> iter(db_->NewIterator(read_options));
+  ASSERT_OK(iter->status());
+
+  iter->SeekToFirst();
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ("A", iter->key().ToString());
+
+  ASSERT_OK(db_->Put(WriteOptions(), "B", "vb"));
+
+  // Next() advances the child iterators positioned by SeekToFirst(). It does
+  // not refresh the mutable memtable iterator to discover keys inserted behind
+  // the current cursor after that seek.
+  iter->Next();
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ("C", iter->key().ToString());
+  ASSERT_OK(iter->status());
+
+  iter->Seek("B");
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ("B", iter->key().ToString());
+  ASSERT_OK(iter->status());
+}
+
 TEST_P(DBTestTailingIterator, TailingIteratorKeepAdding) {
   if (mem_env_ || encrypted_env_) {
     ROCKSDB_GTEST_BYPASS("Test requires non-mem or non-encrypted environment");

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -2358,6 +2358,9 @@ extern ROCKSDB_LIBRARY_API void rocksdb_readoptions_set_read_tier(
     rocksdb_readoptions_t*, int);
 extern ROCKSDB_LIBRARY_API int rocksdb_readoptions_get_read_tier(
     rocksdb_readoptions_t*);
+// Sets whether iterators are tailing. Tailing iterators can read newly added
+// data after a seek refresh, but Next() is not guaranteed to observe keys
+// inserted after the most recent seek that sort before the next visible key.
 extern ROCKSDB_LIBRARY_API void rocksdb_readoptions_set_tailing(
     rocksdb_readoptions_t*, unsigned char);
 extern ROCKSDB_LIBRARY_API unsigned char rocksdb_readoptions_get_tailing(

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -2218,10 +2218,12 @@ struct ReadOptions {
   // point to key without timestamp part.
   const Slice* iterate_upper_bound = nullptr;
 
-  // Specify to create a tailing iterator -- a special iterator that has a
-  // view of the complete database (i.e. it can also be used to read newly
-  // added data) and is optimized for sequential reads. It will return records
-  // that were inserted into the database after the creation of the iterator.
+  // Specify to create a tailing iterator -- a special iterator that is
+  // optimized for sequential reads and can also be used to read newly added
+  // data. The view is refreshed on Seek(), SeekToFirst(), and after internal
+  // iterator renewal, but not on every Next(). In particular, Next() is not
+  // guaranteed to observe keys inserted after the most recent Seek() that sort
+  // before the next key visible to that Seek().
   bool tailing = false;
 
   // Enable a total order seek regardless of index format (e.g. hash index)

--- a/java/rocksjni/ingest_external_file_options.cc
+++ b/java/rocksjni/ingest_external_file_options.cc
@@ -187,6 +187,30 @@ Java_org_rocksdb_IngestExternalFileOptions_setWriteGlobalSeqno(
 
 /*
  * Class:     org_rocksdb_IngestExternalFileOptions
+ * Method:    fillCache
+ * Signature: (J)Z
+ */
+jboolean Java_org_rocksdb_IngestExternalFileOptions_fillCache(JNIEnv*, jclass,
+                                                              jlong jhandle) {
+  auto* options =
+      reinterpret_cast<ROCKSDB_NAMESPACE::IngestExternalFileOptions*>(jhandle);
+  return static_cast<jboolean>(options->fill_cache);
+}
+
+/*
+ * Class:     org_rocksdb_IngestExternalFileOptions
+ * Method:    setFillCache
+ * Signature: (JZ)V
+ */
+void Java_org_rocksdb_IngestExternalFileOptions_setFillCache(
+    JNIEnv*, jclass, jlong jhandle, jboolean jfill_cache) {
+  auto* options =
+      reinterpret_cast<ROCKSDB_NAMESPACE::IngestExternalFileOptions*>(jhandle);
+  options->fill_cache = static_cast<bool>(jfill_cache);
+}
+
+/*
+ * Class:     org_rocksdb_IngestExternalFileOptions
  * Method:    disposeInternal
  * Signature: (J)V
  */

--- a/java/src/main/java/org/rocksdb/IngestExternalFileOptions.java
+++ b/java/src/main/java/org/rocksdb/IngestExternalFileOptions.java
@@ -201,6 +201,30 @@ public class IngestExternalFileOptions extends RocksObject {
     return this;
   }
 
+  /**
+   * Returns true if data and metadata blocks read during file ingestion will
+   * be added to the block cache.
+   *
+   * @return true if blocks read during file ingestion will be cached.
+   */
+  public boolean fillCache() {
+    return fillCache(nativeHandle_);
+  }
+
+  /**
+   * Controls whether data and metadata blocks read during file ingestion will
+   * be added to the block cache.
+   *
+   * @param fillCache true if blocks read during file ingestion should be
+   *     cached.
+   *
+   * @return the reference to the current IngestExternalFileOptions.
+   */
+  public IngestExternalFileOptions setFillCache(final boolean fillCache) {
+    setFillCache(nativeHandle_, fillCache);
+    return this;
+  }
+
   private static native long newIngestExternalFileOptions();
   private static native long newIngestExternalFileOptions(final boolean moveFiles,
       final boolean snapshotConsistency, final boolean allowGlobalSeqNo,
@@ -226,4 +250,6 @@ public class IngestExternalFileOptions extends RocksObject {
   private static native void setIngestBehind(final long handle, final boolean ingestBehind);
   private static native boolean writeGlobalSeqno(final long handle);
   private static native void setWriteGlobalSeqno(final long handle, final boolean writeGlobalSeqNo);
+  private static native boolean fillCache(final long handle);
+  private static native void setFillCache(final long handle, final boolean fillCache);
 }

--- a/java/src/test/java/org/rocksdb/IngestExternalFileOptionsTest.java
+++ b/java/src/test/java/org/rocksdb/IngestExternalFileOptionsTest.java
@@ -104,4 +104,14 @@ public class IngestExternalFileOptionsTest {
       assertThat(options.writeGlobalSeqno()).isTrue();
     }
   }
+
+  @Test
+  public void fillCache() {
+    try (final IngestExternalFileOptions options =
+             new IngestExternalFileOptions()) {
+      assertThat(options.fillCache()).isTrue();
+      options.setFillCache(false);
+      assertThat(options.fillCache()).isFalse();
+    }
+  }
 }


### PR DESCRIPTION
-Summary:
Exposes IngestExternalFileOptions::fill_cache through RocksJava so Java users can control whether file ingestion reads populate the block cache.

Fixes #14801

Test Plan:
git diff --check
make check-sources

Not run:
make rocksdbjava -j8

Java tests were not runnable locally because no Java runtime/JDK is installed and JAVA_HOME is unset.
 **Clarify tailing iterator late insert behavior**
- **Expose fill_cache in RocksJava ingest options**
