### PR TITLE
Use std::make_shared for all shared_ptr objects

### DIFF
--- a/db/compaction/compaction_service_test.cc
+++ b/db/compaction/compaction_service_test.cc
@@ -1674,7 +1674,7 @@ TEST_F(CompactionServiceTest, CompactionFilter) {
 
 TEST_F(CompactionServiceTest, MergeOperator) {
   Options options = CurrentOptions();
-  options.merge_operator.reset(new StringAppendOperator(','));
+  options.merge_operator = std::make_shared<StringAppendOperator>(',');
   ReopenWithCompactionService(&options);
   GenerateTestData();
   ASSERT_OK(dbfull()->TEST_WaitForCompact());

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -7697,7 +7697,7 @@ TEST_F(DBCompactionTest, PartialManualCompaction) {
   opts.num_levels = 3;
   opts.level0_file_num_compaction_trigger = 10;
   opts.compression = kNoCompression;
-  opts.merge_operator.reset(new NoopMergeOperator());
+  opts.merge_operator = std::make_shared<NoopMergeOperator>();
   opts.target_file_size_base = 10240;
   DestroyAndReopen(opts);
 
@@ -7834,7 +7834,7 @@ TEST_F(DBCompactionTest, ManualCompactionBottomLevelOptimized) {
   opts.num_levels = 3;
   opts.level0_file_num_compaction_trigger = 5;
   opts.compression = kNoCompression;
-  opts.merge_operator.reset(new NoopMergeOperator());
+  opts.merge_operator = std::make_shared<NoopMergeOperator>();
   opts.target_file_size_base = 1024;
   opts.max_bytes_for_level_multiplier = 2;
   opts.disable_auto_compactions = true;

--- a/db/db_iterator_test.cc
+++ b/db/db_iterator_test.cc
@@ -703,8 +703,8 @@ TEST_F(DBIteratorTest, ReseekUponDirectionChange) {
   options.create_if_missing = true;
   options.prefix_extractor.reset(NewFixedPrefixTransform(1));
   options.statistics = ROCKSDB_NAMESPACE::CreateDBStatistics();
-  options.merge_operator.reset(
-      new StringAppendTESTOperator(/*delim_char=*/' '));
+  options.merge_operator =
+      std::make_shared<StringAppendTESTOperator>(/*delim_char=*/' ');
   DestroyAndReopen(options);
   ASSERT_OK(Put("foo", "value"));
   ASSERT_OK(Put("bar", "value"));

--- a/db/db_merge_operator_test.cc
+++ b/db/db_merge_operator_test.cc
@@ -143,7 +143,7 @@ TEST_F(DBMergeOperatorTest, LimitMergeOperands) {
 TEST_F(DBMergeOperatorTest, MergeErrorOnRead) {
   Options options = CurrentOptions();
   options.create_if_missing = true;
-  options.merge_operator.reset(new TestPutOperator());
+  options.merge_operator = std::make_shared<TestPutOperator>();
   options.env = env_;
   Reopen(options);
   ASSERT_OK(Merge("k1", "v1"));
@@ -156,7 +156,7 @@ TEST_F(DBMergeOperatorTest, MergeErrorOnRead) {
 TEST_F(DBMergeOperatorTest, MergeErrorOnWrite) {
   Options options = CurrentOptions();
   options.create_if_missing = true;
-  options.merge_operator.reset(new TestPutOperator());
+  options.merge_operator = std::make_shared<TestPutOperator>();
   options.max_successive_merges = 3;
   options.env = env_;
   Reopen(options);
@@ -172,7 +172,7 @@ TEST_F(DBMergeOperatorTest, MergeErrorOnWrite) {
 TEST_F(DBMergeOperatorTest, MergeErrorOnIteration) {
   Options options = CurrentOptions();
   options.create_if_missing = true;
-  options.merge_operator.reset(new TestPutOperator());
+  options.merge_operator = std::make_shared<TestPutOperator>();
   options.env = env_;
 
   DestroyAndReopen(options);
@@ -228,7 +228,7 @@ TEST_F(DBMergeOperatorTest, MergeOperatorFailsWithMustMerge) {
   // only by APIs that do not require merging, such as `GetMergeOperands()`.
   const int kNumOperands = 3;
   Options options = CurrentOptions();
-  options.merge_operator.reset(new TestPutOperator());
+  options.merge_operator = std::make_shared<TestPutOperator>();
   options.env = env_;
   Reopen(options);
 
@@ -461,7 +461,7 @@ TEST_F(DBMergeOperatorTest, DataBlockBinaryAndHash) {
   // DataBlockBinaryAndHash.
   Options options = CurrentOptions();
   options.create_if_missing = true;
-  options.merge_operator.reset(new TestPutOperator());
+  options.merge_operator = std::make_shared<TestPutOperator>();
   options.env = env_;
   BlockBasedTableOptions table_options;
   table_options.block_restart_interval = 16;

--- a/db/db_properties_test.cc
+++ b/db/db_properties_test.cc
@@ -370,7 +370,7 @@ TEST_F(DBPropertiesTest, AggregatedTableProperties) {
     options.level0_file_num_compaction_trigger = 8;
     options.compression = kNoCompression;
     options.create_if_missing = true;
-    options.merge_operator.reset(new TestPutOperator());
+    options.merge_operator = std::make_shared<TestPutOperator>();
 
     BlockBasedTableOptions table_options;
     table_options.filter_policy.reset(
@@ -571,7 +571,7 @@ TEST_F(DBPropertiesTest, AggregatedTablePropertiesAtLevel) {
   options.max_bytes_for_level_multiplier = 2;
   // The checks assume kTableCount number of files
   options.disable_auto_compactions = true;
-  options.merge_operator.reset(new TestPutOperator());
+  options.merge_operator = std::make_shared<TestPutOperator>();
 
   BlockBasedTableOptions table_options;
   table_options.filter_policy.reset(

--- a/db/db_range_del_test.cc
+++ b/db/db_range_del_test.cc
@@ -1274,7 +1274,7 @@ TEST_F(DBRangeDelTest, KeyAtOverlappingEndpointReappears) {
   Options options = CurrentOptions();
   options.compression = kNoCompression;
   options.disable_auto_compactions = true;
-  options.merge_operator.reset(new MockMergeOperator());
+  options.merge_operator = std::make_shared<MockMergeOperator>();
   options.target_file_size_base = kFileBytes;
   Reopen(options);
 
@@ -1361,7 +1361,7 @@ TEST_F(DBRangeDelTest, UntruncatedTombstoneDoesNotDeleteNewerKey) {
   Options options = CurrentOptions();
   options.compression = kNoCompression;
   options.disable_auto_compactions = true;
-  options.merge_operator.reset(new MockMergeOperator());
+  options.merge_operator = std::make_shared<MockMergeOperator>();
   options.num_levels = 2;
   options.target_file_size_base = kFileBytes;
   Reopen(options);
@@ -1461,7 +1461,7 @@ TEST_F(DBRangeDelTest, DeletedMergeOperandReappearsIterPrev) {
   Options options = CurrentOptions();
   options.compression = kNoCompression;
   options.disable_auto_compactions = true;
-  options.merge_operator.reset(new MockMergeOperator());
+  options.merge_operator = std::make_shared<MockMergeOperator>();
   options.target_file_size_base = kFileBytes;
   Reopen(options);
 

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -6297,7 +6297,7 @@ TEST_F(DBTest, MergeTestTime) {
   SetPerfLevel(kEnableTime);
   Options options = CurrentOptions();
   options.statistics = ROCKSDB_NAMESPACE::CreateDBStatistics();
-  options.merge_operator.reset(new DelayedMergeOperator(this));
+  options.merge_operator = std::make_shared<DelayedMergeOperator>(this);
   SetTimeElapseOnlySleepOnReopen(&options);
   DestroyAndReopen(options);
 
@@ -6340,7 +6340,7 @@ TEST_P(DBTestWithParam, MergeCompactionTimeTest) {
   Options options = CurrentOptions();
   options.compaction_filter_factory = std::make_shared<KeepFilterFactory>();
   options.statistics = ROCKSDB_NAMESPACE::CreateDBStatistics();
-  options.merge_operator.reset(new DelayedMergeOperator(this));
+  options.merge_operator = std::make_shared<DelayedMergeOperator>(this);
   options.disable_auto_compactions = true;
   options.max_subcompactions = max_subcompactions_;
   SetTimeElapseOnlySleepOnReopen(&options);

--- a/db/external_sst_file_basic_test.cc
+++ b/db/external_sst_file_basic_test.cc
@@ -964,7 +964,7 @@ TEST_P(ExternalSSTFileBasicTest, IngestFileWithMultipleValueType) {
   do {
     Options options = CurrentOptions();
     options.disable_auto_compactions = true;
-    options.merge_operator.reset(new TestPutOperator());
+    options.merge_operator = std::make_shared<TestPutOperator>();
     DestroyAndReopen(options);
     std::map<std::string, std::string> true_data;
 
@@ -1092,7 +1092,7 @@ TEST_P(ExternalSSTFileBasicTest, IngestFileWithMixedValueType) {
   do {
     Options options = CurrentOptions();
     options.disable_auto_compactions = true;
-    options.merge_operator.reset(new TestPutOperator());
+    options.merge_operator = std::make_shared<TestPutOperator>();
     DestroyAndReopen(options);
     std::map<std::string, std::string> true_data;
 

--- a/db/write_batch_test.cc
+++ b/db/write_batch_test.cc
@@ -38,7 +38,7 @@ static std::string PrintContents(WriteBatch* b,
   Options options;
   options.memtable_factory = factory;
   if (merge_operator_supported) {
-    options.merge_operator.reset(new TestPutOperator());
+    options.merge_operator = std::make_shared<TestPutOperator>();
   }
   ImmutableOptions ioptions(options);
   WriteBufferManager wb(options.db_write_buffer_size);

--- a/examples/compaction_filter_example.cc
+++ b/examples/compaction_filter_example.cc
@@ -75,7 +75,7 @@ int main() {
   }
   ROCKSDB_NAMESPACE::Options options;
   options.create_if_missing = true;
-  options.merge_operator.reset(new MyMerge);
+  options.merge_operator = std::make_shared<MyMerge>();
   options.compaction_filter = &filter;
   status = ROCKSDB_NAMESPACE::DB::Open(options, kDBPath, &db);
   assert(status.ok());

--- a/utilities/cassandra/cassandra_functional_test.cc
+++ b/utilities/cassandra/cassandra_functional_test.cc
@@ -125,8 +125,8 @@ class CassandraFunctionalTest : public testing::Test {
   std::unique_ptr<DB> OpenDb() {
     Options options;
     options.create_if_missing = true;
-    options.merge_operator.reset(
-        new CassandraValueMergeOperator(gc_grace_period_in_seconds_));
+    options.merge_operator = std::make_shared<CassandraValueMergeOperator>(
+        gc_grace_period_in_seconds_);
     auto* cf_factory = new TestCompactionFilterFactory(
         purge_ttl_on_expiration_, gc_grace_period_in_seconds_);
     options.compaction_filter_factory.reset(cf_factory);

--- a/utilities/options/options_util_test.cc
+++ b/utilities/options/options_util_test.cc
@@ -271,7 +271,7 @@ TEST_F(OptionsUtilTest, SanityCheck) {
     ASSERT_NOK(
         CheckOptionsCompatibility(config_options, dbname_, db_opt, cf_descs));
 
-    cf_descs[0].options.merge_operator.reset(new DummyMergeOperator());
+    cf_descs[0].options.merge_operator = std::make_shared<DummyMergeOperator>();
     ASSERT_NOK(
         CheckOptionsCompatibility(config_options, dbname_, db_opt, cf_descs));
 

--- a/utilities/transactions/optimistic_transaction_test.cc
+++ b/utilities/transactions/optimistic_transaction_test.cc
@@ -37,7 +37,7 @@ class OptimisticTransactionTest
     options.create_if_missing = true;
     options.max_write_buffer_number = 2;
     options.max_write_buffer_size_to_maintain = 2 * Arena::kInlineSize;
-    options.merge_operator.reset(new TestPutOperator());
+    options.merge_operator = std::make_shared<TestPutOperator>();
     occ_opts.validate_policy = GetParam();
     dbname = test::PerThreadDBPath("optimistic_transaction_testdb");
 

--- a/utilities/ttl/db_ttl_impl.cc
+++ b/utilities/ttl/db_ttl_impl.cc
@@ -166,8 +166,8 @@ void DBWithTTLImpl::SanitizeOptions(int32_t ttl, ColumnFamilyOptions* options,
   }
 
   if (options->merge_operator) {
-    options->merge_operator.reset(
-        new TtlMergeOperator(options->merge_operator, clock));
+    options->merge_operator =
+        std::make_shared<TtlMergeOperator>(options->merge_operator, clock);
   }
 }
 

--- a/utilities/write_batch_with_index/write_batch_with_index_test.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_test.cc
@@ -2939,7 +2939,7 @@ TEST_P(WriteBatchWithIndexTest, TestBadMergeOperator) {
 
     const char* Name() const override { return "Failing"; }
   };
-  options_.merge_operator.reset(new FailingMergeOperator());
+  options_.merge_operator = std::make_shared<FailingMergeOperator>();
   ASSERT_OK(OpenDB());
 
   ColumnFamilyHandle* column_family = db_->DefaultColumnFamily();


### PR DESCRIPTION
Change/modernize all `.reset` usage in test files to `std::make_shared` . Just a simple PR to get my hands dirty. Thank you! 