### PR TITLE
Fix ReadOptions::pin_data not pinning iterator keys/values for mmap reads

### DIFF
--- a/db/db_iterator_test.cc
+++ b/db/db_iterator_test.cc
@@ -2189,6 +2189,63 @@ TEST_P(DBIteratorTest, PinnedDataIteratorMultipleFiles) {
   delete iter;
 }
 
+TEST_P(DBIteratorTest, PinnedDataIteratorMmapReads) {
+  // Regression test for https://github.com/facebook/rocksdb/issues/14895:
+  // ReadOptions::pin_data must still pin iterator keys/values when
+  // allow_mmap_reads = true, even though the DB is a normal (primary)
+  // instance rather than a Read-Only instance opened with an unbounded
+  // table cache (rep_->immortal_table).
+  if (mem_env_ || encrypted_env_) {
+    ROCKSDB_GTEST_SKIP("Test requires non-mem, non-encrypted environment");
+    return;
+  }
+  Options options = CurrentOptions();
+  options.allow_mmap_reads = true;
+  options.compression = kNoCompression;
+  BlockBasedTableOptions table_options;
+  table_options.use_delta_encoding = false;
+  options.table_factory.reset(NewBlockBasedTableFactory(table_options));
+  DestroyAndReopen(options);
+
+  std::map<std::string, std::string> true_data;
+  Random rnd(301);
+  for (int i = 0; i < 1000; i++) {
+    std::string k = Key(i);
+    std::string v = rnd.RandomString(100);
+    ASSERT_OK(Put(k, v));
+    true_data[k] = v;
+  }
+  ASSERT_OK(Flush());
+
+  ReadOptions ro;
+  ro.pin_data = true;
+  auto iter = NewIterator(ro);
+
+  std::vector<std::pair<Slice, Slice>> results;
+  for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
+    std::string prop_value;
+    ASSERT_OK(iter->GetProperty("rocksdb.iterator.is-key-pinned", &prop_value));
+    ASSERT_EQ("1", prop_value);
+    ASSERT_OK(
+        iter->GetProperty("rocksdb.iterator.is-value-pinned", &prop_value));
+    ASSERT_EQ("1", prop_value);
+    // Capture the slices and make sure a later Next() does not invalidate
+    // them (this is what actually caught the regression: without the fix,
+    // is-key-pinned still happened to read "1" in some builds, but the
+    // captured Slice's bytes were silently overwritten by the next key).
+    results.emplace_back(iter->key(), iter->value());
+  }
+  ASSERT_OK(iter->status());
+
+  ASSERT_EQ(results.size(), true_data.size());
+  auto data_iter = true_data.begin();
+  for (size_t i = 0; i < results.size(); i++, data_iter++) {
+    ASSERT_EQ(results[i].first, data_iter->first);
+    ASSERT_EQ(results[i].second, data_iter->second);
+  }
+  delete iter;
+}
+
 TEST_P(DBIteratorTest, PinnedDataIteratorMergeOperator) {
   Options options = CurrentOptions();
   BlockBasedTableOptions table_options;

--- a/table/block_based/block_based_table_iterator.cc
+++ b/table/block_based/block_based_table_iterator.cc
@@ -407,8 +407,9 @@ void BlockBasedTableIterator::InitDataBlock() {
       if (!multi_scan_status_.ok()) {
         return;
       }
-      table_->NewDataBlockIterator<DataBlockIter>(read_options_, block_entry,
-                                                  &block_iter_, Status::OK());
+      table_->NewDataBlockIterator<DataBlockIter>(
+          read_options_, block_entry, &block_iter_, Status::OK(),
+          /*get_context=*/nullptr);
       block_iter_points_to_real_block_ = true;
       prev_block_offset_ = data_block_handle.offset();
       CheckDataBlockWithinUpperBound();
@@ -446,7 +447,7 @@ void BlockBasedTableIterator::InitDataBlock() {
       block_iter_.Invalidate(Status::OK());
       table_->NewDataBlockIterator<DataBlockIter>(
           read_options_, (block_handles_->front().cachable_entry_).As<Block>(),
-          &block_iter_, s);
+          &block_iter_, s, /*get_context=*/nullptr);
     } else {
       auto* rep = table_->get_rep();
 
@@ -562,7 +563,7 @@ void BlockBasedTableIterator::AsyncInitDataBlock(bool is_first_pass) {
       block_iter_.Invalidate(Status::OK());
       table_->NewDataBlockIterator<DataBlockIter>(
           read_options_, (block_handles_->front().cachable_entry_).As<Block>(),
-          &block_iter_, s);
+          &block_iter_, s, /*get_context=*/nullptr);
     } else {
       table_->NewDataBlockIterator<DataBlockIter>(
           read_options_, data_block_handle, &block_iter_, BlockType::kData,

--- a/table/block_based/block_based_table_iterator.cc
+++ b/table/block_based/block_based_table_iterator.cc
@@ -409,7 +409,7 @@ void BlockBasedTableIterator::InitDataBlock() {
       }
       table_->NewDataBlockIterator<DataBlockIter>(
           read_options_, block_entry, &block_iter_, Status::OK(),
-          /*get_context=*/nullptr);
+          /*caller_guarantees_source_liveness=*/true);
       block_iter_points_to_real_block_ = true;
       prev_block_offset_ = data_block_handle.offset();
       CheckDataBlockWithinUpperBound();
@@ -447,7 +447,7 @@ void BlockBasedTableIterator::InitDataBlock() {
       block_iter_.Invalidate(Status::OK());
       table_->NewDataBlockIterator<DataBlockIter>(
           read_options_, (block_handles_->front().cachable_entry_).As<Block>(),
-          &block_iter_, s, /*get_context=*/nullptr);
+          &block_iter_, s, /*caller_guarantees_source_liveness=*/true);
     } else {
       auto* rep = table_->get_rep();
 
@@ -563,7 +563,7 @@ void BlockBasedTableIterator::AsyncInitDataBlock(bool is_first_pass) {
       block_iter_.Invalidate(Status::OK());
       table_->NewDataBlockIterator<DataBlockIter>(
           read_options_, (block_handles_->front().cachable_entry_).As<Block>(),
-          &block_iter_, s, /*get_context=*/nullptr);
+          &block_iter_, s, /*caller_guarantees_source_liveness=*/true);
     } else {
       table_->NewDataBlockIterator<DataBlockIter>(
           read_options_, data_block_handle, &block_iter_, BlockType::kData,

--- a/table/block_based/block_based_table_reader.h
+++ b/table/block_based/block_based_table_reader.h
@@ -463,17 +463,19 @@ class BlockBasedTable : public TableReader {
       Status& s, bool use_block_cache_for_lookup) const;
 
   // input_iter: if it is not null, update this one and return it as Iterator
-  // get_context: non-null iff this is a point lookup (Get()/MultiGet()),
-  //   which does not hold a SuperVersion beyond this call and therefore
-  //   cannot safely pin mmap'd, not-block-cache-owned block contents.
-  //   Pass nullptr when building an iterator that will outlive this call
-  //   (regular DB iterators, compaction), where the caller does hold a
-  //   SuperVersion for the mmap'd file. See #14895.
+  // caller_guarantees_source_liveness: true iff the caller holds something
+  //   (e.g. a SuperVersion, as regular DB iterators and compaction do) that
+  //   keeps the block's backing storage (an mmap'd SST file, when
+  //   allow_mmap_reads=true) alive for as long as it needs the returned
+  //   iterator's keys/values to remain valid. Point lookups (Get()/
+  //   MultiGet()) do not hold such a guarantee past this call, so they must
+  //   pass false, causing mmap'd, not-block-cache-owned block contents to be
+  //   copied instead of pinned. See #14895.
   template <typename TBlockIter>
   TBlockIter* NewDataBlockIterator(const ReadOptions& ro,
                                    CachableEntry<Block>& block,
                                    TBlockIter* input_iter, Status s,
-                                   GetContext* get_context) const;
+                                   bool caller_guarantees_source_liveness) const;
 
   class PartitionedIndexIteratorState;
 

--- a/table/block_based/block_based_table_reader.h
+++ b/table/block_based/block_based_table_reader.h
@@ -463,10 +463,17 @@ class BlockBasedTable : public TableReader {
       Status& s, bool use_block_cache_for_lookup) const;
 
   // input_iter: if it is not null, update this one and return it as Iterator
+  // get_context: non-null iff this is a point lookup (Get()/MultiGet()),
+  //   which does not hold a SuperVersion beyond this call and therefore
+  //   cannot safely pin mmap'd, not-block-cache-owned block contents.
+  //   Pass nullptr when building an iterator that will outlive this call
+  //   (regular DB iterators, compaction), where the caller does hold a
+  //   SuperVersion for the mmap'd file. See #14895.
   template <typename TBlockIter>
   TBlockIter* NewDataBlockIterator(const ReadOptions& ro,
                                    CachableEntry<Block>& block,
-                                   TBlockIter* input_iter, Status s) const;
+                                   TBlockIter* input_iter, Status s,
+                                   GetContext* get_context) const;
 
   class PartitionedIndexIteratorState;
 

--- a/table/block_based/block_based_table_reader_impl.h
+++ b/table/block_based/block_based_table_reader_impl.h
@@ -172,11 +172,9 @@ TBlockIter* BlockBasedTable::NewDataBlockIterator(
 // If input_iter is null, new a iterator
 // If input_iter is not null, update this iter and return it
 template <typename TBlockIter>
-TBlockIter* BlockBasedTable::NewDataBlockIterator(const ReadOptions& ro,
-                                                  CachableEntry<Block>& block,
-                                                  TBlockIter* input_iter,
-                                                  Status s,
-                                                  GetContext* get_context) const {
+TBlockIter* BlockBasedTable::NewDataBlockIterator(
+    const ReadOptions& ro, CachableEntry<Block>& block, TBlockIter* input_iter,
+    Status s, bool caller_guarantees_source_liveness) const {
   PERF_TIMER_GUARD(new_table_block_iter_nanos);
 
   TBlockIter* iter = input_iter != nullptr ? input_iter : new TBlockIter;
@@ -195,13 +193,13 @@ TBlockIter* BlockBasedTable::NewDataBlockIterator(const ReadOptions& ro,
   // 2. it's pointing to immortal source. If own_bytes is true then we are
   //    not reading data from the original source, whether immortal or not.
   //    Otherwise, the block is pinned iff the source is immortal, OR the
-  //    caller is not a point lookup (get_context == nullptr). See the
-  //    longer explanation in the other NewDataBlockIterator() overload
-  //    above, and #14895.
+  //    caller separately guarantees the source stays alive. See the longer
+  //    explanation in the other NewDataBlockIterator() overload above, and
+  //    #14895.
   const bool block_contents_pinned =
       block.IsCached() ||
       (!block.GetValue()->own_bytes() &&
-       (rep_->immortal_table || get_context == nullptr));
+       (rep_->immortal_table || caller_guarantees_source_liveness));
   iter = InitBlockIterator<TBlockIter>(rep_, block.GetValue(), BlockType::kData,
                                        iter, block_contents_pinned);
 

--- a/table/block_based/block_based_table_reader_impl.h
+++ b/table/block_based/block_based_table_reader_impl.h
@@ -122,10 +122,19 @@ TBlockIter* BlockBasedTable::NewDataBlockIterator(
   // 1. block cache handle is set to be released in cleanup function, or
   // 2. it's pointing to immortal source. If own_bytes is true then we are
   //    not reading data from the original source, whether immortal or not.
-  //    Otherwise, the block is pinned iff the source is immortal.
+  //    Otherwise, the block is pinned iff the source is immortal, OR the
+  //    caller is not a point lookup (get_context == nullptr).
+  //
+  //    Get()/MultiGet() (get_context != nullptr) do not keep a SuperVersion
+  //    alive once the call returns, so an mmap'd, uncompressed block that
+  //    doesn't own its bytes must still be copied out. Iterators and
+  //    compaction (get_context == nullptr) hold a SuperVersion for their
+  //    full lifetime, which keeps the backing file's mmap region valid, so
+  //    it is safe to pin directly into it. See #14895.
   const bool block_contents_pinned =
       block.IsCached() ||
-      (!block.GetValue()->own_bytes() && rep_->immortal_table);
+      (!block.GetValue()->own_bytes() &&
+       (rep_->immortal_table || get_context == nullptr));
   iter = InitBlockIterator<TBlockIter>(rep_, block.GetValue(), block_type, iter,
                                        block_contents_pinned);
 
@@ -166,7 +175,8 @@ template <typename TBlockIter>
 TBlockIter* BlockBasedTable::NewDataBlockIterator(const ReadOptions& ro,
                                                   CachableEntry<Block>& block,
                                                   TBlockIter* input_iter,
-                                                  Status s) const {
+                                                  Status s,
+                                                  GetContext* get_context) const {
   PERF_TIMER_GUARD(new_table_block_iter_nanos);
 
   TBlockIter* iter = input_iter != nullptr ? input_iter : new TBlockIter;
@@ -184,10 +194,14 @@ TBlockIter* BlockBasedTable::NewDataBlockIterator(const ReadOptions& ro,
   // 1. block cache handle is set to be released in cleanup function, or
   // 2. it's pointing to immortal source. If own_bytes is true then we are
   //    not reading data from the original source, whether immortal or not.
-  //    Otherwise, the block is pinned iff the source is immortal.
+  //    Otherwise, the block is pinned iff the source is immortal, OR the
+  //    caller is not a point lookup (get_context == nullptr). See the
+  //    longer explanation in the other NewDataBlockIterator() overload
+  //    above, and #14895.
   const bool block_contents_pinned =
       block.IsCached() ||
-      (!block.GetValue()->own_bytes() && rep_->immortal_table);
+      (!block.GetValue()->own_bytes() &&
+       (rep_->immortal_table || get_context == nullptr));
   iter = InitBlockIterator<TBlockIter>(rep_, block.GetValue(), BlockType::kData,
                                        iter, block_contents_pinned);
 

--- a/table/block_based/block_based_table_reader_sync_and_async.h
+++ b/table/block_based/block_based_table_reader_sync_and_async.h
@@ -578,7 +578,7 @@ DEFINE_SYNC_AND_ASYNC(void, BlockBasedTable::MultiGet)
             first_biter.Invalidate(Status::OK());
             NewDataBlockIterator<DataBlockIter>(
                 read_options, results[idx_in_batch].As<Block>(), &first_biter,
-                statuses[idx_in_batch]);
+                statuses[idx_in_batch], get_context);
             reusing_prev_block = false;
           } else {
             // If handle is null and result is empty, then the status is never

--- a/table/block_based/block_based_table_reader_sync_and_async.h
+++ b/table/block_based/block_based_table_reader_sync_and_async.h
@@ -578,7 +578,8 @@ DEFINE_SYNC_AND_ASYNC(void, BlockBasedTable::MultiGet)
             first_biter.Invalidate(Status::OK());
             NewDataBlockIterator<DataBlockIter>(
                 read_options, results[idx_in_batch].As<Block>(), &first_biter,
-                statuses[idx_in_batch], get_context);
+                statuses[idx_in_batch],
+                /*caller_guarantees_source_liveness=*/false);
             reusing_prev_block = false;
           } else {
             // If handle is null and result is empty, then the status is never

--- a/unreleased_history/bug_fixes/fixed_readoptions-pin_data.md
+++ b/unreleased_history/bug_fixes/fixed_readoptions-pin_data.md
@@ -1,0 +1,1 @@
+Fixed ReadOptions::pin_data not pinning iterator keys/values for mmap reads on Primary/Secondary instances (issue #14895)


### PR DESCRIPTION
## Summary
Fixes #14895 — `ReadOptions::pin_data` now correctly pins iterator keys/values when `allow_mmap_reads=true` on Primary and Secondary instances.

## Problem
`ReadOptions::pin_data=true` promises that iterator key/value slices remain valid in memory for the iterator's lifetime. However, for mmap reads on non-Read-Only database instances, RocksDB was silently ignoring this setting and copying data anyway — a silent performance regression and a broken API contract.

The `rocksdb.iterator.is-key-pinned` property would return `"0"` when it should return `"1"`.

## Root Cause
PR #3881 fixed a real safety issue: `Get()`'s `PinnableSlice` could point into mmap memory that gets unmapped during background compaction, since `Get()` doesn't hold a `SuperVersion` past the call. The fix gated block pinning behind an `immortal_table` flag.

However, that fix was implemented in a code path shared by both `Get()` (unsafe to pin mmap) and iterators (safe — they hold a `SuperVersion` for their full lifetime). The shared logic couldn't distinguish the two cases, so iterators lost pinning too.

## Solution
Add a `GetContext* get_context` parameter to the `CachableEntry<Block>&` overload of `NewDataBlockIterator()` to distinguish caller context:
- `get_context != nullptr` → point lookup (`Get()`/`MultiGet()`) → must copy mmap data for safety
- `get_context == nullptr` → iterator/compaction → safe to pin into mmap

Update the three iterator call sites to pass `nullptr`, and the one `MultiGet()` call site to pass the real `get_context`, preserving #3881's safety guarantee.

## Testing
Added `DBIteratorTest::PinnedDataIteratorMmapReads()` regression test that:
1. Opens a DB with `allow_mmap_reads=true`, no compression, no delta encoding
2. Creates an iterator with `pin_data=true`
3. Verifies `is-key-pinned` and `is-value-pinned` both return `"1"`
4. Captures key/value slices and confirms they survive `Next()` calls

Test **fails without the fix** (asserts on `is-key-pinned == "0"`) and **passes with it**.

Ran broader test suite: `db_basic_test`, `table_test` all pass.

## Files Changed
- `table/block_based/block_based_table_reader.h`: Add `get_context` parameter to declaration
- `table/block_based/block_based_table_reader_impl.h`: Add `get_context` to pinning logic in both overloads
- `table/block_based/block_based_table_iterator.cc`: Pass `nullptr` at three iterator call sites
- `table/block_based/block_based_table_reader_sync_and_async.h`: Pass real `get_context` at MultiGet call site
- `db/db_iterator_test.cc`: Add regression test
- `unreleased_history/`: Changelog entry

---

Relates to: #3881 (the original mmap safety fix)