### PR TITLE
Make range-lock waits interruptible with SetIsKilledCallback

### DIFF
--- a/include/rocksdb/utilities/transaction_db.h
+++ b/include/rocksdb/utilities/transaction_db.h
@@ -119,6 +119,14 @@ class RangeLockManagerHandle : public LockManagerHandle {
   // Set the user-provided barrier check function
   virtual void SetEscalationBarrierFunc(EscalationBarrierFunc func) = 0;
 
+  // Predicate returning true if the thread waiting for a lock has been killed.
+  // A range lock wait polls this and returns promptly (DB_LOCK_INTERRUPTED ->
+  // Status::Aborted()) when it fires.
+  using IsKilledCallback = std::function<bool()>;
+
+  // Set the user-provided kill-check function
+  virtual void SetIsKilledCallback(IsKilledCallback func) = 0;
+
   virtual RangeLockStatus GetRangeLockStatusData() = 0;
 
   class Counters {

--- a/unreleased_history/public_api_changes/range_lock_kill_callback.md
+++ b/unreleased_history/public_api_changes/range_lock_kill_callback.md
@@ -1,0 +1,1 @@
+Added `RangeLockManagerHandle::SetIsKilledCallback()`, a `std::function<bool()>` predicate polled during range-lock waits. When it returns true, a blocked `GetRangeLock()` wait returns promptly with `Status::Aborted()` instead of waiting for the lock timeout. Range-lock users that install no callback keep the original wait-until-grant-or-timeout behavior.

--- a/utilities/transactions/lock/range/range_locking_test.cc
+++ b/utilities/transactions/lock/range/range_locking_test.cc
@@ -475,6 +475,57 @@ TEST_F(RangeLockingTest, LockWaiteeAccess) {
   delete txn1;
 }
 
+// A killed_callback that fires makes a conflicting range-lock wait return
+// Status::Aborted() (DB_LOCK_INTERRUPTED), not a timeout.
+TEST_F(RangeLockingTest, KilledCallbackAbortsWait) {
+  TransactionOptions txn_options;
+  auto cf = db->DefaultColumnFamily();
+  // Large timeout so a timeout cannot masquerade as the interrupt.
+  txn_options.lock_timeout = 100000;
+
+  std::atomic<bool> killed{false};
+  range_lock_mgr->SetIsKilledCallback([&]() { return killed.load(); });
+
+  Transaction* txn0 = db->BeginTransaction(WriteOptions(), txn_options);
+  Transaction* txn1 = db->BeginTransaction(WriteOptions(), txn_options);
+
+  ASSERT_OK(txn0->GetRangeLock(cf, Endpoint("a"), Endpoint("c")));
+
+  killed.store(true);
+  auto s = txn1->GetRangeLock(cf, Endpoint("b"), Endpoint("z"));
+  ASSERT_TRUE(s.IsAborted());
+  ASSERT_FALSE(s.IsTimedOut());
+
+  txn0->Rollback();
+  txn1->Rollback();
+  delete txn0;
+  delete txn1;
+}
+
+// With a killed_callback installed that never fires, a conflicting wait still
+// times out: the interrupt path must not disturb timeout behavior.
+TEST_F(RangeLockingTest, KilledCallbackFalseStillTimesOut) {
+  TransactionOptions txn_options;
+  auto cf = db->DefaultColumnFamily();
+  txn_options.lock_timeout = 50;
+
+  range_lock_mgr->SetIsKilledCallback([]() { return false; });
+
+  Transaction* txn0 = db->BeginTransaction(WriteOptions(), txn_options);
+  Transaction* txn1 = db->BeginTransaction(WriteOptions(), txn_options);
+
+  ASSERT_OK(txn0->GetRangeLock(cf, Endpoint("a"), Endpoint("c")));
+
+  auto s = txn1->GetRangeLock(cf, Endpoint("b"), Endpoint("z"));
+  ASSERT_TRUE(s.IsTimedOut());
+  ASSERT_FALSE(s.IsAborted());
+
+  txn0->Rollback();
+  txn1->Rollback();
+  delete txn0;
+  delete txn1;
+}
+
 void PointLockManagerTestExternalSetup(PointLockManagerTest* self) {
   self->env_ = Env::Default();
   self->db_dir_ = test::PerThreadDBPath("point_lock_manager_test");

--- a/utilities/transactions/lock/range/range_tree/lib/db.h
+++ b/utilities/transactions/lock/range/range_tree/lib/db.h
@@ -58,6 +58,8 @@ typedef struct __toku_engine_status_row {
 #define DB_BUFFER_SMALL -30999
 #define DB_LOCK_DEADLOCK -30995
 #define DB_LOCK_NOTGRANTED -30994
+// wait aborted by killed_callback (vs. timeout)
+#define DB_LOCK_INTERRUPTED -30993
 #define DB_NOTFOUND -30989
 #define DB_KEYEXIST -30996
 #define DB_DBT_MALLOC 8

--- a/utilities/transactions/lock/range/range_tree/lib/locktree/lock_request.cc
+++ b/utilities/transactions/lock/range/range_tree/lib/locktree/lock_request.cc
@@ -234,13 +234,13 @@ int lock_request::start(void) {
 // sleep on the lock request until it becomes resolved or the wait time has
 // elapsed.
 int lock_request::wait(uint64_t wait_time_ms) {
-  return wait(wait_time_ms, 0, nullptr);
+  return wait(wait_time_ms, 0, nullptr, nullptr);
 }
 
 int lock_request::wait(uint64_t wait_time_ms, uint64_t killed_time_ms,
-                       int (*killed_callback)(void),
-                       void (*lock_wait_callback)(void *, lock_wait_infos *),
-                       void *callback_arg) {
+                       int (*killed_callback)(void*), void* killed_callback_arg,
+                       void (*lock_wait_callback)(void*, lock_wait_infos*),
+                       void* callback_arg) {
   uint64_t t_now = toku_current_time_microsec();
   uint64_t t_start = t_now;
   uint64_t t_end = t_start + wait_time_ms * 1000;
@@ -258,9 +258,9 @@ int lock_request::wait(uint64_t wait_time_ms, uint64_t killed_time_ms,
 
   while (m_state == state::PENDING) {
     // check if this thread is killed
-    if (killed_callback && killed_callback()) {
+    if (killed_callback && killed_callback(killed_callback_arg)) {
       remove_from_lock_requests();
-      complete(DB_LOCK_NOTGRANTED);
+      complete(DB_LOCK_INTERRUPTED);
       continue;
     }
 
@@ -439,26 +439,6 @@ void lock_request::report_waits(lock_wait_infos *wait_conflicts,
 }
 
 void *lock_request::get_extra(void) const { return m_extra; }
-
-void lock_request::kill_waiter(void) {
-  remove_from_lock_requests();
-  complete(DB_LOCK_NOTGRANTED);
-  toku_external_cond_broadcast(&m_wait_cond);
-}
-
-void lock_request::kill_waiter(locktree *lt, void *extra) {
-  lt_lock_request_info *info = lt->get_lock_request_info();
-  toku_external_mutex_lock(&info->mutex);
-  for (uint32_t i = 0; i < info->pending_lock_requests.size(); i++) {
-    lock_request *request;
-    int r = info->pending_lock_requests.fetch(i, &request);
-    if (r == 0 && request->get_extra() == extra) {
-      request->kill_waiter();
-      break;
-    }
-  }
-  toku_external_mutex_unlock(&info->mutex);
-}
 
 // find another lock request by txnid. must hold the mutex.
 lock_request *lock_request::find_lock_request(const TXNID &txnid) {

--- a/utilities/transactions/lock/range/range_tree/lib/locktree/lock_request.h
+++ b/utilities/transactions/lock/range/range_tree/lib/locktree/lock_request.h
@@ -108,13 +108,14 @@ class lock_request {
   int start(void);
 
   // effect: Sleeps until either the request is granted or the wait time
-  // expires. returns: The return code of locktree::acquire_[write,read]_lock()
-  //          or simply DB_LOCK_NOTGRANTED if the wait time expired.
+  // expires. returns: The return code of locktree::acquire_[write,read]_lock(),
+  //          DB_LOCK_NOTGRANTED if the wait time expired, or
+  //          DB_LOCK_INTERRUPTED if killed_callback returned true.
   int wait(uint64_t wait_time_ms);
   int wait(uint64_t wait_time_ms, uint64_t killed_time_ms,
-           int (*killed_callback)(void),
-           void (*lock_wait_callback)(void *, lock_wait_infos *) = nullptr,
-           void *callback_arg = nullptr);
+           int (*killed_callback)(void*), void* killed_callback_arg,
+           void (*lock_wait_callback)(void*, lock_wait_infos*) = nullptr,
+           void* callback_arg = nullptr);
 
   // return: left end-point of the lock range
   const DBT *get_left_key(void) const;
@@ -150,9 +151,6 @@ class lock_request {
   void set_retry_test_callback(void (*f)(void));
 
   void *get_extra(void) const;
-
-  void kill_waiter(void);
-  static void kill_waiter(locktree *lt, void *extra);
 
  private:
   enum state {

--- a/utilities/transactions/lock/range/range_tree/lib/locktree/locktree.h
+++ b/utilities/transactions/lock/range/range_tree/lib/locktree/locktree.h
@@ -201,8 +201,6 @@ class locktree_manager {
   // Add time t to the escalator's wait time statistics
   void add_escalator_wait_time(uint64_t t);
 
-  void kill_waiter(void *extra);
-
  private:
   static const uint64_t DEFAULT_MAX_LOCK_MEMORY = 64L * 1024 * 1024;
 

--- a/utilities/transactions/lock/range/range_tree/lib/locktree/manager.cc
+++ b/utilities/transactions/lock/range/range_tree/lib/locktree/manager.cc
@@ -507,19 +507,5 @@ void locktree_manager::get_status(LTM_STATUS statp) {
   *statp = ltm_status;
 }
 
-void locktree_manager::kill_waiter(void *extra) {
-  mutex_lock();
-  int r = 0;
-  uint32_t num_locktrees = m_locktree_map.size();
-  for (uint32_t i = 0; i < num_locktrees; i++) {
-    locktree *lt;
-    r = m_locktree_map.fetch(i, &lt);
-    invariant_zero(r);
-    if (r) continue;  // Get rid of "may be used uninitialized" warning
-    lock_request::kill_waiter(lt, extra);
-  }
-  mutex_unlock();
-}
-
 } /* namespace toku */
 #endif  // OS_WIN

--- a/utilities/transactions/lock/range/range_tree/range_tree_lock_manager.cc
+++ b/utilities/transactions/lock/range/range_tree/range_tree_lock_manager.cc
@@ -87,9 +87,16 @@ Status RangeTreeLockManager::TryLock(PessimisticTransaction* txn,
               exclusive ? toku::lock_request::WRITE : toku::lock_request::READ,
               false /* not a big txn */, &wait_key);
 
-  // This is for "periodically wake up and check if the wait is killed" feature
-  // which we are not using.
+  // Poll for kill only when an embedder installed a kill-check callback;
+  // otherwise IsKilledThunk can never fire and the 100ms wakeups are pure
+  // overhead.
+  constexpr uint64_t kKillPollMs = 100;
   uint64_t killed_time_msec = 0;
+  int (*killed_thunk)(void*) = nullptr;
+  if (killed_callback_) {
+    killed_time_msec = kKillPollMs;
+    killed_thunk = &IsKilledThunk;
+  }
   uint64_t wait_time_msec = txn->GetLockTimeout();
 
   if (wait_time_msec == static_cast<uint64_t>(-1)) {
@@ -116,9 +123,8 @@ Status RangeTreeLockManager::TryLock(PessimisticTransaction* txn,
 
   request.start();
 
-  const int r = request.wait(wait_time_msec, killed_time_msec,
-                             nullptr,  // killed_callback
-                             wait_callback_for_locktree, nullptr);
+  const int r = request.wait(wait_time_msec, killed_time_msec, killed_thunk,
+                             this, wait_callback_for_locktree, nullptr);
 
   // Inform the txn that we are no longer waiting:
   txn->ClearWaitingTxn();
@@ -129,6 +135,8 @@ Status RangeTreeLockManager::TryLock(PessimisticTransaction* txn,
       break;  // fall through
     case DB_LOCK_NOTGRANTED:
       return Status::TimedOut(Status::SubCode::kLockTimeout);
+    case DB_LOCK_INTERRUPTED:
+      return Status::Aborted();
     case TOKUDB_OUT_OF_LOCKS:
       return Status::LockLimit();
     case DB_LOCK_DEADLOCK: {
@@ -143,6 +151,10 @@ Status RangeTreeLockManager::TryLock(PessimisticTransaction* txn,
   }
 
   return Status::OK();
+}
+
+int RangeTreeLockManager::IsKilledThunk(void* extra) {
+  return static_cast<RangeTreeLockManager*>(extra)->killed_callback_() ? 1 : 0;
 }
 
 // Wait callback that locktree library will call to inform us about

--- a/utilities/transactions/lock/range/range_tree/range_tree_lock_manager.h
+++ b/utilities/transactions/lock/range/range_tree/range_tree_lock_manager.h
@@ -94,11 +94,17 @@ class RangeTreeLockManager : public RangeLockManagerBase,
     barrier_func_ = func;
   }
 
+  void SetIsKilledCallback(IsKilledCallback func) override {
+    killed_callback_ = func;
+  }
+
  private:
   toku::locktree_manager ltm_;
 
   EscalationBarrierFunc barrier_func_ =
       [](const Endpoint&, const Endpoint&) -> bool { return false; };
+
+  IsKilledCallback killed_callback_{};
 
   std::shared_ptr<TransactionDBMutexFactory> mutex_factory_;
 
@@ -126,6 +132,10 @@ class RangeTreeLockManager : public RangeLockManagerBase,
                           const toku::range_buffer& buffer, void* extra);
 
   static bool OnEscalationBarrierCheck(const DBT* a, const DBT* b, void* extra);
+
+  // Bridges the C-style toku killed-callback to killed_callback_; extra is the
+  // RangeTreeLockManager*.
+  static int IsKilledThunk(void* extra);
 };
 
 void serialize_endpoint(const Endpoint& endp, std::string* buf);


### PR DESCRIPTION
Add RangeLockManagerHandle::SetIsKilledCallback, a std::function<bool()> predicate mirroring SetEscalationBarrierFunc. When installed, RangeTreeLockManager wakes the toku lock_request::wait loop every 100ms to poll it; if it fires, the wait completes with a new DB_LOCK_INTERRUPTED result mapped to Status::Aborted(), so a blocked GetRangeLock() returns promptly instead of waiting out the lock timeout. Range-lock users that install no callback keep the original wait-until-grant-or-timeout behavior (no extra wakeups).

Also remove the unused toku kill_waiter abort path (lock_request and locktree_manager), which had no caller.

Test Plan:
`build_tools/rocksptest.sh range_locking_test` passes, including the two new tests. KilledCallbackAbortsWait completes in ~90ms despite a 100s lock timeout, confirming the kill callback aborts the wait promptly; KilledCallbackFalseStillTimesOut confirms an installed-but-false callback still times out.

Tested end-to-end together with the MyRocks side in D110890436: with rocksdb_use_range_locking=ON, a KILL QUERY parked on a conflicting range-lock wait is interrupted promptly (rocksdb.range_locking MTR suite) instead of waiting out rocksdb_lock_wait_timeout.