### PR TITLE
Fix build on E2K

### DIFF
--- a/port/port_posix.h
+++ b/port/port_posix.h
@@ -176,6 +176,8 @@ static inline void AsmVolatilePause() {
   asm volatile("or 27,27,27");
 #elif defined(__loongarch64)
   asm volatile("dbar 0");
+#elif defined(__e2k__)
+  asm volatile("nop" : : );
 #endif
   // it's okay for other platforms to be no-ops
 }

--- a/utilities/transactions/lock/range/range_tree/lib/portability/toku_time.h
+++ b/utilities/transactions/lock/range/range_tree/lib/portability/toku_time.h
@@ -61,6 +61,9 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #if defined(__powerpc__)
 #include <sys/platform/ppc.h>
 #endif
+#if defined(__e2k__)
+#include <x86intrin.h> // get __rdtsc
+#endif
 
 #if 0
 static inline float toku_tdiff (struct timeval *a, struct timeval *b) {
@@ -158,6 +161,8 @@ static inline tokutime_t toku_time_now(void) {
   unsigned long result;
   asm volatile("rdtime.d\t%0,$r0" : "=r"(result));
   return result;
+#elif defined(__e2k__)
+  return (uint64_t)__rdtsc();
 #else
 #error No timer implementation for this platform
 #endif


### PR DESCRIPTION
To be able to build rocksdb on this platform, it only needs it's own proper rdtsc implementation in toku_time.h, and a pause instruction.

For the first one use bundled intrinsics header in the compiler suite.