### PR TITLE
Check malloc return values in C API (#13099)

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -1761,6 +1761,12 @@ char** rocksdb_list_column_families(const rocksdb_options_t* options,
   *lencfs = fams.size();
   char** column_families =
       static_cast<char**>(malloc(sizeof(char*) * fams.size()));
+  if (!column_families) {
+    *lencfs = 0;
+    SaveError(errptr,
+              Status::MemoryLimit("Failed to allocate column family list"));
+    return nullptr;
+  }
   for (size_t i = 0; i < fams.size(); i++) {
     column_families[i] = strdup(fams[i].c_str());
   }
@@ -1806,6 +1812,16 @@ rocksdb_column_family_handle_t** rocksdb_create_column_families(
   rocksdb_column_family_handle_t** c_handles =
       static_cast<rocksdb_column_family_handle_t**>(
           malloc(sizeof(rocksdb_column_family_handle_t*) * handles.size()));
+  if (!c_handles) {
+    // Avoid leaking the column family handles that were just created.
+    for (size_t i = 0; i != handles.size(); ++i) {
+      delete handles[i];
+    }
+    *lencfs = 0;
+    SaveError(errptr,
+              Status::MemoryLimit("Failed to allocate column family handles"));
+    return nullptr;
+  }
   for (size_t i = 0; i != handles.size(); ++i) {
     c_handles[i] = new rocksdb_column_family_handle_t;
     c_handles[i]->rep = handles[i];
@@ -3642,6 +3658,17 @@ void rocksdb_load_latest_options(
     char** cf_names = (char**)malloc(cf_descs.size() * sizeof(char*));
     rocksdb_options_t** cf_options = (rocksdb_options_t**)malloc(
         cf_descs.size() * sizeof(rocksdb_options_t*));
+    if (!cf_names || !cf_options) {
+      free(cf_names);
+      free(cf_options);
+      *num_column_families = 0;
+      *db_options = nullptr;
+      *list_column_family_names = nullptr;
+      *list_column_family_options = nullptr;
+      SaveError(errptr, Status::MemoryLimit(
+                            "Failed to allocate column family options"));
+      return;
+    }
     for (size_t i = 0; i < cf_descs.size(); ++i) {
       cf_names[i] = strdup(cf_descs[i].name.c_str());
       cf_options[i] = new rocksdb_options_t{


### PR DESCRIPTION
## Summary

Fixes part of #13099.

Several C API functions in `db/c.cc` allocate buffers with `malloc()` and immediately dereference the result in the following loop without checking for failure. On a low-memory system `malloc()` can return `NULL`, which leads to a null-pointer dereference and a crash.

This PR adds `NULL` checks to the three call sites that already take an `errptr` parameter, so the allocation failure can be propagated cleanly. The handling mirrors the existing pattern already used by `rocksdb_open_and_compact` (report `Status::MemoryLimit` through `errptr` and return `nullptr`).

### Call sites fixed
- **`rocksdb_list_column_families`** — sets `*lencfs = 0`, reports the error and returns `nullptr`.
- **`rocksdb_create_column_families`** — the underlying column families have already been created at this point, so on allocation failure it deletes the created handles to avoid leaking them before returning.
- **`rocksdb_load_latest_options`** — has two allocations; if either fails it frees the other buffer (`free(nullptr)` is a safe no-op), resets all out-params, reports the error and returns.

### Scope
This intentionally covers only the call sites that have an `errptr` to propagate the failure, keeping the change small and consistent with the existing error-handling pattern. Other unchecked `malloc` sites mentioned in the issue (e.g. functions without an `errptr`, the `CopyString` helper, and `cache/lru_cache.cc`) can be addressed in follow-ups since they need different handling.

## Test plan
- `make format-auto` / `build_tools/format-diff.sh -c` — clean.
- `make check-sources` — passes.
- `db/c.o` compiles.

The new branches are only taken under allocation failure, which is not exercised by the existing functional tests; the change preserves existing behavior on the success path.