### PR TITLE
Fix typos in source comments

### DIFF
--- a/cache/clock_cache.cc
+++ b/cache/clock_cache.cc
@@ -1572,7 +1572,7 @@ void FixedHyperClockCache::ReportProblems(
   // First, if the average load factor is within spec, we aren't going to
   // complain about a few shards being out of spec.
   // NOTE: this is only the average among cache shards operating "at limit,"
-  // which should be representative of what we care about. It it normal, even
+  // which should be representative of what we care about. It is normal, even
   // desirable, for a cache to operate "at limit" so this should not create
   // selection bias. See AddShardEvaluation().
   // TODO: Consider detecting cases where decreasing the number of shards

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -6686,7 +6686,7 @@ Status VersionSet::ProcessManifestWrites(
     // successfully, a subsequent recovery attempt will likely see the CURRENT
     // pointing to the new MANIFEST, thus fail. We will not be able to open
     // the DB again. Therefore, if manifest operations succeed, we should keep
-    // the the new MANIFEST. If the process proceeds, any future LogAndApply()
+    // the new MANIFEST. If the process proceeds, any future LogAndApply()
     // call will switch to a new MANIFEST and update CURRENT. If user tries to
     // re-open the DB,
     // a) CURRENT points to the new MANIFEST, and the new MANIFEST is present.

--- a/db/write_thread.cc
+++ b/db/write_thread.cc
@@ -341,7 +341,7 @@ void WriteThread::BeginWriteStall() {
       SetState(w, STATE_COMPLETED);
       // Only update `link_newer` if it's already set.
       // `CreateMissingNewerLinks()` will update the nullptr `link_newer` later,
-      // which assumes the the first non-nullptr `link_newer` is the last
+      // which assumes the first non-nullptr `link_newer` is the last
       // nullptr link in the writer list.
       // If `link_newer` is set here, `CreateMissingNewerLinks()` may stop
       // updating the whole list when it sees the first non nullptr link.

--- a/utilities/write_batch_with_index/write_batch_with_index.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index.cc
@@ -85,7 +85,7 @@ struct WriteBatchWithIndex::Rep {
     AddOrUpdateIndexWithCfId(0, key, type, last_entry_offset);
   }
 
-  // Add a new index entry pointing to the the entry at `last_entry_offset`
+  // Add a new index entry pointing to the entry at `last_entry_offset`
   // in the write batch. `most_recent_entry_update_count` will be used to
   // initialize the update count of the new index entry.
   void AddNewEntry(uint32_t column_family_id, WriteType type,


### PR DESCRIPTION
Fixes a few comment typos in source files (separate from the public-header typo fixes in #14890):

- `cache/clock_cache.cc`: `It it normal` → `It is normal`
- `db/write_thread.cc`, `db/version_set.cc`, `utilities/write_batch_with_index/write_batch_with_index.cc`: removed a duplicated `the`

Comment-only; no behavioral change.