### PR TITLE
perf: Avoid unnecessary object copy (#14843)

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -1084,25 +1084,25 @@ void DBImpl::PrintStatistics() {
 // various options.
 // Returns 0 if all time-based compaction options are disabled.
 static uint64_t GetMinTimeBasedCompactionInterval(
-    const ColumnFamilyOptions& cf_opts) {
+    const MutableCFOptions& mcf_opts) {
   uint64_t min_interval = UINT64_MAX;
-  if (cf_opts.periodic_compaction_seconds > 0) {
-    min_interval = std::min(min_interval, cf_opts.periodic_compaction_seconds);
+  if (mcf_opts.periodic_compaction_seconds > 0) {
+    min_interval = std::min(min_interval, mcf_opts.periodic_compaction_seconds);
   }
-  if (cf_opts.ttl > 0) {
-    min_interval = std::min(min_interval, cf_opts.ttl);
+  if (mcf_opts.ttl > 0) {
+    min_interval = std::min(min_interval, mcf_opts.ttl);
   }
   const auto& fifo_thresholds =
-      cf_opts.compaction_options_fifo.file_temperature_age_thresholds;
+      mcf_opts.compaction_options_fifo.file_temperature_age_thresholds;
   if (!fifo_thresholds.empty() && fifo_thresholds[0].age > 0) {
     // Thresholds are in increasing order by age, so first is smallest
     min_interval = std::min(min_interval, fifo_thresholds[0].age);
   }
-  if (cf_opts.bottommost_file_compaction_delay > 0) {
+  if (mcf_opts.bottommost_file_compaction_delay > 0) {
     // NOTE: 0 does not exactly mean "disabled" in this case but it does mean
     // there's no time component to the relevant compaction picking.
-    min_interval = std::min(min_interval,
-                            uint64_t{cf_opts.bottommost_file_compaction_delay});
+    min_interval = std::min(
+        min_interval, uint64_t{mcf_opts.bottommost_file_compaction_delay});
   }
   // Note: Assume sentinel values like UINT64_MAX - 1 (used by ttl and
   // periodic_compaction_seconds) are like disabling, if they reach here
@@ -1134,7 +1134,7 @@ uint64_t DBImpl::ComputeTriggerCompactionPeriod() {
       continue;
     }
     uint64_t cf_min =
-        GetMinTimeBasedCompactionInterval(cfd->GetLatestCFOptions());
+        GetMinTimeBasedCompactionInterval(cfd->GetLatestMutableCFOptions());
     if (cf_min > 0) {
       compaction_trigger_sec = std::min(compaction_trigger_sec, cf_min);
     }
@@ -7882,7 +7882,8 @@ void DBImpl::TriggerPeriodicCompaction() {
       // Check if this CF has any time-based or read-triggered compaction
       // configured. This includes periodic_compaction_seconds, ttl, FIFO
       // temperature thresholds, or read_triggered_compaction_threshold.
-      if (GetMinTimeBasedCompactionInterval(cfd->GetLatestCFOptions()) > 0 ||
+      if (GetMinTimeBasedCompactionInterval(cfd->GetLatestMutableCFOptions()) >
+              0 ||
           cfd->GetLatestMutableCFOptions().read_triggered_compaction_threshold >
               0.0) {
         TEST_SYNC_POINT_CALLBACK(


### PR DESCRIPTION
Summary:

This function shows up in internal profiles. This is an AI generated performance optimization (but human reviewed):

Optimized `rocksdb::ColumnFamilyOptions::ColumnFamilyOptions` by eliminating unnecessary copy construction calls in the hottest callers.

**Problem:** Strobelight traces (weight 705M+) showed the `ColumnFamilyOptions` copy constructor being called from `GetMinTimeBasedCompactionInterval(cfd->GetLatestCFOptions())` in both `TriggerPeriodicCompaction` and `ComputeTriggerCompactionPeriod`. `GetLatestCFOptions()` calls `BuildColumnFamilyOptions` which copy-constructs an entire `ColumnFamilyOptions` object just to read a few scalar fields.

**Fix:** Changed `GetMinTimeBasedCompactionInterval` to accept `const MutableCFOptions&` instead of `const ColumnFamilyOptions&`. All fields it reads (`periodic_compaction_seconds`, `ttl`, `compaction_options_fifo.file_temperature_age_thresholds`, `bottommost_file_compaction_delay`) exist in `MutableCFOptions`. Updated both call sites to pass `cfd->GetLatestMutableCFOptions()` which returns a `const&` — no copy needed.

**Impact:** Eliminates the expensive `ColumnFamilyOptions` copy construction (which involves copying multiple `shared_ptr` members with atomic ref-count increments, vectors, and strings) on every periodic compaction check and trigger computation period calculation, for every column family in the loop.

Differential Revision: D107676627


