### PR TITLE
Fix crash test Restore() failure with empty trace when replay_write_ops == 0 (#14840)

### DIFF
--- a/db_stress_tool/expected_state.cc
+++ b/db_stress_tool/expected_state.cc
@@ -796,8 +796,13 @@ Status FileExpectedStateManager::Restore(DB* db) {
   std::string trace_file_path = GetPathForFilename(trace_filename);
 
   std::unique_ptr<TraceReader> trace_reader;
-  Status s = NewFileTraceReader(Env::Default(), EnvOptions(), trace_file_path,
-                                &trace_reader);
+  Status s = Status::OK();
+  // If the DB recovered exactly to `saved_seqno_`, skip opening/replaying the
+  // trace and reuse the normal state promotion and cleanup flow below.
+  if (replay_write_ops > 0) {
+    s = NewFileTraceReader(Env::Default(), EnvOptions(), trace_file_path,
+                           &trace_reader);
+  }
 
   std::string persisted_seqno_file_path = GetPathForFilename(
       kPersistedSeqnoBasename + kPersistedSeqnoFilenameSuffix);
@@ -821,7 +826,7 @@ Status FileExpectedStateManager::Restore(DB* db) {
                                         num_column_families_));
       s = state->Open(false /* create */);
     }
-    if (s.ok()) {
+    if (s.ok() && replay_write_ops > 0) {
       handler.reset(
           new ExpectedStateTraceRecordHandler(replay_write_ops, state.get()));
       // TODO(ajkr): An API limitation requires we provide `handles` although
@@ -831,10 +836,10 @@ Status FileExpectedStateManager::Restore(DB* db) {
                                  std::move(trace_reader), &replayer);
     }
 
-    if (s.ok()) {
+    if (s.ok() && replay_write_ops > 0) {
       s = replayer->Prepare();
     }
-    for (; s.ok();) {
+    for (; s.ok() && replay_write_ops > 0;) {
       std::unique_ptr<TraceRecord> record;
       s = replayer->Next(&record);
       if (!s.ok()) {
@@ -857,7 +862,7 @@ Status FileExpectedStateManager::Restore(DB* db) {
       std::unique_ptr<TraceRecordResult> res;
       s = record->Accept(handler.get(), &res);
     }
-    if (s.ok() && !handler->IsDone()) {
+    if (s.ok() && replay_write_ops > 0 && !handler->IsDone()) {
       s = Status::Corruption(
           "Trace ended before replaying all expected write ops",
           std::to_string(handler->NumWriteOps()) + " < " +


### PR DESCRIPTION
Summary:
`ExpectedState::Restore()` always attempted to open and replay the post-`saved_seqno_` trace. In the crash-test failure, recovery had already returned the DB exactly to `saved_seqno_`, so `replay_write_ops == 0` and the trace was legitimately empty. `FileTraceReader` reported `Status::Incomplete()` on that empty trace, which incorrectly failed restore.

Skip the trace replay work when `replay_write_ops == 0`, but still run the normal state promotion, cleanup, and `saved_seqno_` reset path so later saves continue to work.


Reviewed By: xingbowang

Differential Revision: D107968797


