### PR TITLE
Make StringToMap entries self-contained for direct round-trip

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,12 +209,11 @@ The following patterns emerged as frequent sources of review feedback:
 ## Important tips
 
 ### Build system
-* There are 3 build system. Make, CMake, BUCK(meta internal).
+* There are 3 build system. Make for git clones, BUCK (meta internal) for hg
+  clones, and CMake for some special cases.
 * When a new .cc file is added, update Makefile, CMakeLists.txt, src.mk, BUCK.
 * Don't manually edit BUCK file, after updating src.mk, run
     /usr/local/bin/python3 buckifier/buckify_rocksdb.py to update it
-* Use make to build and run the test. CMake and BUCK are not used locally.
-* Use `make dbg` command to build all of the unit test in debug mode.
 * For -j in make command, use the number of CPU cores to decide it.
 
 ### When to run `make clean` (avoid mixing build modes)

--- a/db/db_bloom_filter_test.cc
+++ b/db/db_bloom_filter_test.cc
@@ -2022,7 +2022,11 @@ TEST_F(DBBloomFilterTest, MutableFilterPolicy) {
   double expected_bpk = 10.0;
   // Other configs to try
   std::vector<std::pair<std::string, double>> configs = {
-      {"ribbonfilter:10:-1", 7.0}, {"bloomfilter:5", 5.0}, {"nullptr", 0.0}};
+      {"ribbonfilter:10:-1", 7.0},
+      {"bloomfilter:5", 5.0},
+      {"nullptr", 0.0},
+      // As serialized in OPTIONS file
+      {"{id=ribbonfilter:12:-1;bloom_before_level=-1;}", 8.4}};
 
   table_options.cache_index_and_filter_blocks = true;
   options.table_factory.reset(NewBlockBasedTableFactory(table_options));

--- a/include/rocksdb/convenience.h
+++ b/include/rocksdb/convenience.h
@@ -432,8 +432,32 @@ Status GetOptionsFromString(const ConfigOptions& config_options,
                             const Options& base_options,
                             const std::string& opts_str, Options* new_options);
 
+// StringToMap parses a serialized options string into a map. Each
+// resulting map value is in a self-contained form (it can be embedded
+// directly in a `key=value;` context -- e.g. SetOptions -- without further
+// escaping). Specifically: nested braced values from the input are
+// preserved with their outer braces. Permissive: accepts both braced and
+// unbraced forms; values not requiring braces are returned as-is.
+// Example:
+//   "filter_policy={id=ribbonfilter:10;bloom_before_level=-1};block_size=4096"
+// produces:
+//   {filter_policy -> "{id=ribbonfilter:10;bloom_before_level=-1}",
+//    block_size    -> "4096"}
 Status StringToMap(const std::string& opts_str,
                    std::unordered_map<std::string, std::string>* opts_map);
+
+// MapToString is the inverse of StringToMap: a naive `key=value;` join.
+// Each map value must already be in self-contained form (as returned by
+// StringToMap) -- i.e. simple text or a single balanced `{...}` block.
+// Values from StringToMap satisfy this property, so the round-trip
+//
+//   StringToMap(MapToString(StringToMap(s))) == StringToMap(s)
+//
+// holds. Callers building a map by hand are responsible for ensuring
+// values are self-contained; raw values containing `;` or starting with
+// `{` without matching `}` won't round-trip.
+Status MapToString(const std::unordered_map<std::string, std::string>& opts_map,
+                   std::string* opts_str);
 
 // Request stopping background work, if wait is true wait until it's done
 void CancelAllBackgroundWork(DB* db, bool wait = false);

--- a/include/rocksdb/utilities/options_type.h
+++ b/include/rocksdb/utilities/options_type.h
@@ -453,11 +453,13 @@ class OptionTypeInfo {
                                        const std::string& value, void* addr) {
           std::map<std::string, std::string> map;
           Status s;
+          // Permit `{k1=v1;k2=v2}` (as serialized) or bare `k1=v1;k2=v2`.
+          std::string stripped = OptionTypeInfo::StripOuterBraces(value);
           for (size_t start = 0, end = 0;
-               s.ok() && start < value.size() && end != std::string::npos;
+               s.ok() && start < stripped.size() && end != std::string::npos;
                start = end + 1) {
             std::string token;
-            s = OptionTypeInfo::NextToken(value, item_separator, start, &end,
+            s = OptionTypeInfo::NextToken(stripped, item_separator, start, &end,
                                           &token);
             if (s.ok() && !token.empty()) {
               size_t pos = token.find(kv_separator);
@@ -947,6 +949,14 @@ class OptionTypeInfo {
   static Status NextToken(const std::string& opts, char delimiter, size_t start,
                           size_t* end, std::string* token);
 
+  // Strips a single layer of outer "{" / "}" wrapping iff the leading '{'
+  // pairs with the trailing '}'. This permissively unwraps values that
+  // could legitimately be either braced or bare (e.g. `{a:b:c}` and
+  // `a:b:c` are accepted equivalently by list-style parsers). The check
+  // is done at brace depth: `{a}:{b}` is left as-is because the leading
+  // '{' closes before the end of the string.
+  static std::string StripOuterBraces(const std::string& value);
+
   constexpr static const char* kIdPropName() { return "id"; }
   constexpr static const char* kIdPropSuffix() { return ".id"; }
 
@@ -995,12 +1005,16 @@ Status ParseArray(const ConfigOptions& config_options,
 
   ConfigOptions copy = config_options;
   copy.ignore_unsupported_options = false;
+  // Permit the caller to pass either bare `item1:item2` or wrapped
+  // `{item1:item2}`. Either form parses identically.
+  std::string stripped = OptionTypeInfo::StripOuterBraces(value);
   size_t i = 0, start = 0, end = 0;
-  for (; status.ok() && i < kSize && start < value.size() &&
+  for (; status.ok() && i < kSize && start < stripped.size() &&
          end != std::string::npos;
        i++, start = end + 1) {
     std::string token;
-    status = OptionTypeInfo::NextToken(value, separator, start, &end, &token);
+    status =
+        OptionTypeInfo::NextToken(stripped, separator, start, &end, &token);
     if (status.ok()) {
       status = elem_info.Parse(copy, name, token, &((*result)[i]));
       if (config_options.ignore_unsupported_options &&
@@ -1137,11 +1151,15 @@ Status ParseVector(const ConfigOptions& config_options,
   // object is valid or not.
   ConfigOptions copy = config_options;
   copy.ignore_unsupported_options = false;
+  // Permit the caller to pass either bare `item1:item2` or wrapped
+  // `{item1:item2}`. Either form parses identically.
+  std::string stripped = OptionTypeInfo::StripOuterBraces(value);
   for (size_t start = 0, end = 0;
-       status.ok() && start < value.size() && end != std::string::npos;
+       status.ok() && start < stripped.size() && end != std::string::npos;
        start = end + 1) {
     std::string token;
-    status = OptionTypeInfo::NextToken(value, separator, start, &end, &token);
+    status =
+        OptionTypeInfo::NextToken(stripped, separator, start, &end, &token);
     if (status.ok()) {
       T elem;
       status = elem_info.Parse(copy, name, token, &elem);

--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -557,11 +557,13 @@ static std::unordered_map<std::string, OptionTypeInfo>
             embedded.ignore_unsupported_options = true;
             std::vector<std::shared_ptr<EventListener>> listeners;
             Status s;
+            // Permit `{item1:item2}` or bare `item1:item2`.
+            std::string stripped = OptionTypeInfo::StripOuterBraces(value);
             for (size_t start = 0, end = 0;
-                 s.ok() && start < value.size() && end != std::string::npos;
+                 s.ok() && start < stripped.size() && end != std::string::npos;
                  start = end + 1) {
               std::string token;
-              s = OptionTypeInfo::NextToken(value, ':', start, &end, &token);
+              s = OptionTypeInfo::NextToken(stripped, ':', start, &end, &token);
               if (s.ok() && !token.empty()) {
                 std::shared_ptr<EventListener> listener;
                 s = EventListener::CreateFromString(embedded, token, &listener);

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -1114,7 +1114,7 @@ Status OptionTypeInfo::NextToken(const std::string& opts, char delimiter,
 }
 
 std::string OptionTypeInfo::StripOuterBraces(const std::string& value) {
-  if (value.size() <= 2 || value.front() != '{' || value.back() != '}') {
+  if (value.size() < 2 || value.front() != '{' || value.back() != '}') {
     return value;
   }
   // Verify the leading '{' actually pairs with the trailing '}'.
@@ -1157,7 +1157,13 @@ Status OptionTypeInfo::Parse(const ConfigOptions& config_options,
       copy.invoke_prepare_options = false;
       void* opt_addr = GetOffset(opt_ptr);
       return parse_func_(copy, opt_name, opt_value, opt_addr);
-    } else if (ParseOptionHelper(GetOffset(opt_ptr), type_, opt_value)) {
+    } else if (ParseOptionHelper(GetOffset(opt_ptr), type_,
+                                 StripOuterBraces(opt_value))) {
+      // Scalar types (int, bool, enum, string, ...). StringToMap now
+      // preserves outer braces in nested values, so a hand-crafted
+      // `key={42}` (or `db_log_dir={/tmp}`) lands here with a wrap
+      // that scalar parsers don't expect; permissively strip one
+      // level so braced scalar input still parses as before.
       return Status::OK();
     } else if (IsConfigurable()) {
       // The option is <config>.<name>

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -770,6 +770,11 @@ Status StringToMap(const std::string& opts_str,
   // Example:
   //   opts_str = "write_buffer_size=1024;max_write_buffer_number=2;"
   //              "nested_opt={opt1=1;opt2=2};max_bytes_for_level_base=100"
+  //
+  // Each value in the resulting map can be substituted directly into a
+  // `key=value;` context (e.g. SetOptions) and re-parsed without ambiguity:
+  // values that were wrapped in `{...}` in the input keep their wrapping,
+  // so embedded `;` characters stay escaped.
   size_t pos = 0;
   std::string opts = trim(opts_str);
   // If the input string starts and ends with "{...}", strip off the brackets
@@ -790,20 +795,75 @@ Status StringToMap(const std::string& opts_str,
       return Status::InvalidArgument("Empty key found");
     }
 
+    // Locate value start (after '=' and any whitespace).
+    size_t value_start = eq_pos + 1;
+    while (value_start < opts.size() && isspace(opts[value_start])) {
+      ++value_start;
+    }
+
     std::string value;
-    Status s = OptionTypeInfo::NextToken(opts, ';', eq_pos + 1, &pos, &value);
-    if (!s.ok()) {
-      return s;
-    } else {
-      (*opts_map)[key] = value;
-      if (pos == std::string::npos) {
-        break;
-      } else {
-        pos++;
+    if (value_start < opts.size() && opts[value_start] == '{') {
+      // Braced value: extract the entire `{...}` substring INCLUDING braces
+      // so that the value can be re-emitted as-is in a `key=value;` context.
+      int count = 1;
+      size_t brace_pos = value_start + 1;
+      while (brace_pos < opts.size() && count > 0) {
+        if (opts[brace_pos] == '{') {
+          ++count;
+        } else if (opts[brace_pos] == '}') {
+          --count;
+        }
+        if (count > 0) {
+          ++brace_pos;
+        }
       }
+      if (count != 0) {
+        return Status::InvalidArgument(
+            "Mismatched curly braces for nested options");
+      }
+      value = opts.substr(value_start, brace_pos - value_start + 1);
+      pos = brace_pos + 1;
+      // Allow whitespace, then either delimiter or end.
+      while (pos < opts.size() && isspace(opts[pos])) {
+        ++pos;
+      }
+      if (pos < opts.size() && opts[pos] != ';') {
+        return Status::InvalidArgument("Unexpected chars after nested options");
+      }
+    } else {
+      // Non-braced: scan to the next ';'. The value may contain '=' (only
+      // the first '=' separates key from value).
+      size_t end = opts.find(';', value_start);
+      if (end == std::string::npos) {
+        value = trim(opts.substr(value_start));
+        pos = std::string::npos;
+      } else {
+        value = trim(opts.substr(value_start, end - value_start));
+        pos = end;
+      }
+    }
+
+    (*opts_map)[key] = value;
+    if (pos == std::string::npos) {
+      break;
+    } else {
+      pos++;
     }
   }
 
+  return Status::OK();
+}
+
+Status MapToString(const std::unordered_map<std::string, std::string>& opts_map,
+                   std::string* opts_str) {
+  assert(opts_str);
+  opts_str->clear();
+  for (const auto& [key, value] : opts_map) {
+    opts_str->append(key);
+    opts_str->append("=");
+    opts_str->append(value);
+    opts_str->append(";");
+  }
   return Status::OK();
 }
 
@@ -1051,6 +1111,32 @@ Status OptionTypeInfo::NextToken(const std::string& opts, char delimiter,
     }
   }
   return Status::OK();
+}
+
+std::string OptionTypeInfo::StripOuterBraces(const std::string& value) {
+  if (value.size() <= 2 || value.front() != '{' || value.back() != '}') {
+    return value;
+  }
+  // Verify the leading '{' actually pairs with the trailing '}'.
+  // For `{a:b}` the leading brace closes only at the trailing `}` (one
+  // matching pair, OK to strip). For `{a}:{b}` the leading brace closes
+  // at the first inner `}`, so the leading and trailing braces are
+  // independent -- leave the value alone. We strip at most one layer:
+  // each layer of `{}` corresponds to one level of nesting that the
+  // encoder added for that level, and the typed parser at this level
+  // wants to peel exactly its own layer.
+  int depth = 0;
+  for (size_t i = 0; i + 1 < value.size(); ++i) {
+    if (value[i] == '{') {
+      ++depth;
+    } else if (value[i] == '}') {
+      --depth;
+      if (depth == 0) {
+        return value;  // outer braces are independent
+      }
+    }
+  }
+  return value.substr(1, value.size() - 2);
 }
 
 Status OptionTypeInfo::Parse(const ConfigOptions& config_options,

--- a/options/options_test.cc
+++ b/options/options_test.cc
@@ -1938,11 +1938,13 @@ TEST_F(OptionsTest, StringToMapTest) {
   ASSERT_EQ(opts_map["k2"], "");
   ASSERT_TRUE(opts_map.find("k3") != opts_map.end());
   ASSERT_EQ(opts_map["k3"], "");
-  // Regular nested options
+  // Regular nested options. Braces are preserved on values that came in
+  // braced, so the value is self-contained for direct embedding via
+  // `key=value;` and round-trips through StringToMap/MapToString.
   opts_map.clear();
   ASSERT_OK(StringToMap("k1=v1;k2={nk1=nv1;nk2=nv2};k3=v3", &opts_map));
   ASSERT_EQ(opts_map["k1"], "v1");
-  ASSERT_EQ(opts_map["k2"], "nk1=nv1;nk2=nv2");
+  ASSERT_EQ(opts_map["k2"], "{nk1=nv1;nk2=nv2}");
   ASSERT_EQ(opts_map["k3"], "v3");
   // Multi-level nested options
   opts_map.clear();
@@ -1951,34 +1953,35 @@ TEST_F(OptionsTest, StringToMapTest) {
                   "k3={nk1={nnk1={nnnk1=nnnv1;nnnk2;nnnv2}}};k4=v4",
                   &opts_map));
   ASSERT_EQ(opts_map["k1"], "v1");
-  ASSERT_EQ(opts_map["k2"], "nk1=nv1;nk2={nnk1=nnk2}");
-  ASSERT_EQ(opts_map["k3"], "nk1={nnk1={nnnk1=nnnv1;nnnk2;nnnv2}}");
+  ASSERT_EQ(opts_map["k2"], "{nk1=nv1;nk2={nnk1=nnk2}}");
+  ASSERT_EQ(opts_map["k3"], "{nk1={nnk1={nnnk1=nnnv1;nnnk2;nnnv2}}}");
   ASSERT_EQ(opts_map["k4"], "v4");
   // Garbage inside curly braces
   opts_map.clear();
   ASSERT_OK(StringToMap("k1=v1;k2={dfad=};k3={=};k4=v4", &opts_map));
   ASSERT_EQ(opts_map["k1"], "v1");
-  ASSERT_EQ(opts_map["k2"], "dfad=");
-  ASSERT_EQ(opts_map["k3"], "=");
+  ASSERT_EQ(opts_map["k2"], "{dfad=}");
+  ASSERT_EQ(opts_map["k3"], "{=}");
   ASSERT_EQ(opts_map["k4"], "v4");
   // Empty nested options
   opts_map.clear();
   ASSERT_OK(StringToMap("k1=v1;k2={};", &opts_map));
   ASSERT_EQ(opts_map["k1"], "v1");
-  ASSERT_EQ(opts_map["k2"], "");
+  ASSERT_EQ(opts_map["k2"], "{}");
   opts_map.clear();
   ASSERT_OK(StringToMap("k1=v1;k2={{{{}}}{}{}};", &opts_map));
   ASSERT_EQ(opts_map["k1"], "v1");
-  ASSERT_EQ(opts_map["k2"], "{{{}}}{}{}");
-  // With random spaces
+  ASSERT_EQ(opts_map["k2"], "{{{{}}}{}{}}");
+  // With random spaces. Internal whitespace is preserved verbatim now
+  // (we keep the original substring of the value rather than trimming).
   opts_map.clear();
   ASSERT_OK(
       StringToMap("  k1 =  v1 ; k2= {nk1=nv1; nk2={nnk1=nnk2}}  ; "
                   "k3={  {   } }; k4= v4  ",
                   &opts_map));
   ASSERT_EQ(opts_map["k1"], "v1");
-  ASSERT_EQ(opts_map["k2"], "nk1=nv1; nk2={nnk1=nnk2}");
-  ASSERT_EQ(opts_map["k3"], "{   }");
+  ASSERT_EQ(opts_map["k2"], "{nk1=nv1; nk2={nnk1=nnk2}}");
+  ASSERT_EQ(opts_map["k3"], "{  {   } }");
   ASSERT_EQ(opts_map["k4"], "v4");
 
   // Empty key
@@ -2006,6 +2009,134 @@ TEST_F(OptionsTest, StringToMapTest) {
   ASSERT_NOK(StringToMap("k1=v1;k2={{}}  cfda", &opts_map));
   ASSERT_NOK(StringToMap("k1=v1;k2={{}}{}", &opts_map));
   ASSERT_NOK(StringToMap("k1=v1;k2={{dfdl}adfa}{}", &opts_map));
+}
+
+TEST_F(OptionsTest, MapToStringTest) {
+  using Map = std::unordered_map<std::string, std::string>;
+  std::string s;
+
+  // Simple values.
+  Map simple{{"a", "1"}, {"b", "hello"}};
+  ASSERT_OK(MapToString(simple, &s));
+  Map reparsed;
+  ASSERT_OK(StringToMap(s, &reparsed));
+  ASSERT_EQ(reparsed, simple);
+
+  // A value already in self-contained braced form (as returned by
+  // StringToMap) passes through unchanged. No extra wrapping is needed
+  // for round-trip.
+  Map already_braced{{"k", "{a=b;c=d}"}};
+  ASSERT_OK(MapToString(already_braced, &s));
+  ASSERT_EQ(s, "k={a=b;c=d};");
+  Map reparsed_braced;
+  ASSERT_OK(StringToMap(s, &reparsed_braced));
+  ASSERT_EQ(reparsed_braced, already_braced);
+}
+
+TEST_F(OptionsTest, StringToMapMapToStringRoundTripTest) {
+  using Map = std::unordered_map<std::string, std::string>;
+  // Pull a single entry out of a StringToMap-ed map and re-embed it
+  // directly into a `key=value;` SetOptions-style string. The pulled
+  // value must round-trip without any extra escaping by the caller --
+  // this is the property that lets users compose option strings from
+  // map entries safely.
+  const std::string original =
+      "filter_policy={id=ribbonfilter:10:-1;bloom_before_level=-1;};"
+      "block_size=4096;cache_index_and_filter_blocks=true";
+
+  Map parsed;
+  ASSERT_OK(StringToMap(original, &parsed));
+  // The filter_policy value retains its braces -- it's self-contained.
+  EXPECT_EQ(parsed["filter_policy"],
+            "{id=ribbonfilter:10:-1;bloom_before_level=-1;}");
+  EXPECT_EQ(parsed["block_size"], "4096");
+  EXPECT_EQ(parsed["cache_index_and_filter_blocks"], "true");
+
+  // Pull a single entry out and embed it in a fresh `key=value;`
+  // string. No extra wrapping required by the caller.
+  const std::string embedded =
+      "filter_policy=" + parsed["filter_policy"] + ";other_opt=42";
+  Map reparsed;
+  ASSERT_OK(StringToMap(embedded, &reparsed));
+  EXPECT_EQ(reparsed["filter_policy"], parsed["filter_policy"]);
+  EXPECT_EQ(reparsed["other_opt"], "42");
+
+  // Whole-map round-trip via MapToString.
+  std::string regenerated;
+  ASSERT_OK(MapToString(parsed, &regenerated));
+  Map reparsed2;
+  ASSERT_OK(StringToMap(regenerated, &reparsed2));
+  EXPECT_EQ(reparsed2, parsed);
+}
+
+TEST_F(OptionsTest, FullOptionsStringToMapRoundTripTest) {
+  // Round-trip a populated DBOptions and CFOptions through the
+  // StringToMap -> MapToString path. This catches any custom option
+  // serializer that emits a value containing the StringToMap delimiter
+  // (';') without enclosing it in '{}' -- such a value would survive
+  // StringToMap as a self-contained entry but corrupt subsequent
+  // re-serialization. Existing typed tests
+  // (ColumnFamilyOptionsSerialization, DBOptionsSerialization) cover the
+  // typed Configurable round-trip; this test specifically exercises the
+  // public StringToMap + MapToString path that callers use to compose,
+  // mutate, and re-emit option strings.
+  Random rnd(607);
+  ConfigOptions config_options;
+  config_options.input_strings_escaped = false;
+
+  // ---- ColumnFamilyOptions ----
+  Options options;
+  ColumnFamilyOptions base_cf_opt;
+  base_cf_opt.comparator = test::BytewiseComparatorWithU64TsWrapper();
+  test::RandomInitCFOptions(&base_cf_opt, options, &rnd);
+  std::string cf_str;
+  ASSERT_OK(
+      GetStringFromColumnFamilyOptions(config_options, base_cf_opt, &cf_str));
+
+  std::unordered_map<std::string, std::string> cf_map;
+  ASSERT_OK(StringToMap(cf_str, &cf_map));
+  // Each entry must be embeddable as-is in a `key=value;` context.
+  for (const auto& [k, v] : cf_map) {
+    std::string solo = k + "=" + v + ";";
+    std::unordered_map<std::string, std::string> solo_map;
+    ASSERT_OK(StringToMap(solo, &solo_map))
+        << "single-entry round-trip failed for " << k << ": " << v;
+    ASSERT_EQ(solo_map.size(), 1u) << k << "=" << v;
+    ASSERT_EQ(solo_map[k], v) << "single-entry value mismatch for " << k;
+  }
+  // Whole-map MapToString must reproduce a string parseable into a CF
+  // options object equivalent to the original.
+  std::string cf_round;
+  ASSERT_OK(MapToString(cf_map, &cf_round));
+  ColumnFamilyOptions cf_back;
+  ASSERT_OK(GetColumnFamilyOptionsFromString(
+      config_options, ColumnFamilyOptions(), cf_round, &cf_back));
+  ASSERT_OK(RocksDBOptionsParser::VerifyCFOptions(config_options, base_cf_opt,
+                                                  cf_back));
+
+  // ---- DBOptions ----
+  DBOptions base_db_opt;
+  test::RandomInitDBOptions(&base_db_opt, &rnd);
+  std::string db_str;
+  ASSERT_OK(GetStringFromDBOptions(config_options, base_db_opt, &db_str));
+
+  std::unordered_map<std::string, std::string> db_map;
+  ASSERT_OK(StringToMap(db_str, &db_map));
+  for (const auto& [k, v] : db_map) {
+    std::string solo = k + "=" + v + ";";
+    std::unordered_map<std::string, std::string> solo_map;
+    ASSERT_OK(StringToMap(solo, &solo_map))
+        << "single-entry round-trip failed for " << k << ": " << v;
+    ASSERT_EQ(solo_map.size(), 1u) << k << "=" << v;
+    ASSERT_EQ(solo_map[k], v) << "single-entry value mismatch for " << k;
+  }
+  std::string db_round;
+  ASSERT_OK(MapToString(db_map, &db_round));
+  DBOptions db_back;
+  ASSERT_OK(
+      GetDBOptionsFromString(config_options, DBOptions(), db_round, &db_back));
+  ASSERT_OK(RocksDBOptionsParser::VerifyDBOptions(config_options, base_db_opt,
+                                                  db_back));
 }
 
 TEST_F(OptionsTest, StringToMapRandomTest) {

--- a/options/options_test.cc
+++ b/options/options_test.cc
@@ -2190,6 +2190,15 @@ TEST_F(OptionsTest, StringToMapRandomTest) {
         str[pos] = ' ';
         Status s = StringToMap(str, &opts_map);
         ASSERT_TRUE(s.ok() || s.IsInvalidArgument());
+        if (s.ok()) {
+          // Round-trip: StringToMap entries are self-contained, so
+          // MapToString of them must parse back to the same map.
+          std::string regen;
+          ASSERT_OK(MapToString(opts_map, &regen));
+          std::unordered_map<std::string, std::string> reparsed;
+          ASSERT_OK(StringToMap(regen, &reparsed));
+          ASSERT_EQ(reparsed, opts_map) << "regen=" << regen;
+        }
         opts_map.clear();
       }
     }
@@ -2209,8 +2218,22 @@ TEST_F(OptionsTest, StringToMapRandomTest) {
     }
     Status s = StringToMap(str, &opts_map);
     ASSERT_TRUE(s.ok() || s.IsInvalidArgument());
+    if (s.ok()) {
+      std::string regen;
+      ASSERT_OK(MapToString(opts_map, &regen));
+      std::unordered_map<std::string, std::string> reparsed;
+      ASSERT_OK(StringToMap(regen, &reparsed));
+      ASSERT_EQ(reparsed, opts_map) << "regen=" << regen;
+    }
     s = StringToMap("name=" + str, &opts_map);
     ASSERT_TRUE(s.ok() || s.IsInvalidArgument());
+    if (s.ok()) {
+      std::string regen;
+      ASSERT_OK(MapToString(opts_map, &regen));
+      std::unordered_map<std::string, std::string> reparsed;
+      ASSERT_OK(StringToMap(regen, &reparsed));
+      ASSERT_EQ(reparsed, opts_map) << "regen=" << regen;
+    }
     opts_map.clear();
   }
 }

--- a/options/options_test.cc
+++ b/options/options_test.cc
@@ -2011,6 +2011,31 @@ TEST_F(OptionsTest, StringToMapTest) {
   ASSERT_NOK(StringToMap("k1=v1;k2={{dfdl}adfa}{}", &opts_map));
 }
 
+TEST_F(OptionsTest, EmptyBracedVectorAndBracedScalarTest) {
+  // An empty braced list value (`key={}`) must parse as an empty
+  // collection, not as a vector with one empty element. StringToMap
+  // preserves the braces, so the typed vector parser sees `{}`; its
+  // outer-brace strip needs to handle the size-2 case.
+  ColumnFamilyOptions cf_opts;
+  ConfigOptions cfg;
+  ASSERT_OK(GetColumnFamilyOptionsFromString(
+      cfg, ColumnFamilyOptions(), "compression_per_level={};", &cf_opts));
+  EXPECT_TRUE(cf_opts.compression_per_level.empty());
+
+  // A scalar value wrapped in `{}` (e.g. hand-crafted `key={42}`) must
+  // still parse. StringToMap preserves the braces, so the scalar
+  // dispatch in OptionTypeInfo::Parse permissively strips one outer
+  // layer.
+  DBOptions db_opts;
+  ASSERT_OK(GetDBOptionsFromString(cfg, DBOptions(), "max_open_files={42};",
+                                   &db_opts));
+  EXPECT_EQ(db_opts.max_open_files, 42);
+
+  ASSERT_OK(GetDBOptionsFromString(cfg, DBOptions(),
+                                   "create_if_missing={true};", &db_opts));
+  EXPECT_TRUE(db_opts.create_if_missing);
+}
+
 TEST_F(OptionsTest, MapToStringTest) {
   using Map = std::unordered_map<std::string, std::string>;
   std::string s;

--- a/options/options_test.cc
+++ b/options/options_test.cc
@@ -2122,7 +2122,8 @@ TEST_F(OptionsTest, FullOptionsStringToMapRoundTripTest) {
   ASSERT_OK(StringToMap(cf_str, &cf_map));
   // Each entry must be embeddable as-is in a `key=value;` context.
   for (const auto& [k, v] : cf_map) {
-    std::string solo = k + "=" + v + ";";
+    std::string solo;
+    solo.append(k).append("=").append(v).append(";");
     std::unordered_map<std::string, std::string> solo_map;
     ASSERT_OK(StringToMap(solo, &solo_map))
         << "single-entry round-trip failed for " << k << ": " << v;
@@ -2148,7 +2149,8 @@ TEST_F(OptionsTest, FullOptionsStringToMapRoundTripTest) {
   std::unordered_map<std::string, std::string> db_map;
   ASSERT_OK(StringToMap(db_str, &db_map));
   for (const auto& [k, v] : db_map) {
-    std::string solo = k + "=" + v + ";";
+    std::string solo;
+    solo.append(k).append("=").append(v).append(";");
     std::unordered_map<std::string, std::string> solo_map;
     ASSERT_OK(StringToMap(solo, &solo_map))
         << "single-entry round-trip failed for " << k << ": " << v;
@@ -2162,6 +2164,10 @@ TEST_F(OptionsTest, FullOptionsStringToMapRoundTripTest) {
       GetDBOptionsFromString(config_options, DBOptions(), db_round, &db_back));
   ASSERT_OK(RocksDBOptionsParser::VerifyDBOptions(config_options, base_db_opt,
                                                   db_back));
+
+  // RandomInitCFOptions allocates a raw CompactionFilter*; the
+  // ColumnFamilyOptions destructor doesn't own it.
+  delete base_cf_opt.compaction_filter;
 }
 
 TEST_F(OptionsTest, StringToMapRandomTest) {

--- a/unreleased_history/behavior_changes/string_to_map_self_contained.md
+++ b/unreleased_history/behavior_changes/string_to_map_self_contained.md
@@ -1,0 +1,1 @@
+StringToMap (rocksdb/convenience.h) now preserves the outer braces of nested values so each map entry is in self-contained form and can be embedded directly into another `key=value;` string (e.g. SetOptions) without losing inner ';' delimiters. A new symmetric MapToString utility is provided.

--- a/util/string_util.cc
+++ b/util/string_util.cc
@@ -251,21 +251,22 @@ std::string UnescapeOptionString(const std::string& escaped_string) {
 }
 
 std::string trim(const std::string& str) {
-  if (str.empty()) {
-    return std::string();
-  }
   size_t start = 0;
-  size_t end = str.size() - 1;
-  while (isspace(str[start]) != 0 && start < end) {
+  size_t end = str.size();
+  for (;;) {
+    if (start >= end) {
+      return {};  // all whitespace
+    }
+    if (!isspace(str[start])) {
+      break;  // first non-whitespace found
+    }
     ++start;
   }
-  while (isspace(str[end]) != 0 && start < end) {
+  while (isspace(str[end - 1]) != 0) {
     --end;
+    assert(end > start);
   }
-  if (start <= end) {
-    return str.substr(start, end - start + 1);
-  }
-  return std::string();
+  return str.substr(start, end - start);
 }
 
 bool EndsWith(const std::string& string, const std::string& pattern) {

--- a/util/string_util_test.cc
+++ b/util/string_util_test.cc
@@ -27,6 +27,31 @@ TEST(StringUtilTest, NumberToHumanString) {
   ASSERT_EQ("-10G", NumberToHumanString(-10000000000));
 }
 
+TEST(StringUtilTest, Trim) {
+  // Empty input.
+  EXPECT_EQ("", trim(""));
+  // No whitespace to strip.
+  EXPECT_EQ("a", trim("a"));
+  EXPECT_EQ("abc", trim("abc"));
+  // Leading whitespace only.
+  EXPECT_EQ("a", trim(" a"));
+  EXPECT_EQ("abc", trim("   abc"));
+  // Trailing whitespace only.
+  EXPECT_EQ("a", trim("a "));
+  EXPECT_EQ("abc", trim("abc   "));
+  // Both ends.
+  EXPECT_EQ("a", trim(" a "));
+  EXPECT_EQ("abc", trim("   abc   "));
+  EXPECT_EQ("a b c", trim("  a b c  "));  // interior whitespace preserved
+  // All-whitespace inputs of various lengths must trim to empty.
+  EXPECT_EQ("", trim(" "));
+  EXPECT_EQ("", trim("  "));
+  EXPECT_EQ("", trim("   "));
+  EXPECT_EQ("", trim("\t"));
+  EXPECT_EQ("", trim("\n"));
+  EXPECT_EQ("", trim(" \t\n\r"));
+}
+
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Summary:
StringToMap previously stripped the outer braces from nested values,
making single-entry round-trip via `key=value;` (e.g. SetOptions)
silently corrupt values that contain ';'. For example, a filter_policy
with sub-options serialized as
  filter_policy={id=ribbonfilter:10:-1;bloom_before_level=-1;}
parsed to map[filter_policy] = "id=ribbonfilter:10:-1;bloom_before_level=-1;",
and embedding that map entry directly into another `key=value;` string
re-exposed the inner ';' as a top-level delimiter.

This change is a step toward the "essential view": the outer `{...}` of
a nested value is part of the value's identity. StringToMap preserves it, so
each map entry is in self-contained form (a simple value or a single
balanced `{...}` block) and can be embedded directly without further
escaping by the caller. However some permissiveness is kept for
compatibility: list-style typed parsers (ParseVector, ParseArray,
kStringMap, the listener parser) and scalar dispatch in
OptionTypeInfo::Parse accept either the bare or the wrapped form via a
new OptionTypeInfo::StripOuterBraces helper that peels at most one
outer-pair-matched layer. So braced scalar input like `key={42};` and
`key={true};` still parses, and `key={};` denotes an empty list,
distinct from `key={{}};` which denotes a one-element list with an
empty element.

A new public MapToString is added to convenience.h as the symmetric
inverse of StringToMap: a trivial `key=value;` joiner that relies on
each value already being self-contained (which StringToMap guarantees).

Also fixed and refactored our trim() function because it would do the wrong
thing for a single space. This problem was detected by expanding the
StringToMapRandomTest based on code review feedback, and should only
improve existing callers to trim().

The OPTIONS-file serializer code is untouched, so the on-disk format
is byte-for-byte identical and format-compatibility is preserved.

Bonus: fixes / clarifications to CLAUDE.md's build-system note.

Test Plan:
db_bloom_filter_test extends MutableFilterPolicy with the OPTIONS-file
format for filter_policy to confirm that form round-trips through
SetOptions.

options_test updates StringToMapTest expectations for the new
brace-preserving behavior, and adds:
- MapToStringTest covering the new joiner.
- StringToMapMapToStringRoundTripTest including a single-entry
  pull-and-embed scenario that previously corrupted on round-trip.
- FullOptionsStringToMapRoundTripTest that drives a populated
  DBOptions and CFOptions through GetStringFromXxx -> StringToMap ->
  per-entry single round-trip -> MapToString -> GetXxxFromString ->
  VerifyXxxOptions, catching any custom serializer that emits a
  value with ';' without enclosing it in '{}'.
- EmptyBracedVectorAndBracedScalarTest covering `key={};` (empty
  list) and braced scalar input like `key={42};`, `key={true};`.
- Expanded StringToMapRandomTest with round-tripping.

Some explicit trim() tests added to string_util_test.cc

Format compatibility verified with
  SHORT_TEST=1 tools/check_format_compatible.sh

Other existing tests in options_test, customizable_test, options_settable_test,
listener_test, options_file_test, options_util_test, db_options_test,
and compaction_service_test have extensive coverage of serialization /
deserialization logic.
