### PR TITLE
Disable backward scan in stress test when separate_key_value_in_data_block is enabled

### DIFF
--- a/db_stress_tool/db_stress_tool.cc
+++ b/db_stress_tool/db_stress_tool.cc
@@ -488,6 +488,13 @@ int db_stress_tool(int argc, char** argv) {
         "all be 0 when using compaction filter or inplace update support\n");
     exit(1);
   }
+  if (FLAGS_separate_key_value_in_data_block && FLAGS_test_backward_scan) {
+    // When keys and values are stored separately in data blocks, the
+    // block-based table iterator cannot pin values. DBIter requires pinned
+    // values for backward iteration (Prev/SeekForPrev), returning
+    // NotSupported otherwise. Disable backward scan automatically.
+    FLAGS_test_backward_scan = false;
+  }
   if (FLAGS_test_multi_ops_txns) {
     CheckAndSetOptionsForMultiOpsTxnStressTest();
   }


### PR DESCRIPTION
Summary: When `separate_key_value_in_data_block=true`, the data block iterator stores keys and values in separate sections. Under certain conditions during backward iteration (Prev/SeekForPrev), `DBIter::FindValueForCurrentKey` encounters entries whose values cannot be pinned, causing a `NotSupported` error: "Backward iteration not supported if underlying iterator's value cannot be pinned." This manifests in the crash test as `TestIterateAgainstExpected` failures when the random flag combination includes `separate_key_value_in_data_block=1` (added in 47cfeb656ff3) with `test_backward_scan=1` (the default). The fix automatically disables `test_backward_scan` when `separate_key_value_in_data_block` is enabled, matching the pattern used for other option incompatibilities in the stress tool.

Differential Revision: D109837793


