### PR TITLE
Add parallel gtest flake reproduction runner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -294,12 +294,9 @@ phantom bug.
     COERCE_CONTEXT_SWITCH=1 make {test_binary}
     ./{test_binary} --gtest_filter="*YourTestName*" --gtest_repeat=5
     ```
-* For flaky tests that only reproduce when CI shards or other test processes
-    make the host CPU busy, see `tools/gtest_parallel_repro.py --help`. It runs
-    fresh gtest processes with isolated `TEST_TMPDIR` values, optional CPU
-    pinning, and optional `COERCE_CONTEXT_SWITCH=1` rebuilds. Use it when
-    `gtest_parallel.py`, `--gtest_repeat`, and normal coerce-mode runs do not
-    reproduce process-level scheduling failures.
+* For CI-style flaky tests that do not reproduce with `gtest_parallel.py`,
+    `--gtest_repeat`, or normal coerce-mode runs, inspect
+    `tools/gtest_parallel_repro.py --help`.
 
 ### Unit test dedup guidelines
 * Extract helper functions for repeated patterns such as object

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -294,25 +294,12 @@ phantom bug.
     COERCE_CONTEXT_SWITCH=1 make {test_binary}
     ./{test_binary} --gtest_filter="*YourTestName*" --gtest_repeat=5
     ```
-* For flakes that only reproduce when CI shards or other test processes make
-    the host CPU busy, use `tools/gtest_parallel_repro.py`. It runs many fresh
-    gtest processes concurrently, gives each process its own `TEST_TMPDIR`, can
-    pin them to a small CPU set, and can build the binary with
-    `COERCE_CONTEXT_SWITCH=1` before running. This complements
-    `COERCE_CONTEXT_SWITCH`: coerce mode injects sleeps/yields at selected
-    RocksDB code points, but it does not fully simulate OS-level CPU starvation
-    and arbitrary worker-thread scheduling delays.
-    ```bash
-    python3 tools/gtest_parallel_repro.py \
-      --binary ./env_test \
-      --gtest_filter="*YourTestName*" \
-      --jobs 100 \
-      --batches 100 \
-      --cpu-count 8 \
-      --build \
-      --clean \
-      --coerce-context-switch
-    ```
+* For flaky tests that only reproduce when CI shards or other test processes
+    make the host CPU busy, see `tools/gtest_parallel_repro.py --help`. It runs
+    fresh gtest processes with isolated `TEST_TMPDIR` values, optional CPU
+    pinning, and optional `COERCE_CONTEXT_SWITCH=1` rebuilds. Use it when
+    `gtest_parallel.py`, `--gtest_repeat`, and normal coerce-mode runs do not
+    reproduce process-level scheduling failures.
 
 ### Unit test dedup guidelines
 * Extract helper functions for repeated patterns such as object

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -294,6 +294,25 @@ phantom bug.
     COERCE_CONTEXT_SWITCH=1 make {test_binary}
     ./{test_binary} --gtest_filter="*YourTestName*" --gtest_repeat=5
     ```
+* For flakes that only reproduce when CI shards or other test processes make
+    the host CPU busy, use `tools/gtest_parallel_repro.py`. It runs many fresh
+    gtest processes concurrently, gives each process its own `TEST_TMPDIR`, can
+    pin them to a small CPU set, and can build the binary with
+    `COERCE_CONTEXT_SWITCH=1` before running. This complements
+    `COERCE_CONTEXT_SWITCH`: coerce mode injects sleeps/yields at selected
+    RocksDB code points, but it does not fully simulate OS-level CPU starvation
+    and arbitrary worker-thread scheduling delays.
+    ```bash
+    python3 tools/gtest_parallel_repro.py \
+      --binary ./env_test \
+      --gtest_filter="*YourTestName*" \
+      --jobs 100 \
+      --batches 100 \
+      --cpu-count 8 \
+      --build \
+      --clean \
+      --coerce-context-switch
+    ```
 
 ### Unit test dedup guidelines
 * Extract helper functions for repeated patterns such as object

--- a/db/c_test.c
+++ b/db/c_test.c
@@ -6,6 +6,7 @@
 #include "rocksdb/c.h"
 
 #include <assert.h>
+#include <inttypes.h>
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -14,7 +15,6 @@
 #ifndef OS_WIN
 #include <unistd.h>
 #endif
-#include <inttypes.h>
 
 // Can not use port/port.h macros as this is a c file
 #ifdef OS_WIN
@@ -31,6 +31,14 @@ int geteuid() {
 }
 
 #endif
+
+static uint64_t GetTestId(void) {
+#ifdef OS_WIN
+  return (uint64_t)geteuid();
+#else
+  return ((uint64_t)geteuid() << 32) ^ (uint64_t)getpid();
+#endif
+}
 
 const char* phase = "";
 static char dbname[200];
@@ -848,20 +856,21 @@ int main(int argc, char** argv) {
   char* err = NULL;
   int run = -1;
 
-  snprintf(dbname, sizeof(dbname), "%s/rocksdb_c_test-%d", GetTempDir(),
-           ((int)geteuid()));
+  snprintf(dbname, sizeof(dbname), "%s/rocksdb_c_test-%" PRIu64, GetTempDir(),
+           GetTestId());
 
-  snprintf(dbbackupname, sizeof(dbbackupname), "%s/rocksdb_c_test-%d-backup",
-           GetTempDir(), ((int)geteuid()));
+  snprintf(dbbackupname, sizeof(dbbackupname),
+           "%s/rocksdb_c_test-%" PRIu64 "-backup", GetTempDir(), GetTestId());
 
   snprintf(dbcheckpointname, sizeof(dbcheckpointname),
-           "%s/rocksdb_c_test-%d-checkpoint", GetTempDir(), ((int)geteuid()));
+           "%s/rocksdb_c_test-%" PRIu64 "-checkpoint", GetTempDir(),
+           GetTestId());
 
-  snprintf(sstfilename, sizeof(sstfilename), "%s/rocksdb_c_test-%d-sst",
-           GetTempDir(), ((int)geteuid()));
+  snprintf(sstfilename, sizeof(sstfilename),
+           "%s/rocksdb_c_test-%" PRIu64 "-sst", GetTempDir(), GetTestId());
 
-  snprintf(dbpathname, sizeof(dbpathname), "%s/rocksdb_c_test-%d-dbpath",
-           GetTempDir(), ((int)geteuid()));
+  snprintf(dbpathname, sizeof(dbpathname),
+           "%s/rocksdb_c_test-%" PRIu64 "-dbpath", GetTempDir(), GetTestId());
 
   StartPhase("create_objects");
   cmp = rocksdb_comparator_create(NULL, CmpDestroy, CmpCompare, CmpName);
@@ -1147,9 +1156,11 @@ int main(int argc, char** argv) {
     static char cf_export_path[200];
     static char db_import_path[200];
     snprintf(cf_export_path, sizeof(cf_export_path),
-             "%s/rocksdb_c_test-%d-cf_export", GetTempDir(), ((int)geteuid()));
+             "%s/rocksdb_c_test-%" PRIu64 "-cf_export", GetTempDir(),
+             GetTestId());
     snprintf(db_import_path, sizeof(db_import_path),
-             "%s/rocksdb_c_test-%d-db_import", GetTempDir(), ((int)geteuid()));
+             "%s/rocksdb_c_test-%" PRIu64 "-db_import", GetTempDir(),
+             GetTestId());
 
     rocksdb_options_t* db_options = rocksdb_options_create();
     rocksdb_column_family_handle_t* cf_export =
@@ -2058,8 +2069,9 @@ int main(int argc, char** argv) {
     // use dbpathname2 as the cf_path for "cf1"
     rocksdb_dbpath_t* dbpath2;
     char dbpathname2[200];
-    snprintf(dbpathname2, sizeof(dbpathname2), "%s/rocksdb_c_test-%d-dbpath2",
-             GetTempDir(), ((int)geteuid()));
+    snprintf(dbpathname2, sizeof(dbpathname2),
+             "%s/rocksdb_c_test-%" PRIu64 "-dbpath2", GetTempDir(),
+             GetTestId());
     dbpath2 = rocksdb_dbpath_create(dbpathname2, 1024 * 1024);
     const rocksdb_dbpath_t* cf_paths[1] = {dbpath2};
     rocksdb_options_set_cf_paths(cf_options_2, cf_paths, 1);
@@ -3813,8 +3825,8 @@ int main(int argc, char** argv) {
     char wp_dbname[200];
     rocksdb_transactiondb_t* wp_txn_db;
     rocksdb_transactiondb_options_t* wp_txn_opts;
-    snprintf(wp_dbname, sizeof(wp_dbname), "%s/rocksdb_c_test-txnwp-%d",
-             GetTempDir(), (int)geteuid());
+    snprintf(wp_dbname, sizeof(wp_dbname), "%s/rocksdb_c_test-txnwp-%" PRIu64,
+             GetTempDir(), GetTestId());
     rocksdb_destroy_db(options, wp_dbname, &err);
     Free(&err);
     wp_txn_opts = rocksdb_transactiondb_options_create();
@@ -4482,7 +4494,7 @@ int main(int argc, char** argv) {
     rocksdb_options_set_max_open_files(opts, -1);
     rocksdb_options_set_create_if_missing(opts, 1);
     snprintf(secondary_path, sizeof(secondary_path),
-             "%s/rocksdb_c_test_secondary-%d", GetTempDir(), ((int)geteuid()));
+             "%s/rocksdb_c_test_secondary-%" PRIu64, GetTempDir(), GetTestId());
     db1 = rocksdb_open_as_secondary(opts, dbname, secondary_path, &err);
     CheckNoError(err);
 
@@ -4941,7 +4953,10 @@ int main(int argc, char** argv) {
     rocksdb_options_set_create_if_missing(null_opts, 1);
     rocksdb_options_set_compaction_service(null_opts, null_service);
 
-    const char* null_db = "rocksdb_c_test_null_service";
+    char null_db[200];
+    snprintf(null_db, sizeof(null_db),
+             "%s/rocksdb_c_test_null_service-%" PRIu64, GetTempDir(),
+             GetTestId());
 
     rocksdb_t* null_db_handle = rocksdb_open(null_opts, null_db, &err);
     CheckNoError(err);

--- a/db/c_test.c
+++ b/db/c_test.c
@@ -4954,13 +4954,12 @@ int main(int argc, char** argv) {
     rocksdb_options_set_compaction_service(null_opts, null_service);
 
     char null_db[200];
-    // c_test.c constructs fixed-size test paths with snprintf; verify this
-    // path is not truncated.
-    // NOLINTNEXTLINE
     int null_db_len = snprintf(null_db, sizeof(null_db),
                                "%s/rocksdb_c_test_null_service-%" PRIu64,
                                GetTempDir(), GetTestId());
-    CheckCondition(null_db_len > 0 && (size_t)null_db_len < sizeof(null_db));
+    if (null_db_len <= 0 || (size_t)null_db_len >= sizeof(null_db)) {
+      abort();
+    }
 
     rocksdb_t* null_db_handle = rocksdb_open(null_opts, null_db, &err);
     CheckNoError(err);

--- a/db/c_test.c
+++ b/db/c_test.c
@@ -4954,9 +4954,13 @@ int main(int argc, char** argv) {
     rocksdb_options_set_compaction_service(null_opts, null_service);
 
     char null_db[200];
-    snprintf(null_db, sizeof(null_db),
-             "%s/rocksdb_c_test_null_service-%" PRIu64, GetTempDir(),
-             GetTestId());
+    // c_test.c constructs fixed-size test paths with snprintf; verify this
+    // path is not truncated.
+    // NOLINTNEXTLINE
+    int null_db_len = snprintf(null_db, sizeof(null_db),
+                               "%s/rocksdb_c_test_null_service-%" PRIu64,
+                               GetTempDir(), GetTestId());
+    CheckCondition(null_db_len > 0 && (size_t)null_db_len < sizeof(null_db));
 
     rocksdb_t* null_db_handle = rocksdb_open(null_opts, null_db, &err);
     CheckNoError(err);

--- a/env/env_test.cc
+++ b/env/env_test.cc
@@ -4125,10 +4125,12 @@ TEST_F(TestAsyncRead, ReadAsyncQueueFull) {
     std::unique_ptr<FSRandomAccessFile> file;
     ASSERT_OK(fs->NewRandomAccessFile(fname, FileOptions(), &file, nullptr));
 
-    // Force io_uring_get_sqe to appear to return null via SyncPoint.
+    // Force the queue-full path without consuming an SQ slot. Overwriting the
+    // SQE pointer after io_uring_get_sqe() would leave a stale submission in
+    // the ring and pollute later tests using the same thread-local io_uring.
     SyncPoint::GetInstance()->SetCallBack(
-        "PosixRandomAccessFile::ReadAsync:io_uring_get_sqe",
-        [](void* arg) { *static_cast<io_uring_sqe**>(arg) = nullptr; });
+        "PosixRandomAccessFile::ReadAsync:skip_io_uring_get_sqe",
+        [](void* arg) { *static_cast<bool*>(arg) = true; });
     SyncPoint::GetInstance()->EnableProcessing();
 
     IOOptions opts;

--- a/env/io_posix.cc
+++ b/env/io_posix.cc
@@ -1116,10 +1116,15 @@ IOStatus PosixRandomAccessFile::ReadAsync(
   posix_handle->iov.iov_len = req.len;
 
   // Step 3: io_uring_sqe_set_data
-  struct io_uring_sqe* sqe;
-  sqe = io_uring_get_sqe(iu);
-  TEST_SYNC_POINT_CALLBACK("PosixRandomAccessFile::ReadAsync:io_uring_get_sqe",
-                           &sqe);
+  bool skip_get_sqe = false;
+  TEST_SYNC_POINT_CALLBACK(
+      "PosixRandomAccessFile::ReadAsync:skip_io_uring_get_sqe", &skip_get_sqe);
+  struct io_uring_sqe* sqe = nullptr;
+  if (!skip_get_sqe) {
+    sqe = io_uring_get_sqe(iu);
+    TEST_SYNC_POINT_CALLBACK(
+        "PosixRandomAccessFile::ReadAsync:io_uring_get_sqe", &sqe);
+  }
   if (sqe == nullptr) {
     // Submission queue is full, so outstanding completions have not been
     // reaped yet. Submission never succeeded, so clean up the local handle and

--- a/tools/gtest_parallel_repro.py
+++ b/tools/gtest_parallel_repro.py
@@ -3,7 +3,8 @@
 
 Synopsis:
   python3 tools/gtest_parallel_repro.py --binary ./env_test \\
-      --gtest_filter='*ReserveThreads*' --jobs 100 --batches 100
+      --gtest_filter='*ReserveThreads*' --processes-per-iteration 100 \\
+      --iteration-count 100
 
 This tool is for flaky tests that do not reproduce with a single-process
 `--gtest_repeat` loop. Some RocksDB tests only fail when their process competes
@@ -37,24 +38,12 @@ ASSERT_RE = re.compile(r"Assertion `([^`]+)' failed\.")
 HELP_EPILOG = """\
 Examples:
   python3 tools/gtest_parallel_repro.py --binary ./env_test \\
-      --gtest_filter='*ReserveThreads*' --jobs 100 --batches 100 --cpu-count 8
+      --gtest_filter='*ReserveThreads*' --processes-per-iteration 100 \\
+      --iteration-count 100 --cpu-count 8
 
   python3 tools/gtest_parallel_repro.py --binary ./env_test \\
-      --gtest_filter='*ReserveThreads*' --jobs 32 --batches 50 --build \\
-      --coerce-context-switch --make-arg=-j40
-
-What this adds over gtest-parallel -r:
-  - It starts fresh OS processes for each run instead of repeating tests inside
-    one long-lived process.
-  - Each process gets an isolated TEST_TMPDIR, which avoids accidental DB path
-    sharing while preserving process-level contention.
-  - The whole batch can be pinned to a small CPU set to create scheduler
-    pressure similar to a busy CI host.
-  - The output keeps one log per process plus a failure histogram, so repeated
-    failures can be grouped quickly.
-  - With --build --coerce-context-switch, the same entry point can rebuild with
-    RocksDB's compile-time COERCE_CONTEXT_SWITCH hooks before running the
-    process-level repro loop.
+      --gtest_filter='*ReserveThreads*' --processes-per-iteration 32 \\
+      --iteration-count 50 --build --coerce-context-switch --make-arg=-j40
 """
 
 
@@ -196,115 +185,163 @@ def write_jsonl(path: Path, records: Iterable[Dict[str, object]]) -> None:
             fh.write(json.dumps(record, sort_keys=True) + "\n")
 
 
-def run_batch(
+def launch_process(
+    cmd: List[str],
+    base_env: Dict[str, str],
+    run_dir: Path,
+    proc_index: int,
+) -> Dict[str, Any]:
+    tmp_dir = run_dir / "tmp"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+    log_path = run_dir / "log.txt"
+    env = base_env.copy()
+    env["TEST_TMPDIR"] = str(tmp_dir)
+    log_fh = log_path.open("w")
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            stdout=log_fh,
+            stderr=subprocess.STDOUT,
+            env=env,
+            start_new_session=True,
+        )
+    except BaseException:
+        log_fh.close()
+        raise
+    return {
+        "proc": proc,
+        "proc_index": proc_index,
+        "run_dir": run_dir,
+        "log_path": log_path,
+        "log_fh": log_fh,
+        "start": time.monotonic(),
+        "timed_out": False,
+    }
+
+
+def launch_iteration_processes(
     args: argparse.Namespace,
-    batch: int,
+    iteration_dir: Path,
+    cmd: List[str],
+    base_env: Dict[str, str],
+) -> List[Dict[str, Any]]:
+    processes: List[Dict[str, Any]] = []
+    try:
+        for proc_index in range(1, args.processes_per_iteration + 1):
+            processes.append(
+                launch_process(
+                    cmd,
+                    base_env,
+                    iteration_dir / f"proc_{proc_index:04d}",
+                    proc_index,
+                )
+            )
+    except BaseException:
+        terminate_processes(processes)
+        close_log_handles(processes)
+        raise
+    return processes
+
+
+def monitor_processes(processes: List[Dict[str, Any]], timeout: int) -> None:
+    remaining = set(range(len(processes)))
+    while remaining:
+        now = time.monotonic()
+        for index in list(remaining):
+            proc = processes[index]["proc"]
+            assert isinstance(proc, subprocess.Popen)
+            if proc.poll() is not None:
+                processes[index]["end"] = time.monotonic()
+                remaining.remove(index)
+                continue
+            elapsed = now - float(processes[index]["start"])
+            if elapsed > timeout:
+                processes[index]["timed_out"] = True
+                terminate_process(proc)
+                processes[index]["end"] = time.monotonic()
+                remaining.remove(index)
+        if remaining:
+            time.sleep(0.05)
+
+
+def collect_process_result(
+    info: Dict[str, Any],
+    iteration: int,
+    keep_success_artifacts: bool,
+) -> Tuple[Optional[Dict[str, object]], Dict[str, int]]:
+    log_fh = info["log_fh"]
+    assert hasattr(log_fh, "close")
+    log_fh.close()
+    proc = info["proc"]
+    assert isinstance(proc, subprocess.Popen)
+    timed_out = bool(info["timed_out"])
+    log_path = Path(info["log_path"])
+    run_dir = Path(info["run_dir"])
+    elapsed = float(info.get("end", time.monotonic())) - float(info["start"])
+    if not timed_out and proc.returncode == 0:
+        if not keep_success_artifacts:
+            shutil.rmtree(run_dir)
+        return None, {}
+
+    keys = extract_failure_keys(log_path)
+    histogram = {key: keys.count(key) for key in set(keys)}
+    return (
+        {
+            "iteration": iteration,
+            "proc": info["proc_index"],
+            "returncode": "TIMEOUT" if timed_out else proc.returncode,
+            "elapsed_sec": round(elapsed, 3),
+            "log": str(log_path),
+            "failure_keys": keys,
+        },
+        histogram,
+    )
+
+
+def collect_iteration_results(
+    processes: List[Dict[str, Any]],
+    iteration: int,
+    keep_success_artifacts: bool,
+) -> Tuple[List[Dict[str, object]], Dict[str, int]]:
+    failures: List[Dict[str, object]] = []
+    histogram: Dict[str, int] = {}
+    for info in processes:
+        failure, process_histogram = collect_process_result(
+            info, iteration, keep_success_artifacts
+        )
+        if failure is not None:
+            failures.append(failure)
+        for key, count in process_histogram.items():
+            histogram[key] = histogram.get(key, 0) + count
+    return failures, histogram
+
+
+def run_iteration(
+    args: argparse.Namespace,
+    iteration: int,
     out_dir: Path,
     cmd: List[str],
     base_env: Dict[str, str],
 ) -> Tuple[List[Dict[str, object]], Dict[str, int]]:
     processes: List[Dict[str, Any]] = []
-    batch_dir = out_dir / f"batch_{batch:04d}"
-    batch_dir.mkdir(parents=True, exist_ok=True)
+    iteration_dir = out_dir / f"iteration_{iteration:04d}"
+    iteration_dir.mkdir(parents=True, exist_ok=True)
 
     try:
-        for proc_index in range(1, args.jobs + 1):
-            run_dir = batch_dir / f"proc_{proc_index:04d}"
-            tmp_dir = run_dir / "tmp"
-            run_dir.mkdir(parents=True, exist_ok=True)
-            tmp_dir.mkdir(parents=True, exist_ok=True)
-            log_path = run_dir / "log.txt"
-            env = base_env.copy()
-            env["TEST_TMPDIR"] = str(tmp_dir)
-            log_fh = log_path.open("w")
-            try:
-                proc = subprocess.Popen(
-                    cmd,
-                    stdout=log_fh,
-                    stderr=subprocess.STDOUT,
-                    env=env,
-                    start_new_session=True,
-                )
-            except BaseException:
-                log_fh.close()
-                raise
-            processes.append(
-                {
-                    "proc": proc,
-                    "proc_index": proc_index,
-                    "run_dir": run_dir,
-                    "log_path": log_path,
-                    "log_fh": log_fh,
-                    "start": time.monotonic(),
-                    "timed_out": False,
-                }
-            )
-
-        remaining = set(range(len(processes)))
-        while remaining:
-            now = time.monotonic()
-            for index in list(remaining):
-                proc = processes[index]["proc"]
-                assert isinstance(proc, subprocess.Popen)
-                if proc.poll() is not None:
-                    processes[index]["end"] = time.monotonic()
-                    remaining.remove(index)
-                    continue
-                elapsed = now - float(processes[index]["start"])
-                if elapsed > args.timeout:
-                    processes[index]["timed_out"] = True
-                    terminate_process(proc)
-                    processes[index]["end"] = time.monotonic()
-                    remaining.remove(index)
-            if remaining:
-                time.sleep(0.05)
+        processes = launch_iteration_processes(args, iteration_dir, cmd, base_env)
+        monitor_processes(processes, args.timeout)
     except BaseException:
         terminate_processes(processes)
         close_log_handles(processes)
         raise
 
-    failures: List[Dict[str, object]] = []
-    histogram: Dict[str, int] = {}
-    for info in processes:
-        log_fh = info["log_fh"]
-        assert hasattr(log_fh, "close")
-        log_fh.close()
-        proc = info["proc"]
-        assert isinstance(proc, subprocess.Popen)
-        rc = proc.returncode
-        timed_out = bool(info["timed_out"])
-        log_path = Path(info["log_path"])
-        run_dir = Path(info["run_dir"])
-        elapsed = float(info.get("end", time.monotonic())) - float(info["start"])
-        if timed_out or rc != 0:
-            keys = extract_failure_keys(log_path)
-            for key in keys:
-                histogram[key] = histogram.get(key, 0) + 1
-            failures.append(
-                {
-                    "batch": batch,
-                    "proc": info["proc_index"],
-                    "returncode": "TIMEOUT" if timed_out else rc,
-                    "elapsed_sec": round(elapsed, 3),
-                    "log": str(log_path),
-                    "failure_keys": keys,
-                }
-            )
-        elif not args.keep_success_artifacts:
-            shutil.rmtree(run_dir)
-
-    return failures, histogram
-
-
-def main() -> int:
-    parser = argparse.ArgumentParser(
-        description=(
-            "Run many fresh gtest processes concurrently to reproduce flaky "
-            "tests that depend on CPU contention or process-level scheduling."
-        ),
-        epilog=HELP_EPILOG,
-        formatter_class=argparse.RawDescriptionHelpFormatter,
+    return collect_iteration_results(
+        processes, iteration, args.keep_success_artifacts
     )
+
+
+def add_gtest_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--binary", required=True, help="Path to gtest binary")
     parser.add_argument(
         "--gtest_filter",
@@ -320,9 +357,28 @@ def main() -> int:
         default=[],
         help="Additional gtest argument; repeat for multiple arguments",
     )
-    parser.add_argument("--jobs", type=positive_int, default=8)
-    parser.add_argument("--batches", type=positive_int, default=1)
+
+
+def add_run_control_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--processes-per-iteration",
+        type=positive_int,
+        default=8,
+        help="Number of gtest processes to run concurrently in each iteration",
+    )
+    parser.add_argument(
+        "--iteration-count",
+        type=positive_int,
+        default=1,
+        help=(
+            "Number of iterations to run; total invocations are iterations "
+            "times processes per iteration"
+        ),
+    )
     parser.add_argument("--timeout", type=positive_int, default=60)
+
+
+def add_output_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--out",
         default=None,
@@ -346,10 +402,13 @@ def main() -> int:
         "--stop-on-failure",
         action="store_true",
         help=(
-            "Stop after the first batch with any failed process. The current "
-            "batch always finishes and cleans up first."
+            "Stop after the first iteration with any failed process. The "
+            "current iteration always finishes and cleans up first."
         ),
     )
+
+
+def add_cpu_args(parser: argparse.ArgumentParser) -> None:
     cpu_group = parser.add_mutually_exclusive_group()
     cpu_group.add_argument(
         "--cpus",
@@ -360,6 +419,9 @@ def main() -> int:
         type=positive_int,
         help="Pin all test processes to the first N CPUs available to this process",
     )
+
+
+def add_build_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--build",
         action="store_true",
@@ -389,39 +451,64 @@ def main() -> int:
             "COERCE_CONTEXT_SWITCH alone does not simulate CPU starvation."
         ),
     )
-    args = parser.parse_args()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run many fresh gtest processes concurrently to reproduce flaky "
+            "tests that depend on CPU contention or process-level scheduling."
+        ),
+        epilog=HELP_EPILOG,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    add_gtest_args(parser)
+    add_run_control_args(parser)
+    add_output_args(parser)
+    add_cpu_args(parser)
+    add_build_args(parser)
+    return parser
+
+
+def parse_env_or_error(
+    parser: argparse.ArgumentParser, args: argparse.Namespace
+) -> Dict[str, str]:
+    try:
+        return parse_env(args.env)
+    except argparse.ArgumentTypeError as err:
+        parser.error(str(err))
+    raise AssertionError("unreachable")
+
+
+def validate_build_args(
+    parser: argparse.ArgumentParser, args: argparse.Namespace
+) -> None:
     if args.clean and not args.build:
         parser.error("--clean requires --build")
-
     binary = Path(args.binary)
     if not binary.exists() and not args.build:
         parser.error(f"--binary does not exist: {args.binary}")
 
-    try:
-        env_overrides = parse_env(args.env)
-    except argparse.ArgumentTypeError as err:
-        parser.error(str(err))
-    build_if_requested(args, env_overrides)
-    if not binary.exists():
-        parser.error(f"--binary does not exist after build: {args.binary}")
 
-    try:
-        cpu_list = resolve_cpu_list(args.cpu_count, args.cpus)
-        cmd = make_run_command(args, cpu_list)
-    except (RuntimeError, ValueError) as err:
-        parser.error(str(err))
+def make_output_dir(parser: argparse.ArgumentParser, args: argparse.Namespace) -> Path:
     out_dir = Path(args.out or f"/tmp/gtest_parallel_repro_{int(time.time())}")
     if out_dir.exists() and any(out_dir.iterdir()):
         parser.error(f"--out exists and is not empty: {out_dir}")
     out_dir.mkdir(parents=True, exist_ok=True)
+    return out_dir
 
-    base_env = os.environ.copy()
-    base_env.update(env_overrides)
 
+def write_metadata(
+    out_dir: Path,
+    args: argparse.Namespace,
+    cmd: List[str],
+    cpu_list: Optional[str],
+    env_overrides: Dict[str, str],
+) -> None:
     metadata = {
         "cmd": cmd,
-        "jobs": args.jobs,
-        "batches": args.batches,
+        "processes_per_iteration": args.processes_per_iteration,
+        "iteration_count": args.iteration_count,
         "timeout": args.timeout,
         "cpu_list": cpu_list,
         "coerce_context_switch": args.coerce_context_switch,
@@ -430,27 +517,64 @@ def main() -> int:
     }
     (out_dir / "metadata.json").write_text(json.dumps(metadata, indent=2) + "\n")
 
-    print("Command:", " ".join(cmd))
-    print("Output:", out_dir)
-    print(f"Running {args.batches} batch(es) x {args.jobs} process(es)")
 
+def prepare_run(
+    parser: argparse.ArgumentParser, args: argparse.Namespace
+) -> Tuple[Path, List[str], Dict[str, str]]:
+    validate_build_args(parser, args)
+    env_overrides = parse_env_or_error(parser, args)
+    build_if_requested(args, env_overrides)
+    if not Path(args.binary).exists():
+        parser.error(f"--binary does not exist after build: {args.binary}")
+
+    try:
+        cpu_list = resolve_cpu_list(args.cpu_count, args.cpus)
+        cmd = make_run_command(args, cpu_list)
+    except (RuntimeError, ValueError) as err:
+        parser.error(str(err))
+
+    out_dir = make_output_dir(parser, args)
+    base_env = os.environ.copy()
+    base_env.update(env_overrides)
+    write_metadata(out_dir, args, cmd, cpu_list, env_overrides)
+    return out_dir, cmd, base_env
+
+
+def merge_histogram(total: Dict[str, int], update: Dict[str, int]) -> None:
+    for key, count in update.items():
+        total[key] = total.get(key, 0) + count
+
+
+def print_failure_progress(
+    iteration: int, failures: int, total_failures: int
+) -> None:
+    print(
+        f"iteration {iteration}: failures={failures} "
+        f"total_failures={total_failures}",
+        flush=True,
+    )
+
+
+def run_iterations(
+    args: argparse.Namespace,
+    out_dir: Path,
+    cmd: List[str],
+    base_env: Dict[str, str],
+) -> Tuple[List[Dict[str, object]], Dict[str, int], int, bool]:
     all_failures: List[Dict[str, object]] = []
     total_histogram: Dict[str, int] = {}
     total_runs = 0
     interrupted = False
     try:
-        for batch in range(1, args.batches + 1):
-            failures, histogram = run_batch(args, batch, out_dir, cmd, base_env)
-            total_runs += args.jobs
+        for iteration in range(1, args.iteration_count + 1):
+            failures, histogram = run_iteration(
+                args, iteration, out_dir, cmd, base_env
+            )
+            total_runs += args.processes_per_iteration
             all_failures.extend(failures)
-            for key, count in histogram.items():
-                total_histogram[key] = total_histogram.get(key, 0) + count
+            merge_histogram(total_histogram, histogram)
             if failures:
-                print(
-                    f"batch {batch}: failures={len(failures)} "
-                    f"total_failures={len(all_failures)}",
-                    flush=True,
-                )
+                print_failure_progress(iteration, len(failures), len(all_failures))
                 if args.stop_on_failure:
                     break
     except KeyboardInterrupt:
@@ -459,9 +583,15 @@ def main() -> int:
             "\nInterrupted; active child process groups were terminated.",
             file=sys.stderr,
         )
+    return all_failures, total_histogram, total_runs, interrupted
 
-    write_jsonl(out_dir / "failures.jsonl", all_failures)
 
+def print_summary(
+    out_dir: Path,
+    all_failures: List[Dict[str, object]],
+    total_histogram: Dict[str, int],
+    total_runs: int,
+) -> None:
     print(f"TOTAL_RUNS={total_runs}")
     print(f"TOTAL_FAILURES={len(all_failures)}")
     print(f"FAILURES_FILE={out_dir / 'failures.jsonl'}")
@@ -472,6 +602,22 @@ def main() -> int:
         )[:20]:
             print(f"  {count} {key}")
 
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    out_dir, cmd, base_env = prepare_run(parser, args)
+    print("Command:", " ".join(cmd))
+    print("Output:", out_dir)
+    print(
+        f"Running {args.iteration_count} iteration(s) x "
+        f"{args.processes_per_iteration} process(es)"
+    )
+    all_failures, total_histogram, total_runs, interrupted = run_iterations(
+        args, out_dir, cmd, base_env
+    )
+    write_jsonl(out_dir / "failures.jsonl", all_failures)
+    print_summary(out_dir, all_failures, total_histogram, total_runs)
     if interrupted:
         return 130
     return 1 if all_failures else 0

--- a/tools/gtest_parallel_repro.py
+++ b/tools/gtest_parallel_repro.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python3
 """Run a gtest binary repeatedly under process-level scheduler pressure.
 
-This tool is for flakes that do not reproduce with a single-process
+Synopsis:
+  python3 tools/gtest_parallel_repro.py --binary ./env_test \\
+      --gtest_filter='*ReserveThreads*' --jobs 100 --batches 100
+
+This tool is for flaky tests that do not reproduce with a single-process
 `--gtest_repeat` loop. Some RocksDB tests only fail when their process competes
 with many other CPU-heavy test processes, because OS scheduling can delay
 arbitrary worker threads and expose timing assumptions.
@@ -30,6 +34,28 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple
 FAILURE_LINE_RE = re.compile(r"^(.+?:\d+): Failure$")
 SANITIZER_RE = re.compile(r"^==\d+==ERROR: ([^:]+): (.+)$")
 ASSERT_RE = re.compile(r"Assertion `([^`]+)' failed\.")
+HELP_EPILOG = """\
+Examples:
+  python3 tools/gtest_parallel_repro.py --binary ./env_test \\
+      --gtest_filter='*ReserveThreads*' --jobs 100 --batches 100 --cpu-count 8
+
+  python3 tools/gtest_parallel_repro.py --binary ./env_test \\
+      --gtest_filter='*ReserveThreads*' --jobs 32 --batches 50 --build \\
+      --coerce-context-switch --make-arg=-j40
+
+What this adds over gtest-parallel -r:
+  - It starts fresh OS processes for each run instead of repeating tests inside
+    one long-lived process.
+  - Each process gets an isolated TEST_TMPDIR, which avoids accidental DB path
+    sharing while preserving process-level contention.
+  - The whole batch can be pinned to a small CPU set to create scheduler
+    pressure similar to a busy CI host.
+  - The output keeps one log per process plus a failure histogram, so repeated
+    failures can be grouped quickly.
+  - With --build --coerce-context-switch, the same entry point can rebuild with
+    RocksDB's compile-time COERCE_CONTEXT_SWITCH hooks before running the
+    process-level repro loop.
+"""
 
 
 def positive_int(value: str) -> int:
@@ -109,14 +135,16 @@ def terminate_process(proc: subprocess.Popen) -> None:
         os.killpg(proc.pid, signal.SIGTERM)
     except ProcessLookupError:
         return
-    except Exception:
+    except OSError:
         proc.terminate()
     try:
         proc.wait(timeout=2)
     except subprocess.TimeoutExpired:
         try:
             os.killpg(proc.pid, signal.SIGKILL)
-        except Exception:
+        except ProcessLookupError:
+            pass
+        except OSError:
             proc.kill()
         try:
             proc.wait(timeout=10)
@@ -271,9 +299,11 @@ def run_batch(
 def main() -> int:
     parser = argparse.ArgumentParser(
         description=(
-            "Run many fresh gtest processes concurrently to reproduce flakes "
-            "that depend on CPU contention or process-level scheduling."
-        )
+            "Run many fresh gtest processes concurrently to reproduce flaky "
+            "tests that depend on CPU contention or process-level scheduling."
+        ),
+        epilog=HELP_EPILOG,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument("--binary", required=True, help="Path to gtest binary")
     parser.add_argument(
@@ -307,12 +337,18 @@ def main() -> int:
     parser.add_argument(
         "--keep-success-artifacts",
         action="store_true",
-        help="Keep logs and TEST_TMPDIR for successful runs",
+        help=(
+            "Keep each successful process run directory, including log.txt and "
+            "TEST_TMPDIR. By default successful run directories are deleted."
+        ),
     )
     parser.add_argument(
         "--stop-on-failure",
         action="store_true",
-        help="Stop launching new batches after the first failed batch",
+        help=(
+            "Stop after the first batch with any failed process. The current "
+            "batch always finishes and cleans up first."
+        ),
     )
     cpu_group = parser.add_mutually_exclusive_group()
     cpu_group.add_argument(

--- a/tools/gtest_parallel_repro.py
+++ b/tools/gtest_parallel_repro.py
@@ -24,7 +24,7 @@ import signal
 import subprocess
 import sys
 import time
-from typing import Dict, Iterable, List, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 
 FAILURE_LINE_RE = re.compile(r"^(.+?:\d+): Failure$")
@@ -118,7 +118,27 @@ def terminate_process(proc: subprocess.Popen) -> None:
             os.killpg(proc.pid, signal.SIGKILL)
         except Exception:
             proc.kill()
-        proc.wait()
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            print(
+                f"WARNING: process {proc.pid} did not exit after SIGKILL",
+                file=sys.stderr,
+            )
+
+
+def close_log_handles(processes: List[Dict[str, Any]]) -> None:
+    for info in processes:
+        log_fh = info.get("log_fh")
+        if hasattr(log_fh, "close") and not getattr(log_fh, "closed", False):
+            log_fh.close()
+
+
+def terminate_processes(processes: List[Dict[str, Any]]) -> None:
+    for info in processes:
+        proc = info.get("proc")
+        if isinstance(proc, subprocess.Popen) and proc.poll() is None:
+            terminate_process(proc)
 
 
 def extract_failure_keys(log_path: Path) -> List[str]:
@@ -155,54 +175,65 @@ def run_batch(
     cmd: List[str],
     base_env: Dict[str, str],
 ) -> Tuple[List[Dict[str, object]], Dict[str, int]]:
-    processes = []
+    processes: List[Dict[str, Any]] = []
     batch_dir = out_dir / f"batch_{batch:04d}"
     batch_dir.mkdir(parents=True, exist_ok=True)
 
-    for proc_index in range(1, args.jobs + 1):
-        run_dir = batch_dir / f"proc_{proc_index:04d}"
-        tmp_dir = run_dir / "tmp"
-        run_dir.mkdir(parents=True, exist_ok=True)
-        tmp_dir.mkdir(parents=True, exist_ok=True)
-        log_path = run_dir / "log.txt"
-        env = base_env.copy()
-        env["TEST_TMPDIR"] = str(tmp_dir)
-        log_fh = log_path.open("w")
-        proc = subprocess.Popen(
-            cmd,
-            stdout=log_fh,
-            stderr=subprocess.STDOUT,
-            env=env,
-            start_new_session=True,
-        )
-        processes.append(
-            {
-                "proc": proc,
-                "proc_index": proc_index,
-                "run_dir": run_dir,
-                "log_path": log_path,
-                "log_fh": log_fh,
-                "start": time.monotonic(),
-                "timed_out": False,
-            }
-        )
+    try:
+        for proc_index in range(1, args.jobs + 1):
+            run_dir = batch_dir / f"proc_{proc_index:04d}"
+            tmp_dir = run_dir / "tmp"
+            run_dir.mkdir(parents=True, exist_ok=True)
+            tmp_dir.mkdir(parents=True, exist_ok=True)
+            log_path = run_dir / "log.txt"
+            env = base_env.copy()
+            env["TEST_TMPDIR"] = str(tmp_dir)
+            log_fh = log_path.open("w")
+            try:
+                proc = subprocess.Popen(
+                    cmd,
+                    stdout=log_fh,
+                    stderr=subprocess.STDOUT,
+                    env=env,
+                    start_new_session=True,
+                )
+            except BaseException:
+                log_fh.close()
+                raise
+            processes.append(
+                {
+                    "proc": proc,
+                    "proc_index": proc_index,
+                    "run_dir": run_dir,
+                    "log_path": log_path,
+                    "log_fh": log_fh,
+                    "start": time.monotonic(),
+                    "timed_out": False,
+                }
+            )
 
-    remaining = set(range(len(processes)))
-    while remaining:
-        now = time.monotonic()
-        for index in list(remaining):
-            proc = processes[index]["proc"]
-            assert isinstance(proc, subprocess.Popen)
-            if proc.poll() is not None:
-                remaining.remove(index)
-                continue
-            elapsed = now - float(processes[index]["start"])
-            if elapsed > args.timeout:
-                processes[index]["timed_out"] = True
-                terminate_process(proc)
-                remaining.remove(index)
-        if remaining:
-            time.sleep(0.05)
+        remaining = set(range(len(processes)))
+        while remaining:
+            now = time.monotonic()
+            for index in list(remaining):
+                proc = processes[index]["proc"]
+                assert isinstance(proc, subprocess.Popen)
+                if proc.poll() is not None:
+                    processes[index]["end"] = time.monotonic()
+                    remaining.remove(index)
+                    continue
+                elapsed = now - float(processes[index]["start"])
+                if elapsed > args.timeout:
+                    processes[index]["timed_out"] = True
+                    terminate_process(proc)
+                    processes[index]["end"] = time.monotonic()
+                    remaining.remove(index)
+            if remaining:
+                time.sleep(0.05)
+    except BaseException:
+        terminate_processes(processes)
+        close_log_handles(processes)
+        raise
 
     failures: List[Dict[str, object]] = []
     histogram: Dict[str, int] = {}
@@ -216,7 +247,7 @@ def run_batch(
         timed_out = bool(info["timed_out"])
         log_path = Path(info["log_path"])
         run_dir = Path(info["run_dir"])
-        elapsed = time.monotonic() - float(info["start"])
+        elapsed = float(info.get("end", time.monotonic())) - float(info["start"])
         if timed_out or rc != 0:
             keys = extract_failure_keys(log_path)
             for key in keys:
@@ -350,8 +381,6 @@ def main() -> int:
 
     base_env = os.environ.copy()
     base_env.update(env_overrides)
-    if args.coerce_context_switch:
-        base_env["COERCE_CONTEXT_SWITCH"] = "1"
 
     metadata = {
         "cmd": cmd,
@@ -371,23 +400,33 @@ def main() -> int:
 
     all_failures: List[Dict[str, object]] = []
     total_histogram: Dict[str, int] = {}
-    for batch in range(1, args.batches + 1):
-        failures, histogram = run_batch(args, batch, out_dir, cmd, base_env)
-        all_failures.extend(failures)
-        for key, count in histogram.items():
-            total_histogram[key] = total_histogram.get(key, 0) + count
-        if failures:
-            print(
-                f"batch {batch}: failures={len(failures)} "
-                f"total_failures={len(all_failures)}",
-                flush=True,
-            )
-            if args.stop_on_failure:
-                break
+    total_runs = 0
+    interrupted = False
+    try:
+        for batch in range(1, args.batches + 1):
+            failures, histogram = run_batch(args, batch, out_dir, cmd, base_env)
+            total_runs += args.jobs
+            all_failures.extend(failures)
+            for key, count in histogram.items():
+                total_histogram[key] = total_histogram.get(key, 0) + count
+            if failures:
+                print(
+                    f"batch {batch}: failures={len(failures)} "
+                    f"total_failures={len(all_failures)}",
+                    flush=True,
+                )
+                if args.stop_on_failure:
+                    break
+    except KeyboardInterrupt:
+        interrupted = True
+        print(
+            "\nInterrupted; active child process groups were terminated.",
+            file=sys.stderr,
+        )
 
     write_jsonl(out_dir / "failures.jsonl", all_failures)
 
-    print(f"TOTAL_RUNS={args.jobs * (batch if 'batch' in locals() else 0)}")
+    print(f"TOTAL_RUNS={total_runs}")
     print(f"TOTAL_FAILURES={len(all_failures)}")
     print(f"FAILURES_FILE={out_dir / 'failures.jsonl'}")
     if total_histogram:
@@ -397,6 +436,8 @@ def main() -> int:
         )[:20]:
             print(f"  {count} {key}")
 
+    if interrupted:
+        return 130
     return 1 if all_failures else 0
 
 

--- a/tools/gtest_parallel_repro.py
+++ b/tools/gtest_parallel_repro.py
@@ -11,11 +11,11 @@ with many other CPU-heavy test processes, because OS scheduling can delay
 arbitrary worker threads and expose timing assumptions.
 
 `COERCE_CONTEXT_SWITCH=1` is still useful and this runner can build with it, but
-it is not enough for this class of flakes by itself. COERCE_CONTEXT_SWITCH adds
-voluntary sleeps/yields at selected RocksDB hooks, while busy CI shards cause
-involuntary preemption and CPU starvation across the whole process. Running many
-fresh test processes in parallel, optionally pinned to a small CPU set, more
-closely matches that failure mode.
+it is not enough for this class of flaky test by itself.
+COERCE_CONTEXT_SWITCH adds voluntary sleeps/yields at selected RocksDB hooks,
+while busy CI shards cause involuntary preemption and CPU starvation across the
+whole process. Running many fresh test processes in parallel, optionally pinned
+to a small CPU set, more closely matches that failure mode.
 """
 
 import argparse

--- a/tools/gtest_parallel_repro.py
+++ b/tools/gtest_parallel_repro.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+"""Run a gtest binary repeatedly under process-level scheduler pressure.
+
+This tool is for flakes that do not reproduce with a single-process
+`--gtest_repeat` loop. Some RocksDB tests only fail when their process competes
+with many other CPU-heavy test processes, because OS scheduling can delay
+arbitrary worker threads and expose timing assumptions.
+
+`COERCE_CONTEXT_SWITCH=1` is still useful and this runner can build with it, but
+it is not enough for this class of flakes by itself. COERCE_CONTEXT_SWITCH adds
+voluntary sleeps/yields at selected RocksDB hooks, while busy CI shards cause
+involuntary preemption and CPU starvation across the whole process. Running many
+fresh test processes in parallel, optionally pinned to a small CPU set, more
+closely matches that failure mode.
+"""
+
+import argparse
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import signal
+import subprocess
+import sys
+import time
+from typing import Dict, Iterable, List, Optional, Tuple
+
+
+FAILURE_LINE_RE = re.compile(r"^(.+?:\d+): Failure$")
+SANITIZER_RE = re.compile(r"^==\d+==ERROR: ([^:]+): (.+)$")
+ASSERT_RE = re.compile(r"Assertion `([^`]+)' failed\.")
+
+
+def positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be positive")
+    return parsed
+
+
+def parse_env(overrides: Iterable[str]) -> Dict[str, str]:
+    env: Dict[str, str] = {}
+    for override in overrides:
+        key, sep, value = override.partition("=")
+        if not sep or not key:
+            raise argparse.ArgumentTypeError(
+                f"environment override must be KEY=VALUE: {override}"
+            )
+        env[key] = value
+    return env
+
+
+def resolve_cpu_list(cpu_count: Optional[int], cpus: Optional[str]) -> Optional[str]:
+    if cpus:
+        return cpus
+    if cpu_count is None:
+        return None
+    if hasattr(os, "sched_getaffinity"):
+        available = sorted(os.sched_getaffinity(0))
+    else:
+        available = list(range(os.cpu_count() or 1))
+    if cpu_count > len(available):
+        raise ValueError(
+            f"--cpu-count={cpu_count} exceeds available CPU count {len(available)}"
+        )
+    return ",".join(str(cpu) for cpu in available[:cpu_count])
+
+
+def build_if_requested(args: argparse.Namespace, env: Dict[str, str]) -> None:
+    if not args.build:
+        if args.coerce_context_switch:
+            print(
+                "NOTE: --coerce-context-switch only affects compilation. "
+                "Rebuild with --build, or make sure the binary was already "
+                "built with COERCE_CONTEXT_SWITCH=1.",
+                file=sys.stderr,
+            )
+        return
+
+    target = args.make_target or Path(args.binary).name
+    build_env = os.environ.copy()
+    build_env.update(env)
+    if args.coerce_context_switch:
+        build_env["COERCE_CONTEXT_SWITCH"] = "1"
+    if args.clean:
+        print("Cleaning: make clean", flush=True)
+        subprocess.run(["make", "clean"], env=build_env, check=True)
+    cmd = ["make"] + args.make_arg + [target]
+    print("Building:", " ".join(cmd), flush=True)
+    subprocess.run(cmd, env=build_env, check=True)
+
+
+def make_run_command(args: argparse.Namespace, cpu_list: Optional[str]) -> List[str]:
+    cmd = [str(Path(args.binary).resolve())]
+    if args.gtest_filter:
+        cmd.append(f"--gtest_filter={args.gtest_filter}")
+    cmd.extend(args.gtest_arg)
+    if cpu_list:
+        taskset = shutil.which("taskset")
+        if not taskset:
+            raise RuntimeError("--cpus/--cpu-count requires taskset in PATH")
+        cmd = [taskset, "-c", cpu_list] + cmd
+    return cmd
+
+
+def terminate_process(proc: subprocess.Popen) -> None:
+    try:
+        os.killpg(proc.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return
+    except Exception:
+        proc.terminate()
+    try:
+        proc.wait(timeout=2)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except Exception:
+            proc.kill()
+        proc.wait()
+
+
+def extract_failure_keys(log_path: Path) -> List[str]:
+    keys: List[str] = []
+    try:
+        lines = log_path.read_text(errors="replace").splitlines()
+    except OSError:
+        return ["<missing log>"]
+    for line in lines:
+        match = FAILURE_LINE_RE.match(line)
+        if match:
+            keys.append(match.group(1))
+            continue
+        match = SANITIZER_RE.match(line)
+        if match:
+            keys.append(f"{match.group(1)}: {match.group(2)}")
+            continue
+        match = ASSERT_RE.search(line)
+        if match:
+            keys.append(f"assertion failed: {match.group(1)}")
+    return keys or ["<non-gtest failure>"]
+
+
+def write_jsonl(path: Path, records: Iterable[Dict[str, object]]) -> None:
+    with path.open("w") as fh:
+        for record in records:
+            fh.write(json.dumps(record, sort_keys=True) + "\n")
+
+
+def run_batch(
+    args: argparse.Namespace,
+    batch: int,
+    out_dir: Path,
+    cmd: List[str],
+    base_env: Dict[str, str],
+) -> Tuple[List[Dict[str, object]], Dict[str, int]]:
+    processes = []
+    batch_dir = out_dir / f"batch_{batch:04d}"
+    batch_dir.mkdir(parents=True, exist_ok=True)
+
+    for proc_index in range(1, args.jobs + 1):
+        run_dir = batch_dir / f"proc_{proc_index:04d}"
+        tmp_dir = run_dir / "tmp"
+        run_dir.mkdir(parents=True, exist_ok=True)
+        tmp_dir.mkdir(parents=True, exist_ok=True)
+        log_path = run_dir / "log.txt"
+        env = base_env.copy()
+        env["TEST_TMPDIR"] = str(tmp_dir)
+        log_fh = log_path.open("w")
+        proc = subprocess.Popen(
+            cmd,
+            stdout=log_fh,
+            stderr=subprocess.STDOUT,
+            env=env,
+            start_new_session=True,
+        )
+        processes.append(
+            {
+                "proc": proc,
+                "proc_index": proc_index,
+                "run_dir": run_dir,
+                "log_path": log_path,
+                "log_fh": log_fh,
+                "start": time.monotonic(),
+                "timed_out": False,
+            }
+        )
+
+    remaining = set(range(len(processes)))
+    while remaining:
+        now = time.monotonic()
+        for index in list(remaining):
+            proc = processes[index]["proc"]
+            assert isinstance(proc, subprocess.Popen)
+            if proc.poll() is not None:
+                remaining.remove(index)
+                continue
+            elapsed = now - float(processes[index]["start"])
+            if elapsed > args.timeout:
+                processes[index]["timed_out"] = True
+                terminate_process(proc)
+                remaining.remove(index)
+        if remaining:
+            time.sleep(0.05)
+
+    failures: List[Dict[str, object]] = []
+    histogram: Dict[str, int] = {}
+    for info in processes:
+        log_fh = info["log_fh"]
+        assert hasattr(log_fh, "close")
+        log_fh.close()
+        proc = info["proc"]
+        assert isinstance(proc, subprocess.Popen)
+        rc = proc.returncode
+        timed_out = bool(info["timed_out"])
+        log_path = Path(info["log_path"])
+        run_dir = Path(info["run_dir"])
+        elapsed = time.monotonic() - float(info["start"])
+        if timed_out or rc != 0:
+            keys = extract_failure_keys(log_path)
+            for key in keys:
+                histogram[key] = histogram.get(key, 0) + 1
+            failures.append(
+                {
+                    "batch": batch,
+                    "proc": info["proc_index"],
+                    "returncode": "TIMEOUT" if timed_out else rc,
+                    "elapsed_sec": round(elapsed, 3),
+                    "log": str(log_path),
+                    "failure_keys": keys,
+                }
+            )
+        elif not args.keep_success_artifacts:
+            shutil.rmtree(run_dir)
+
+    return failures, histogram
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run many fresh gtest processes concurrently to reproduce flakes "
+            "that depend on CPU contention or process-level scheduling."
+        )
+    )
+    parser.add_argument("--binary", required=True, help="Path to gtest binary")
+    parser.add_argument(
+        "--gtest_filter",
+        "--gtest-filter",
+        dest="gtest_filter",
+        help="gtest filter to pass to the binary",
+    )
+    parser.add_argument(
+        "--gtest_arg",
+        "--gtest-arg",
+        dest="gtest_arg",
+        action="append",
+        default=[],
+        help="Additional gtest argument; repeat for multiple arguments",
+    )
+    parser.add_argument("--jobs", type=positive_int, default=8)
+    parser.add_argument("--batches", type=positive_int, default=1)
+    parser.add_argument("--timeout", type=positive_int, default=60)
+    parser.add_argument(
+        "--out",
+        default=None,
+        help="Output directory. Defaults to /tmp/gtest_parallel_repro_<time>",
+    )
+    parser.add_argument(
+        "--env",
+        action="append",
+        default=[],
+        help="Environment override for build and test process, KEY=VALUE",
+    )
+    parser.add_argument(
+        "--keep-success-artifacts",
+        action="store_true",
+        help="Keep logs and TEST_TMPDIR for successful runs",
+    )
+    parser.add_argument(
+        "--stop-on-failure",
+        action="store_true",
+        help="Stop launching new batches after the first failed batch",
+    )
+    cpu_group = parser.add_mutually_exclusive_group()
+    cpu_group.add_argument(
+        "--cpus",
+        help="CPU list for taskset, for example 0-7 or 0,1,2,3",
+    )
+    cpu_group.add_argument(
+        "--cpu-count",
+        type=positive_int,
+        help="Pin all test processes to the first N CPUs available to this process",
+    )
+    parser.add_argument(
+        "--build",
+        action="store_true",
+        help="Run make before the repro loop",
+    )
+    parser.add_argument(
+        "--clean",
+        action="store_true",
+        help="Run make clean before --build. Use when switching build flags.",
+    )
+    parser.add_argument(
+        "--make-target",
+        help="Target to build. Defaults to basename of --binary",
+    )
+    parser.add_argument(
+        "--make-arg",
+        action="append",
+        default=[],
+        help="Extra make argument; use --make-arg=-j40 for options",
+    )
+    parser.add_argument(
+        "--coerce-context-switch",
+        action="store_true",
+        help=(
+            "When --build is set, build with COERCE_CONTEXT_SWITCH=1. "
+            "The repro loop still uses process-level parallelism because "
+            "COERCE_CONTEXT_SWITCH alone does not simulate CPU starvation."
+        ),
+    )
+    args = parser.parse_args()
+    if args.clean and not args.build:
+        parser.error("--clean requires --build")
+
+    binary = Path(args.binary)
+    if not binary.exists() and not args.build:
+        parser.error(f"--binary does not exist: {args.binary}")
+
+    try:
+        env_overrides = parse_env(args.env)
+    except argparse.ArgumentTypeError as err:
+        parser.error(str(err))
+    build_if_requested(args, env_overrides)
+    if not binary.exists():
+        parser.error(f"--binary does not exist after build: {args.binary}")
+
+    try:
+        cpu_list = resolve_cpu_list(args.cpu_count, args.cpus)
+        cmd = make_run_command(args, cpu_list)
+    except (RuntimeError, ValueError) as err:
+        parser.error(str(err))
+    out_dir = Path(args.out or f"/tmp/gtest_parallel_repro_{int(time.time())}")
+    if out_dir.exists() and any(out_dir.iterdir()):
+        parser.error(f"--out exists and is not empty: {out_dir}")
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    base_env = os.environ.copy()
+    base_env.update(env_overrides)
+    if args.coerce_context_switch:
+        base_env["COERCE_CONTEXT_SWITCH"] = "1"
+
+    metadata = {
+        "cmd": cmd,
+        "jobs": args.jobs,
+        "batches": args.batches,
+        "timeout": args.timeout,
+        "cpu_list": cpu_list,
+        "coerce_context_switch": args.coerce_context_switch,
+        "env_overrides": env_overrides,
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "metadata.json").write_text(json.dumps(metadata, indent=2) + "\n")
+
+    print("Command:", " ".join(cmd))
+    print("Output:", out_dir)
+    print(f"Running {args.batches} batch(es) x {args.jobs} process(es)")
+
+    all_failures: List[Dict[str, object]] = []
+    total_histogram: Dict[str, int] = {}
+    for batch in range(1, args.batches + 1):
+        failures, histogram = run_batch(args, batch, out_dir, cmd, base_env)
+        all_failures.extend(failures)
+        for key, count in histogram.items():
+            total_histogram[key] = total_histogram.get(key, 0) + count
+        if failures:
+            print(
+                f"batch {batch}: failures={len(failures)} "
+                f"total_failures={len(all_failures)}",
+                flush=True,
+            )
+            if args.stop_on_failure:
+                break
+
+    write_jsonl(out_dir / "failures.jsonl", all_failures)
+
+    print(f"TOTAL_RUNS={args.jobs * (batch if 'batch' in locals() else 0)}")
+    print(f"TOTAL_FAILURES={len(all_failures)}")
+    print(f"FAILURES_FILE={out_dir / 'failures.jsonl'}")
+    if total_histogram:
+        print("FAILURE_HISTOGRAM:")
+        for key, count in sorted(
+            total_histogram.items(), key=lambda item: (-item[1], item[0])
+        )[:20]:
+            print(f"  {count} {key}")
+
+    return 1 if all_failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Add `tools/gtest_parallel_repro.py` to reproduce gtest flaky tests that depend on process-level CPU contention and scheduler delays.
- Run many fresh gtest processes concurrently, isolate each process with its own `TEST_TMPDIR`, and optionally pin the workload to a smaller CPU set with `taskset`.
- Record per-run logs, write `failures.jsonl`, summarize failure keys, support stopping on first failed batch, and optionally rebuild with `COERCE_CONTEXT_SWITCH=1`.
- Document when to use the runner in `CLAUDE.md` for CI-style flaky tests that single-process `--gtest_repeat` or coerce mode alone does not reproduce.
- Using the new runner, we found and fixed one flaky test and improved c_test harness
  - Flaky test: EnvPosixTest.ReadAsyncQueueFull simulated a full io_uring submission queue by overwriting the SQE pointer after io_uring_get_sqe() had already consumed a submission slot. That left stale state in the thread-local ring, so later AbortIO tests could process an unexpected completion and crash. Add a skip_io_uring_get_sqe syncpoint before the io_uring_get_sqe() call and use it from the test so the Busy path is exercised without mutating the ring.

## Test Plan

- CI
