### PR TITLE
Fix range lock manager crash with reverse comparator

### DIFF
--- a/unreleased_history/bug_fixes/range_lock_reverse_comparator.md
+++ b/unreleased_history/bug_fixes/range_lock_reverse_comparator.md
@@ -1,0 +1,1 @@
+Fixed a bug where the range lock manager would crash with an assertion failure when using a reverse comparator column family.

--- a/utilities/transactions/lock/range/range_locking_test.cc
+++ b/utilities/transactions/lock/range/range_locking_test.cc
@@ -102,6 +102,40 @@ TEST_F(RangeLockingTest, BasicRangeLocking) {
   delete txn1;
 }
 
+// CompareDbtEndpoints must honor ReverseBytewiseComparator direction
+// in length-disparity case.
+TEST_F(RangeLockingTest, RangeLockWithReverseComparator) {
+  delete db;
+  db = nullptr;
+  ASSERT_OK(DestroyDB(dbname, options));
+
+  options.comparator = ReverseBytewiseComparator();
+  range_lock_mgr.reset(NewRangeLockManager(nullptr));
+  txn_db_options.lock_mgr_handle = range_lock_mgr;
+
+  ASSERT_OK(TransactionDB::Open(options, txn_db_options, dbname, &db));
+
+  WriteOptions write_options;
+  TransactionOptions txn_options;
+  txn_options.lock_timeout = 50;
+  auto cf = db->DefaultColumnFamily();
+
+  Transaction* txn0 = db->BeginTransaction(write_options, txn_options);
+  Transaction* txn1 = db->BeginTransaction(write_options, txn_options);
+
+  ASSERT_OK(txn0->GetRangeLock(cf, Endpoint("aa"), Endpoint("a")));
+
+  auto s = txn1->GetRangeLock(cf, Endpoint("ab"), Endpoint("a"));
+  ASSERT_TRUE(s.IsTimedOut());
+
+  ASSERT_OK(txn1->GetRangeLock(cf, Endpoint("b"), Endpoint("b")));
+
+  txn0->Rollback();
+  txn1->Rollback();
+  delete txn0;
+  delete txn1;
+}
+
 // CompareDbtEndpoints must use CompareWithoutTimestamp for range lock
 // endpoints, which never contain user-defined timestamps.
 TEST_F(RangeLockingTest, RangeLockWithTimestampComparator) {

--- a/utilities/transactions/lock/range/range_tree/range_tree_lock_manager.cc
+++ b/utilities/transactions/lock/range/range_tree/range_tree_lock_manager.cc
@@ -39,6 +39,18 @@ RangeLockManagerHandle* NewRangeLockManager(
 static const char SUFFIX_INFIMUM = 0x0;
 static const char SUFFIX_SUPREMUM = 0x1;
 
+struct RangeTreeCmpContext {
+  const Comparator* cmp;
+  bool is_reverse;
+};
+
+namespace {
+[[nodiscard]] bool IsReverseComparator(const Comparator* cmp) {
+  return cmp == ReverseBytewiseComparator() ||
+         cmp == ReverseBytewiseComparatorWithU64Ts();
+}
+}  // namespace
+
 // Convert Endpoint into an internal format used for storing it in locktree
 // (DBT structure is used for passing endpoints to locktree and getting back)
 void serialize_endpoint(const Endpoint& endp, std::string* buf) {
@@ -213,9 +225,9 @@ int RangeTreeLockManager::CompareDbtEndpoints(void* arg, const DBT* a_key,
 
   // Compare the values. The first byte encodes the endpoint type, its value
   // is either SUFFIX_INFIMUM or SUFFIX_SUPREMUM.
-  Comparator* cmp = (Comparator*)arg;
-  bool is_reverse = cmp == ReverseBytewiseComparator() ||
-                    cmp == ReverseBytewiseComparatorWithU64Ts();
+  const auto* ctx = static_cast<const RangeTreeCmpContext*>(arg);
+  const auto* cmp = ctx->cmp;
+  const bool is_reverse = ctx->is_reverse;
   int res = cmp->CompareWithoutTimestamp(
       Slice(a + 1, min_len - 1), /*a_has_ts=*/false, Slice(b + 1, min_len - 1),
       /*b_has_ts=*/false);
@@ -353,10 +365,11 @@ RangeLockManagerHandle::Counters RangeTreeLockManager::GetStatus() {
 }
 
 std::shared_ptr<toku::locktree> RangeTreeLockManager::MakeLockTreePtr(
-    toku::locktree* lt) {
+    toku::locktree* lt, std::unique_ptr<RangeTreeCmpContext> ctx) {
   toku::locktree_manager* ltm = &ltm_;
   return std::shared_ptr<toku::locktree>(
-      lt, [ltm](toku::locktree* p) { ltm->release_lt(p); });
+      lt,
+      [ltm, ctx = std::move(ctx)](toku::locktree* p) { ltm->release_lt(p); });
 }
 
 void RangeTreeLockManager::AddColumnFamily(const ColumnFamilyHandle* cfh) {
@@ -365,15 +378,18 @@ void RangeTreeLockManager::AddColumnFamily(const ColumnFamilyHandle* cfh) {
   InstrumentedMutexLock l(&ltree_map_mutex_);
   if (ltree_map_.find(column_family_id) == ltree_map_.end()) {
     DICTIONARY_ID dict_id = {.dictid = column_family_id};
+    auto ctx = std::make_unique<RangeTreeCmpContext>(RangeTreeCmpContext{
+        cfh->GetComparator(), IsReverseComparator(cfh->GetComparator())});
     toku::comparator cmp;
-    cmp.create(CompareDbtEndpoints, (void*)cfh->GetComparator());
+    cmp.create(CompareDbtEndpoints, ctx.get());
     toku::locktree* ltree =
         ltm_.get_lt(dict_id, cmp,
                     /* on_create_extra*/ static_cast<void*>(this));
     // This is ok to because get_lt has copied the comparator:
     cmp.destroy();
 
-    ltree_map_.insert({column_family_id, MakeLockTreePtr(ltree)});
+    ltree_map_.insert(
+        {column_family_id, MakeLockTreePtr(ltree, std::move(ctx))});
   }
 }
 

--- a/utilities/transactions/lock/range/range_tree/range_tree_lock_manager.cc
+++ b/utilities/transactions/lock/range/range_tree/range_tree_lock_manager.cc
@@ -214,32 +214,23 @@ int RangeTreeLockManager::CompareDbtEndpoints(void* arg, const DBT* a_key,
   // Compare the values. The first byte encodes the endpoint type, its value
   // is either SUFFIX_INFIMUM or SUFFIX_SUPREMUM.
   Comparator* cmp = (Comparator*)arg;
+  bool is_reverse = cmp == ReverseBytewiseComparator() ||
+                    cmp == ReverseBytewiseComparatorWithU64Ts();
   int res = cmp->CompareWithoutTimestamp(
       Slice(a + 1, min_len - 1), /*a_has_ts=*/false, Slice(b + 1, min_len - 1),
       /*b_has_ts=*/false);
   if (!res) {
     if (b_len > min_len) {
-      // a is shorter;
-      if (a[0] == SUFFIX_INFIMUM) {
-        return -1;  //"a is smaller"
-      } else {
-        // a is considered padded with 0xFF:FF:FF:FF...
-        return 1;  // "a" is bigger
-      }
+      int r = a[0] == SUFFIX_INFIMUM ? -1 : 1;
+      return is_reverse ? -r : r;
     } else if (a_len > min_len) {
-      // the opposite of the above: b is shorter.
-      if (b[0] == SUFFIX_INFIMUM) {
-        return 1;  //"b is smaller"
-      } else {
-        // b is considered padded with 0xFF:FF:FF:FF...
-        return -1;  // "b" is bigger
-      }
+      int r = b[0] == SUFFIX_INFIMUM ? 1 : -1;
+      return is_reverse ? -r : r;
     } else {
-      // the lengths are equal (and the key values, too)
       if (a[0] < b[0]) {
-        return -1;
+        return is_reverse ? 1 : -1;
       } else if (a[0] > b[0]) {
-        return 1;
+        return is_reverse ? -1 : 1;
       } else {
         return 0;
       }

--- a/utilities/transactions/lock/range/range_tree/range_tree_lock_manager.h
+++ b/utilities/transactions/lock/range/range_tree/range_tree_lock_manager.h
@@ -20,6 +20,8 @@ namespace ROCKSDB_NAMESPACE {
 
 typedef DeadlockInfoBufferTempl<RangeDeadlockPath> RangeDeadlockInfoBuffer;
 
+struct RangeTreeCmpContext;
+
 // A Range Lock Manager that uses PerconaFT's locktree library
 class RangeTreeLockManager : public RangeLockManagerBase,
                              public RangeLockManagerHandle {
@@ -116,7 +118,8 @@ class RangeTreeLockManager : public RangeLockManagerBase,
 
   RangeDeadlockInfoBuffer dlock_buffer_;
 
-  std::shared_ptr<toku::locktree> MakeLockTreePtr(toku::locktree* lt);
+  std::shared_ptr<toku::locktree> MakeLockTreePtr(
+      toku::locktree* lt, std::unique_ptr<RangeTreeCmpContext> ctx = nullptr);
   static int CompareDbtEndpoints(void* arg, const DBT* a_key, const DBT* b_key);
 
   // Callbacks


### PR DESCRIPTION
Summary:
Fixed a bug where the range lock manager would crash with an assertion failure when using a reverse comparator column family. The CompareDbtEndpoints function used bytewise ordering for length-disparity comparisons, ignoring the user comparator direction.

Test Plan:
- Added unit test RangeLockWithReverseComparator
- Ran make check (4552 tests, 0 failures)
- Verified range_locking_test passes (9/9)