### PR TITLE
docs: fix typos in comments

### DIFF
--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -1118,7 +1118,7 @@ bool DBImpl::InvokeWalFilterIfNeededOnWalRecord(uint64_t wal_number,
 
   if (batch_changed) {
     // Make sure that the count in the new batch is
-    // within the orignal count.
+    // within the original count.
     int new_count = WriteBatchInternal::Count(&new_batch);
     int original_count = WriteBatchInternal::Count(&batch);
     if (new_count > original_count) {

--- a/db/memtable_list.cc
+++ b/db/memtable_list.cc
@@ -650,7 +650,7 @@ Status MemTableList::TryInstallMemtableFlushResults(
         RemoveMemTablesOrRestoreFlags(s, cfd, num_mem_to_flush, log_buffer,
                                       to_delete, mu);
         // Note: cfd->SetLogNumber is only called when a VersionEdit
-        // is written to MANIFEST. When mempurge is succesful, we skip
+        // is written to MANIFEST. When mempurge is successful, we skip
         // this step, therefore cfd->GetLogNumber is always is
         // earliest log with data unflushed.
         // Notify new head of manifest write queue.

--- a/db/write_thread.cc
+++ b/db/write_thread.cc
@@ -131,7 +131,7 @@ uint8_t WriteThread::AwaitState(Writer* w, uint8_t goal_mask,
   const size_t kMaxSlowYieldsWhileSpinning = 3;
 
   // Whether the yield approach has any credit in this context. The credit is
-  // added by yield being succesfull before timing out, and decreased otherwise.
+  // added by yield being successful before timing out, and decreased otherwise.
   auto& yield_credit = ctx->value;
   // Update the yield_credit based on sample runs or right after a hard failure
   bool update_ctx = false;

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -825,7 +825,7 @@ class DB {
 
   // NOTE: Pure virtual => was virtual (optional). If the concrete
   // implementation
-  //       doesn't support returning timestamps, and the timestamps paramater is
+  //       doesn't support returning timestamps, and the timestamps parameter is
   //       non-null, it should return Status::NotSupported() for all the keys.
   virtual void MultiGet(const ReadOptions& options, const size_t num_keys,
                         ColumnFamilyHandle** column_families, const Slice* keys,

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1287,7 +1287,7 @@ struct DBOptions {
   uint64_t bytes_per_sync = 0;
 
   // Same as bytes_per_sync, but applies to WAL files
-  // This does not gaurantee the WALs are synced in the order of creation. New
+  // This does not guarantee the WALs are synced in the order of creation. New
   // WAL can be synced while an older WAL doesn't. Therefore upon system crash,
   // this hole in the WAL data can create partial data loss.
   //

--- a/include/rocksdb/write_buffer_manager.h
+++ b/include/rocksdb/write_buffer_manager.h
@@ -117,7 +117,7 @@ class WriteBufferManager final {
   }
 
   // Returns true if total memory usage exceeded buffer_size.
-  // We stall the writes untill memory_usage drops below buffer_size. When the
+  // We stall the writes until memory_usage drops below buffer_size. When the
   // function returns true, all writer threads (including one checking this
   // condition) across all DBs will be stalled. Stall is allowed only if user
   // pass allow_stall = true during WriteBufferManager instance creation.


### PR DESCRIPTION
Six spelling fixes in comments across six files — no code logic changes:

- `write_thread.cc`: `succesfull` → `successful`
- `memtable_list.cc`: `succesful` → `successful`
- `db_impl_open.cc`: `orignal` → `original`
- `db.h`: `paramater` → `parameter`
- `options.h`: `gaurantee` → `guarantee`
- `write_buffer_manager.h`: `untill` → `until`