### PR TITLE
Disable db_stress backward scan with embedded blob SSTs

### DIFF
--- a/db_stress_tool/db_stress_tool.cc
+++ b/db_stress_tool/db_stress_tool.cc
@@ -488,11 +488,18 @@ int db_stress_tool(int argc, char** argv) {
         "all be 0 when using compaction filter or inplace update support\n");
     exit(1);
   }
-  if (FLAGS_separate_key_value_in_data_block && FLAGS_test_backward_scan) {
-    // When keys and values are stored separately in data blocks, the
-    // block-based table iterator cannot pin values. DBIter requires pinned
-    // values for backward iteration (Prev/SeekForPrev), returning
-    // NotSupported otherwise. Disable backward scan automatically.
+  if (FLAGS_ingest_external_file_with_embedded_blobs &&
+      FLAGS_test_backward_scan) {
+    // Embedded blob SSTs are read through EmbeddedBlobResolvingIterator, which
+    // resolves same-file blob references (and wide-column entities with same-
+    // file blob columns) into an iterator-owned buffer. Such resolved values
+    // are not pinnable, but DBIter requires pinned values for backward
+    // iteration (Prev/SeekForPrev) and otherwise returns NotSupported (or hits
+    // the IsValuePinned() assertion in FindValueForCurrentKeyUsingSeek).
+    // Disable backward scan automatically.
+    fprintf(stdout,
+            "Disabling test_backward_scan because "
+            "ingest_external_file_with_embedded_blobs is set\n");
     FLAGS_test_backward_scan = false;
   }
   if (FLAGS_test_multi_ops_txns) {


### PR DESCRIPTION
Summary:
Replace the earlier mitigation that disabled test_backward_scan when
separate_key_value_in_data_block is set (D109837793). That gate was incorrect:
separate_key_value_in_data_block does not affect value pinning -- it was only
coincidentally correlated with the failing crash-test runs (the crash test
biases it on ~2/3 of the time).

Root cause: embedded blob SSTs are read through EmbeddedBlobResolvingIterator,
which resolves same-file blob references (and wide-column entities with same-file
blob columns) into an iterator-owned buffer. Those resolved values are not
pinnable, but DBIter requires pinned values for backward iteration
(Prev/SeekForPrev), returning NotSupported (surfaced as "Iterator diverged from
control iterator") or hitting the IsValuePinned() assertion in
FindValueForCurrentKeyUsingSeek (db_iter.cc).

Gate test_backward_scan on ingest_external_file_with_embedded_blobs instead.
This is a stress-test mitigation only; the underlying limitation (backward
iteration over unpinnable resolved values) should be fixed separately by making
the resolved value pinnable via the PinnedIteratorsManager.

___

Differential Revision: D110140135


