### PR TITLE
ci: pin claude-code-base-action to a full commit SHA in ai-review-analysis.yml

### DIFF
--- a/.github/workflows/ai-review-analysis.yml
+++ b/.github/workflows/ai-review-analysis.yml
@@ -495,7 +495,7 @@ jobs:
           steps.check_existing.outputs.skip != 'true' &&
           inputs.provider == 'claude'
         id: classify_claude
-        uses: anthropics/claude-code-base-action@beta
+        uses: anthropics/claude-code-base-action@e8132bc5e637a42c27763fc757faa37e1ee43b34 # beta
         with:
           prompt_file: /tmp/complexity_prompt.txt
           model: ${{ inputs.classifier_model }}
@@ -616,7 +616,7 @@ jobs:
         env:
           MAX_THINKING_TOKENS: ${{ steps.budget_claude.outputs.tokens }}
           CLAUDE_COMPLEXITY: ${{ steps.budget_claude.outputs.label }}
-        uses: anthropics/claude-code-base-action@beta
+        uses: anthropics/claude-code-base-action@e8132bc5e637a42c27763fc757faa37e1ee43b34 # beta
         with:
           prompt_file: /tmp/prompt.txt
           model: ${{ inputs.default_model }}
@@ -656,7 +656,7 @@ jobs:
           inputs.provider == 'claude' &&
           steps.recover_claude.outputs.needs_recovery == 'true'
         id: format_recovery_claude
-        uses: anthropics/claude-code-base-action@beta
+        uses: anthropics/claude-code-base-action@e8132bc5e637a42c27763fc757faa37e1ee43b34 # beta
         with:
           prompt_file: claude_md/ci_recovery_prompt.md
           model: ${{ inputs.recovery_model }}
@@ -1086,7 +1086,7 @@ jobs:
           steps.request.outputs.type == 'review' &&
           inputs.provider == 'claude'
         id: manual_classify_claude
-        uses: anthropics/claude-code-base-action@beta
+        uses: anthropics/claude-code-base-action@e8132bc5e637a42c27763fc757faa37e1ee43b34 # beta
         with:
           prompt_file: /tmp/complexity_prompt.txt
           model: ${{ inputs.classifier_model }}
@@ -1242,7 +1242,7 @@ jobs:
         env:
           MAX_THINKING_TOKENS: ${{ steps.manual_budget_claude.outputs.tokens }}
           CLAUDE_COMPLEXITY: ${{ steps.manual_budget_claude.outputs.label }}
-        uses: anthropics/claude-code-base-action@beta
+        uses: anthropics/claude-code-base-action@e8132bc5e637a42c27763fc757faa37e1ee43b34 # beta
         with:
           prompt_file: /tmp/prompt.txt
           model: ${{ inputs.selected_model != '' && inputs.selected_model || inputs.default_model }}
@@ -1283,7 +1283,7 @@ jobs:
           inputs.provider == 'claude' &&
           steps.manual_recover_claude.outputs.needs_recovery == 'true'
         id: manual_format_recovery_claude
-        uses: anthropics/claude-code-base-action@beta
+        uses: anthropics/claude-code-base-action@e8132bc5e637a42c27763fc757faa37e1ee43b34 # beta
         with:
           prompt_file: claude_md/ci_recovery_prompt.md
           model: ${{ inputs.recovery_model }}


### PR DESCRIPTION
## What
Pin `anthropics/claude-code-base-action` in `.github/workflows/ai-review-analysis.yml` from the mutable `@beta` tag to the commit it currently resolves to (`e8132bc`), across all 6 usages.

## Why
Each of those steps passes `anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}`, and this reusable workflow is invoked from `claude-review.yml` on `pull_request_target` / `issue_comment` with `secrets: inherit`. `@beta` is a mutable lightweight tag, so the exact code that runs with those secrets can change without any change in this repo — the third-party-action supply-chain risk (tj-actions/changed-files, 2025). Pinning to a full SHA fixes the code; Dependabot can bump it as reviewed diffs. Behaviour is unchanged.

This complements the hardening already in flight in #14796, and is the concrete fix for #14936.

I used AI assistance to identify this and draft the change; I verified every line myself and take responsibility for it. (I understand this needs the Meta CLA and am signing it.)