### PR TITLE
Flush no-WAL live-file data with LockWAL (#14931)

### DIFF
--- a/db/db_filesnapshot.cc
+++ b/db/db_filesnapshot.cc
@@ -252,7 +252,7 @@ Status DBImpl::GetLiveFilesStorageInfo(
         "capturing live files. Retry with flush enabled.");
   }
   if (flush_memtable) {
-    wal_locked = lock_wal_count_ > 0;
+    wal_locked = !lock_wal_owner_thread_id_counts_.empty();
     if (wal_locked) {
       if (needs_blob_direct_write_flush) {
         mutex_.Unlock();
@@ -260,8 +260,12 @@ Status DBImpl::GetLiveFilesStorageInfo(
             "Blob direct write requires flushing active blob files before "
             "capturing live files. Retry with WAL unlocked.");
       }
-      ROCKS_LOG_INFO(immutable_db_options_.info_log,
-                     "Can't FlushForGetLiveFiles while WAL is locked");
+    }
+    if (wal_locked && !has_unpersisted_data_.load(std::memory_order_relaxed)) {
+      ROCKS_LOG_INFO(
+          immutable_db_options_.info_log,
+          "Skipping FlushForGetLiveFiles while WAL is locked and all data is "
+          "already persisted");
     } else {
       Status status = FlushForGetLiveFiles(opts.atomic_flush);
       if (!status.ok()) {

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -2169,11 +2169,12 @@ Status DBImpl::ApplyWALToManifest(const ReadOptions& read_options,
 }
 
 Status DBImpl::LockWAL() {
+  const uint64_t thread_id = env_->GetThreadID();
   {
     InstrumentedMutexLock lock(&mutex_);
-    if (lock_wal_count_ > 0) {
+    if (!lock_wal_owner_thread_id_counts_.empty()) {
       assert(lock_wal_write_token_);
-      ++lock_wal_count_;
+      ++lock_wal_owner_thread_id_counts_[thread_id];
     } else {
       // NOTE: this will "unnecessarily" wait for other non-LockWAL() write
       // stalls to clear before LockWAL returns, however fixing that would
@@ -2191,12 +2192,13 @@ Status DBImpl::LockWAL() {
       }
 
       // NOTE: releasing mutex in EnterUnbatched might mean we are actually
-      // now lock_wal_count > 0
-      if (lock_wal_count_ == 0) {
+      // now locked by another thread.
+      if (lock_wal_owner_thread_id_counts_.empty()) {
         assert(!lock_wal_write_token_);
         lock_wal_write_token_ = write_controller_.GetStopToken();
       }
-      ++lock_wal_count_;
+      assert(lock_wal_write_token_);
+      ++lock_wal_owner_thread_id_counts_[thread_id];
 
       if (two_write_queues_) {
         nonmem_write_thread_.ExitUnbatched(&nonmem_w);
@@ -2207,23 +2209,27 @@ Status DBImpl::LockWAL() {
   // NOTE: avoid I/O holding DB mutex
   Status s = FlushWAL(/*sync=*/false);
   if (!s.ok()) {
-    // Non-OK return should not be in locked state
+    // Undo this LockWAL().
     UnlockWAL().PermitUncheckedError();
   }
   return s;
 }
 
 Status DBImpl::UnlockWAL() {
+  const uint64_t thread_id = env_->GetThreadID();
   bool signal = false;
   uint64_t maybe_stall_begun_count = 0;
   uint64_t nonmem_maybe_stall_begun_count = 0;
   {
     InstrumentedMutexLock lock(&mutex_);
-    if (lock_wal_count_ == 0) {
-      return Status::Aborted("No LockWAL() in effect");
+    const auto owner = lock_wal_owner_thread_id_counts_.find(thread_id);
+    if (owner == lock_wal_owner_thread_id_counts_.end()) {
+      return Status::Aborted("No LockWAL() held by current thread");
     }
-    --lock_wal_count_;
-    if (lock_wal_count_ == 0) {
+    if (--owner->second == 0) {
+      lock_wal_owner_thread_id_counts_.erase(owner);
+    }
+    if (lock_wal_owner_thread_id_counts_.empty()) {
       lock_wal_write_token_.reset();
       signal = true;
       // For the last UnlockWAL, we don't want to return from UnlockWAL()

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -2541,7 +2541,7 @@ class DBImpl : public DB {
     }
 
     // Wait for any LockWAL to clear
-    while (lock_wal_count_ > 0) {
+    while (!lock_wal_owner_thread_id_counts_.empty()) {
       bg_cv_.Wait();
     }
   }
@@ -3600,12 +3600,13 @@ class DBImpl : public DB {
 
   // Stop write token that is acquired when first LockWAL() is called.
   // Destroyed when last UnlockWAL() is called. Controlled by DB mutex.
-  // See lock_wal_count_
+  // See lock_wal_owner_thread_id_counts_
   std::unique_ptr<WriteControllerToken> lock_wal_write_token_;
 
-  // The number of LockWAL called without matching UnlockWAL call.
-  // See also lock_wal_write_token_
-  uint32_t lock_wal_count_ = 0;
+  // Thread IDs of valid LockWAL() owners and their recursive lock counts. Each
+  // owning thread must call UnlockWAL() the same number of times before writes
+  // can resume.
+  std::unordered_map<uint64_t, uint32_t> lock_wal_owner_thread_id_counts_;
 };
 
 class GetWithTimestampReadCallback : public ReadCallback {

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -2649,6 +2649,13 @@ Status DBImpl::FlushMemTable(ColumnFamilyData* cfd,
            "Please try again later after writes are resumed";
     return Status::TryAgain(oss.str());
   }
+  if (flush_options.wait) {
+    InstrumentedMutexLock lock(&mutex_);
+    if (lock_wal_owner_thread_id_counts_.count(env_->GetThreadID()) > 0) {
+      return Status::Aborted(
+          "Likely deadlock as the same thread called LockWAL()");
+    }
+  }
   Status s;
   if (!flush_options.allow_write_stall) {
     bool flush_needed = true;
@@ -2806,6 +2813,13 @@ Status DBImpl::AtomicFlushMemTables(
     oss << "Writes have been stopped, thus unable to perform manual flush. "
            "Please try again later after writes are resumed";
     return Status::TryAgain(oss.str());
+  }
+  if (flush_options.wait) {
+    InstrumentedMutexLock lock(&mutex_);
+    if (lock_wal_owner_thread_id_counts_.count(env_->GetThreadID()) > 0) {
+      return Status::Aborted(
+          "Likely deadlock as the same thread called LockWAL()");
+    }
   }
   Status s;
   autovector<ColumnFamilyData*> candidate_cfds;

--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -3119,7 +3119,7 @@ Status DBImpl::SwitchMemtable(ColumnFamilyData* cfd, WriteContext* context,
                               ReadOnlyMemTable* new_imm,
                               SequenceNumber last_seqno) {
   mutex_.AssertHeld();
-  assert(lock_wal_count_ == 0);
+  assert(lock_wal_owner_thread_id_counts_.empty());
 
   // TODO: plumb Env::IOActivity, Env::IOPriority
   const WriteOptions write_options;

--- a/db/db_write_test.cc
+++ b/db/db_write_test.cc
@@ -782,19 +782,30 @@ TEST_P(DBWriteTest, LockWALConcurrentRecursive) {
     ASSERT_OK(db_->GetLiveFilesStorageInfo({lf_opts}, &files));
   }
 
-  port::Thread parallel_lock_wal{[&]() {
-    ASSERT_OK(db_->LockWAL());  // 2 -> 3 or 1 -> 2
-  }};
+  SyncPoint::GetInstance()->LoadDependency(
+      {{"DBWriteTest::LockWALConcurrentRecursive:ParallelLockAcquired",
+        "DBWriteTest::LockWALConcurrentRecursive:MainUnlocks"},
+       {"DBWriteTest::LockWALConcurrentRecursive:MainAllowsParallelUnlock",
+        "DBWriteTest::LockWALConcurrentRecursive:ParallelUnlocks"}});
+  SyncPoint::GetInstance()->EnableProcessing();
 
-  ASSERT_OK(db_->UnlockWAL());  // 2 -> 1 or 3 -> 2
+  port::Thread parallel_lock_wal{[&]() {
+    ASSERT_OK(db_->LockWAL());  // 2 -> 3
+    TEST_SYNC_POINT(
+        "DBWriteTest::LockWALConcurrentRecursive:ParallelLockAcquired");
+    TEST_SYNC_POINT("DBWriteTest::LockWALConcurrentRecursive:ParallelUnlocks");
+    ASSERT_OK(db_->UnlockWAL());
+  }};
+  TEST_SYNC_POINT("DBWriteTest::LockWALConcurrentRecursive:MainUnlocks");
+
+  ASSERT_OK(db_->UnlockWAL());  // 3 -> 2
   // Give parallel_put an extra chance to jump in case of bug
   std::this_thread::yield();
-  parallel_lock_wal.join();
   ASSERT_FALSE(parallel_put_completed.Load());
   ASSERT_FALSE(parallel_ingest_completed.Load());
   ASSERT_FALSE(flush_completed.Load());
 
-  // Should now have 2 outstanding LockWAL
+  // Should still have 2 outstanding LockWAL().
   ASSERT_EQ(Get("k1"), "k1_orig");
 
   ASSERT_OK(db_->UnlockWAL());  // 2 -> 1
@@ -807,26 +818,11 @@ TEST_P(DBWriteTest, LockWALConcurrentRecursive) {
   ASSERT_EQ(Get("k2"), "NOT_FOUND");
   ASSERT_EQ(frozen_seqno, db_->GetLatestSequenceNumber());
 
-  // Ensure final Unlock is concurrency safe and extra Unlock is safe but
-  // non-OK
-  std::atomic<int> unlock_ok{0};
-  port::Thread parallel_stuff{[&]() {
-    if (db_->UnlockWAL().ok()) {
-      unlock_ok++;
-    }
-    ASSERT_OK(db_->LockWAL());
-    if (db_->UnlockWAL().ok()) {
-      unlock_ok++;
-    }
-  }};
-
-  if (db_->UnlockWAL().ok()) {
-    unlock_ok++;
-  }
-  parallel_stuff.join();
-
-  // There was one extra unlock, so just one non-ok
-  ASSERT_EQ(unlock_ok.load(), 2);
+  TEST_SYNC_POINT(
+      "DBWriteTest::LockWALConcurrentRecursive:MainAllowsParallelUnlock");
+  parallel_lock_wal.join();
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->LoadDependency({});
 
   // Write can proceed
   parallel_put.join();

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1828,16 +1828,17 @@ class DB {
   // state, though while the WAL is locked, flushes as part of CreateCheckpoint
   // and simiar are skipped. Other operations allowed on a "read only" DB should
   // work while frozen. Each LockWAL() call that returns OK must eventually be
-  // followed by a corresponding call to UnlockWAL(). Where supported, non-OK
-  // status is generally only possible with some kind of corruption or I/O
-  // error.
+  // followed by a corresponding call to UnlockWAL(). It is also expected that
+  // UnlockWAL() is called on the same thread that called LockWAL(). Where
+  // supported, non-OK status is generally only possible with some kind of
+  // corruption or I/O error.
   virtual Status LockWAL() {
     return Status::NotSupported("LockWAL not implemented");
   }
 
-  // Unfreeze the DB state from a successful LockWAL().
-  // The write stop on the database will be cleared when UnlockWAL() have been
-  // called for each successful LockWAL().
+  // Unfreeze the DB state from a successful LockWAL(). The write stop on the
+  // database will be cleared when UnlockWAL() have been called for each
+  // successful LockWAL(). Must be called from the same thread as LockWAL().
   virtual Status UnlockWAL() {
     return Status::NotSupported("UnlockWAL not implemented");
   }

--- a/include/rocksdb/utilities/backup_engine.h
+++ b/include/rocksdb/utilities/backup_engine.h
@@ -309,6 +309,9 @@ struct CreateBackupOptions {
   // Flush will always trigger if 2PC is enabled.
   // If write-ahead logs are disabled, set flush_before_backup=true to
   // avoid losing unflushed key/value pairs from the memtable.
+  //
+  // NOTE: If LockWAL() is active and WAL-disabled writes left unpersisted data,
+  // backup may wait for UnlockWAL() before it can flush.
   bool flush_before_backup = false;
 
   // Callback for reporting progress, based on callback_trigger_interval_size.

--- a/unreleased_history/behavior_changes/lock_wal_live_file_flush.md
+++ b/unreleased_history/behavior_changes/lock_wal_live_file_flush.md
@@ -1,0 +1,1 @@
+When using `LockWAL()`, live-file capture APIs such as checkpoint and backup now flush WAL-disabled unpersisted data; they can block until `UnlockWAL()` or return `Aborted` when called from the same thread that holds `LockWAL()` to avoid deadlock. `UnlockWAL()` must now also be called from the same thread that called `LockWAL()`.

--- a/utilities/checkpoint/checkpoint_test.cc
+++ b/utilities/checkpoint/checkpoint_test.cc
@@ -13,6 +13,7 @@
 #ifndef OS_WIN
 #include <unistd.h>
 #endif
+#include <atomic>
 #include <cstdlib>
 #include <iostream>
 #include <thread>
@@ -895,6 +896,70 @@ TEST_F(CheckpointTest, CheckpointWithLockWAL) {
   checkpoint = nullptr;
 
   ASSERT_OK(db_->UnlockWAL());
+  Close();
+
+  std::unique_ptr<DB> snapshot_db;
+  ASSERT_OK(DB::Open(options, snapshot_name_, &snapshot_db));
+  ReadOptions read_opts;
+  std::string get_result;
+  ASSERT_OK(snapshot_db->Get(read_opts, "foo", &get_result));
+  ASSERT_EQ("foo_value", get_result);
+}
+
+TEST_F(CheckpointTest, CheckpointWithLockWALNoWALSameThreadAborted) {
+  WriteOptions write_options;
+  write_options.disableWAL = true;
+  ASSERT_OK(db_->Put(write_options, "foo", "foo_value"));
+  ASSERT_OK(db_->LockWAL());
+
+  Checkpoint* checkpoint = nullptr;
+  ASSERT_OK(Checkpoint::Create(db_.get(), &checkpoint));
+  std::unique_ptr<Checkpoint> checkpoint_holder(checkpoint);
+
+  Status s = checkpoint->CreateCheckpoint(snapshot_name_);
+  ASSERT_TRUE(s.IsAborted()) << s.ToString();
+  ASSERT_NE(s.ToString().find("Likely deadlock"), std::string::npos)
+      << s.ToString();
+
+  ASSERT_OK(db_->UnlockWAL());
+}
+
+TEST_F(CheckpointTest, CheckpointWithLockWALNoWALCrossThreadFlushes) {
+  Options options = CurrentOptions();
+  WriteOptions write_options;
+  write_options.disableWAL = true;
+  ASSERT_OK(db_->Put(write_options, "foo", "foo_value"));
+  ASSERT_OK(db_->LockWAL());
+
+  Checkpoint* checkpoint = nullptr;
+  ASSERT_OK(Checkpoint::Create(db_.get(), &checkpoint));
+  std::unique_ptr<Checkpoint> checkpoint_holder(checkpoint);
+
+  SyncPoint::GetInstance()->LoadDependency(
+      {{"DBImpl::WaitForPendingWrites:BeforeBlock",
+        "CheckpointTest::CheckpointWithLockWALNoWALCrossThreadFlushes:"
+        "BeforeUnlock"}});
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  std::atomic<bool> checkpoint_done{false};
+  Status checkpoint_status;
+  port::Thread checkpoint_thread([&]() {
+    checkpoint_status = checkpoint->CreateCheckpoint(snapshot_name_);
+    checkpoint_done.store(true);
+  });
+
+  TEST_SYNC_POINT(
+      "CheckpointTest::CheckpointWithLockWALNoWALCrossThreadFlushes:"
+      "BeforeUnlock");
+  const bool finished_early = checkpoint_done.load();
+  Status unlock_status = db_->UnlockWAL();
+  checkpoint_thread.join();
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->LoadDependency({});
+
+  ASSERT_OK(unlock_status);
+  ASSERT_FALSE(finished_early) << checkpoint_status.ToString();
+  ASSERT_OK(checkpoint_status);
   Close();
 
   std::unique_ptr<DB> snapshot_db;


### PR DESCRIPTION
Summary:

The failing crash-test scenario combines `disable_wal=1`, `LockWAL()`, and backup/checkpoint live-file-copy verification. A WAL-disabled write can leave a key only in the memtable. The old live-file path skipped `FlushForGetLiveFiles()` whenever `LockWAL()` was active, so the copied SST/WAL file set could omit that memtable-only key even though the original DB still served it. Restore verification could then report the key as present in the original DB but missing from the restored backup/checkpoint.

Fix live-file capture to flush unpersisted WAL-disabled data even while `LockWAL()` is active. If all data is already persisted, the path still skips the flush while WAL is locked. If unpersisted data exists, backup/checkpoint can now block behind `LockWAL()` until another thread calls `UnlockWAL()` and the flush can safely proceed.

To avoid self-deadlock, track `LockWAL()` ownership by thread with recursive counts. `UnlockWAL()` now has to be called by the same thread that successfully called `LockWAL()`, and wait=true flushes called by that same owner return `Aborted("Likely deadlock as the same thread called LockWAL()")` instead of waiting forever. Cross-thread flushes remain allowed and wait for all `LockWAL()` owners to unlock.

Also audited MyRocks and can confirm they already conform to the Lock/Unlock on same thread semantics.

Reviewed By: pdillinger

Differential Revision: D111793089


