### PR TITLE
feat(write_thread): add writer state transition validation guards

### DIFF
--- a/db/write_thread.cc
+++ b/db/write_thread.cc
@@ -209,12 +209,55 @@ uint8_t WriteThread::AwaitState(Writer* w, uint8_t goal_mask,
   return state;
 }
 
+bool WriteThread::IsValidStateTransition(uint8_t old_state,
+                                         uint8_t new_state) {
+  if (new_state == STATE_INIT || new_state == STATE_LOCKED_WAITING) {
+    return false;
+  }
+
+  if (old_state == new_state) {
+    return false;
+  }
+
+  switch (old_state) {
+    case STATE_INIT:
+      return new_state == STATE_GROUP_LEADER ||
+             new_state == STATE_MEMTABLE_WRITER_LEADER ||
+             new_state == STATE_PARALLEL_MEMTABLE_CALLER ||
+             new_state == STATE_PARALLEL_MEMTABLE_WRITER ||
+             new_state == STATE_COMPLETED;
+    case STATE_GROUP_LEADER:
+      return new_state == STATE_MEMTABLE_WRITER_LEADER ||
+             new_state == STATE_PARALLEL_MEMTABLE_WRITER ||
+             new_state == STATE_COMPLETED;
+    case STATE_MEMTABLE_WRITER_LEADER:
+      return new_state == STATE_PARALLEL_MEMTABLE_CALLER ||
+             new_state == STATE_PARALLEL_MEMTABLE_WRITER ||
+             new_state == STATE_COMPLETED;
+    case STATE_PARALLEL_MEMTABLE_CALLER:
+      return new_state == STATE_PARALLEL_MEMTABLE_WRITER ||
+             new_state == STATE_COMPLETED;
+    case STATE_PARALLEL_MEMTABLE_WRITER:
+      return new_state == STATE_COMPLETED;
+    case STATE_LOCKED_WAITING:
+      return new_state == STATE_GROUP_LEADER ||
+             new_state == STATE_MEMTABLE_WRITER_LEADER ||
+             new_state == STATE_PARALLEL_MEMTABLE_CALLER ||
+             new_state == STATE_PARALLEL_MEMTABLE_WRITER ||
+             new_state == STATE_COMPLETED;
+    default:
+      return false;
+  }
+}
+
 void WriteThread::SetState(Writer* w, uint8_t new_state) {
   assert(w);
   auto state = w->state.load(std::memory_order_acquire);
+  assert(IsValidStateTransition(state, new_state));
   if (state == STATE_LOCKED_WAITING ||
       !w->state.compare_exchange_strong(state, new_state)) {
     assert(state == STATE_LOCKED_WAITING);
+    assert(IsValidStateTransition(state, new_state));
 
     std::lock_guard<std::mutex> guard(w->StateMutex());
     assert(w->state.load(std::memory_order_relaxed) != new_state);

--- a/db/write_thread.h
+++ b/db/write_thread.h
@@ -81,6 +81,38 @@ class WriteThread {
     STATE_PARALLEL_MEMTABLE_CALLER = 64,
   };
 
+  // Writer state transitions are centralized in SetState(), which verifies
+  // the transition with IsValidStateTransition() before publishing it.
+  //
+  // Normal transitions:
+  //   STATE_INIT ->
+  //     STATE_GROUP_LEADER
+  //     STATE_MEMTABLE_WRITER_LEADER
+  //     STATE_PARALLEL_MEMTABLE_CALLER
+  //     STATE_PARALLEL_MEMTABLE_WRITER
+  //     STATE_COMPLETED
+  //
+  //   STATE_GROUP_LEADER ->
+  //     STATE_MEMTABLE_WRITER_LEADER
+  //     STATE_PARALLEL_MEMTABLE_WRITER
+  //     STATE_COMPLETED
+  //
+  //   STATE_MEMTABLE_WRITER_LEADER ->
+  //     STATE_PARALLEL_MEMTABLE_CALLER
+  //     STATE_PARALLEL_MEMTABLE_WRITER
+  //     STATE_COMPLETED
+  //
+  //   STATE_PARALLEL_MEMTABLE_CALLER ->
+  //     STATE_PARALLEL_MEMTABLE_WRITER
+  //     STATE_COMPLETED
+  //
+  //   STATE_PARALLEL_MEMTABLE_WRITER ->
+  //     STATE_COMPLETED
+  //
+  // STATE_LOCKED_WAITING is a wait marker installed by BlockingAwaitState().
+  // It temporarily hides the writer's prior state from the waker, so SetState()
+  // accepts any normal wake-up state from it.
+
   struct Writer;
 
   struct WriteGroup {
@@ -481,6 +513,11 @@ class WriteThread {
 
   // Set writer state and wake the writer up if it is waiting.
   void SetState(Writer* w, uint8_t new_state);
+
+  // Returns true when SetState() may publish `new_state` for a writer currently
+  // observed in `old_state`. This documents the state machine in executable
+  // form without changing the lock-free handoff protocol.
+  static bool IsValidStateTransition(uint8_t old_state, uint8_t new_state);
 
   // Links w into the newest_writer list. Return true if w was linked directly
   // into the leader position.  Safe to call from multiple threads without


### PR DESCRIPTION
## Summary

Every writer state transition in `WriteThread` is funneled through `SetState()`, but until now the set of *legal* transitions was only implicit — encoded indirectly in the control flow of `JoinBatchGroup`, `ExitAsBatchGroupLeader`, the parallel-memtable path, and a handful of scattered comments. There was no single place that stated "a writer in state X may only move to Y or Z," which makes the lock-free handoff protocol harder to reason about and easy to break silently during refactors. A bad transition would not fail loudly; it would just corrupt the writer state machine and surface later as a hang or a mysterious assertion far from the root cause.

This PR makes the writer state machine explicit and self-checking, without changing any runtime behavior.

- Add `IsValidStateTransition(old_state, new_state)`, a `static` helper that encodes the allowed writer state transitions as executable rules. It rejects no-op transitions (`old == new`), rejects publishing the internal-only states (`STATE_INIT`, `STATE_LOCKED_WAITING`) as a *destination*, and otherwise enforces the per-state transition table via a `switch` on `old_state`.
- Assert on it inside `SetState()` on both paths: once before the fast atomic-publish `compare_exchange_strong`, and again on the `STATE_LOCKED_WAITING` slow path after the observed state has been re-read. The slow-path check matters because the waker may overwrite the observed state between the initial relaxed load and taking the mutex.
- Document the full transition table directly in `write_thread.h`, next to the state enum, including the special role of `STATE_LOCKED_WAITING` as a temporary wait marker installed by `BlockingAwaitState()`. Because that marker hides the writer's prior state from the waker, `SetState()` accepts any normal wake-up state out of it — the comment now spells this out so the asymmetry is not mistaken for a bug.

### Why debug-only

`IsValidStateTransition()` is only ever called from `assert()`, so it compiles out entirely in release builds (`NDEBUG` / `-fno-rtti`). `SetState()` is on the hot write path, hit thousands of times per second under load, so paying zero cost in production is deliberate. The value is concentrated where it belongs: debug, ASAN/TSAN, and stress builds, where an illegal transition now fails immediately at the offending call site instead of much later.

### What this does not change

- No change to the lock-free handoff protocol, memory ordering, or the CAS in `SetState()`.
- No change to release-build behavior — the guard is purely an assertion.
- No API or option surface change; `IsValidStateTransition()` is a private static helper.

## Test Plan

- `make check` (debug) passes.
- `ASSERT_STATUS_CHECKED=1 make check` passes.
- `COERCE_CONTEXT_SWITCH=1` stress runs of the write-path tests (`db_write_test`, `write_batch_test`, `db_test`) to drive the new assertions under contention and exercise the `STATE_LOCKED_WAITING` slow path.
- Confirmed release build is unaffected: the helper is fully optimized out when `NDEBUG` is set.