### PR TITLE
Speed up secondary DB open by avoiding point-in-time MANIFEST recovery

### DIFF
--- a/db/version_edit_handler.cc
+++ b/db/version_edit_handler.cc
@@ -569,6 +569,10 @@ Status VersionEditHandler::LoadTables(ColumnFamilyData* cfd,
       version_set_->db_options_->max_file_opening_threads,
       prefetch_index_and_filter_in_cache, is_initial_load, moptions,
       MaxFileSizeForL0MetaPin(moptions), read_options_);
+  return MaybeHandleLoadTablesStatus(s);
+}
+
+Status VersionEditHandler::MaybeHandleLoadTablesStatus(Status s) const {
   if ((s.IsPathNotFound() || s.IsCorruption()) && no_error_if_files_missing_) {
     s = Status::OK();
   }
@@ -1052,6 +1056,51 @@ Status ManifestTailer::Initialize() {
     initialized_ = true;
   }
   return s;
+}
+
+Status ManifestTailer::PrepareForCatchUpAfterRecover(
+    const VersionEditHandler& recovered_handler) {
+  assert(Mode::kRecovery == mode_);
+  assert(!initialized_);
+  // Preserve any AtomicGroup that reached EOF before becoming replayable.
+  GetReadBuffer() = recovered_handler.GetReadBuffer();
+  CopyDoNotOpenColumnFamiliesFrom(recovered_handler);
+
+  ColumnFamilySet* cfd_set = version_set_->GetColumnFamilySet();
+  assert(cfd_set);
+  bool has_log_number = false;
+  uint64_t log_number = 0;
+  for (auto* cfd : *cfd_set) {
+    if (cfd->IsDropped()) {
+      continue;
+    }
+    assert(cfd->initialized());
+    if (!has_log_number || cfd->GetLogNumber() > log_number) {
+      log_number = cfd->GetLogNumber();
+      has_log_number = true;
+    }
+    assert(builders_.find(cfd->GetID()) == builders_.end());
+    builders_.emplace(cfd->GetID(), VersionBuilderUPtr(
+                                        new BaseReferencedVersionBuilder(
+                                            cfd, this,
+                                            track_found_and_missing_files_,
+                                            allow_incomplete_valid_version_)));
+  }
+  assert(has_log_number);
+
+  version_edit_params_.SetLogNumber(log_number);
+  version_edit_params_.SetPrevLogNumber(version_set_->prev_log_number());
+  auto next_file_number = version_set_->current_next_file_number();
+  assert(next_file_number > 0);
+  version_edit_params_.SetNextFile(next_file_number - 1);
+  version_edit_params_.SetMaxColumnFamily(cfd_set->GetMaxColumnFamily());
+  version_edit_params_.SetMinLogNumberToKeep(
+      version_set_->min_log_number_to_keep());
+  version_edit_params_.SetLastSequence(version_set_->LastSequence());
+
+  initialized_ = true;
+  mode_ = Mode::kCatchUp;
+  return Status::OK();
 }
 
 Status ManifestTailer::ApplyVersionEdit(VersionEdit& edit,

--- a/db/version_edit_handler.h
+++ b/db/version_edit_handler.h
@@ -30,6 +30,7 @@ class VersionEditHandlerBase {
   const Status& status() const { return status_; }
 
   AtomicGroupReadBuffer& GetReadBuffer() { return read_buffer_; }
+  const AtomicGroupReadBuffer& GetReadBuffer() const { return read_buffer_; }
 
   uint64_t GetLastValidRecordEnd() const { return last_valid_record_end_; }
 
@@ -227,8 +228,14 @@ class VersionEditHandler : public VersionEditHandlerBase {
                             bool prefetch_index_and_filter_in_cache,
                             bool is_initial_load);
 
+  virtual Status MaybeHandleLoadTablesStatus(Status s) const;
+
   virtual bool MustOpenAllColumnFamilies() const {
     return !version_set_->unchanging();
+  }
+
+  void CopyDoNotOpenColumnFamiliesFrom(const VersionEditHandler& handler) {
+    do_not_open_column_families_ = handler.do_not_open_column_families_;
   }
 
   const bool read_only_;
@@ -282,9 +289,9 @@ class VersionEditHandler : public VersionEditHandlerBase {
 // Building a point in time version when end version is not available can
 // be useful for best efforts recovery (options.best_efforts_recovery), which
 // uses this class and sets `allow_incomplete_valid_version` to true.
-// It's also useful for secondary instances/follower instances for which end
-// version could be transiently unavailable. These two cases use subclass
-// `ManifestTailer` and sets `allow_incomplete_valid_version` to false.
+// It's also used by subclass `ManifestTailer` for secondary instances/follower
+// instances that tail MANIFEST updates, with `allow_incomplete_valid_version`
+// set to false.
 //
 // Not thread-safe, external synchronization is necessary if an object of
 // VersionEditHandlerPointInTime is shared by multiple threads.
@@ -378,6 +385,9 @@ class ManifestTailer : public VersionEditHandlerPointInTime {
     initialized_ = false;
     ClearReadBuffer();
   }
+
+  Status PrepareForCatchUpAfterRecover(
+      const VersionEditHandler& recovered_handler);
 
   std::unordered_set<ColumnFamilyData*>& GetUpdatedColumnFamilies() {
     return cfds_changed_;

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -8220,6 +8220,85 @@ ReactiveVersionSet::ReactiveVersionSet(
 
 ReactiveVersionSet::~ReactiveVersionSet() = default;
 
+namespace {
+class FastSecondaryVersionEditHandler : public VersionEditHandler {
+ public:
+  FastSecondaryVersionEditHandler(
+      const std::vector<ColumnFamilyDescriptor>& column_families,
+      VersionSet* version_set, const std::shared_ptr<IOTracer>& io_tracer,
+      const ReadOptions& read_options)
+      : VersionEditHandler(
+            /*read_only=*/true, column_families, version_set,
+            /*track_found_and_missing_files=*/false,
+            /*no_error_if_files_missing=*/false, io_tracer, read_options,
+            /*allow_incomplete_valid_version=*/false,
+            EpochNumberRequirement::kMightMissing) {}
+
+  Status VerifyLiveSstFiles() const {
+    ColumnFamilySet* cfd_set = version_set_->GetColumnFamilySet();
+    assert(cfd_set);
+    const auto* db_options = version_set_->db_options();
+    assert(db_options);
+    assert(db_options->fs);
+
+    for (auto* cfd : *cfd_set) {
+      if (cfd->IsDropped()) {
+        continue;
+      }
+      assert(cfd->initialized());
+      Version* current = cfd->current();
+      assert(current);
+      const VersionStorageInfo* storage_info = current->storage_info();
+      assert(storage_info);
+      const auto& ioptions = cfd->ioptions();
+      for (int level = 0; level < storage_info->num_levels(); ++level) {
+        for (const FileMetaData* file_meta : storage_info->LevelFiles(level)) {
+          assert(file_meta);
+          const std::string fname =
+              TableFileName(ioptions.cf_paths, file_meta->fd.GetNumber(),
+                            file_meta->fd.GetPathId());
+          uint64_t file_size = 0;
+          Status s = db_options->fs->GetFileSize(fname, IOOptions(),
+                                                 &file_size, nullptr);
+          if (s.IsPathNotFound() || s.IsNotFound() || s.IsCorruption()) {
+            return Status::TryAgain(
+                "Secondary DB could not open the current MANIFEST state. A "
+                "referenced SST file may be temporarily unavailable; retry "
+                "opening the secondary DB. Original status: " +
+                s.ToString());
+          } else if (!s.ok()) {
+            return s;
+          } else if (file_size != file_meta->fd.GetFileSize()) {
+            return Status::TryAgain(
+                "Secondary DB could not open the current MANIFEST state. A "
+                "referenced SST file size does not match the MANIFEST; retry "
+                "opening the secondary DB. File: " +
+                fname + ", expected size: " +
+                std::to_string(file_meta->fd.GetFileSize()) +
+                ", actual size: " + std::to_string(file_size));
+          }
+        }
+      }
+    }
+    return Status::OK();
+  }
+
+ protected:
+  bool MustOpenAllColumnFamilies() const override { return false; }
+
+  Status MaybeHandleLoadTablesStatus(Status s) const override {
+    if (s.IsPathNotFound() || s.IsCorruption()) {
+      return Status::TryAgain(
+          "Secondary DB could not open the current MANIFEST state. A "
+          "referenced SST file may be temporarily unavailable; retry opening "
+          "the secondary DB. Original status: " +
+          s.ToString());
+    }
+    return VersionEditHandler::MaybeHandleLoadTablesStatus(s);
+  }
+};
+}  // anonymous namespace
+
 Status ReactiveVersionSet::Recover(
     const std::vector<ColumnFamilyDescriptor>& column_families,
     std::unique_ptr<log::FragmentBufferedReader>* manifest_reader,
@@ -8240,16 +8319,38 @@ Status ReactiveVersionSet::Recover(
   log::Reader* reader = manifest_reader->get();
   assert(reader);
 
+  if (db_options_->best_efforts_recovery) {
+    manifest_tailer_.reset(new ManifestTailer(
+        column_families, const_cast<ReactiveVersionSet*>(this), io_tracer_,
+        read_options_, EpochNumberRequirement::kMightMissing));
+
+    manifest_tailer_->Iterate(*reader, manifest_reader_status->get());
+
+    s = manifest_tailer_->status();
+    if (s.ok()) {
+      RecoverEpochNumbers();
+    }
+    return s;
+  }
+
+  FastSecondaryVersionEditHandler handler(
+      column_families, const_cast<ReactiveVersionSet*>(this), io_tracer_,
+      read_options_);
+  handler.Iterate(*reader, manifest_reader_status->get());
+  s = handler.status();
+  if (!s.ok()) {
+    return s;
+  }
+  s = handler.VerifyLiveSstFiles();
+  if (!s.ok()) {
+    return s;
+  }
+  RecoverEpochNumbers();
+
   manifest_tailer_.reset(new ManifestTailer(
       column_families, const_cast<ReactiveVersionSet*>(this), io_tracer_,
       read_options_, EpochNumberRequirement::kMightMissing));
-
-  manifest_tailer_->Iterate(*reader, manifest_reader_status->get());
-
-  s = manifest_tailer_->status();
-  if (s.ok()) {
-    RecoverEpochNumbers();
-  }
+  s = manifest_tailer_->PrepareForCatchUpAfterRecover(handler);
   return s;
 }
 

--- a/db/version_set_test.cc
+++ b/db/version_set_test.cc
@@ -3194,6 +3194,110 @@ TEST_F(VersionSetAtomicGroupTest,
             edit_with_incorrect_group_size_.DebugString());
 }
 
+class ReactiveVersionSetRecoverTest : public VersionSetTestBase,
+                                      public testing::Test {
+ public:
+  ReactiveVersionSetRecoverTest()
+      : VersionSetTestBase("reactive_version_set_recover_test") {}
+
+  void SetUp() override {
+    PrepareManifest(&column_families_, &last_seqno_, &log_writer_);
+    CreateCurrentFile();
+  }
+
+  void AddFileEdit(const FileMetaData& file_meta) {
+    VersionEdit edit;
+    edit.SetColumnFamily(0);
+    edit.SetLogNumber(0);
+    edit.SetNextFile(12);
+    edit.SetLastSequence(++last_seqno_);
+    edit.AddFile(0 /* level */, file_meta);
+
+    std::string record;
+    ASSERT_TRUE(edit.EncodeTo(&record, 0 /* ts_sz */));
+    ASSERT_OK(log_writer_->AddRecord(WriteOptions(), record));
+  }
+
+  void AddValidFileThenMissingFileEdits() {
+    std::vector<SstInfo> file_infos;
+    file_infos.emplace_back(10, kDefaultColumnFamilyName, "" /* key */,
+                            0 /* level */, 10 /* epoch_number */);
+    file_infos.emplace_back(11, kDefaultColumnFamilyName, "" /* key */,
+                            0 /* level */, 11 /* epoch_number */,
+                            true /* file_missing */);
+
+    std::vector<FileMetaData> file_metas;
+    CreateDummyTableFiles(file_infos, &file_metas);
+    ASSERT_EQ(2, file_metas.size());
+
+    AddFileEdit(file_metas[0]);
+    AddFileEdit(file_metas[1]);
+  }
+
+  void TearDown() override { log_writer_.reset(); }
+
+ protected:
+  SequenceNumber last_seqno_;
+  std::unique_ptr<log::Writer> log_writer_;
+};
+
+TEST_F(ReactiveVersionSetRecoverTest,
+       FastRecoverReturnsTryAgainForMissingFinalFile) {
+  AddValidFileThenMissingFileEdits();
+
+  std::unique_ptr<log::FragmentBufferedReader> manifest_reader;
+  std::unique_ptr<log::Reader::Reporter> manifest_reporter;
+  std::unique_ptr<Status> manifest_reader_status;
+  Status s = reactive_versions_->Recover(column_families_, &manifest_reader,
+                                         &manifest_reporter,
+                                         &manifest_reader_status);
+  ASSERT_TRUE(s.IsTryAgain()) << s.ToString();
+}
+
+TEST_F(ReactiveVersionSetRecoverTest,
+       FastRecoverChecksLiveFilesWhenTableLoadingIsSkipped) {
+  AddValidFileThenMissingFileEdits();
+
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+  Defer cleanup_sync_point([]() {
+    SyncPoint::GetInstance()->DisableProcessing();
+    SyncPoint::GetInstance()->ClearAllCallBacks();
+  });
+  SyncPoint::GetInstance()->SetCallBack(
+      "VersionEditHandler::LoadTables:skip_load_table_files", [](void* arg) {
+        *static_cast<bool*>(arg) = true;
+      });
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  std::unique_ptr<log::FragmentBufferedReader> manifest_reader;
+  std::unique_ptr<log::Reader::Reporter> manifest_reporter;
+  std::unique_ptr<Status> manifest_reader_status;
+  Status s = reactive_versions_->Recover(column_families_, &manifest_reader,
+                                         &manifest_reporter,
+                                         &manifest_reader_status);
+  ASSERT_TRUE(s.IsTryAgain()) << s.ToString();
+}
+
+TEST_F(ReactiveVersionSetRecoverTest,
+       BestEffortsRecoverUsesPreviousValidPointInTimeVersion) {
+  AddValidFileThenMissingFileEdits();
+  imm_db_options_.best_efforts_recovery = true;
+
+  std::unique_ptr<log::FragmentBufferedReader> manifest_reader;
+  std::unique_ptr<log::Reader::Reporter> manifest_reporter;
+  std::unique_ptr<Status> manifest_reader_status;
+  ASSERT_OK(reactive_versions_->Recover(column_families_, &manifest_reader,
+                                        &manifest_reporter,
+                                        &manifest_reader_status));
+
+  std::vector<uint64_t> all_table_files;
+  std::vector<uint64_t> all_blob_files;
+  reactive_versions_->AddLiveFiles(&all_table_files, &all_blob_files);
+  ASSERT_EQ(1, all_table_files.size());
+  ASSERT_EQ(10, all_table_files[0]);
+}
+
 class AtomicGroupBestEffortRecoveryTest : public VersionSetAtomicGroupTest {
  public:
   AtomicGroupBestEffortRecoveryTest()


### PR DESCRIPTION
## Summary

Speed up `DB::OpenAsSecondary()` by avoiding point-in-time MANIFEST recovery on the initial secondary open when `best_efforts_recovery` is disabled.

The initial secondary recovery now replays the MANIFEST with a regular `VersionEditHandler` to build the final Version directly, verifies that all live SST files referenced by the recovered Version are present and have the expected size, and then initializes `ManifestTailer` from that recovered state for subsequent catch-up reads.

## Motivation

Since #12928, secondary recovery goes through `ManifestTailer`, whose point-in-time recovery path tracks found/missing/intermediate files while replaying the MANIFEST. On large or long-lived MANIFEST files this can make opening a secondary DB take minutes.

This matches the regression reported in #14117, where opening as secondary is much slower than opening the same DB read-only.

## Changes

- Add a fast secondary MANIFEST recovery handler for initial `ReactiveVersionSet::Recover()`.
- Preserve existing `ManifestTailer` behavior for `best_efforts_recovery`.
- Convert transient missing/corrupt referenced SST files during secondary open to `Status::TryAgain()`.
- Verify live SST file existence and size after fast recovery, including cases where table loading was skipped.
- Initialize `ManifestTailer` after fast recovery so later `ReadAndApply()` calls continue tailing from the recovered state.
- Preserve incomplete trailing atomic-group replay state across the handoff to `ManifestTailer`.

## Testing

Added `ReactiveVersionSetRecoverTest` coverage for:
  - missing final SST returning `TryAgain`;
  - live-file verification when table loading is skipped;
  - preserving best-efforts point-in-time recovery behavior.