### PR TITLE
Add db_stress liveness profile and fix lost flush request

### DIFF
--- a/db/external_sst_file_test.cc
+++ b/db/external_sst_file_test.cc
@@ -2415,6 +2415,253 @@ TEST_F(ExternalSSTFileTest, SstFileWriterNonSharedKeys) {
   ASSERT_OK(DeprecatedAddFile({file_path}));
 }
 
+TEST_F(ExternalSSTFileTest, IngestFlushRequestNotLostBehindQueuedFlush) {
+  // These waits only prevent broken test paths from hanging forever. Keep them
+  // large enough to avoid treating slow CI scheduling as a regression.
+  constexpr uint64_t kHangGuardMicros = 30 * 1000 * 1000;
+  constexpr uint64_t kSetupWaitMicros = kHangGuardMicros;
+  constexpr uint64_t kIngestWaitMicros = kHangGuardMicros;
+  constexpr uint64_t kPollMicros = 1000;
+
+  Options options = CurrentOptions();
+  options.atomic_flush = false;
+  options.disable_auto_compactions = true;
+  options.write_buffer_size = 1024;
+  options.max_write_buffer_number = 8;
+  options.min_write_buffer_number_to_merge = 2;
+  env_->SetBackgroundThreads(1, Env::HIGH);
+  Reopen(options);
+
+  std::string external_file_path;
+  std::vector<std::pair<std::string, std::string>> external_file_data = {
+      {"ingest_key", "ingested_value"}};
+  ASSERT_OK(GenerateOneExternalFile(options, nullptr, external_file_data, -1,
+                                    true /* sort_data */, &external_file_path,
+                                    nullptr /* true_data */));
+
+  auto sleeping_task = std::make_shared<test::SleepingBackgroundTask>();
+  env_->Schedule(&test::SleepingBackgroundTask::DoSleepTask,
+                 sleeping_task.get(), Env::Priority::HIGH);
+  sleeping_task->WaitUntilSleeping();
+
+  std::atomic<int> atomic_flush_scheduled{0};
+  std::atomic<int> get_live_files_done{0};
+  std::atomic<bool> ingest_waiting_for_flush{false};
+  std::atomic<bool> ingest_done{false};
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+  SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::AtomicFlushMemTables:AfterScheduleFlush", [&](void*) {
+        atomic_flush_scheduled.fetch_add(1, std::memory_order_acq_rel);
+      });
+  SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::FlushMemTable:BeforeWaitForBgFlush", [&](void*) {
+        ingest_waiting_for_flush.store(true, std::memory_order_release);
+      });
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  auto wait_until = [&](const std::function<bool()>& predicate,
+                        uint64_t timeout_micros) {
+    for (uint64_t waited_micros = 0; waited_micros < timeout_micros;
+         waited_micros += kPollMicros) {
+      if (predicate()) {
+        return true;
+      }
+      env_->SleepForMicroseconds(kPollMicros);
+    }
+    return predicate();
+  };
+
+  auto wake_sleeping_task = [&] {
+    if (!sleeping_task->WokenUp()) {
+      sleeping_task->WakeUp();
+    }
+    return !sleeping_task->TimedWaitUntilDone(kSetupWaitMicros);
+  };
+
+  auto wait_or_cancel_background_work =
+      [&](const std::function<bool()>& predicate, uint64_t timeout_micros) {
+        if (wait_until(predicate, timeout_micros)) {
+          return true;
+        }
+        dbfull()->CancelAllBackgroundWork(false /* wait */);
+        if (wait_until(predicate, timeout_micros)) {
+          return true;
+        }
+        dbfull()->CancelAllBackgroundWork(true /* wait */);
+        return wait_until(predicate, timeout_micros);
+      };
+
+  ASSERT_OK(Put("atomic_flush_key", "value"));
+
+  Status get_live_files_status[2];
+  std::vector<LiveFileStorageInfo> live_files[2];
+  ThreadGuard get_live_files_thread_1(port::Thread([&] {
+    LiveFilesStorageInfoOptions lfsi_opts;
+    lfsi_opts.wal_size_for_flush = 0;
+    lfsi_opts.atomic_flush = true;
+    get_live_files_status[0] =
+        db_->GetLiveFilesStorageInfo(lfsi_opts, &live_files[0]);
+    get_live_files_done.fetch_add(1, std::memory_order_acq_rel);
+  }));
+  ThreadGuard get_live_files_thread_2(port::Thread([&] {
+    LiveFilesStorageInfoOptions lfsi_opts;
+    lfsi_opts.wal_size_for_flush = 0;
+    lfsi_opts.atomic_flush = true;
+    get_live_files_status[1] =
+        db_->GetLiveFilesStorageInfo(lfsi_opts, &live_files[1]);
+    get_live_files_done.fetch_add(1, std::memory_order_acq_rel);
+  }));
+  ThreadGuard ingest_thread;
+
+  auto get_live_files_finished = [&] {
+    return get_live_files_done.load(std::memory_order_acquire) == 2;
+  };
+  auto ingest_finished = [&] {
+    return ingest_done.load(std::memory_order_acquire);
+  };
+  auto wait_for_get_live_files_finished = [&] {
+    return wait_or_cancel_background_work(get_live_files_finished,
+                                          kSetupWaitMicros);
+  };
+  auto wait_for_ingest_finished = [&](uint64_t timeout_micros) {
+    return wait_or_cancel_background_work(ingest_finished, timeout_micros);
+  };
+  auto join_get_live_files_threads = [&] {
+    if (get_live_files_thread_1.GetThread().joinable()) {
+      get_live_files_thread_1.GetThread().join();
+    }
+    if (get_live_files_thread_2.GetThread().joinable()) {
+      get_live_files_thread_2.GetThread().join();
+    }
+  };
+  auto join_ingest_thread = [&] {
+    if (ingest_thread.GetThread().joinable()) {
+      ingest_thread.GetThread().join();
+    }
+  };
+
+  class CleanupGuard {
+   public:
+    explicit CleanupGuard(const std::function<void()>& cleanup)
+        : cleanup_(cleanup) {}
+
+    ~CleanupGuard() {
+      if (armed_) {
+        cleanup_();
+      }
+    }
+
+    void Disarm() { armed_ = false; }
+
+   private:
+    std::function<void()> cleanup_;
+    bool armed_ = true;
+  };
+
+  CleanupGuard cleanup_guard([&] {
+    wake_sleeping_task();
+    wait_for_get_live_files_finished();
+    if (ingest_thread.GetThread().joinable()) {
+      wait_for_ingest_finished(kSetupWaitMicros);
+    }
+    join_get_live_files_threads();
+    join_ingest_thread();
+  });
+
+  const bool saw_both_atomic_flushes = wait_until(
+      [&] {
+        return atomic_flush_scheduled.load(std::memory_order_acquire) >= 2;
+      },
+      kSetupWaitMicros);
+
+  if (!saw_both_atomic_flushes) {
+    const bool sleeping_task_done = wake_sleeping_task();
+    const bool get_live_files_finished_after_cleanup =
+        wait_for_get_live_files_finished();
+    join_get_live_files_threads();
+    EXPECT_OK(get_live_files_status[0]);
+    EXPECT_OK(get_live_files_status[1]);
+    EXPECT_TRUE(get_live_files_finished_after_cleanup);
+    ASSERT_TRUE(saw_both_atomic_flushes)
+        << "Timed out waiting for both GetLiveFilesStorageInfo calls to "
+           "schedule their flushes. scheduled="
+        << atomic_flush_scheduled.load(std::memory_order_acquire)
+        << " get_live_files_done="
+        << get_live_files_done.load(std::memory_order_acquire)
+        << " sleeping_task_done=" << sleeping_task_done;
+  }
+
+  ASSERT_OK(Put("ingest_key", "memtable_value"));
+
+  Status ingest_status;
+  ingest_thread = ThreadGuard(port::Thread([&] {
+    IngestExternalFileOptions ifo;
+    ingest_status = db_->IngestExternalFile({external_file_path}, ifo);
+    ingest_done.store(true, std::memory_order_release);
+  }));
+
+  const bool saw_ingest_wait = wait_until(
+      [&] {
+        return ingest_waiting_for_flush.load(std::memory_order_acquire) ||
+               ingest_done.load(std::memory_order_acquire);
+      },
+      kSetupWaitMicros);
+  const bool ingest_finished_before_wait =
+      ingest_done.load(std::memory_order_acquire);
+
+  if (!saw_ingest_wait || ingest_finished_before_wait) {
+    const bool sleeping_task_done = wake_sleeping_task();
+    const bool get_live_files_finished_after_cleanup =
+        wait_for_get_live_files_finished();
+    join_get_live_files_threads();
+    const bool ingest_finished_after_cleanup =
+        wait_for_ingest_finished(kSetupWaitMicros);
+    join_ingest_thread();
+    EXPECT_OK(get_live_files_status[0]);
+    EXPECT_OK(get_live_files_status[1]);
+    EXPECT_OK(ingest_status);
+    EXPECT_TRUE(get_live_files_finished_after_cleanup);
+    EXPECT_TRUE(ingest_finished_after_cleanup);
+    ASSERT_TRUE(sleeping_task_done);
+    ASSERT_TRUE(saw_ingest_wait)
+        << "Timed out waiting for IngestExternalFile to enter its flush wait";
+    ASSERT_FALSE(ingest_finished_before_wait)
+        << "IngestExternalFile finished before entering the expected flush "
+           "wait";
+  }
+
+  const bool sleeping_task_done = wake_sleeping_task();
+  join_get_live_files_threads();
+
+  const bool ingest_completed_without_unblock =
+      wait_until(ingest_finished, kIngestWaitMicros);
+
+  if (!ingest_completed_without_unblock) {
+    FlushOptions unblock_flush_options;
+    unblock_flush_options.wait = false;
+    const Status unblock_flush_status = db_->Flush(unblock_flush_options);
+    const bool ingest_finished_after_unblock =
+        wait_for_ingest_finished(kIngestWaitMicros);
+    join_ingest_thread();
+    ASSERT_TRUE(sleeping_task_done);
+    ASSERT_OK(get_live_files_status[0]);
+    ASSERT_OK(get_live_files_status[1]);
+    ASSERT_OK(unblock_flush_status);
+    ASSERT_TRUE(ingest_finished_after_unblock);
+    FAIL() << "IngestExternalFile remained blocked waiting for a flush that "
+              "was deduped behind an older queued flush request";
+  }
+
+  join_ingest_thread();
+  ASSERT_TRUE(sleeping_task_done);
+  ASSERT_OK(get_live_files_status[0]);
+  ASSERT_OK(get_live_files_status[1]);
+  ASSERT_OK(ingest_status);
+  ASSERT_EQ("ingested_value", Get("ingest_key"));
+  cleanup_guard.Disarm();
+}
+
 TEST_F(ExternalSSTFileTest, WithUnorderedWrite) {
   SyncPoint::GetInstance()->DisableProcessing();
   SyncPoint::GetInstance()->LoadDependency(

--- a/db/memtable_list.cc
+++ b/db/memtable_list.cc
@@ -498,7 +498,6 @@ void MemTableList::PickMemtablesToFlush(uint64_t max_memtable_id,
   AutoThreadOperationStageUpdater stage_updater(
       ThreadStatus::STAGE_PICK_MEMTABLES_TO_FLUSH);
   const auto& memlist = current_->memlist_;
-  bool atomic_flush = false;
 
   // Note: every time MemTableList::Add(mem) is called, it adds the new mem
   // at the FRONT of the memlist (memlist.push_front(mem)). Therefore, by
@@ -509,9 +508,6 @@ void MemTableList::PickMemtablesToFlush(uint64_t max_memtable_id,
   auto it = memlist.rbegin();
   for (; it != memlist.rend(); ++it) {
     ReadOnlyMemTable* m = *it;
-    if (!atomic_flush && m->atomic_flush_seqno_ != kMaxSequenceNumber) {
-      atomic_flush = true;
-    }
     if (m->GetID() > max_memtable_id) {
       break;
     }
@@ -542,7 +538,12 @@ void MemTableList::PickMemtablesToFlush(uint64_t max_memtable_id,
     // since they map to the same WAL and have the same NextLogNumber().
     assert(strcmp((*it)->Name(), "WBWIMemTable") != 0);
   }
-  if (!atomic_flush || num_flush_not_started_ == 0) {
+  // The flush request is complete only after every unstarted immutable
+  // memtable has been picked. A request can be older than a newer immutable
+  // memtable; clearing flush_requested_ after a partial or empty pick would
+  // make the queued newer request look unnecessary and leave that memtable
+  // unflushed.
+  if (num_flush_not_started_ == 0) {
     flush_requested_ = false;  // start-flush request is complete
   }
 }

--- a/db/memtable_list.h
+++ b/db/memtable_list.h
@@ -402,11 +402,11 @@ class MemTableList {
   // Returns an estimate of the timestamp of the earliest key.
   uint64_t ApproximateOldestKeyTime() const;
 
-  // Request a flush of all existing memtables to storage.  This will
-  // cause future calls to IsFlushPending() to return true if this list is
-  // non-empty (regardless of the min_write_buffer_number_to_merge
-  // parameter). This flush request will persist until the next time
-  // PickMemtablesToFlush() is called.
+  // Request a flush of all existing memtables to storage. This will cause
+  // future calls to IsFlushPending() to return true if this list is non-empty
+  // (regardless of the min_write_buffer_number_to_merge parameter). This flush
+  // request will persist until PickMemtablesToFlush() has picked all unstarted
+  // memtables.
   void FlushRequested() {
     flush_requested_ = true;
     // If there are some memtables stored in imm() that don't trigger

--- a/db/memtable_list_test.cc
+++ b/db/memtable_list_test.cc
@@ -890,8 +890,8 @@ TEST_F(MemTableListTest, FlushPendingTest) {
   ASSERT_TRUE(to_flush5.empty());
   ASSERT_EQ(1, list.NumNotFlushed());
   ASSERT_TRUE(list.imm_flush_needed.load(std::memory_order_acquire));
-  ASSERT_FALSE(list.IsFlushPending());
-  ASSERT_FALSE(list.HasFlushRequested());
+  ASSERT_TRUE(list.IsFlushPending());
+  ASSERT_TRUE(list.HasFlushRequested());
 
   // Pick tables to flush. The tables to pick must have ID smaller than or
   // equal to 5. Therefore, only tables[5] will be selected.
@@ -918,6 +918,52 @@ TEST_F(MemTableListTest, FlushPendingTest) {
     delete m;
   }
   to_delete.clear();
+}
+
+TEST_F(MemTableListTest, FlushRequestPersistsAfterPartialPick) {
+  SequenceNumber seq = 1;
+
+  auto factory = std::make_shared<SkipListFactory>();
+  options.memtable_factory = factory;
+  ImmutableOptions ioptions(options);
+  InternalKeyComparator cmp(BytewiseComparator());
+  WriteBufferManager wb(options.db_write_buffer_size);
+  MutableCFOptions mutable_cf_options(options);
+  autovector<ReadOnlyMemTable*> to_delete;
+
+  MemTableList list(10 /* min_write_buffer_number_to_merge */,
+                    0 /* max_write_buffer_size_to_maintain */);
+
+  for (uint64_t memtable_id = 0; memtable_id < 2; ++memtable_id) {
+    MemTable* mem = new MemTable(cmp, ioptions, mutable_cf_options, &wb,
+                                 kMaxSequenceNumber, 0 /* column_family_id */);
+    mem->SetID(memtable_id);
+    mem->Ref();
+    ASSERT_OK(mem->Add(++seq, kTypeValue, "key" + std::to_string(memtable_id),
+                       "value", nullptr /* kv_prot_info */));
+    list.Add(mem, &to_delete);
+  }
+
+  list.FlushRequested();
+  ASSERT_TRUE(list.IsFlushPending());
+
+  autovector<ReadOnlyMemTable*> to_flush;
+  list.PickMemtablesToFlush(0 /* max_memtable_id */, &to_flush);
+  ASSERT_EQ(1, to_flush.size());
+  ASSERT_TRUE(list.IsFlushPending());
+  ASSERT_TRUE(list.HasFlushRequested());
+
+  autovector<ReadOnlyMemTable*> to_flush2;
+  list.PickMemtablesToFlush(1 /* max_memtable_id */, &to_flush2);
+  ASSERT_EQ(1, to_flush2.size());
+  ASSERT_FALSE(list.IsFlushPending());
+  ASSERT_FALSE(list.HasFlushRequested());
+
+  list.current()->Unref(&to_delete);
+  ASSERT_EQ(2, to_delete.size());
+  for (ReadOnlyMemTable* m : to_delete) {
+    delete m;
+  }
 }
 
 TEST_F(MemTableListTest, EmptyAtomicFlushTest) {

--- a/db_stress_tool/db_stress_common.cc
+++ b/db_stress_tool/db_stress_common.cc
@@ -11,8 +11,11 @@
 #ifdef GFLAGS
 #include "db_stress_tool/db_stress_common.h"
 
+#include <algorithm>
+#include <chrono>
 #include <cmath>
 #include <condition_variable>
+#include <limits>
 #include <mutex>
 
 #include "db_stress_tool/db_stress_test_base.h"
@@ -168,6 +171,245 @@ int64_t GetOneHotKeyID(double rand_seed, int64_t max_key) {
   int64_t tmp_zipf_seed = zipf * max_key / zipf_sum_size;
   Random64 rand_local(tmp_zipf_seed);
   return rand_local.Next() % max_key;
+}
+
+namespace {
+
+constexpr uint64_t kLongActiveOperationTimeoutMultiplier = 4;
+
+int LivenessSleepMicros() {
+  const std::chrono::microseconds max_sleep_micros(
+      std::numeric_limits<int>::max());
+  const uint64_t max_sleep_seconds =
+      std::chrono::duration_cast<std::chrono::seconds>(max_sleep_micros)
+          .count();
+  const std::chrono::seconds sleep_seconds(
+      std::min(FLAGS_liveness_check_interval_sec, max_sleep_seconds));
+  return static_cast<int>(
+      std::chrono::duration_cast<std::chrono::microseconds>(sleep_seconds)
+          .count());
+}
+
+bool StopBgThreadIfNeeded(SharedState* shared) {
+  port::Mutex* mu = shared->GetMutex();
+  // The liveness watchdog must not block on the shared harness mutex; a stuck
+  // holder is one of the failure modes it needs to report.
+  if (!mu->TryLock()) {
+    return false;
+  }
+
+  if (!shared->ShouldStopBgThread()) {
+    mu->Unlock();
+    return false;
+  }
+
+  shared->IncBgThreadsFinished();
+  if (shared->BgThreadsFinished()) {
+    shared->GetCondVar()->SignalAll();
+  }
+  mu->Unlock();
+  return true;
+}
+
+uint64_t ElapsedMicros(uint64_t now, uint64_t start) {
+  return now >= start ? now - start : 0;
+}
+
+uint64_t ElapsedSeconds(uint64_t now, uint64_t start) {
+  constexpr uint64_t kMicrosPerSecond = 1000 * 1000;
+  return ElapsedMicros(now, start) / kMicrosPerSecond;
+}
+
+uint64_t ActiveOperationTimeoutSeconds(StressOperationType type,
+                                       uint64_t no_progress_timeout_sec) {
+  switch (type) {
+    case StressOperationType::kNone:
+    case StressOperationType::kCount:
+      return 0;
+    case StressOperationType::kCompactFiles:
+    case StressOperationType::kCompactRange:
+    case StressOperationType::kFlush:
+    case StressOperationType::kVerifyDb:
+    case StressOperationType::kVerifyChecksum:
+    case StressOperationType::kVerifyFileChecksums:
+    case StressOperationType::kIngestExternalFile:
+    case StressOperationType::kBackup:
+    case StressOperationType::kCheckpoint:
+    case StressOperationType::kApproximateSize:
+    case StressOperationType::kPauseBackground:
+    case StressOperationType::kGetLiveFiles:
+      return no_progress_timeout_sec * kLongActiveOperationTimeoutMultiplier;
+    case StressOperationType::kReopen:
+    case StressOperationType::kSetOptions:
+    case StressOperationType::kManualWalFlush:
+    case StressOperationType::kLockWal:
+    case StressOperationType::kSyncWal:
+    case StressOperationType::kMetadata:
+    case StressOperationType::kDisableFileDeletions:
+    case StressOperationType::kDisableManualCompaction:
+    case StressOperationType::kAbortResumeCompactions:
+    case StressOperationType::kGetProperty:
+    case StressOperationType::kTableProperties:
+    case StressOperationType::kSnapshot:
+    case StressOperationType::kKeyMayExist:
+    case StressOperationType::kRead:
+    case StressOperationType::kPrefixScan:
+    case StressOperationType::kWrite:
+    case StressOperationType::kDelete:
+    case StressOperationType::kDeleteRange:
+    case StressOperationType::kIterate:
+    case StressOperationType::kCustom:
+      return no_progress_timeout_sec;
+  }
+  return no_progress_timeout_sec;
+}
+
+void PrintLivenessState(SharedState* shared, uint64_t now) {
+  fprintf(stderr, "Finished db_stress operations=%" PRIu64 "\n",
+          shared->GetFinishedOps());
+  fprintf(stderr, "Successful compactions=%" PRIu64 "\n",
+          shared->GetSuccessfulCompactions());
+  fprintf(stderr, "Completed db_stress operation scopes by type:");
+  bool printed_completed_op_count = false;
+  for (size_t i = 1; i < kStressOperationTypeCount; ++i) {
+    const auto type = static_cast<StressOperationType>(i);
+    const uint64_t count = shared->GetCompletedOpsForDiagnostics(type);
+    if (count > 0) {
+      fprintf(stderr, " %s=%" PRIu64, StressOperationTypeName(type), count);
+      printed_completed_op_count = true;
+    }
+  }
+  if (!printed_completed_op_count) {
+    fprintf(stderr, " none");
+  }
+  fprintf(stderr, "\n");
+
+  for (uint32_t tid = 0; tid < shared->GetNumThreads(); ++tid) {
+    const ThreadOperationSnapshot snapshot =
+        shared->GetThreadOperationSnapshot(tid);
+    if (snapshot.type == StressOperationType::kNone ||
+        snapshot.started_micros == 0) {
+      fprintf(stderr, "thread %" PRIu32 " active_op=none\n", tid);
+      continue;
+    }
+
+    fprintf(stderr,
+            "thread %" PRIu32 " active_op=%s active_op_started_micros=%" PRIu64
+            " active_op_elapsed_micros=%" PRIu64 "\n",
+            tid, StressOperationTypeName(snapshot.type),
+            snapshot.started_micros,
+            ElapsedMicros(now, snapshot.started_micros));
+  }
+}
+
+bool HasStuckWriteOperation(SharedState* shared, uint64_t now,
+                            uint64_t timeout_sec) {
+  for (uint32_t tid = 0; tid < shared->GetNumThreads(); ++tid) {
+    const ThreadOperationSnapshot snapshot =
+        shared->GetThreadOperationSnapshot(tid);
+    const uint64_t elapsed_micros = ElapsedMicros(now, snapshot.started_micros);
+    const uint64_t elapsed_seconds =
+        ElapsedSeconds(now, snapshot.started_micros);
+    if (snapshot.type == StressOperationType::kWrite &&
+        snapshot.started_micros != 0 && elapsed_seconds >= timeout_sec) {
+      fprintf(stderr,
+              "Liveness watchdog detected a stuck write operation on thread "
+              "%" PRIu32 " for %" PRIu64
+              " seconds. active_op_elapsed_micros=%" PRIu64
+              " active_op_timeout_seconds=%" PRIu64 "\n",
+              tid, elapsed_seconds, elapsed_micros, timeout_sec);
+      return true;
+    }
+  }
+  return false;
+}
+
+bool HasTimedOutNonWriteOperation(SharedState* shared, uint64_t now,
+                                  uint64_t no_progress_timeout_sec) {
+  for (uint32_t tid = 0; tid < shared->GetNumThreads(); ++tid) {
+    const ThreadOperationSnapshot snapshot =
+        shared->GetThreadOperationSnapshot(tid);
+    if (snapshot.type == StressOperationType::kWrite ||
+        snapshot.started_micros == 0) {
+      continue;
+    }
+
+    const uint64_t timeout_sec =
+        ActiveOperationTimeoutSeconds(snapshot.type, no_progress_timeout_sec);
+    if (timeout_sec != 0 &&
+        ElapsedSeconds(now, snapshot.started_micros) >= timeout_sec) {
+      fprintf(stderr,
+              "Liveness watchdog detected a timed out active operation on "
+              "thread %" PRIu32
+              ". active_op=%s active_op_elapsed_micros=%" PRIu64
+              " active_op_timeout_seconds=%" PRIu64 "\n",
+              tid, StressOperationTypeName(snapshot.type),
+              ElapsedMicros(now, snapshot.started_micros), timeout_sec);
+      return true;
+    }
+  }
+  return false;
+}
+
+}  // namespace
+
+void LivenessWatchdogThread(void* v) {
+  assert(FLAGS_liveness_check_interval_sec > 0);
+  assert(FLAGS_liveness_no_progress_timeout_sec > 0);
+
+  auto* thread = static_cast<ThreadState*>(v);
+  SharedState* shared = thread->shared;
+
+  uint64_t last_finished_ops = shared->GetFinishedOps();
+  uint64_t last_progress_time_micros = raw_env->NowMicros();
+  const uint64_t no_progress_timeout_sec =
+      FLAGS_liveness_no_progress_timeout_sec;
+
+  while (true) {
+    if (StopBgThreadIfNeeded(shared)) {
+      return;
+    }
+
+    const bool started = shared->OperationStarted();
+    const bool all_operated = shared->OperationFinished();
+
+    const uint64_t now = raw_env->NowMicros();
+    if (!started || all_operated) {
+      last_finished_ops = shared->GetFinishedOps();
+      last_progress_time_micros = now;
+      raw_env->SleepForMicroseconds(LivenessSleepMicros());
+      continue;
+    }
+
+    const uint64_t finished_ops = shared->GetFinishedOps();
+    if (HasStuckWriteOperation(shared, now, no_progress_timeout_sec)) {
+      PrintLivenessState(shared, now);
+      fflush(stderr);
+      shared->TerminateWithoutMutex();
+    } else if (HasTimedOutNonWriteOperation(shared, now,
+                                            no_progress_timeout_sec)) {
+      PrintLivenessState(shared, now);
+      fflush(stderr);
+      shared->TerminateWithoutMutex();
+    } else if (finished_ops != last_finished_ops) {
+      last_finished_ops = finished_ops;
+      last_progress_time_micros = now;
+    } else if (now >= last_progress_time_micros &&
+               ElapsedSeconds(now, last_progress_time_micros) >=
+                   no_progress_timeout_sec) {
+      fprintf(stderr,
+              "Liveness watchdog detected no completed db_stress operations "
+              "for %" PRIu64 " seconds. finished_ops=%" PRIu64 "\n",
+              FLAGS_liveness_no_progress_timeout_sec, finished_ops);
+      PrintLivenessState(shared, now);
+      fflush(stderr);
+      shared->TerminateWithoutMutex();
+    } else if (now < last_progress_time_micros) {
+      last_progress_time_micros = now;
+    }
+
+    raw_env->SleepForMicroseconds(LivenessSleepMicros());
+  }
 }
 
 void PoolSizeChangeThread(void* v) {

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -827,6 +827,8 @@ void PoolSizeChangeThread(void* v);
 
 void DbVerificationThread(void* v);
 
+void LivenessWatchdogThread(void* v);
+
 void RemoteCompactionWorkerThread(void* v);
 
 void CompressedCacheSetCapacityThread(void* v);

--- a/db_stress_tool/db_stress_driver.cc
+++ b/db_stress_tool/db_stress_driver.cc
@@ -92,6 +92,13 @@ bool RunStressTestImpl(SharedState* shared) {
 
   shared->SetThreads(n);
 
+  const bool liveness_watchdog_enabled =
+      FLAGS_liveness_check_interval_sec > 0 &&
+      FLAGS_liveness_no_progress_timeout_sec > 0;
+  if (liveness_watchdog_enabled) {
+    shared->IncBgThreads();
+  }
+
   if (FLAGS_continuous_verification_interval > 0) {
     shared->IncBgThreads();
   }
@@ -126,6 +133,11 @@ bool RunStressTestImpl(SharedState* shared) {
   ThreadState continuous_verification_thread(0, shared);
   if (FLAGS_continuous_verification_interval > 0) {
     raw_env->StartThread(DbVerificationThread, &continuous_verification_thread);
+  }
+
+  ThreadState liveness_watchdog_thread(0, shared);
+  if (liveness_watchdog_enabled) {
+    raw_env->StartThread(LivenessWatchdogThread, &liveness_watchdog_thread);
   }
 
   // Spawn at most one CompressedCacheSetCapacityThread globally. The cache
@@ -262,7 +274,7 @@ bool RunStressTestImpl(SharedState* shared) {
   }
 
   if (FLAGS_compaction_thread_pool_adjust_interval > 0 ||
-      FLAGS_continuous_verification_interval > 0 ||
+      FLAGS_continuous_verification_interval > 0 || liveness_watchdog_enabled ||
       FLAGS_compressed_secondary_cache_size > 0 ||
       FLAGS_compressed_secondary_cache_ratio > 0.0 ||
       remote_compaction_worker_thread_count > 0) {

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -156,6 +156,16 @@ DEFINE_bool(verbose, false, "Verbose");
 DEFINE_bool(progress_reports, true,
             "If true, db_stress will report number of finished operations");
 
+DEFINE_uint64(
+    liveness_check_interval_sec, 0,
+    "If non-zero, check periodically whether db_stress operations are making "
+    "progress. Requires --liveness_no_progress_timeout_sec to be non-zero.");
+
+DEFINE_uint64(
+    liveness_no_progress_timeout_sec, 0,
+    "If non-zero with --liveness_check_interval_sec, terminate db_stress when "
+    "no operation completes for this many seconds during the operation phase.");
+
 DEFINE_uint64(db_write_buffer_size,
               ROCKSDB_NAMESPACE::Options().db_write_buffer_size,
               "Number of bytes to buffer in all memtables before compacting");

--- a/db_stress_tool/db_stress_listener.h
+++ b/db_stress_tool/db_stress_listener.h
@@ -231,6 +231,10 @@ class DbStressListener : public EventListener {
       precommitted_jobs_.erase(it);
     }
 
+    if (ci.status.ok() && !ci.aborted) {
+      shared_->IncSuccessfulCompactions();
+    }
+
     // pretending doing some work here
     RandomSleep();
   }

--- a/db_stress_tool/db_stress_shared_state.cc
+++ b/db_stress_tool/db_stress_shared_state.cc
@@ -12,12 +12,14 @@
 #include "db_stress_tool/db_stress_shared_state.h"
 
 #include "db_stress_tool/db_stress_test_base.h"
+#include "rocksdb/env.h"
 
 namespace ROCKSDB_NAMESPACE {
 thread_local bool SharedState::ignore_read_error;
 
-SharedState::SharedState(Env* /*env*/, StressTest* stress_test)
+SharedState::SharedState(Env* env, StressTest* stress_test)
     : cv_(&mu_),
+      env_(env != nullptr ? env : Env::Default()),
       seed_(static_cast<uint32_t>(FLAGS_seed)),
       max_key_(FLAGS_max_key),
       log2_keys_per_lock_(static_cast<uint32_t>(FLAGS_log2_keys_per_lock)),
@@ -28,16 +30,26 @@ SharedState::SharedState(Env* /*env*/, StressTest* stress_test)
       num_done_(0),
       start_(false),
       start_verify_(false),
+      operation_started_(false),
+      operation_finished_(false),
       num_bg_threads_(0),
       should_stop_bg_thread_(false),
       bg_thread_finished_(0),
       stress_test_(stress_test),
+      finished_ops_(0),
+      successful_compactions_(0),
+      successful_compactions_at_last_compaction_abort_(0),
+      abort_resume_compactions_running_(false),
       verification_failure_(false),
       should_stop_test_(false),
       no_overwrite_ids_(GenerateNoOverwriteIds()),
       expected_state_manager_(nullptr),
       printing_verification_results_(false),
-      start_timestamp_(Env::Default()->NowNanos()) {
+      start_timestamp_(env_->NowNanos()) {
+  for (auto& completed_ops : completed_ops_by_type_) {
+    completed_ops.store(0, std::memory_order_relaxed);
+  }
+
   Status status;
   // TODO: We should introduce a way to explicitly disable verification
   // during shutdown. When that is disabled and FLAGS_expected_values_dir
@@ -105,6 +117,21 @@ SharedState::SharedState(Env* /*env*/, StressTest* stress_test)
     SyncPoint::GetInstance()->EnableProcessing();
 #endif        // NDEBUG
   }
+}
+
+bool SharedState::BeginOperation(uint32_t tid, StressOperationType type) {
+  assert(tid < static_cast<uint32_t>(num_threads_));
+  ThreadOperationState& state = thread_operation_states_[tid];
+  const uint32_t active_type =
+      state.active_type.load(std::memory_order_acquire);
+  assert(active_type == static_cast<uint32_t>(StressOperationType::kNone));
+  if (active_type != static_cast<uint32_t>(StressOperationType::kNone)) {
+    return false;
+  }
+  state.started_micros.store(env_->NowMicros(), std::memory_order_relaxed);
+  state.active_type.store(static_cast<uint32_t>(type),
+                          std::memory_order_release);
+  return true;
 }
 
 bool SharedState::ShouldVerifyAtBeginning() const {

--- a/db_stress_tool/db_stress_shared_state.h
+++ b/db_stress_tool/db_stress_shared_state.h
@@ -10,6 +10,11 @@
 #ifdef GFLAGS
 #pragma once
 
+#include <array>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+
 #include "db_stress_tool/db_stress_stat.h"
 #include "db_stress_tool/expected_state.h"
 // SyncPoint is not supported in Released Windows Mode.
@@ -30,6 +35,8 @@ DECLARE_int32(compaction_thread_pool_adjust_interval);
 DECLARE_int32(continuous_verification_interval);
 DECLARE_bool(error_recovery_with_no_fault_injection);
 DECLARE_bool(sync_fault_injection);
+DECLARE_uint64(liveness_check_interval_sec);
+DECLARE_uint64(liveness_no_progress_timeout_sec);
 DECLARE_int32(range_deletion_width);
 DECLARE_bool(disable_wal);
 DECLARE_int32(manual_wal_flush_one_in);
@@ -50,6 +57,134 @@ DECLARE_bool(enable_compaction_filter);
 
 namespace ROCKSDB_NAMESPACE {
 class StressTest;
+
+enum class StressOperationType : uint32_t {
+  kNone = 0,
+  kReopen,
+  kSetOptions,
+  kVerifyDb,
+  kManualWalFlush,
+  kLockWal,
+  kSyncWal,
+  kCompactFiles,
+  kCompactRange,
+  kFlush,
+  kGetLiveFiles,
+  kMetadata,
+  kPauseBackground,
+  kDisableFileDeletions,
+  kDisableManualCompaction,
+  kAbortResumeCompactions,
+  kVerifyChecksum,
+  kVerifyFileChecksums,
+  kGetProperty,
+  kTableProperties,
+  kIngestExternalFile,
+  kBackup,
+  kCheckpoint,
+  kApproximateSize,
+  kSnapshot,
+  kKeyMayExist,
+  kRead,
+  kPrefixScan,
+  kWrite,
+  kDelete,
+  kDeleteRange,
+  kIterate,
+  kCustom,
+  kCount,
+};
+
+static constexpr size_t kStressOperationTypeCount =
+    static_cast<size_t>(StressOperationType::kCount);
+
+inline const char* StressOperationTypeName(StressOperationType type) {
+  switch (type) {
+    case StressOperationType::kNone:
+      return "none";
+    case StressOperationType::kReopen:
+      return "reopen";
+    case StressOperationType::kSetOptions:
+      return "set_options";
+    case StressOperationType::kVerifyDb:
+      return "verify_db";
+    case StressOperationType::kManualWalFlush:
+      return "manual_wal_flush";
+    case StressOperationType::kLockWal:
+      return "lock_wal";
+    case StressOperationType::kSyncWal:
+      return "sync_wal";
+    case StressOperationType::kCompactFiles:
+      return "compact_files";
+    case StressOperationType::kCompactRange:
+      return "compact_range";
+    case StressOperationType::kFlush:
+      return "flush";
+    case StressOperationType::kGetLiveFiles:
+      return "get_live_files";
+    case StressOperationType::kMetadata:
+      return "metadata";
+    case StressOperationType::kPauseBackground:
+      return "pause_background";
+    case StressOperationType::kDisableFileDeletions:
+      return "disable_file_deletions";
+    case StressOperationType::kDisableManualCompaction:
+      return "disable_manual_compaction";
+    case StressOperationType::kAbortResumeCompactions:
+      return "abort_resume_compactions";
+    case StressOperationType::kVerifyChecksum:
+      return "verify_checksum";
+    case StressOperationType::kVerifyFileChecksums:
+      return "verify_file_checksums";
+    case StressOperationType::kGetProperty:
+      return "get_property";
+    case StressOperationType::kTableProperties:
+      return "table_properties";
+    case StressOperationType::kIngestExternalFile:
+      return "ingest_external_file";
+    case StressOperationType::kBackup:
+      return "backup";
+    case StressOperationType::kCheckpoint:
+      return "checkpoint";
+    case StressOperationType::kApproximateSize:
+      return "approximate_size";
+    case StressOperationType::kSnapshot:
+      return "snapshot";
+    case StressOperationType::kKeyMayExist:
+      return "key_may_exist";
+    case StressOperationType::kRead:
+      return "read";
+    case StressOperationType::kPrefixScan:
+      return "prefix_scan";
+    case StressOperationType::kWrite:
+      return "write";
+    case StressOperationType::kDelete:
+      return "delete";
+    case StressOperationType::kDeleteRange:
+      return "delete_range";
+    case StressOperationType::kIterate:
+      return "iterate";
+    case StressOperationType::kCustom:
+      return "custom";
+    case StressOperationType::kCount:
+      break;
+  }
+  return "unknown";
+}
+
+struct ThreadOperationSnapshot {
+  StressOperationType type;
+  uint64_t started_micros;
+};
+
+struct ThreadOperationState {
+  ThreadOperationState()
+      : active_type(static_cast<uint32_t>(StressOperationType::kNone)),
+        started_micros(0) {}
+
+  std::atomic<uint32_t> active_type;
+  std::atomic<uint64_t> started_micros;
+};
 
 struct RemoteCompactionQueueItem {
   std::string job_id;
@@ -100,11 +235,19 @@ class SharedState {
 
   uint32_t GetNumThreads() const { return num_threads_; }
 
-  void SetThreads(int num_threads) { num_threads_ = num_threads; }
+  void SetThreads(int num_threads) {
+    num_threads_ = num_threads;
+    thread_operation_states_.reset(new ThreadOperationState[num_threads]);
+  }
 
   void IncInitialized() { num_initialized_++; }
 
-  void IncOperated() { num_populated_++; }
+  void IncOperated() {
+    num_populated_++;
+    if (num_populated_ >= num_threads_) {
+      operation_finished_.store(true, std::memory_order_release);
+    }
+  }
 
   void IncDone() { num_done_++; }
 
@@ -118,7 +261,10 @@ class SharedState {
 
   bool AllVotedReopen() { return (vote_reopen_ == 0); }
 
-  void SetStart() { start_ = true; }
+  void SetStart() {
+    start_ = true;
+    operation_started_.store(true, std::memory_order_release);
+  }
 
   void SetStartVerify() { start_verify_ = true; }
 
@@ -126,9 +272,116 @@ class SharedState {
 
   bool VerifyStarted() const { return start_verify_; }
 
+  bool OperationStarted() const {
+    return operation_started_.load(std::memory_order_acquire);
+  }
+
+  bool OperationFinished() const {
+    return operation_finished_.load(std::memory_order_acquire);
+  }
+
   void SetVerificationFailure() { verification_failure_.store(true); }
 
   bool HasVerificationFailedYet() const { return verification_failure_.load(); }
+
+  void IncFinishedOps() {
+    finished_ops_.fetch_add(1, std::memory_order_relaxed);
+  }
+
+  uint64_t GetFinishedOps() const {
+    return finished_ops_.load(std::memory_order_relaxed);
+  }
+
+  void IncCompletedOpForDiagnostics(StressOperationType type) {
+    const size_t index = static_cast<size_t>(type);
+    if (index == static_cast<size_t>(StressOperationType::kNone) ||
+        index >= kStressOperationTypeCount) {
+      return;
+    }
+    completed_ops_by_type_[index].fetch_add(1, std::memory_order_relaxed);
+  }
+
+  uint64_t GetCompletedOpsForDiagnostics(StressOperationType type) const {
+    const size_t index = static_cast<size_t>(type);
+    if (index >= kStressOperationTypeCount) {
+      return 0;
+    }
+    return completed_ops_by_type_[index].load(std::memory_order_relaxed);
+  }
+
+  void IncSuccessfulCompactions() {
+    successful_compactions_.fetch_add(1, std::memory_order_relaxed);
+  }
+
+  uint64_t GetSuccessfulCompactions() const {
+    return successful_compactions_.load(std::memory_order_relaxed);
+  }
+
+  bool TryBeginAbortAndResumeCompactions(uint64_t* successful_compactions) {
+    bool expected = false;
+    if (!abort_resume_compactions_running_.compare_exchange_strong(
+            expected, true, std::memory_order_acq_rel,
+            std::memory_order_relaxed)) {
+      return false;
+    }
+
+    *successful_compactions = GetSuccessfulCompactions();
+    if (*successful_compactions <=
+        successful_compactions_at_last_compaction_abort_.load(
+            std::memory_order_relaxed)) {
+      EndAbortAndResumeCompactions();
+      return false;
+    }
+    return true;
+  }
+
+  void MarkAbortAndResumeCompactions(uint64_t successful_compactions) {
+    successful_compactions_at_last_compaction_abort_.store(
+        successful_compactions, std::memory_order_relaxed);
+  }
+
+  void EndAbortAndResumeCompactions() {
+    abort_resume_compactions_running_.store(false, std::memory_order_release);
+  }
+
+  bool BeginOperation(uint32_t tid, StressOperationType type);
+
+  bool EndOperation(uint32_t tid, StressOperationType type) {
+    assert(tid < static_cast<uint32_t>(num_threads_));
+    ThreadOperationState& state = thread_operation_states_[tid];
+    const uint32_t active_type =
+        state.active_type.load(std::memory_order_acquire);
+    assert(active_type == static_cast<uint32_t>(type));
+    if (active_type != static_cast<uint32_t>(type)) {
+      return false;
+    }
+    state.active_type.store(static_cast<uint32_t>(StressOperationType::kNone),
+                            std::memory_order_release);
+    state.started_micros.store(0, std::memory_order_relaxed);
+    return true;
+  }
+
+  void ClearOperation(uint32_t tid) {
+    assert(tid < static_cast<uint32_t>(num_threads_));
+    ThreadOperationState& state = thread_operation_states_[tid];
+    state.active_type.store(static_cast<uint32_t>(StressOperationType::kNone),
+                            std::memory_order_release);
+    state.started_micros.store(0, std::memory_order_relaxed);
+  }
+
+  ThreadOperationSnapshot GetThreadOperationSnapshot(uint32_t tid) const {
+    assert(tid < static_cast<uint32_t>(num_threads_));
+    const ThreadOperationState& state = thread_operation_states_[tid];
+    // This is a diagnostic snapshot, not one atomic value. A concurrent
+    // begin/end/clear can produce a torn pair; timeout checks must treat
+    // `kNone` and `started_micros == 0` as no active operation.
+    const auto type = static_cast<StressOperationType>(
+        state.active_type.load(std::memory_order_acquire));
+    if (type == StressOperationType::kNone) {
+      return {StressOperationType::kNone, 0};
+    }
+    return {type, state.started_micros.load(std::memory_order_relaxed)};
+  }
 
   void SetShouldStopTest() { should_stop_test_.store(true); }
 
@@ -352,10 +605,16 @@ class SharedState {
 
   uint64_t GetStartTimestamp() const { return start_timestamp_; }
 
-  void SafeTerminate() {
+  [[noreturn]] void SafeTerminate() {
     // Grab mutex so that we don't call terminate while another thread is
-    // attempting to print a stack trace due to the first one
+    // attempting to print a stack trace due to the first one.
     MutexLock l(&mu_);
+    std::terminate();
+  }
+
+  [[noreturn]] void TerminateWithoutMutex() {
+    // The liveness watchdog must still terminate when the no-progress failure
+    // mode itself is holding the shared harness mutex.
     std::terminate();
   }
 
@@ -394,6 +653,7 @@ class SharedState {
 
   port::Mutex mu_;
   port::CondVar cv_;
+  Env* env_;
   port::Mutex persist_seqno_mu_;
   const uint32_t seed_;
   const int64_t max_key_;
@@ -405,12 +665,21 @@ class SharedState {
   long num_done_;
   bool start_;
   bool start_verify_;
+  std::atomic<bool> operation_started_;
+  std::atomic<bool> operation_finished_;
   int num_bg_threads_;
   bool should_stop_bg_thread_;
   int bg_thread_finished_;
   StressTest* stress_test_;
+  std::atomic<uint64_t> finished_ops_;
+  std::array<std::atomic<uint64_t>, kStressOperationTypeCount>
+      completed_ops_by_type_;
+  std::atomic<uint64_t> successful_compactions_;
+  std::atomic<uint64_t> successful_compactions_at_last_compaction_abort_;
+  std::atomic<bool> abort_resume_compactions_running_;
   std::atomic<bool> verification_failure_;
   std::atomic<bool> should_stop_test_;
+  std::unique_ptr<ThreadOperationState[]> thread_operation_states_;
 
   // Queue for the remote compaction.
   port::Mutex remote_compaction_queue_mu_;
@@ -459,6 +728,49 @@ struct ThreadState {
 
   ThreadState(uint32_t index, SharedState* _shared)
       : tid(index), rand(1000 + index + _shared->GetSeed()), shared(_shared) {}
+
+  bool LivenessTrackingEnabled() const {
+    return FLAGS_liveness_check_interval_sec > 0 &&
+           FLAGS_liveness_no_progress_timeout_sec > 0;
+  }
+
+  bool BeginOperation(StressOperationType type) {
+    if (LivenessTrackingEnabled()) {
+      return shared->BeginOperation(tid, type);
+    }
+    return false;
+  }
+
+  bool EndOperation(StressOperationType type) {
+    if (LivenessTrackingEnabled()) {
+      return shared->EndOperation(tid, type);
+    }
+    return false;
+  }
+
+  void ClearOperation() {
+    if (LivenessTrackingEnabled()) {
+      shared->ClearOperation(tid);
+    }
+  }
+
+  void CompletedOpForDiagnostics(StressOperationType type) {
+    if (LivenessTrackingEnabled()) {
+      shared->IncCompletedOpForDiagnostics(type);
+    }
+  }
+
+  void RecordSingleOpFinished() {
+    stats.FinishedSingleOp();
+    if (LivenessTrackingEnabled()) {
+      shared->IncFinishedOps();
+    }
+  }
+
+  void FinishedSingleOp() {
+    RecordSingleOpFinished();
+    ClearOperation();
+  }
 };
 }  // namespace ROCKSDB_NAMESPACE
 #endif  // GFLAGS

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -59,6 +59,44 @@ namespace ROCKSDB_NAMESPACE {
 
 namespace {
 
+constexpr int kMaxAbortResumeCompactionsSleepMicros = 3 * 1000 * 1000;
+
+class ScopedThreadOperation {
+ public:
+  enum class FinishAction { kPop, kFinishSingleOp };
+
+  ScopedThreadOperation(ThreadState* thread, StressOperationType type,
+                        FinishAction finish_action = FinishAction::kPop)
+      : thread_(thread),
+        type_(type),
+        finish_action_(finish_action),
+        tracking_(false) {
+    tracking_ = thread_->BeginOperation(type);
+  }
+
+  ~ScopedThreadOperation() {
+    if (tracking_) {
+      thread_->CompletedOpForDiagnostics(type_);
+    }
+    switch (finish_action_) {
+      case FinishAction::kPop:
+        break;
+      case FinishAction::kFinishSingleOp:
+        thread_->RecordSingleOpFinished();
+        break;
+    }
+    if (tracking_) {
+      thread_->EndOperation(type_);
+    }
+  }
+
+ private:
+  ThreadState* thread_;
+  StressOperationType type_;
+  FinishAction finish_action_;
+  bool tracking_;
+};
+
 class StressReadScopedBlockBufferProvider
     : public ReadScopedBlockBufferProvider {
  public:
@@ -2101,7 +2139,9 @@ void StressTest::OperateDb(ThreadState* thread) {
       break;
     }
     if (open_cnt != 0) {
-      thread->stats.FinishedSingleOp();
+      ScopedThreadOperation op(
+          thread, StressOperationType::kReopen,
+          ScopedThreadOperation::FinishAction::kFinishSingleOp);
       MutexLock l(thread->shared->GetMutex());
       while (!thread->snapshot_queue.empty()) {
         db_->ReleaseSnapshot(thread->snapshot_queue.front().second.snapshot);
@@ -2162,9 +2202,9 @@ void StressTest::OperateDb(ThreadState* thread) {
       if (thread->shared->HasVerificationFailedYet()) {
         break;
       }
-
       // Change Options
       if (thread->rand.OneInOpt(FLAGS_set_options_one_in)) {
+        ScopedThreadOperation op(thread, StressOperationType::kSetOptions);
         Status s = SetOptions(thread);
         ProcessStatus(shared, "SetOptions", s);
       }
@@ -2175,6 +2215,7 @@ void StressTest::OperateDb(ThreadState* thread) {
 
       if (thread->tid == 0 && FLAGS_verify_db_one_in > 0 &&
           thread->rand.OneIn(FLAGS_verify_db_one_in)) {
+        ScopedThreadOperation op(thread, StressOperationType::kVerifyDb);
         //  Temporarily disable error injection for verification
         if (db_fault_injection_fs_) {
           db_fault_injection_fs_->DisableAllThreadLocalErrorInjection();
@@ -2194,6 +2235,7 @@ void StressTest::OperateDb(ThreadState* thread) {
       MaybeClearOneColumnFamily(thread);
 
       if (thread->rand.OneInOpt(FLAGS_manual_wal_flush_one_in)) {
+        ScopedThreadOperation op(thread, StressOperationType::kManualWalFlush);
         bool sync = thread->rand.OneIn(2) ? true : false;
         Status s = db_->FlushWAL(sync);
         if (!s.ok() && !IsErrorInjectedAndRetryable(s) &&
@@ -2204,6 +2246,7 @@ void StressTest::OperateDb(ThreadState* thread) {
       }
 
       if (thread->rand.OneInOpt(FLAGS_lock_wal_one_in)) {
+        ScopedThreadOperation op(thread, StressOperationType::kLockWal);
         Status s = db_->LockWAL();
         if (!s.ok() && !IsErrorInjectedAndRetryable(s)) {
           fprintf(stderr, "LockWAL() failed: %s\n", s.ToString().c_str());
@@ -2271,6 +2314,7 @@ void StressTest::OperateDb(ThreadState* thread) {
       }
 
       if (thread->rand.OneInOpt(FLAGS_sync_wal_one_in)) {
+        ScopedThreadOperation op(thread, StressOperationType::kSyncWal);
         Status s = db_->SyncWAL();
         if (!s.ok() && !s.IsNotSupported() && !IsErrorInjectedAndRetryable(s)) {
           fprintf(stderr, "SyncWAL() failed: %s\n", s.ToString().c_str());
@@ -2281,6 +2325,7 @@ void StressTest::OperateDb(ThreadState* thread) {
       ColumnFamilyHandle* column_family = column_families_[rand_column_family];
 
       if (thread->rand.OneInOpt(FLAGS_compact_files_one_in)) {
+        ScopedThreadOperation op(thread, StressOperationType::kCompactFiles);
         TestCompactFiles(thread, column_family);
       }
 
@@ -2289,6 +2334,7 @@ void StressTest::OperateDb(ThreadState* thread) {
       Slice key = keystr;
 
       if (thread->rand.OneInOpt(FLAGS_compact_range_one_in)) {
+        ScopedThreadOperation op(thread, StressOperationType::kCompactRange);
         TestCompactRange(thread, rand_key, key, column_family);
         if (thread->shared->HasVerificationFailedYet()) {
           break;
@@ -2303,10 +2349,12 @@ void StressTest::OperateDb(ThreadState* thread) {
           GenerateColumnFamilies(FLAGS_column_families, rand_column_family);
 
       if (thread->rand.OneInOpt(FLAGS_flush_one_in)) {
+        ScopedThreadOperation op(thread, StressOperationType::kFlush);
         TestFlush(thread, rand_column_families);
       }
 
       if (thread->rand.OneInOpt(FLAGS_get_live_files_apis_one_in)) {
+        ScopedThreadOperation op(thread, StressOperationType::kGetLiveFiles);
         Status s_1 = TestGetLiveFiles();
         ProcessStatus(shared, "GetLiveFiles", s_1);
         Status s_2 = TestGetLiveFilesMetaData();
@@ -2320,16 +2368,19 @@ void StressTest::OperateDb(ThreadState* thread) {
       }
 
       if (thread->rand.OneInOpt(FLAGS_get_all_column_family_metadata_one_in)) {
+        ScopedThreadOperation op(thread, StressOperationType::kMetadata);
         Status status = TestGetAllColumnFamilyMetaData();
         ProcessStatus(shared, "GetAllColumnFamilyMetaData", status);
       }
 
       if (thread->rand.OneInOpt(FLAGS_get_sorted_wal_files_one_in)) {
+        ScopedThreadOperation op(thread, StressOperationType::kMetadata);
         Status status = TestGetSortedWalFiles();
         ProcessStatus(shared, "GetSortedWalFiles", status);
       }
 
       if (thread->rand.OneInOpt(FLAGS_get_current_wal_file_one_in)) {
+        ScopedThreadOperation op(thread, StressOperationType::kMetadata);
         Status status = TestGetCurrentWalFile();
         ProcessStatus(shared, "GetCurrentWalFile", status);
       }
@@ -2340,16 +2391,21 @@ void StressTest::OperateDb(ThreadState* thread) {
       }
 
       if (thread->rand.OneInOpt(FLAGS_pause_background_one_in)) {
+        ScopedThreadOperation op(thread, StressOperationType::kPauseBackground);
         Status status = TestPauseBackground(thread);
         ProcessStatus(shared, "Pause/ContinueBackgroundWork", status);
       }
 
       if (thread->rand.OneInOpt(FLAGS_disable_file_deletions_one_in)) {
+        ScopedThreadOperation op(thread,
+                                 StressOperationType::kDisableFileDeletions);
         Status status = TestDisableFileDeletions(thread);
         ProcessStatus(shared, "TestDisableFileDeletions", status);
       }
 
       if (thread->rand.OneInOpt(FLAGS_disable_manual_compaction_one_in)) {
+        ScopedThreadOperation op(thread,
+                                 StressOperationType::kDisableManualCompaction);
         Status status = TestDisableManualCompaction(thread);
         ProcessStatus(shared, "TestDisableManualCompaction", status);
       }
@@ -2365,6 +2421,7 @@ void StressTest::OperateDb(ThreadState* thread) {
       }
 
       if (thread->rand.OneInOpt(FLAGS_verify_checksum_one_in)) {
+        ScopedThreadOperation op(thread, StressOperationType::kVerifyChecksum);
         ThreadStatusUtil::SetEnableTracking(FLAGS_enable_thread_tracking);
         ThreadStatusUtil::SetThreadOperation(
             ThreadStatus::OperationType::OP_VERIFY_DB_CHECKSUM);
@@ -2374,6 +2431,8 @@ void StressTest::OperateDb(ThreadState* thread) {
       }
 
       if (thread->rand.OneInOpt(FLAGS_verify_file_checksums_one_in)) {
+        ScopedThreadOperation op(thread,
+                                 StressOperationType::kVerifyFileChecksums);
         ThreadStatusUtil::SetEnableTracking(FLAGS_enable_thread_tracking);
         ThreadStatusUtil::SetThreadOperation(
             ThreadStatus::OperationType::OP_VERIFY_FILE_CHECKSUMS);
@@ -2383,6 +2442,7 @@ void StressTest::OperateDb(ThreadState* thread) {
       }
 
       if (thread->rand.OneInOpt(FLAGS_get_property_one_in)) {
+        ScopedThreadOperation op(thread, StressOperationType::kGetProperty);
         // TestGetProperty doesn't return status for us to tell whether it has
         // failed due to injected error. So we disable fault injection to avoid
         // false positive
@@ -2398,6 +2458,7 @@ void StressTest::OperateDb(ThreadState* thread) {
       }
 
       if (thread->rand.OneInOpt(FLAGS_get_properties_of_all_tables_one_in)) {
+        ScopedThreadOperation op(thread, StressOperationType::kTableProperties);
         Status status = TestGetPropertiesOfAllTables();
         ProcessStatus(shared, "TestGetPropertiesOfAllTables", status);
       }
@@ -2405,10 +2466,13 @@ void StressTest::OperateDb(ThreadState* thread) {
       std::vector<int64_t> rand_keys = GenerateKeys(rand_key);
 
       if (thread->rand.OneInOpt(FLAGS_ingest_external_file_one_in)) {
+        ScopedThreadOperation op(thread,
+                                 StressOperationType::kIngestExternalFile);
         TestIngestExternalFile(thread, rand_column_families, rand_keys);
       }
 
       if (thread->rand.OneInOpt(FLAGS_backup_one_in)) {
+        ScopedThreadOperation op(thread, StressOperationType::kBackup);
         // Beyond a certain DB size threshold, this test becomes heavier than
         // it's worth.
         uint64_t total_size = 0;
@@ -2435,20 +2499,24 @@ void StressTest::OperateDb(ThreadState* thread) {
       }
 
       if (thread->rand.OneInOpt(FLAGS_checkpoint_one_in)) {
+        ScopedThreadOperation op(thread, StressOperationType::kCheckpoint);
         Status s = TestCheckpoint(thread, rand_column_families, rand_keys);
         ProcessStatus(shared, "Checkpoint", s);
       }
 
       if (thread->rand.OneInOpt(FLAGS_approximate_size_one_in)) {
+        ScopedThreadOperation op(thread, StressOperationType::kApproximateSize);
         Status s =
             TestApproximateSize(thread, i, rand_column_families, rand_keys);
         ProcessStatus(shared, "ApproximateSize", s);
       }
       if (thread->rand.OneInOpt(FLAGS_acquire_snapshot_one_in)) {
+        ScopedThreadOperation op(thread, StressOperationType::kSnapshot);
         TestAcquireSnapshot(thread, rand_column_family, keystr, i);
       }
 
       /*always*/ {
+        ScopedThreadOperation op(thread, StressOperationType::kSnapshot);
         Status s = MaybeReleaseSnapshots(thread, i);
         ProcessStatus(shared, "Snapshot", s);
       }
@@ -2463,6 +2531,7 @@ void StressTest::OperateDb(ThreadState* thread) {
       }
 
       if (thread->rand.OneInOpt(FLAGS_key_may_exist_one_in)) {
+        ScopedThreadOperation op(thread, StressOperationType::kKeyMayExist);
         TestKeyMayExist(thread, read_opts, rand_column_families, rand_keys);
       }
       // Historical expected-state restore replays exactly
@@ -2473,12 +2542,12 @@ void StressTest::OperateDb(ThreadState* thread) {
       bool disable_fault_injection_during_user_write =
           db_fault_injection_fs_ && MightHaveUnsyncedDataLoss();
       int prob_op = thread->rand.Uniform(100);
-      // Reset this in case we pick something other than a read op. We don't
-      // want to use a stale value when deciding at the beginning of the loop
-      // whether to vote to reopen
       if (prob_op >= 0 && prob_op < static_cast<int>(FLAGS_readpercent)) {
         assert(0 <= prob_op);
         // OPERATION read
+        ScopedThreadOperation op(
+            thread, StressOperationType::kRead,
+            ScopedThreadOperation::FinishAction::kFinishSingleOp);
         ThreadStatusUtil::SetEnableTracking(FLAGS_enable_thread_tracking);
         if (FLAGS_use_multi_get_entity) {
           constexpr uint64_t max_batch_size = 64;
@@ -2522,6 +2591,9 @@ void StressTest::OperateDb(ThreadState* thread) {
       } else if (prob_op < prefix_bound) {
         assert(static_cast<int>(FLAGS_readpercent) <= prob_op);
         // OPERATION prefix scan
+        ScopedThreadOperation op(
+            thread, StressOperationType::kPrefixScan,
+            ScopedThreadOperation::FinishAction::kFinishSingleOp);
         // keys are 8 bytes long, prefix size is FLAGS_prefix_size. There are
         // (8 - FLAGS_prefix_size) bytes besides the prefix. So there will
         // be 2 ^ ((8 - FLAGS_prefix_size) * 8) possible keys with the same
@@ -2530,6 +2602,9 @@ void StressTest::OperateDb(ThreadState* thread) {
       } else if (prob_op < write_bound) {
         assert(prefix_bound <= prob_op);
         // OPERATION write
+        ScopedThreadOperation op(
+            thread, StressOperationType::kWrite,
+            ScopedThreadOperation::FinishAction::kFinishSingleOp);
         if (disable_fault_injection_during_user_write) {
           db_fault_injection_fs_->DisableAllThreadLocalErrorInjection();
         }
@@ -2541,6 +2616,9 @@ void StressTest::OperateDb(ThreadState* thread) {
       } else if (prob_op < del_bound) {
         assert(write_bound <= prob_op);
         // OPERATION delete
+        ScopedThreadOperation op(
+            thread, StressOperationType::kDelete,
+            ScopedThreadOperation::FinishAction::kFinishSingleOp);
         if (disable_fault_injection_during_user_write) {
           db_fault_injection_fs_->DisableAllThreadLocalErrorInjection();
         }
@@ -2551,6 +2629,9 @@ void StressTest::OperateDb(ThreadState* thread) {
       } else if (prob_op < delrange_bound) {
         assert(del_bound <= prob_op);
         // OPERATION delete range
+        ScopedThreadOperation op(
+            thread, StressOperationType::kDeleteRange,
+            ScopedThreadOperation::FinishAction::kFinishSingleOp);
         if (disable_fault_injection_during_user_write) {
           db_fault_injection_fs_->DisableAllThreadLocalErrorInjection();
         }
@@ -2561,6 +2642,9 @@ void StressTest::OperateDb(ThreadState* thread) {
       } else if (prob_op < iterate_bound) {
         assert(delrange_bound <= prob_op);
         // OPERATION iterate
+        ScopedThreadOperation op(
+            thread, StressOperationType::kIterate,
+            ScopedThreadOperation::FinishAction::kFinishSingleOp);
         if (FLAGS_use_multiscan) {
           int num_seeks = static_cast<int>(
               std::min(static_cast<uint64_t>(thread->rand.Uniform(64)),
@@ -2609,9 +2693,11 @@ void StressTest::OperateDb(ThreadState* thread) {
         }
       } else {
         assert(iterate_bound <= prob_op);
+        ScopedThreadOperation op(
+            thread, StressOperationType::kCustom,
+            ScopedThreadOperation::FinishAction::kFinishSingleOp);
         TestCustomOperations(thread, rand_column_families);
       }
-      thread->stats.FinishedSingleOp();
     }
 
 #ifndef NDEBUG
@@ -4572,17 +4658,79 @@ Status StressTest::TestDisableManualCompaction(ThreadState* thread) {
   return Status::OK();
 }
 
+bool StressTest::ShouldAbortAndResumeCompactions() const {
+  uint64_t is_write_stopped = 0;
+  if (db_->GetIntProperty(DB::Properties::kIsWriteStopped, &is_write_stopped) &&
+      is_write_stopped != 0) {
+    return false;
+  }
+
+  uint64_t delayed_write_rate = 0;
+  if (db_->GetIntProperty(DB::Properties::kActualDelayedWriteRate,
+                          &delayed_write_rate) &&
+      delayed_write_rate != 0) {
+    return false;
+  }
+
+  uint64_t running_compactions = 0;
+  const bool has_running_compactions =
+      db_->GetIntProperty(DB::Properties::kNumRunningCompactions,
+                          &running_compactions) &&
+      running_compactions != 0;
+
+  uint64_t pending_compactions = 0;
+  uint64_t pending_compaction_bytes = 0;
+  for (auto* column_family : column_families_) {
+    uint64_t cf_pending_compactions = 0;
+    if (db_->GetIntProperty(column_family, DB::Properties::kCompactionPending,
+                            &cf_pending_compactions)) {
+      pending_compactions += cf_pending_compactions;
+    }
+
+    uint64_t cf_pending_compaction_bytes = 0;
+    if (db_->GetIntProperty(column_family,
+                            DB::Properties::kEstimatePendingCompactionBytes,
+                            &cf_pending_compaction_bytes)) {
+      pending_compaction_bytes += cf_pending_compaction_bytes;
+    }
+  }
+
+  return has_running_compactions || pending_compactions != 0 ||
+         pending_compaction_bytes != 0;
+}
+
 Status StressTest::TestAbortAndResumeCompactions(ThreadState* thread) {
+  uint64_t successful_compactions = 0;
+  if (!thread->shared->TryBeginAbortAndResumeCompactions(
+          &successful_compactions)) {
+    return Status::OK();
+  }
+
+  if (!ShouldAbortAndResumeCompactions()) {
+    thread->shared->EndAbortAndResumeCompactions();
+    return Status::OK();
+  }
+
+  // Each abort must be paid for by at least one completed non-aborted
+  // compaction, and concurrent abort/resume sections are serialized. This keeps
+  // aggressive random sampling from starving compactions and causing unrelated
+  // write stalls.
+  thread->shared->MarkAbortAndResumeCompactions(successful_compactions);
+  ScopedThreadOperation op(thread,
+                           StressOperationType::kAbortResumeCompactions);
+
   // Abort all running compactions and prevent new ones from starting
   db_->AbortAllCompactions();
   // Sleep to allow other threads to attempt operations while aborted
-  // Uses same sleep pattern as TestPauseBackground and
-  // TestDisableManualCompaction
+  // Uses the same short-skewed pattern as TestPauseBackground, capped to avoid
+  // creating long compaction starvation windows.
   int pwr2_micros =
       std::min(thread->rand.Uniform(25), thread->rand.Uniform(25));
-  clock_->SleepForMicroseconds(1 << pwr2_micros);
+  clock_->SleepForMicroseconds(
+      std::min(1 << pwr2_micros, kMaxAbortResumeCompactionsSleepMicros));
   // Resume compactions
   db_->ResumeAllCompactions();
+  thread->shared->EndAbortAndResumeCompactions();
   return Status::OK();
 }
 

--- a/db_stress_tool/db_stress_test_base.h
+++ b/db_stress_tool/db_stress_test_base.h
@@ -478,6 +478,8 @@ class StressTest {
 
   Status TestDisableManualCompaction(ThreadState* thread);
 
+  bool ShouldAbortAndResumeCompactions() const;
+
   Status TestAbortAndResumeCompactions(ThreadState* thread);
 
   Status TestAbortAndResumeCfCompactions(ThreadState* thread);

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -43,6 +43,7 @@ _TSAN_OPTIONS_ENV_VAR = "TSAN_OPTIONS"
 _TSAN_SUPPRESSIONS_FILE = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "tsan_suppressions.txt")
 )
+DEFAULT_LIVENESS_TIMEOUT_SEC = 3600
 _FAULT_INJECTION_LOG_DIR_NAME = "fault_injection_logs"
 
 
@@ -120,20 +121,25 @@ early_argument_parsing_before_main()
 
 # params overwrite priority:
 #   for default:
-#       default_params < {blackbox,whitebox}_default_params < args
+#       default_params < {blackbox,whitebox,liveness}_default_params < args
 #   for simple:
-#       default_params < {blackbox,whitebox}_default_params <
+#       default_params < {blackbox,whitebox,liveness}_default_params <
 #       simple_default_params <
 #       {blackbox,whitebox}_simple_default_params < args
 #   for cf_consistency:
-#       default_params < {blackbox,whitebox}_default_params <
+#       default_params < {blackbox,whitebox,liveness}_default_params <
 #       cf_consistency_params < args
 #   for txn:
-#       default_params < {blackbox,whitebox}_default_params < txn_params < args
+#       default_params < {blackbox,whitebox,liveness}_default_params <
+#       txn_params < args
 #   for ts:
-#       default_params < {blackbox,whitebox}_default_params < ts_params < args
+#       default_params < {blackbox,whitebox,liveness}_default_params <
+#       ts_params < args
 #   for multiops_txn:
-#       default_params < {blackbox,whitebox}_default_params < multiops_txn_params < args
+#       default_params < {blackbox,whitebox,liveness}_default_params <
+#       multiops_txn_params < args
+# Liveness mode reapplies liveness_fault_injection_params after args so the
+# base liveness profile cannot accidentally turn fault injection back on.
 
 
 default_params = {
@@ -254,7 +260,7 @@ default_params = {
     "pause_background_one_in": lambda: random.choice([10000, 1000000]),
     "disable_file_deletions_one_in": lambda: random.choice([10000, 1000000]),
     "disable_manual_compaction_one_in": lambda: random.choice([10000, 1000000]),
-    "abort_and_resume_compactions_one_in": lambda: random.choice([10000, 1000000]),
+    "abort_and_resume_compactions_one_in": lambda: random.choice([0, 1000, 10000]),
     "abort_and_resume_cf_compactions_one_in": lambda: random.choice([10000, 1000000]),
     "prefix_size": lambda: random.choice([-1, 1, 5, 7, 8]),
     "prefixpercent": 5,
@@ -662,6 +668,43 @@ whitebox_default_params = {
     "reopen": 20,
 }
 
+# Liveness mode inherits the normal randomized stress-test matrix and mixed
+# workload by default. The C++ watchdog tracks the active operation and
+# per-operation completion counts, so liveness does not need to force an
+# all-write workload to keep the failure signal understandable. Keep fault
+# injection disabled, though: injected read/open/write/sync/cache faults can
+# legitimately put the DB into background-error recovery or a no-progress write
+# stall for longer than the liveness timeout. Those cases are covered by other
+# test modes.
+# The Python wrapper owns duration, so keep db_stress's operation budget high
+# enough for long liveness runs. The C++ abort/resume path is additionally
+# gated on completed compaction progress and backs off when write stall pressure
+# is already visible.
+liveness_fault_injection_params = {
+    "error_recovery_with_no_fault_injection": 0,
+    "exclude_wal_from_write_fault_injection": 0,
+    "metadata_read_fault_one_in": 0,
+    "metadata_write_fault_one_in": 0,
+    "open_metadata_read_fault_one_in": 0,
+    "open_metadata_write_fault_one_in": 0,
+    "open_read_fault_one_in": 0,
+    "open_write_fault_one_in": 0,
+    "read_fault_one_in": 0,
+    "secondary_cache_fault_one_in": 0,
+    "sync_fault_injection": 0,
+    "write_fault_one_in": 0,
+}
+
+liveness_default_params = {
+    "duration": DEFAULT_LIVENESS_TIMEOUT_SEC,
+    "enable_thread_tracking": 1,
+    "liveness_check_interval_sec": 1,
+    "liveness_no_progress_timeout_sec": 300,
+    "ops_per_thread": 100000000,
+    "progress_reports": 1,
+}
+liveness_default_params.update(liveness_fault_injection_params)
+
 simple_default_params = {
     "allow_concurrent_memtable_write": lambda: random.randint(0, 1),
     "column_families": 1,
@@ -990,7 +1033,7 @@ def finalize_and_sanitize(src_params):
     # remote --env_uri / --fs_uri is in use.
     if is_remote_db:
         dest_params["enable_blob_direct_write"] = 0
-    
+
     # Not to accidentally ignore errors on local dbs
     # (e.g. errors on IO Uring would be categorized as IO error)
     if not is_remote_db:
@@ -1630,6 +1673,8 @@ def gen_cmd_params(args):
         params.update(blackbox_default_params)
     if args.test_type == "whitebox":
         params.update(whitebox_default_params)
+    if args.test_type == "liveness":
+        params.update(liveness_default_params)
     if args.simple:
         params.update(simple_default_params)
         if args.test_type == "blackbox":
@@ -1658,6 +1703,7 @@ def gen_cmd_params(args):
     if (
         not args.test_best_efforts_recovery
         and not args.test_tiered_storage
+        and args.test_type != "liveness"
         and params.get("test_secondary", 0) == 0
         and random.choice([0] * 9 + [1]) == 1
     ):
@@ -1683,6 +1729,8 @@ def gen_cmd_params(args):
     for k, v in vars(args).items():
         if v is not None:
             params[k] = v
+    if args.test_type == "liveness":
+        params.update(liveness_fault_injection_params)
     return params
 
 
@@ -1982,7 +2030,7 @@ def diagnostic_paths(finalized_params):
     ]
 
 
-def execute_cmd(cmd, timeout=None, timeout_pstack=False):
+def execute_cmd(cmd, timeout=None, timeout_pstack=False, expected_to_timeout=True):
     child = subprocess.Popen(
         cmd, stderr=subprocess.PIPE, stdout=subprocess.PIPE, env=stress_cmd_env()
     )
@@ -1995,11 +2043,20 @@ def execute_cmd(cmd, timeout=None, timeout_pstack=False):
     try:
         outs, errs = child.communicate(timeout=timeout)
         hit_timeout = False
-        print("WARNING: db_stress ended before kill: exitcode=%d\n" % child.returncode)
+        if expected_to_timeout:
+            print(
+                "WARNING: db_stress ended before kill: exitcode=%d\n"
+                % child.returncode
+            )
+        else:
+            print("db_stress ended: exitcode=%d\n" % child.returncode)
     except subprocess.TimeoutExpired:
         hit_timeout = True
         if timeout_pstack:
-            os.system("pstack %d" % pid)
+            try:
+                subprocess.call(["pstack", str(pid)], env=stress_cmd_env())
+            except OSError as exc:
+                print("WARNING: failed to run pstack for pid %d: %s\n" % (pid, exc))
         child.terminate()  # SIGTERM -- triggers TerminationHandler
         try:
             outs, errs = child.communicate(timeout=3)
@@ -2134,6 +2191,60 @@ def print_fault_injection_log(pid):
                 "WARNING: failed to decode fault injection log %s: %s\n"
                 % (raw_log, exc)
             )
+
+
+def liveness_timeout(cmd_params):
+    duration = cmd_params.get("duration", 0)
+    if duration is None or duration <= 0:
+        return DEFAULT_LIVENESS_TIMEOUT_SEC
+    return duration
+
+
+def liveness_main(args, unknown_args):
+    cmd_params = gen_cmd_params(args)
+    db_parent_dir = get_db_parent_dir("liveness")
+    num_dbs = cmd_params.get("num_dbs", 1)
+
+    if not cmd_params.get("db"):
+        cmd_params["db"] = db_parent_dir
+
+    apply_random_seed_per_iteration()
+    wrapper_timeout = liveness_timeout(cmd_params)
+
+    print(
+        "Running liveness-test with \n"
+        + "liveness_check_interval_sec="
+        + str(cmd_params["liveness_check_interval_sec"])
+        + "\n"
+        + "liveness_no_progress_timeout_sec="
+        + str(cmd_params["liveness_no_progress_timeout_sec"])
+        + "\n"
+        + "wrapper-duration="
+        + str(wrapper_timeout)
+        + "\n"
+    )
+
+    cmd, finalized_params = gen_cmd(dict(list(cmd_params.items())), unknown_args)
+    hit_timeout, retcode, outs, errs, pid = execute_cmd(
+        cmd, wrapper_timeout, False, False
+    )
+
+    print_fault_injection_log(pid)
+    outs, errs = strip_expected_sigterm_stderr(outs, errs, hit_timeout)
+    print_run_output_and_exit_on_error(args, finalized_params, outs, errs)
+
+    if hit_timeout:
+        if retcode == -9:
+            print("TEST FAILED. db_stress ignored SIGTERM on wrapper timeout\n")
+            sys.exit(1)
+        print("db_stress reached liveness wrapper duration\n")
+        cleanup_after_success(cmd_params["db"], num_dbs)
+        return
+    if retcode != 0:
+        print("TEST FAILED. db_stress exited with code %d\n" % retcode)
+        sys.exit(1)
+
+    cleanup_after_success(cmd_params["db"], num_dbs)
 
 
 # This script runs and kills db_stress multiple times. It checks consistency
@@ -2398,7 +2509,7 @@ def main():
         description="This script runs and kills \
         db_stress multiple times"
     )
-    parser.add_argument("test_type", choices=["blackbox", "whitebox"])
+    parser.add_argument("test_type", choices=["blackbox", "whitebox", "liveness"])
     parser.add_argument("--simple", action="store_true")
     parser.add_argument("--cf_consistency", action="store_true")
     parser.add_argument("--txn", action="store_true")
@@ -2415,6 +2526,7 @@ def main():
         list(default_params.items())
         + list(blackbox_default_params.items())
         + list(whitebox_default_params.items())
+        + list(liveness_default_params.items())
         + list(simple_default_params.items())
         + list(blackbox_simple_default_params.items())
         + list(whitebox_simple_default_params.items())
@@ -2456,6 +2568,8 @@ def main():
         blackbox_crash_main(args, unknown_args)
     if args.test_type == "whitebox":
         whitebox_crash_main(args, unknown_args)
+    if args.test_type == "liveness":
+        liveness_main(args, unknown_args)
     # Delete the expected values base dir if test passes.
     # Per-DB subdirectories (db_0, db_1, ...) live under the base,
     # so rmtree of the parent cleans everything.

--- a/tools/db_crashtest_test.py
+++ b/tools/db_crashtest_test.py
@@ -12,6 +12,7 @@ import sys
 import tempfile
 import unittest
 from contextlib import redirect_stdout
+from types import SimpleNamespace
 
 
 _DB_CRASHTEST_PATH = os.path.join(os.path.dirname(__file__), "db_crashtest.py")
@@ -88,6 +89,22 @@ class DBCrashTestTest(unittest.TestCase):
         if overrides:
             params.update(overrides)
         return params
+
+    def build_mode_args(self, test_type="liveness", **overrides):
+        args = {
+            "test_type": test_type,
+            "simple": False,
+            "cf_consistency": False,
+            "txn": False,
+            "optimistic_txn": False,
+            "test_best_efforts_recovery": False,
+            "enable_ts": False,
+            "test_multiops_txn": False,
+            "test_tiered_storage": False,
+            "print_stderr_separately": False,
+        }
+        args.update(overrides)
+        return SimpleNamespace(**args)
 
     def test_stress_cmd_env_defaults_tsan_suppressions(self):
         os.environ.pop(_TSAN_OPTIONS_ENV_VAR, None)
@@ -422,6 +439,148 @@ class DBCrashTestTest(unittest.TestCase):
             f"{remote_output_dir} subtree=5B local=5B local_files=1 local_dirs=0",
             diagnostics,
         )
+
+    def test_liveness_params_keep_mixed_workload_and_enable_watchdog(self):
+        db_crashtest = self.load_db_crashtest()
+
+        # Liveness mode should inherit the normal mixed workload. The C++
+        # watchdog tracks per-thread active operation type, so Python does not
+        # need to force an all-write workload to keep the signal readable.
+        params = db_crashtest.gen_cmd_params(self.build_mode_args())
+        params["db"] = self.test_tmpdir
+        finalized_params = db_crashtest.finalize_and_sanitize(params)
+
+        self.assertEqual(db_crashtest.DEFAULT_LIVENESS_TIMEOUT_SEC, params["duration"])
+        self.assertEqual(1, params["liveness_check_interval_sec"])
+        self.assertEqual(300, params["liveness_no_progress_timeout_sec"])
+        self.assertEqual(1, params["enable_thread_tracking"])
+        self.assertEqual(1, params["progress_reports"])
+        self.assertEqual(100000000, params["ops_per_thread"])
+        for fault_param in [
+            "error_recovery_with_no_fault_injection",
+            "exclude_wal_from_write_fault_injection",
+            "metadata_read_fault_one_in",
+            "metadata_write_fault_one_in",
+            "open_metadata_read_fault_one_in",
+            "open_metadata_write_fault_one_in",
+            "open_read_fault_one_in",
+            "open_write_fault_one_in",
+            "read_fault_one_in",
+            "secondary_cache_fault_one_in",
+            "sync_fault_injection",
+            "write_fault_one_in",
+        ]:
+            self.assertEqual(0, finalized_params[fault_param])
+        self.assertIn(
+            finalized_params["abort_and_resume_compactions_one_in"],
+            [0, 1000, 10000],
+        )
+        self.assertEqual(db_crashtest.default_params["readpercent"], params["readpercent"])
+        self.assertEqual(
+            db_crashtest.default_params["prefixpercent"], params["prefixpercent"]
+        )
+        self.assertEqual(
+            db_crashtest.default_params["writepercent"], params["writepercent"]
+        )
+        self.assertGreaterEqual(params["writepercent"], 20)
+        self.assertEqual(db_crashtest.default_params["delpercent"], params["delpercent"])
+        self.assertEqual(
+            db_crashtest.default_params["delrangepercent"], params["delrangepercent"]
+        )
+        self.assertEqual(db_crashtest.default_params["iterpercent"], params["iterpercent"])
+
+        params = db_crashtest.gen_cmd_params(
+            self.build_mode_args(read_fault_one_in=32, sync_fault_injection=1)
+        )
+        self.assertEqual(0, params["read_fault_one_in"])
+        self.assertEqual(0, params["sync_fault_injection"])
+
+    def test_liveness_command_passes_watchdog_flags_not_wrapper_duration(self):
+        db_crashtest = self.load_db_crashtest()
+        check_interval_sec = 2
+        no_progress_timeout_sec = 7
+        wrapper_duration_sec = 17
+        args = self.build_mode_args(
+            duration=wrapper_duration_sec,
+            liveness_check_interval_sec=check_interval_sec,
+            liveness_no_progress_timeout_sec=no_progress_timeout_sec,
+        )
+        params = db_crashtest.gen_cmd_params(args)
+        params["db"] = self.test_tmpdir
+
+        # The Python wrapper owns duration; db_stress only needs the watchdog
+        # interval and no-progress timeout flags.
+        cmd, _ = db_crashtest.gen_cmd(params, [])
+        cmd_flags = {}
+        for arg in cmd:
+            if arg.startswith("--") and "=" in arg:
+                key, value = arg[2:].split("=", 1)
+                cmd_flags[key] = value
+
+        self.assertEqual(
+            str(check_interval_sec), cmd_flags["liveness_check_interval_sec"]
+        )
+        self.assertEqual(
+            str(no_progress_timeout_sec),
+            cmd_flags["liveness_no_progress_timeout_sec"],
+        )
+        self.assertNotIn("duration", cmd_flags)
+
+    def test_liveness_timeout_zero_uses_default_duration(self):
+        db_crashtest = self.load_db_crashtest()
+
+        # A zero/None duration still needs a finite wrapper runtime.
+        self.assertEqual(
+            db_crashtest.DEFAULT_LIVENESS_TIMEOUT_SEC,
+            db_crashtest.liveness_timeout({"duration": 0}),
+        )
+        self.assertEqual(
+            db_crashtest.DEFAULT_LIVENESS_TIMEOUT_SEC,
+            db_crashtest.liveness_timeout({"duration": None}),
+        )
+        self.assertEqual(30, db_crashtest.liveness_timeout({"duration": 30}))
+
+    def test_liveness_wrapper_timeout_is_successful_end_of_run(self):
+        db_crashtest = self.load_db_crashtest()
+        execute_calls = []
+        cleanups = []
+
+        def fake_execute_cmd(cmd, timeout=None, timeout_pstack=False, expected_to_timeout=True):
+            execute_calls.append((cmd, timeout, timeout_pstack, expected_to_timeout))
+            return (
+                True,
+                -15,
+                "Received signal 15 (Terminated)\n",
+                "",
+                123,
+            )
+
+        db_crashtest.execute_cmd = fake_execute_cmd
+        db_crashtest.print_fault_injection_log = lambda pid: None
+        db_crashtest.cleanup_after_success = lambda db_arg, num_dbs=1: cleanups.append(
+            (db_arg, num_dbs)
+        )
+
+        db_crashtest.liveness_main(self.build_mode_args(duration=17), [])
+
+        self.assertEqual(1, len(execute_calls))
+        self.assertEqual(17, execute_calls[0][1])
+        self.assertFalse(execute_calls[0][2])
+        self.assertFalse(execute_calls[0][3])
+        self.assertEqual(1, len(cleanups))
+
+    def test_liveness_can_target_transaction_lock_manager(self):
+        db_crashtest = self.load_db_crashtest()
+
+        # Transaction mode remains composable with liveness mode, which lets
+        # the same watchdog cover point-lock-manager deadlocks/livelocks.
+        params = db_crashtest.gen_cmd_params(self.build_mode_args(txn=True))
+
+        self.assertEqual(1, params["use_txn"])
+        self.assertEqual(0, params["use_optimistic_txn"])
+        self.assertIn("use_per_key_point_lock_mgr", params)
+        self.assertEqual(0, params.get("kill_random_test", 0))
+        self.assertGreater(params["liveness_no_progress_timeout_sec"], 0)
 
     # Goal: verify db_crashtest decodes the headerless streaming binary fault
     # injection log format used on crash paths while keeping stdout concise.


### PR DESCRIPTION
## Summary

  Add a db_crashtest liveness mode that runs db_stress with a watchdog for
  foreground progress. The profile disables fault injection and uses longer runs
  so failures are more likely to represent real forward-progress bugs instead of
  expected injected I/O errors. The watchdog tracks completed operations, active
  operation type/start time, and per-operation completion counts to distinguish
  stuck writes from long admin operations.

  Bug: The new mode exposed a latent flush scheduling bug. A flush request can be queued
  with an effective max memtable id, then a newer immutable memtable can be added
  before the background flush picks work. PickMemtablesToFlush() could pick only
  the older memtables and still clear flush_requested_. A later queued flush for
  the newer memtable would then be skipped because the column family no longer
  looked flush-pending, leaving the immutable memtable permanently unflushed. In
  stress this surfaced as IngestExternalFile() waiting in WaitForFlushMemTables(),
  with writes eventually blocked behind the same unflushed memtable.

  Fix: Keep flush_requested_ set until all unstarted immutable memtables have been
  picked. Add a direct MemTableList regression for the partial-pick case and a
  DB-level regression covering the ingest/get-live-files ordering that reproduced
  the lost request.

## Testing

- CI
- Local liveness mode 32 full 20-minute runs passed, 0 failures
