### PR TITLE
Fix typos in public header comments

### DIFF
--- a/include/rocksdb/file_system.h
+++ b/include/rocksdb/file_system.h
@@ -962,7 +962,7 @@ struct FSReadRequest {
   //
   // This optimization is enabled for MultiReads (sync and async) with non
   // direct io, when these conditions hold:
-  // 1. The FileSystem has overriden the SupportedOps() API and set
+  // 1. The FileSystem has overridden the SupportedOps() API and set
   // FSSupportedOps::kFSBuffer.
   // 2. FSReadRequest::scratch is set to nullptr.
   //

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -3121,7 +3121,7 @@ struct CompactionServiceOptionsOverride {
   // to set it here.
   std::shared_ptr<Statistics> statistics = nullptr;
 
-  // Info Log. If not overriden, default one will be used.
+  // Info Log. If not overridden, default one will be used.
   std::shared_ptr<Logger> info_log = nullptr;
 
   // Only compaction generated SST files use this user defined table properties

--- a/include/rocksdb/sst_file_reader.h
+++ b/include/rocksdb/sst_file_reader.h
@@ -50,7 +50,7 @@ class SstFileReader {
              PinnableSlice* value);
 
   // Returns a new iterator over the table contents as a raw table iterator,
-  // a.k.a a `TableIterator`that iterates all point data entries in the table
+  // a.k.a a `TableIterator` that iterates all point data entries in the table
   // including logically invisible entries like delete entries.
   // This API is intended to provide a programmatic way to observe SST files
   // created by a DB, to be used by third party tools. DB optimization

--- a/include/rocksdb/utilities/transaction.h
+++ b/include/rocksdb/utilities/transaction.h
@@ -526,7 +526,7 @@ class Transaction {
   // on the keys being written.
   //
   // assume_tracked=true expects the key be already tracked. More
-  // specifically, it means the the key was previous tracked in the same
+  // specifically, it means the key was previously tracked in the same
   // savepoint, with the same exclusive flag, and at a lower sequence number.
   // If valid then it skips ValidateSnapshot.  Returns error otherwise.
   //

--- a/include/rocksdb/write_buffer_manager.h
+++ b/include/rocksdb/write_buffer_manager.h
@@ -117,7 +117,7 @@ class WriteBufferManager final {
   }
 
   // Returns true if total memory usage exceeded buffer_size.
-  // We stall the writes untill memory_usage drops below buffer_size. When the
+  // We stall the writes until memory_usage drops below buffer_size. When the
   // function returns true, all writer threads (including one checking this
   // condition) across all DBs will be stalled. Stall is allowed only if user
   // pass allow_stall = true during WriteBufferManager instance creation.


### PR DESCRIPTION
Fixes a handful of small comment typos in public API headers. These are visible to consumers since the headers are part of the public RocksDB API surface. Comment-only; no behavioral change.

| File | Before | After |
|------|--------|-------|
| `include/rocksdb/utilities/transaction.h` | the the key was previous tracked | the key was previously tracked |
| `include/rocksdb/sst_file_reader.h` | ``TableIterator`that`` (missing space) | ``TableIterator` that`` |
| `include/rocksdb/write_buffer_manager.h` | untill | until |
| `include/rocksdb/options.h` | overriden | overridden |
| `include/rocksdb/file_system.h` | overriden | overridden |

No build/behavior impact.