### PR TITLE
Make file opens multi-threaded for commit external sst file ingestion

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -6982,6 +6982,8 @@ Status DBImpl::CommitFileIngestionHandles(
   std::vector<ExternalSstFileIngestionJob*> ingestion_jobs;
   const bool fill_cache =
       static_cast<FileIngestionHandleImpl*>(handles[0].get())->fill_cache_;
+  int max_file_opening_threads = 1;
+
   {
     UnorderedMap<ColumnFamilyData*, ExternalSstFileIngestionJob*>
         primary_job_for_cfd;
@@ -7003,6 +7005,8 @@ Status DBImpl::CommitFileIngestionHandles(
 
       hs.push_back(h);
       for (auto& job : h->jobs_) {
+        max_file_opening_threads =
+            std::max(max_file_opening_threads, job.file_opening_threads());
         auto [it, inserted] =
             primary_job_for_cfd.try_emplace(job.GetColumnFamilyData(), &job);
         if (inserted) {
@@ -7180,9 +7184,11 @@ Status DBImpl::CommitFileIngestionHandles(
         }
         assert(0 == num_entries);
       }
-      status =
-          versions_->LogAndApply(cfds_to_commit, read_options, write_options,
-                                 edit_lists, &mutex_, directories_.GetDbDir());
+      status = versions_->LogAndApply(
+          cfds_to_commit, read_options, write_options, edit_lists, &mutex_,
+          directories_.GetDbDir(), false /* new_descriptor_log */,
+          nullptr /* new_cf_options */, {} /* manifest_wcbs */, {} /* pre_cb */,
+          max_file_opening_threads);
       // It is safe to update VersionSet last seqno here after LogAndApply since
       // LogAndApply persists last sequence number from VersionEdits,
       // which are from file's largest seqno and not from VersionSet.

--- a/db/external_sst_file_ingestion_job.h
+++ b/db/external_sst_file_ingestion_job.h
@@ -302,6 +302,12 @@ class ExternalSstFileIngestionJob {
     return max_assigned_seqno_;
   }
 
+  // Max threads requested for opening this job's files during commit, from the
+  // per-CF IngestExternalFileOptions.
+  int file_opening_threads() const {
+    return ingestion_options_.file_opening_threads;
+  }
+
   // Merge another already-Prepare()d job for the SAME column family into this
   // one so both sets of files are committed by a single Run(). The other job's
   // files are appended after this job's, so for any overlapping keys the other

--- a/db/external_sst_file_test.cc
+++ b/db/external_sst_file_test.cc
@@ -430,6 +430,40 @@ TEST_F(ExternalSSTFileTest, PrepareThenCommit) {
   ASSERT_EQ("v3", Get("k3"));
 }
 
+TEST_F(ExternalSSTFileTest, ParallelFileOpenWithFileOpeningThreads) {
+  // Ingest many non-overlapping files with file_opening_threads > 1 so commit
+  // opens table readers with multiple threads. max_open_files == -1 makes
+  // commit open every new file.
+  Options options = CurrentOptions();
+  options.max_open_files = -1;
+  DestroyAndReopen(options);
+
+  constexpr int kNumFiles = 8;
+  constexpr int kKeysPerFile = 50;
+  std::vector<std::string> files;
+  std::map<std::string, std::string> true_data;
+  for (int f = 0; f < kNumFiles; f++) {
+    std::vector<std::pair<std::string, std::string>> data;
+    for (int k = 0; k < kKeysPerFile; k++) {
+      const int key = f * kKeysPerFile + k;
+      const std::string value = "val" + std::to_string(key);
+      data.emplace_back(Key(key), value);
+      true_data[Key(key)] = value;
+    }
+    std::string file_path;
+    ASSERT_OK(GenerateExternalFileOnly(options, data, &file_path));
+    files.push_back(file_path);
+  }
+
+  IngestExternalFileOptions ifo;
+  ifo.file_opening_threads = 4;
+  ASSERT_OK(db_->IngestExternalFile(files, ifo));
+
+  for (const auto& [key, value] : true_data) {
+    ASSERT_EQ(value, Get(key));
+  }
+}
+
 TEST_F(ExternalSSTFileTest, AbortPreparedIngestion) {
   Options options = CurrentOptions();
   DestroyAndReopen(options);

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -5722,16 +5722,19 @@ struct VersionSet::ManifestWriter {
   ColumnFamilyData* cfd;
   const autovector<VersionEdit*>& edit_list;
   const std::function<void(const Status&)> manifest_write_callback;
+  int max_file_opening_threads;
 
   explicit ManifestWriter(
       InstrumentedMutex* mu, ColumnFamilyData* _cfd,
       const autovector<VersionEdit*>& e,
-      const std::function<void(const Status&)>& manifest_wcb)
+      const std::function<void(const Status&)>& manifest_wcb,
+      int _max_file_opening_threads = 1)
       : done(false),
         cv(mu),
         cfd(_cfd),
         edit_list(e),
-        manifest_write_callback(manifest_wcb) {}
+        manifest_write_callback(manifest_wcb),
+        max_file_opening_threads(_max_file_opening_threads) {}
   ~ManifestWriter() { status.PermitUncheckedError(); }
 
   bool IsAllWalEdits() const {
@@ -6106,6 +6109,10 @@ Status VersionSet::ProcessManifestWrites(
   ManifestWriter& first_writer = writers.front();
   ManifestWriter* last_writer = &first_writer;
 
+  // Supports opening table readers with multiple threads, mostly useful for
+  // batched external sst file ingestion.
+  int batch_max_file_opening_threads = 1;
+
   assert(!manifest_writers_.empty());
   assert(manifest_writers_.front() == &first_writer);
 
@@ -6142,6 +6149,9 @@ Status VersionSet::ProcessManifestWrites(
     for (;;) {
       assert(!(*it)->edit_list.front()->IsColumnFamilyManipulation());
       last_writer = *it;
+      batch_max_file_opening_threads =
+          std::max(batch_max_file_opening_threads,
+                   last_writer->max_file_opening_threads);
       assert(last_writer != nullptr);
       assert(last_writer->cfd != nullptr);
       if (last_writer->cfd->IsDropped()) {
@@ -6400,7 +6410,7 @@ Status VersionSet::ProcessManifestWrites(
                builder_guards.size() == versions.size());
         ColumnFamilyData* cfd = versions[i]->cfd_;
         s = builder_guards[i]->version_builder()->LoadTableHandlers(
-            cfd->internal_stats(), 1 /* max_threads */,
+            cfd->internal_stats(), batch_max_file_opening_threads,
             true /* prefetch_index_and_filter_in_cache */,
             false /* is_initial_load */, versions[i]->GetMutableCFOptions(),
             MaxFileSizeForL0MetaPin(versions[i]->GetMutableCFOptions()),
@@ -6763,7 +6773,7 @@ Status VersionSet::LogAndApply(
     InstrumentedMutex* mu, FSDirectory* dir_contains_current_file,
     bool new_descriptor_log, const ColumnFamilyOptions* new_cf_options,
     const std::vector<std::function<void(const Status&)>>& manifest_wcbs,
-    const std::function<Status()>& pre_cb) {
+    const std::function<Status()>& pre_cb, int max_file_opening_threads) {
   mu->AssertHeld();
   int num_edits = 0;
   for (const auto& elist : edit_lists) {
@@ -6795,7 +6805,8 @@ Status VersionSet::LogAndApply(
   for (int i = 0; i < num_cfds; ++i) {
     const auto wcb =
         manifest_wcbs.empty() ? [](const Status&) {} : manifest_wcbs[i];
-    writers.emplace_back(mu, column_family_datas[i], edit_lists[i], wcb);
+    writers.emplace_back(mu, column_family_datas[i], edit_lists[i], wcb,
+                         max_file_opening_threads);
     manifest_writers_.push_back(&writers[i]);
   }
   assert(!writers.empty());

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -1330,7 +1330,8 @@ class VersionSet {
       bool new_descriptor_log = false,
       const ColumnFamilyOptions* new_cf_options = nullptr,
       const std::vector<std::function<void(const Status&)>>& manifest_wcbs = {},
-      const std::function<Status()>& pre_cb = {});
+      const std::function<Status()>& pre_cb = {},
+      int max_file_opening_threads = 1);
 
   void WakeUpWaitingManifestWriters();
 
@@ -1965,7 +1966,8 @@ class ReactiveVersionSet : public VersionSet {
       InstrumentedMutex* /*mu*/, FSDirectory* /*dir_contains_current_file*/,
       bool /*new_descriptor_log*/, const ColumnFamilyOptions* /*new_cf_option*/,
       const std::vector<std::function<void(const Status&)>>& /*manifest_wcbs*/,
-      const std::function<Status()>& /*pre_cb*/) override {
+      const std::function<Status()>& /*pre_cb*/,
+      int /*max_file_opening_threads*/) override {
     return Status::NotSupported("not supported in reactive mode");
   }
 

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -14,6 +14,7 @@
 #include "rocksdb/status.h"
 #ifdef GFLAGS
 #include <cinttypes>
+#include <deque>
 #include <unordered_map>
 
 #include "db/wide/wide_columns_helper.h"
@@ -2332,60 +2333,9 @@ class NonBatchedOpsStressTest : public StressTest {
     bool use_file_info =
         !test_standalone_range_deletion &&
         thread->rand.OneInOpt(FLAGS_ingest_external_file_use_file_info_one_in);
-    std::vector<std::string> external_files;
-    const std::string sst_filename =
-        GetDbPath() + "/." + std::to_string(thread->tid) + ".sst";
-    external_files.push_back(sst_filename);
-    std::string standalone_rangedel_filename;
-    if (test_standalone_range_deletion) {
-      standalone_rangedel_filename = GetDbPath() + "/." +
-                                     std::to_string(thread->tid) +
-                                     "_standalone_rangedel.sst";
-      external_files.push_back(standalone_rangedel_filename);
-    }
+
     Status s;
     std::ostringstream ingest_options_oss;
-
-    // Temporarily disable error injection for preparation
-    if (db_fault_injection_fs_) {
-      db_fault_injection_fs_->DisableThreadLocalErrorInjection(
-          FaultInjectionIOType::kMetadataRead);
-      db_fault_injection_fs_->DisableThreadLocalErrorInjection(
-          FaultInjectionIOType::kMetadataWrite);
-    }
-
-    for (const auto& filename : external_files) {
-      if (raw_env->FileExists(filename).ok()) {
-        // Maybe we terminated abnormally before, so cleanup to give this file
-        // ingestion a clean slate
-        s = raw_env->DeleteFile(filename);
-      }
-      if (!s.ok()) {
-        return;
-      }
-    }
-
-    if (db_fault_injection_fs_) {
-      db_fault_injection_fs_->EnableThreadLocalErrorInjection(
-          FaultInjectionIOType::kMetadataRead);
-      db_fault_injection_fs_->EnableThreadLocalErrorInjection(
-          FaultInjectionIOType::kMetadataWrite);
-    }
-
-    SstFileWriter sst_file_writer(EnvOptions(options_), options_);
-    SstFileWriter standalone_rangedel_sst_file_writer(EnvOptions(options_),
-                                                      options_);
-    ExternalSstFileInfo file_info;
-    if (s.ok()) {
-      s = sst_file_writer.Open(sst_filename);
-    }
-    if (s.ok() && test_standalone_range_deletion) {
-      s = standalone_rangedel_sst_file_writer.Open(
-          standalone_rangedel_filename);
-    }
-    if (!s.ok()) {
-      return;
-    }
 
     int64_t key_base = rand_keys[0];
     int column_family = rand_column_families[0];
@@ -2435,13 +2385,76 @@ class NonBatchedOpsStressTest : public StressTest {
       }
     }
 
-    if (s.ok() && keys.empty()) {
+    if (keys.empty()) {
+      return;
+    }
+    size_t total_keys = keys.size();
+
+    const size_t data_file_count =
+        std::min<size_t>(1 + thread->rand.Uniform(3), total_keys);
+    std::vector<std::string> external_files;
+    std::vector<std::string> data_filenames;
+    data_filenames.reserve(data_file_count);
+    for (size_t file_idx = 0; file_idx < data_file_count; ++file_idx) {
+      data_filenames.push_back(GetDbPath() + "/." +
+                               std::to_string(thread->tid) + "_" +
+                               std::to_string(file_idx) + ".sst");
+      external_files.push_back(data_filenames.back());
+    }
+    std::string standalone_rangedel_filename;
+    if (test_standalone_range_deletion) {
+      standalone_rangedel_filename = GetDbPath() + "/." +
+                                     std::to_string(thread->tid) +
+                                     "_standalone_rangedel.sst";
+      external_files.push_back(standalone_rangedel_filename);
+    }
+
+    // Temporarily disable error injection for preparation
+    if (db_fault_injection_fs_) {
+      db_fault_injection_fs_->DisableThreadLocalErrorInjection(
+          FaultInjectionIOType::kMetadataRead);
+      db_fault_injection_fs_->DisableThreadLocalErrorInjection(
+          FaultInjectionIOType::kMetadataWrite);
+    }
+
+    for (const auto& filename : external_files) {
+      if (raw_env->FileExists(filename).ok()) {
+        // Maybe we terminated abnormally before, so cleanup to give this file
+        // ingestion a clean slate
+        s = raw_env->DeleteFile(filename);
+      }
+      if (!s.ok()) {
+        return;
+      }
+    }
+
+    if (db_fault_injection_fs_) {
+      db_fault_injection_fs_->EnableThreadLocalErrorInjection(
+          FaultInjectionIOType::kMetadataRead);
+      db_fault_injection_fs_->EnableThreadLocalErrorInjection(
+          FaultInjectionIOType::kMetadataWrite);
+    }
+
+    std::vector<ExternalSstFileInfo> file_infos(data_file_count);
+    std::deque<SstFileWriter> sst_file_writers;
+    for (size_t file_idx = 0; s.ok() && file_idx < data_file_count;
+         ++file_idx) {
+      sst_file_writers.emplace_back(EnvOptions(options_), options_);
+      s = sst_file_writers.back().Open(data_filenames[file_idx]);
+    }
+    SstFileWriter standalone_rangedel_sst_file_writer(EnvOptions(options_),
+                                                      options_);
+    if (s.ok() && test_standalone_range_deletion) {
+      s = standalone_rangedel_sst_file_writer.Open(
+          standalone_rangedel_filename);
+    }
+    if (!s.ok()) {
       return;
     }
 
     // set pending state on expected values, create and ingest files.
-    size_t total_keys = keys.size();
     for (size_t i = 0; s.ok() && i < total_keys; i++) {
+      auto& sst_file_writer = sst_file_writers[i % sst_file_writers.size()];
       int64_t key = keys.at(i);
       char value[100];
       auto key_str = Key(key);
@@ -2469,7 +2482,9 @@ class NonBatchedOpsStressTest : public StressTest {
       }
     }
     if (s.ok() && !keys.empty()) {
-      s = sst_file_writer.Finish(&file_info);
+      for (size_t i = 0; s.ok() && i < sst_file_writers.size(); i++) {
+        s = sst_file_writers[i].Finish(&file_infos[i]);
+      }
     }
 
     if (s.ok() && total_keys != 0 && test_standalone_range_deletion) {
@@ -2495,6 +2510,7 @@ class NonBatchedOpsStressTest : public StressTest {
       ingest_options.verify_checksums_readahead_size =
           thread->rand.OneInOpt(2) ? 1024 * 1024 : 0;
       ingest_options.fill_cache = thread->rand.OneInOpt(4);
+      ingest_options.file_opening_threads = 1 + thread->rand.Uniform(4);
       const bool use_prepare_commit = thread->rand.OneInOpt(
           FLAGS_ingest_external_file_prepare_commit_one_in);
       const bool use_separate_prepare_calls = use_prepare_commit &&
@@ -2506,6 +2522,11 @@ class NonBatchedOpsStressTest : public StressTest {
                          << ", verify_checksums_readahead_size: "
                          << ingest_options.verify_checksums_readahead_size
                          << ", fill_cache: " << ingest_options.fill_cache
+                         << ", file_opening_threads: "
+                         << ingest_options.file_opening_threads
+                         << ", ingest_external_file_data_file_count: "
+                         << data_file_count
+                         << ", num_external_files: " << external_files.size()
                          << ", test_standalone_range_deletion: "
                          << test_standalone_range_deletion
                          << ", use_prepare_commit: " << use_prepare_commit
@@ -2516,8 +2537,10 @@ class NonBatchedOpsStressTest : public StressTest {
       arg.column_family = column_families_[column_family];
       arg.external_files = external_files;
       arg.options = ingest_options;
-      if (use_file_info && file_info.prepared_file_info) {
-        arg.file_infos = {file_info.prepared_file_info.get()};
+      if (use_file_info) {
+        for (const auto& file_info : file_infos) {
+          arg.file_infos.push_back(file_info.prepared_file_info.get());
+        }
       }
       if (use_prepare_commit) {
         std::vector<std::unique_ptr<FileIngestionHandle>> handles;

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -2952,6 +2952,11 @@ struct IngestExternalFileOptions {
   // ingestion options.
   bool fill_cache = true;
 
+  // Maximum number of threads used to open table readers for the files being
+  // ingested during commit, can speed up ingestion performance, when ingesting
+  // multiple files at once.
+  int file_opening_threads = 1;
+
   bool operator==(const IngestExternalFileOptions& rhs) const = default;
 };
 

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -1334,6 +1334,11 @@ DEFINE_int32(ingest_external_file_num_batches, 1,
              "ingestexternalfile benchmark. Total files ingested is "
              "batch_size * num_batches; each file holds --num keys.");
 
+DEFINE_int32(ingest_external_file_file_opening_threads, 1,
+             "IngestExternalFileOptions::file_opening_threads used by the "
+             "ingestexternalfile benchmark (threads for opening table readers "
+             "during commit).");
+
 DEFINE_bool(
     ingest_external_file_use_file_info, false,
     "If true, the ingestexternalfile benchmark passes each file's metadata "
@@ -9414,7 +9419,9 @@ class Benchmark {
   // the same key range, so the files overlap and are assigned new global
   // sequence numbers. With --ingest_external_file_use_file_info the writer's
   // metadata is passed via IngestExternalFileArg::file_infos so ingestion
-  // reuses it instead of re-opening and scanning the files. Single threaded.
+  // reuses it instead of re-opening and scanning the files.
+  // file_opening_threads controls how many threads open table readers during
+  // commit.
   //
   // NOTE: db_bench's reported micros/op includes file generation; use the
   // rocksdb.ingest.external.file.micros histogram (--statistics) for the
@@ -9424,6 +9431,8 @@ class Benchmark {
 
     const int batch_size = std::max(1, FLAGS_ingest_external_file_batch_size);
     const int num_batches = std::max(1, FLAGS_ingest_external_file_num_batches);
+    const int file_opening_threads =
+        FLAGS_ingest_external_file_file_opening_threads;
     const bool use_file_info = FLAGS_ingest_external_file_use_file_info;
     // --num is the number of keys in each file; all files cover this same key
     // range, so they overlap (which is fine -- a global seqno is assigned).
@@ -9493,6 +9502,7 @@ class Benchmark {
       // throughput. allow_global_seqno (default) handles the overlap.
       IngestExternalFileOptions ingest_options;
       ingest_options.move_files = true;
+      ingest_options.file_opening_threads = file_opening_threads;
       ingest_options.fill_cache = FLAGS_ingest_external_file_fill_cache;
       if (use_file_info) {
         // Reuse the writer's metadata so ingestion skips re-opening/scanning.
@@ -9522,11 +9532,11 @@ class Benchmark {
     thread->stats.AddBytes(bytes);
     char msg[100];
     snprintf(msg, sizeof(msg),
-             "(%d batches x %d files, %" PRId64 " keys/file%s)", num_batches,
-             batch_size, keys_per_file, use_file_info ? ", file_info" : "");
+             "(%d batches x %d files, %" PRId64 " keys/file, %d threads%s)",
+             num_batches, batch_size, keys_per_file, file_opening_threads,
+             use_file_info ? ", file_info" : "");
     thread->stats.AddMessage(msg);
   }
-
   void CompactAll() {
     CompactRangeOptions cro;
     cro.max_subcompactions = static_cast<uint32_t>(FLAGS_subcompactions);

--- a/tools/db_bench_tool_test.cc
+++ b/tools/db_bench_tool_test.cc
@@ -87,8 +87,8 @@ class DBBenchTest : public testing::Test {
 
   // Every flag is passed explicitly because gflags state persists across
   // db_bench_tool() calls within the same test process.
-  void RunIngestBench(int batch_size, int num_batches, bool use_file_info,
-                      bool fill_cache) {
+  void RunIngestBench(int batch_size, int num_batches, int file_opening_threads,
+                      bool use_file_info, bool fill_cache) {
     ResetArgs();
     AppendArgs(
         {"./db_bench", "--benchmarks=ingestexternalfile", "--use_existing_db=0",
@@ -96,6 +96,8 @@ class DBBenchTest : public testing::Test {
          "--wal_dir=" + wal_path_,
          "--ingest_external_file_batch_size=" + std::to_string(batch_size),
          "--ingest_external_file_num_batches=" + std::to_string(num_batches),
+         "--ingest_external_file_file_opening_threads=" +
+             std::to_string(file_opening_threads),
          "--ingest_external_file_use_file_info=" +
              std::string(use_file_info ? "true" : "false"),
          "--ingest_external_file_fill_cache=" +
@@ -163,17 +165,23 @@ TEST_F(DBBenchTest, OptionsFile) {
 }
 
 TEST_F(DBBenchTest, IngestExternalFile) {
-  RunIngestBench(/*batch_size=*/3, /*num_batches=*/2,
-                 /*use_file_info=*/false, /*fill_cache=*/true);
+  // Exercise the ingestexternalfile benchmark with both serial and parallel
+  // (file_opening_threads > 1) commit-time table-reader opening.
+  for (int file_opening_threads : {1, 4}) {
+    RunIngestBench(/*batch_size=*/3, /*num_batches=*/2, file_opening_threads,
+                   /*use_file_info=*/false, /*fill_cache=*/true);
+  }
 }
 
 TEST_F(DBBenchTest, IngestExternalFileWithFileInfo) {
   RunIngestBench(/*batch_size=*/3, /*num_batches=*/2,
+                 /*file_opening_threads=*/4,
                  /*use_file_info=*/true, /*fill_cache=*/true);
 }
 
 TEST_F(DBBenchTest, IngestExternalFileWithoutFillCache) {
   RunIngestBench(/*batch_size=*/3, /*num_batches=*/2,
+                 /*file_opening_threads=*/1,
                  /*use_file_info=*/false, /*fill_cache=*/false);
 }
 

--- a/unreleased_history/performance_improvements/ingest_external_file_file_opening_threads.md
+++ b/unreleased_history/performance_improvements/ingest_external_file_file_opening_threads.md
@@ -1,0 +1,1 @@
+Reduced commit latency when ingesting many external files by allowing `IngestExternalFileOptions::file_opening_threads` to open table readers for committed ingested files using multiple threads.


### PR DESCRIPTION
Summary:
`IngestExternalFileOptions` now exposes `file_opening_threads` so external file ingestion can open table readers for newly committed SSTs in parallel. The requested thread count is carried from each ingestion job into commit and then into manifest `LogAndApply`, where `VersionBuilder::LoadTableHandlers()` uses it while installing the ingested files.

This is intended for workloads that ingest many external SSTs in one call, where serial table-reader opens can dominate commit latency. The ingestexternalfile benchmark now has a flag for this option, and `db_stress` now creates multiple data SSTs per ingest operation so stress runs cover multi-file ingestion, file-info ingestion, and the parallel file-opening path together.

Benchmarks

Ran `db_bench --benchmarks=ingestexternalfile --use_existing_db=0 --num=2200000 --compression_type=none --statistics --use_direct_reads=true --ingest_external_file_batch_size=200 --ingest_external_file_num_batches=1 --ingest_external_file_use_file_info=true --ingest_external_file_fill_cache=false` while varying `--ingest_external_file_file_opening_threads`. The generated SST files were about 256 MiB each.

| `file_opening_threads` | `rocksdb.ingest.external.file.prepare.micros` | `rocksdb.ingest.external.file.run.micros` | File opens |
| 1 | 16,150 us | 327,136 us | 200 |
| 32 | 16,665 us | 38,349 us | 200 |

At the same ~256 MiB SST size, 2,000 files is roughly 500 GiB of SST data. A straight 10x extrapolation of the 200-file ingest histograms puts prepare+run at about 3.43s with `file_opening_threads=1` and 0.55s with `file_opening_threads=32`; run alone is about 3.27s vs. 0.38s.

Reviewed By: pdillinger

Differential Revision: D108347952


