### PR TITLE
Stress test concurrent primary and read-only DB on the same directory (#14938)

### DIFF
--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -192,6 +192,7 @@ DECLARE_bool(test_backward_scan);
 DECLARE_string(db);
 DECLARE_string(secondaries_base);
 DECLARE_bool(test_secondary);
+DECLARE_int32(open_read_only_one_in);
 DECLARE_string(expected_values_dir);
 DECLARE_int32(num_dbs);
 DECLARE_bool(expected_state_trace_debug);

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -704,6 +704,14 @@ DEFINE_bool(test_secondary, false,
             "If true, start an additional secondary instance which can be used "
             "for verification.");
 
+DEFINE_int32(open_read_only_one_in, 0,
+             "If greater than 0, on thread 0 with probability 1/N per "
+             "operation, open a read-only DB instance on the primary's live "
+             "directory, flush the primary, then close the reader. Stresses "
+             "concurrent primary + read-only DB on the same directory to guard "
+             "against a read-only DB's close deleting the primary's live SST "
+             "files. 0 disables.");
+
 DEFINE_string(
     expected_values_dir, "",
     "Dir where files containing info about the latest/historical values will "

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -1666,6 +1666,8 @@ void StressTest::OperateDb(ThreadState* thread) {
         }
       }
 
+      MaybeOpenReadOnlyOnPrimary(thread);
+
       MaybeClearOneColumnFamily(thread);
 
       if (thread->rand.OneInOpt(FLAGS_manual_wal_flush_one_in)) {
@@ -4859,6 +4861,93 @@ void StressTest::Open(SharedState* shared, bool reopen) {
             "sequence number %" PRIu64 " from last DB session\n",
             db_->GetLatestSequenceNumber(), shared->GetPersistedSeqno());
     port::ImmediateExit(1);
+  }
+}
+
+void StressTest::MaybeOpenReadOnlyOnPrimary(ThreadState* thread) {
+  assert(thread);
+  if (FLAGS_open_read_only_one_in <= 0 || thread->tid != 0 ||
+      !thread->rand.OneIn(FLAGS_open_read_only_one_in)) {
+    return;
+  }
+
+  // Snapshot the current column family names for the read-only open. Other
+  // worker threads can rename families via MaybeClearOneColumnFamily(), which
+  // writes column_family_names_[cf] while holding that family's per-CF lock, so
+  // read each name under the same lock to avoid a data race. This only builds a
+  // local descriptor list; it must not mutate any shared member state.
+  std::vector<ColumnFamilyDescriptor> cf_descriptors;
+  cf_descriptors.reserve(column_family_names_.size());
+  for (int cf = 0; cf < static_cast<int>(column_family_names_.size()); ++cf) {
+    thread->shared->LockColumnFamily(cf);
+    cf_descriptors.emplace_back(column_family_names_[cf],
+                                ColumnFamilyOptions(options_));
+    thread->shared->UnlockColumnFamily(cf);
+  }
+
+  // A read-only instance opened concurrently with the primary can trip over
+  // injected faults or files the primary mutates underneath it, so disable
+  // error injection while we open, read, and close the reader. The primary's
+  // own subsequent operations run with injection re-enabled, so a genuinely
+  // deleted live file still surfaces on the normal verification path.
+  if (db_fault_injection_fs_) {
+    db_fault_injection_fs_->DisableAllThreadLocalErrorInjection();
+  }
+
+  std::vector<ColumnFamilyHandle*> ro_cfhs;
+  std::unique_ptr<DB> ro_db;
+  // A read-only reader never compacts, so it must not share the primary's
+  // background-coordination services. Sharing the compaction service in
+  // particular would let the reader's open/close abort the primary's in-flight
+  // remote compactions, and sharing listeners would fire primary callbacks for
+  // the reader instance.
+  DBOptions read_only_db_options(options_);
+  read_only_db_options.compaction_service = nullptr;
+  read_only_db_options.listeners.clear();
+  Status s = DB::OpenForReadOnly(read_only_db_options, GetDbPath(),
+                                 cf_descriptors, &ro_cfhs, &ro_db);
+  // Opening read-only while the primary mutates the same directory is
+  // best-effort; a transient failure here is expected and not a bug.
+  if (s.ok()) {
+    // Create new SST files in the primary that are absent from the reader's
+    // frozen live-file snapshot, so that a read-only close wrongly running
+    // obsolete-file cleanup would delete these live files. Flush all column
+    // families; error injection is disabled here, so the flush is expected to
+    // succeed and any real failure is surfaced via ProcessStatus().
+    Status flush_s = db_->Flush(FlushOptions(), column_families_);
+    ProcessStatus(thread->shared, "Flush read-only-primary", flush_s);
+
+    ReadOptions read_opts;
+    std::string ts_str;
+    Slice ts;
+    if (FLAGS_user_timestamp_size > 0) {
+      ts_str = GetNowNanos();
+      ts = ts_str;
+      read_opts.timestamp = &ts;
+    }
+    std::string value;
+    for (auto* handle : ro_cfhs) {
+      // Error injection is disabled, so a read is expected to either find the
+      // key or return NotFound; any other status (for example, a missing file
+      // from a wrongly deleted live SST) is a real failure.
+      Status get_s = ro_db->Get(read_opts, handle, Key(0), &value);
+      if (!get_s.IsNotFound()) {
+        ProcessStatus(thread->shared, "Read-only Get", get_s);
+      }
+    }
+
+    // Closing the reader runs the read-only close path. If it wrongly purges
+    // obsolete files based on its stale snapshot, the primary's live files are
+    // deleted and later detected by db_stress's read/verification paths.
+    for (auto* handle : ro_cfhs) {
+      delete handle;
+    }
+    ro_cfhs.clear();
+    ro_db.reset();
+  }
+
+  if (db_fault_injection_fs_) {
+    db_fault_injection_fs_->EnableAllThreadLocalErrorInjection();
   }
 }
 

--- a/db_stress_tool/db_stress_test_base.h
+++ b/db_stress_tool/db_stress_test_base.h
@@ -465,6 +465,13 @@ class StressTest {
 
   void Reopen(ThreadState* thread);
 
+  // Periodically opens a read-only DB instance on the primary's live directory
+  // while the primary keeps writing, then closes it. Exercises the concurrent
+  // primary + read-only-DB-on-the-same-directory topology to guard against a
+  // read-only DB's close deleting the primary's live SST files. Detection
+  // relies on db_stress's existing missing-file/corruption checks.
+  void MaybeOpenReadOnlyOnPrimary(ThreadState* thread);
+
   virtual void RegisterAdditionalListeners() {}
 
   virtual void PrepareTxnDbOptions(SharedState* /*shared*/,

--- a/db_stress_tool/db_stress_tool.cc
+++ b/db_stress_tool/db_stress_tool.cc
@@ -139,7 +139,7 @@ int db_stress_tool(int argc, char** argv) {
   int env_opts = !FLAGS_env_uri.empty() + !FLAGS_fs_uri.empty();
   if (env_opts > 1) {
     fprintf(stderr, "Error: --env_uri and --fs_uri are mutually exclusive\n");
-    exit(1);
+    exit(1);  // NOLINT(concurrency-mt-unsafe)
   }
 
   Status s = Env::CreateFromUri(ConfigOptions(), FLAGS_env_uri, FLAGS_fs_uri,
@@ -147,7 +147,7 @@ int db_stress_tool(int argc, char** argv) {
   if (!s.ok()) {
     fprintf(stderr, "Error Creating Env URI: %s: %s\n", FLAGS_env_uri.c_str(),
             s.ToString().c_str());
-    exit(1);
+    exit(1);  // NOLINT(concurrency-mt-unsafe)
   }
 
   // Handle --destroy_db_and_exit early
@@ -227,20 +227,20 @@ int db_stress_tool(int argc, char** argv) {
     fprintf(stderr,
             "Error: prefixpercent is non-zero while prefix_size is "
             "not positive!\n");
-    exit(1);
+    exit(1);  // NOLINT(concurrency-mt-unsafe)
   }
   if (FLAGS_test_batches_snapshots && FLAGS_prefix_size <= 0) {
     fprintf(stderr,
             "Error: please specify prefix_size for "
             "test_batches_snapshots test!\n");
-    exit(1);
+    exit(1);  // NOLINT(concurrency-mt-unsafe)
   }
   if (FLAGS_memtable_prefix_bloom_size_ratio > 0.0 && FLAGS_prefix_size < 0 &&
       !FLAGS_memtable_whole_key_filtering) {
     fprintf(stderr,
             "Error: please specify positive prefix_size or enable whole key "
             "filtering in order to use memtable_prefix_bloom_size_ratio\n");
-    exit(1);
+    exit(1);  // NOLINT(concurrency-mt-unsafe)
   }
   if ((FLAGS_readpercent + FLAGS_prefixpercent + FLAGS_writepercent +
        FLAGS_delpercent + FLAGS_delrangepercent + FLAGS_iterpercent +
@@ -255,41 +255,41 @@ int db_stress_tool(int argc, char** argv) {
         FLAGS_readpercent, FLAGS_prefixpercent, FLAGS_writepercent,
         FLAGS_delpercent, FLAGS_delrangepercent, FLAGS_iterpercent,
         FLAGS_customopspercent);
-    exit(1);
+    exit(1);  // NOLINT(concurrency-mt-unsafe)
   }
   if (FLAGS_disable_wal == 1 && FLAGS_reopen > 0) {
     fprintf(stderr, "Error: Db cannot reopen safely with disable_wal set!\n");
-    exit(1);
+    exit(1);  // NOLINT(concurrency-mt-unsafe)
   }
   if ((unsigned)FLAGS_reopen >= FLAGS_ops_per_thread) {
     fprintf(stderr,
             "Error: #DB-reopens should be < ops_per_thread\n"
             "Provided reopens = %d and ops_per_thread = %lu\n",
             FLAGS_reopen, (unsigned long)FLAGS_ops_per_thread);
-    exit(1);
+    exit(1);  // NOLINT(concurrency-mt-unsafe)
   }
   if (FLAGS_test_batches_snapshots && FLAGS_delrangepercent > 0) {
     fprintf(stderr,
             "Error: nonzero delrangepercent unsupported in "
             "test_batches_snapshots mode\n");
-    exit(1);
+    exit(1);  // NOLINT(concurrency-mt-unsafe)
   }
   if (FLAGS_active_width > FLAGS_max_key) {
     fprintf(stderr, "Error: active_width can be at most max_key\n");
-    exit(1);
+    exit(1);  // NOLINT(concurrency-mt-unsafe)
   } else if (FLAGS_active_width == 0) {
     FLAGS_active_width = FLAGS_max_key;
   }
   if (FLAGS_value_size_mult * kRandomValueMaxFactor > kValueMaxLen) {
     fprintf(stderr, "Error: value_size_mult can be at most %d\n",
             kValueMaxLen / kRandomValueMaxFactor);
-    exit(1);
+    exit(1);  // NOLINT(concurrency-mt-unsafe)
   }
   if (FLAGS_use_merge && FLAGS_nooverwritepercent == 100) {
     fprintf(
         stderr,
         "Error: nooverwritepercent must not be 100 when using merge operands");
-    exit(1);
+    exit(1);  // NOLINT(concurrency-mt-unsafe)
   }
   if (FLAGS_enable_blob_direct_write) {
     // Blob direct write is intentionally validated as a reduced-scope stress
@@ -375,12 +375,12 @@ int db_stress_tool(int argc, char** argv) {
     fprintf(
         stderr,
         "Error: nooverwritepercent must not be 100 when using file ingestion");
-    exit(1);
+    exit(1);  // NOLINT(concurrency-mt-unsafe)
   }
   if (FLAGS_clear_column_family_one_in > 0 && FLAGS_backup_one_in > 0) {
     fprintf(stderr,
             "Error: clear_column_family_one_in must be 0 when using backup\n");
-    exit(1);
+    exit(1);  // NOLINT(concurrency-mt-unsafe)
   }
   if (FLAGS_test_cf_consistency && FLAGS_disable_wal) {
     FLAGS_atomic_flush = true;
@@ -393,7 +393,7 @@ int db_stress_tool(int argc, char** argv) {
             "Error: use_trie_index is incompatible with mmap_read. "
             "The trie index uses zero-copy pointers into block data "
             "which is unsafe with mmap'd reads.\n");
-    exit(1);
+    exit(1);  // NOLINT(concurrency-mt-unsafe)
   }
 
   // TrieIndexFactory requires plain BytewiseComparator, but timestamps use
@@ -403,19 +403,35 @@ int db_stress_tool(int argc, char** argv) {
             "Error: use_trie_index is incompatible with user-defined "
             "timestamps. TrieIndexFactory requires BytewiseComparator "
             "but timestamps use BytewiseComparator.u64ts.\n");
-    exit(1);
+    exit(1);  // NOLINT(concurrency-mt-unsafe)
   }
 
   if (FLAGS_read_only) {
     if (FLAGS_writepercent != 0 || FLAGS_delpercent != 0 ||
         FLAGS_delrangepercent != 0) {
       fprintf(stderr, "Error: updates are not supported in read only mode\n");
-      exit(1);
+      exit(1);  // NOLINT(concurrency-mt-unsafe)
     } else if (FLAGS_checkpoint_one_in > 0 &&
                FLAGS_clear_column_family_one_in > 0) {
       fprintf(stdout,
               "Warn: checkpoint won't be validated since column families may "
               "be dropped.\n");
+    }
+  }
+
+  if (FLAGS_open_read_only_one_in > 0) {
+    if (FLAGS_read_only) {
+      fprintf(stderr,
+              "Error: open_read_only_one_in needs a read-write primary and is "
+              "incompatible with read_only\n");
+      exit(1);  // NOLINT(concurrency-mt-unsafe)
+    }
+    if (FLAGS_use_txn || FLAGS_use_optimistic_txn || FLAGS_use_blob_db ||
+        FLAGS_ttl != -1) {
+      fprintf(stderr,
+              "Error: open_read_only_one_in is not supported with "
+              "transactions, BlobDB, or TTL\n");
+      exit(1);  // NOLINT(concurrency-mt-unsafe)
     }
   }
 
@@ -438,7 +454,7 @@ int db_stress_tool(int argc, char** argv) {
     if (!s.ok()) {
       fprintf(stderr, "Failed to create directory %s: %s\n", FLAGS_db.c_str(),
               s.ToString().c_str());
-      exit(1);
+      exit(1);  // NOLINT(concurrency-mt-unsafe)
     }
   }
   std::vector<std::string> db_paths;
@@ -452,7 +468,7 @@ int db_stress_tool(int argc, char** argv) {
       if (!s.ok()) {
         fprintf(stderr, "Failed to create directory %s: %s\n", ep.c_str(),
                 s.ToString().c_str());
-        exit(1);
+        exit(1);  // NOLINT(concurrency-mt-unsafe)
       }
       ev_paths.push_back(std::move(ep));
     }
@@ -475,7 +491,7 @@ int db_stress_tool(int argc, char** argv) {
     if (!s.ok()) {
       fprintf(stderr, "Failed to create directory %s: %s\n", sec_parent.c_str(),
               s.ToString().c_str());
-      exit(1);
+      exit(1);  // NOLINT(concurrency-mt-unsafe)
     }
     for (int i = 0; i < num_dbs; i++) {
       std::string suffix = (num_dbs == 1) ? "" : "/db_" + std::to_string(i);
@@ -484,7 +500,7 @@ int db_stress_tool(int argc, char** argv) {
       if (!s.ok()) {
         fprintf(stderr, "Failed to create directory %s: %s\n", sec_path.c_str(),
                 s.ToString().c_str());
-        exit(1);
+        exit(1);  // NOLINT(concurrency-mt-unsafe)
       }
       sec_paths.push_back(std::move(sec_path));
     }
@@ -498,19 +514,19 @@ int db_stress_tool(int argc, char** argv) {
     fprintf(stderr,
             "With best-efforts recovery, skip_verifydb and disable_wal "
             "should be set to true.\n");
-    exit(1);
+    exit(1);  // NOLINT(concurrency-mt-unsafe)
   }
   if (FLAGS_skip_verifydb) {
     if (FLAGS_verify_db_one_in > 0) {
       fprintf(stderr,
               "Must set -verify_db_one_in=0 if skip_verifydb is true.\n");
-      exit(1);
+      exit(1);  // NOLINT(concurrency-mt-unsafe)
     }
     if (FLAGS_continuous_verification_interval > 0) {
       fprintf(stderr,
               "Must set -continuous_verification_interval=0 if skip_verifydb "
               "is true.\n");
-      exit(1);
+      exit(1);  // NOLINT(concurrency-mt-unsafe)
     }
   }
   if ((FLAGS_enable_compaction_filter || FLAGS_inplace_update_support) &&
@@ -525,7 +541,7 @@ int db_stress_tool(int argc, char** argv) {
         "prefixpercent, test_batches_snapshots, test_cf_consistency, "
         "check_multiget_consistency, check_multiget_entity_consistency must "
         "all be 0 when using compaction filter or inplace update support\n");
-    exit(1);
+    exit(1);  // NOLINT(concurrency-mt-unsafe)
   }
   if (FLAGS_test_multi_ops_txns) {
     CheckAndSetOptionsForMultiOpsTxnStressTest();
@@ -536,24 +552,24 @@ int db_stress_tool(int argc, char** argv) {
         stderr,
         "You cannot set use_optimistic_txn true while use_txn is false. Please "
         "set use_txn true if you want to use OptimisticTransactionDB\n");
-    exit(1);
+    exit(1);  // NOLINT(concurrency-mt-unsafe)
   }
 
   if (FLAGS_create_timestamped_snapshot_one_in > 0) {
     if (!FLAGS_use_txn) {
       fprintf(stderr, "timestamped snapshot supported only in TransactionDB\n");
-      exit(1);
+      exit(1);  // NOLINT(concurrency-mt-unsafe)
     } else if (FLAGS_txn_write_policy != 0) {
       fprintf(stderr,
               "timestamped snapshot supported only in write-committed\n");
-      exit(1);
+      exit(1);  // NOLINT(concurrency-mt-unsafe)
     }
   }
 
   if (FLAGS_preserve_unverified_changes && FLAGS_reopen != 0) {
     fprintf(stderr,
             "Reopen DB is incompatible with preserving unverified changes\n");
-    exit(1);
+    exit(1);  // NOLINT(concurrency-mt-unsafe)
   }
 
   if (FLAGS_use_txn && !FLAGS_use_optimistic_txn &&
@@ -561,7 +577,7 @@ int db_stress_tool(int argc, char** argv) {
     fprintf(stderr,
             "For TransactionDB, correctness testing with unsync data loss is "
             "currently compatible with only write committed policy\n");
-    exit(1);
+    exit(1);  // NOLINT(concurrency-mt-unsafe)
   }
 
   if (FLAGS_use_put_entity_one_in > 0 &&
@@ -570,7 +586,7 @@ int db_stress_tool(int argc, char** argv) {
     fprintf(stderr,
             "Wide columns are incompatible with V1 Merge, the multi-op "
             "transaction test, and user-defined timestamps\n");
-    exit(1);
+    exit(1);  // NOLINT(concurrency-mt-unsafe)
   }
 
 #ifndef NDEBUG
@@ -589,7 +605,7 @@ int db_stress_tool(int argc, char** argv) {
       fprintf(stderr,
               "Number of weights in key_len_dist should be equal to"
               " max_key_len");
-      exit(1);
+      exit(1);  // NOLINT(concurrency-mt-unsafe)
     }
 
     uint64_t total_weight = 0;
@@ -600,7 +616,7 @@ int db_stress_tool(int argc, char** argv) {
     }
     if (total_weight != 100) {
       fprintf(stderr, "Sum of all weights in key_len_dist should be 100");
-      exit(1);
+      exit(1);  // NOLINT(concurrency-mt-unsafe)
     }
   } else {
     uint64_t keys_per_level = key_gen_ctx.window / levels;

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -665,6 +665,7 @@ simple_default_params = {
     "level_compaction_dynamic_level_bytes": lambda: random.randint(0, 1),
     "paranoid_file_checks": lambda: random.choice([0, 1, 1, 1]),
     "test_secondary": lambda: random.choice([0, 1]),
+    "open_read_only_one_in": lambda: random.choice([0, 0, 0, 16]),
 }
 
 blackbox_simple_default_params = {
@@ -1539,6 +1540,15 @@ def finalize_and_sanitize(src_params):
     # Continuous verification fails with secondaries inside NonBatchedOpsStressTest
     if dest_params.get("test_secondary") == 1:
         dest_params["continuous_verification_interval"] = 0
+    # Opening a read-only DB on the primary's directory needs a plain read-write
+    # primary; it is not wired up for transactions, BlobDB, or TTL DBs.
+    if (
+        dest_params.get("use_txn", 0) == 1
+        or dest_params.get("use_optimistic_txn", 0) == 1
+        or dest_params.get("use_blob_db", 0) == 1
+        or dest_params.get("ttl", -1) != -1
+    ):
+        dest_params["open_read_only_one_in"] = 0
     if dest_params.get("use_multiscan") == 1:
         dest_params["async_io"] = 0
         dest_params["delpercent"] += dest_params["delrangepercent"]


### PR DESCRIPTION
Summary:

Adds db_stress coverage for the topology where a read-only DB (`DB::OpenForReadOnly`) is opened on the same directory as a live read-write primary. This interaction was previously untested: `FLAGS_read_only` runs a DB by itself in read-only mode (no live writer), and `FLAGS_test_secondary` co-locates a secondary that tails the MANIFEST and never owns/deletes files, so neither exercises a read-only instance holding a stale live-file snapshot while the primary keeps creating files. That gap allowed a bug where a read-only DB's close ran obsolete-file cleanup against its stale snapshot and deleted the primary's live SST files.

New flag `open_read_only_one_in=N`: on thread 0, with probability 1/N per operation, open a read-only instance on the primary's live directory, flush the primary (so new SSTs exist that are absent from the reader's frozen snapshot), do a few reads, then close the reader. If the read-only close wrongly purges obsolete files, the primary's live files are deleted and surface through db_stress's existing missing-file/corruption detection (deterministically on the next reopen).

The read-only reader is opened with the primary's options (so it inherits the table factory, e.g. UDI) but with `compaction_service` and `listeners` cleared, since a read-only reader never compacts and must not share the primary's background-coordination services -- otherwise the reader's open/close would abort the primary's in-flight remote compactions.

`db_crashtest.py` enables the mode randomly and excludes configurations it does not support (transactions, BlobDB, TTL, and the blob-direct-write profile). Startup validation in `db_stress_tool.cc` rejects those same combinations when the flag is set directly.

Reviewed By: joshkang97

Differential Revision: D111995911


