### PR TITLE
Expose fallback copy option in RocksJava ingest options

### DIFF
--- a/java/rocksjni/ingest_external_file_options.cc
+++ b/java/rocksjni/ingest_external_file_options.cc
@@ -65,6 +65,31 @@ void Java_org_rocksdb_IngestExternalFileOptions_setMoveFiles(
 
 /*
  * Class:     org_rocksdb_IngestExternalFileOptions
+ * Method:    failedMoveFallBackToCopy
+ * Signature: (J)Z
+ */
+jboolean Java_org_rocksdb_IngestExternalFileOptions_failedMoveFallBackToCopy(
+    JNIEnv*, jclass, jlong jhandle) {
+  auto* options =
+      reinterpret_cast<ROCKSDB_NAMESPACE::IngestExternalFileOptions*>(jhandle);
+  return static_cast<jboolean>(options->failed_move_fall_back_to_copy);
+}
+
+/*
+ * Class:     org_rocksdb_IngestExternalFileOptions
+ * Method:    setFailedMoveFallBackToCopy
+ * Signature: (JZ)V
+ */
+void Java_org_rocksdb_IngestExternalFileOptions_setFailedMoveFallBackToCopy(
+    JNIEnv*, jclass, jlong jhandle, jboolean jfailed_move_fall_back_to_copy) {
+  auto* options =
+      reinterpret_cast<ROCKSDB_NAMESPACE::IngestExternalFileOptions*>(jhandle);
+  options->failed_move_fall_back_to_copy =
+      static_cast<bool>(jfailed_move_fall_back_to_copy);
+}
+
+/*
+ * Class:     org_rocksdb_IngestExternalFileOptions
  * Method:    snapshotConsistency
  * Signature: (J)Z
  */

--- a/java/src/main/java/org/rocksdb/IngestExternalFileOptions.java
+++ b/java/src/main/java/org/rocksdb/IngestExternalFileOptions.java
@@ -51,6 +51,32 @@ public class IngestExternalFileOptions extends RocksObject {
   }
 
   /**
+   * Returns true if ingestion will fall back to copying when hard linking
+   * fails.
+   *
+   * @return true if ingestion will fall back to copying when hard linking
+   *     fails.
+   */
+  public boolean failedMoveFallBackToCopy() {
+    return failedMoveFallBackToCopy(nativeHandle_);
+  }
+
+  /**
+   * If set to true, ingestion falls back to copying when hard linking fails.
+   * This applies when {@link #moveFiles()} is true.
+   *
+   * @param failedMoveFallBackToCopy true if ingestion should fall back to
+   *     copying when hard linking fails.
+   *
+   * @return the reference to the current IngestExternalFileOptions.
+   */
+  public IngestExternalFileOptions setFailedMoveFallBackToCopy(
+      final boolean failedMoveFallBackToCopy) {
+    setFailedMoveFallBackToCopy(nativeHandle_, failedMoveFallBackToCopy);
+    return this;
+  }
+
+  /**
    * If set to false, an ingested file keys could appear in existing snapshots
    * that where created before the file was ingested.
    *
@@ -214,6 +240,9 @@ public class IngestExternalFileOptions extends RocksObject {
 
   private static native boolean moveFiles(final long handle);
   private static native void setMoveFiles(final long handle, final boolean move_files);
+  private static native boolean failedMoveFallBackToCopy(final long handle);
+  private static native void setFailedMoveFallBackToCopy(
+      final long handle, final boolean failedMoveFallBackToCopy);
   private static native boolean snapshotConsistency(final long handle);
   private static native void setSnapshotConsistency(
       final long handle, final boolean snapshotConsistency);

--- a/java/src/test/java/org/rocksdb/IngestExternalFileOptionsTest.java
+++ b/java/src/test/java/org/rocksdb/IngestExternalFileOptionsTest.java
@@ -56,6 +56,16 @@ public class IngestExternalFileOptionsTest {
   }
 
   @Test
+  public void failedMoveFallBackToCopy() {
+    try (final IngestExternalFileOptions options =
+        new IngestExternalFileOptions()) {
+      assertThat(options.failedMoveFallBackToCopy()).isTrue();
+      options.setFailedMoveFallBackToCopy(false);
+      assertThat(options.failedMoveFallBackToCopy()).isFalse();
+    }
+  }
+
+  @Test
   public void snapshotConsistency() {
     try (final IngestExternalFileOptions options =
         new IngestExternalFileOptions()) {


### PR DESCRIPTION
Summary:
Exposes IngestExternalFileOptions::failed_move_fall_back_to_copy through RocksJava so Java users can control whether ingestion falls back to copying when hard linking fails.

Fixes #14803

Test Plan:
git diff --check
make check-sources

Not run:
make rocksdbjava -j8

Java tests were not runnable locally because no Java runtime/JDK is installed and JAVA_HOME is unset.
