### PR TITLE
Disable parallel compression for fast built-in compressors

### DIFF
--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -1464,7 +1464,9 @@ DEFINE_int32(min_level_to_compress, -1,
              "all levels.");
 
 DEFINE_int32(compression_parallel_threads, 1,
-             "Number of threads for parallel compression.");
+             "Number of threads for parallel compression. NOTE: known *fast* "
+             "compression configurations can quietly override this setting to "
+             "non-parallel, for efficiency");
 
 DEFINE_uint64(compression_max_dict_buffer_bytes,
               ROCKSDB_NAMESPACE::CompressionOptions().max_dict_buffer_bytes,

--- a/tools/sst_dump_test.cc
+++ b/tools/sst_dump_test.cc
@@ -279,6 +279,28 @@ TEST_F(SSTDumpToolTest, CompressedSizes) {
                       "--command=recompress");
 }
 
+TEST_F(SSTDumpToolTest, VerifyCompression) {
+  Options opts;
+  opts.env = env();
+  BlockBasedTableOptions table_opts;
+  table_opts.filter_policy.reset(NewBloomFilterPolicy(10, false));
+  opts.table_factory.reset(new BlockBasedTableFactory(table_opts));
+  std::string file_path = MakeFilePath("rocksdb_sst_test.sst");
+  createSST(opts, file_path, 10);
+
+  char* usage[4];
+  auto cleanup_usage = CleanupUsage{usage};
+  PopulateCommandArgs(file_path, "--command=recompress", usage);
+  snprintf(usage[3], kOptLength, "--verify_compression=1");
+
+  SSTDumpTool tool;
+  ASSERT_TOOL_PASS(tool.Run(4, usage, opts));
+  snprintf(usage[3], kOptLength, "--verify_compression=0");
+  ASSERT_TOOL_PASS(tool.Run(4, usage, opts));
+
+  cleanup(opts, file_path);
+}
+
 TEST_F(SSTDumpToolTest, ListMetaBlocks) {
   Options opts;
   SSTDumpToolTestCase(opts, /*filter=*/true, /*wide_column_one_in=*/0,

--- a/tools/sst_dump_tool.cc
+++ b/tools/sst_dump_tool.cc
@@ -108,6 +108,10 @@ void print_help(bool to_stderr) {
       Used with --command=recompress to specify whether to compress index
       blocks (in addition to data blocks).
 
+    --verify_compression=<bool>
+      Used with --command=recompress to specify whether to verify that
+      decompressing the compressed block gives back the input.
+
     --parse_internal_key=<0xKEY>
       Convenience option to parse an internal key on the command line. Dumps the
       internal key in hex format {'key' @ SN: type}
@@ -131,6 +135,8 @@ void print_help(bool to_stderr) {
 
     --compression_parallel_threads=<uint32_t>
       Number of parallel threads to use with --command=recompress
+      NOTE: known *fast* compression configurations can quietly override this setting
+      to non-parallel, for efficiency
 
     --compression_use_zstd_finalize_dict
       Use zstd's finalizeDictionary() API instead of zstd's dictionary trainer to generate dictionary.
@@ -206,6 +212,7 @@ int SSTDumpTool::Run(int argc, char const* const* argv, Options options) {
   std::shared_ptr<CompressionManager> compression_manager;
   bool enable_index_compression =
       BlockBasedTableOptions{}.enable_index_compression;
+  bool verify_compression = BlockBasedTableOptions{}.verify_compression;
   uint64_t total_num_files = 0;
   uint64_t total_num_data_blocks = 0;
   uint64_t total_data_block_size = 0;
@@ -315,6 +322,11 @@ int SSTDumpTool::Run(int argc, char const* const* argv, Options options) {
       if (strlen(argv[i]) > 27) {
         enable_index_compression =
             argv[i][27] == '1' || argv[i][27] == 't' || argv[i][27] == 'T';
+      }
+    } else if (strncmp(argv[i], "--verify_compression=", 21) == 0) {
+      if (strlen(argv[i]) > 21) {
+        verify_compression =
+            argv[i][21] == '1' || argv[i][21] == 't' || argv[i][21] == 'T';
       }
     } else if (strncmp(argv[i], "--parse_internal_key=", 21) == 0) {
       std::string in_key(argv[i] + 21);
@@ -522,6 +534,7 @@ int SSTDumpTool::Run(int argc, char const* const* argv, Options options) {
       }
       bbto.block_size = block_size;
       bbto.enable_index_compression = enable_index_compression;
+      bbto.verify_compression = verify_compression;
       // Maximize compression features available
       bbto.format_version = kLatestBbtFormatVersion;
       options.table_factory = std::make_shared<BlockBasedTableFactory>(bbto);

--- a/unreleased_history/behavior_changes/fast_compressors_no_parallel.md
+++ b/unreleased_history/behavior_changes/fast_compressors_no_parallel.md
@@ -1,0 +1,1 @@
+* Disable parallel compression (ignore `CompressionOptions::parallel_threads`) for fast built-in compressors: Snappy, LZ4 (accelerated, not LZ4HC), and accelerated levels of ZSTD (level < 0). These do not generally benefit from parallel compression. This behavior can be overridden with a custom Compressor from a custom CompressionManager.

--- a/util/compression.cc
+++ b/util/compression.cc
@@ -486,6 +486,9 @@ class BuiltinSnappyCompressorV2 final : public CompressorWithSimpleDictBase {
     return kSnappyCompression;
   }
 
+  // Snappy is more often SLOWER with parallel compression than faster.
+  uint32_t GetRecommendedParallelThreads() const override { return 1; }
+
   std::unique_ptr<Compressor> CloneForDict(
       std::string&& dict_data) const override {
     return std::make_unique<BuiltinSnappyCompressorV2>(opts_,
@@ -757,6 +760,10 @@ class BuiltinLZ4CompressorV2WithDict : public CompressorWithSimpleDictBase {
   CompressionType GetPreferredCompressionType() const override {
     return kLZ4Compression;
   }
+
+  // LZ4 (accelerated, not LZ4HC) is more often SLOWER with parallel
+  // compression than faster.
+  uint32_t GetRecommendedParallelThreads() const override { return 1; }
 
   std::unique_ptr<Compressor> CloneForDict(
       std::string&& dict_data) const override {
@@ -1070,6 +1077,14 @@ class BuiltinZSTDCompressorV2 final : public CompressorBase {
   const char* Name() const override { return "BuiltinZSTDCompressorV2"; }
 
   CompressionType GetPreferredCompressionType() const override { return kZSTD; }
+
+  uint32_t GetRecommendedParallelThreads() const override {
+    // Accelerated ZSTD levels could see a small throughput increase with
+    // parallel compression, but the overall CPU overhead is generally not worth
+    // it.
+    return opts_.level < 0 ? 1
+                           : CompressorBase::GetRecommendedParallelThreads();
+  }
 
   std::unique_ptr<Compressor> Clone() const override {
     CompressionDict dict_copy{dict_.GetRawDict().ToString(), kZSTD,

--- a/util/compression_test.cc
+++ b/util/compression_test.cc
@@ -2482,7 +2482,7 @@ TEST_F(DBCompressionTest, PreDefinedDictionaryCompression) {
 
 TEST_F(DBCompressionTest, GetRecommendedParallelThreads) {
   // Verify that built-in compressors return parallel_threads from their
-  // CompressionOptions
+  // CompressionOptions, except fast compressors override to 1
   auto mgr = GetBuiltinV2CompressionManager();
   CompressionOptions opts;
 
@@ -2498,8 +2498,10 @@ TEST_F(DBCompressionTest, GetRecommendedParallelThreads) {
     ASSERT_EQ(compressor->GetRecommendedParallelThreads(), 1U);
   }
 
-  // Custom parallel_threads value is returned
+  // Custom parallel_threads value is returned, except fast compressors
+  // (Snappy, LZ4, ZSTD with level < 0) override to 1
   opts.parallel_threads = 8;
+  opts.level = 3;  // non-negative for ZSTD
   for (auto type : {kSnappyCompression, kZlibCompression, kLZ4Compression,
                     kLZ4HCCompression, kZSTD}) {
     if (!mgr->SupportsCompressionType(type)) {
@@ -2507,7 +2509,19 @@ TEST_F(DBCompressionTest, GetRecommendedParallelThreads) {
     }
     auto compressor = mgr->GetCompressor(opts, type);
     ASSERT_NE(compressor, nullptr);
-    ASSERT_EQ(compressor->GetRecommendedParallelThreads(), 8U);
+    uint32_t expected = 8U;
+    if (type == kSnappyCompression || type == kLZ4Compression) {
+      expected = 1U;
+    }
+    ASSERT_EQ(compressor->GetRecommendedParallelThreads(), expected);
+  }
+
+  // ZSTD with negative level should override to 1
+  opts.level = -1;
+  opts.parallel_threads = 8;
+  auto zstd_compressor = mgr->GetCompressor(opts, kZSTD);
+  if (zstd_compressor) {
+    ASSERT_EQ(zstd_compressor->GetRecommendedParallelThreads(), 1U);
   }
 }
 


### PR DESCRIPTION
Summary: Use Compressor::GetRecommendedParallelThreads() overrides to disable parallel compression for Snappy, LZ4 (accelerated, not LZ4HC), and for accelerated levels of ZSTD (level < 0). These do not generally benefit from parallel compression.

Also add --verify_compression option to sst_dump for some basic "recompress" benchmarking with that option.

Test Plan: unit test updated.

In planning the scope of this change, I manually tested some production SST files with release build sst_dump --command=recompress and various settings for --compression_parallel_threads, --compression_types, and --compression_level, while I had the CPUs mostly busy using cache_bench in the background. Here's an example, before the change to override parallel_threads:

```
$ for PT in 1 8; do /usr/bin/time ./sst_dump --command=recompress --compression_parallel_threads=$PT --block_size=16384 --compression_types=kLZ4Compression --verify_compression=1 test.sst; done
...
Compression: kLZ4Compression          Block Size: 16384  Threads: 1
Cx level: 32767 Cx size:  168501634 Uncx size:  791721664 Ratio:   4.698599 Write usec:    2345894  Read usec:     429022  Cx count:  48661 (100.0%) Not cx for ratio:      0 (  0.0%) Not cx otherwise:      0 (  0.0%)
2.54user 0.29system 0:02.84elapsed 99%CPU (0avgtext+0avgdata 460816maxresident)k
...
Compression: kLZ4Compression          Block Size: 16384  Threads: 8
Cx level: 32767 Cx size:  168501634 Uncx size:  791721664 Ratio:   4.698599 Write usec:    2476459  Read usec:     439464  Cx count:  48661 (100.0%) Not cx for ratio:      0 (  0.0%) Not cx otherwise:      0 (  0.0%)
3.95user 0.33system 0:02.98elapsed 143%CPU (0avgtext+0avgdata 455504maxresident)k
```

Here as in many of the cases I'm changing, it actually takes longer to compress with parallel, despite the added parallel opportunity of verify_compression. And overall CPU is much higher from 2.54 CPU*s to 3.95 CPU*s.

The difference disappears with the change, because both use single-threaded SST construction.