### PR TITLE
Fix compaction CPU stats underflow

### DIFF
--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -63,6 +63,21 @@
 
 namespace ROCKSDB_NAMESPACE {
 
+namespace {
+uint64_t SaturatingSub(uint64_t minuend, uint64_t subtrahend) {
+  return minuend >= subtrahend ? minuend - subtrahend : 0;
+}
+
+uint64_t SaturatingSubWithUnderflowTicker(uint64_t minuend, uint64_t subtrahend,
+                                          Statistics* stats) {
+  if (minuend >= subtrahend) {
+    return minuend - subtrahend;
+  }
+  RecordTick(stats, COMPACTION_IOSTATS_CPU_NANOS_COUNTER_UNDERFLOW);
+  return 0;
+}
+}  // namespace
+
 const char* GetCompactionReasonString(CompactionReason compaction_reason) {
   switch (compaction_reason) {
     case CompactionReason::kUnknown:
@@ -1431,6 +1446,7 @@ CompactionJob::CompactionIOStatsSnapshot CompactionJob::InitializeIOStats() {
   if (measure_io_stats_) {
     io_stats.prev_perf_level = GetPerfLevel();
     SetPerfLevel(PerfLevel::kEnableTimeAndCPUTimeExceptForMutex);
+    TEST_SYNC_POINT("CompactionJob::InitializeIOStats:BeforeReadIOStats");
     io_stats.prev_write_nanos = IOSTATS(write_nanos);
     io_stats.prev_fsync_nanos = IOSTATS(fsync_nanos);
     io_stats.prev_range_sync_nanos = IOSTATS(range_sync_nanos);
@@ -1831,6 +1847,8 @@ void CompactionJob::FinalizeSubcompactionJobStats(
       cur_cpu_micros - start_cpu_micros + sub_compact->GetWorkerCPUMicros();
 
   if (measure_io_stats_) {
+    TEST_SYNC_POINT(
+        "CompactionJob::FinalizeSubcompactionJobStats:BeforeReadIOStats");
     sub_compact->compaction_job_stats.file_write_nanos +=
         IOSTATS(write_nanos) - io_stats.prev_write_nanos;
     sub_compact->compaction_job_stats.file_fsync_nanos +=
@@ -1839,10 +1857,18 @@ void CompactionJob::FinalizeSubcompactionJobStats(
         IOSTATS(range_sync_nanos) - io_stats.prev_range_sync_nanos;
     sub_compact->compaction_job_stats.file_prepare_write_nanos +=
         IOSTATS(prepare_write_nanos) - io_stats.prev_prepare_write_nanos;
-    sub_compact->compaction_job_stats.cpu_micros -=
-        (IOSTATS(cpu_write_nanos) - io_stats.prev_cpu_write_nanos +
-         IOSTATS(cpu_read_nanos) - io_stats.prev_cpu_read_nanos) /
-        1000;
+    const uint64_t file_cpu_write_nanos = SaturatingSubWithUnderflowTicker(
+        IOSTATS(cpu_write_nanos), io_stats.prev_cpu_write_nanos, stats_);
+    const uint64_t file_cpu_read_nanos = SaturatingSubWithUnderflowTicker(
+        IOSTATS(cpu_read_nanos), io_stats.prev_cpu_read_nanos, stats_);
+    uint64_t file_cpu_micros =
+        (file_cpu_write_nanos + file_cpu_read_nanos) / 1000;
+    TEST_SYNC_POINT_CALLBACK(
+        "CompactionJob::FinalizeSubcompactionJobStats:"
+        "BeforeSubtractFileCpuMicros",
+        &file_cpu_micros);
+    sub_compact->compaction_job_stats.cpu_micros = SaturatingSub(
+        sub_compact->compaction_job_stats.cpu_micros, file_cpu_micros);
     if (io_stats.prev_perf_level !=
         PerfLevel::kEnableTimeAndCPUTimeExceptForMutex) {
       SetPerfLevel(io_stats.prev_perf_level);

--- a/db/compaction/compaction_job_stats_test.cc
+++ b/db/compaction/compaction_job_stats_test.cc
@@ -8,8 +8,11 @@
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
 #include <algorithm>
+#include <atomic>
 #include <cinttypes>
 #include <iostream>
+#include <limits>
+#include <memory>
 #include <mutex>
 #include <queue>
 #include <set>
@@ -34,6 +37,7 @@
 #include "rocksdb/env.h"
 #include "rocksdb/experimental.h"
 #include "rocksdb/filter_policy.h"
+#include "rocksdb/iostats_context.h"
 #include "rocksdb/options.h"
 #include "rocksdb/perf_context.h"
 #include "rocksdb/slice.h"
@@ -508,6 +512,23 @@ class CompactionJobDeletionStatsChecker : public CompactionJobStatsChecker {
   }
 };
 
+class CompactionJobCpuStatsChecker : public EventListener {
+ public:
+  void OnCompactionCompleted(DB* /*db*/, const CompactionJobInfo& ci) override {
+    observed_.store(true);
+    observed_cpu_micros_.store(ci.stats.cpu_micros);
+    ASSERT_EQ(0, ci.stats.cpu_micros);
+  }
+
+  bool observed() const { return observed_.load(); }
+
+  uint64_t observed_cpu_micros() const { return observed_cpu_micros_.load(); }
+
+ private:
+  std::atomic<bool> observed_{false};
+  std::atomic<uint64_t> observed_cpu_micros_{0};
+};
+
 namespace {
 
 uint64_t EstimatedFileSize(uint64_t num_records, size_t key_size,
@@ -793,6 +814,86 @@ TEST_P(CompactionJobStatsTest, CompactionJobStatsTest) {
     ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();
   }
   ASSERT_EQ(stats_checker->NumberOfUnverifiedStats(), 0U);
+}
+
+TEST_P(CompactionJobStatsTest, CompactionCpuMicrosDoesNotUnderflow) {
+  auto stats_checker = std::make_shared<CompactionJobCpuStatsChecker>();
+  Options options;
+  options.create_if_missing = true;
+  options.disable_auto_compactions = true;
+  options.level0_file_num_compaction_trigger = 4;
+  options.max_subcompactions = max_subcompactions_;
+  options.num_levels = 3;
+  options.report_bg_io_stats = true;
+  options.listeners.emplace_back(stats_checker);
+
+  DestroyAndReopen(options);
+  for (int i = 0; i < 2; ++i) {
+    ASSERT_OK(Put("a", "begin"));
+    ASSERT_OK(Put("z", "end"));
+    ASSERT_OK(Flush());
+  }
+
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
+      "CompactionJob::FinalizeSubcompactionJobStats:"
+      "BeforeSubtractFileCpuMicros",
+      [](void* arg) {
+        *static_cast<uint64_t*>(arg) = std::numeric_limits<uint64_t>::max();
+      });
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
+
+  ASSERT_OK(dbfull()->TEST_CompactRange(0, nullptr, nullptr,
+                                        nullptr /* column_family */,
+                                        true /* disallow_trivial_move */));
+
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->ClearAllCallBacks();
+
+  ASSERT_TRUE(stats_checker->observed());
+  ASSERT_EQ(0, stats_checker->observed_cpu_micros());
+}
+
+TEST_P(CompactionJobStatsTest, CompactionIOStatsCpuNanosUnderflowIsRecorded) {
+  Options options;
+  options.create_if_missing = true;
+  options.disable_auto_compactions = true;
+  options.level0_file_num_compaction_trigger = 4;
+  options.max_subcompactions = 1;
+  options.num_levels = 3;
+  options.report_bg_io_stats = true;
+  options.statistics = CreateDBStatistics();
+
+  DestroyAndReopen(options);
+  for (int i = 0; i < 2; ++i) {
+    ASSERT_OK(Put("a", "begin"));
+    ASSERT_OK(Put("z", "end"));
+    ASSERT_OK(Flush());
+  }
+
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
+      "CompactionJob::InitializeIOStats:BeforeReadIOStats", [](void* /*arg*/) {
+        IOStatsContext* iostats = get_iostats_context();
+        iostats->cpu_write_nanos = 2000;
+        iostats->cpu_read_nanos = 3000;
+      });
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
+      "CompactionJob::FinalizeSubcompactionJobStats:BeforeReadIOStats",
+      [](void* /*arg*/) {
+        IOStatsContext* iostats = get_iostats_context();
+        iostats->cpu_write_nanos = 0;
+        iostats->cpu_read_nanos = 0;
+      });
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
+
+  ASSERT_OK(dbfull()->TEST_CompactRange(0, nullptr, nullptr,
+                                        nullptr /* column_family */,
+                                        true /* disallow_trivial_move */));
+
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->ClearAllCallBacks();
+
+  ASSERT_EQ(2, options.statistics->getTickerCount(
+                   COMPACTION_IOSTATS_CPU_NANOS_COUNTER_UNDERFLOW));
 }
 
 TEST_P(CompactionJobStatsTest, DeletionStatsTest) {

--- a/include/rocksdb/statistics.h
+++ b/include/rocksdb/statistics.h
@@ -649,6 +649,10 @@ enum Tickers : uint32_t {
   // dedicated atomic flush request reason ticker.
   ATOMIC_FLUSH_REQUEST_REASON_OTHER,
 
+  // # of times compaction observed an IOStatsContext CPU counter below the
+  // value captured at compaction start
+  COMPACTION_IOSTATS_CPU_NANOS_COUNTER_UNDERFLOW,
+
   TICKER_ENUM_MAX
 };
 

--- a/java/rocksjni/portal.h
+++ b/java/rocksjni/portal.h
@@ -5357,6 +5357,9 @@ class TickerTypeJni {
         return -0x7E;
       case ROCKSDB_NAMESPACE::Tickers::ATOMIC_FLUSH_REQUEST_REASON_OTHER:
         return -0x7F;
+      case ROCKSDB_NAMESPACE::Tickers::
+          COMPACTION_IOSTATS_CPU_NANOS_COUNTER_UNDERFLOW:
+        return -0x80;
       case ROCKSDB_NAMESPACE::Tickers::TICKER_ENUM_MAX:
         // -0x54 is the max value at this time. Since these values are exposed
         // directly to Java clients, we'll keep the value the same till the next
@@ -5904,6 +5907,9 @@ class TickerTypeJni {
             ATOMIC_FLUSH_REQUEST_REASON_MEMTABLE_MAX_RANGE_DELETIONS;
       case -0x7F:
         return ROCKSDB_NAMESPACE::Tickers::ATOMIC_FLUSH_REQUEST_REASON_OTHER;
+      case -0x80:
+        return ROCKSDB_NAMESPACE::Tickers::
+            COMPACTION_IOSTATS_CPU_NANOS_COUNTER_UNDERFLOW;
       case -0x54:
         // -0x54 is the max value at this time. Since these values are exposed
         // directly to Java clients, we'll keep the value the same till the next

--- a/java/src/main/java/org/rocksdb/TickerType.java
+++ b/java/src/main/java/org/rocksdb/TickerType.java
@@ -1077,6 +1077,12 @@ public enum TickerType {
      */
     ATOMIC_FLUSH_REQUEST_REASON_OTHER((byte) -0x7F),
 
+    /**
+     * # of times compaction observed an IOStatsContext CPU counter below the
+     * value captured at compaction start
+     */
+    COMPACTION_IOSTATS_CPU_NANOS_COUNTER_UNDERFLOW((byte) -0x80),
+
     TICKER_ENUM_MAX((byte) -0x54);
 
     private final byte value;

--- a/monitoring/statistics.cc
+++ b/monitoring/statistics.cc
@@ -334,6 +334,8 @@ const std::vector<std::pair<Tickers, std::string>> TickersNameMap = {
      "rocksdb.atomic_flush.request.reason.memtable_max_range_deletions"},
     {ATOMIC_FLUSH_REQUEST_REASON_OTHER,
      "rocksdb.atomic_flush.request.reason.other"},
+    {COMPACTION_IOSTATS_CPU_NANOS_COUNTER_UNDERFLOW,
+     "rocksdb.compaction.iostats.cpu.nanos.counter.underflow"},
 };
 
 const std::vector<std::pair<Histograms, std::string>> HistogramsNameMap = {

--- a/unreleased_history/bug_fixes/compaction_cpu_underflow.md
+++ b/unreleased_history/bug_fixes/compaction_cpu_underflow.md
@@ -1,0 +1,1 @@
+Fixed a compaction stats reporting bug where `CompMergeCPU(sec)` could underflow to a huge value when `report_bg_io_stats` was enabled. Added `rocksdb.compaction.iostats.cpu.nanos.counter.underflow` to count compaction I/O CPU counter underflows.


### PR DESCRIPTION
## Summary

- Prevent `CompMergeCPU(sec)` from wrapping to a huge value when `report_bg_io_stats` is enabled and compaction observes an `IOStatsContext` CPU counter below its start snapshot.
- Use saturating subtraction for compaction file I/O CPU deltas and for the final `cpu_micros` adjustment.
- Add `rocksdb.compaction.iostats.cpu.nanos.counter.underflow` to count observed compaction I/O CPU counter underflows, including Java ticker mappings.
- Add focused compaction stats coverage and an unreleased bug-fix note.

## Test Plan

- `make format-auto`
- `build_tools/rockstest.sh compaction_job_stats_test --gtest_filter='*Underflow*'`
- `build_tools/rocksptest.sh compaction_job_stats_test`
- `build_tools/rockstest.sh statistics_test --gtest_filter='StatisticsTest.SanityTickers'`
- `make check-sources`
- `git diff --check`
