### PR TITLE
External file ingestion, support fast prepare path from DB generated files (#14854)

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -102,6 +102,7 @@
 #include "table/get_context.h"
 #include "table/merging_iterator.h"
 #include "table/multiget_context.h"
+#include "table/prepared_file_info.h"
 #include "table/sst_file_dumper.h"
 #include "table/table_builder.h"
 #include "table/two_level_iterator.h"
@@ -5997,6 +5998,79 @@ void DBImpl::GetLiveFilesMetaData(std::vector<LiveFileMetaData>* metadata) {
 Status DBImpl::GetLiveFilesChecksumInfo(FileChecksumList* checksum_list) {
   InstrumentedMutexLock l(&mutex_);
   return versions_->GetLiveFilesChecksumInfo(checksum_list);
+}
+
+Status DBImpl::GetPreparedFileInfoForExternalSstIngestion(
+    const std::string& file_path,
+    std::shared_ptr<const PreparedFileInfo>* file_info) {
+  if (file_info == nullptr) {
+    return Status::InvalidArgument("file_info must not be null");
+  }
+  file_info->reset();
+
+  const size_t file_name_pos = file_path.find_last_of("/\\");
+  const std::string file_name = file_name_pos == std::string::npos
+                                    ? file_path
+                                    : file_path.substr(file_name_pos + 1);
+  uint64_t file_number = 0;
+  FileType file_type;
+  if (!ParseFileName(file_name, &file_number, &file_type) ||
+      file_type != kTableFile || file_number == 0) {
+    return Status::InvalidArgument("Invalid table file name: " + file_path);
+  }
+
+  int file_level = -1;
+  FileMetaData* file_meta = nullptr;
+  ColumnFamilyData* file_cfd = nullptr;
+  Version* file_version = nullptr;
+  std::shared_ptr<const TableProperties> table_properties;
+  ReadOptions read_options;
+
+  {
+    InstrumentedMutexLock l(&mutex_);
+    Status s = versions_->GetMetadataForFile(file_number, &file_level,
+                                             &file_meta, &file_cfd);
+    if (!s.ok()) {
+      return s;
+    }
+
+    const std::string expected_file_path = TableFileName(
+        file_cfd->ioptions().cf_paths, file_number, file_meta->fd.GetPathId());
+    if (file_path != expected_file_path) {
+      return Status::InvalidArgument("Path does not match live table file: " +
+                                     file_path);
+    }
+
+    file_cfd->Ref();
+    file_version = file_cfd->current();
+    file_version->Ref();
+  }
+  const Defer cleanup_refs([&]() {
+    InstrumentedMutexLock l(&mutex_);
+    file_version->Unref();
+    file_cfd->UnrefAndTryDelete();
+  });
+
+  Status s = file_cfd->table_cache()->GetTableProperties(
+      file_options_, read_options, file_cfd->internal_comparator(), *file_meta,
+      &table_properties, file_version->GetMutableCFOptions(),
+      false /* no_io */);
+  if (!s.ok()) {
+    return s;
+  }
+  assert(table_properties != nullptr);
+
+  auto prepared_file_info = std::make_shared<PreparedFileInfo>();
+  prepared_file_info->file_size = file_meta->fd.GetFileSize();
+  prepared_file_info->smallest = file_meta->smallest;
+  prepared_file_info->largest = file_meta->largest;
+  prepared_file_info->table_properties = *table_properties;
+  prepared_file_info->table_properties.key_largest_seqno =
+      file_meta->fd.largest_seqno;
+  prepared_file_info->table_properties.key_smallest_seqno =
+      file_meta->fd.smallest_seqno;
+  *file_info = std::move(prepared_file_info);
+  return s;
 }
 
 void DBImpl::GetColumnFamilyMetaData(ColumnFamilyHandle* column_family,

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -576,6 +576,10 @@ class DBImpl : public DB {
       const LiveFilesStorageInfoOptions& opts,
       std::vector<LiveFileStorageInfo>* files) override;
 
+  Status GetPreparedFileInfoForExternalSstIngestion(
+      const std::string& file_path,
+      std::shared_ptr<const PreparedFileInfo>* file_info) override;
+
   // Obtains the meta data of the specified column family of the DB.
   // TODO(yhchiang): output parameter is placed in the end in this codebase.
   void GetColumnFamilyMetaData(ColumnFamilyHandle* column_family,

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -3785,6 +3785,12 @@ class ModelDB : public DB {
     return Status::OK();
   }
 
+  Status GetPreparedFileInfoForExternalSstIngestion(
+      const std::string& /*file_path*/,
+      std::shared_ptr<const PreparedFileInfo>* /*file_info*/) override {
+    return Status::NotSupported();
+  }
+
   Status GetSortedWalFiles(VectorLogPtr& /*files*/) override {
     return Status::OK();
   }

--- a/db/external_sst_file_test.cc
+++ b/db/external_sst_file_test.cc
@@ -5,6 +5,7 @@
 
 #include <table/block_based/block_based_table_factory.h>
 
+#include <atomic>
 #include <functional>
 #include <memory>
 #include <sstream>
@@ -741,6 +742,70 @@ TEST_F(ExternalSSTFileTest, IngestWithFileInfoRejectsWriteGlobalSeqno) {
   arg.file_infos = {file_info.prepared_file_info.get()};
   arg.options.write_global_seqno = true;
   ASSERT_TRUE(db_->IngestExternalFiles({arg}).IsInvalidArgument());
+}
+
+TEST_F(ExternalSSTFileTest, GetPreparedFileInfoForExternalSstIngestion) {
+  Options options = CurrentOptions();
+  DestroyAndReopen(options);
+
+  const std::string source_dbname = dbname_ + "_source";
+  ASSERT_OK(DestroyDB(source_dbname, options));
+  std::unique_ptr<DB> source_db;
+  ASSERT_OK(DB::Open(options, source_dbname, &source_db));
+
+  ASSERT_OK(source_db->Put(WriteOptions(), Key(10), "v10"));
+  ASSERT_OK(source_db->Flush(FlushOptions()));
+
+  std::vector<LiveFileMetaData> live_meta;
+  source_db->GetLiveFilesMetaData(&live_meta);
+  ASSERT_EQ(live_meta.size(), 1);
+  ASSERT_GT(live_meta[0].largest_seqno, 0);
+  const std::string file_path =
+      live_meta[0].directory + "/" + live_meta[0].relative_filename;
+
+  std::shared_ptr<const PreparedFileInfo> prepared_file_info;
+  ASSERT_TRUE(source_db
+                  ->GetPreparedFileInfoForExternalSstIngestion(
+                      live_meta[0].relative_filename, &prepared_file_info)
+                  .IsInvalidArgument());
+  ASSERT_EQ(prepared_file_info, nullptr);
+  prepared_file_info = std::make_shared<PreparedFileInfo>();
+  ASSERT_TRUE(source_db
+                  ->GetPreparedFileInfoForExternalSstIngestion(
+                      dbname_ + "_wrong/" + live_meta[0].relative_filename,
+                      &prepared_file_info)
+                  .IsInvalidArgument());
+  ASSERT_EQ(prepared_file_info, nullptr);
+
+  ASSERT_OK(source_db->GetPreparedFileInfoForExternalSstIngestion(
+      file_path, &prepared_file_info));
+  ASSERT_TRUE(prepared_file_info != nullptr);
+  ASSERT_EQ(prepared_file_info->file_size, live_meta[0].size);
+  ASSERT_EQ(prepared_file_info->table_properties.key_largest_seqno,
+            live_meta[0].largest_seqno);
+
+  IngestExternalFileArg arg;
+  arg.column_family = db_->DefaultColumnFamily();
+  arg.external_files = {file_path};
+  arg.file_infos = {prepared_file_info.get()};
+  arg.options.allow_db_generated_files = true;
+  arg.options.snapshot_consistency = false;
+
+  SyncPoint::GetInstance()->SetCallBack(
+      "ExternalSstFileIngestionJob::GetIngestedFileInfo:ReadPath",
+      [](void*) { FAIL() << "Prepared file info should skip the read path"; });
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  ASSERT_OK(db_->IngestExternalFiles({arg}));
+
+  ASSERT_EQ(Get(Key(10)), "v10");
+
+  ASSERT_OK(source_db->Close());
+  source_db.reset();
+  ASSERT_OK(DestroyDB(source_dbname, options));
+
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
 }
 
 TEST_F(ExternalSSTFileTest,

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1952,6 +1952,14 @@ class DB {
       const LiveFilesStorageInfoOptions& opts,
       std::vector<LiveFileStorageInfo>* files) = 0;
 
+  // Prepares a live DB-generated table file for use with IngestExternalFiles().
+  // See `PreparedFileInfo` for details. The path must exactly match a live
+  // table file owned by this DB. This may open the table file and populate this
+  // DB's table cache if the table reader is not already cached.
+  virtual Status GetPreparedFileInfoForExternalSstIngestion(
+      const std::string& /*file_path*/,
+      std::shared_ptr<const PreparedFileInfo>* /*file_info*/) = 0;
+
   // Obtains the LSM-tree meta data of the specified column family of the DB,
   // including metadata for each live table (SST) file in that column family.
   virtual void GetColumnFamilyMetaData(ColumnFamilyHandle* /*column_family*/,

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -2960,11 +2960,12 @@ struct IngestExternalFileOptions {
   bool operator==(const IngestExternalFileOptions& rhs) const = default;
 };
 
-// PreparedFileInfo is an opaque description of an SST file produced in
-// ExternalSstFileInfo::prepared_file_info by SstFileWriter::Finish(). A
-// borrowed pointer to one can be placed in IngestExternalFileArg::file_infos to
-// skip re-opening and scanning the file when computing its metadata, reducing
-// ingestion I/O.
+// Opaque per-file metadata accepted through IngestExternalFileArg::file_infos.
+// Supplying it lets DB::IngestExternalFiles() and DB::PrepareFileIngestion()
+// prepare ingestion without re-opening and scanning the SST to recompute file
+// metadata. It is produced by SstFileWriter::Finish() for writer-created files
+// or by DB::GetPreparedFileInfoForExternalSstIngestion() for live DB-generated
+// files.
 struct PreparedFileInfo;
 
 // It is valid that files_checksums and files_checksum_func_names are both
@@ -3004,12 +3005,8 @@ struct IngestExternalFileArg {
   // sorted out.
   std::optional<RangeOpt> atomic_replace_range;
 
-  // Optional per-file opaque metadata, parallel to `external_files` (same size
-  // and order). Each entry is a borrowed pointer to a PreparedFileInfo owned by
-  // ExternalSstFileInfo::prepared_file_info; the owning handle must stay alive
-  // until ingestion completes. When provided, ingestion reuses this metadata
-  // instead of re-opening and scanning each file to recompute it, avoiding that
-  // extra I/O.
+  // Optimizes for prepare performance, see `PreparedFileInfo` for details.
+  // The owning handle must stay alive until ingestion completes.
   // Not compatible with options.write_global_seqno (the file is not opened, so
   // a global seqno cannot be written back into it). Because the file is not
   // opened, ingestion does not read its storage temperature and trusts the

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -461,6 +461,13 @@ class StackableDB : public DB {
     return db_->GetLiveFilesStorageInfo(opts, files);
   }
 
+  Status GetPreparedFileInfoForExternalSstIngestion(
+      const std::string& file_path,
+      std::shared_ptr<const PreparedFileInfo>* file_info) override {
+    return db_->GetPreparedFileInfoForExternalSstIngestion(file_path,
+                                                           file_info);
+  }
+
   void GetColumnFamilyMetaData(ColumnFamilyHandle* column_family,
                                ColumnFamilyMetaData* cf_meta) override {
     db_->GetColumnFamilyMetaData(column_family, cf_meta);

--- a/table/prepared_file_info.h
+++ b/table/prepared_file_info.h
@@ -12,9 +12,6 @@
 
 namespace ROCKSDB_NAMESPACE {
 
-// Produced by SstFileWriter::Finish and consumed by ExternalSstFileIngestionJob
-// so ingestion can skip re-opening and scanning the file to recompute its
-// metadata.
 struct PreparedFileInfo {
   uint64_t file_size = 0;
   // Final ingestion bounds, after considering both point keys and range

--- a/unreleased_history/public_api_changes/get_prepared_file_info_for_external_sst_ingestion.md
+++ b/unreleased_history/public_api_changes/get_prepared_file_info_for_external_sst_ingestion.md
@@ -1,0 +1,1 @@
+`DB::GetPreparedFileInfoForExternalSstIngestion()` can now prepare metadata for a live DB-generated SST file so it can be passed to `IngestExternalFileArg::file_infos`. The input path must exactly match a live table file owned by the source DB, and the returned metadata handle must outlive the ingestion.


### PR DESCRIPTION
Summary:

External SST ingestion can already skip the open-and-scan metadata path when ingesting files produced by `SstFileWriter`. This extends that fast path to live SST files produced by a DB, so applications that move DB-generated files between DBs can request prepared metadata directly from the source DB and pass it through ingestion.

The API is intentionally limited to live table files whose metadata is already available from the DB and cached table reader. Callers remain responsible for keeping the source file alive and unchanged until ingestion completes.

Reviewed By: xingbowang

Differential Revision: D108440584


