### PR TITLE
Disable embedded-blob ingestion in crash test (T277310719)

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -221,7 +221,11 @@ default_params = {
     "ingest_external_file_one_in": lambda: random.choice([1000, 1000000]),
     "ingest_external_file_prepare_commit_one_in": lambda: random.choice([0, 1, 2]),
     "ingest_external_file_use_file_info_one_in": lambda: random.choice([0, 1, 2]),
-    "ingest_external_file_with_embedded_blobs": lambda: random.choice([0, 1]),
+    # Disabled in crash test: the experimental embedded-blob ingestion path can
+    # return corrupted values on Get(), tripping the
+    # IsValueBaseValid(value_base) assertion in TestGet (see T277310719). Keep
+    # off until the underlying feature bug is root-caused and fixed.
+    "ingest_external_file_with_embedded_blobs": lambda: 0,
     "test_ingest_standalone_range_deletion_one_in": lambda: random.choice([0, 5, 10]),
     "iterpercent": 10,
     "lock_wal_one_in": lambda: random.choice([10000, 1000000]),


### PR DESCRIPTION
Summary:
Disables the experimental embedded-blob SST ingestion path in the crash test (`ingest_external_file_with_embedded_blobs` is forced to 0) to unblock the `fbcode_blackbox_crash_test` CI signal tracked in T277310719. The feature still has unresolved correctness bugs, so this keeps it out of the crash test until they are fixed. Re-enable by reverting the one-line change; the gating logic in `finalize_and_sanitize` is left in place.

## Culprit

The embedded-blob feature was introduced by D108564468 (commit `5f01ffb1d40c`, "[rocksdb][PR] Add experimental embedded blob SST support"), which also enabled `ingest_external_file_with_embedded_blobs` in `db_crashtest.py`. The first crash-test failure on T277310719 appeared the same day, shortly after that commit. D109796428 ("Fix use-after-free in EmbeddedBlobResolvingIterator when key() called before value()") fixed one of the bugs below but the corruption persists, so disabling in the crash test is still required.

## Bugs found in the embedded-blob feature

These all stem from one root cause: `EmbeddedBlobResolvingIterator` resolves a same-file blob payload into a buffer (`resolved_pinned_value_` / `resolved_value_`) that is invalidated on the next iterator reposition, but consumers expect the value to outlive a `Next()`.

1. heap-use-after-free (FIXED by D109796428): calling `key()` before `value()` on a whole-value blob entry made `value()` -> `MaterializeValue()` move-assign `resolved_internal_key_`, freeing the buffer the earlier `key()` Slice still pointed to. Surfaced under ASAN during compaction (`CompactionIterator::NextFromInput` -> `ParseInternalKey`).

2. `IsValuePinned()` assertion (NOT fixed): `EmbeddedBlobResolvingIterator::IsValuePinned()` only reports a resolved value as pinned when a `PinnedIteratorsManager` is active, but `DBIter::FindValueForCurrentKeyUsingSeek` (`db_iter.cc:1464`) asserts `iter_.iter()->IsValuePinned()` without setting one. Reproduces under ASAN via the user-iteration path.

3. `IsValueBaseValid(value_base)` assertion / value corruption (NOT fixed): this is the failure in T277310719. With `use_merge=1` plus embedded blobs, a value persisted to the DB comes back with a garbage value base, tripping the assert in `db_stress` (`expected_value.cc:102`, reached from `VerifyDb` -> `VerifyOrSyncValue` and from `TestGet`). Reproduced reliably on the post-D109796428 tree by forcing `use_merge=1` + embedded-blob ingestion (read-heavy, no iteration): fails on the first crash-test iteration; without merge, 36 iterations passed. Same value-lifetime root cause as (2), surfacing through the merge/compaction write path. Exact line not yet pinned down; needs the feature author.

Differential Revision: D110100542


