### PR TITLE
Add async I/O release UAF regression coverage

### DIFF
--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -1021,7 +1021,8 @@ DEFINE_int32(iterpercent, 10,
 static const bool FLAGS_iterpercent_dummy __attribute__((__unused__)) =
     RegisterFlagValidator(&FLAGS_iterpercent, &ValidateInt32Percent);
 
-DEFINE_uint64(num_iterations, 10, "Number of iterations per MultiIterate run");
+DEFINE_uint64(num_iterations, 10,
+              "Number of iterations per iterator or MultiScan run");
 static const bool FLAGS_num_iterations_dummy __attribute__((__unused__)) =
     RegisterFlagValidator(&FLAGS_num_iterations, &ValidateUint32Range);
 

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -2088,6 +2088,16 @@ Status StressTest::TestMultiScan(ThreadState* thread,
     return true;
   };
 
+  // Sometimes stop before draining all prefetched blocks, matching applications
+  // that stop after a bounded number of results. In one mode the whole prepared
+  // MultiScan is abandoned. In the other mode only the current range is
+  // stopped, so the next range's Seek() exercises releasing skipped blocks on
+  // the same prepared iterator.
+  const bool early_exit = thread->rand.OneIn(2);
+  const bool abandon_scan_after_early_exit =
+      early_exit && thread->rand.OneIn(2);
+  bool abandon_prepared_scan = false;
+
   for (const ScanOptions& scan_opt : scan_opts.GetScanRanges()) {
     if (op_logs.size() > kOpLogsLimit) {
       // Shouldn't take too much memory for the history log. Clear it.
@@ -2148,13 +2158,25 @@ Status StressTest::TestMultiScan(ThreadState* thread,
     VerifyIterator(thread, cmp_cfh, ro, iter.get(), cmp_iter.get(), last_op,
                    key, rand_column_families, op_logs, verify_func, &diverged);
 
+    uint64_t range_iterations = 0;
     while (iter->Valid()) {
+      if (early_exit && range_iterations >= FLAGS_num_iterations) {
+        if (abandon_scan_after_early_exit) {
+          op_logs += "E";
+          abandon_prepared_scan = true;
+        } else {
+          op_logs += "R";
+        }
+        break;
+      }
+
       iter->Next();
       if (!diverged) {
         assert(cmp_iter->Valid());
         cmp_iter->Next();
       }
       op_logs += "N";
+      ++range_iterations;
 
       if (iter->Valid() && ro.allow_unprepared_value) {
         op_logs += "*";
@@ -2193,7 +2215,7 @@ Status StressTest::TestMultiScan(ThreadState* thread,
     thread->stats.AddIterations(1);
 
     op_logs += "; ";
-    if (diverged) {
+    if (diverged || abandon_prepared_scan) {
       break;
     }
   }

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -521,8 +521,7 @@ default_params = {
     "use_multiscan": random.choice([1] + [0] * 3),
     # By default, `statistics` use kExceptDetailedTimers level
     "statistics": random.choice([0, 1]),
-    # TODO: re-enable after resolving "Req failed: Unknown error -14" errors
-    "multiscan_use_async_io": 0,  # random.randint(0, 1),
+    "multiscan_use_async_io": lambda: random.randint(0, 1),
 }
 
 _TEST_DIR_ENV_VAR = "TEST_TMPDIR"

--- a/util/io_dispatcher_test.cc
+++ b/util/io_dispatcher_test.cc
@@ -182,6 +182,168 @@ IOStatus ReadTrackingRandomAccessFile::ReadAsync(
   return target()->ReadAsync(req, opts, cb, cb_arg, io_handle, del_fn, dbg);
 }
 
+class ControlledAsyncFS;
+
+// Test-only async handle used by ControlledAsyncFS. It stores the callback and
+// original read parameters so the test filesystem can decide exactly when the
+// async read completes.
+struct ControlledAsyncHandle {
+  FSRandomAccessFile* target = nullptr;
+  IOOptions opts;
+  uint64_t offset = 0;
+  size_t len = 0;
+  char* scratch = nullptr;
+  std::function<void(FSReadRequest&, void*)> cb;
+  void* cb_arg = nullptr;
+};
+
+// Wraps a real random-access file but defers ReadAsync() completion to
+// ControlledAsyncFS. This keeps the read data realistic while making completion
+// ordering deterministic.
+class ControlledAsyncRandomAccessFile : public FSRandomAccessFileOwnerWrapper {
+ public:
+  ControlledAsyncRandomAccessFile(std::unique_ptr<FSRandomAccessFile>&& file,
+                                  ControlledAsyncFS* fs)
+      : FSRandomAccessFileOwnerWrapper(std::move(file)), fs_(fs) {}
+
+  IOStatus ReadAsync(FSReadRequest& req, const IOOptions& opts,
+                     std::function<void(FSReadRequest&, void*)> cb,
+                     void* cb_arg, void** io_handle, IOHandleDeleter* del_fn,
+                     IODebugContext* dbg) override;
+
+ private:
+  ControlledAsyncFS* fs_;
+};
+
+// A scheduling wrapper around the real filesystem. ReadAsync() requests stay
+// pending until Poll() or AbortIO() is called, letting tests model io_uring
+// completing an unrelated request while waiting for a requested handle.
+class ControlledAsyncFS : public ReadTrackingFS {
+ public:
+  explicit ControlledAsyncFS(const std::shared_ptr<FileSystem>& target)
+      : ReadTrackingFS(target) {}
+
+  IOStatus NewRandomAccessFile(const std::string& fname,
+                               const FileOptions& opts,
+                               std::unique_ptr<FSRandomAccessFile>* result,
+                               IODebugContext* dbg) override {
+    std::unique_ptr<FSRandomAccessFile> file;
+    IOStatus s = target()->NewRandomAccessFile(fname, opts, &file, dbg);
+    if (s.ok()) {
+      result->reset(new ControlledAsyncRandomAccessFile(std::move(file), this));
+    }
+    return s;
+  }
+
+  IOStatus Poll(std::vector<void*>& io_handles,
+                size_t /*min_completions*/) override {
+    assert(!io_handles.empty());
+    auto* requested_handle =
+        static_cast<ControlledAsyncHandle*>(io_handles.front());
+
+    // io_uring can reap completions for handles other than the one the caller
+    // is waiting on. Complete a different pending handle first to exercise that
+    // ordering deterministically.
+    if (complete_stray_first_) {
+      for (auto it = pending_handles_.begin(); it != pending_handles_.end();
+           ++it) {
+        if (*it != requested_handle) {
+          ControlledAsyncHandle* stray_handle = *it;
+          pending_handles_.erase(it);
+          stray_completion_count_++;
+          CompleteHandle(stray_handle);
+          break;
+        }
+      }
+    }
+
+    auto requested_it = std::find(pending_handles_.begin(),
+                                  pending_handles_.end(), requested_handle);
+    if (requested_it != pending_handles_.end()) {
+      pending_handles_.erase(requested_it);
+      CompleteHandle(requested_handle);
+    }
+
+    return IOStatus::OK();
+  }
+
+  IOStatus AbortIO(std::vector<void*>& io_handles) override {
+    for (void* io_handle : io_handles) {
+      auto* handle = static_cast<ControlledAsyncHandle*>(io_handle);
+      auto it =
+          std::find(pending_handles_.begin(), pending_handles_.end(), handle);
+      if (it == pending_handles_.end()) {
+        continue;
+      }
+      pending_handles_.erase(it);
+      abort_count_++;
+
+      // Match the filesystem contract: aborting an in-flight read completes its
+      // callback with an aborted status before the handle is deleted.
+      FSReadRequest req;
+      req.offset = handle->offset;
+      req.len = handle->len;
+      req.scratch = handle->scratch;
+      req.status = IOStatus::Aborted();
+      handle->cb(req, handle->cb_arg);
+    }
+    return IOStatus::OK();
+  }
+
+  void AddHandle(ControlledAsyncHandle* handle) {
+    pending_handles_.push_back(handle);
+  }
+
+  void SetCompleteStrayFirst(bool complete_stray_first) {
+    complete_stray_first_ = complete_stray_first;
+  }
+
+  size_t abort_count() const { return abort_count_; }
+  size_t stray_completion_count() const { return stray_completion_count_; }
+
+ private:
+  void CompleteHandle(ControlledAsyncHandle* handle) {
+    FSReadRequest req;
+    req.offset = handle->offset;
+    req.len = handle->len;
+    req.scratch = handle->scratch;
+    // Use the wrapped file for the actual bytes; only scheduling is mocked.
+    req.status =
+        handle->target->Read(handle->offset, handle->len, handle->opts,
+                             &req.result, handle->scratch, nullptr /*dbg*/);
+    handle->cb(req, handle->cb_arg);
+  }
+
+  std::vector<ControlledAsyncHandle*> pending_handles_;
+  bool complete_stray_first_ = true;
+  size_t abort_count_ = 0;
+  size_t stray_completion_count_ = 0;
+};
+
+IOStatus ControlledAsyncRandomAccessFile::ReadAsync(
+    FSReadRequest& req, const IOOptions& opts,
+    std::function<void(FSReadRequest&, void*)> cb, void* cb_arg,
+    void** io_handle, IOHandleDeleter* del_fn, IODebugContext* /*dbg*/) {
+  fs_->RecordReadAsync(req.offset, req.len);
+
+  // Do not submit to the real filesystem here. The handle is queued until the
+  // test explicitly completes it through ControlledAsyncFS::Poll() or
+  // AbortIO().
+  auto* handle = new ControlledAsyncHandle();
+  handle->target = target();
+  handle->opts = opts;
+  handle->offset = req.offset;
+  handle->len = req.len;
+  handle->scratch = req.scratch;
+  handle->cb = std::move(cb);
+  handle->cb_arg = cb_arg;
+
+  *io_handle = handle;
+  *del_fn = [](void* arg) { delete static_cast<ControlledAsyncHandle*>(arg); };
+  fs_->AddHandle(handle);
+  return IOStatus::OK();
+}
+
 class IODispatcherTest : public DBTestBase {
  public:
   IODispatcherTest()
@@ -449,12 +611,15 @@ class IODispatcherTest : public DBTestBase {
       const BlockBasedTableOptions* table_options_override = nullptr,
       bool use_direct_reads = false,
       CompressionType compression_type = kNoCompression,
-      bool allow_mmap_reads = false) {
+      bool allow_mmap_reads = false, Env* env_override = nullptr) {
     // Create options - store in member variables to avoid use-after-scope
     // The BlockBasedTable will keep references to these options
     Options options{};
     options.statistics = nullptr;
     options.allow_mmap_reads = allow_mmap_reads;
+    if (env_override != nullptr) {
+      options.env = env_override;
+    }
     BlockBasedTableOptions table_options;
     if (table_options_override != nullptr) {
       table_options = *table_options_override;
@@ -2951,6 +3116,123 @@ TEST_F(IODispatcherTest, ReleaseLastBlockFromCoalescedAsyncReadAbortsIO) {
 
   sync_point->DisableProcessing();
   sync_point->ClearAllCallBacks();
+}
+
+// Uses a controlled async filesystem to force the old failure mode: after block
+// 0 is released, a later Poll() for block 1 completes block 0's raw filesystem
+// callback first. With the old ReleaseBlock() behavior, that callback reaches
+// RandomAccessFileReader::ReadAsyncCallback after AsyncIOState is gone. The fix
+// aborts block 0's handle during ReleaseBlock(), so Poll() must never see it.
+TEST_F(IODispatcherTest, ReleasedDirectIOAsyncReadIsNotCompletedByLaterPoll) {
+  if (!kIOUringPresent) {
+    ROCKSDB_GTEST_SKIP("Async IO not supported on this platform");
+    return;
+  }
+
+  auto controlled_fs = std::make_shared<ControlledAsyncFS>(base_fs_);
+  tracking_fs_ = controlled_fs;
+  std::unique_ptr<Env> controlled_env = NewCompositeEnv(controlled_fs);
+
+  std::unique_ptr<BlockBasedTable> table;
+  std::vector<BlockHandle> block_handles;
+  Status s = CreateAndOpenSST(
+      20, &table, &block_handles, nullptr /* table_options_override */,
+      true /* use_direct_reads */, kNoCompression, false /* allow_mmap_reads */,
+      controlled_env.get());
+  ASSERT_OK(s);
+  ASSERT_GT(block_handles.size(), 2);
+
+  std::vector<BlockHandle> test_handles = {block_handles[0], block_handles[2]};
+
+  tracking_fs_->ClearReadOps();
+  std::unique_ptr<IODispatcher> dispatcher(NewIODispatcher());
+
+  auto job = std::make_shared<IOJob>();
+  job->block_handles = test_handles;
+  job->table = table.get();
+  job->job_options.read_options.async_io = true;
+  job->job_options.io_coalesce_threshold = 0;
+
+  std::shared_ptr<ReadSet> read_set;
+  s = dispatcher->SubmitJob(job, &read_set);
+  ASSERT_OK(s);
+  ASSERT_NE(read_set, nullptr);
+  ASSERT_EQ(tracking_fs_->GetReadAsyncCount(), test_handles.size());
+  ASSERT_EQ(tracking_fs_->GetMultiReadCount(), 0);
+
+  read_set->ReleaseBlock(0);
+  EXPECT_FALSE(read_set->IsBlockAvailable(0));
+
+  CachableEntry<Block> block;
+  ASSERT_OK(read_set->ReadIndex(1, &block));
+  ASSERT_NE(block.GetValue(), nullptr);
+  EXPECT_EQ(controlled_fs->abort_count(), 1);
+  EXPECT_EQ(controlled_fs->stray_completion_count(), 0);
+}
+
+// Simulates a MultiScan that reads one block from a first range, skips the
+// remaining pending block in that range, and then seeks into a later range. The
+// skipped block must be aborted before polling the later range so Poll() only
+// drains completions for blocks still owned by the ReadSet.
+TEST_F(IODispatcherTest, ReleasedRangeRemainderDoesNotBlockLaterAsyncRead) {
+  if (!kIOUringPresent) {
+    ROCKSDB_GTEST_SKIP("Async IO not supported on this platform");
+    return;
+  }
+
+  auto controlled_fs = std::make_shared<ControlledAsyncFS>(base_fs_);
+  tracking_fs_ = controlled_fs;
+  std::unique_ptr<Env> controlled_env = NewCompositeEnv(controlled_fs);
+
+  std::unique_ptr<BlockBasedTable> table;
+  std::vector<BlockHandle> block_handles;
+  Status s = CreateAndOpenSST(
+      30, &table, &block_handles, nullptr /* table_options_override */,
+      true /* use_direct_reads */, kNoCompression, false /* allow_mmap_reads */,
+      controlled_env.get());
+  ASSERT_OK(s);
+  ASSERT_GT(block_handles.size(), 6);
+
+  // Logical ranges: [0, 1] and [2, 3]. Each block uses a separate async IO.
+  std::vector<BlockHandle> test_handles = {block_handles[0], block_handles[2],
+                                           block_handles[4], block_handles[6]};
+
+  tracking_fs_->ClearReadOps();
+  std::unique_ptr<IODispatcher> dispatcher(NewIODispatcher());
+
+  auto job = std::make_shared<IOJob>();
+  job->block_handles = test_handles;
+  job->table = table.get();
+  job->job_options.read_options.async_io = true;
+  job->job_options.io_coalesce_threshold = 0;
+
+  std::shared_ptr<ReadSet> read_set;
+  s = dispatcher->SubmitJob(job, &read_set);
+  ASSERT_OK(s);
+  ASSERT_NE(read_set, nullptr);
+  ASSERT_EQ(tracking_fs_->GetReadAsyncCount(), test_handles.size());
+  ASSERT_EQ(tracking_fs_->GetMultiReadCount(), 0);
+
+  controlled_fs->SetCompleteStrayFirst(false);
+  CachableEntry<Block> block;
+  ASSERT_OK(read_set->ReadIndex(0, &block));
+  ASSERT_NE(block.GetValue(), nullptr);
+  EXPECT_FALSE(read_set->IsBlockAvailable(0));
+  EXPECT_EQ(controlled_fs->abort_count(), 0);
+  EXPECT_EQ(controlled_fs->stray_completion_count(), 0);
+
+  controlled_fs->SetCompleteStrayFirst(true);
+  read_set->ReleaseBlock(1);
+  EXPECT_FALSE(read_set->IsBlockAvailable(1));
+  EXPECT_EQ(controlled_fs->abort_count(), 1);
+
+  ASSERT_OK(read_set->ReadIndex(2, &block));
+  ASSERT_NE(block.GetValue(), nullptr);
+  EXPECT_EQ(controlled_fs->abort_count(), 1);
+  EXPECT_EQ(controlled_fs->stray_completion_count(), 1);
+
+  ASSERT_OK(read_set->ReadIndex(3, &block));
+  ASSERT_NE(block.GetValue(), nullptr);
 }
 
 // Regression test: when ReadAsync returns NotSupported (e.g., io_uring


### PR DESCRIPTION
## Summary

- Add a controlled async filesystem regression test for released direct I/O async reads, verifying released handles are aborted before a later `Poll()` can complete them.
- Add a MultiScan-style regression test for skipping a pending range remainder before seeking into a later async read.
- Extend db_stress/crashtest coverage so MultiScan can stop early after `--num_iterations` results and randomize `--multiscan_use_async_io` again.

## Test Plan

CI
