### PR TITLE
Add C API bindings for manifest and file size tuning options

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -4590,6 +4590,16 @@ int rocksdb_options_get_target_file_size_multiplier(rocksdb_options_t* opt) {
   return opt->rep.target_file_size_multiplier;
 }
 
+void rocksdb_options_set_target_file_size_is_upper_bound(rocksdb_options_t* opt,
+                                                         unsigned char v) {
+  opt->rep.target_file_size_is_upper_bound = v;
+}
+
+unsigned char rocksdb_options_get_target_file_size_is_upper_bound(
+    rocksdb_options_t* opt) {
+  return opt->rep.target_file_size_is_upper_bound;
+}
+
 void rocksdb_options_set_max_bytes_for_level_base(rocksdb_options_t* opt,
                                                   uint64_t n) {
   opt->rep.max_bytes_for_level_base = n;
@@ -5037,6 +5047,15 @@ uint64_t rocksdb_options_get_WAL_size_limit_MB(rocksdb_options_t* opt) {
 void rocksdb_options_set_manifest_preallocation_size(rocksdb_options_t* opt,
                                                      size_t v) {
   opt->rep.manifest_preallocation_size = v;
+}
+
+int rocksdb_options_get_max_manifest_space_amp_pct(rocksdb_options_t* opt) {
+  return opt->rep.max_manifest_space_amp_pct;
+}
+
+void rocksdb_options_set_max_manifest_space_amp_pct(rocksdb_options_t* opt,
+                                                    int v) {
+  opt->rep.max_manifest_space_amp_pct = v;
 }
 
 size_t rocksdb_options_get_manifest_preallocation_size(rocksdb_options_t* opt) {

--- a/db/c_test.c
+++ b/db/c_test.c
@@ -2935,6 +2935,12 @@ int main(int argc, char** argv) {
     rocksdb_options_set_prepopulate_blob_cache(o, 1 /* flush only */);
     CheckCondition(1 == rocksdb_options_get_prepopulate_blob_cache(o));
 
+    rocksdb_options_set_target_file_size_is_upper_bound(o, 1);
+    CheckCondition(1 == rocksdb_options_get_target_file_size_is_upper_bound(o));
+
+    rocksdb_options_set_max_manifest_space_amp_pct(o, 31);
+    CheckCondition(31 == rocksdb_options_get_max_manifest_space_amp_pct(o));
+
     // Create a copy that should be equal to the original.
     rocksdb_options_t* copy;
     copy = rocksdb_options_create_copy(o);
@@ -3036,6 +3042,9 @@ int main(int argc, char** argv) {
     CheckCondition(1 == rocksdb_options_get_atomic_flush(copy));
     CheckCondition(29.0 ==
                    rocksdb_options_get_experimental_mempurge_threshold(copy));
+    CheckCondition(31 == rocksdb_options_get_max_manifest_space_amp_pct(copy));
+    CheckCondition(1 ==
+                   rocksdb_options_get_target_file_size_is_upper_bound(copy));
 
     // Copies should be independent.
     rocksdb_options_set_allow_ingest_behind(copy, 0);
@@ -3410,6 +3419,15 @@ int main(int argc, char** argv) {
                    rocksdb_options_get_experimental_mempurge_threshold(copy));
     CheckCondition(29.0 ==
                    rocksdb_options_get_experimental_mempurge_threshold(o));
+
+    rocksdb_options_set_max_manifest_space_amp_pct(copy, 330);
+    CheckCondition(330 == rocksdb_options_get_max_manifest_space_amp_pct(copy));
+    CheckCondition(31 == rocksdb_options_get_max_manifest_space_amp_pct(o));
+
+    rocksdb_options_set_target_file_size_is_upper_bound(copy, 0);
+    CheckCondition(0 ==
+                   rocksdb_options_get_target_file_size_is_upper_bound(copy));
+    CheckCondition(1 == rocksdb_options_get_target_file_size_is_upper_bound(o));
 
     rocksdb_options_destroy(copy);
     rocksdb_options_destroy(o);

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -1645,6 +1645,11 @@ extern ROCKSDB_LIBRARY_API void rocksdb_options_set_target_file_size_multiplier(
     rocksdb_options_t*, int);
 extern ROCKSDB_LIBRARY_API int rocksdb_options_get_target_file_size_multiplier(
     rocksdb_options_t*);
+extern ROCKSDB_LIBRARY_API void
+rocksdb_options_set_target_file_size_is_upper_bound(rocksdb_options_t*,
+                                                    unsigned char);
+extern ROCKSDB_LIBRARY_API unsigned char
+rocksdb_options_get_target_file_size_is_upper_bound(rocksdb_options_t*);
 extern ROCKSDB_LIBRARY_API void rocksdb_options_set_max_bytes_for_level_base(
     rocksdb_options_t*, uint64_t);
 extern ROCKSDB_LIBRARY_API uint64_t
@@ -1863,6 +1868,10 @@ extern ROCKSDB_LIBRARY_API void rocksdb_options_set_max_manifest_file_size(
     rocksdb_options_t*, size_t);
 extern ROCKSDB_LIBRARY_API size_t
 rocksdb_options_get_max_manifest_file_size(rocksdb_options_t*);
+extern ROCKSDB_LIBRARY_API void rocksdb_options_set_max_manifest_space_amp_pct(
+    rocksdb_options_t*, int);
+extern ROCKSDB_LIBRARY_API int rocksdb_options_get_max_manifest_space_amp_pct(
+    rocksdb_options_t*);
 extern ROCKSDB_LIBRARY_API void rocksdb_options_set_table_cache_numshardbits(
     rocksdb_options_t*, int);
 extern ROCKSDB_LIBRARY_API int rocksdb_options_get_table_cache_numshardbits(

--- a/unreleased_history/public_api_changes/c_api_manifest_file_size_tuning.md
+++ b/unreleased_history/public_api_changes/c_api_manifest_file_size_tuning.md
@@ -1,0 +1,2 @@
+Added `rocksdb_options_set_target_file_size_is_upper_bound`, `rocksdb_options_get_target_file_size_is_upper_bound`, `rocksdb_options_get_max_manifest_space_amp_pct`, `rocksdb_options_set_max_manifest_space_amp_pct` to the C API, exposing the exisiting options - max_manifest_space_amp_pct , target_file_size_is_upper_bound. This allows C API users (and downstream language bindings) for finer-grained control over manifest and SST file sizings.
+


### PR DESCRIPTION
## Summary
This PR is to fix issue : #14285
- Expose `max_manifest_space_amp_pct` and `target_file_size_is_upper_bound` to the C API.
  - `rocksdb_options_set_max_manifest_space_amp_pct` takes in int 
  - `rocksdb_options_get_max_manifest_space_amp_pct` returns int
  - `rocksdb_options_set_target_file_size_is_upper_bound` takes in unsigned char
  - `rocksdb_options_get_target_file_size_is_upper_bound` returns unsigned char 

- Allows C API users to have more finer grained control over manifest and SST file sizings.

## Test Plan

- Tests are added to `c_test` , under "options" , to validate getter and setters for the two fields.