### PR TITLE
Fix spelling of memtable_verify_per_key_checksum_on_seek

### DIFF
--- a/claude_md/add_option.md
+++ b/claude_md/add_option.md
@@ -46,7 +46,7 @@ This document provides guidance on how to add new options to RocksDB's public AP
 
 ## Pattern 1: Adding a Standard Column Family Option
 
-Example reference: commit `94e65a2e0b4f817aa4bfa4c96cdf867e7980d7bc` (memtable_veirfy_per_key_checksum_on_seek)
+Example reference: commit `94e65a2e0b4f817aa4bfa4c96cdf867e7980d7bc` (memtable_verify_per_key_checksum_on_seek)
 
 ### Step 1: Define the Option in Public Header
 
@@ -63,7 +63,7 @@ Add the option with documentation in `AdvancedColumnFamilyOptions` struct:
 // operation.
 // This option depends on memtable_protection_bytes_per_key to be non zero.
 // If memtable_protection_bytes_per_key is zero, no validation is performed.
-bool memtable_veirfy_per_key_checksum_on_seek = false;
+bool memtable_verify_per_key_checksum_on_seek = false;
 ```
 
 ### Step 2: Add to Internal Options Structs
@@ -74,14 +74,14 @@ Add to `MutableCFOptions` struct (or `ImmutableCFOptions` for immutable options)
 
 ```cpp
 // In MutableCFOptions constructor from Options:
-memtable_veirfy_per_key_checksum_on_seek(
-    options.memtable_veirfy_per_key_checksum_on_seek),
+memtable_verify_per_key_checksum_on_seek(
+    options.memtable_verify_per_key_checksum_on_seek),
 
 // In MutableCFOptions default constructor:
-memtable_veirfy_per_key_checksum_on_seek(false),
+memtable_verify_per_key_checksum_on_seek(false),
 
 // In MutableCFOptions struct member declarations:
-bool memtable_veirfy_per_key_checksum_on_seek;
+bool memtable_verify_per_key_checksum_on_seek;
 ```
 
 ### Step 3: Register for Serialization/Deserialization
@@ -91,9 +91,9 @@ bool memtable_veirfy_per_key_checksum_on_seek;
 Add to the options type info map for serialization:
 
 ```cpp
-{"memtable_veirfy_per_key_checksum_on_seek",
+{"memtable_verify_per_key_checksum_on_seek",
  {offsetof(struct MutableCFOptions,
-           memtable_veirfy_per_key_checksum_on_seek),
+           memtable_verify_per_key_checksum_on_seek),
   OptionType::kBoolean, OptionVerificationType::kNormal,
   OptionTypeFlags::kMutable}},
 ```
@@ -101,8 +101,8 @@ Add to the options type info map for serialization:
 Add logging in `MutableCFOptions::Dump()`:
 
 ```cpp
-ROCKS_LOG_INFO(log, "memtable_veirfy_per_key_checksum_on_seek: %d",
-               memtable_veirfy_per_key_checksum_on_seek);
+ROCKS_LOG_INFO(log, "memtable_verify_per_key_checksum_on_seek: %d",
+               memtable_verify_per_key_checksum_on_seek);
 ```
 
 ### Step 4: Update Options Helper
@@ -112,8 +112,8 @@ ROCKS_LOG_INFO(log, "memtable_veirfy_per_key_checksum_on_seek: %d",
 Add to `UpdateColumnFamilyOptions()`:
 
 ```cpp
-cf_opts->memtable_veirfy_per_key_checksum_on_seek =
-    moptions.memtable_veirfy_per_key_checksum_on_seek;
+cf_opts->memtable_verify_per_key_checksum_on_seek =
+    moptions.memtable_verify_per_key_checksum_on_seek;
 ```
 
 ### Step 5: Add to Options Settable Test
@@ -123,7 +123,7 @@ cf_opts->memtable_veirfy_per_key_checksum_on_seek =
 Add to the test string in `ColumnFamilyOptionsAllFieldsSettable`:
 
 ```cpp
-"memtable_veirfy_per_key_checksum_on_seek=1;"
+"memtable_verify_per_key_checksum_on_seek=1;"
 ```
 
 ### Step 6: Add db_stress Support
@@ -131,23 +131,23 @@ Add to the test string in `ColumnFamilyOptionsAllFieldsSettable`:
 **File: `db_stress_tool/db_stress_common.h`**
 
 ```cpp
-DECLARE_bool(memtable_veirfy_per_key_checksum_on_seek);
+DECLARE_bool(memtable_verify_per_key_checksum_on_seek);
 ```
 
 **File: `db_stress_tool/db_stress_gflags.cc`**
 
 ```cpp
 DEFINE_bool(
-    memtable_veirfy_per_key_checksum_on_seek,
-    ROCKSDB_NAMESPACE::Options().memtable_veirfy_per_key_checksum_on_seek,
-    "Sets CF option memtable_veirfy_per_key_checksum_on_seek.");
+    memtable_verify_per_key_checksum_on_seek,
+    ROCKSDB_NAMESPACE::Options().memtable_verify_per_key_checksum_on_seek,
+    "Sets CF option memtable_verify_per_key_checksum_on_seek.");
 ```
 
 **File: `db_stress_tool/db_stress_test_base.cc`**
 
 ```cpp
-options.memtable_veirfy_per_key_checksum_on_seek =
-    FLAGS_memtable_veirfy_per_key_checksum_on_seek;
+options.memtable_verify_per_key_checksum_on_seek =
+    FLAGS_memtable_verify_per_key_checksum_on_seek;
 ```
 
 ### Step 7: Add db_bench Support
@@ -156,12 +156,12 @@ options.memtable_veirfy_per_key_checksum_on_seek =
 
 ```cpp
 // Flag definition (near related flags):
-DEFINE_bool(memtable_veirfy_per_key_checksum_on_seek, false,
-            "Sets CF option memtable_veirfy_per_key_checksum_on_seek");
+DEFINE_bool(memtable_verify_per_key_checksum_on_seek, false,
+            "Sets CF option memtable_verify_per_key_checksum_on_seek");
 
 // Apply flag to options (in InitializeOptionsFromFlags or similar):
-options.memtable_veirfy_per_key_checksum_on_seek =
-    FLAGS_memtable_veirfy_per_key_checksum_on_seek;
+options.memtable_verify_per_key_checksum_on_seek =
+    FLAGS_memtable_verify_per_key_checksum_on_seek;
 ```
 
 ### Step 8: Add Crash Test Support
@@ -169,7 +169,7 @@ options.memtable_veirfy_per_key_checksum_on_seek =
 **File: `tools/db_crashtest.py`**
 
 ```python
-"memtable_veirfy_per_key_checksum_on_seek": lambda: random.choice([0] * 7 + [1]),
+"memtable_verify_per_key_checksum_on_seek": lambda: random.choice([0] * 7 + [1]),
 ```
 
 Also add constraint handling in `finalize_and_sanitize()` if needed:
@@ -177,7 +177,7 @@ Also add constraint handling in `finalize_and_sanitize()` if needed:
 ```python
 # only skip list memtable representation supports paranoid memory checks
 if dest_params.get("memtablerep") != "skip_list":
-    dest_params["memtable_veirfy_per_key_checksum_on_seek"] = 0
+    dest_params["memtable_verify_per_key_checksum_on_seek"] = 0
 ```
 
 ### Step 9: Add Release Note
@@ -185,7 +185,7 @@ if dest_params.get("memtablerep") != "skip_list":
 **File: `unreleased_history/new_features/<descriptive_name>.md`**
 
 ```markdown
-A new flag memtable_veirfy_per_key_checksum_on_seek is added to AdvancedColumnFamilyOptions. When it is enabled, it will validate key checksum along the binary search path on skiplist based memtable during seek operation.
+A new flag memtable_verify_per_key_checksum_on_seek is added to AdvancedColumnFamilyOptions. When it is enabled, it will validate key checksum along the binary search path on skiplist based memtable during seek operation.
 ```
 
 ---

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -6331,7 +6331,7 @@ TEST_F(DBBasicTest, DisallowMemtableWrite) {
   Options options_disallow = options_allow;
   options_disallow.disallow_memtable_writes = true;
   options_disallow.paranoid_memory_checks = true;
-  options_disallow.memtable_veirfy_per_key_checksum_on_seek = true;
+  options_disallow.memtable_verify_per_key_checksum_on_seek = true;
 
   DestroyAndReopen(options_allow);
   // CFs allowing and disallowing memtable write

--- a/db/db_memtable_test.cc
+++ b/db/db_memtable_test.cc
@@ -359,7 +359,7 @@ class DBMemTableTestForSeek : public DBMemTableTest,
 TEST_P(DBMemTableTestForSeek, IntegrityChecks) {
   // Validate key corruption could be detected during seek.
   // We insert many keys into skiplist. Then we corrupt the each key one at a
-  // time. With memtable_veirfy_per_key_checksum_on_seek enabled, when the
+  // time. With memtable_verify_per_key_checksum_on_seek enabled, when the
   // corrupted key is searched, the checksum of every key visited during the
   // seek is validated. It will report data corruption. Otherwise seek returns
   // not found.
@@ -367,7 +367,7 @@ TEST_P(DBMemTableTestForSeek, IntegrityChecks) {
   Options options = CurrentOptions();
   options.allow_data_in_errors = allow_data_in_error;
   options.paranoid_memory_checks = std::get<1>(GetParam());
-  options.memtable_veirfy_per_key_checksum_on_seek = std::get<2>(GetParam());
+  options.memtable_verify_per_key_checksum_on_seek = std::get<2>(GetParam());
   options.memtable_protection_bytes_per_key = 8;
   DestroyAndReopen(options);
 
@@ -410,7 +410,7 @@ TEST_P(DBMemTableTestForSeek, IntegrityChecks) {
   ASSERT_EQ(raw_data_pointer.size(), key_count);
 
   bool enable_key_validation_on_seek =
-      options.memtable_veirfy_per_key_checksum_on_seek;
+      options.memtable_verify_per_key_checksum_on_seek;
 
   // For each key, corrupt it, validate corruption is detected correctly, then
   // revert it.

--- a/db/db_open_with_config_test.cc
+++ b/db/db_open_with_config_test.cc
@@ -151,8 +151,8 @@ TEST_F(DBOpenWithConfigTest, OpenWithComprehensiveConfig) {
   // memtable_op_scan_flush_trigger=0
   options.memtable_op_scan_flush_trigger = 0;
 
-  // memtable_veirfy_per_key_checksum_on_seek=false
-  options.memtable_veirfy_per_key_checksum_on_seek = false;
+  // memtable_verify_per_key_checksum_on_seek=false
+  options.memtable_verify_per_key_checksum_on_seek = false;
 
   // Level and compaction settings
   // num_levels=50

--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -159,8 +159,8 @@ ImmutableMemTableOptions::ImmutableMemTableOptions(
           mutable_cf_options.memtable_protection_bytes_per_key),
       allow_data_in_errors(ioptions.allow_data_in_errors),
       paranoid_memory_checks(mutable_cf_options.paranoid_memory_checks),
-      memtable_veirfy_per_key_checksum_on_seek(
-          mutable_cf_options.memtable_veirfy_per_key_checksum_on_seek),
+      memtable_verify_per_key_checksum_on_seek(
+          mutable_cf_options.memtable_verify_per_key_checksum_on_seek),
       memtable_batch_lookup_optimization(
           ioptions.memtable_batch_lookup_optimization) {}
 
@@ -256,7 +256,7 @@ MemTable::MemTable(const InternalKeyComparator& cmp,
           mutable_cf_options.memtable_max_range_deletions),
       key_validation_callback_(
           (moptions_.protection_bytes_per_key != 0 &&
-           moptions_.memtable_veirfy_per_key_checksum_on_seek)
+           moptions_.memtable_verify_per_key_checksum_on_seek)
               ? std::bind(&MemTable::ValidateKey, this, std::placeholders::_1,
                           std::placeholders::_2)
               : std::function<Status(const char*, bool)>(nullptr)) {
@@ -528,7 +528,7 @@ class MemTableIterator : public InternalIterator {
         paranoid_memory_checks_(mem.moptions_.paranoid_memory_checks),
         validate_on_seek_(
             mem.moptions_.paranoid_memory_checks ||
-            mem.moptions_.memtable_veirfy_per_key_checksum_on_seek),
+            mem.moptions_.memtable_verify_per_key_checksum_on_seek),
         allow_data_in_error_(mem.moptions_.allow_data_in_errors),
         key_validation_callback_(mem.key_validation_callback_) {
     if (kind == kRangeDelEntries) {
@@ -1682,7 +1682,7 @@ void MemTable::GetFromTable(const LookupKey& key,
   saver.protection_bytes_per_key = moptions_.protection_bytes_per_key;
 
   if (!moptions_.paranoid_memory_checks &&
-      !moptions_.memtable_veirfy_per_key_checksum_on_seek) {
+      !moptions_.memtable_verify_per_key_checksum_on_seek) {
     table_->Get(key, &saver, SaveValue);
   } else {
     Status check_s = table_->GetAndValidate(
@@ -1750,7 +1750,7 @@ void MemTable::MultiGet(const ReadOptions& read_options, MultiGetRange* range,
   // Use batch lookup optimization when enabled
   bool use_batch_optimization = moptions_.memtable_batch_lookup_optimization;
   bool validate = moptions_.paranoid_memory_checks ||
-                  moptions_.memtable_veirfy_per_key_checksum_on_seek;
+                  moptions_.memtable_verify_per_key_checksum_on_seek;
 
   if (use_batch_optimization) {
     // Phase 1: Handle range tombstones and set up Savers for batched lookup

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -68,7 +68,7 @@ struct ImmutableMemTableOptions {
   uint32_t protection_bytes_per_key;
   bool allow_data_in_errors;
   bool paranoid_memory_checks;
-  bool memtable_veirfy_per_key_checksum_on_seek;
+  bool memtable_verify_per_key_checksum_on_seek;
   bool memtable_batch_lookup_optimization;
 };
 

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -303,7 +303,7 @@ DECLARE_string(default_write_temperature);
 DECLARE_string(default_temperature);
 DECLARE_uint32(verify_output_flags);
 DECLARE_bool(paranoid_memory_checks);
-DECLARE_bool(memtable_veirfy_per_key_checksum_on_seek);
+DECLARE_bool(memtable_verify_per_key_checksum_on_seek);
 DECLARE_bool(memtable_batch_lookup_optimization);
 
 // Options for transaction dbs.

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -1630,9 +1630,9 @@ DEFINE_bool(paranoid_memory_checks,
             "Sets CF option paranoid_memory_checks.");
 
 DEFINE_bool(
-    memtable_veirfy_per_key_checksum_on_seek,
-    ROCKSDB_NAMESPACE::Options().memtable_veirfy_per_key_checksum_on_seek,
-    "Sets CF option memtable_veirfy_per_key_checksum_on_seek.");
+    memtable_verify_per_key_checksum_on_seek,
+    ROCKSDB_NAMESPACE::Options().memtable_verify_per_key_checksum_on_seek,
+    "Sets CF option memtable_verify_per_key_checksum_on_seek.");
 
 DEFINE_bool(memtable_batch_lookup_optimization,
             ROCKSDB_NAMESPACE::Options().memtable_batch_lookup_optimization,

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -5126,8 +5126,8 @@ void InitializeOptionsFromFlags(
   options.verify_output_flags =
       static_cast<VerifyOutputFlags>(FLAGS_verify_output_flags);
   options.paranoid_memory_checks = FLAGS_paranoid_memory_checks;
-  options.memtable_veirfy_per_key_checksum_on_seek =
-      FLAGS_memtable_veirfy_per_key_checksum_on_seek;
+  options.memtable_verify_per_key_checksum_on_seek =
+      FLAGS_memtable_verify_per_key_checksum_on_seek;
   options.memtable_batch_lookup_optimization =
       FLAGS_memtable_batch_lookup_optimization;
 

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -1364,7 +1364,7 @@ struct AdvancedColumnFamilyOptions {
   // operation.
   // This option depends on memtable_protection_bytes_per_key to be non zero.
   // If memtable_protection_bytes_per_key is zero, no validation is performed.
-  bool memtable_veirfy_per_key_checksum_on_seek = false;
+  bool memtable_verify_per_key_checksum_on_seek = false;
 
   // When an iterator scans this number of invisible entries (tombstones or
   // hidden puts) from the active memtable during a single iterator operation,

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -621,7 +621,7 @@ struct DBOptions {
   // checking for corruption, including
   // * paranoid_file_checks
   // * paranoid_memory_checks
-  // * memtable_veirfy_per_key_checksum_on_seek
+  // * memtable_verify_per_key_checksum_on_seek
   // * DB::VerifyChecksum()
   //
   // Default: true

--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -702,6 +702,12 @@ static std::unordered_map<std::string, OptionTypeInfo>
          {offsetof(struct MutableCFOptions, paranoid_memory_checks),
           OptionType::kBoolean, OptionVerificationType::kNormal,
           OptionTypeFlags::kMutable}},
+        // Keep parsing the old misspelled name for existing OPTIONS files.
+        {"memtable_veirfy_per_key_checksum_on_seek",
+         {offsetof(struct MutableCFOptions,
+                   memtable_verify_per_key_checksum_on_seek),
+          OptionType::kBoolean, OptionVerificationType::kAlias,
+          OptionTypeFlags::kMutable}},
         {"memtable_verify_per_key_checksum_on_seek",
          {offsetof(struct MutableCFOptions,
                    memtable_verify_per_key_checksum_on_seek),

--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -702,9 +702,9 @@ static std::unordered_map<std::string, OptionTypeInfo>
          {offsetof(struct MutableCFOptions, paranoid_memory_checks),
           OptionType::kBoolean, OptionVerificationType::kNormal,
           OptionTypeFlags::kMutable}},
-        {"memtable_veirfy_per_key_checksum_on_seek",
+        {"memtable_verify_per_key_checksum_on_seek",
          {offsetof(struct MutableCFOptions,
-                   memtable_veirfy_per_key_checksum_on_seek),
+                   memtable_verify_per_key_checksum_on_seek),
           OptionType::kBoolean, OptionVerificationType::kNormal,
           OptionTypeFlags::kMutable}},
         {kOptNameCompOpts,
@@ -1258,8 +1258,8 @@ void MutableCFOptions::Dump(Logger* log) const {
                  preserve_internal_time_seconds);
   ROCKS_LOG_INFO(log, "                   paranoid_memory_checks: %d",
                  paranoid_memory_checks);
-  ROCKS_LOG_INFO(log, "memtable_veirfy_per_key_checksum_on_seek: %d",
-                 memtable_veirfy_per_key_checksum_on_seek);
+  ROCKS_LOG_INFO(log, "memtable_verify_per_key_checksum_on_seek: %d",
+                 memtable_verify_per_key_checksum_on_seek);
   std::string result;
   char buf[10];
   for (const auto m : max_bytes_for_level_multiplier_additional) {

--- a/options/cf_options.h
+++ b/options/cf_options.h
@@ -191,8 +191,8 @@ struct MutableCFOptions {
             options.memtable_protection_bytes_per_key),
         block_protection_bytes_per_key(options.block_protection_bytes_per_key),
         paranoid_memory_checks(options.paranoid_memory_checks),
-        memtable_veirfy_per_key_checksum_on_seek(
-            options.memtable_veirfy_per_key_checksum_on_seek),
+        memtable_verify_per_key_checksum_on_seek(
+            options.memtable_verify_per_key_checksum_on_seek),
         sample_for_compression(
             options.sample_for_compression),  // TODO: is 0 fine here?
         compression_per_level(options.compression_per_level),
@@ -260,7 +260,7 @@ struct MutableCFOptions {
         memtable_protection_bytes_per_key(0),
         block_protection_bytes_per_key(0),
         paranoid_memory_checks(false),
-        memtable_veirfy_per_key_checksum_on_seek(false),
+        memtable_verify_per_key_checksum_on_seek(false),
         sample_for_compression(0),
         memtable_max_range_deletions(0),
         bottommost_file_compaction_delay(0),
@@ -372,7 +372,7 @@ struct MutableCFOptions {
   uint32_t memtable_protection_bytes_per_key;
   uint8_t block_protection_bytes_per_key;
   bool paranoid_memory_checks;
-  bool memtable_veirfy_per_key_checksum_on_seek;
+  bool memtable_verify_per_key_checksum_on_seek;
 
   uint64_t sample_for_compression;
   std::vector<CompressionType> compression_per_level;

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -244,8 +244,8 @@ void UpdateColumnFamilyOptions(const MutableCFOptions& moptions,
   cf_opts->block_protection_bytes_per_key =
       moptions.block_protection_bytes_per_key;
   cf_opts->paranoid_memory_checks = moptions.paranoid_memory_checks;
-  cf_opts->memtable_veirfy_per_key_checksum_on_seek =
-      moptions.memtable_veirfy_per_key_checksum_on_seek;
+  cf_opts->memtable_verify_per_key_checksum_on_seek =
+      moptions.memtable_verify_per_key_checksum_on_seek;
   cf_opts->bottommost_file_compaction_delay =
       moptions.bottommost_file_compaction_delay;
 

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -715,7 +715,7 @@ TEST_F(OptionsSettableTest, ColumnFamilyOptionsAllFieldsSettable) {
       "bottommost_file_compaction_delay=7200;"
       "uncache_aggressiveness=1234;"
       "paranoid_memory_checks=1;"
-      "memtable_veirfy_per_key_checksum_on_seek=1;"
+      "memtable_verify_per_key_checksum_on_seek=1;"
       "memtable_op_scan_flush_trigger=123;"
       "memtable_avg_op_scan_flush_trigger=12;"
       "min_tombstones_for_range_conversion=8;"

--- a/options/options_test.cc
+++ b/options/options_test.cc
@@ -417,6 +417,10 @@ TEST_F(OptionsTest, GetColumnFamilyOptionsFromStringTest) {
       config_options, base_cf_opt, "write_buffer_size=6;", &new_cf_opt));
   ASSERT_EQ(new_cf_opt.write_buffer_size, 6U);
   ASSERT_OK(GetColumnFamilyOptionsFromString(
+      config_options, base_cf_opt,
+      "memtable_verify_per_key_checksum_on_seek=true", &new_cf_opt));
+  ASSERT_TRUE(new_cf_opt.memtable_verify_per_key_checksum_on_seek);
+  ASSERT_OK(GetColumnFamilyOptionsFromString(
       config_options, base_cf_opt, "  write_buffer_size =  7  ", &new_cf_opt));
   ASSERT_EQ(new_cf_opt.write_buffer_size, 7U);
   ASSERT_OK(GetColumnFamilyOptionsFromString(
@@ -2668,6 +2672,7 @@ TEST_F(OptionsOldApiTest, GetOptionsFromMapTest) {
       {"default_temperature", "kHot"},
       {"persist_user_defined_timestamps", "true"},
       {"memtable_max_range_deletions", "0"},
+      {"memtable_veirfy_per_key_checksum_on_seek", "true"},
   };
 
   std::unordered_map<std::string, std::string> db_options_map = {
@@ -2823,6 +2828,7 @@ TEST_F(OptionsOldApiTest, GetOptionsFromMapTest) {
   ASSERT_EQ(new_cf_opt.default_write_temperature, Temperature::kCold);
   ASSERT_EQ(new_cf_opt.default_temperature, Temperature::kHot);
   ASSERT_EQ(new_cf_opt.persist_user_defined_timestamps, true);
+  ASSERT_TRUE(new_cf_opt.memtable_verify_per_key_checksum_on_seek);
   ASSERT_EQ(new_cf_opt.memtable_max_range_deletions, 0);
 
   cf_options_map["write_buffer_size"] = "hello";
@@ -3557,11 +3563,18 @@ TEST_F(OptionsOldApiTest, ColumnFamilyOptionsSerialization) {
   // Phase 1: randomly assign base_opt
   // custom type options
   test::RandomInitCFOptions(&base_opt, options, &rnd);
+  base_opt.memtable_verify_per_key_checksum_on_seek = true;
 
   // Phase 2: obtain a string from base_opt
   std::string base_options_file_content;
   ASSERT_OK(
       GetStringFromColumnFamilyOptions(&base_options_file_content, base_opt));
+  ASSERT_EQ(base_options_file_content.find(
+                "memtable_veirfy_per_key_checksum_on_seek="),
+            std::string::npos);
+  ASSERT_NE(base_options_file_content.find(
+                "memtable_verify_per_key_checksum_on_seek="),
+            std::string::npos);
 
   // Phase 3: Set new_opt from the derived string and expect
   //          new_opt == base_opt

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -1338,8 +1338,8 @@ DEFINE_bool(
 DEFINE_bool(paranoid_memory_checks, false,
             "Sets CF option paranoid_memory_checks");
 
-DEFINE_bool(memtable_veirfy_per_key_checksum_on_seek, false,
-            "Sets CF option memtable_veirfy_per_key_checksum_on_seek");
+DEFINE_bool(memtable_verify_per_key_checksum_on_seek, false,
+            "Sets CF option memtable_verify_per_key_checksum_on_seek");
 
 DEFINE_bool(
     auto_refresh_iterator_with_snapshot, false,
@@ -5237,8 +5237,8 @@ class Benchmark {
     options.block_protection_bytes_per_key =
         FLAGS_block_protection_bytes_per_key;
     options.paranoid_memory_checks = FLAGS_paranoid_memory_checks;
-    options.memtable_veirfy_per_key_checksum_on_seek =
-        FLAGS_memtable_veirfy_per_key_checksum_on_seek;
+    options.memtable_verify_per_key_checksum_on_seek =
+        FLAGS_memtable_verify_per_key_checksum_on_seek;
     options.memtable_op_scan_flush_trigger =
         FLAGS_memtable_op_scan_flush_trigger;
     options.min_tombstones_for_range_conversion =

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -494,7 +494,7 @@ default_params = {
     # local, 0xC07 = all types + local + remote, 0xFFFFFFFF = all.
     "verify_output_flags": lambda: random.choice([0] * 3 + [0x407, 0xC07, 0xFFFFFFFF]),
     "paranoid_memory_checks": lambda: random.choice([0] * 7 + [1]),
-    "memtable_veirfy_per_key_checksum_on_seek": lambda: random.choice([0] * 7 + [1]),
+    "memtable_verify_per_key_checksum_on_seek": lambda: random.choice([0] * 7 + [1]),
     "memtable_batch_lookup_optimization": lambda: random.randint(0, 1),
     "allow_unprepared_value": lambda: random.choice([0, 1]),
     # TODO(hx235): enable `track_and_verify_wals` after stabalizing the stress test
@@ -1066,7 +1066,7 @@ def finalize_and_sanitize(src_params):
     # only skip list memtable representation supports paranoid memory checks
     if dest_params.get("memtablerep") != "skip_list":
         dest_params["paranoid_memory_checks"] = 0
-        dest_params["memtable_veirfy_per_key_checksum_on_seek"] = 0
+        dest_params["memtable_verify_per_key_checksum_on_seek"] = 0
 
     if dest_params["test_batches_snapshots"] == 1:
         dest_params["enable_compaction_filter"] = 0
@@ -1543,9 +1543,9 @@ def finalize_and_sanitize(src_params):
         dest_params["open_files_async"] = 0
 
     # inplace update and key checksum verification during seek would cause race condition
-    # Therefore, when inplace_update_support is enabled, disable memtable_veirfy_per_key_checksum_on_seek
+    # Therefore, when inplace_update_support is enabled, disable memtable_verify_per_key_checksum_on_seek
     if dest_params["inplace_update_support"] == 1:
-        dest_params["memtable_veirfy_per_key_checksum_on_seek"] = 0
+        dest_params["memtable_verify_per_key_checksum_on_seek"] = 0
 
     # allow_resumption requires remote compaction
     if dest_params.get("remote_compaction_worker_threads", 0) == 0:

--- a/unreleased_history/public_api_changes/memtable_verify_checksum_spelling.md
+++ b/unreleased_history/public_api_changes/memtable_verify_checksum_spelling.md
@@ -1,0 +1,1 @@
+Corrected the public C++ option spelling from `memtable_veirfy_per_key_checksum_on_seek` to `memtable_verify_per_key_checksum_on_seek`. RocksDB continues to accept the old misspelled OPTIONS-file key for compatibility, while newly serialized OPTIONS files use the corrected key.


### PR DESCRIPTION
## Summary

- Rename the misspelled `memtable_veirfy_per_key_checksum_on_seek` option and related flags/config keys to `memtable_verify_per_key_checksum_on_seek`.
- Update memtable option plumbing, options serialization/logging, db_bench/db_stress/crash-test flags, tests, and the option-addition guide to use the corrected name.
- Keep the checksum-on-seek behavior unchanged.

## Test Plan

CI
