### PR TITLE
Expose error recovery events in C listener API

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -61,6 +61,7 @@
 #include "utilities/merge_operators.h"
 
 using ROCKSDB_NAMESPACE::BackgroundErrorReason;
+using ROCKSDB_NAMESPACE::BackgroundErrorRecoveryInfo;
 using ROCKSDB_NAMESPACE::BackupEngine;
 using ROCKSDB_NAMESPACE::BackupEngineOptions;
 using ROCKSDB_NAMESPACE::BackupID;
@@ -254,6 +255,9 @@ struct rocksdb_t {
 };
 struct rocksdb_status_ptr_t {
   Status* rep;
+};
+struct rocksdb_backgrounderrorrecoveryinfo_t {
+  const BackgroundErrorRecoveryInfo* rep;
 };
 struct rocksdb_backup_engine_t {
   BackupEngine* rep;
@@ -1949,8 +1953,46 @@ void rocksdb_backup_engine_options_destroy(
   delete options;
 }
 
+static_assert(rocksdb_status_severity_no_error ==
+              static_cast<unsigned char>(Status::Severity::kNoError));
+static_assert(rocksdb_status_severity_soft_error ==
+              static_cast<unsigned char>(Status::Severity::kSoftError));
+static_assert(rocksdb_status_severity_hard_error ==
+              static_cast<unsigned char>(Status::Severity::kHardError));
+static_assert(rocksdb_status_severity_fatal_error ==
+              static_cast<unsigned char>(Status::Severity::kFatalError));
+static_assert(
+    rocksdb_status_severity_unrecoverable_error ==
+    static_cast<unsigned char>(Status::Severity::kUnrecoverableError));
+static_assert(rocksdb_status_severity_unrecoverable_error + 1 ==
+              static_cast<unsigned char>(Status::Severity::kMaxSeverity));
+
 void rocksdb_status_ptr_get_error(rocksdb_status_ptr_t* status, char** errptr) {
   SaveError(errptr, *(status->rep));
+}
+
+unsigned char rocksdb_status_ptr_get_severity(rocksdb_status_ptr_t* status) {
+  return static_cast<unsigned char>(status->rep->severity());
+}
+
+void rocksdb_backgrounderrorrecoveryinfo_old_bg_error(
+    const rocksdb_backgrounderrorrecoveryinfo_t* info, char** errptr) {
+  SaveError(errptr, info->rep->old_bg_error);
+}
+
+unsigned char rocksdb_backgrounderrorrecoveryinfo_old_bg_error_severity(
+    const rocksdb_backgrounderrorrecoveryinfo_t* info) {
+  return static_cast<unsigned char>(info->rep->old_bg_error.severity());
+}
+
+void rocksdb_backgrounderrorrecoveryinfo_new_bg_error(
+    const rocksdb_backgrounderrorrecoveryinfo_t* info, char** errptr) {
+  SaveError(errptr, info->rep->new_bg_error);
+}
+
+unsigned char rocksdb_backgrounderrorrecoveryinfo_new_bg_error_severity(
+    const rocksdb_backgrounderrorrecoveryinfo_t* info) {
+  return static_cast<unsigned char>(info->rep->new_bg_error.severity());
 }
 
 rocksdb_checkpoint_t* rocksdb_checkpoint_object_create(rocksdb_t* db,
@@ -5582,6 +5624,10 @@ struct rocksdb_eventlistener_t : public EventListener {
   void (*on_external_file_ingested)(
       void*, rocksdb_t*, const rocksdb_externalfileingestioninfo_t*){};
   void (*on_background_error)(void*, uint32_t, rocksdb_status_ptr_t*){};
+  void (*on_error_recovery_begin)(void*, uint32_t, rocksdb_status_ptr_t*,
+                                  unsigned char*){};
+  void (*on_error_recovery_end)(void*,
+                                const rocksdb_backgrounderrorrecoveryinfo_t*){};
   void (*on_stall_conditions_changed)(void*, const rocksdb_writestallinfo_t*){};
   void (*on_memtable_sealed)(void*, const rocksdb_memtableinfo_t*){};
 
@@ -5593,68 +5639,124 @@ struct rocksdb_eventlistener_t : public EventListener {
   rocksdb_eventlistener_t& operator=(rocksdb_eventlistener_t&&) = delete;
 
   void OnFlushBegin(DB* db, const FlushJobInfo& info) override {
-    rocksdb_t c_db = {db};
-    on_flush_begin(state_, &c_db,
-                   reinterpret_cast<const rocksdb_flushjobinfo_t*>(&info));
+    if (on_flush_begin != nullptr) {
+      rocksdb_t c_db = {db};
+      on_flush_begin(state_, &c_db,
+                     reinterpret_cast<const rocksdb_flushjobinfo_t*>(&info));
+    }
   }
 
   void OnFlushCompleted(DB* db, const FlushJobInfo& info) override {
-    rocksdb_t c_db = {db};
-    on_flush_completed(state_, &c_db,
-                       reinterpret_cast<const rocksdb_flushjobinfo_t*>(&info));
+    if (on_flush_completed != nullptr) {
+      rocksdb_t c_db = {db};
+      on_flush_completed(
+          state_, &c_db,
+          reinterpret_cast<const rocksdb_flushjobinfo_t*>(&info));
+    }
   }
 
   void OnCompactionBegin(DB* db, const CompactionJobInfo& info) override {
-    rocksdb_t c_db = {db};
-    on_compaction_begin(
-        state_, &c_db,
-        reinterpret_cast<const rocksdb_compactionjobinfo_t*>(&info));
+    if (on_compaction_begin != nullptr) {
+      rocksdb_t c_db = {db};
+      on_compaction_begin(
+          state_, &c_db,
+          reinterpret_cast<const rocksdb_compactionjobinfo_t*>(&info));
+    }
   }
 
   void OnCompactionCompleted(DB* db, const CompactionJobInfo& info) override {
-    rocksdb_t c_db = {db};
-    on_compaction_completed(
-        state_, &c_db,
-        reinterpret_cast<const rocksdb_compactionjobinfo_t*>(&info));
+    if (on_compaction_completed != nullptr) {
+      rocksdb_t c_db = {db};
+      on_compaction_completed(
+          state_, &c_db,
+          reinterpret_cast<const rocksdb_compactionjobinfo_t*>(&info));
+    }
   }
 
   void OnSubcompactionBegin(const SubcompactionJobInfo& info) override {
-    on_subcompaction_begin(
-        state_, reinterpret_cast<const rocksdb_subcompactionjobinfo_t*>(&info));
+    if (on_subcompaction_begin != nullptr) {
+      on_subcompaction_begin(
+          state_,
+          reinterpret_cast<const rocksdb_subcompactionjobinfo_t*>(&info));
+    }
   }
 
   void OnSubcompactionCompleted(const SubcompactionJobInfo& info) override {
-    on_subcompaction_completed(
-        state_, reinterpret_cast<const rocksdb_subcompactionjobinfo_t*>(&info));
+    if (on_subcompaction_completed != nullptr) {
+      on_subcompaction_completed(
+          state_,
+          reinterpret_cast<const rocksdb_subcompactionjobinfo_t*>(&info));
+    }
   }
 
   void OnExternalFileIngested(DB* db,
                               const ExternalFileIngestionInfo& info) override {
-    rocksdb_t c_db = {db};
-    on_external_file_ingested(
-        state_, &c_db,
-        reinterpret_cast<const rocksdb_externalfileingestioninfo_t*>(&info));
+    if (on_external_file_ingested != nullptr) {
+      rocksdb_t c_db = {db};
+      on_external_file_ingested(
+          state_, &c_db,
+          reinterpret_cast<const rocksdb_externalfileingestioninfo_t*>(&info));
+    }
   }
 
   void OnBackgroundError(BackgroundErrorReason reason,
                          Status* status) override {
-    rocksdb_status_ptr_t* s = new rocksdb_status_ptr_t;
-    s->rep = status;
-    on_background_error(state_, static_cast<uint32_t>(reason), s);
-    delete s;
+    if (on_background_error != nullptr) {
+      rocksdb_status_ptr_t s;
+      s.rep = status;
+      on_background_error(state_, static_cast<uint32_t>(reason), &s);
+    }
+  }
+
+  void OnErrorRecoveryBegin(BackgroundErrorReason reason, Status bg_error,
+                            bool* auto_recovery) override {
+    // Recovery callbacks are optional because rocksdb_eventlistener_create()
+    // delegates here with nullptrs for the newer callbacks.
+    if (on_error_recovery_begin != nullptr) {
+      // bg_error is callback-local; the C status pointer must not escape.
+      rocksdb_status_ptr_t s;
+      s.rep = &bg_error;
+      unsigned char c_auto_recovery =
+          auto_recovery != nullptr && *auto_recovery;
+      on_error_recovery_begin(state_, static_cast<uint32_t>(reason), &s,
+                              &c_auto_recovery);
+      if (auto_recovery != nullptr) {
+        *auto_recovery = c_auto_recovery != 0;
+      }
+    }
+    bg_error.PermitUncheckedError();
+  }
+
+  void OnErrorRecoveryEnd(const BackgroundErrorRecoveryInfo& info) override {
+    // Recovery callbacks are optional because rocksdb_eventlistener_create()
+    // delegates here with nullptrs for the newer callbacks.
+    if (on_error_recovery_end != nullptr) {
+      // info is callback-local; callers should copy anything needed later.
+      rocksdb_backgrounderrorrecoveryinfo_t c_info;
+      c_info.rep = &info;
+      on_error_recovery_end(state_, &c_info);
+    }
   }
 
   void OnStallConditionsChanged(const WriteStallInfo& info) override {
-    on_stall_conditions_changed(
-        state_, reinterpret_cast<const rocksdb_writestallinfo_t*>(&info));
+    if (on_stall_conditions_changed != nullptr) {
+      on_stall_conditions_changed(
+          state_, reinterpret_cast<const rocksdb_writestallinfo_t*>(&info));
+    }
   }
 
   void OnMemTableSealed(const MemTableInfo& info) override {
-    on_memtable_sealed(state_,
-                       reinterpret_cast<const rocksdb_memtableinfo_t*>(&info));
+    if (on_memtable_sealed != nullptr) {
+      on_memtable_sealed(
+          state_, reinterpret_cast<const rocksdb_memtableinfo_t*>(&info));
+    }
   }
 
-  ~rocksdb_eventlistener_t() override { destructor_(state_); }
+  ~rocksdb_eventlistener_t() override {
+    if (destructor_ != nullptr) {
+      destructor_(state_);
+    }
+  }
 };
 
 rocksdb_eventlistener_t* rocksdb_eventlistener_create(
@@ -5668,6 +5770,27 @@ rocksdb_eventlistener_t* rocksdb_eventlistener_create(
     on_background_error_cb on_background_error,
     on_stall_conditions_changed_cb on_stall_conditions_changed,
     on_memtable_sealed_cb on_memtable_sealed) {
+  return rocksdb_eventlistener_create_with_error_recovery(
+      state_, destructor_, on_flush_begin, on_flush_completed,
+      on_compaction_begin, on_compaction_completed, on_subcompaction_begin,
+      on_subcompaction_completed, on_external_file_ingested,
+      on_background_error, nullptr, nullptr, on_stall_conditions_changed,
+      on_memtable_sealed);
+}
+
+rocksdb_eventlistener_t* rocksdb_eventlistener_create_with_error_recovery(
+    void* state_, void (*destructor_)(void*), on_flush_begin_cb on_flush_begin,
+    on_flush_completed_cb on_flush_completed,
+    on_compaction_begin_cb on_compaction_begin,
+    on_compaction_completed_cb on_compaction_completed,
+    on_subcompaction_begin_cb on_subcompaction_begin,
+    on_subcompaction_completed_cb on_subcompaction_completed,
+    on_external_file_ingested_cb on_external_file_ingested,
+    on_background_error_cb on_background_error,
+    on_error_recovery_begin_cb on_error_recovery_begin,
+    on_error_recovery_end_cb on_error_recovery_end,
+    on_stall_conditions_changed_cb on_stall_conditions_changed,
+    on_memtable_sealed_cb on_memtable_sealed) {
   rocksdb_eventlistener_t* et = new rocksdb_eventlistener_t;
   et->state_ = state_;
   et->destructor_ = destructor_;
@@ -5679,6 +5802,8 @@ rocksdb_eventlistener_t* rocksdb_eventlistener_create(
   et->on_subcompaction_completed = on_subcompaction_completed;
   et->on_external_file_ingested = on_external_file_ingested;
   et->on_background_error = on_background_error;
+  et->on_error_recovery_begin = on_error_recovery_begin;
+  et->on_error_recovery_end = on_error_recovery_end;
   et->on_stall_conditions_changed = on_stall_conditions_changed;
   et->on_memtable_sealed = on_memtable_sealed;
   return et;

--- a/db/c_test.c
+++ b/db/c_test.c
@@ -116,6 +116,11 @@ static long GetLocalFileSize(const char* path) {
   return size;
 }
 
+static void CTestSetInt(void* state) {
+  int* value = (int*)state;
+  *value = 1;
+}
+
 static void CheckValue(char* err, const char* expected, char** actual,
                        size_t actual_length) {
   CheckNoError(err);
@@ -6847,6 +6852,37 @@ int main(int argc, char** argv) {
                                sst_file_manager));
 
     rocksdb_sst_file_manager_destroy(sst_file_manager);
+  }
+
+  StartPhase("eventlistener_error_recovery_api");
+  {
+    int destroyed;
+    rocksdb_options_t* recovery_options;
+    rocksdb_eventlistener_t* listener;
+
+    destroyed = 0;
+
+    recovery_options = rocksdb_options_create();
+    rocksdb_options_set_create_if_missing(recovery_options, 1);
+    rocksdb_options_set_error_if_exists(recovery_options, 0);
+    rocksdb_options_set_env(recovery_options, env);
+    rocksdb_options_set_info_log(recovery_options, NULL);
+    rocksdb_options_set_compression(recovery_options, rocksdb_no_compression);
+
+    listener = rocksdb_eventlistener_create_with_error_recovery(
+        &destroyed, CTestSetInt, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+        NULL, NULL, NULL, NULL);
+    CheckCondition(listener != NULL);
+    rocksdb_options_add_eventlistener(recovery_options, listener);
+
+    CheckCondition(rocksdb_status_severity_no_error == 0);
+    CheckCondition(rocksdb_status_severity_soft_error == 1);
+    CheckCondition(rocksdb_status_severity_hard_error == 2);
+    CheckCondition(rocksdb_status_severity_fatal_error == 3);
+    CheckCondition(rocksdb_status_severity_unrecoverable_error == 4);
+
+    rocksdb_options_destroy(recovery_options);
+    CheckCondition(destroyed == 1);
   }
 
   StartPhase("create_column_family_error_returns_null");

--- a/db/listener_test.cc
+++ b/db/listener_test.cc
@@ -3,6 +3,8 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
+#include <cstdlib>
+#include <cstring>
 #include <memory>
 
 #include "db/blob/blob_index.h"
@@ -13,6 +15,7 @@
 #include "db/write_batch_internal.h"
 #include "file/filename.h"
 #include "monitoring/statistics_impl.h"
+#include "rocksdb/c.h"
 #include "rocksdb/cache.h"
 #include "rocksdb/compaction_filter.h"
 #include "rocksdb/db.h"
@@ -50,6 +53,193 @@ class EventListenerTest : public DBTestBase {
 
   const size_t k110KB = 110 << 10;
 };
+
+struct CApiErrorRecoveryState {
+  bool destroyed = false;
+  int begin_called = 0;
+  int end_called = 0;
+  uint32_t begin_reason = 0;
+  unsigned char begin_status_severity = 0;
+  unsigned char begin_auto_recovery_in = 0;
+  unsigned char old_bg_error_severity = 0;
+  unsigned char new_bg_error_severity = 0;
+  bool old_bg_error_seen = false;
+  bool new_bg_error_seen = false;
+};
+
+void CApiErrorRecoveryDestructor(void* state) {
+  static_cast<CApiErrorRecoveryState*>(state)->destroyed = true;
+}
+
+void CApiErrorRecoveryBegin(void* state, uint32_t reason,
+                            rocksdb_status_ptr_t* status,
+                            unsigned char* auto_recovery) {
+  auto* recovery_state = static_cast<CApiErrorRecoveryState*>(state);
+  char* err = nullptr;
+  recovery_state->begin_called++;
+  recovery_state->begin_reason = reason;
+  recovery_state->begin_status_severity =
+      rocksdb_status_ptr_get_severity(status);
+  rocksdb_status_ptr_get_error(status, &err);
+  ASSERT_NE(err, nullptr);
+  ASSERT_NE(std::strstr(err, "Max allowed space was reached"), nullptr);
+  std::free(err);
+  ASSERT_NE(auto_recovery, nullptr);
+  recovery_state->begin_auto_recovery_in = *auto_recovery;
+  *auto_recovery = 0;
+}
+
+void CApiErrorRecoveryEnd(void* state,
+                          const rocksdb_backgrounderrorrecoveryinfo_t* info) {
+  auto* recovery_state = static_cast<CApiErrorRecoveryState*>(state);
+  char* old_bg_error = nullptr;
+  char* new_bg_error = nullptr;
+  recovery_state->end_called++;
+  recovery_state->old_bg_error_severity =
+      rocksdb_backgrounderrorrecoveryinfo_old_bg_error_severity(info);
+  recovery_state->new_bg_error_severity =
+      rocksdb_backgrounderrorrecoveryinfo_new_bg_error_severity(info);
+  rocksdb_backgrounderrorrecoveryinfo_old_bg_error(info, &old_bg_error);
+  rocksdb_backgrounderrorrecoveryinfo_new_bg_error(info, &new_bg_error);
+  recovery_state->old_bg_error_seen = old_bg_error != nullptr;
+  recovery_state->new_bg_error_seen = new_bg_error != nullptr;
+  ASSERT_NE(old_bg_error, nullptr);
+  ASSERT_NE(std::strstr(old_bg_error, "Max allowed space was reached"),
+            nullptr);
+  ASSERT_EQ(new_bg_error, nullptr);
+  std::free(old_bg_error);
+  std::free(new_bg_error);
+}
+
+TEST_F(EventListenerTest, CApiErrorRecoveryCallbacks) {
+  CApiErrorRecoveryState recovery_state;
+  rocksdb_eventlistener_t* listener =
+      rocksdb_eventlistener_create_with_error_recovery(
+          &recovery_state, CApiErrorRecoveryDestructor, nullptr, nullptr,
+          nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+          CApiErrorRecoveryBegin, CApiErrorRecoveryEnd, nullptr, nullptr);
+  ASSERT_NE(listener, nullptr);
+
+  Status bg_error(Status::SpaceLimit("Max allowed space was reached"),
+                  Status::Severity::kHardError);
+  bool auto_recovery = true;
+  reinterpret_cast<EventListener*>(listener)->OnErrorRecoveryBegin(
+      BackgroundErrorReason::kFlush, bg_error, &auto_recovery);
+  ASSERT_EQ(recovery_state.begin_called, 1);
+  ASSERT_EQ(recovery_state.begin_reason,
+            static_cast<uint32_t>(BackgroundErrorReason::kFlush));
+  ASSERT_EQ(recovery_state.begin_status_severity,
+            rocksdb_status_severity_hard_error);
+  ASSERT_EQ(recovery_state.begin_auto_recovery_in, 1);
+  ASSERT_FALSE(auto_recovery);
+  bg_error.PermitUncheckedError();
+
+  BackgroundErrorRecoveryInfo info;
+  info.old_bg_error =
+      Status(Status::SpaceLimit("Max allowed space was reached"),
+             Status::Severity::kHardError);
+  info.new_bg_error = Status::OK();
+  reinterpret_cast<EventListener*>(listener)->OnErrorRecoveryEnd(info);
+  info.old_bg_error.PermitUncheckedError();
+  info.new_bg_error.PermitUncheckedError();
+  ASSERT_EQ(recovery_state.end_called, 1);
+  ASSERT_EQ(recovery_state.old_bg_error_severity,
+            rocksdb_status_severity_hard_error);
+  ASSERT_EQ(recovery_state.new_bg_error_severity,
+            rocksdb_status_severity_no_error);
+  ASSERT_TRUE(recovery_state.old_bg_error_seen);
+  ASSERT_FALSE(recovery_state.new_bg_error_seen);
+
+  rocksdb_eventlistener_destroy(listener);
+  ASSERT_TRUE(recovery_state.destroyed);
+}
+
+TEST_F(EventListenerTest, CApiListenerNullCallbacks) {
+  rocksdb_eventlistener_t* listener =
+      rocksdb_eventlistener_create_with_error_recovery(
+          nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+          nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
+  ASSERT_NE(listener, nullptr);
+  auto* event_listener = reinterpret_cast<EventListener*>(listener);
+
+  FlushJobInfo flush_info;
+  event_listener->OnFlushBegin(nullptr, flush_info);
+  event_listener->OnFlushCompleted(nullptr, flush_info);
+
+  CompactionJobInfo compaction_info;
+  event_listener->OnCompactionBegin(nullptr, compaction_info);
+  event_listener->OnCompactionCompleted(nullptr, compaction_info);
+
+  SubcompactionJobInfo subcompaction_info;
+  event_listener->OnSubcompactionBegin(subcompaction_info);
+  event_listener->OnSubcompactionCompleted(subcompaction_info);
+
+  ExternalFileIngestionInfo ingestion_info;
+  event_listener->OnExternalFileIngested(nullptr, ingestion_info);
+
+  Status background_error = Status::IOError("background error");
+  event_listener->OnBackgroundError(BackgroundErrorReason::kFlush,
+                                    &background_error);
+  background_error.PermitUncheckedError();
+
+  Status recovery_error(Status::SpaceLimit("Max allowed space was reached"),
+                        Status::Severity::kHardError);
+  bool auto_recovery = true;
+  event_listener->OnErrorRecoveryBegin(BackgroundErrorReason::kFlush,
+                                       recovery_error, &auto_recovery);
+  ASSERT_TRUE(auto_recovery);
+  recovery_error.PermitUncheckedError();
+
+  BackgroundErrorRecoveryInfo recovery_info;
+  recovery_info.old_bg_error =
+      Status(Status::SpaceLimit("Max allowed space was reached"),
+             Status::Severity::kHardError);
+  recovery_info.new_bg_error = Status::OK();
+  event_listener->OnErrorRecoveryEnd(recovery_info);
+  recovery_info.old_bg_error.PermitUncheckedError();
+  recovery_info.new_bg_error.PermitUncheckedError();
+
+  WriteStallInfo stall_info;
+  event_listener->OnStallConditionsChanged(stall_info);
+
+  MemTableInfo memtable_info;
+  event_listener->OnMemTableSealed(memtable_info);
+
+  rocksdb_eventlistener_destroy(listener);
+}
+
+TEST_F(EventListenerTest, CApiLegacyListenerSkipsRecoveryCallbacks) {
+  rocksdb_eventlistener_t* listener = rocksdb_eventlistener_create(
+      nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+      nullptr, nullptr, nullptr, nullptr);
+  ASSERT_NE(listener, nullptr);
+  auto* event_listener = reinterpret_cast<EventListener*>(listener);
+
+  Status recovery_error(Status::SpaceLimit("Max allowed space was reached"),
+                        Status::Severity::kHardError);
+  bool auto_recovery = true;
+  event_listener->OnErrorRecoveryBegin(BackgroundErrorReason::kFlush,
+                                       recovery_error, &auto_recovery);
+  ASSERT_TRUE(auto_recovery);
+  recovery_error.PermitUncheckedError();
+
+  BackgroundErrorRecoveryInfo recovery_info;
+  recovery_info.old_bg_error =
+      Status(Status::SpaceLimit("Max allowed space was reached"),
+             Status::Severity::kHardError);
+  recovery_info.new_bg_error = Status::OK();
+  event_listener->OnErrorRecoveryEnd(recovery_info);
+  recovery_info.old_bg_error.PermitUncheckedError();
+  recovery_info.new_bg_error.PermitUncheckedError();
+
+  WriteStallInfo stall_info;
+  event_listener->OnStallConditionsChanged(stall_info);
+
+  MemTableInfo memtable_info;
+  event_listener->OnMemTableSealed(memtable_info);
+
+  rocksdb_eventlistener_destroy(listener);
+}
 
 struct TestPropertiesCollector
     : public ROCKSDB_NAMESPACE::TablePropertiesCollector {

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -201,6 +201,8 @@ typedef struct rocksdb_blob_file_addition_info_t
 typedef struct rocksdb_blob_file_garbage_info_t
     rocksdb_blob_file_garbage_info_t;
 typedef struct rocksdb_eventlistener_t rocksdb_eventlistener_t;
+typedef struct rocksdb_backgrounderrorrecoveryinfo_t
+    rocksdb_backgrounderrorrecoveryinfo_t;
 typedef struct rocksdb_writestallinfo_t rocksdb_writestallinfo_t;
 typedef struct rocksdb_writestallcondition_t rocksdb_writestallcondition_t;
 typedef struct rocksdb_memtableinfo_t rocksdb_memtableinfo_t;
@@ -1980,6 +1982,27 @@ extern ROCKSDB_LIBRARY_API void rocksdb_reset_status(
     rocksdb_status_ptr_t* status_ptr);
 extern ROCKSDB_LIBRARY_API void rocksdb_status_ptr_get_error(
     rocksdb_status_ptr_t* status, char** errptr);
+enum {
+  rocksdb_status_severity_no_error = 0,
+  rocksdb_status_severity_soft_error = 1,
+  rocksdb_status_severity_hard_error = 2,
+  rocksdb_status_severity_fatal_error = 3,
+  rocksdb_status_severity_unrecoverable_error = 4,
+};
+extern ROCKSDB_LIBRARY_API unsigned char rocksdb_status_ptr_get_severity(
+    rocksdb_status_ptr_t* status);
+extern ROCKSDB_LIBRARY_API void
+rocksdb_backgrounderrorrecoveryinfo_old_bg_error(
+    const rocksdb_backgrounderrorrecoveryinfo_t* info, char** errptr);
+extern ROCKSDB_LIBRARY_API unsigned char
+rocksdb_backgrounderrorrecoveryinfo_old_bg_error_severity(
+    const rocksdb_backgrounderrorrecoveryinfo_t* info);
+extern ROCKSDB_LIBRARY_API void
+rocksdb_backgrounderrorrecoveryinfo_new_bg_error(
+    const rocksdb_backgrounderrorrecoveryinfo_t* info, char** errptr);
+extern ROCKSDB_LIBRARY_API unsigned char
+rocksdb_backgrounderrorrecoveryinfo_new_bg_error_severity(
+    const rocksdb_backgrounderrorrecoveryinfo_t* info);
 extern ROCKSDB_LIBRARY_API unsigned char
 rocksdb_table_properties_has_key_largest_seqno(
     const rocksdb_table_properties_t* props);
@@ -2063,6 +2086,8 @@ rocksdb_externalfileingestioninfo_table_properties(
 
 /* Event listener */
 
+/* Except for state, pointers passed to callbacks are borrowed. They are valid
+   only until the callback returns and must not be retained. */
 typedef void (*on_flush_begin_cb)(void*, rocksdb_t*,
                                   const rocksdb_flushjobinfo_t*);
 typedef void (*on_flush_completed_cb)(void*, rocksdb_t*,
@@ -2078,10 +2103,19 @@ typedef void (*on_subcompaction_completed_cb)(
 typedef void (*on_external_file_ingested_cb)(
     void*, rocksdb_t*, const rocksdb_externalfileingestioninfo_t*);
 typedef void (*on_background_error_cb)(void*, uint32_t, rocksdb_status_ptr_t*);
+/* Changes to auto_recovery are copied back when the callback returns. Zero
+   disables automatic recovery and any nonzero value enables it. */
+typedef void (*on_error_recovery_begin_cb)(void* state, uint32_t reason,
+                                           rocksdb_status_ptr_t* bg_error,
+                                           unsigned char* auto_recovery);
+typedef void (*on_error_recovery_end_cb)(
+    void* state, const rocksdb_backgrounderrorrecoveryinfo_t* info);
 typedef void (*on_stall_conditions_changed_cb)(void*,
                                                const rocksdb_writestallinfo_t*);
 typedef void (*rocksdb_logger_logv_cb)(void*, uint32_t log_level, const char*);
 typedef void (*on_memtable_sealed_cb)(void*, const rocksdb_memtableinfo_t*);
+/* Callback function pointers can be NULL. Events without a callback are
+   skipped. */
 extern ROCKSDB_LIBRARY_API rocksdb_eventlistener_t*
 rocksdb_eventlistener_create(
     void* state_, void (*destructor_)(void*), on_flush_begin_cb on_flush_begin,
@@ -2092,6 +2126,20 @@ rocksdb_eventlistener_create(
     on_subcompaction_completed_cb on_subcompaction_completed,
     on_external_file_ingested_cb on_external_file_ingested,
     on_background_error_cb on_background_error,
+    on_stall_conditions_changed_cb on_stall_conditions_changed,
+    on_memtable_sealed_cb on_memtable_sealed);
+extern ROCKSDB_LIBRARY_API rocksdb_eventlistener_t*
+rocksdb_eventlistener_create_with_error_recovery(
+    void* state_, void (*destructor_)(void*), on_flush_begin_cb on_flush_begin,
+    on_flush_completed_cb on_flush_completed,
+    on_compaction_begin_cb on_compaction_begin,
+    on_compaction_completed_cb on_compaction_completed,
+    on_subcompaction_begin_cb on_subcompaction_begin,
+    on_subcompaction_completed_cb on_subcompaction_completed,
+    on_external_file_ingested_cb on_external_file_ingested,
+    on_background_error_cb on_background_error,
+    on_error_recovery_begin_cb on_error_recovery_begin,
+    on_error_recovery_end_cb on_error_recovery_end,
     on_stall_conditions_changed_cb on_stall_conditions_changed,
     on_memtable_sealed_cb on_memtable_sealed);
 extern ROCKSDB_LIBRARY_API void rocksdb_eventlistener_destroy(

--- a/tools/c_api_gen/c_base.cc
+++ b/tools/c_api_gen/c_base.cc
@@ -57,6 +57,7 @@
 #include "utilities/merge_operators.h"
 
 using ROCKSDB_NAMESPACE::BackgroundErrorReason;
+using ROCKSDB_NAMESPACE::BackgroundErrorRecoveryInfo;
 using ROCKSDB_NAMESPACE::BackupEngine;
 using ROCKSDB_NAMESPACE::BackupEngineOptions;
 using ROCKSDB_NAMESPACE::BackupID;
@@ -250,6 +251,9 @@ struct rocksdb_t {
 };
 struct rocksdb_status_ptr_t {
   Status* rep;
+};
+struct rocksdb_backgrounderrorrecoveryinfo_t {
+  const BackgroundErrorRecoveryInfo* rep;
 };
 struct rocksdb_backup_engine_t {
   BackupEngine* rep;
@@ -1945,8 +1949,46 @@ void rocksdb_backup_engine_options_destroy(
   delete options;
 }
 
+static_assert(rocksdb_status_severity_no_error ==
+              static_cast<unsigned char>(Status::Severity::kNoError));
+static_assert(rocksdb_status_severity_soft_error ==
+              static_cast<unsigned char>(Status::Severity::kSoftError));
+static_assert(rocksdb_status_severity_hard_error ==
+              static_cast<unsigned char>(Status::Severity::kHardError));
+static_assert(rocksdb_status_severity_fatal_error ==
+              static_cast<unsigned char>(Status::Severity::kFatalError));
+static_assert(
+    rocksdb_status_severity_unrecoverable_error ==
+    static_cast<unsigned char>(Status::Severity::kUnrecoverableError));
+static_assert(rocksdb_status_severity_unrecoverable_error + 1 ==
+              static_cast<unsigned char>(Status::Severity::kMaxSeverity));
+
 void rocksdb_status_ptr_get_error(rocksdb_status_ptr_t* status, char** errptr) {
   SaveError(errptr, *(status->rep));
+}
+
+unsigned char rocksdb_status_ptr_get_severity(rocksdb_status_ptr_t* status) {
+  return static_cast<unsigned char>(status->rep->severity());
+}
+
+void rocksdb_backgrounderrorrecoveryinfo_old_bg_error(
+    const rocksdb_backgrounderrorrecoveryinfo_t* info, char** errptr) {
+  SaveError(errptr, info->rep->old_bg_error);
+}
+
+unsigned char rocksdb_backgrounderrorrecoveryinfo_old_bg_error_severity(
+    const rocksdb_backgrounderrorrecoveryinfo_t* info) {
+  return static_cast<unsigned char>(info->rep->old_bg_error.severity());
+}
+
+void rocksdb_backgrounderrorrecoveryinfo_new_bg_error(
+    const rocksdb_backgrounderrorrecoveryinfo_t* info, char** errptr) {
+  SaveError(errptr, info->rep->new_bg_error);
+}
+
+unsigned char rocksdb_backgrounderrorrecoveryinfo_new_bg_error_severity(
+    const rocksdb_backgrounderrorrecoveryinfo_t* info) {
+  return static_cast<unsigned char>(info->rep->new_bg_error.severity());
 }
 
 rocksdb_checkpoint_t* rocksdb_checkpoint_object_create(rocksdb_t* db,
@@ -4446,6 +4488,10 @@ struct rocksdb_eventlistener_t : public EventListener {
   void (*on_external_file_ingested)(
       void*, rocksdb_t*, const rocksdb_externalfileingestioninfo_t*){};
   void (*on_background_error)(void*, uint32_t, rocksdb_status_ptr_t*){};
+  void (*on_error_recovery_begin)(void*, uint32_t, rocksdb_status_ptr_t*,
+                                  unsigned char*){};
+  void (*on_error_recovery_end)(void*,
+                                const rocksdb_backgrounderrorrecoveryinfo_t*){};
   void (*on_stall_conditions_changed)(void*, const rocksdb_writestallinfo_t*){};
   void (*on_memtable_sealed)(void*, const rocksdb_memtableinfo_t*){};
 
@@ -4457,68 +4503,124 @@ struct rocksdb_eventlistener_t : public EventListener {
   rocksdb_eventlistener_t& operator=(rocksdb_eventlistener_t&&) = delete;
 
   void OnFlushBegin(DB* db, const FlushJobInfo& info) override {
-    rocksdb_t c_db = {db};
-    on_flush_begin(state_, &c_db,
-                   reinterpret_cast<const rocksdb_flushjobinfo_t*>(&info));
+    if (on_flush_begin != nullptr) {
+      rocksdb_t c_db = {db};
+      on_flush_begin(state_, &c_db,
+                     reinterpret_cast<const rocksdb_flushjobinfo_t*>(&info));
+    }
   }
 
   void OnFlushCompleted(DB* db, const FlushJobInfo& info) override {
-    rocksdb_t c_db = {db};
-    on_flush_completed(state_, &c_db,
-                       reinterpret_cast<const rocksdb_flushjobinfo_t*>(&info));
+    if (on_flush_completed != nullptr) {
+      rocksdb_t c_db = {db};
+      on_flush_completed(
+          state_, &c_db,
+          reinterpret_cast<const rocksdb_flushjobinfo_t*>(&info));
+    }
   }
 
   void OnCompactionBegin(DB* db, const CompactionJobInfo& info) override {
-    rocksdb_t c_db = {db};
-    on_compaction_begin(
-        state_, &c_db,
-        reinterpret_cast<const rocksdb_compactionjobinfo_t*>(&info));
+    if (on_compaction_begin != nullptr) {
+      rocksdb_t c_db = {db};
+      on_compaction_begin(
+          state_, &c_db,
+          reinterpret_cast<const rocksdb_compactionjobinfo_t*>(&info));
+    }
   }
 
   void OnCompactionCompleted(DB* db, const CompactionJobInfo& info) override {
-    rocksdb_t c_db = {db};
-    on_compaction_completed(
-        state_, &c_db,
-        reinterpret_cast<const rocksdb_compactionjobinfo_t*>(&info));
+    if (on_compaction_completed != nullptr) {
+      rocksdb_t c_db = {db};
+      on_compaction_completed(
+          state_, &c_db,
+          reinterpret_cast<const rocksdb_compactionjobinfo_t*>(&info));
+    }
   }
 
   void OnSubcompactionBegin(const SubcompactionJobInfo& info) override {
-    on_subcompaction_begin(
-        state_, reinterpret_cast<const rocksdb_subcompactionjobinfo_t*>(&info));
+    if (on_subcompaction_begin != nullptr) {
+      on_subcompaction_begin(
+          state_,
+          reinterpret_cast<const rocksdb_subcompactionjobinfo_t*>(&info));
+    }
   }
 
   void OnSubcompactionCompleted(const SubcompactionJobInfo& info) override {
-    on_subcompaction_completed(
-        state_, reinterpret_cast<const rocksdb_subcompactionjobinfo_t*>(&info));
+    if (on_subcompaction_completed != nullptr) {
+      on_subcompaction_completed(
+          state_,
+          reinterpret_cast<const rocksdb_subcompactionjobinfo_t*>(&info));
+    }
   }
 
   void OnExternalFileIngested(DB* db,
                               const ExternalFileIngestionInfo& info) override {
-    rocksdb_t c_db = {db};
-    on_external_file_ingested(
-        state_, &c_db,
-        reinterpret_cast<const rocksdb_externalfileingestioninfo_t*>(&info));
+    if (on_external_file_ingested != nullptr) {
+      rocksdb_t c_db = {db};
+      on_external_file_ingested(
+          state_, &c_db,
+          reinterpret_cast<const rocksdb_externalfileingestioninfo_t*>(&info));
+    }
   }
 
   void OnBackgroundError(BackgroundErrorReason reason,
                          Status* status) override {
-    rocksdb_status_ptr_t* s = new rocksdb_status_ptr_t;
-    s->rep = status;
-    on_background_error(state_, static_cast<uint32_t>(reason), s);
-    delete s;
+    if (on_background_error != nullptr) {
+      rocksdb_status_ptr_t s;
+      s.rep = status;
+      on_background_error(state_, static_cast<uint32_t>(reason), &s);
+    }
+  }
+
+  void OnErrorRecoveryBegin(BackgroundErrorReason reason, Status bg_error,
+                            bool* auto_recovery) override {
+    // Recovery callbacks are optional because rocksdb_eventlistener_create()
+    // delegates here with nullptrs for the newer callbacks.
+    if (on_error_recovery_begin != nullptr) {
+      // bg_error is callback-local; the C status pointer must not escape.
+      rocksdb_status_ptr_t s;
+      s.rep = &bg_error;
+      unsigned char c_auto_recovery =
+          auto_recovery != nullptr && *auto_recovery;
+      on_error_recovery_begin(state_, static_cast<uint32_t>(reason), &s,
+                              &c_auto_recovery);
+      if (auto_recovery != nullptr) {
+        *auto_recovery = c_auto_recovery != 0;
+      }
+    }
+    bg_error.PermitUncheckedError();
+  }
+
+  void OnErrorRecoveryEnd(const BackgroundErrorRecoveryInfo& info) override {
+    // Recovery callbacks are optional because rocksdb_eventlistener_create()
+    // delegates here with nullptrs for the newer callbacks.
+    if (on_error_recovery_end != nullptr) {
+      // info is callback-local; callers should copy anything needed later.
+      rocksdb_backgrounderrorrecoveryinfo_t c_info;
+      c_info.rep = &info;
+      on_error_recovery_end(state_, &c_info);
+    }
   }
 
   void OnStallConditionsChanged(const WriteStallInfo& info) override {
-    on_stall_conditions_changed(
-        state_, reinterpret_cast<const rocksdb_writestallinfo_t*>(&info));
+    if (on_stall_conditions_changed != nullptr) {
+      on_stall_conditions_changed(
+          state_, reinterpret_cast<const rocksdb_writestallinfo_t*>(&info));
+    }
   }
 
   void OnMemTableSealed(const MemTableInfo& info) override {
-    on_memtable_sealed(state_,
-                       reinterpret_cast<const rocksdb_memtableinfo_t*>(&info));
+    if (on_memtable_sealed != nullptr) {
+      on_memtable_sealed(
+          state_, reinterpret_cast<const rocksdb_memtableinfo_t*>(&info));
+    }
   }
 
-  ~rocksdb_eventlistener_t() override { destructor_(state_); }
+  ~rocksdb_eventlistener_t() override {
+    if (destructor_ != nullptr) {
+      destructor_(state_);
+    }
+  }
 };
 
 rocksdb_eventlistener_t* rocksdb_eventlistener_create(
@@ -4532,6 +4634,27 @@ rocksdb_eventlistener_t* rocksdb_eventlistener_create(
     on_background_error_cb on_background_error,
     on_stall_conditions_changed_cb on_stall_conditions_changed,
     on_memtable_sealed_cb on_memtable_sealed) {
+  return rocksdb_eventlistener_create_with_error_recovery(
+      state_, destructor_, on_flush_begin, on_flush_completed,
+      on_compaction_begin, on_compaction_completed, on_subcompaction_begin,
+      on_subcompaction_completed, on_external_file_ingested,
+      on_background_error, nullptr, nullptr, on_stall_conditions_changed,
+      on_memtable_sealed);
+}
+
+rocksdb_eventlistener_t* rocksdb_eventlistener_create_with_error_recovery(
+    void* state_, void (*destructor_)(void*), on_flush_begin_cb on_flush_begin,
+    on_flush_completed_cb on_flush_completed,
+    on_compaction_begin_cb on_compaction_begin,
+    on_compaction_completed_cb on_compaction_completed,
+    on_subcompaction_begin_cb on_subcompaction_begin,
+    on_subcompaction_completed_cb on_subcompaction_completed,
+    on_external_file_ingested_cb on_external_file_ingested,
+    on_background_error_cb on_background_error,
+    on_error_recovery_begin_cb on_error_recovery_begin,
+    on_error_recovery_end_cb on_error_recovery_end,
+    on_stall_conditions_changed_cb on_stall_conditions_changed,
+    on_memtable_sealed_cb on_memtable_sealed) {
   rocksdb_eventlistener_t* et = new rocksdb_eventlistener_t;
   et->state_ = state_;
   et->destructor_ = destructor_;
@@ -4543,6 +4666,8 @@ rocksdb_eventlistener_t* rocksdb_eventlistener_create(
   et->on_subcompaction_completed = on_subcompaction_completed;
   et->on_external_file_ingested = on_external_file_ingested;
   et->on_background_error = on_background_error;
+  et->on_error_recovery_begin = on_error_recovery_begin;
+  et->on_error_recovery_end = on_error_recovery_end;
   et->on_stall_conditions_changed = on_stall_conditions_changed;
   et->on_memtable_sealed = on_memtable_sealed;
   return et;

--- a/tools/c_api_gen/c_base.h
+++ b/tools/c_api_gen/c_base.h
@@ -199,6 +199,8 @@ typedef struct rocksdb_blob_file_addition_info_t
 typedef struct rocksdb_blob_file_garbage_info_t
     rocksdb_blob_file_garbage_info_t;
 typedef struct rocksdb_eventlistener_t rocksdb_eventlistener_t;
+typedef struct rocksdb_backgrounderrorrecoveryinfo_t
+    rocksdb_backgrounderrorrecoveryinfo_t;
 typedef struct rocksdb_writestallinfo_t rocksdb_writestallinfo_t;
 typedef struct rocksdb_writestallcondition_t rocksdb_writestallcondition_t;
 typedef struct rocksdb_memtableinfo_t rocksdb_memtableinfo_t;
@@ -1176,6 +1178,27 @@ extern ROCKSDB_LIBRARY_API void rocksdb_reset_status(
     rocksdb_status_ptr_t* status_ptr);
 extern ROCKSDB_LIBRARY_API void rocksdb_status_ptr_get_error(
     rocksdb_status_ptr_t* status, char** errptr);
+enum {
+  rocksdb_status_severity_no_error = 0,
+  rocksdb_status_severity_soft_error = 1,
+  rocksdb_status_severity_hard_error = 2,
+  rocksdb_status_severity_fatal_error = 3,
+  rocksdb_status_severity_unrecoverable_error = 4,
+};
+extern ROCKSDB_LIBRARY_API unsigned char rocksdb_status_ptr_get_severity(
+    rocksdb_status_ptr_t* status);
+extern ROCKSDB_LIBRARY_API void
+rocksdb_backgrounderrorrecoveryinfo_old_bg_error(
+    const rocksdb_backgrounderrorrecoveryinfo_t* info, char** errptr);
+extern ROCKSDB_LIBRARY_API unsigned char
+rocksdb_backgrounderrorrecoveryinfo_old_bg_error_severity(
+    const rocksdb_backgrounderrorrecoveryinfo_t* info);
+extern ROCKSDB_LIBRARY_API void
+rocksdb_backgrounderrorrecoveryinfo_new_bg_error(
+    const rocksdb_backgrounderrorrecoveryinfo_t* info, char** errptr);
+extern ROCKSDB_LIBRARY_API unsigned char
+rocksdb_backgrounderrorrecoveryinfo_new_bg_error_severity(
+    const rocksdb_backgrounderrorrecoveryinfo_t* info);
 extern ROCKSDB_LIBRARY_API unsigned char
 rocksdb_table_properties_has_key_largest_seqno(
     const rocksdb_table_properties_t* props);
@@ -1259,6 +1282,8 @@ rocksdb_externalfileingestioninfo_table_properties(
 
 /* Event listener */
 
+/* Except for state, pointers passed to callbacks are borrowed. They are valid
+   only until the callback returns and must not be retained. */
 typedef void (*on_flush_begin_cb)(void*, rocksdb_t*,
                                   const rocksdb_flushjobinfo_t*);
 typedef void (*on_flush_completed_cb)(void*, rocksdb_t*,
@@ -1274,10 +1299,19 @@ typedef void (*on_subcompaction_completed_cb)(
 typedef void (*on_external_file_ingested_cb)(
     void*, rocksdb_t*, const rocksdb_externalfileingestioninfo_t*);
 typedef void (*on_background_error_cb)(void*, uint32_t, rocksdb_status_ptr_t*);
+/* Changes to auto_recovery are copied back when the callback returns. Zero
+   disables automatic recovery and any nonzero value enables it. */
+typedef void (*on_error_recovery_begin_cb)(void* state, uint32_t reason,
+                                           rocksdb_status_ptr_t* bg_error,
+                                           unsigned char* auto_recovery);
+typedef void (*on_error_recovery_end_cb)(
+    void* state, const rocksdb_backgrounderrorrecoveryinfo_t* info);
 typedef void (*on_stall_conditions_changed_cb)(void*,
                                                const rocksdb_writestallinfo_t*);
 typedef void (*rocksdb_logger_logv_cb)(void*, uint32_t log_level, const char*);
 typedef void (*on_memtable_sealed_cb)(void*, const rocksdb_memtableinfo_t*);
+/* Callback function pointers can be NULL. Events without a callback are
+   skipped. */
 extern ROCKSDB_LIBRARY_API rocksdb_eventlistener_t*
 rocksdb_eventlistener_create(
     void* state_, void (*destructor_)(void*), on_flush_begin_cb on_flush_begin,
@@ -1288,6 +1322,20 @@ rocksdb_eventlistener_create(
     on_subcompaction_completed_cb on_subcompaction_completed,
     on_external_file_ingested_cb on_external_file_ingested,
     on_background_error_cb on_background_error,
+    on_stall_conditions_changed_cb on_stall_conditions_changed,
+    on_memtable_sealed_cb on_memtable_sealed);
+extern ROCKSDB_LIBRARY_API rocksdb_eventlistener_t*
+rocksdb_eventlistener_create_with_error_recovery(
+    void* state_, void (*destructor_)(void*), on_flush_begin_cb on_flush_begin,
+    on_flush_completed_cb on_flush_completed,
+    on_compaction_begin_cb on_compaction_begin,
+    on_compaction_completed_cb on_compaction_completed,
+    on_subcompaction_begin_cb on_subcompaction_begin,
+    on_subcompaction_completed_cb on_subcompaction_completed,
+    on_external_file_ingested_cb on_external_file_ingested,
+    on_background_error_cb on_background_error,
+    on_error_recovery_begin_cb on_error_recovery_begin,
+    on_error_recovery_end_cb on_error_recovery_end,
     on_stall_conditions_changed_cb on_stall_conditions_changed,
     on_memtable_sealed_cb on_memtable_sealed);
 extern ROCKSDB_LIBRARY_API void rocksdb_eventlistener_destroy(


### PR DESCRIPTION
## Summary
- expose background error Status severity through rocksdb_status_ptr_get_severity and C severity constants
- add an additive rocksdb_eventlistener_create_with_error_recovery constructor for OnErrorRecoveryBegin and OnErrorRecoveryEnd callbacks
- keep the existing rocksdb_eventlistener_create signature compatible by delegating without recovery callbacks
- add C API smoke coverage for the new listener constructor and severity constants

## Testing
- make -C librocksdb-sys/rocksdb c_test -j4
- ./c_test