### PR TITLE
Prevent transaction write-batch wrapper from deleting borrowed state

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -280,6 +280,7 @@ struct rocksdb_writebatch_t {
 };
 struct rocksdb_writebatch_wi_t {
   WriteBatchWithIndex* rep;
+  bool owns_rep;
 };
 struct rocksdb_table_properties_t {
   TableProperties rep;
@@ -3865,6 +3866,7 @@ rocksdb_writebatch_wi_t* rocksdb_writebatch_wi_create(
   rocksdb_writebatch_wi_t* b = new rocksdb_writebatch_wi_t;
   b->rep = new WriteBatchWithIndex(BytewiseComparator(), reserved_bytes,
                                    overwrite_key);
+  b->owns_rep = true;
   return b;
 }
 
@@ -3876,6 +3878,7 @@ rocksdb_writebatch_wi_t* rocksdb_writebatch_wi_create_with_params(
   b->rep = new WriteBatchWithIndex(backup_index_comparator, reserved_bytes,
                                    overwrite_key, max_bytes,
                                    protection_bytes_per_key);
+  b->owns_rep = true;
   return b;
 }
 
@@ -3898,10 +3901,12 @@ void rocksdb_writebatch_wi_update_timestamps(
 }
 
 void rocksdb_writebatch_wi_destroy(rocksdb_writebatch_wi_t* b) {
-  if (b->rep) {
+  if (b->owns_rep) {
     delete b->rep;
+    delete b;
+  } else {
+    free(b);
   }
-  delete b;
 }
 
 void rocksdb_writebatch_wi_clear(rocksdb_writebatch_wi_t* b) {
@@ -12377,6 +12382,7 @@ rocksdb_writebatch_wi_t* rocksdb_transaction_get_writebatch_wi(
   rocksdb_writebatch_wi_t* wi =
       (rocksdb_writebatch_wi_t*)malloc(sizeof(rocksdb_writebatch_wi_t));
   wi->rep = txn->rep->GetWriteBatch();
+  wi->owns_rep = false;
 
   return wi;
 }

--- a/db/c_test.c
+++ b/db/c_test.c
@@ -5428,6 +5428,16 @@ int main(int argc, char** argv) {
 
     // begin a transaction
     txn = rocksdb_transaction_begin(txn_db, woptions, txn_options, NULL);
+    {
+      rocksdb_writebatch_wi_t* txn_wi =
+          rocksdb_transaction_get_writebatch_wi(txn);
+      CheckCondition(rocksdb_writebatch_wi_count(txn_wi) == 0);
+      rocksdb_free(txn_wi);
+
+      txn_wi = rocksdb_transaction_get_writebatch_wi(txn);
+      CheckCondition(rocksdb_writebatch_wi_count(txn_wi) == 0);
+      rocksdb_writebatch_wi_destroy(txn_wi);
+    }
     // put
     rocksdb_transaction_put(txn, "foo", 3, "hello", 5, &err);
     CheckNoError(err);

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -4218,6 +4218,8 @@ extern ROCKSDB_LIBRARY_API void rocksdb_transaction_rollback_to_savepoint(
 extern ROCKSDB_LIBRARY_API void rocksdb_transaction_destroy(
     rocksdb_transaction_t* txn);
 
+// The returned wrapper does not own the transaction's write batch. It can be
+// released with rocksdb_free or rocksdb_writebatch_wi_destroy.
 extern ROCKSDB_LIBRARY_API rocksdb_writebatch_wi_t*
 rocksdb_transaction_get_writebatch_wi(rocksdb_transaction_t* txn);
 
@@ -4225,7 +4227,6 @@ extern ROCKSDB_LIBRARY_API void rocksdb_transaction_rebuild_from_writebatch(
     rocksdb_transaction_t* txn, rocksdb_writebatch_t* writebatch,
     char** errptr);
 
-// This rocksdb_writebatch_wi_t should be freed with rocksdb_free
 extern ROCKSDB_LIBRARY_API void rocksdb_transaction_rebuild_from_writebatch_wi(
     rocksdb_transaction_t* txn, rocksdb_writebatch_wi_t* wi, char** errptr);
 

--- a/tools/c_api_gen/c_base.cc
+++ b/tools/c_api_gen/c_base.cc
@@ -276,6 +276,7 @@ struct rocksdb_writebatch_t {
 };
 struct rocksdb_writebatch_wi_t {
   WriteBatchWithIndex* rep;
+  bool owns_rep;
 };
 struct rocksdb_table_properties_t {
   TableProperties rep;
@@ -3612,6 +3613,7 @@ rocksdb_writebatch_wi_t* rocksdb_writebatch_wi_create(
   rocksdb_writebatch_wi_t* b = new rocksdb_writebatch_wi_t;
   b->rep = new WriteBatchWithIndex(BytewiseComparator(), reserved_bytes,
                                    overwrite_key);
+  b->owns_rep = true;
   return b;
 }
 
@@ -3623,6 +3625,7 @@ rocksdb_writebatch_wi_t* rocksdb_writebatch_wi_create_with_params(
   b->rep = new WriteBatchWithIndex(backup_index_comparator, reserved_bytes,
                                    overwrite_key, max_bytes,
                                    protection_bytes_per_key);
+  b->owns_rep = true;
   return b;
 }
 
@@ -3645,10 +3648,12 @@ void rocksdb_writebatch_wi_update_timestamps(
 }
 
 void rocksdb_writebatch_wi_destroy(rocksdb_writebatch_wi_t* b) {
-  if (b->rep) {
+  if (b->owns_rep) {
     delete b->rep;
+    delete b;
+  } else {
+    free(b);
   }
-  delete b;
 }
 
 void rocksdb_writebatch_wi_clear(rocksdb_writebatch_wi_t* b) {
@@ -7665,6 +7670,7 @@ rocksdb_writebatch_wi_t* rocksdb_transaction_get_writebatch_wi(
   rocksdb_writebatch_wi_t* wi =
       (rocksdb_writebatch_wi_t*)malloc(sizeof(rocksdb_writebatch_wi_t));
   wi->rep = txn->rep->GetWriteBatch();
+  wi->owns_rep = false;
 
   return wi;
 }

--- a/tools/c_api_gen/c_base.h
+++ b/tools/c_api_gen/c_base.h
@@ -3177,6 +3177,8 @@ extern ROCKSDB_LIBRARY_API void rocksdb_transaction_prepare(
 extern ROCKSDB_LIBRARY_API void rocksdb_transaction_destroy(
     rocksdb_transaction_t* txn);
 
+// The returned wrapper does not own the transaction's write batch. It can be
+// released with rocksdb_free or rocksdb_writebatch_wi_destroy.
 extern ROCKSDB_LIBRARY_API rocksdb_writebatch_wi_t*
 rocksdb_transaction_get_writebatch_wi(rocksdb_transaction_t* txn);
 
@@ -3184,7 +3186,6 @@ extern ROCKSDB_LIBRARY_API void rocksdb_transaction_rebuild_from_writebatch(
     rocksdb_transaction_t* txn, rocksdb_writebatch_t* writebatch,
     char** errptr);
 
-// This rocksdb_writebatch_wi_t should be freed with rocksdb_free
 extern ROCKSDB_LIBRARY_API void rocksdb_transaction_rebuild_from_writebatch_wi(
     rocksdb_transaction_t* txn, rocksdb_writebatch_wi_t* wi, char** errptr);
 


### PR DESCRIPTION
  ## Summary

  Fix a C API ownership bug in `rocksdb_transaction_get_writebatch_wi()`.

  That API returns a `rocksdb_writebatch_wi_t` wrapper around the transaction-owned `WriteBatchWithIndex`. Previously, `rocksdb_writebatch_wi_destroy()` always deleted
  the wrapped `rep`, so using it on the transaction-returned wrapper could free transaction-owned state and later cause double free / use-after-free when the
  transaction is destroyed.

  This change adds an internal `owns_rep` flag:
  - `rocksdb_writebatch_wi_create*()` wrappers own and delete `rep`
  - `rocksdb_transaction_get_writebatch_wi()` wrappers borrow `rep`
  - `rocksdb_writebatch_wi_destroy()` only deletes `rep` for owning wrappers

  Also updates the public C API comment and adds regression coverage for both accepted release paths.

  ## Test Plan

  - `AUTO_CLEAN=1 make c_test`
  - `timeout 60 ./c_test`
  - `AUTO_CLEAN=1 make check-sources`
  - `python3 tools/c_api_gen/check_api_completeness.py`
  - `python3 tools/c_api_gen/check_api_compatibility.py --ref HEAD`
  - `git diff --check`

  ## Notes

  `make check-c-api-c_test` could not run locally because `clang-format` is missing from PATH; it fails in the generated-file precheck before running `c_test`.