### PR TITLE
fix package fault injection log parser in db stress fbpkg (#14874)

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -5795,3 +5795,5 @@ cpp_unittest_wrapper(name="write_unprepared_transaction_test",
 
 
 export_file(name = "tools/db_crashtest.py")
+
+export_file(name = "tools/fault_injection_log_parser.py")

--- a/buckifier/buckify_rocksdb.py
+++ b/buckifier/buckify_rocksdb.py
@@ -360,6 +360,7 @@ def generate_buck(repo_path, deps_map):
                         extra_compiler_flags=json.dumps(deps["extra_compiler_flags"]),
                     )
     BUCK.export_file("tools/db_crashtest.py")
+    BUCK.export_file("tools/fault_injection_log_parser.py")
 
     print(ColorString.info("Generated BUCK Summary:"))
     print(ColorString.info("- %d libs" % BUCK.total_lib))


### PR DESCRIPTION
### Problem

RocksDB alert fired after the job started crashlooping with `ModuleNotFoundError: No module named fault_injection_log_parser`.

### RCA
https://github.com/facebook/rocksdb/pull/14651 added `import fault_injection_log_parser` to `db_crashtest.py`, but `rocksdb_db_stress` only packaged `crashtest.py` and `rocks_db_stress`, so the `release_test` fbpkg rolled to TW without the new helper module.

### Fix
Export `tools/fault_injection_log_parser.py` and include it in the `rocksdb_db_stress` fbpkg `path_actions` so it is installed next to `crashtest.py`.

Reviewed By: xingbowang

Differential Revision: D109346224


