### PR TITLE
fix use-after-free: drain background purge in CloseHelper (#14842)

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -853,6 +853,8 @@ Status DBImpl::CloseHelper() {
   if (default_cf_handle_ != nullptr || persist_stats_cf_handle_ != nullptr) {
     // we need to delete handle outside of lock because it does its own locking
     mutex_.Unlock();
+    TEST_SYNC_POINT("DBImpl::CloseHelper:CFHandleCleanupUnlocked");
+    TEST_SYNC_POINT("DBImpl::CloseHelper:CFHandleCleanupAllowed");
     if (default_cf_handle_) {
       delete default_cf_handle_;
       default_cf_handle_ = nullptr;
@@ -920,25 +922,6 @@ Status DBImpl::CloseHelper() {
     logs_.clear();
   }
 
-  // Table cache may have table handles holding blocks from the block cache.
-  // We need to release them before the block cache is destroyed. The block
-  // cache may be destroyed inside versions_.reset(), when column family data
-  // list is destroyed, so leaving handles in table cache after
-  // versions_.reset() may cause issues. Here we clean all unreferenced handles
-  // in table cache, and (for certain builds/conditions) assert that no obsolete
-  // files are hanging around unreferenced (leak) in the table/blob file cache.
-  // Now we assume all user queries have finished, so only version set itself
-  // can possibly hold the blocks from block cache. After releasing unreferenced
-  // handles here, only handles held by version set left and inside
-  // versions_.reset(), we will release them. There, we need to make sure every
-  // time a handle is released, we erase it from the cache too. By doing that,
-  // we can guarantee that after versions_.reset(), table cache is empty
-  // so the cache can be safely destroyed.
-#ifndef NDEBUG
-  TEST_VerifyNoObsoleteFilesCached(/*db_mutex_already_held=*/true);
-#endif  // !NDEBUG
-  table_cache_->EraseUnRefEntries();
-
   for (auto& txn_entry : recovered_transactions_) {
     delete txn_entry.second;
   }
@@ -963,6 +946,42 @@ Status DBImpl::CloseHelper() {
       }
     }
   }
+
+  // Drain obsolete-file purge work started AFTER the early CloseHelper wait
+  // near the top of this method. A late SuperVersion cleanup -- a dropped
+  // column family handle, or an in-flight iterator/Get whose ReadOptions or
+  // immutable_db_options_.avoid_unnecessary_blocking_io selected background
+  // purge -- can run in one of the mutex-unlocked windows above and enter the
+  // FindObsoleteFiles() -> PurgeObsoleteFiles(..., true) handoff. During that
+  // handoff pending_purge_obsolete_files_ is already nonzero, but
+  // bg_purge_scheduled_ may still be zero until SchedulePurge() runs at the end
+  // of PurgeObsoleteFiles(). Wait for both states while mutex_/this are still
+  // alive; bg_cv_.Wait() releases mutex_ so pending and scheduled purges can
+  // finish and signal.
+  TEST_SYNC_POINT("DBImpl::CloseHelper:BeforeFinalPurgeDrain");
+  while (pending_purge_obsolete_files_ || bg_purge_scheduled_) {
+    TEST_SYNC_POINT("DBImpl::CloseHelper:FinalPurgeDrainWait");
+    bg_cv_.Wait();
+  }
+
+  // Table cache may have table handles holding blocks from the block cache.
+  // We need to release them before the block cache is destroyed. The block
+  // cache may be destroyed inside versions_.reset(), when column family data
+  // list is destroyed, so leaving handles in table cache after
+  // versions_.reset() may cause issues. Here we clean all unreferenced handles
+  // in table cache, and (for certain builds/conditions) assert that no obsolete
+  // files are hanging around unreferenced (leak) in the table/blob file cache.
+  // Now we assume all user queries have finished, and close-time purge work has
+  // settled, so only version set itself can possibly hold the blocks from block
+  // cache. After releasing unreferenced handles here, only handles held by
+  // version set left and inside versions_.reset(), we will release them. There,
+  // we need to make sure every time a handle is released, we erase it from the
+  // cache too. By doing that, we can guarantee that after versions_.reset(),
+  // table cache is empty so the cache can be safely destroyed.
+#ifndef NDEBUG
+  TEST_VerifyNoObsoleteFilesCached(/*db_mutex_already_held=*/true);
+#endif  // !NDEBUG
+  table_cache_->EraseUnRefEntries();
 
   versions_.reset();
   mutex_.Unlock();

--- a/db/db_impl/db_impl_files.cc
+++ b/db/db_impl/db_impl_files.cc
@@ -833,6 +833,7 @@ void DBImpl::PurgeObsoleteFiles(JobContext& state, bool schedule_only) {
   }
   wal_manager_.PurgeObsoleteWALFiles();
   LogFlush(immutable_db_options_.info_log);
+  TEST_SYNC_POINT("DBImpl::PurgeObsoleteFiles:BeforePendingPurgeFinished");
   InstrumentedMutexLock l(&mutex_);
   --pending_purge_obsolete_files_;
   assert(pending_purge_obsolete_files_ >= 0);

--- a/db/deletefile_test.cc
+++ b/db/deletefile_test.cc
@@ -7,6 +7,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
+#include <atomic>
 #include <cstdlib>
 #include <map>
 #include <string>
@@ -256,6 +257,108 @@ TEST_F(DeleteFileTest, BackgroundPurgeIteratorTest) {
   sleeping_task_after.WaitUntilDone();
   // 1 sst after iterator deletion
   CheckFileTypeCounts(dbname_, 0, 1, 1);
+}
+
+// Regression test for a use-after-free where an obsolete-file purge started
+// DURING DB close -- after CloseHelper's early purge drain -- continued using
+// DBImpl after ~DBImpl destroyed mutex_. Seen as a vhost-user-blk SIGABRT when
+// many RocksDB instances closed concurrently under a Warm Storage fault, with
+// avoid_unnecessary_blocking_io=true on a shared, process-wide Env.
+//
+// Here we make the straggler deterministic: keep a dropped column family handle
+// alive, delete it only after CloseHelper has passed its early purge drain,
+// then park that cleanup after FindObsoleteFiles() has incremented
+// pending_purge_obsolete_files_ but before PurgeObsoleteFiles(..., true)
+// schedules BGWorkPurge. Without the fix, the final drain sees
+// bg_purge_scheduled_ == 0 and can destroy DBImpl while the pending cleanup is
+// still about to lock/use it. With the fix, CloseHelper waits through the
+// pending handoff and then through the scheduled purge.
+TEST_F(DeleteFileTest, CloseWaitsForPurgeScheduledDuringClose) {
+  Options options = CurrentOptions();
+  SetOptions(&options);
+  Destroy(options);
+  options.create_if_missing = true;
+  // Route obsolete-file deletion through the background purge queue, matching
+  // the production config that hit the bug.
+  options.avoid_unnecessary_blocking_io = true;
+  Reopen(options);
+
+  // A dropped CF whose handle we keep alive: deleting the handle schedules a
+  // *background* purge (the dropped-CF teardown path).
+  ColumnFamilyHandle* cfh = nullptr;
+  ASSERT_OK(db_->CreateColumnFamily(ColumnFamilyOptions(), "dropme", &cfh));
+  ASSERT_OK(db_->Put(WriteOptions(), cfh, "key", "value"));
+  ASSERT_OK(db_->Flush(FlushOptions(), cfh));
+  ASSERT_OK(db_->DropColumnFamily(cfh));
+  ASSERT_OK(dbfull()->TEST_WaitForPurge());  // settle setup purges
+
+  std::atomic<bool> block_pending_handoff{false};
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+  SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::PurgeObsoleteFiles:BeforePendingPurgeFinished", [&](void*) {
+        if (!block_pending_handoff.exchange(false)) {
+          return;
+        }
+        TEST_SYNC_POINT(
+            "DeleteFileTest::CloseWaitsForPurge:PendingHandoffReady");
+        TEST_SYNC_POINT(
+            "DeleteFileTest::CloseWaitsForPurge:PendingHandoffBlocked");
+      });
+  SyncPoint::GetInstance()->LoadDependency({
+      // Delete the dropped CF handle only after CloseHelper has passed its
+      // early purge drain and entered a mutex-unlocked close window.
+      {"DBImpl::CloseHelper:CFHandleCleanupUnlocked",
+       "DeleteFileTest::CloseWaitsForPurge:DropDuringCloseUnlock"},
+      // Let the test thread observe that the deleter is parked in the pending
+      // handoff window.
+      {"DeleteFileTest::CloseWaitsForPurge:PendingHandoffReady",
+       "DeleteFileTest::CloseWaitsForPurge:WaitForPendingHandoff"},
+      // Keep CloseHelper in the mutex-unlocked close window until the
+      // dropped-CF cleanup reaches the pending-to-scheduled handoff.
+      {"DeleteFileTest::CloseWaitsForPurge:PendingHandoffReady",
+       "DBImpl::CloseHelper:CFHandleCleanupAllowed"},
+      // Observe that CloseHelper is actually waiting in the final purge drain
+      // while the dropped-CF cleanup is still parked in the pending handoff.
+      {"DBImpl::CloseHelper:FinalPurgeDrainWait",
+       "DeleteFileTest::CloseWaitsForPurge:WaitForFinalPurgeDrain"},
+      // Keep the dropped-CF cleanup parked in the pending handoff window until
+      // the test releases it.
+      {"DeleteFileTest::CloseWaitsForPurge:ReleasePendingHandoff",
+       "DeleteFileTest::CloseWaitsForPurge:PendingHandoffBlocked"},
+      // Park the scheduled BGWorkPurge before it locks mutex_ until we release
+      // it, so CloseHelper also has to wait for bg_purge_scheduled_.
+      {"DeleteFileTest::CloseWaitsForPurge:ReleaseBackgroundPurge",
+       "DBImpl::BackgroundCallPurge:beforeMutexLock"},
+  });
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  port::Thread closer([&]() { db_.reset(); });
+
+  // Unblocks once CloseHelper is in a mutex-unlocked close window; then
+  // deleting the dropped CF handle starts purge work the early drain missed.
+  TEST_SYNC_POINT("DeleteFileTest::CloseWaitsForPurge:DropDuringCloseUnlock");
+  block_pending_handoff.store(true);
+  ColumnFamilyHandle* dropped_cfh = cfh;
+  cfh = nullptr;
+  port::Thread dropped_cf_deleter([dropped_cfh]() { delete dropped_cfh; });
+
+  TEST_SYNC_POINT("DeleteFileTest::CloseWaitsForPurge:WaitForPendingHandoff");
+
+  // Wait until CloseHelper is blocked in the final drain with no scheduled
+  // purge yet. Without the fix, it would proceed while the dropped-CF cleanup
+  // is still pending. With the fix, it waits for pending_purge_obsolete_files_.
+  TEST_SYNC_POINT("DeleteFileTest::CloseWaitsForPurge:WaitForFinalPurgeDrain");
+
+  // Release the pending cleanup, then the BGWorkPurge it schedules. With the
+  // fix, the closer waits for both transitions and completes cleanly.
+  TEST_SYNC_POINT("DeleteFileTest::CloseWaitsForPurge:ReleasePendingHandoff");
+  dropped_cf_deleter.join();
+  TEST_SYNC_POINT("DeleteFileTest::CloseWaitsForPurge:ReleaseBackgroundPurge");
+  closer.join();
+
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
 }
 
 TEST_F(DeleteFileTest, PurgeDuringOpen) {


### PR DESCRIPTION
Summary:

### Problem

A process using RocksDB can hit an ASAN `heap-use-after-free` in `rocksdb::InstrumentedMutex::Lock()` when a `DBImpl` is closed while obsolete-file purge work is still in flight. This can happen during close storms with `avoid_unnecessary_blocking_io=true` on a shared Env, where a queued or late handoff purge can run after `~DBImpl` has destroyed `mutex_`.

### Root Cause

`CloseHelper()` has several mutex-unlocked windows late in shutdown. A dropped column-family handle or SuperVersion cleanup can run in one of those windows and start obsolete-file purge work. `FindObsoleteFiles()` marks that work by incrementing `pending_purge_obsolete_files_`, but `PurgeObsoleteFiles(..., true)` can then spend time outside the DB mutex before transferring the work to `bg_purge_scheduled_` via `SchedulePurge()`. During that handoff, `bg_purge_scheduled_` is still zero even though purge work is pending.

### Fix

Make the final `CloseHelper()` drain wait for both `pending_purge_obsolete_files_` and `bg_purge_scheduled_` before destroying `versions_` / `DBImpl`. This covers both the pending handoff and the scheduled `BGWorkPurge` state. Also move `TEST_VerifyNoObsoleteFilesCached()` and `table_cache_->EraseUnRefEntries()` after the final drain, so debug/ASAN table-cache verification runs only after close-time purge work has settled. The regression test parks a dropped-CF cleanup in the pending handoff window and verifies `CloseHelper()` blocks in the final drain until that handoff is released.

Differential Revision: D107920881


