### PR TITLE
Fix range lock manager assertion crash on reverse-comparator CF point locks

### DIFF
--- a/utilities/transactions/lock/range/range_locking_test.cc
+++ b/utilities/transactions/lock/range/range_locking_test.cc
@@ -136,6 +136,38 @@ TEST_F(RangeLockingTest, RangeLockWithReverseComparator) {
   delete txn1;
 }
 
+// A point-equality range lock passes [infimum(K), supremum(K)]: the same user
+// key with the infimum endpoint as the left bound and the supremum endpoint as
+// the right bound. The infimum endpoint must sort before the supremum endpoint
+// even under a reverse comparator (the suffix marker is positional, not key
+// content), otherwise the locktree's left <= right invariant is violated and
+// try_acquire_lock aborts. Regression test for a crash on MyRocks equality
+// lookups on a reverse ('rev:') column family.
+TEST_F(RangeLockingTest, PointRangeLockWithReverseComparator) {
+  delete db;
+  db = nullptr;
+  ASSERT_OK(DestroyDB(dbname, options));
+
+  options.comparator = ReverseBytewiseComparator();
+  range_lock_mgr.reset(NewRangeLockManager(nullptr));
+  txn_db_options.lock_mgr_handle = range_lock_mgr;
+
+  ASSERT_OK(TransactionDB::Open(options, txn_db_options, dbname, &db));
+
+  WriteOptions write_options;
+  TransactionOptions txn_options;
+  txn_options.lock_timeout = 50;
+  auto cf = db->DefaultColumnFamily();
+
+  Transaction* txn0 = db->BeginTransaction(write_options, txn_options);
+
+  // [infimum("a"), supremum("a")] : same user key, infimum -> supremum.
+  ASSERT_OK(txn0->GetRangeLock(cf, Endpoint("a", false), Endpoint("a", true)));
+
+  txn0->Rollback();
+  delete txn0;
+}
+
 // CompareDbtEndpoints must use CompareWithoutTimestamp for range lock
 // endpoints, which never contain user-defined timestamps.
 TEST_F(RangeLockingTest, RangeLockWithTimestampComparator) {

--- a/utilities/transactions/lock/range/range_tree/range_tree_lock_manager.cc
+++ b/utilities/transactions/lock/range/range_tree/range_tree_lock_manager.cc
@@ -239,10 +239,18 @@ int RangeTreeLockManager::CompareDbtEndpoints(void* arg, const DBT* a_key,
       int r = b[0] == SUFFIX_INFIMUM ? 1 : -1;
       return is_reverse ? -r : r;
     } else {
+      // Same user key, differing only in the endpoint-type suffix byte. The
+      // suffix (SUFFIX_INFIMUM vs SUFFIX_SUPREMUM) is a positional boundary
+      // marker for that key, not key content, so the infimum endpoint always
+      // sorts before the supremum endpoint regardless of the column family's
+      // sort direction. This must NOT be flipped for a reverse comparator:
+      // doing so makes m_cmp(infimum(K), supremum(K)) > 0 and trips the
+      // locktree's "left <= right" invariant for a [infimum(K), supremum(K)]
+      // point range (e.g. a MyRocks equality lookup on a reverse 'rev:' CF).
       if (a[0] < b[0]) {
-        return is_reverse ? 1 : -1;
+        return -1;
       } else if (a[0] > b[0]) {
-        return is_reverse ? -1 : 1;
+        return 1;
       } else {
         return 0;
       }


### PR DESCRIPTION
Summary:
The RocksDB 11.5.0 reverse-comparator range-lock fix (https://github.com/facebook/rocksdb/pull/14831) made `RangeTreeLockManager::CompareDbtEndpoints` reverse-aware by wrapping the endpoint-suffix tie-break results in an `is_reverse` flip. The length-disparity (different user key) branches need that flip, but the equal-length / equal-user-key branch was flipped too, and that is incorrect.

Range-lock endpoints are encoded as `[suffix_byte][user_key]` where the suffix is `SUFFIX_INFIMUM` (0x0) or `SUFFIX_SUPREMUM` (0x1). When two endpoints share the same user key and differ only in the suffix byte, the suffix is a positional boundary marker for that key, not key content, so the infimum endpoint must sort before the supremum endpoint in any total order, regardless of the column family sort direction. Flipping it for a reverse comparator makes `m_cmp(infimum(K), supremum(K)) > 0`.

MyRocks issues an equality lock (e.g. `UPDATE t1 SET a=123 WHERE a=35`) as the range `[infimum(K), supremum(K)]` over the same user key K. On a reverse (`rev:`) column family — which uses the stock `ReverseBytewiseComparator()`, so `is_reverse` is true — the flipped comparator reports `left > right`, tripping `paranoid_invariant(m_cmp(left_key, right_key) <= 0)` in `toku::locktree::try_acquire_lock` and aborting the server with SIGABRT. This broke many MyRocks `---range_locking` MTR tests (partial_index*, bypass_select_range_sk*, alter_table_online_debug, allow_no_primary_key_with_sk) after RocksDB was bumped to 11.5.0.

Fix: in the equal-length / equal-user-key branch of `CompareDbtEndpoints`, compare the suffix bytes without the `is_reverse` flip so infimum always precedes supremum. The length-disparity branches keep the reverse-aware flip (still covered by `RangeLockWithReverseComparator`).

Differential Revision: D109591908


