### PR TITLE
BuiltinSnappyCompressorV2: Skip memcpy when not needed (fix UB)

### DIFF
--- a/util/compression.cc
+++ b/util/compression.cc
@@ -507,7 +507,11 @@ class BuiltinSnappyCompressorV2 final : public CompressorWithSimpleDictBase {
 
       void Append(const char* data, size_t n) override {
         if (pos_ + n <= output_size_) {
-          std::memcpy(output_ + pos_, data, n);
+          // if data is our buffer from GetAppendBuffer, skip memcpy (also
+          // avoids UB)
+          if (data != output_ + pos_) {
+            std::memcpy(output_ + pos_, data, n);
+          }
           pos_ += n;
         } else {
           // Virtual abort

--- a/util/compression_test.cc
+++ b/util/compression_test.cc
@@ -2729,6 +2729,40 @@ TEST_F(DBCompressionTest, UnifiedLZ4LZ4HCLevels) {
   }
 }
 
+TEST_F(DBCompressionTest, SnappyCompressBlockRoundTrip) {
+  auto mgr = GetBuiltinV2CompressionManager();
+  if (!mgr->SupportsCompressionType(kSnappyCompression)) {
+    ROCKSDB_GTEST_SKIP("Snappy not supported");
+    return;
+  }
+  auto decompressor = mgr->GetDecompressor();
+
+  // 4 KB of highly compressible bytes: Snappy calls GetAppendBuffer then calls
+  // Append with the same pointer. This triggered a valgrind memcheck warning:
+  // Source and destination overlap in memcpy
+  std::string input(4096, 'a');
+
+  CompressionOptions opts;
+  auto compressor = mgr->GetCompressor(opts, kSnappyCompression);
+  ASSERT_NE(compressor, nullptr);
+
+  std::string output(input.size() * 2 + 1024, '\0');
+  size_t out_size = output.size();
+  CompressionType actual = kNoCompression;
+  ASSERT_OK(compressor->CompressBlock(input, output.data(), &out_size, &actual,
+                                      nullptr));
+  ASSERT_EQ(actual, kSnappyCompression);
+  output.resize(out_size);
+
+  Decompressor::Args args;
+  args.compression_type = kSnappyCompression;
+  args.compressed_data = Slice(output);
+  ASSERT_OK(decompressor->ExtractUncompressedSize(args));
+  std::string recovered(args.uncompressed_size, '\0');
+  ASSERT_OK(decompressor->DecompressBlock(args, recovered.data()));
+  ASSERT_EQ(recovered, input);
+}
+
 TEST_F(DBCompressionTest, ZSTDLevelZeroMapsToMinusOne) {
   // ZSTD itself treats a requested compression level of 0 as "use the default
   // level" (historically 3). That makes level 0 a discontinuity in the


### PR DESCRIPTION
Running the rust-rocksdb tests under valgrind failed with the following memcheck error. The error is that snappy first calls GetAppendBuffer() to get an output buffer. It then writes into the prefix, then passes it to Append(). The current implementation was doing an unnecessary memcpy in this case, with the same source and destination pointer. This is technically undefined behavior since the arguments to memcpy are restrict pointers.

Add a unit test that reproduces the valgrind error:
```
Source and destination overlap in memcpy(0x8aa5122, 0x8aa5122, 194)
  at 0x49206AC: __GI_memcpy (vg_replace_strmem.c:1155)
  by 0x550788F: rocksdb::(anonymous namespace)::BuiltinSnappyCompressorV2::CompressBlock(rocksdb::Slice, char*, unsigned long*, rocksdb::CompressionType*, rocksdb::ManagedPtr<rocksdb::Compressor::WorkingArea, rocksdb::Compressor, &rocksdb::Compressor::ReleaseWorkingArea>*)::MySink::Append(char const*, unsigned long) (util/compression.cc:510)
  by 0x574445B: snappy::Compress(snappy::Source*, snappy::Sink*) (in /usr/lib/aarch64-linux-gnu/libsnappy.so.1.1.8)
  by 0x550765F: rocksdb::(anonymous namespace)::BuiltinSnappyCompressorV2::CompressBlock(rocksdb::Slice, char*, unsigned long*, rocksdb::CompressionType*, rocksdb::ManagedPtr<rocksdb::Compressor::WorkingArea, rocksdb::Compressor, &rocksdb::Compressor::ReleaseWorkingArea>*) (util/compression.cc:529)
  by 0x405D4BF: rocksdb::DBCompressionTest_SnappyCompressBlockRoundTrip_Test::TestBody() (util/compression_test.cc:2755)
```