### PR TITLE
Three misc CI fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2450,7 +2450,7 @@ BUILD_SIG_NONBUILD_GOALS := \
 	clean-ext-libraries-bin \
 	format format-auto check-format check-buck-targets check-headers \
 	check-sources check-workflow-yaml check-progress clang-tidy \
-	tags tags0 package jclean checkout_folly \
+	tags tags0 package jclean checkout_folly build_folly \
 	watch-log dump-log suggest-slow-tests list_all_tests gen-pc \
 	gen_parallel_tests check-c-api-gen \
 	setup-hooks install-hooks uninstall-hooks uninstall db_crashtest_tests

--- a/tools/ldb_test.py
+++ b/tools/ldb_test.py
@@ -787,7 +787,7 @@ class LDBTestCase(unittest.TestCase):
             # the appearance of an "00xxx.sst" pattern.
             sstLines = re.findall(r".*\d+.sst.*", data)
             for line in sstLines:
-                sstFilename = re.findall(r"\d+.sst", line)[0]
+                sstFilename = re.findall(r"\d+\.sst", line)[0]
                 sstLevel = re.findall(r"(?<=level )\d+", line)[0]
                 cf = re.findall(r"(?<=column family \')\w+(?=\')", line)[0]
                 testMap[sstFilename] = [sstLevel, cf]

--- a/util/rate_limiter_test.cc
+++ b/util/rate_limiter_test.cc
@@ -410,6 +410,10 @@ TEST_F(RateLimiterTest, Rate) {
       true;
 #elif defined(OS_MACOSX)
       getenv("CIRCLECI") || getenv("GITHUB_ACTIONS");
+#elif defined(__aarch64__) || defined(__arm__)
+      // Unlike x86_64, the small/loaded ARM CI runners can't reliably sustain
+      // the target rate, so also exempt GitHub Actions here.
+      getenv("SANDCASTLE") || getenv("GITHUB_ACTIONS");
 #else
       getenv("SANDCASTLE");
 #endif


### PR DESCRIPTION
Summary:
Fixes three unrelated nightly/CI failures.

Makefile: 'make build_folly' was tripping the build-signature change check, causing the folly-flavored jobs (e.g. nightly clang-21 ASAN+UBSAN+folly, which runs 'make build_folly' then 'USE_FOLLY=1 ... make check') to abort with 'Build parameters changed since the last build'. build_folly only builds the external folly library under third-party/folly and never compiles RocksDB objects into OBJ_DIR, so it should not record or check a build signature; add it to BUILD_SIG_NONBUILD_GOALS alongside checkout_folly.

util/rate_limiter_test.cc: RateLimiterTest.Rate's minimum-rate assertion is timing-sensitive and flakes on the small/loaded ARM CI runners, which (unlike x86_64) can't reliably sustain the target rate. Extend the existing CI exemption with an ARM-only GITHUB_ACTIONS branch, preserving the check on x86_64.

tools/ldb_test.py: the list_live_files_metadata output includes the full DB path, and the unescaped-dot regex '\d+.sst' could match a <digit><char>sst run inside the random tempfile.mkdtemp suffix (drawn from [a-z0-9_]) that precedes the real filename, collapsing testMap to a single bogus key such as '8asst'. Require a literal '.sst'; temp-dir characters can never contain a dot, so only the real filename matches.

Test Plan:
- build_folly: confirmed 'make build_folly' no longer writes .build_signature and that BUILD_SIG_DO_BUILD resolves empty for that goal.
- rate_limiter_test: confirmed via the C preprocessor that x86_64 keeps the SANDCASTLE-only exemption while aarch64 selects the new GITHUB_ACTIONS branch.
- ldb_test: reproduced the collapse with a poisoned temp suffix (produces {'8asst': ['0', 'mycol2']}) and confirmed the escaped-dot regex yields the correct 4-entry map.