### PR TITLE
Reserve key_context capacity in MultiGetCommon to avoid autovector reallocs (#14909)

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -3761,6 +3761,7 @@ void DBImpl::MultiGetCommon(const ReadOptions& read_options,
   }
 
   autovector<KeyContext, MultiGetContext::MAX_BATCH_SIZE> key_context;
+  key_context.reserve(num_keys);
   autovector<KeyContext*, MultiGetContext::MAX_BATCH_SIZE> sorted_keys;
   sorted_keys.resize(num_keys);
   for (size_t i = 0; i < num_keys; ++i) {
@@ -3951,6 +3952,7 @@ void DBImpl::MultiGetCommon(const ReadOptions& read_options,
     }
   }
   autovector<KeyContext, MultiGetContext::MAX_BATCH_SIZE> key_context;
+  key_context.reserve(num_keys);
   autovector<KeyContext*, MultiGetContext::MAX_BATCH_SIZE> sorted_keys;
   sorted_keys.resize(num_keys);
   for (size_t i = 0; i < num_keys; ++i) {


### PR DESCRIPTION
Summary: Pull Request resolved: https://github.com/facebook/rocksdb/pull/14909

Differential Revision: D110380492


