### PR TITLE
Add reverse order support to MultiScan (#14876)

### DIFF
--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -1921,6 +1921,9 @@ Status DBIter::ValidateScanOptions(const MultiScanArgs& multiscan_opts) const {
 
   const std::vector<ScanOptions>& scan_opts = multiscan_opts.GetScanRanges();
   const bool has_limit = scan_opts.front().range.limit.has_value();
+  if (multiscan_opts.reverse && !has_limit) {
+    return Status::InvalidArgument("Reverse MultiScan requires limit");
+  }
   if (!has_limit && scan_opts.size() > 1) {
     return Status::InvalidArgument("Scan has no upper bound");
   }
@@ -2004,6 +2007,12 @@ void DBIter::Seek(const Slice& target) {
   StopWatch sw(clock_, statistics_, DB_SEEK);
 
   if (scan_opts_.has_value()) {
+    if (scan_opts_->reverse) {
+      status_ = Status::InvalidArgument("Seek called on reverse MultiScan");
+      valid_ = false;
+      return;
+    }
+
     // Validate the seek target is as expected in the previously prepared range
     auto const& scan_ranges = scan_opts_.value().GetScanRanges();
     if (scan_index_ >= scan_ranges.size()) {
@@ -2109,6 +2118,61 @@ void DBIter::SeekForPrev(const Slice& target) {
   PERF_COUNTER_ADD(iter_seek_count, 1);
   PERF_CPU_TIMER_GUARD(iter_seek_cpu_nanos, clock_);
   StopWatch sw(clock_, statistics_, DB_SEEK);
+
+  if (scan_opts_.has_value()) {
+    if (!scan_opts_->reverse) {
+      status_ =
+          Status::InvalidArgument("SeekForPrev called on forward MultiScan");
+      valid_ = false;
+      return;
+    }
+
+    auto const& scan_ranges = scan_opts_.value().GetScanRanges();
+    if (scan_index_ >= scan_ranges.size()) {
+      status_ = Status::InvalidArgument(
+          "SeekForPrev called after exhausting all of the scan ranges");
+      valid_ = false;
+      return;
+    }
+
+    auto const& range = scan_ranges[scan_index_];
+    auto const& limit = range.range.limit;
+    assert(limit.has_value());
+    if (!limit.has_value() ||
+        user_comparator_.CompareWithoutTimestamp(target, *limit) != 0) {
+      status_ = Status::InvalidArgument(
+          "SeekForPrev target does not match the limit of the next prepared "
+          "range at index " +
+          std::to_string(scan_index_));
+      valid_ = false;
+      return;
+    }
+
+    auto const& start = range.range.start;
+    assert(start.has_value());
+    if (iterate_lower_bound_ == nullptr ||
+        user_comparator_.CompareWithoutTimestamp(start.value(),
+                                                 *iterate_lower_bound_) != 0) {
+      status_ = Status::InvalidArgument(
+          "Lower bound is not set to the same start value of the next "
+          "prepared range at index " +
+          std::to_string(scan_index_));
+      valid_ = false;
+      return;
+    }
+    if (iterate_upper_bound_ == nullptr ||
+        user_comparator_.CompareWithoutTimestamp(limit.value(),
+                                                 *iterate_upper_bound_) != 0) {
+      status_ = Status::InvalidArgument(
+          "Upper bound is not set to the same limit value of the next "
+          "prepared range at index " +
+          std::to_string(scan_index_));
+      valid_ = false;
+      return;
+    }
+
+    scan_index_++;
+  }
 
   if (has_trace_state_) {
     // TODO: What do we do if this returns an error?

--- a/db/db_iterator_test.cc
+++ b/db/db_iterator_test.cc
@@ -5418,6 +5418,98 @@ TEST_P(DBMultiScanIteratorTest, AsyncPrefetchAcrossMultipleFiles) {
   iter.reset();
 }
 
+TEST_P(DBMultiScanIteratorTest, ReversePrefetchAcrossMultipleRanges) {
+  auto options = CurrentOptions();
+  options.target_file_size_base = 1 << 15;  // 32KiB
+  options.compaction_style = kCompactionStyleUniversal;
+  options.num_levels = 50;
+  options.compression = kNoCompression;
+  DestroyAndReopen(options);
+
+  Random rnd(303);
+  for (int i = 0; i < 1000; ++i) {
+    ASSERT_OK(Put(Key(i), rnd.RandomString(1 << 10)));
+  }
+  ASSERT_OK(Flush());
+  ASSERT_OK(db_->CompactRange({}, nullptr, nullptr));
+  ASSERT_GT(NumTableFilesAtLevel(49), 3);
+
+  ReadOptions ro;
+  ro.fill_cache = GetParam();
+  ColumnFamilyHandle* cfh = dbfull()->DefaultColumnFamily();
+  auto tracking_dispatcher = std::make_shared<TrackingIODispatcher>();
+
+  MultiScanArgs scan_options(BytewiseComparator());
+  scan_options.use_async_io = false;
+  scan_options.reverse = true;
+  scan_options.io_dispatcher = tracking_dispatcher;
+  std::vector<std::string> key_ranges(
+      {Key(100), Key(200), Key(500), Key(600), Key(800), Key(900)});
+  scan_options.insert(key_ranges[0], key_ranges[1]);
+  scan_options.insert(key_ranges[2], key_ranges[3]);
+  scan_options.insert(key_ranges[4], key_ranges[5]);
+
+  std::unique_ptr<MultiScan> iter =
+      dbfull()->NewMultiScan(ro, cfh, scan_options);
+  ASSERT_NE(iter, nullptr);
+
+  std::vector<std::string> actual_keys;
+  try {
+    for (auto range : *iter) {
+      for (auto it : range) {
+        actual_keys.push_back(it.first.ToString());
+      }
+    }
+  } catch (MultiScanException& ex) {
+    FAIL() << "Iterator returned status " << ex.what();
+  } catch (std::logic_error& ex) {
+    FAIL() << "Iterator returned logic error " << ex.what();
+  }
+
+  std::vector<std::string> expected_keys;
+  for (int i = 199; i >= 100; --i) {
+    expected_keys.push_back(Key(i));
+  }
+  for (int i = 599; i >= 500; --i) {
+    expected_keys.push_back(Key(i));
+  }
+  for (int i = 899; i >= 800; --i) {
+    expected_keys.push_back(Key(i));
+  }
+  ASSERT_EQ(actual_keys, expected_keys);
+  ASSERT_GT(tracking_dispatcher->GetReadSets().size(), 0);
+}
+
+TEST_P(DBMultiScanIteratorTest, ReverseRequiresLimits) {
+  auto options = CurrentOptions();
+  options.compression = kNoCompression;
+  DestroyAndReopen(options);
+
+  ASSERT_OK(Put("a", "va"));
+  ASSERT_OK(Put("b", "vb"));
+  ASSERT_OK(Flush());
+
+  ReadOptions ro;
+  ro.fill_cache = GetParam();
+  ColumnFamilyHandle* cfh = dbfull()->DefaultColumnFamily();
+
+  MultiScanArgs scan_options(BytewiseComparator());
+  scan_options.reverse = true;
+  scan_options.insert("a");
+  scan_options.insert("b", "c");
+
+  std::unique_ptr<MultiScan> iter =
+      dbfull()->NewMultiScan(ro, cfh, scan_options);
+  ASSERT_NE(iter, nullptr);
+  try {
+    (void)iter->begin();
+    FAIL() << "Expected reverse MultiScan without an upper bound to fail";
+  } catch (MultiScanException& ex) {
+    ASSERT_NOK(ex.status());
+    ASSERT_TRUE(ex.status().IsInvalidArgument());
+  }
+}
+
 // Wrapper filesystem that does not support async IO.
 // Used to verify that MultiScan gracefully falls back to sync IO.
 class NoAsyncIOFS : public FileSystemWrapper {

--- a/db/multi_scan.cc
+++ b/db/multi_scan.cc
@@ -3,13 +3,55 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
+#include <string>
+#include <vector>
+
 #include "file/file_util.h"
 #include "rocksdb/db.h"
 #include "rocksdb/file_system.h"
+#include "rocksdb/iterator.h"
 
 namespace ROCKSDB_NAMESPACE {
 
 using MultiScanIterator = MultiScan::MultiScanIterator;
+
+namespace {
+
+Status ValidateScanOptionsForMultiScan(const MultiScanArgs& multiscan_opts) {
+  if (multiscan_opts.empty()) {
+    return Status::InvalidArgument("Empty MultiScanArgs");
+  }
+
+  const Comparator* comparator = multiscan_opts.GetComparator();
+  if (comparator == nullptr) {
+    return Status::InvalidArgument("MultiScanArgs requires comparator");
+  }
+
+  const std::vector<ScanOptions>& scan_opts = multiscan_opts.GetScanRanges();
+  for (size_t i = 0; i < scan_opts.size(); ++i) {
+    const auto& scan_range = scan_opts[i].range;
+    if (!scan_range.start.has_value()) {
+      return Status::InvalidArgument("Scan has no start key at index " +
+                                     std::to_string(i));
+    }
+    if (multiscan_opts.reverse && !scan_range.limit.has_value()) {
+      return Status::InvalidArgument(
+          "Reverse MultiScan requires limit at index " + std::to_string(i));
+    }
+    if (scan_range.limit.has_value() &&
+        comparator->CompareWithoutTimestamp(
+            scan_range.start.value(), /*a_has_ts=*/false,
+            scan_range.limit.value(), /*b_has_ts=*/false) >= 0) {
+      return Status::InvalidArgument(
+          "Scan start key is large or equal than limit at index " +
+          std::to_string(i));
+    }
+  }
+
+  return Status::OK();
+}
+
+}  // namespace
 
 MultiScan::MultiScan(const ReadOptions& read_options,
                      const MultiScanArgs& scan_opts, DB* db,
@@ -28,14 +70,28 @@ MultiScan::MultiScan(const ReadOptions& read_options,
       }()),
       db_(db),
       cfh_(cfh) {
+  Status validate_status = ValidateScanOptionsForMultiScan(scan_opts_);
+  if (!validate_status.ok()) {
+    db_iter_.reset(NewErrorIterator(validate_status));
+    return;
+  }
+
   bool slow_path = false;
-  // Setup read_options with iterate_uuper_bound based on the first scan.
-  // Subsequent scans will update and allocate a new DB iterator as necessary
-  if (scan_opts_.GetScanRanges()[0].range.limit) {
-    upper_bound_ = *scan_opts_.GetScanRanges()[0].range.limit;
-    read_options_.iterate_upper_bound = &upper_bound_;
-  } else {
-    read_options_.iterate_upper_bound = nullptr;
+  // Setup read_options bounds based on the first scan. Subsequent scans will
+  // update the bounds and allocate a new DB iterator as necessary.
+  {
+    const ScanOptions& first_scan = scan_opts_.GetScanRanges()[0];
+    if (scan_opts_.reverse) {
+      lower_bound_ = *first_scan.range.start;
+      read_options_.iterate_lower_bound = &lower_bound_;
+      upper_bound_ = *first_scan.range.limit;
+      read_options_.iterate_upper_bound = &upper_bound_;
+    } else if (first_scan.range.limit) {
+      upper_bound_ = *first_scan.range.limit;
+      read_options_.iterate_upper_bound = &upper_bound_;
+    } else {
+      read_options_.iterate_upper_bound = nullptr;
+    }
   }
   for (const auto& opts : scan_opts_.GetScanRanges()) {
     // Check that all the ScanOptions either specify an upper bound or not. If
@@ -54,36 +110,55 @@ MultiScan::MultiScan(const ReadOptions& read_options,
   }
 }
 
+void MultiScanIterator::SeekCurrentRange() {
+  const ScanOptions& scan_opt = scan_opts_[idx_];
+  if (scan_opt.range.limit) {
+    *upper_bound_ = *scan_opt.range.limit;
+    read_options_.iterate_upper_bound = upper_bound_;
+  } else {
+    read_options_.iterate_upper_bound = nullptr;
+  }
+
+  if (reverse_) {
+    *lower_bound_ = *scan_opt.range.start;
+    read_options_.iterate_lower_bound = lower_bound_;
+    assert(scan_opt.range.limit.has_value());
+    db_iter_->SeekForPrev(*scan_opt.range.limit);
+  } else {
+    db_iter_->Seek(*scan_opt.range.start);
+  }
+}
+
 MultiScanIterator& MultiScanIterator::operator++() {
   status_ = db_iter_->status();
   if (!status_.ok()) {
     throw MultiScanException(status_);
   }
 
-  if (idx_ >= scan_opts_.size()) {
-    throw std::logic_error("Index out of range");
+  if (!valid_) {
+    throw std::logic_error("Incrementing exhausted MultiScan iterator");
   }
-  idx_++;
-  if (idx_ < scan_opts_.size()) {
-    // Check if we need to update read_options_
-    if (scan_opts_[idx_].range.limit.has_value() !=
-        (read_options_.iterate_upper_bound != nullptr)) {
-      if (scan_opts_[idx_].range.limit) {
-        *upper_bound_ = *scan_opts_[idx_].range.limit;
-        read_options_.iterate_upper_bound = upper_bound_;
-      } else {
-        read_options_.iterate_upper_bound = nullptr;
-      }
-      db_iter_.reset(db_->NewIterator(read_options_, cfh_));
-      scan_.Reset(db_iter_.get());
-    } else if (scan_opts_[idx_].range.limit) {
-      *upper_bound_ = *scan_opts_[idx_].range.limit;
+  ++idx_;
+  if (idx_ >= scan_opts_.size()) {
+    valid_ = false;
+    return *this;
+  }
+
+  // Check if we need to update read_options_
+  if (scan_opts_[idx_].range.limit.has_value() !=
+      (read_options_.iterate_upper_bound != nullptr)) {
+    if (scan_opts_[idx_].range.limit) {
+      read_options_.iterate_upper_bound = upper_bound_;
+    } else {
+      read_options_.iterate_upper_bound = nullptr;
     }
-    db_iter_->Seek(*scan_opts_[idx_].range.start);
-    status_ = db_iter_->status();
-    if (!status_.ok()) {
-      throw MultiScanException(status_);
-    }
+    db_iter_.reset(db_->NewIterator(read_options_, cfh_));
+    scan_.Reset(db_iter_.get(), reverse_);
+  }
+  SeekCurrentRange();
+  status_ = db_iter_->status();
+  if (!status_.ok()) {
+    throw MultiScanException(status_);
   }
   return *this;
 }

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -470,6 +470,7 @@ DECLARE_uint32(min_tombstones_for_range_conversion);
 DECLARE_uint32(ingest_wbwi_one_in);
 DECLARE_bool(universal_reduce_file_locking);
 DECLARE_bool(use_multiscan);
+DECLARE_bool(multiscan_reverse);
 DECLARE_bool(multiscan_use_async_io);
 DECLARE_bool(read_scoped_block_buffer_provider);
 DECLARE_uint64(multiscan_max_prefetch_memory_bytes);

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -1723,6 +1723,10 @@ DEFINE_bool(
 DEFINE_bool(use_multiscan, false,
             "If set, use the batched MultiScan API for scans.");
 
+DEFINE_bool(multiscan_reverse, false,
+            "If set with use_multiscan, scan each MultiScan range in reverse "
+            "using SeekForPrev and Prev.");
+
 DEFINE_bool(multiscan_use_async_io, false,
             "If set, enable async_io for MultiScan operations.");
 

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -1021,14 +1021,14 @@ void StressTest::VerificationAbort(SharedState* shared, int cf, int64_t key,
 // Under --verify_cpu_corruption_dir, right after each write op
 // (put/delete/deleterange), flush, and compaction (compactrange/compactfiles),
 // verifies that op for corruption and, on the first one found, writes a result
-// file into the directory and marks the run as a verification failure. It catches:
-// (a) a corruption returned by the op itself or by the read-back
+// file into the directory and marks the run as a verification failure. It
+// catches: (a) a corruption returned by the op itself or by the read-back
 // (Status::Corruption); or (b) a silent data corruption (SDC) -- a read-back
 // that SUCCEEDS but returns the wrong result vs the committed expected state: a
-// lost key (NotFound), a resurrected key (deleted but present), or a wrong value
-// (bytes differ). Surfacing these with an immediate read right after the op
-// (instead of waiting for a later read or the end-of-run db verification) gives
-// the most immediate and accurate verification when an external CPU-fault
+// lost key (NotFound), a resurrected key (deleted but present), or a wrong
+// value (bytes differ). Surfacing these with an immediate read right after the
+// op (instead of waiting for a later read or the end-of-run db verification)
+// gives the most immediate and accurate verification when an external CPU-fault
 // injector (e.g. gdb) flips a register inside that op.
 //
 // REQUIRES (enforced at startup) --threads=1 and all fault injection off (every
@@ -1037,9 +1037,9 @@ void StressTest::VerificationAbort(SharedState* shared, int cf, int64_t key,
 // would otherwise taint it.
 //
 // OUTPUT CONTRACT (one file per worker thread):
-// <dir>/data_corruption.<thread_id>.json -- a JSON object with fields: kind (one
-// of lost|resurrected|wrong-value|detected-corruption), cf (int), key (int),
-// value_from_db (hex), value_from_expected (hex), op_status (string).
+// <dir>/data_corruption.<thread_id>.json -- a JSON object with fields: kind
+// (one of lost|resurrected|wrong-value|detected-corruption), cf (int), key
+// (int), value_from_db (hex), value_from_expected (hex), op_status (string).
 //
 // PERFORMANCE: the read-back scans the entire keyspace after every op
 // (O(max_key) Get calls per op), so this is meant for single-op
@@ -2028,8 +2028,9 @@ void StressTest::OperateDb(ThreadState* thread) {
           ThreadStatusUtil::SetEnableTracking(FLAGS_enable_thread_tracking);
           ThreadStatusUtil::SetThreadOperation(
               ThreadStatus::OperationType::OP_DBITERATOR);
-          Status s;
-          s = TestMultiScan(thread, read_opts, rand_column_families, rand_keys);
+          Status s =
+              TestMultiScan(thread, read_opts, rand_column_families, rand_keys);
+          ProcessStatus(shared, "MultiScan", s);
           ThreadStatusUtil::ResetThreadStatus();
         } else if (!FLAGS_skip_verifydb &&
                    thread->rand.OneInOpt(
@@ -2236,6 +2237,9 @@ Status StressTest::TestMultiScan(ThreadState* thread,
   std::vector<std::string> end_key_strs;
   // TODO support reverse BytewiseComparator in the stress test
   MultiScanArgs scan_opts(options_.comparator);
+  const bool reverse_multiscan =
+      FLAGS_multiscan_reverse && FLAGS_test_backward_scan;
+  scan_opts.reverse = reverse_multiscan;
   scan_opts.use_async_io =
       FLAGS_multiscan_use_async_io &&
       CheckFSFeatureSupport(options_.env->GetFileSystem().get(),
@@ -2252,7 +2256,11 @@ Status StressTest::TestMultiScan(ThreadState* thread,
   end_key_strs.reserve(num_scans);
 
   // Will be initialized before Seek() below.
+  Slice lb;
   Slice ub;
+  if (reverse_multiscan) {
+    ro.iterate_lower_bound = &lb;
+  }
   ro.iterate_upper_bound = &ub;
   for (size_t i = 0; i < num_scans * 2; i += 2) {
     assert(rand_keys[i] <= rand_keys[i + 1]);
@@ -2295,7 +2303,9 @@ Status StressTest::TestMultiScan(ThreadState* thread,
       early_exit && thread->rand.OneIn(2);
   bool abandon_prepared_scan = false;
 
-  for (const ScanOptions& scan_opt : scan_opts.GetScanRanges()) {
+  const std::vector<ScanOptions>& scan_ranges = scan_opts.GetScanRanges();
+  for (size_t scan_idx = 0; scan_idx < scan_ranges.size(); ++scan_idx) {
+    const ScanOptions& scan_opt = scan_ranges[scan_idx];
     if (op_logs.size() > kOpLogsLimit) {
       // Shouldn't take too much memory for the history log. Clear it.
       op_logs = "(cleared...)\n";
@@ -2327,14 +2337,27 @@ Status StressTest::TestMultiScan(ThreadState* thread,
 
     assert(scan_opt.range.start);
     assert(scan_opt.range.limit);
-    Slice key = scan_opt.range.start.value();
+    lb = scan_opt.range.start.value();
     ub = scan_opt.range.limit.value();
+    Slice key = reverse_multiscan ? ub : lb;
 
     LastIterateOp last_op;
-    iter->Seek(key);
-    cmp_iter->Seek(key);
-    last_op = kLastOpSeek;
-    op_logs += "S " + key.ToString(true) + " ";
+    if (reverse_multiscan) {
+      iter->SeekForPrev(key);
+      cmp_iter->SeekForPrev(key);
+      while (cmp_iter->Valid() && options_.comparator->CompareWithoutTimestamp(
+                                      cmp_iter->key(), /*a_has_ts=*/false, ub,
+                                      /*b_has_ts=*/false) >= 0) {
+        cmp_iter->Prev();
+      }
+      last_op = kLastOpSeekForPrev;
+      op_logs += "SFP " + key.ToString(true) + " ";
+    } else {
+      iter->Seek(key);
+      cmp_iter->Seek(key);
+      last_op = kLastOpSeek;
+      op_logs += "S " + key.ToString(true) + " ";
+    }
 
     if (iter->Valid() && ro.allow_unprepared_value) {
       op_logs += "*";
@@ -2352,8 +2375,64 @@ Status StressTest::TestMultiScan(ThreadState* thread,
       return cmp_iter->status();
     }
 
-    VerifyIterator(thread, cmp_cfh, ro, iter.get(), cmp_iter.get(), last_op,
-                   key, rand_column_families, op_logs, verify_func, &diverged);
+    auto verify_reverse_multiscan = [&]() {
+      if (diverged || ro.iter_start_ts != nullptr) {
+        return;
+      }
+
+      if (!iter->status().ok()) {
+        fprintf(stderr, "Reverse MultiScan error: %s\n",
+                iter->status().ToString().c_str());
+        diverged = true;
+        thread->stats.AddErrors(1);
+        thread->shared->SetVerificationFailure();
+        return;
+      }
+
+      const bool cmp_valid =
+          cmp_iter->Valid() && options_.comparator->CompareWithoutTimestamp(
+                                   cmp_iter->key(), /*a_has_ts=*/false, lb,
+                                   /*b_has_ts=*/false) >= 0;
+      if (iter->Valid() != cmp_valid ||
+          (iter->Valid() && iter->key() != cmp_iter->key())) {
+        fprintf(stderr,
+                "Reverse MultiScan diverged from control iterator %s under "
+                "range [%s, %s)\n",
+                op_logs.c_str(), lb.ToString(true).c_str(),
+                ub.ToString(true).c_str());
+        if (iter->Valid()) {
+          fprintf(stderr, "iterator has key %s\n",
+                  iter->key().ToString(true).c_str());
+        } else {
+          fprintf(stderr, "iterator is not valid with status: %s\n",
+                  iter->status().ToString().c_str());
+        }
+        if (cmp_valid) {
+          fprintf(stderr, "control iterator has key %s\n",
+                  cmp_iter->key().ToString(true).c_str());
+        } else {
+          fprintf(stderr, "control iterator is outside range or invalid\n");
+        }
+        diverged = true;
+        thread->stats.AddErrors(1);
+        thread->shared->SetVerificationFailure();
+        return;
+      }
+
+      if (iter->Valid() && !verify_func(iter.get())) {
+        diverged = true;
+        thread->stats.AddErrors(1);
+        thread->shared->SetVerificationFailure();
+      }
+    };
+
+    if (reverse_multiscan) {
+      verify_reverse_multiscan();
+    } else {
+      VerifyIterator(thread, cmp_cfh, ro, iter.get(), cmp_iter.get(), last_op,
+                     key, rand_column_families, op_logs, verify_func,
+                     &diverged);
+    }
 
     uint64_t range_iterations = 0;
     while (iter->Valid()) {
@@ -2367,13 +2446,23 @@ Status StressTest::TestMultiScan(ThreadState* thread,
         break;
       }
 
-      iter->Next();
-      if (!diverged) {
-        assert(cmp_iter->Valid());
-        cmp_iter->Next();
+      if (reverse_multiscan) {
+        iter->Prev();
+        if (!diverged) {
+          assert(cmp_iter->Valid());
+          cmp_iter->Prev();
+        }
+        op_logs += "P";
+      } else {
+        iter->Next();
+        if (!diverged) {
+          assert(cmp_iter->Valid());
+          cmp_iter->Next();
+        }
+        op_logs += "N";
       }
-      op_logs += "N";
       ++range_iterations;
+      last_op = kLastOpNextOrPrev;
 
       if (iter->Valid() && ro.allow_unprepared_value) {
         op_logs += "*";
@@ -2391,9 +2480,13 @@ Status StressTest::TestMultiScan(ThreadState* thread,
         return cmp_iter->status();
       }
 
-      VerifyIterator(thread, cmp_cfh, ro, iter.get(), cmp_iter.get(), last_op,
-                     key, rand_column_families, op_logs, verify_func,
-                     &diverged);
+      if (reverse_multiscan) {
+        verify_reverse_multiscan();
+      } else {
+        VerifyIterator(thread, cmp_cfh, ro, iter.get(), cmp_iter.get(), last_op,
+                       key, rand_column_families, op_logs, verify_func,
+                       &diverged);
+      }
 
       if (diverged) {
         if (thread->shared->HasVerificationFailedYet()) {

--- a/include/rocksdb/multi_scan.h
+++ b/include/rocksdb/multi_scan.h
@@ -71,11 +71,15 @@ class Scan {
  public:
   class ScanIterator;
 
-  explicit Scan(Iterator* db_iter) : db_iter_(db_iter) {}
+  explicit Scan(Iterator* db_iter, bool reverse = false)
+      : db_iter_(db_iter), reverse_(reverse) {}
 
-  void Reset(Iterator* db_iter) { db_iter_ = db_iter; }
+  void Reset(Iterator* db_iter, bool reverse) {
+    db_iter_ = db_iter;
+    reverse_ = reverse;
+  }
 
-  ScanIterator begin() { return ScanIterator(db_iter_); }
+  ScanIterator begin() { return ScanIterator(db_iter_, reverse_); }
 
   std::nullptr_t end() { return nullptr; }
 
@@ -88,7 +92,8 @@ class Scan {
     using difference_type = int;
     using iterator_category = std::input_iterator_tag;
 
-    explicit ScanIterator(Iterator* db_iter) : db_iter_(db_iter) {
+    explicit ScanIterator(Iterator* db_iter, bool reverse = false)
+        : db_iter_(db_iter), reverse_(reverse) {
       valid_ = db_iter_->Valid();
       if (valid_) {
         result_ = value_type(db_iter_->key(), db_iter_->value());
@@ -109,7 +114,11 @@ class Scan {
       if (!valid_) {
         throw std::logic_error("Trying to advance invalid iterator");
       } else {
-        db_iter_->Next();
+        if (reverse_) {
+          db_iter_->Prev();
+        } else {
+          db_iter_->Next();
+        }
         status_ = db_iter_->status();
         if (!status_.ok()) {
           throw MultiScanException(status_);
@@ -142,6 +151,7 @@ class Scan {
 
    private:
     Iterator* db_iter_;
+    bool reverse_{};
     bool valid_;
     Status status_;
     value_type result_;
@@ -149,6 +159,7 @@ class Scan {
 
  private:
   Iterator* db_iter_;
+  bool reverse_;
 };
 
 // A container object encapsulating the scan ranges for a multi scan.
@@ -179,15 +190,19 @@ class MultiScan {
 
     MultiScanIterator(const std::vector<ScanOptions>& scan_opts, DB* db,
                       ColumnFamilyHandle* cfh, ReadOptions& read_options,
-                      Slice* upper_bound, std::unique_ptr<Iterator>& db_iter)
+                      Slice* lower_bound, Slice* upper_bound,
+                      std::unique_ptr<Iterator>& db_iter, bool reverse)
         : scan_opts_(scan_opts),
           db_(db),
           cfh_(cfh),
           read_options_(read_options),
+          lower_bound_(lower_bound),
           upper_bound_(upper_bound),
           idx_(0),
+          reverse_(reverse),
+          valid_(true),
           db_iter_(db_iter),
-          scan_(db_iter_.get()) {
+          scan_(db_iter_.get(), reverse_) {
       if (scan_opts_.empty()) {
         throw std::logic_error("Zero scans in multi-scan");
       }
@@ -195,7 +210,7 @@ class MultiScan {
       if (!status_.ok()) {
         throw MultiScanException(status_);
       }
-      db_iter_->Seek(*scan_opts_[idx_].range.start);
+      SeekCurrentRange();
       status_ = db_iter_->status();
       if (!status_.ok()) {
         throw MultiScanException(status_);
@@ -206,13 +221,9 @@ class MultiScan {
 
     MultiScanIterator& operator++();
 
-    bool operator==(std::nullptr_t /*other*/) const {
-      return idx_ >= scan_opts_.size();
-    }
+    bool operator==(std::nullptr_t /*other*/) const { return !valid_; }
 
-    bool operator!=(std::nullptr_t /*other*/) const {
-      return idx_ < scan_opts_.size();
-    }
+    bool operator!=(std::nullptr_t /*other*/) const { return valid_; }
 
     reference operator*() { return scan_; }
     reference operator->() { return scan_; }
@@ -222,16 +233,22 @@ class MultiScan {
     DB* db_;
     ColumnFamilyHandle* cfh_;
     ReadOptions& read_options_;
+    Slice* lower_bound_;
     Slice* upper_bound_;
     size_t idx_;
+    bool reverse_;
+    bool valid_;
     std::unique_ptr<Iterator>& db_iter_;
     Status status_;
     Scan scan_;
+
+    void SeekCurrentRange();
   };
 
   MultiScanIterator begin() {
     return MultiScanIterator(scan_opts_.GetScanRanges(), db_, cfh_,
-                             read_options_, &upper_bound_, db_iter_);
+                             read_options_, &lower_bound_, &upper_bound_,
+                             db_iter_, scan_opts_.reverse);
   }
 
   std::nullptr_t end() { return nullptr; }
@@ -240,7 +257,8 @@ class MultiScan {
   ReadOptions read_options_;
   const MultiScanArgs scan_opts_;
   DB* db_;
-  ColumnFamilyHandle* cfh_;
+  ColumnFamilyHandle* cfh_{};
+  Slice lower_bound_;
   Slice upper_bound_;
   std::unique_ptr<Iterator> db_iter_;
 };

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1995,12 +1995,14 @@ class MultiScanArgs {
     io_coalesce_threshold = other.io_coalesce_threshold;
     max_prefetch_size = other.max_prefetch_size;
     use_async_io = other.use_async_io;
+    reverse = other.reverse;
     io_dispatcher = other.io_dispatcher;
   }
   MultiScanArgs(MultiScanArgs&& other) noexcept
       : io_coalesce_threshold(other.io_coalesce_threshold),
         max_prefetch_size(other.max_prefetch_size),
         use_async_io(other.use_async_io),
+        reverse(other.reverse),
         io_dispatcher(std::move(other.io_dispatcher)),
         comp_(other.comp_),
         original_ranges_(std::move(other.original_ranges_)) {}
@@ -2011,6 +2013,7 @@ class MultiScanArgs {
     io_coalesce_threshold = other.io_coalesce_threshold;
     max_prefetch_size = other.max_prefetch_size;
     use_async_io = other.use_async_io;
+    reverse = other.reverse;
     io_dispatcher = other.io_dispatcher;
     return *this;
   }
@@ -2022,6 +2025,7 @@ class MultiScanArgs {
       io_coalesce_threshold = other.io_coalesce_threshold;
       max_prefetch_size = other.max_prefetch_size;
       use_async_io = other.use_async_io;
+      reverse = other.reverse;
       io_dispatcher = std::move(other.io_dispatcher);
     }
     return *this;
@@ -2085,6 +2089,7 @@ class MultiScanArgs {
     io_coalesce_threshold = other.io_coalesce_threshold;
     max_prefetch_size = other.max_prefetch_size;
     use_async_io = other.use_async_io;
+    reverse = other.reverse;
     io_dispatcher = other.io_dispatcher;
   }
 
@@ -2106,6 +2111,10 @@ class MultiScanArgs {
   // When true, BlockBasedTableIterator will use ReadAsync() for reading blocks
   // When false, it will use synchronous MultiRead().
   bool use_async_io = false;
+
+  // Scan ranges in reverse order. Ranges are still specified in comparator
+  // order as [start, limit), and reverse scans require bounded ranges.
+  bool reverse = false;
 
   // Optional IODispatcher for multi-scan operations.
   // If nullptr (default), a new IODispatcher is created internally.

--- a/table/block_based/block_based_table_iterator.cc
+++ b/table/block_based/block_based_table_iterator.cc
@@ -205,7 +205,9 @@ void BlockBasedTableIterator::SeekImpl(const Slice* target,
 }
 
 void BlockBasedTableIterator::SeekForPrev(const Slice& target) {
-  ResetMultiScan();
+  if (!IsReverseMultiScan()) {
+    ResetMultiScan();
+  }
   direction_ = IterDirection::kBackward;
   ResetBlockCacheLookupVar();
   is_out_of_bound_ = false;
@@ -243,7 +245,11 @@ void BlockBasedTableIterator::SeekForPrev(const Slice& target) {
   // first block, rather than the second. However, we don't have the information
   // to distinguish the two unless we read the second block. In this case, we'll
   // end up with reading two blocks.
-  index_iter_->Seek(target);
+  if (IsReverseMultiScan()) {
+    index_iter_->SeekForPrev(target);
+  } else {
+    index_iter_->Seek(target);
+  }
   is_index_at_curr_block_ = true;
 
   if (!index_iter_->Valid()) {
@@ -280,7 +286,9 @@ void BlockBasedTableIterator::SeekForPrev(const Slice& target) {
 }
 
 void BlockBasedTableIterator::SeekToLast() {
-  ResetMultiScan();
+  if (!IsReverseMultiScan()) {
+    ResetMultiScan();
+  }
   direction_ = IterDirection::kBackward;
   ResetBlockCacheLookupVar();
   is_out_of_bound_ = false;
@@ -327,7 +335,8 @@ bool BlockBasedTableIterator::NextAndGetResult(IterateResult* result) {
 }
 
 void BlockBasedTableIterator::Prev() {
-  if ((readahead_cache_lookup_ && !IsIndexAtCurr()) || multi_scan_read_set_) {
+  if ((readahead_cache_lookup_ && !IsIndexAtCurr()) ||
+      (multi_scan_read_set_ && !IsReverseMultiScan())) {
     ResetMultiScan();
     // In case of readahead_cache_lookup_, index_iter_ has moved forward. So we
     // need to reseek the index_iter_ to point to current block by using
@@ -382,7 +391,7 @@ void BlockBasedTableIterator::InitDataBlock() {
         ResetDataIter();
       }
       size_t rs_idx = multi_scan_index_iter_->current_read_set_index();
-      if (rs_idx >= prefetch_max_idx_) {
+      if (rs_idx >= multi_scan_index_iter_->GetPrefetchBlockCount()) {
         if (multi_scan_index_iter_->GetMaxPrefetchSize() == 0) {
           // max_prefetch_size is not set, treat as end of file
           return;
@@ -1000,9 +1009,10 @@ void BlockBasedTableIterator::BlockCacheLookupForReadAheadSize(
 // multiscan with regular iterator usage.
 // - scan ranges should be non-overlapping, and have increasing start keys.
 // If a scan range's limit is not set, then there should only be one scan range.
-// - After Prepare(), the iterator expects Seek to be called on the start key
-// of each ScanOption in order. If any other Seek is done, an error status is
-// returned
+// - After Prepare(), a forward scan expects Seek to be called on the start key
+// of each ScanOption in order. A reverse scan expects SeekForPrev to be called
+// on the limit key of each ScanOption in reverse order. If any other Seek is
+// done, an error status is returned.
 // - Whenever all blocks of a scan opt are exhausted, the iterator will become
 // invalid and UpperBoundCheckResult() will return kOutOfBound. So that the
 // upper layer (LevelIterator) will stop scanning instead thinking EOF is
@@ -1048,24 +1058,37 @@ void BlockBasedTableIterator::Prepare(const MultiScanArgs* multiscan_opts) {
     return;
   }
 
-  // Calculate prefetch_max_idx (enforces max_prefetch_size)
+  // Calculate prefetch range (enforces max_prefetch_size)
+  size_t prefetch_start_idx = 0;
   size_t prefetch_max_idx = scan_block_handles.size();
   if (multiscan_opts->max_prefetch_size > 0) {
     uint64_t total_size = 0;
-    for (size_t i = 0; i < scan_block_handles.size(); ++i) {
-      total_size +=
-          BlockBasedTable::BlockSizeWithTrailer(scan_block_handles[i]);
-      if (total_size > multiscan_opts->max_prefetch_size) {
-        prefetch_max_idx = i;
-        break;
+    if (multiscan_opts->reverse) {
+      for (size_t i = scan_block_handles.size(); i > 0; --i) {
+        const size_t block_idx = i - 1;
+        total_size += BlockBasedTable::BlockSizeWithTrailer(
+            scan_block_handles[block_idx]);
+        if (total_size > multiscan_opts->max_prefetch_size) {
+          prefetch_start_idx = block_idx + 1;
+          break;
+        }
+      }
+    } else {
+      for (size_t i = 0; i < scan_block_handles.size(); ++i) {
+        total_size +=
+            BlockBasedTable::BlockSizeWithTrailer(scan_block_handles[i]);
+        if (total_size > multiscan_opts->max_prefetch_size) {
+          prefetch_max_idx = i;
+          break;
+        }
       }
     }
   }
 
-  // Create block handles vector for IODispatcher (limited to prefetch_max_idx)
+  // Create block handles vector for IODispatcher (limited to prefetch range)
   std::vector<BlockHandle> blocks_to_prefetch;
-  if (prefetch_max_idx > 0) {
-    blocks_to_prefetch.assign(scan_block_handles.begin(),
+  if (prefetch_start_idx < prefetch_max_idx) {
+    blocks_to_prefetch.assign(scan_block_handles.begin() + prefetch_start_idx,
                               scan_block_handles.begin() + prefetch_max_idx);
   }
 
@@ -1099,11 +1122,11 @@ void BlockBasedTableIterator::Prepare(const MultiScanArgs* multiscan_opts) {
   // the index iterator. The original index_iter_ is saved for restoration
   // on backward operations.
   // Note: data_block_separators keeps full size for seek logic, even though
-  // only blocks up to prefetch_max_idx are actually prefetched.
+  // only blocks in [prefetch_start_idx, prefetch_max_idx) are prefetched.
   auto multi_scan_idx_iter = std::make_unique<MultiScanIndexIterator>(
       std::move(scan_block_handles), std::move(data_block_separators),
       std::move(block_index_ranges_per_scan), multiscan_opts, read_set,
-      prefetch_max_idx, icomp_, table_->GetStatistics());
+      prefetch_start_idx, prefetch_max_idx, icomp_, table_->GetStatistics());
   assert(multi_scan_idx_iter->status().ok());
 
   multi_scan_read_set_ = std::move(read_set);

--- a/table/block_based/block_based_table_iterator.h
+++ b/table/block_based/block_based_table_iterator.h
@@ -315,6 +315,11 @@ class BlockBasedTableIterator : public InternalIteratorBase<Slice> {
 
   bool IsIndexAtCurr() const { return is_index_at_curr_block_; }
 
+  inline bool IsReverseMultiScan() const {
+    return multi_scan_read_set_ && multi_scan_index_iter_ &&
+           multi_scan_index_iter_->scan_opts()->reverse;
+  }
+
   const BlockBasedTable* table_;
   const ReadOptions& read_options_;
   const InternalKeyComparator& icomp_;

--- a/table/block_based/block_based_table_reader_test.cc
+++ b/table/block_based/block_based_table_reader_test.cc
@@ -1152,12 +1152,11 @@ class BlockBasedTableReaderMultiScanAsyncIOTest
     : public BlockBasedTableReaderMultiScanTest {};
 
 // TODO: test no block cache case
-TEST_P(BlockBasedTableReaderMultiScanAsyncIOTest, DISABLED_MultiScanPrepare) {
+TEST_P(BlockBasedTableReaderMultiScanAsyncIOTest, MultiScanPrepare) {
   auto param = GetParam();
   auto fill_cache = param.fill_cache;
   auto use_async_io = param.use_async_io;
 
-  options_.statistics = CreateDBStatistics();
   std::shared_ptr<FileSystem> fs = options_.env->GetFileSystem();
   int64_t supported_ops = 0;
   fs->SupportedOps(supported_ops);
@@ -1171,244 +1170,202 @@ TEST_P(BlockBasedTableReaderMultiScanAsyncIOTest, DISABLED_MultiScanPrepare) {
           100 /* num_block */,
           true /* mixed_with_human_readable_string_value */, ts_sz,
           same_key_diff_ts_, comparator_);
-  std::string table_name = "BlockBasedTableReaderTest_NewIterator" +
-                           CompressionTypeToString(compression_type_) +
-                           "_async" + std::to_string(use_async_io);
-  ImmutableOptions ioptions(options_);
-  // Only insert 60 out of 100 blocks
-  CreateTable(table_name, ioptions, compression_type_,
-              std::vector<std::pair<std::string, std::string>>{
-                  kv.begin() + 20 * kEntriesPerBlock,
-                  kv.begin() + 80 * kEntriesPerBlock},
-              compression_parallel_threads_, compression_dict_bytes_);
 
-  std::unique_ptr<BlockBasedTable> table;
-  FileOptions foptions;
-  foptions.use_direct_reads = use_direct_reads_;
-  InternalKeyComparator comparator(options_.comparator);
-  NewBlockBasedTableReader(foptions, ioptions, comparator, table_name, &table,
-                           true /* bool prefetch_index_and_filter_in_cache */,
-                           nullptr /* status */, persist_udt_);
-
-  // 1. Should coalesce into a single I/O
-  std::unique_ptr<InternalIterator> iter;
-  iter.reset(table->NewIterator(
-      read_opts, options_.prefix_extractor.get(), /*arena=*/nullptr,
-      /*skip_filters=*/false, TableReaderCaller::kUncategorized));
-
-  MultiScanArgs scan_options(comparator_);
-  scan_options.use_async_io = use_async_io;
-  scan_options.insert(ExtractUserKey(kv[30 * kEntriesPerBlock].first),
-                      ExtractUserKey(kv[31 * kEntriesPerBlock].first));
-  scan_options.insert(ExtractUserKey(kv[32 * kEntriesPerBlock].first),
-                      ExtractUserKey(kv[33 * kEntriesPerBlock].first));
-  auto read_count_before =
-      options_.statistics->getTickerCount(NON_LAST_LEVEL_READ_COUNT);
-
-  iter->Prepare(&scan_options);
-  iter->Seek(kv[30 * kEntriesPerBlock].first);
-  for (size_t i = 30 * kEntriesPerBlock; i <= 31 * kEntriesPerBlock; ++i) {
-    ASSERT_TRUE(iter->status().ok()) << iter->status().ToString();
-    ASSERT_TRUE(iter->Valid()) << i;
-    ASSERT_EQ(iter->key().ToString(), kv[i].first);
-    iter->Next();
-  }
-  // Iter may still be valid after scan range. Upper layer (DBIter) handles
-  // exact upper bound checking. So we don't check !iter->Valid() here.
-  ASSERT_OK(iter->status());
-  iter->Seek(kv[32 * kEntriesPerBlock].first);
-  for (size_t i = 32 * kEntriesPerBlock; i < 33 * kEntriesPerBlock; ++i) {
-    ASSERT_TRUE(iter->Valid());
-    ASSERT_EQ(iter->key().ToString(), kv[i].first);
-    iter->Next();
-  }
-  ASSERT_OK(iter->status());
-  auto read_count_after =
-      options_.statistics->getTickerCount(NON_LAST_LEVEL_READ_COUNT);
-  ASSERT_EQ(read_count_before + 1, read_count_after);
-
-  // 2. No IO coalesce, should do MultiRead/ReadAsync with 2 read requests.
-  iter.reset(table->NewIterator(
-      read_opts, options_.prefix_extractor.get(), /*arena=*/nullptr,
-      /*skip_filters=*/false, TableReaderCaller::kUncategorized));
-  scan_options = MultiScanArgs(comparator_);
-  scan_options.insert(ExtractUserKey(kv[40 * kEntriesPerBlock].first),
-                      ExtractUserKey(kv[45 * kEntriesPerBlock].first));
-  scan_options.insert(ExtractUserKey(kv[70 * kEntriesPerBlock].first),
-                      ExtractUserKey(kv[75 * kEntriesPerBlock].first));
-
-  read_count_before =
-      options_.statistics->getTickerCount(NON_LAST_LEVEL_READ_COUNT);
-  iter->Prepare(&scan_options);
-
-  iter->Seek(kv[40 * kEntriesPerBlock].first);
-  for (size_t i = 40 * kEntriesPerBlock; i < 45 * kEntriesPerBlock; ++i) {
-    ASSERT_TRUE(iter->Valid());
-    ASSERT_EQ(iter->key().ToString(), kv[i].first);
-    iter->Next();
-  }
-  ASSERT_OK(iter->status());
-  iter->Seek(kv[70 * kEntriesPerBlock].first);
-  for (size_t i = 70 * kEntriesPerBlock; i < 75 * kEntriesPerBlock; ++i) {
-    ASSERT_TRUE(iter->Valid());
-    ASSERT_EQ(iter->key().ToString(), kv[i].first);
-    iter->Next();
-  }
-  ASSERT_OK(iter->status());
-
-  read_count_after =
-      options_.statistics->getTickerCount(NON_LAST_LEVEL_READ_COUNT);
-  ASSERT_EQ(read_count_before + 2, read_count_after);
-
-  iter.reset(table->NewIterator(
-      read_opts, options_.prefix_extractor.get(), /*arena=*/nullptr,
-      /*skip_filters=*/false, TableReaderCaller::kUncategorized));
-
-  // 3. Tests I/O excludes blocks already in cache.
-  // Reading blocks from 40-79
-  // From reads above, blocks 40-44 and 70-74 already in cache
-  // So we should read 45-69, 75-79 in two I/Os.
-  // If fill_cache is false, then we'll do one giant I/O.
-  scan_options = MultiScanArgs(comparator_);
-  scan_options.use_async_io = use_async_io;
-  scan_options.insert(ExtractUserKey(kv[40 * kEntriesPerBlock].first),
-                      ExtractUserKey(kv[80 * kEntriesPerBlock].first));
-  read_count_before =
-      options_.statistics->getTickerCount(NON_LAST_LEVEL_READ_COUNT);
-  iter->Prepare(&scan_options);
-  read_count_after =
-      options_.statistics->getTickerCount(NON_LAST_LEVEL_READ_COUNT);
-  // When async IO is available on this thread, Prepare() only queues the reads
-  // and stats are updated later during Poll(). Otherwise it falls back to the
-  // synchronous path and records the reads immediately.
-  const uint64_t expected_prepare_reads =
-      async_supported ? 0 : (fill_cache ? 2 : 1);
-  ASSERT_EQ(read_count_before + expected_prepare_reads, read_count_after);
-
-  iter->Seek(kv[40 * kEntriesPerBlock].first);
-  for (size_t i = 40 * kEntriesPerBlock; i < 80 * kEntriesPerBlock; ++i) {
-    ASSERT_TRUE(iter->Valid());
-    ASSERT_EQ(iter->key().ToString(), kv[i].first);
-    iter->Next();
-  }
-  ASSERT_FALSE(iter->Valid());
-  ASSERT_OK(iter->status());
-  read_count_after =
-      options_.statistics->getTickerCount(NON_LAST_LEVEL_READ_COUNT);
-  if (!fill_cache) {
-    ASSERT_EQ(read_count_before + 1, read_count_after);
-  } else {
-    ASSERT_EQ(read_count_before + 2, read_count_after);
-  }
-
-  // 4. Check cases when Seek key does not match start key in ScanOptions
-  iter.reset(table->NewIterator(
-      read_opts, options_.prefix_extractor.get(), /*arena=*/nullptr,
-      /*skip_filters=*/false, TableReaderCaller::kUncategorized));
-  scan_options = MultiScanArgs(comparator_);
-  scan_options.use_async_io = use_async_io;
-  scan_options.insert(ExtractUserKey(kv[30 * kEntriesPerBlock].first),
-                      ExtractUserKey(kv[40 * kEntriesPerBlock].first));
-  scan_options.insert(ExtractUserKey(kv[50 * kEntriesPerBlock].first),
-                      ExtractUserKey(kv[60 * kEntriesPerBlock].first));
-  iter->Prepare(&scan_options);
-  // Match start key
-  iter->Seek(kv[30 * kEntriesPerBlock].first);
-  for (size_t i = 30 * kEntriesPerBlock; i < 40 * kEntriesPerBlock; ++i) {
-    ASSERT_TRUE(iter->Valid());
-    ASSERT_EQ(iter->key().ToString(), kv[i].first);
-    iter->Next();
-  }
-  ASSERT_OK(iter->status());
-
-  // Seek a key that is larger than next start key is allowed, as long as it is
-  // larger than the previous key
-  iter->Seek(kv[50 * kEntriesPerBlock + 1].first);
-  ASSERT_OK(iter->status());
-
-  // Check seek key going backward
-  iter.reset(table->NewIterator(
-      read_opts, options_.prefix_extractor.get(), /*arena=*/nullptr,
-      /*skip_filters=*/false, TableReaderCaller::kUncategorized));
-  scan_options = MultiScanArgs(comparator_);
-  scan_options.use_async_io = use_async_io;
-  scan_options.insert(ExtractUserKey(kv[30 * kEntriesPerBlock].first),
-                      ExtractUserKey(kv[31 * kEntriesPerBlock].first));
-  scan_options.insert(ExtractUserKey(kv[32 * kEntriesPerBlock].first),
-                      ExtractUserKey(kv[33 * kEntriesPerBlock].first));
-  iter->Prepare(&scan_options);
-  iter->Seek(kv[32 * kEntriesPerBlock].first);
-  auto key = iter->key();
-  ASSERT_OK(iter->status());
-  iter->Seek(kv[30 * kEntriesPerBlock].first);
-  // When seek key goes backward, it is adjusted to the last seeked position.
-  // Assert the key read is same as before.
-  ASSERT_EQ(key, iter->key());
-  ASSERT_OK(iter->status());
-
-  // Test prefetch limit reached.
-  iter.reset(table->NewIterator(
-      read_opts, options_.prefix_extractor.get(), /*arena=*/nullptr,
-      /*skip_filters=*/false, TableReaderCaller::kUncategorized));
-  scan_options = MultiScanArgs(comparator_);
-  scan_options.use_async_io = use_async_io;
-  scan_options.max_prefetch_size = 1024;  // less than block size
-  scan_options.insert(ExtractUserKey(kv[30 * kEntriesPerBlock].first),
-                      ExtractUserKey(kv[40 * kEntriesPerBlock].first));
-  iter->Prepare(&scan_options);
-  iter->Seek(kv[31 * kEntriesPerBlock].first);
-  ASSERT_TRUE(iter->status().IsIncomplete());
-
-  // Randomly seek keys on the file, as long as the key is moving forward, it
-  // is allowed
-
-  if (use_async_io) {
-    // Skip following test when async io is enabled. There is some issue with
-    // IO_uring that I am still trying to root cause.
-    // TODO : enable the test again with async IO
-    return;
-  }
-  for (int i = 0; i < 100; i++) {
-    iter.reset(table->NewIterator(
+  auto user_key = [&](size_t key_idx) {
+    return ExtractUserKey(kv[key_idx].first);
+  };
+  auto reverse_seek_key = [&](size_t key_idx) {
+    std::string target;
+    AppendInternalKey(&target,
+                      ParsedInternalKey(user_key(key_idx), kMaxSequenceNumber,
+                                        kValueTypeForSeekForPrev));
+    return target;
+  };
+  auto new_iter = [&](BlockBasedTable* table) {
+    return std::unique_ptr<InternalIterator>(table->NewIterator(
         read_opts, options_.prefix_extractor.get(), /*arena=*/nullptr,
         /*skip_filters=*/false, TableReaderCaller::kUncategorized));
-    scan_options = MultiScanArgs(comparator_);
+  };
+  auto add_range = [&](MultiScanArgs* scan_options, size_t start_block,
+                       size_t limit_block) {
+    scan_options->insert(user_key(start_block * kEntriesPerBlock),
+                         user_key(limit_block * kEntriesPerBlock));
+  };
+  auto scan_block_range = [&](InternalIterator* iter, size_t start_block,
+                              size_t limit_block, bool reverse) {
+    const size_t start_idx = start_block * kEntriesPerBlock;
+    const size_t limit_idx = limit_block * kEntriesPerBlock;
+    if (reverse) {
+      const std::string target = reverse_seek_key(limit_idx);
+      iter->SeekForPrev(target);
+      for (size_t i = limit_idx; i > start_idx; --i) {
+        ASSERT_TRUE(iter->status().ok()) << iter->status().ToString();
+        ASSERT_TRUE(iter->Valid()) << i;
+        ASSERT_EQ(iter->key().ToString(), kv[i - 1].first);
+        iter->Prev();
+      }
+    } else {
+      iter->Seek(kv[start_idx].first);
+      for (size_t i = start_idx; i < limit_idx; ++i) {
+        ASSERT_TRUE(iter->status().ok()) << iter->status().ToString();
+        ASSERT_TRUE(iter->Valid()) << i;
+        ASSERT_EQ(iter->key().ToString(), kv[i].first);
+        iter->Next();
+      }
+    }
+    ASSERT_OK(iter->status());
+  };
+
+  for (const bool reverse : {false, true}) {
+    SCOPED_TRACE(reverse ? "reverse" : "forward");
+    options_.statistics = CreateDBStatistics();
+    std::string table_name = "BlockBasedTableReaderTest_NewIterator" +
+                             CompressionTypeToString(compression_type_) +
+                             "_async" + std::to_string(use_async_io) +
+                             "_reverse" + std::to_string(reverse);
+    ImmutableOptions ioptions(options_);
+    CreateTable(table_name, ioptions, compression_type_,
+                std::vector<std::pair<std::string, std::string>>{
+                    kv.begin() + 20 * kEntriesPerBlock,
+                    kv.begin() + 80 * kEntriesPerBlock},
+                compression_parallel_threads_, compression_dict_bytes_);
+
+    std::unique_ptr<BlockBasedTable> table;
+    FileOptions foptions;
+    foptions.use_direct_reads = use_direct_reads_;
+    InternalKeyComparator comparator(options_.comparator);
+    NewBlockBasedTableReader(foptions, ioptions, comparator, table_name, &table,
+                             true /* bool prefetch_index_and_filter_in_cache */,
+                             nullptr /* status */, persist_udt_);
+
+    // 1. Should coalesce into a single I/O
+    std::unique_ptr<InternalIterator> iter = new_iter(table.get());
+    MultiScanArgs scan_options(comparator_);
     scan_options.use_async_io = use_async_io;
-    scan_options.insert(ExtractUserKey(kv[5 * kEntriesPerBlock].first),
-                        ExtractUserKey(kv[10 * kEntriesPerBlock].first));
-    scan_options.insert(ExtractUserKey(kv[25 * kEntriesPerBlock].first),
-                        ExtractUserKey(kv[35 * kEntriesPerBlock].first));
-    scan_options.insert(ExtractUserKey(kv[35 * kEntriesPerBlock].first),
-                        ExtractUserKey(kv[40 * kEntriesPerBlock].first));
-    scan_options.insert(ExtractUserKey(kv[45 * kEntriesPerBlock].first),
-                        ExtractUserKey(kv[50 * kEntriesPerBlock].first));
-    scan_options.insert(ExtractUserKey(kv[75 * kEntriesPerBlock].first),
-                        ExtractUserKey(kv[85 * kEntriesPerBlock].first));
-    scan_options.insert(ExtractUserKey(kv[85 * kEntriesPerBlock].first),
-                        ExtractUserKey(kv[95 * kEntriesPerBlock].first));
+    scan_options.reverse = reverse;
+    add_range(&scan_options, 30, 31);
+    add_range(&scan_options, 32, 33);
+    auto read_count_before =
+        options_.statistics->getTickerCount(NON_LAST_LEVEL_READ_COUNT);
 
     iter->Prepare(&scan_options);
+    scan_block_range(iter.get(), 30, 31, reverse);
+    scan_block_range(iter.get(), 32, 33, reverse);
+    auto read_count_after =
+        options_.statistics->getTickerCount(NON_LAST_LEVEL_READ_COUNT);
+    ASSERT_EQ(read_count_before + 1, read_count_after);
 
-    auto random_seed = static_cast<uint32_t>(
-        std::chrono::duration_cast<std::chrono::nanoseconds>(
-            std::chrono::system_clock::now().time_since_epoch())
-            .count());
-    Random rnd(random_seed);
-    std::cout << random_seed << std::endl;
-    SCOPED_TRACE("Random seed " + std::to_string(random_seed));
+    // 2. No IO coalesce, should do MultiRead/ReadAsync with 2 read requests.
+    iter = new_iter(table.get());
+    scan_options = MultiScanArgs(comparator_);
+    scan_options.use_async_io = use_async_io;
+    scan_options.reverse = reverse;
+    add_range(&scan_options, 40, 45);
+    add_range(&scan_options, 70, 75);
 
-    // Search key always start from the start key of first prepared range.
-    int last_read_key_index = rnd.Uniform(100) + 5 * kEntriesPerBlock;
-    while (last_read_key_index < 100 * kEntriesPerBlock) {
-      iter->Seek(kv[last_read_key_index].first);
-      EXPECT_OK(iter->status());
-      // iterate for a few keys
-      while (iter->Valid()) {
-        iter->Next();
-        last_read_key_index++;
-        EXPECT_OK(iter->status());
+    read_count_before =
+        options_.statistics->getTickerCount(NON_LAST_LEVEL_READ_COUNT);
+    iter->Prepare(&scan_options);
+    scan_block_range(iter.get(), 40, 45, reverse);
+    scan_block_range(iter.get(), 70, 75, reverse);
+
+    read_count_after =
+        options_.statistics->getTickerCount(NON_LAST_LEVEL_READ_COUNT);
+    ASSERT_EQ(read_count_before + 2, read_count_after);
+
+    // 3. Tests I/O excludes blocks already in cache.
+    // Reading blocks from 40-79. From reads above, blocks 40-44 and 70-74
+    // are already in cache. So fill_cache=true should read 45-69, 75-79 in
+    // two I/Os. If fill_cache is false, then we'll do one giant I/O.
+    iter = new_iter(table.get());
+    scan_options = MultiScanArgs(comparator_);
+    scan_options.use_async_io = use_async_io;
+    scan_options.reverse = reverse;
+    add_range(&scan_options, 40, 80);
+    read_count_before =
+        options_.statistics->getTickerCount(NON_LAST_LEVEL_READ_COUNT);
+    iter->Prepare(&scan_options);
+    read_count_after =
+        options_.statistics->getTickerCount(NON_LAST_LEVEL_READ_COUNT);
+    const uint64_t expected_prepare_reads =
+        async_supported ? 0 : (fill_cache ? 2 : 1);
+    ASSERT_EQ(read_count_before + expected_prepare_reads, read_count_after);
+
+    scan_block_range(iter.get(), 40, 80, reverse);
+    read_count_after =
+        options_.statistics->getTickerCount(NON_LAST_LEVEL_READ_COUNT);
+    if (!fill_cache) {
+      ASSERT_EQ(read_count_before + 1, read_count_after);
+    } else {
+      ASSERT_EQ(read_count_before + 2, read_count_after);
+    }
+
+    // 4. Check cases when seek key does not match scan range boundary.
+    iter = new_iter(table.get());
+    scan_options = MultiScanArgs(comparator_);
+    scan_options.use_async_io = use_async_io;
+    scan_options.reverse = reverse;
+    add_range(&scan_options, 30, 40);
+    add_range(&scan_options, 50, 60);
+    iter->Prepare(&scan_options);
+    scan_block_range(iter.get(), 30, 40, reverse);
+    if (reverse) {
+      iter->SeekForPrev(kv[50 * kEntriesPerBlock + 1].first);
+    } else {
+      iter->Seek(kv[50 * kEntriesPerBlock + 1].first);
+    }
+    ASSERT_OK(iter->status());
+
+    // Test prefetch limit reached.
+    iter = new_iter(table.get());
+    scan_options = MultiScanArgs(comparator_);
+    scan_options.use_async_io = use_async_io;
+    scan_options.reverse = reverse;
+    scan_options.max_prefetch_size = 1024;  // less than block size
+    add_range(&scan_options, 30, 40);
+    iter->Prepare(&scan_options);
+    if (reverse) {
+      iter->SeekForPrev(reverse_seek_key(40 * kEntriesPerBlock));
+    } else {
+      iter->Seek(kv[31 * kEntriesPerBlock].first);
+    }
+    ASSERT_TRUE(iter->status().IsIncomplete() ||
+                iter->status().IsPrefetchLimitReached());
+
+    if (!reverse) {
+      // Randomly seek keys on the file, as long as the key is moving forward.
+      for (int i = 0; i < 100; i++) {
+        iter = new_iter(table.get());
+        scan_options = MultiScanArgs(comparator_);
+        scan_options.use_async_io = use_async_io;
+        add_range(&scan_options, 5, 10);
+        add_range(&scan_options, 25, 35);
+        add_range(&scan_options, 35, 40);
+        add_range(&scan_options, 45, 50);
+        add_range(&scan_options, 75, 85);
+        add_range(&scan_options, 85, 95);
+
+        iter->Prepare(&scan_options);
+
+        auto random_seed = static_cast<uint32_t>(
+            std::chrono::duration_cast<std::chrono::nanoseconds>(
+                std::chrono::system_clock::now().time_since_epoch())
+                .count());
+        Random rnd(random_seed);
+        SCOPED_TRACE("Random seed " + std::to_string(random_seed));
+
+        int last_read_key_index = rnd.Uniform(100) + 5 * kEntriesPerBlock;
+        while (last_read_key_index < 100 * kEntriesPerBlock) {
+          iter->Seek(kv[last_read_key_index].first);
+          EXPECT_OK(iter->status());
+          while (iter->Valid()) {
+            iter->Next();
+            last_read_key_index++;
+            EXPECT_OK(iter->status());
+          }
+          last_read_key_index += rnd.Uniform(100);
+        }
       }
-      last_read_key_index += rnd.Uniform(100);
     }
   }
 }
@@ -1609,6 +1566,90 @@ TEST_P(BlockBasedTableReaderMultiScanTest, MultiScanPrefetchSizeLimit) {
     ASSERT_OK(iter->status());
     ASSERT_EQ(scanned_keys, 5 + 4 * kEntriesPerBlock + 1 * kEntriesPerBlock);
   }
+}
+
+TEST_P(BlockBasedTableReaderMultiScanTest, ReverseMultiScanPrepare) {
+  if (std::string(options_.comparator->Name()).find("Reverse") !=
+      std::string::npos) {
+    ROCKSDB_GTEST_BYPASS("This test asserts bytewise iterator order.");
+    return;
+  }
+
+  ReadOptions read_opts;
+  size_t ts_sz = options_.comparator->timestamp_size();
+
+  std::vector<std::pair<std::string, std::string>> kv =
+      BlockBasedTableReaderBaseTest::GenerateKVMap(
+          20 /* num_block */, true /* mixed_with_human_readable_string_value */,
+          ts_sz, same_key_diff_ts_, comparator_);
+
+  std::string table_name = "BlockBasedTableReaderTest_ReverseMultiScanPrepare" +
+                           CompressionTypeToString(compression_type_);
+
+  ImmutableOptions ioptions(options_);
+  CreateTable(table_name, ioptions, compression_type_, kv,
+              compression_parallel_threads_, compression_dict_bytes_);
+
+  std::unique_ptr<BlockBasedTable> table;
+  FileOptions foptions;
+  foptions.use_direct_reads = use_direct_reads_;
+  InternalKeyComparator comparator(options_.comparator);
+  NewBlockBasedTableReader(foptions, ioptions, comparator, table_name, &table,
+                           true /* bool prefetch_index_and_filter_in_cache */,
+                           nullptr /* status */, persist_udt_);
+
+  std::unique_ptr<InternalIterator> iter;
+  iter.reset(table->NewIterator(
+      read_opts, options_.prefix_extractor.get(), /*arena=*/nullptr,
+      /*skip_filters=*/false, TableReaderCaller::kUncategorized));
+
+  MultiScanArgs scan_options(comparator_);
+  scan_options.reverse = true;
+  scan_options.max_prefetch_size = 10 * 1024 * 1024;  // 10MB
+  scan_options.insert(ExtractUserKey(kv[2 * kEntriesPerBlock].first),
+                      ExtractUserKey(kv[4 * kEntriesPerBlock].first));
+  scan_options.insert(ExtractUserKey(kv[8 * kEntriesPerBlock].first),
+                      ExtractUserKey(kv[10 * kEntriesPerBlock].first));
+  scan_options.insert(ExtractUserKey(kv[14 * kEntriesPerBlock].first),
+                      ExtractUserKey(kv[16 * kEntriesPerBlock].first));
+
+  iter->Prepare(&scan_options);
+
+  iter->SeekForPrev(kv[19 * kEntriesPerBlock].first);
+  ASSERT_TRUE(iter->status().ok()) << iter->status().ToString();
+  ASSERT_TRUE(iter->Valid());
+
+  std::string limit_seek_key;
+  AppendInternalKey(
+      &limit_seek_key,
+      ParsedInternalKey(ExtractUserKey(kv[16 * kEntriesPerBlock].first),
+                        kMaxSequenceNumber, kValueTypeForSeekForPrev));
+  iter->SeekForPrev(limit_seek_key);
+  for (size_t i = 16 * kEntriesPerBlock; i > 14 * kEntriesPerBlock; --i) {
+    ASSERT_TRUE(iter->status().ok()) << iter->status().ToString();
+    ASSERT_TRUE(iter->Valid()) << i;
+    ASSERT_EQ(iter->key().ToString(), kv[i - 1].first);
+    iter->Prev();
+  }
+  ASSERT_OK(iter->status());
+
+  iter->SeekForPrev(kv[10 * kEntriesPerBlock - 1].first);
+  for (size_t i = 10 * kEntriesPerBlock; i > 8 * kEntriesPerBlock; --i) {
+    ASSERT_TRUE(iter->status().ok()) << iter->status().ToString();
+    ASSERT_TRUE(iter->Valid()) << i;
+    ASSERT_EQ(iter->key().ToString(), kv[i - 1].first);
+    iter->Prev();
+  }
+  ASSERT_OK(iter->status());
+
+  iter->SeekForPrev(kv[4 * kEntriesPerBlock - 1].first);
+  for (size_t i = 4 * kEntriesPerBlock; i > 2 * kEntriesPerBlock; --i) {
+    ASSERT_TRUE(iter->status().ok()) << iter->status().ToString();
+    ASSERT_TRUE(iter->Valid()) << i;
+    ASSERT_EQ(iter->key().ToString(), kv[i - 1].first);
+    iter->Prev();
+  }
+  ASSERT_OK(iter->status());
 }
 
 TEST_P(BlockBasedTableReaderMultiScanTest, MultiScanUnpinPreviousBlocks) {
@@ -2358,12 +2399,17 @@ INSTANTIATE_TEST_CASE_P(
 INSTANTIATE_TEST_CASE_P(
     BlockBasedTableReaderMultiScanAsyncIOTest,
     BlockBasedTableReaderMultiScanAsyncIOTest,
-    ::testing::ValuesIn(BlockBasedTableReaderTestParamBuilder()
-                            .WithComparators({BytewiseComparator(),
-                                              ReverseBytewiseComparator()})
-                            .WithFillCacheFlags(Bool())
-                            .WithUseAsyncIoFlags(IOUringFlags())
-                            .build()));
+    ::testing::ValuesIn(
+        BlockBasedTableReaderTestParamBuilder()
+            .WithCompressionTypes({kNoCompression})
+            .WithUseDirectReadFlags({false})
+            .WithIndexTypes({BlockBasedTableOptions::IndexType::kBinarySearch})
+            .WithParallelCompressionThreadCounts({1})
+            .WithCompressionDictByteCounts({0})
+            .WithComparators({BytewiseComparator()})
+            .WithFillCacheFlags(Bool())
+            .WithUseAsyncIoFlags(IOUringFlags())
+            .build()));
 
 INSTANTIATE_TEST_CASE_P(
     BlockBasedTableReaderMultiScanTest, BlockBasedTableReaderMultiScanTest,

--- a/table/block_based/multi_scan_index_iterator.cc
+++ b/table/block_based/multi_scan_index_iterator.cc
@@ -5,6 +5,8 @@
 
 #include "table/block_based/multi_scan_index_iterator.h"
 
+#include <algorithm>
+
 #include "monitoring/statistics_impl.h"
 #include "rocksdb/options.h"
 
@@ -15,14 +17,19 @@ MultiScanIndexIterator::MultiScanIndexIterator(
     std::vector<std::string>&& data_block_separators,
     std::vector<std::tuple<size_t, size_t>>&& block_index_ranges_per_scan,
     const MultiScanArgs* scan_opts, std::shared_ptr<ReadSet> read_set,
-    size_t prefetch_max_idx, const InternalKeyComparator& icomp,
-    Statistics* statistics)
+    size_t prefetch_start_idx, size_t prefetch_max_idx,
+    const InternalKeyComparator& icomp, Statistics* statistics)
     : block_handles_(std::move(block_handles)),
       data_block_separators_(std::move(data_block_separators)),
       block_index_ranges_per_scan_(std::move(block_index_ranges_per_scan)),
       scan_opts_(scan_opts),
       read_set_(std::move(read_set)),
+      prefetch_start_idx_(prefetch_start_idx),
       prefetch_max_idx_(prefetch_max_idx),
+      first_unreleased_prefetch_idx_(prefetch_start_idx),
+      one_past_last_unreleased_prefetch_idx_(prefetch_max_idx),
+      released_prefetch_blocks_(prefetch_max_idx - prefetch_start_idx, false),
+      unreleased_prefetch_blocks_(prefetch_max_idx - prefetch_start_idx),
       icomp_(icomp),
       user_comparator_(icomp.user_comparator()),
       statistics_(statistics) {}
@@ -34,23 +41,85 @@ MultiScanIndexIterator::~MultiScanIndexIterator() {
   }
   // Release any remaining pinned blocks
   if (read_set_) {
-    for (size_t i = cur_idx_; i < block_handles_.size(); ++i) {
-      read_set_->ReleaseBlock(i);
+    for (size_t i = first_unreleased_prefetch_idx_;
+         i < one_past_last_unreleased_prefetch_idx_ &&
+         unreleased_prefetch_blocks_ > 0;
+         ++i) {
+      ReleasePrefetchedBlock(i);
     }
   }
 }
 
+bool MultiScanIndexIterator::IsPrefetchedBlock(size_t block_idx) const {
+  return block_idx >= prefetch_start_idx_ && block_idx < prefetch_max_idx_;
+}
+
+size_t MultiScanIndexIterator::current_read_set_index() const {
+  if (!IsPrefetchedBlock(cur_idx_)) {
+    return prefetch_max_idx_ - prefetch_start_idx_;
+  }
+  return cur_idx_ - prefetch_start_idx_;
+}
+
+void MultiScanIndexIterator::ReleaseBlock(size_t block_idx) {
+  ReleasePrefetchedBlock(block_idx);
+}
+
+bool MultiScanIndexIterator::ReleasePrefetchedBlock(size_t block_idx) {
+  if (!IsPrefetchedBlock(block_idx) || unreleased_prefetch_blocks_ == 0) {
+    return false;
+  }
+
+  const size_t read_set_idx = block_idx - prefetch_start_idx_;
+  if (released_prefetch_blocks_[read_set_idx]) {
+    return false;
+  }
+
+  assert(read_set_);
+  read_set_->ReleaseBlock(read_set_idx);
+  released_prefetch_blocks_[read_set_idx] = true;
+  --unreleased_prefetch_blocks_;
+  ShrinkUnreleasedPrefetchBounds();
+  return true;
+}
+
+void MultiScanIndexIterator::ShrinkUnreleasedPrefetchBounds() {
+  while (first_unreleased_prefetch_idx_ <
+             one_past_last_unreleased_prefetch_idx_ &&
+         released_prefetch_blocks_[first_unreleased_prefetch_idx_ -
+                                   prefetch_start_idx_]) {
+    ++first_unreleased_prefetch_idx_;
+  }
+  while (first_unreleased_prefetch_idx_ <
+             one_past_last_unreleased_prefetch_idx_ &&
+         released_prefetch_blocks_[one_past_last_unreleased_prefetch_idx_ - 1 -
+                                   prefetch_start_idx_]) {
+    --one_past_last_unreleased_prefetch_idx_;
+  }
+}
+
 void MultiScanIndexIterator::ReleaseBlocks(size_t from_idx, size_t to_idx) {
-  for (size_t i = from_idx; i < to_idx; ++i) {
-    if (i < prefetch_max_idx_) {
+  const size_t release_from = std::max(from_idx, prefetch_start_idx_);
+  const size_t release_to = std::min(to_idx, prefetch_max_idx_);
+  if (release_from >= release_to || unreleased_prefetch_blocks_ == 0) {
+    return;
+  }
+
+  for (size_t i = release_from; i < release_to; ++i) {
+    if (ReleasePrefetchedBlock(i)) {
       wasted_blocks_count_++;
     }
-    read_set_->ReleaseBlock(i);
   }
 }
 
 void MultiScanIndexIterator::Seek(const Slice& target) {
   if (!status_.ok()) {
+    return;
+  }
+  if (scan_opts_->reverse) {
+    status_ = Status::InvalidArgument("Seek called on reverse MultiScan");
+    RecordTick(statistics_, MULTISCAN_SEEK_ERRORS);
+    valid_ = false;
     return;
   }
 
@@ -186,10 +255,10 @@ void MultiScanIndexIterator::SeekToBlock(const Slice* user_seek_target) {
              *user_seek_target, /*a_has_ts=*/true,
              data_block_separators_[block_idx],
              /*b_has_ts=*/false) > 0) {
-    if (block_idx < prefetch_max_idx_) {
+    if (IsPrefetchedBlock(block_idx)) {
       wasted_blocks_count_++;
     }
-    read_set_->ReleaseBlock(block_idx);
+    ReleaseBlock(block_idx);
     block_idx++;
   }
 
@@ -218,6 +287,22 @@ void MultiScanIndexIterator::SeekToBlockIdx(size_t block_idx) {
   valid_ = true;
 }
 
+void MultiScanIndexIterator::SeekToBlockIdxReverse(size_t block_idx) {
+  if (cur_idx_ > block_idx && cur_idx_ < block_handles_.size()) {
+    ReleaseBlocks(block_idx + 1, cur_idx_ + 1);
+  }
+
+  cur_idx_ = block_idx;
+  if (!IsPrefetchedBlock(cur_idx_)) {
+    valid_ = false;
+    if (scan_opts_->max_prefetch_size > 0) {
+      status_ = Status::PrefetchLimitReached();
+    }
+    return;
+  }
+  valid_ = true;
+}
+
 void MultiScanIndexIterator::SetExhausted() {
   scan_range_exhausted_ = true;
   if (next_scan_idx_ < block_index_ranges_per_scan_.size()) {
@@ -243,7 +328,7 @@ void MultiScanIndexIterator::Next() {
   assert(valid_);
 
   // Release current block
-  read_set_->ReleaseBlock(cur_idx_);
+  ReleaseBlock(cur_idx_);
   ++cur_idx_;
 
   // Check if we've crossed a scan range boundary
@@ -258,7 +343,7 @@ void MultiScanIndexIterator::Next() {
   }
 
   // Check prefetch limit
-  if (cur_idx_ >= prefetch_max_idx_) {
+  if (!IsPrefetchedBlock(cur_idx_)) {
     valid_ = false;
     if (scan_opts_->max_prefetch_size > 0) {
       status_ = Status::PrefetchLimitReached();
@@ -292,13 +377,109 @@ void MultiScanIndexIterator::SeekToFirst() {
   valid_ = true;
 }
 
-void MultiScanIndexIterator::SeekForPrev(const Slice& /*target*/) {
+void MultiScanIndexIterator::SeekForPrev(const Slice& target) {
+  if (!scan_opts_->reverse || !status_.ok()) {
+    valid_ = false;
+    return;
+  }
+
+  scan_range_exhausted_ = false;
+  if (scan_opts_->size() == 0) {
+    valid_ = false;
+    return;
+  }
+
+  const auto& scan_ranges = scan_opts_->GetScanRanges();
+  Slice user_seek_target = ExtractUserKey(target);
+  size_t scan_idx = scan_ranges.size();
+  for (size_t i = scan_ranges.size(); i > 0; --i) {
+    const size_t candidate = i - 1;
+    const auto& range = scan_ranges[candidate].range;
+    if (!range.start.has_value() || !range.limit.has_value()) {
+      continue;
+    }
+    const int cmp_start = user_comparator_.CompareWithoutTimestamp(
+        user_seek_target, /*a_has_ts=*/true, range.start.value(),
+        /*b_has_ts=*/false);
+    if (cmp_start >= 0) {
+      scan_idx = candidate;
+      break;
+    }
+  }
+
+  if (scan_idx == scan_ranges.size()) {
+    status_ = Status::InvalidArgument(
+        "SeekForPrev target is outside prepared ranges");
+    RecordTick(statistics_, MULTISCAN_SEEK_ERRORS);
+    valid_ = false;
+    return;
+  }
+
+  cur_scan_idx_ = scan_idx;
+  auto [cur_scan_start_idx, cur_scan_end_idx] =
+      block_index_ranges_per_scan_[cur_scan_idx_];
+  if (cur_scan_start_idx >= cur_scan_end_idx) {
+    valid_ = false;
+    return;
+  }
+
+  size_t block_idx = cur_scan_start_idx;
+  while (block_idx + 1 < cur_scan_end_idx &&
+         user_comparator_.CompareWithoutTimestamp(
+             user_seek_target, /*a_has_ts=*/true,
+             data_block_separators_[block_idx], /*b_has_ts=*/false) > 0) {
+    ++block_idx;
+  }
+
+  SeekToBlockIdxReverse(block_idx);
+}
+
+void MultiScanIndexIterator::SeekToLast() {
+  if (!scan_opts_->reverse) {
+    valid_ = false;
+    return;
+  }
+  for (size_t i = block_index_ranges_per_scan_.size(); i > 0; --i) {
+    const size_t scan_idx = i - 1;
+    auto [start, end] = block_index_ranges_per_scan_[scan_idx];
+    if (start < end) {
+      cur_scan_idx_ = scan_idx;
+      SeekToBlockIdxReverse(end - 1);
+      return;
+    }
+  }
   valid_ = false;
 }
 
-void MultiScanIndexIterator::SeekToLast() { valid_ = false; }
+void MultiScanIndexIterator::Prev() {
+  assert(valid_);
+  if (!scan_opts_->reverse) {
+    valid_ = false;
+    return;
+  }
 
-void MultiScanIndexIterator::Prev() { valid_ = false; }
+  ReleaseBlock(cur_idx_);
+  auto [cur_scan_start_idx, cur_scan_end_idx] =
+      block_index_ranges_per_scan_[cur_scan_idx_];
+  (void)cur_scan_end_idx;
+  if (cur_idx_ <= cur_scan_start_idx) {
+    // Reverse scan range transitions are driven by DBIter's lower bound and
+    // the next SeekForPrev(), so this path does not need the forward
+    // out-of-bound signal from SetExhausted().
+    valid_ = false;
+    return;
+  }
+
+  --cur_idx_;
+  if (!IsPrefetchedBlock(cur_idx_)) {
+    valid_ = false;
+    if (scan_opts_->max_prefetch_size > 0) {
+      status_ = Status::PrefetchLimitReached();
+    }
+    return;
+  }
+  valid_ = true;
+}
 
 Slice MultiScanIndexIterator::key() const {
   assert(valid_);

--- a/table/block_based/multi_scan_index_iterator.h
+++ b/table/block_based/multi_scan_index_iterator.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <cassert>
 #include <string>
 #include <tuple>
 #include <vector>
@@ -26,10 +27,8 @@ class Statistics;
 // to use the same SeekImpl()/FindBlockForward() code path for both
 // regular iteration and MultiScan.
 //
-// The iterator supports forward-only Seek() and Next(). Seek targets must
-// be non-decreasing (enforced via prev_seek_key_). When a scan range is
-// exhausted, Next() jumps to the start of the next scan range. When all
-// ranges are exhausted, the iterator becomes invalid.
+// The iterator supports forward Seek()/Next() or reverse SeekForPrev()/Prev()
+// depending on MultiScanArgs::reverse.
 class MultiScanIndexIterator : public InternalIteratorBase<IndexValue> {
  public:
   // scan_opts and icomp must outlive this iterator. read_set is shared.
@@ -38,8 +37,8 @@ class MultiScanIndexIterator : public InternalIteratorBase<IndexValue> {
       std::vector<std::string>&& data_block_separators,
       std::vector<std::tuple<size_t, size_t>>&& block_index_ranges_per_scan,
       const MultiScanArgs* scan_opts, std::shared_ptr<ReadSet> read_set,
-      size_t prefetch_max_idx, const InternalKeyComparator& icomp,
-      Statistics* statistics);
+      size_t prefetch_start_idx, size_t prefetch_max_idx,
+      const InternalKeyComparator& icomp, Statistics* statistics);
 
   ~MultiScanIndexIterator() override;
 
@@ -58,7 +57,6 @@ class MultiScanIndexIterator : public InternalIteratorBase<IndexValue> {
   // Move to the first block of the first scan range.
   void SeekToFirst() override;
 
-  // Not supported -- sets valid_ = false.
   void SeekForPrev(const Slice& target) override;
   void SeekToLast() override;
   void Prev() override;
@@ -78,11 +76,18 @@ class MultiScanIndexIterator : public InternalIteratorBase<IndexValue> {
 
   Status status() const override { return status_; }
 
-  // Returns the current index into the block_handles/read_set arrays.
-  size_t current_read_set_index() const { return cur_idx_; }
+  const MultiScanArgs* scan_opts() const { return scan_opts_; }
+
+  // Returns the current index into the ReadSet, or prefetch size if the
+  // current block was not prefetched.
+  size_t current_read_set_index() const;
 
   // Returns the max_prefetch_size from scan options.
   uint64_t GetMaxPrefetchSize() const;
+
+  size_t GetPrefetchBlockCount() const {
+    return prefetch_max_idx_ - prefetch_start_idx_;
+  }
 
   // Returns true if the last Next() crossed a scan range boundary.
   // Only valid immediately after Next(); reset to false on the next Seek().
@@ -90,6 +95,7 @@ class MultiScanIndexIterator : public InternalIteratorBase<IndexValue> {
 
   // Returns true if there are more scan ranges after the current one.
   bool HasMoreScanRanges() const {
+    assert(!scan_opts_->reverse);
     return next_scan_idx_ < block_index_ranges_per_scan_.size();
   }
 
@@ -97,6 +103,10 @@ class MultiScanIndexIterator : public InternalIteratorBase<IndexValue> {
   // Release blocks from from_idx (inclusive) to to_idx (exclusive),
   // counting wasted prefetched blocks.
   void ReleaseBlocks(size_t from_idx, size_t to_idx);
+  void ReleaseBlock(size_t block_idx);
+  bool ReleasePrefetchedBlock(size_t block_idx);
+  void ShrinkUnreleasedPrefetchBounds();
+  bool IsPrefetchedBlock(size_t block_idx) const;
 
   // Find the correct scan range and block for an unexpected seek target
   // (target doesn't match expected scan range start).
@@ -104,6 +114,7 @@ class MultiScanIndexIterator : public InternalIteratorBase<IndexValue> {
 
   // Position at block_idx after releasing any skipped blocks.
   void SeekToBlockIdx(size_t block_idx);
+  void SeekToBlockIdxReverse(size_t block_idx);
 
   // Mark the current scan range as exhausted. If more ranges remain,
   // positions at the next range's start (stays valid for out-of-bound
@@ -115,13 +126,19 @@ class MultiScanIndexIterator : public InternalIteratorBase<IndexValue> {
   std::vector<std::tuple<size_t, size_t>> block_index_ranges_per_scan_;
   const MultiScanArgs* scan_opts_;
   std::shared_ptr<ReadSet> read_set_;
+  size_t prefetch_start_idx_;
   size_t prefetch_max_idx_;
+  size_t first_unreleased_prefetch_idx_;
+  size_t one_past_last_unreleased_prefetch_idx_;
+  std::vector<bool> released_prefetch_blocks_;
+  size_t unreleased_prefetch_blocks_;
   const InternalKeyComparator& icomp_;
   UserComparatorWrapper user_comparator_;
   Statistics* statistics_;
 
   size_t cur_idx_ = 0;
   size_t next_scan_idx_ = 0;
+  size_t cur_scan_idx_ = 0;
   bool valid_ = false;
   Status status_;
   std::string prev_seek_key_;

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -8256,9 +8256,52 @@ class UserDefinedIndexTestBase : public BlockBasedTableTestBase {
           return Status::OK();
         }
 
+        Status SeekToLastAndGetResult(IterateResult* result) override {
+          if (index_.empty()) {
+            result->bound_check_result = IterBoundCheck::kUnknown;
+            result->key = Slice();
+            return Status::OK();
+          }
+
+          iter_ = index_.end();
+          --iter_;
+          SetPreviousValidResult(result);
+          return Status::OK();
+        }
+
+        Status PrevAndGetResult(IterateResult* result) override {
+          if (iter_ == index_.end() || iter_ == index_.begin()) {
+            iter_ = index_.end();
+            result->bound_check_result = IterBoundCheck::kUnknown;
+            result->key = Slice();
+            return Status::OK();
+          }
+
+          --iter_;
+          SetPreviousValidResult(result);
+          return Status::OK();
+        }
+
         void AdvanceToNextIndexEntry() {
           while (iter_ != index_.end() && iter_->second.second == 0) {
             iter_++;
+          }
+        }
+
+        void SetPreviousValidResult(IterateResult* result) {
+          while (iter_ != index_.end() && iter_->second.second == 0) {
+            if (iter_ == index_.begin()) {
+              iter_ = index_.end();
+              break;
+            }
+            --iter_;
+          }
+          if (iter_ != index_.end()) {
+            result->bound_check_result = IterBoundCheck::kInbound;
+            result->key = Slice(iter_->first);
+          } else {
+            result->bound_check_result = IterBoundCheck::kUnknown;
+            result->key = Slice();
           }
         }
 
@@ -9768,14 +9811,16 @@ struct UserDefinedIndexStressTestParam {
   const Comparator* comparator;
   bool enable_udi;
   bool enable_compaction_with_sst_partitioner;
+  bool reverse_scan;
 
   using UserDefinedIndexStressTestTuple =
-      std::tuple<const Comparator*, bool, bool>;
+      std::tuple<const Comparator*, bool, bool, bool>;
 
   UserDefinedIndexStressTestParam(const UserDefinedIndexStressTestTuple& tuple)
       : comparator(std::get<0>(tuple)),
         enable_udi(std::get<1>(tuple)),
-        enable_compaction_with_sst_partitioner(std::get<2>(tuple)) {}
+        enable_compaction_with_sst_partitioner(std::get<2>(tuple)),
+        reverse_scan(std::get<3>(tuple)) {}
 };
 
 std::ostream& operator<<(std::ostream& os,
@@ -9784,7 +9829,8 @@ std::ostream& operator<<(std::ostream& os,
             << (param.comparator ? param.comparator->Name() : "nullptr")
             << ", enable_udi=" << param.enable_udi
             << ", enable_compaction_with_sst_partitioner="
-            << param.enable_compaction_with_sst_partitioner << "}";
+            << param.enable_compaction_with_sst_partitioner
+            << ", reverse_scan=" << param.reverse_scan << "}";
 }
 
 struct DataRange {
@@ -9826,6 +9872,7 @@ class UserDefinedIndexStressTest
     enable_udi_ = param.enable_udi;
     enable_compaction_with_sst_partitioner_ =
         param.enable_compaction_with_sst_partitioner;
+    reverse_scan_ = param.reverse_scan;
     options_.comparator = comparator_;
     is_reverse_comparator_ = comparator_ == ReverseBytewiseComparator();
     options_.compaction_style = kCompactionStyleUniversal;
@@ -9849,6 +9896,7 @@ class UserDefinedIndexStressTest
   static constexpr auto kKeyRange = 100;
   bool enable_udi_{};
   bool enable_compaction_with_sst_partitioner_{};
+  bool reverse_scan_{};
   uint32_t rand_seed_{};
   std::shared_ptr<UserDefinedIndexFactory> user_defined_index_factory_;
   BlockBasedTableOptions table_options_;
@@ -9985,7 +10033,8 @@ class UserDefinedIndexStressTest
   }
 
   void RangeScan(std::unique_ptr<Iterator>& iter,
-                 const std::vector<DataRange>& ranges, Slice& upper_bound,
+                 const std::vector<DataRange>& ranges, Slice& lower_bound,
+                 Slice& upper_bound,
                  std::vector<std::pair<std::string, std::string>>& result,
                  bool use_multi_scan) {
     ASSERT_NE(iter, nullptr);
@@ -9993,6 +10042,7 @@ class UserDefinedIndexStressTest
     ASSERT_TRUE(!ranges.empty());
 
     MultiScanArgs scan_opts(options_.comparator);
+    scan_opts.reverse = reverse_scan_;
     std::unordered_map<std::string, std::string> property_bag;
     if (use_multi_scan) {
       for (auto const& range : ranges) {
@@ -10016,19 +10066,36 @@ class UserDefinedIndexStressTest
         continue;
       }
       size_t scan_key_count = 0;
-      if (kVerbose) {
-        std::cout << "seek key " << range.start_key << std::endl;
-      }
+      lower_bound = range.start_key;
       upper_bound = range.end_key;
-      for (iter->Seek(range.start_key);
-           iter->Valid() && scan_key_count < range.scan_key_count_limit;
-           iter->Next()) {
+      if (reverse_scan_) {
         if (kVerbose) {
-          std::cout << "key " << iter->key().ToString() << " value "
-                    << iter->value().ToString() << std::endl;
+          std::cout << "seek for prev key " << range.end_key << std::endl;
         }
-        result.emplace_back(iter->key().ToString(), iter->value().ToString());
-        scan_key_count++;
+        for (iter->SeekForPrev(range.end_key);
+             iter->Valid() && scan_key_count < range.scan_key_count_limit;
+             iter->Prev()) {
+          if (kVerbose) {
+            std::cout << "key " << iter->key().ToString() << " value "
+                      << iter->value().ToString() << std::endl;
+          }
+          result.emplace_back(iter->key().ToString(), iter->value().ToString());
+          scan_key_count++;
+        }
+      } else {
+        if (kVerbose) {
+          std::cout << "seek key " << range.start_key << std::endl;
+        }
+        for (iter->Seek(range.start_key);
+             iter->Valid() && scan_key_count < range.scan_key_count_limit;
+             iter->Next()) {
+          if (kVerbose) {
+            std::cout << "key " << iter->key().ToString() << " value "
+                      << iter->value().ToString() << std::endl;
+          }
+          result.emplace_back(iter->key().ToString(), iter->value().ToString());
+          scan_key_count++;
+        }
       }
       ASSERT_OK(iter->status());
     }
@@ -10066,36 +10133,53 @@ class UserDefinedIndexStressTest
 
       // Query regular CF
       std::vector<std::pair<std::string, std::string>> expected_result;
+      Slice lower_bound("");
       Slice upper_bound("");
       ReadOptions ro;
+      if (reverse_scan_) {
+        ro.iterate_lower_bound = &lower_bound;
+      }
       ro.iterate_upper_bound = &upper_bound;
 
       std::unique_ptr<Iterator> iter(db_->NewIterator(ro, regular_cfh_));
-      ASSERT_NO_FATAL_FAILURE(
-          RangeScan(iter, ranges, upper_bound, expected_result, false));
+      ASSERT_NO_FATAL_FAILURE(RangeScan(iter, ranges, lower_bound, upper_bound,
+                                        expected_result, false));
       ASSERT_OK(iter->status());
 
       // Query ingest CF
       iter.reset(db_->NewIterator(ro, ingest_cfh_));
       std::vector<std::pair<std::string, std::string>> ingest_cf_result;
-      ASSERT_NO_FATAL_FAILURE(
-          RangeScan(iter, ranges, upper_bound, ingest_cf_result, false));
+      ASSERT_NO_FATAL_FAILURE(RangeScan(iter, ranges, lower_bound, upper_bound,
+                                        ingest_cf_result, false));
 
       ASSERT_EQ(expected_result, ingest_cf_result);
       ASSERT_OK(iter->status());
 
-      // Query ingest CF with UDI if it is enabled
-      if (enable_udi_) {
+      // Query ingest CF with UDI if it is enabled.
+      if (enable_udi_ && reverse_scan_) {
         ro.table_index_factory = user_defined_index_factory_.get();
+        iter.reset(db_->NewIterator(ro, ingest_cfh_));
+        std::vector<std::pair<std::string, std::string>> ingest_cf_udi_result;
+        ASSERT_NO_FATAL_FAILURE(RangeScan(iter, ranges, lower_bound,
+                                          upper_bound, ingest_cf_udi_result,
+                                          false));
+        ASSERT_EQ(expected_result, ingest_cf_udi_result);
+        ASSERT_OK(iter->status());
       }
 
-      iter.reset(db_->NewIterator(ro, ingest_cfh_));
-      std::vector<std::pair<std::string, std::string>>
-          ingest_cf_multi_scan_result;
-      ASSERT_NO_FATAL_FAILURE(RangeScan(iter, ranges, upper_bound,
-                                        ingest_cf_multi_scan_result, true));
-      ASSERT_EQ(expected_result, ingest_cf_multi_scan_result);
-      ASSERT_OK(iter->status());
+      if (!reverse_scan_) {
+        if (enable_udi_) {
+          ro.table_index_factory = user_defined_index_factory_.get();
+        }
+        iter.reset(db_->NewIterator(ro, ingest_cfh_));
+        std::vector<std::pair<std::string, std::string>>
+            ingest_cf_multi_scan_result;
+        ASSERT_NO_FATAL_FAILURE(RangeScan(iter, ranges, lower_bound,
+                                          upper_bound,
+                                          ingest_cf_multi_scan_result, true));
+        ASSERT_EQ(expected_result, ingest_cf_multi_scan_result);
+        ASSERT_OK(iter->status());
+      }
     }
   }
 
@@ -10403,7 +10487,7 @@ INSTANTIATE_TEST_CASE_P(
     UserDefinedIndexStressTest, UserDefinedIndexStressTest,
     testing::Combine(testing::Values(BytewiseComparator(),
                                      ReverseBytewiseComparator()),
-                     testing::Bool(), testing::Bool()));
+                     testing::Bool(), testing::Bool(), testing::Bool()));
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -4097,6 +4097,8 @@ class Benchmark {
                 FLAGS_io_dispatcher_max_prefetch_memory_bytes);
         fprintf(stderr, "multiscan_max_prefetch_size = %" PRIu64 "\n",
                 FLAGS_multiscan_max_prefetch_size);
+        fprintf(stderr, "reverse_iterator = %s\n",
+                FLAGS_reverse_iterator ? "true" : "false");
         method = &Benchmark::MultiScan;
       } else if (name == "multiscanrandom") {
         int64_t max_range_keys = std::max<int64_t>(
@@ -4114,6 +4116,8 @@ class Benchmark {
                 FLAGS_multiscan_use_async_io ? "true" : "false");
         fprintf(stderr, "use_multiscan = %s\n",
                 FLAGS_use_multiscan ? "true" : "false");
+        fprintf(stderr, "reverse_iterator = %s\n",
+                FLAGS_reverse_iterator ? "true" : "false");
         method = &Benchmark::MultiScanRandom;
       } else if (name == "multireadwhilewriting") {
         fprintf(stderr, "entries_per_batch = %" PRIi64 "\n",
@@ -7366,6 +7370,7 @@ class Benchmark {
       opts.io_coalesce_threshold = FLAGS_multiscan_coalesce_threshold;
       opts.use_async_io = FLAGS_multiscan_use_async_io;
       opts.max_prefetch_size = FLAGS_multiscan_max_prefetch_size;
+      opts.reverse = FLAGS_reverse_iterator;
       if (io_dispatcher) {
         opts.io_dispatcher = io_dispatcher;
       }
@@ -7436,6 +7441,7 @@ class Benchmark {
     }
 
     int64_t multiscans_done = 0;
+    uint64_t rows_scanned = 0;
     auto duration = thread->shared->MakeDuration(FLAGS_duration, reads_);
     int64_t num_keys = 1;
     while (!duration.Done(num_keys)) {
@@ -7500,6 +7506,7 @@ class Benchmark {
         opts.io_coalesce_threshold = FLAGS_multiscan_coalesce_threshold;
         opts.use_async_io = FLAGS_multiscan_use_async_io;
         opts.max_prefetch_size = FLAGS_multiscan_max_prefetch_size;
+        opts.reverse = FLAGS_reverse_iterator;
         if (io_dispatcher) {
           opts.io_dispatcher = io_dispatcher;
         }
@@ -7530,7 +7537,7 @@ class Benchmark {
           fprintf(stderr, "MultiScanException: %s\n", e.what());
         }
       } else {
-        // Normal iterator path: Seek + Next for each range
+        // Normal iterator path: Seek + Next/SeekForPrev + Prev for each range
         std::unique_ptr<const char[]> skey_guard;
         Slice skey = AllocateKey(&skey_guard);
         std::unique_ptr<const char[]> ekey_guard;
@@ -7538,21 +7545,45 @@ class Benchmark {
 
         std::unique_ptr<Iterator> iter(
             db->NewIterator(read_options_, db->DefaultColumnFamily()));
-        for (auto& r : non_overlapping) {
+        auto scan_range = [&](const RangeSpec& r) {
           GenerateKeyFromInt(r.start, FLAGS_num, &skey);
           GenerateKeyFromInt(r.start + r.size, FLAGS_num, &ekey);
-          for (iter->Seek(skey); iter->Valid() && iter->key().compare(ekey) < 0;
-               iter->Next()) {
-            keys++;
+          if (FLAGS_reverse_iterator) {
+            iter->SeekForPrev(ekey);
+            if (iter->Valid() && iter->key().compare(ekey) >= 0) {
+              iter->Prev();
+            }
+            for (; iter->Valid() && iter->key().compare(skey) >= 0;
+                 iter->Prev()) {
+              keys++;
+            }
+          } else {
+            for (iter->Seek(skey);
+                 iter->Valid() && iter->key().compare(ekey) < 0; iter->Next()) {
+              keys++;
+            }
           }
           if (!iter->status().ok()) {
             fprintf(stderr, "Iterator error: %s\n",
                     iter->status().ToString().c_str());
-            break;
+          }
+        };
+        if (FLAGS_reverse_iterator) {
+          for (auto it = non_overlapping.rbegin();
+               it != non_overlapping.rend() && iter->status().ok(); ++it) {
+            scan_range(*it);
+          }
+        } else {
+          for (auto& r : non_overlapping) {
+            scan_range(r);
+            if (!iter->status().ok()) {
+              break;
+            }
           }
         }
       }
       num_keys = std::max<int64_t>(1, keys);
+      rows_scanned += static_cast<uint64_t>(keys);
 
       if (thread->shared->read_rate_limiter.get() != nullptr) {
         thread->shared->read_rate_limiter->Request(
@@ -7563,10 +7594,13 @@ class Benchmark {
       multiscans_done += 1;
     }
 
-    char msg[100];
+    const uint64_t rows_per_multiscan =
+        multiscans_done == 0 ? 0 : rows_scanned / multiscans_done;
+    char msg[200];
     snprintf(msg, sizeof(msg),
-             "(multiscans:%" PRIu64 " max_range_keys:%" PRId64 ")",
-             multiscans_done, max_range_keys);
+             "(multiscans:%" PRIu64 " rows_scanned:%" PRIu64
+             " rows_per_multiscan:%" PRIu64 " max_range_keys:%" PRId64 ")",
+             multiscans_done, rows_scanned, rows_per_multiscan, max_range_keys);
     thread->stats.AddMessage(msg);
   }
 

--- a/utilities/trie_index/trie_index_factory.cc
+++ b/utilities/trie_index/trie_index_factory.cc
@@ -308,12 +308,13 @@ Status TrieIndexIterator::SeekToLastAndGetResult(IterateResult* result) {
 }
 
 Status TrieIndexIterator::PrevAndGetResult(IterateResult* result) {
-  // Overflow fast path: key doesn't change within the same run, so
-  // current_key_scratch_ can be passed directly to CheckBounds (no copy).
+  // Upper-bound checks are based on forward movement. While moving backward,
+  // DBIter's lower-bound handling decides when to stop.
+  // Overflow fast path: key doesn't change within the same run.
   if (overflow_run_index_ > 0) {
     overflow_run_index_--;
     result->key = Slice(current_key_scratch_);
-    result->bound_check_result = CheckBounds(Slice(current_key_scratch_));
+    result->bound_check_result = IterBoundCheck::kInbound;
     return Status::OK();
   }
 
@@ -332,7 +333,7 @@ Status TrieIndexIterator::PrevAndGetResult(IterateResult* result) {
 
   CopyTrieKeyToResult(result);
   SetupOverflowForCurrentLeaf(/*position_at_last=*/true);
-  result->bound_check_result = CheckBounds(Slice(prev_key_scratch_));
+  result->bound_check_result = IterBoundCheck::kInbound;
   return Status::OK();
 }
 

--- a/utilities/trie_index/trie_index_test.cc
+++ b/utilities/trie_index/trie_index_test.cc
@@ -2687,6 +2687,33 @@ TEST_F(TrieIndexFactoryTest, UpperBoundDoesNotDropValidBlocks) {
   ASSERT_EQ(result.bound_check_result, IterBoundCheck::kOutOfBound);
 }
 
+TEST_F(TrieIndexFactoryTest, PrevAfterPrepareDoesNotUseForwardUpperBound) {
+  auto ctx = BuildTrieAndGetIterator({
+      {"az", "b", 0, 500, 0, 0},
+      {"bz", "d", 1000, 500, 0, 0},
+      {"dz", "f", 2000, 500, 0, 0},
+  });
+
+  ScanOptions scans[] = {
+      ScanOptions(Slice("a"), Slice("c")),
+  };
+  ctx.iter->Prepare(scans, 1);
+
+  IterateResult result;
+  ASSERT_OK(ctx.iter->SeekAndGetResult(Slice("a"), &result,
+                                       SeekCtx(kMaxSequenceNumber)));
+  ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
+  ASSERT_EQ(ctx.iter->value().offset, 0u);
+
+  ASSERT_OK(ctx.iter->NextAndGetResult(&result));
+  ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
+  ASSERT_EQ(ctx.iter->value().offset, 1000u);
+
+  ASSERT_OK(ctx.iter->PrevAndGetResult(&result));
+  ASSERT_EQ(result.bound_check_result, IterBoundCheck::kInbound);
+  ASSERT_EQ(ctx.iter->value().offset, 0u);
+}
+
 TEST_F(TrieIndexFactoryTest, MultiScanBoundsAdvanceCorrectly) {
   // Validates that current_scan_idx_ advances correctly when
   // the seek target is past the current scan's limit. Otherwise all


### PR DESCRIPTION
Summary:

Add reverse scan support to `MultiScanArgs`/`MultiScan` so callers can iterate bounded scan ranges in descending order. Plumb reverse scan state through `DBIter`, `BlockBasedTableIterator`, and `MultiScanIndexIterator`, including reverse prefetch windowing and async I/O support. Update `db_bench` `multiscanrandom` to honor `--reverse_iterator` and report rows scanned so reverse MultiScan and iterator baselines can be compared on row throughput.

Add `db_stress --multiscan_reverse` coverage so the prepared MultiScan path can be stressed with `SeekForPrev()`/`Prev()` against a control iterator.

Also fix the table child iterator path to accept reverse `SeekForPrev()` targets above a file's prepared ranges. `MergingIterator` and `LevelIterator` can legally seek every child to the current range limit; a child file may only have lower prepared ranges, so treating that as invalid caused intermittent `SeekForPrev target is outside prepared ranges` exceptions in the benchmark.

Differential Revision: D109357730


