### PR TITLE
Add RocksDB rate limiter I/O usage metrics

### DIFF
--- a/include/rocksdb/statistics.h
+++ b/include/rocksdb/statistics.h
@@ -311,6 +311,22 @@ enum Tickers : uint32_t {
 
   // Number of refill intervals where rate limiter's bytes are fully consumed.
   NUMBER_RATE_LIMITER_DRAINS,
+  // Bytes granted by the rate limiter for read requests.
+  RATE_LIMITER_BYTES_READ,
+  // Bytes granted by the rate limiter for write requests.
+  RATE_LIMITER_BYTES_WRITE,
+  // Number of read requests granted by the rate limiter.
+  RATE_LIMITER_REQUESTS_READ,
+  // Number of write requests granted by the rate limiter.
+  RATE_LIMITER_REQUESTS_WRITE,
+  // Number of read requests that waited for a future rate limiter refill.
+  RATE_LIMITER_DELAYED_REQUESTS_READ,
+  // Number of write requests that waited for a future rate limiter refill.
+  RATE_LIMITER_DELAYED_REQUESTS_WRITE,
+  // Total time read requests spent waiting for rate limiter refills.
+  RATE_LIMITER_TOTAL_WAIT_MICROS_READ,
+  // Total time write requests spent waiting for rate limiter refills.
+  RATE_LIMITER_TOTAL_WAIT_MICROS_WRITE,
 
   // BlobDB specific stats
   // # of Put/PutWithTTL to BlobDB. Only applicable to legacy BlobDB.
@@ -774,6 +790,11 @@ enum Histograms : uint32_t {
   // (work under the DB mutex while writes are blocked). One sample per
   // successful call; requires stats level > kExceptTimers.
   INGEST_EXTERNAL_FILE_RUN_TIME,
+
+  // Time read requests spent waiting for rate limiter refills.
+  RATE_LIMITER_WAIT_MICROS_READ,
+  // Time write requests spent waiting for rate limiter refills.
+  RATE_LIMITER_WAIT_MICROS_WRITE,
 
   HISTOGRAM_ENUM_MAX
 };

--- a/java/rocksjni/portal.h
+++ b/java/rocksjni/portal.h
@@ -5089,6 +5089,22 @@ class TickerTypeJni {
         return 0x75;
       case ROCKSDB_NAMESPACE::Tickers::NUMBER_RATE_LIMITER_DRAINS:
         return 0x76;
+      case ROCKSDB_NAMESPACE::Tickers::RATE_LIMITER_BYTES_READ:
+        return -0x71;
+      case ROCKSDB_NAMESPACE::Tickers::RATE_LIMITER_BYTES_WRITE:
+        return -0x72;
+      case ROCKSDB_NAMESPACE::Tickers::RATE_LIMITER_REQUESTS_READ:
+        return -0x73;
+      case ROCKSDB_NAMESPACE::Tickers::RATE_LIMITER_REQUESTS_WRITE:
+        return -0x74;
+      case ROCKSDB_NAMESPACE::Tickers::RATE_LIMITER_DELAYED_REQUESTS_READ:
+        return -0x75;
+      case ROCKSDB_NAMESPACE::Tickers::RATE_LIMITER_DELAYED_REQUESTS_WRITE:
+        return -0x76;
+      case ROCKSDB_NAMESPACE::Tickers::RATE_LIMITER_TOTAL_WAIT_MICROS_READ:
+        return -0x77;
+      case ROCKSDB_NAMESPACE::Tickers::RATE_LIMITER_TOTAL_WAIT_MICROS_WRITE:
+        return -0x78;
       case ROCKSDB_NAMESPACE::Tickers::BLOB_DB_NUM_PUT:
         return 0x77;
       case ROCKSDB_NAMESPACE::Tickers::BLOB_DB_NUM_WRITE:
@@ -5597,6 +5613,22 @@ class TickerTypeJni {
         return ROCKSDB_NAMESPACE::Tickers::READ_AMP_TOTAL_READ_BYTES;
       case 0x76:
         return ROCKSDB_NAMESPACE::Tickers::NUMBER_RATE_LIMITER_DRAINS;
+      case -0x71:
+        return ROCKSDB_NAMESPACE::Tickers::RATE_LIMITER_BYTES_READ;
+      case -0x72:
+        return ROCKSDB_NAMESPACE::Tickers::RATE_LIMITER_BYTES_WRITE;
+      case -0x73:
+        return ROCKSDB_NAMESPACE::Tickers::RATE_LIMITER_REQUESTS_READ;
+      case -0x74:
+        return ROCKSDB_NAMESPACE::Tickers::RATE_LIMITER_REQUESTS_WRITE;
+      case -0x75:
+        return ROCKSDB_NAMESPACE::Tickers::RATE_LIMITER_DELAYED_REQUESTS_READ;
+      case -0x76:
+        return ROCKSDB_NAMESPACE::Tickers::RATE_LIMITER_DELAYED_REQUESTS_WRITE;
+      case -0x77:
+        return ROCKSDB_NAMESPACE::Tickers::RATE_LIMITER_TOTAL_WAIT_MICROS_READ;
+      case -0x78:
+        return ROCKSDB_NAMESPACE::Tickers::RATE_LIMITER_TOTAL_WAIT_MICROS_WRITE;
       case 0x77:
         return ROCKSDB_NAMESPACE::Tickers::BLOB_DB_NUM_PUT;
       case 0x78:
@@ -6002,6 +6034,10 @@ class HistogramTypeJni {
         return 0x43;
       case ROCKSDB_NAMESPACE::Histograms::INGEST_EXTERNAL_FILE_RUN_TIME:
         return 0x44;
+      case ROCKSDB_NAMESPACE::Histograms::RATE_LIMITER_WAIT_MICROS_READ:
+        return 0x45;
+      case ROCKSDB_NAMESPACE::Histograms::RATE_LIMITER_WAIT_MICROS_WRITE:
+        return 0x46;
       case ROCKSDB_NAMESPACE::Histograms::HISTOGRAM_ENUM_MAX:
         // 0x3E is reserved for backwards compatibility on current minor
         // version.
@@ -6159,6 +6195,10 @@ class HistogramTypeJni {
         return ROCKSDB_NAMESPACE::Histograms::INGEST_EXTERNAL_FILE_PREPARE_TIME;
       case 0x44:
         return ROCKSDB_NAMESPACE::Histograms::INGEST_EXTERNAL_FILE_RUN_TIME;
+      case 0x45:
+        return ROCKSDB_NAMESPACE::Histograms::RATE_LIMITER_WAIT_MICROS_READ;
+      case 0x46:
+        return ROCKSDB_NAMESPACE::Histograms::RATE_LIMITER_WAIT_MICROS_WRITE;
       case 0x3E:
         // 0x3E is reserved for backwards compatibility on current minor
         // version.

--- a/java/src/main/java/org/rocksdb/HistogramType.java
+++ b/java/src/main/java/org/rocksdb/HistogramType.java
@@ -241,6 +241,16 @@ public enum HistogramType {
    */
   INGEST_EXTERNAL_FILE_RUN_TIME((byte) 0x44),
 
+  /**
+   * Time read requests spent waiting for rate limiter refills.
+   */
+  RATE_LIMITER_WAIT_MICROS_READ((byte) 0x45),
+
+  /**
+   * Time write requests spent waiting for rate limiter refills.
+   */
+  RATE_LIMITER_WAIT_MICROS_WRITE((byte) 0x46),
+
   // 0x3E is reserved for backwards compatibility on current minor version.
   HISTOGRAM_ENUM_MAX((byte) 0x3E);
 

--- a/java/src/main/java/org/rocksdb/TickerType.java
+++ b/java/src/main/java/org/rocksdb/TickerType.java
@@ -519,6 +519,46 @@ public enum TickerType {
     NUMBER_RATE_LIMITER_DRAINS((byte) 0x76),
 
     /**
+     * Bytes granted by the rate limiter for read requests.
+     */
+    RATE_LIMITER_BYTES_READ((byte) -0x71),
+
+    /**
+     * Bytes granted by the rate limiter for write requests.
+     */
+    RATE_LIMITER_BYTES_WRITE((byte) -0x72),
+
+    /**
+     * Number of read requests granted by the rate limiter.
+     */
+    RATE_LIMITER_REQUESTS_READ((byte) -0x73),
+
+    /**
+     * Number of write requests granted by the rate limiter.
+     */
+    RATE_LIMITER_REQUESTS_WRITE((byte) -0x74),
+
+    /**
+     * Number of read requests that waited for a future rate limiter refill.
+     */
+    RATE_LIMITER_DELAYED_REQUESTS_READ((byte) -0x75),
+
+    /**
+     * Number of write requests that waited for a future rate limiter refill.
+     */
+    RATE_LIMITER_DELAYED_REQUESTS_WRITE((byte) -0x76),
+
+    /**
+     * Total time read requests spent waiting for rate limiter refills.
+     */
+    RATE_LIMITER_TOTAL_WAIT_MICROS_READ((byte) -0x77),
+
+    /**
+     * Total time write requests spent waiting for rate limiter refills.
+     */
+    RATE_LIMITER_TOTAL_WAIT_MICROS_WRITE((byte) -0x78),
+
+    /**
      * BlobDB specific stats
      * # of Put/PutTTL/PutUntil to BlobDB.
      */

--- a/monitoring/statistics.cc
+++ b/monitoring/statistics.cc
@@ -164,6 +164,18 @@ const std::vector<std::pair<Tickers, std::string>> TickersNameMap = {
     {READ_AMP_ESTIMATE_USEFUL_BYTES, "rocksdb.read.amp.estimate.useful.bytes"},
     {READ_AMP_TOTAL_READ_BYTES, "rocksdb.read.amp.total.read.bytes"},
     {NUMBER_RATE_LIMITER_DRAINS, "rocksdb.number.rate_limiter.drains"},
+    {RATE_LIMITER_BYTES_READ, "rocksdb.rate.limiter.bytes.read"},
+    {RATE_LIMITER_BYTES_WRITE, "rocksdb.rate.limiter.bytes.write"},
+    {RATE_LIMITER_REQUESTS_READ, "rocksdb.rate.limiter.requests.read"},
+    {RATE_LIMITER_REQUESTS_WRITE, "rocksdb.rate.limiter.requests.write"},
+    {RATE_LIMITER_DELAYED_REQUESTS_READ,
+     "rocksdb.rate.limiter.delayed.requests.read"},
+    {RATE_LIMITER_DELAYED_REQUESTS_WRITE,
+     "rocksdb.rate.limiter.delayed.requests.write"},
+    {RATE_LIMITER_TOTAL_WAIT_MICROS_READ,
+     "rocksdb.rate.limiter.total.wait.micros.read"},
+    {RATE_LIMITER_TOTAL_WAIT_MICROS_WRITE,
+     "rocksdb.rate.limiter.total.wait.micros.write"},
     {BLOB_DB_NUM_PUT, "rocksdb.blobdb.num.put"},
     {BLOB_DB_NUM_WRITE, "rocksdb.blobdb.num.write"},
     {BLOB_DB_NUM_GET, "rocksdb.blobdb.num.get"},
@@ -389,6 +401,8 @@ const std::vector<std::pair<Histograms, std::string>> HistogramsNameMap = {
     {INGEST_EXTERNAL_FILE_PREPARE_TIME,
      "rocksdb.ingest.external.file.prepare.micros"},
     {INGEST_EXTERNAL_FILE_RUN_TIME, "rocksdb.ingest.external.file.run.micros"},
+    {RATE_LIMITER_WAIT_MICROS_READ, "rocksdb.rate.limiter.wait.micros.read"},
+    {RATE_LIMITER_WAIT_MICROS_WRITE, "rocksdb.rate.limiter.wait.micros.write"},
 };
 
 std::shared_ptr<Statistics> CreateDBStatistics() {

--- a/util/rate_limiter.cc
+++ b/util/rate_limiter.cc
@@ -17,6 +17,65 @@
 #include "util/rate_limiter_impl.h"
 
 namespace ROCKSDB_NAMESPACE {
+namespace {
+
+Tickers RateLimiterBytesTicker(RateLimiter::OpType op_type) {
+  switch (op_type) {
+    case RateLimiter::OpType::kRead:
+      return RATE_LIMITER_BYTES_READ;
+    case RateLimiter::OpType::kWrite:
+      return RATE_LIMITER_BYTES_WRITE;
+  }
+  assert(false);
+  return RATE_LIMITER_BYTES_WRITE;
+}
+
+Tickers RateLimiterRequestsTicker(RateLimiter::OpType op_type) {
+  switch (op_type) {
+    case RateLimiter::OpType::kRead:
+      return RATE_LIMITER_REQUESTS_READ;
+    case RateLimiter::OpType::kWrite:
+      return RATE_LIMITER_REQUESTS_WRITE;
+  }
+  assert(false);
+  return RATE_LIMITER_REQUESTS_WRITE;
+}
+
+Tickers RateLimiterDelayedRequestsTicker(RateLimiter::OpType op_type) {
+  switch (op_type) {
+    case RateLimiter::OpType::kRead:
+      return RATE_LIMITER_DELAYED_REQUESTS_READ;
+    case RateLimiter::OpType::kWrite:
+      return RATE_LIMITER_DELAYED_REQUESTS_WRITE;
+  }
+  assert(false);
+  return RATE_LIMITER_DELAYED_REQUESTS_WRITE;
+}
+
+Tickers RateLimiterTotalWaitTicker(RateLimiter::OpType op_type) {
+  switch (op_type) {
+    case RateLimiter::OpType::kRead:
+      return RATE_LIMITER_TOTAL_WAIT_MICROS_READ;
+    case RateLimiter::OpType::kWrite:
+      return RATE_LIMITER_TOTAL_WAIT_MICROS_WRITE;
+  }
+  assert(false);
+  return RATE_LIMITER_TOTAL_WAIT_MICROS_WRITE;
+}
+
+Histograms RateLimiterWaitHistogram(RateLimiter::OpType op_type) {
+  switch (op_type) {
+    case RateLimiter::OpType::kRead:
+      return RATE_LIMITER_WAIT_MICROS_READ;
+    case RateLimiter::OpType::kWrite:
+      return RATE_LIMITER_WAIT_MICROS_WRITE;
+  }
+  assert(false);
+  return RATE_LIMITER_WAIT_MICROS_WRITE;
+}
+
+}  // namespace
+
 size_t RateLimiter::RequestToken(size_t bytes, size_t alignment,
                                  Env::IOPriority io_priority, Statistics* stats,
                                  RateLimiter::OpType op_type) {
@@ -121,113 +180,161 @@ Status GenericRateLimiter::SetSingleBurstBytes(int64_t single_burst_bytes) {
 
 void GenericRateLimiter::Request(int64_t bytes, const Env::IOPriority pri,
                                  Statistics* stats) {
+  RequestImpl(bytes, pri, stats, RateLimiter::OpType::kWrite);
+}
+
+void GenericRateLimiter::Request(int64_t bytes, const Env::IOPriority pri,
+                                 Statistics* stats,
+                                 RateLimiter::OpType op_type) {
+  if (!IsRateLimited(op_type)) {
+    return;
+  }
+  RequestImpl(bytes, pri, stats, op_type);
+}
+
+void GenericRateLimiter::RequestImpl(int64_t bytes, const Env::IOPriority pri,
+                                     Statistics* stats,
+                                     RateLimiter::OpType op_type) {
   assert(bytes <= GetSingleBurstBytes());
   bytes = std::max(static_cast<int64_t>(0), bytes);
+  const int64_t requested_bytes = bytes;
   TEST_SYNC_POINT("GenericRateLimiter::Request");
   TEST_SYNC_POINT_CALLBACK("GenericRateLimiter::Request:1",
                            &rate_bytes_per_sec_);
-  MutexLock g(&request_mutex_);
 
-  if (auto_tuned_) {
-    static const int kRefillsPerTune = 100;
-    std::chrono::microseconds now(NowMicrosMonotonicLocked());
-    if (now - tuned_time_ >=
-        kRefillsPerTune * std::chrono::microseconds(refill_period_us_)) {
-      Status s = TuneLocked();
-      s.PermitUncheckedError();  //**TODO: What to do on error?
-    }
-  }
+  bool request_granted = false;
+  bool request_delayed = false;
+  int64_t wait_start_us = 0;
+  int64_t wait_micros = 0;
 
-  if (stop_) {
-    // It is now in the clean-up of ~GenericRateLimiter().
-    // Therefore any new incoming request will exit from here
-    // and not get satiesfied.
-    return;
-  }
+  {
+    MutexLock g(&request_mutex_);
 
-  ++total_requests_[pri];
-
-  if (available_bytes_ > 0) {
-    int64_t bytes_through = std::min(available_bytes_, bytes);
-    total_bytes_through_[pri] += bytes_through;
-    available_bytes_ -= bytes_through;
-    bytes -= bytes_through;
-  }
-
-  if (bytes == 0) {
-    return;
-  }
-
-  // Request cannot be satisfied at this moment, enqueue
-  Req r(bytes, &request_mutex_);
-  queue_[pri].push_back(&r);
-  TEST_SYNC_POINT_CALLBACK("GenericRateLimiter::Request:PostEnqueueRequest",
-                           &request_mutex_);
-  // A thread representing a queued request coordinates with other such threads.
-  // There are two main duties.
-  //
-  // (1) Waiting for the next refill time.
-  // (2) Refilling the bytes and granting requests.
-  do {
-    int64_t time_until_refill_us = next_refill_us_ - NowMicrosMonotonicLocked();
-    if (time_until_refill_us > 0) {
-      if (wait_until_refill_pending_) {
-        // Somebody is performing (1). Trust we'll be woken up when our request
-        // is granted or we are needed for future duties.
-        r.cv.Wait();
-      } else {
-        // Whichever thread reaches here first performs duty (1) as described
-        // above.
-        int64_t wait_until = clock_->NowMicros() + time_until_refill_us;
-        RecordTick(stats, NUMBER_RATE_LIMITER_DRAINS);
-        ++num_drains_;
-        wait_until_refill_pending_ = true;
-        clock_->TimedWait(&r.cv, std::chrono::microseconds(wait_until));
-        TEST_SYNC_POINT_CALLBACK("GenericRateLimiter::Request:PostTimedWait",
-                                 &time_until_refill_us);
-        wait_until_refill_pending_ = false;
+    if (auto_tuned_) {
+      static const int kRefillsPerTune = 100;
+      std::chrono::microseconds now(NowMicrosMonotonicLocked());
+      if (now - tuned_time_ >=
+          kRefillsPerTune * std::chrono::microseconds(refill_period_us_)) {
+        Status s = TuneLocked();
+        s.PermitUncheckedError();  //**TODO: What to do on error?
       }
-    } else {
-      // Whichever thread reaches here first performs duty (2) as described
-      // above.
-      RefillBytesAndGrantRequestsLocked();
     }
-    if (r.request_bytes == 0) {
-      // If there is any remaining requests, make sure there exists at least
-      // one candidate is awake for future duties by signaling a front request
-      // of a queue.
-      for (int i = Env::IO_TOTAL - 1; i >= Env::IO_LOW; --i) {
-        auto& queue = queue_[i];
-        if (!queue.empty()) {
-          queue.front()->cv.Signal();
-          break;
+
+    if (stop_) {
+      // It is now in the clean-up of ~GenericRateLimiter().
+      // Therefore any new incoming request will exit from here
+      // and not get satiesfied.
+      return;
+    }
+
+    ++total_requests_[pri];
+
+    if (available_bytes_ > 0) {
+      int64_t bytes_through = std::min(available_bytes_, bytes);
+      total_bytes_through_[pri] += bytes_through;
+      available_bytes_ -= bytes_through;
+      bytes -= bytes_through;
+    }
+
+    if (bytes == 0) {
+      request_granted = true;
+    } else {
+      // Request cannot be satisfied at this moment, enqueue
+      Req r(bytes, &request_mutex_);
+      queue_[pri].push_back(&r);
+      TEST_SYNC_POINT_CALLBACK("GenericRateLimiter::Request:PostEnqueueRequest",
+                               &request_mutex_);
+      // A thread representing a queued request coordinates with other such
+      // threads. There are two main duties.
+      //
+      // (1) Waiting for the next refill time.
+      // (2) Refilling the bytes and granting requests.
+      do {
+        int64_t now = static_cast<int64_t>(NowMicrosMonotonicLocked());
+        int64_t time_until_refill_us = next_refill_us_ - now;
+        if (time_until_refill_us > 0) {
+          if (!request_delayed) {
+            request_delayed = true;
+            wait_start_us = now;
+          }
+          if (wait_until_refill_pending_) {
+            // Somebody is performing (1). Trust we'll be woken up when our
+            // request is granted or we are needed for future duties.
+            r.cv.Wait();
+          } else {
+            // Whichever thread reaches here first performs duty (1) as
+            // described above.
+            int64_t wait_until = clock_->NowMicros() + time_until_refill_us;
+            RecordTick(stats, NUMBER_RATE_LIMITER_DRAINS);
+            ++num_drains_;
+            wait_until_refill_pending_ = true;
+            clock_->TimedWait(&r.cv, std::chrono::microseconds(wait_until));
+            TEST_SYNC_POINT_CALLBACK(
+                "GenericRateLimiter::Request:PostTimedWait",
+                &time_until_refill_us);
+            wait_until_refill_pending_ = false;
+          }
+        } else {
+          // Whichever thread reaches here first performs duty (2) as described
+          // above.
+          RefillBytesAndGrantRequestsLocked();
+        }
+        if (r.request_bytes == 0) {
+          // If there is any remaining requests, make sure there exists at least
+          // one candidate is awake for future duties by signaling a front
+          // request of a queue.
+          for (int i = Env::IO_TOTAL - 1; i >= Env::IO_LOW; --i) {
+            auto& queue = queue_[i];
+            if (!queue.empty()) {
+              queue.front()->cv.Signal();
+              break;
+            }
+          }
+        }
+        // Invariant: non-granted request is always in one queue, and granted
+        // request is always in zero queues.
+#ifndef NDEBUG
+        int num_found = 0;
+        for (int i = Env::IO_LOW; i < Env::IO_TOTAL; ++i) {
+          if (std::find(queue_[i].begin(), queue_[i].end(), &r) !=
+              queue_[i].end()) {
+            ++num_found;
+          }
+        }
+        if (r.request_bytes == 0) {
+          assert(num_found == 0);
+        } else {
+          assert(num_found == 1);
+        }
+#endif  // NDEBUG
+      } while (!stop_ && r.request_bytes > 0);
+
+      if (stop_) {
+        // It is now in the clean-up of ~GenericRateLimiter().
+        // Therefore any woken-up request will have come out of the loop and
+        // then exit here. It might or might not have been satisfied.
+        --requests_to_wait_;
+        exit_cv_.Signal();
+      } else {
+        request_granted = true;
+        if (request_delayed) {
+          wait_micros =
+              static_cast<int64_t>(NowMicrosMonotonicLocked()) - wait_start_us;
         }
       }
     }
-    // Invariant: non-granted request is always in one queue, and granted
-    // request is always in zero queues.
-#ifndef NDEBUG
-    int num_found = 0;
-    for (int i = Env::IO_LOW; i < Env::IO_TOTAL; ++i) {
-      if (std::find(queue_[i].begin(), queue_[i].end(), &r) !=
-          queue_[i].end()) {
-        ++num_found;
-      }
-    }
-    if (r.request_bytes == 0) {
-      assert(num_found == 0);
-    } else {
-      assert(num_found == 1);
-    }
-#endif  // NDEBUG
-  } while (!stop_ && r.request_bytes > 0);
+  }
 
-  if (stop_) {
-    // It is now in the clean-up of ~GenericRateLimiter().
-    // Therefore any woken-up request will have come out of the loop and then
-    // exit here. It might or might not have been satisfied.
-    --requests_to_wait_;
-    exit_cv_.Signal();
+  if (request_granted) {
+    RecordTick(stats, RateLimiterRequestsTicker(op_type));
+    RecordTick(stats, RateLimiterBytesTicker(op_type), requested_bytes);
+    if (request_delayed) {
+      RecordTick(stats, RateLimiterDelayedRequestsTicker(op_type));
+      RecordTick(stats, RateLimiterTotalWaitTicker(op_type),
+                 static_cast<uint64_t>(wait_micros));
+      RecordInHistogram(stats, RateLimiterWaitHistogram(op_type),
+                        static_cast<uint64_t>(wait_micros));
+    }
   }
 }
 

--- a/util/rate_limiter_impl.h
+++ b/util/rate_limiter_impl.h
@@ -45,6 +45,8 @@ class GenericRateLimiter : public RateLimiter {
   using RateLimiter::Request;
   void Request(const int64_t bytes, const Env::IOPriority pri,
                Statistics* stats) override;
+  void Request(const int64_t bytes, const Env::IOPriority pri,
+               Statistics* stats, RateLimiter::OpType op_type) override;
 
   int64_t GetSingleBurstBytes() const override {
     int64_t raw_single_burst_bytes =
@@ -110,6 +112,8 @@ class GenericRateLimiter : public RateLimiter {
 
  private:
   static constexpr int kMicrosecondsPerSecond = 1000000;
+  void RequestImpl(int64_t bytes, Env::IOPriority pri, Statistics* stats,
+                   RateLimiter::OpType op_type);
   void RefillBytesAndGrantRequestsLocked();
   std::vector<Env::IOPriority> GeneratePriorityIterationOrderLocked();
   int64_t CalculateRefillBytesPerPeriodLocked(int64_t rate_bytes_per_sec);

--- a/util/rate_limiter_test.cc
+++ b/util/rate_limiter_test.cc
@@ -183,6 +183,64 @@ TEST_F(RateLimiterTest, Modes) {
   }
 }
 
+TEST_F(RateLimiterTest, Statistics) {
+  constexpr int64_t kBytesPerSecond = 100;
+  constexpr int64_t kMicrosPerSecond = 1000 * 1000;
+  constexpr int64_t kBytesPerRefill = kBytesPerSecond;
+
+  auto stats = CreateDBStatistics();
+  auto mock_clock =
+      std::make_shared<MockSystemClock>(Env::Default()->GetSystemClock());
+  GenericRateLimiter write_limiter(
+      kBytesPerSecond, kMicrosPerSecond, 10 /* fairness */,
+      RateLimiter::Mode::kWritesOnly, mock_clock, false /* auto_tuned */,
+      0 /* single_burst_bytes */);
+
+  write_limiter.Request(1 /* bytes */, Env::IO_HIGH, stats.get(),
+                        RateLimiter::OpType::kRead);
+  EXPECT_EQ(0, stats->getTickerCount(RATE_LIMITER_BYTES_READ));
+  EXPECT_EQ(0, stats->getTickerCount(RATE_LIMITER_REQUESTS_READ));
+
+  write_limiter.Request(kBytesPerRefill, Env::IO_HIGH, stats.get(),
+                        RateLimiter::OpType::kWrite);
+  EXPECT_EQ(kBytesPerRefill, stats->getTickerCount(RATE_LIMITER_BYTES_WRITE));
+  EXPECT_EQ(1, stats->getTickerCount(RATE_LIMITER_REQUESTS_WRITE));
+  EXPECT_EQ(0, stats->getTickerCount(RATE_LIMITER_DELAYED_REQUESTS_WRITE));
+  EXPECT_EQ(0, stats->getTickerCount(RATE_LIMITER_TOTAL_WAIT_MICROS_WRITE));
+
+  HistogramData hist;
+  stats->histogramData(RATE_LIMITER_WAIT_MICROS_WRITE, &hist);
+  EXPECT_EQ(0, hist.count);
+
+  write_limiter.Request(1 /* bytes */, Env::IO_HIGH, stats.get(),
+                        RateLimiter::OpType::kWrite);
+  EXPECT_EQ(kBytesPerRefill + 1,
+            stats->getTickerCount(RATE_LIMITER_BYTES_WRITE));
+  EXPECT_EQ(2, stats->getTickerCount(RATE_LIMITER_REQUESTS_WRITE));
+  EXPECT_EQ(1, stats->getTickerCount(RATE_LIMITER_DELAYED_REQUESTS_WRITE));
+  EXPECT_GT(stats->getTickerCount(NUMBER_RATE_LIMITER_DRAINS), 0);
+  EXPECT_GT(stats->getTickerCount(RATE_LIMITER_TOTAL_WAIT_MICROS_WRITE), 0);
+
+  stats->histogramData(RATE_LIMITER_WAIT_MICROS_WRITE, &hist);
+  EXPECT_EQ(1, hist.count);
+  EXPECT_GT(hist.sum, 0);
+
+  auto read_stats = CreateDBStatistics();
+  auto read_mock_clock =
+      std::make_shared<MockSystemClock>(Env::Default()->GetSystemClock());
+  GenericRateLimiter read_limiter(kBytesPerSecond, kMicrosPerSecond,
+                                  10 /* fairness */, RateLimiter::Mode::kAllIo,
+                                  read_mock_clock, false /* auto_tuned */,
+                                  0 /* single_burst_bytes */);
+
+  read_limiter.Request(10 /* bytes */, Env::IO_HIGH, read_stats.get(),
+                       RateLimiter::OpType::kRead);
+  EXPECT_EQ(10, read_stats->getTickerCount(RATE_LIMITER_BYTES_READ));
+  EXPECT_EQ(1, read_stats->getTickerCount(RATE_LIMITER_REQUESTS_READ));
+  EXPECT_EQ(0, read_stats->getTickerCount(RATE_LIMITER_BYTES_WRITE));
+  EXPECT_EQ(0, read_stats->getTickerCount(RATE_LIMITER_REQUESTS_WRITE));
+}
+
 TEST_F(RateLimiterTest, GeneratePriorityIterationOrder) {
   std::unique_ptr<RateLimiter> limiter(NewGenericRateLimiter(
       200 /* rate_bytes_per_sec */, 1000 * 1000 /* refill_period_us */,


### PR DESCRIPTION
## Summary:
Add rate limiter statistics that make it easier to diagnose whether RocksDB background IO is being throttled by the GenericRateLimiter.

New ticker counters:
- rocksdb.rate.limiter.bytes.read/write: bytes granted by the limiter, split by operation type.
- rocksdb.rate.limiter.requests.read/write: requests granted by the limiter, split by operation type.
- rocksdb.rate.limiter.delayed.requests.read/write: requests that actually had to wait for a future refill because available tokens were exhausted.
- rocksdb.rate.limiter.total.wait.micros.read/write: cumulative wait time for delayed requests.

New histograms:
- rocksdb.rate.limiter.wait.micros.read/write: per-request wait latency for delayed requests, enabling percentile debugging.

GenericRateLimiter now overrides the OpType-aware Request() path so these stats preserve the configured limiter mode. The legacy three-argument Request() path is treated as write IO for compatibility. Existing NUMBER_RATE_LIMITER_DRAINS is left intact, but the new delayed request counters are the clearer signal for out-of-token throttling because one delayed request can observe multiple drain intervals.

Also update the Java ticker and histogram mappings so Java consumers can access the new statistics.

## Test Plan:
- make format-auto
- make -j16 rate_limiter_test statistics_test
- ./rate_limiter_test
- ./statistics_test
- make check-sources