### PR TITLE
Tolerate remote IO errors in db_stress crash test and db_bench (#14942)

### DIFF
--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -1092,6 +1092,13 @@ DEFINE_string(fs_uri, "",
               " with --env_uri."
               " Creates a default environment with the specified filesystem.");
 
+DEFINE_bool(
+    tolerate_non_injected_io_errors_for_remote_dbs, false,
+    "Treat non-injected, non-data-loss IO errors as retryable. Intended "
+    "only for remote DBs (--env_uri / --fs_uri) where infrastructure "
+    "can return transient IO errors; db_crashtest.py forces it off for "
+    "local DBs so real local IO errors are not masked.");
+
 DEFINE_uint64(ops_per_thread, 1200000, "Number of operations per thread.");
 static const bool FLAGS_ops_per_thread_dummy __attribute__((__unused__)) =
     RegisterFlagValidator(&FLAGS_ops_per_thread, &ValidateUint32Range);

--- a/db_stress_tool/db_stress_shared_state.h
+++ b/db_stress_tool/db_stress_shared_state.h
@@ -44,6 +44,7 @@ DECLARE_int32(open_write_fault_one_in);
 DECLARE_int32(open_read_fault_one_in);
 
 DECLARE_int32(inject_error_severity);
+DECLARE_bool(tolerate_non_injected_io_errors_for_remote_dbs);
 DECLARE_bool(disable_auto_compactions);
 DECLARE_bool(enable_compaction_filter);
 

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -379,6 +379,17 @@ void WriteDataCorruption(uint32_t thread_id, int cf, int64_t key,
 
 }  // namespace
 
+bool StressTest::IsErrorInjectedAndRetryable(const Status& error_s) {
+  assert(!error_s.ok());
+  const IOStatus io_s = status_to_io_status(Status(error_s));
+  return !io_s.GetDataLoss() &&
+         ((error_s.getState() &&
+           FaultInjectionTestFS::IsInjectedError(error_s)) ||
+          (FLAGS_tolerate_non_injected_io_errors_for_remote_dbs &&
+           (!FLAGS_env_uri.empty() || !FLAGS_fs_uri.empty()) &&
+           error_s.IsIOError()));
+}
+
 const std::string& StressTest::GetDbLabel() const { return db_label_; }
 
 const std::string& StressTest::GetDbPath() const { return db_path_; }

--- a/db_stress_tool/db_stress_test_base.h
+++ b/db_stress_tool/db_stress_test_base.h
@@ -29,12 +29,18 @@ using experimental::SstQueryFilterConfigsManager;
 
 class StressTest {
  public:
-  static bool IsErrorInjectedAndRetryable(const Status& error_s) {
-    assert(!error_s.ok());
-    return error_s.getState() &&
-           FaultInjectionTestFS::IsInjectedError(error_s) &&
-           !status_to_io_status(Status(error_s)).GetDataLoss();
-  }
+  // Returns true if `error_s` should be treated as retryable rather than a real
+  // failure. Covers injected fault-injection errors, and -- despite the name --
+  // also non-injected IO errors, but only when a remote backend (--env_uri /
+  // --fs_uri) is in use and --tolerate_non_injected_io_errors_for_remote_dbs is
+  // set (infrastructure behind a remote backend can return transient IO
+  // errors). Gating on a remote backend guarantees non-injected IO errors on
+  // local DBs are never masked. Data-loss errors are never retryable.
+  //
+  // Defined out-of-line in db_stress_test_base.cc: it reads FLAGS_env_uri /
+  // FLAGS_fs_uri, which db_stress_common.h declares only after it includes this
+  // header, so they are not visible here.
+  static bool IsErrorInjectedAndRetryable(const Status& error_s);
 
   static bool IsTolerableCompactionFailure(const Status& s) {
     // TOOD (hx235): allow an exact list of tolerable failures under stress

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -55,6 +55,7 @@
 #include "rocksdb/env.h"
 #include "rocksdb/filter_policy.h"
 #include "rocksdb/io_dispatcher.h"
+#include "rocksdb/io_status.h"
 #include "rocksdb/memtablerep.h"
 #include "rocksdb/options.h"
 #include "rocksdb/perf_context.h"
@@ -1412,6 +1413,16 @@ DEFINE_uint32(min_tombstones_for_range_conversion,
 DEFINE_bool(verify_compression, false,
             "See BlockBasedTableOptions::verify_compression");
 
+DEFINE_bool(
+    tolerate_io_errors_for_remote_dbs, false,
+    "If true, a non-data-loss IO error surfaced by a benchmark "
+    "operation ends the run gracefully with an INVALID result instead "
+    "of aborting the process. Only takes effect when a remote backend "
+    "(--env_uri / --fs_uri) is in use, so IO errors on local DBs are never "
+    "masked. Intended for remote storage backends that can return transient "
+    "infrastructure IO errors, where a crashed process is worse than an "
+    "invalidated run. Data-loss errors are never tolerated.");
+
 ROCKSDB_NAMESPACE::ToolHooks* hooks_ = nullptr;
 // db_bench_exit() ultimately calls exit() (directly or via ToolHooks::Exit),
 // which runs atexit handlers and C++ static/global destructors. That is only
@@ -2084,6 +2095,21 @@ static Status CreateMemTableRepFactory(
     }
   }
   return s;
+}
+
+// Returns true when `s` is an IO error that db_bench has been asked to tolerate
+// via --tolerate_io_errors_for_remote_dbs, but only when a remote backend
+// (--env_uri /
+// --fs_uri) is in use. Gating on a remote backend guarantees IO errors on local
+// DBs are never masked. Data-loss errors are never tolerated because they
+// indicate corruption rather than a transient infrastructure failure. Lets the
+// benchmark end gracefully with an invalid result against remote storage that
+// can return transient IO errors, instead of crashing the whole process.
+static bool IsTolerableIOError(const Status& s) {
+  assert(!s.ok());
+  return FLAGS_tolerate_io_errors_for_remote_dbs &&
+         (!FLAGS_env_uri.empty() || !FLAGS_fs_uri.empty()) && s.IsIOError() &&
+         !status_to_io_status(Status(s)).GetDataLoss();
 }
 
 }  // namespace
@@ -3104,6 +3130,26 @@ struct SharedState {
 
 // Convenience alias so call sites can keep referring to `Duration`.
 using Duration = SharedState::Duration;
+
+// Handles an IO error surfaced by a benchmark op running on a worker thread.
+// `context` is logged and reused as the fatal message prefix.
+//
+// With --tolerate_io_errors_for_remote_dbs a non-data-loss IO error is recorded
+// as fatal so the run unwinds and shuts down gracefully, reporting the
+// benchmark result as INVALID instead of aborting the process; the caller
+// should then `return` out of its op. Without the flag (the default) it aborts,
+// which yields a core dump for local debugging. Data-loss errors are never
+// tolerated. Intended for remote storage backends that can return transient
+// infrastructure IO errors, where a crashed process is worse than an
+// invalidated run.
+static void HandleBenchmarkIOError(SharedState* shared, const Status& s,
+                                   const char* context) {
+  fprintf(stderr, "%s: %s\n", context, s.ToString().c_str());
+  if (!IsTolerableIOError(s)) {
+    abort();
+  }
+  shared->SetFatal(s, std::string(context) + "; benchmark result is INVALID");
+}
 
 // Per-thread state for concurrent executions of the same benchmark.
 struct ThreadState {
@@ -6986,8 +7032,8 @@ class Benchmark {
         found++;
         bytes += key.size() + pinnable_val.size();
       } else if (!s.IsNotFound()) {
-        fprintf(stderr, "Get returned an error: %s\n", s.ToString().c_str());
-        abort();
+        HandleBenchmarkIOError(thread->shared, s, "Get returned an error");
+        return;
       }
 
       if (thread->shared->read_rate_limiter.get() != nullptr &&
@@ -7074,9 +7120,9 @@ class Benchmark {
         if (status.ok()) {
           ++found;
         } else if (!status.IsNotFound()) {
-          fprintf(stderr, "Get returned an error: %s\n",
-                  status.ToString().c_str());
-          abort();
+          HandleBenchmarkIOError(thread->shared, status,
+                                 "Get returned an error");
+          return;
         }
         if (key_rand >= FLAGS_num) {
           ++nonexist;
@@ -7215,8 +7261,8 @@ class Benchmark {
           pinnable_vals[i].Reset();
         }
       } else if (!s.IsNotFound()) {
-        fprintf(stderr, "Get returned an error: %s\n", s.ToString().c_str());
-        abort();
+        HandleBenchmarkIOError(thread->shared, s, "Get returned an error");
+        return;
       }
 
       if (thread->shared->read_rate_limiter.get() != nullptr &&
@@ -7294,9 +7340,9 @@ class Benchmark {
             bytes += keys[i].size() + values[i].size() + user_timestamp_size_;
             ++found;
           } else if (!statuses[i].IsNotFound()) {
-            fprintf(stderr, "MultiGet returned an error: %s\n",
-                    statuses[i].ToString().c_str());
-            abort();
+            HandleBenchmarkIOError(thread->shared, statuses[i],
+                                   "MultiGet returned an error");
+            return;
           }
         }
       } else {
@@ -7311,9 +7357,9 @@ class Benchmark {
                 keys[i].size() + pin_values[i].size() + user_timestamp_size_;
             ++found;
           } else if (!stat_list[i].IsNotFound()) {
-            fprintf(stderr, "MultiGet returned an error: %s\n",
-                    stat_list[i].ToString().c_str());
-            abort();
+            HandleBenchmarkIOError(thread->shared, stat_list[i],
+                                   "MultiGet returned an error");
+            return;
           }
           stat_list[i] = Status::OK();
           pin_values[i].Reset();
@@ -8018,8 +8064,8 @@ class Benchmark {
           get_found++;
           bytes += key.size() + pinnable_val.size();
         } else if (!s.IsNotFound()) {
-          fprintf(stderr, "Get returned an error: %s\n", s.ToString().c_str());
-          abort();
+          HandleBenchmarkIOError(thread->shared, s, "Get returned an error");
+          return;
         }
 
         if (thread->shared->read_rate_limiter && (gets + seek) % 100 == 0) {
@@ -8547,7 +8593,14 @@ class Benchmark {
       } else if (!iter->status().ok()) {
         fprintf(stderr, "Iterator error: %s\n",
                 iter->status().ToString().c_str());
-        abort();
+        if (!IsTolerableIOError(iter->status())) {
+          abort();
+        }
+        // Tolerated IO error: record it as fatal (result INVALID) and stop
+        // scanning so the iterator below is deleted and RunBenchmark shuts
+        // down gracefully.
+        thread->shared->SetFatal(iter->status(), "BGScan iterator error");
+        break;
       } else {
         iter->Next();
         num_next++;
@@ -8858,9 +8911,8 @@ class Benchmark {
         ++found;
         bytes += key.size() + value.size() + user_timestamp_size_;
       } else if (!status.IsNotFound()) {
-        fprintf(stderr, "Get returned an error: %s\n",
-                status.ToString().c_str());
-        abort();
+        HandleBenchmarkIOError(thread->shared, status, "Get returned an error");
+        return;
       }
 
       if (thread->shared->write_rate_limiter) {
@@ -8993,9 +9045,8 @@ class Benchmark {
         ++found;
         bytes += key.size() + value.size() + user_timestamp_size_;
       } else if (!status.IsNotFound()) {
-        fprintf(stderr, "Get returned an error: %s\n",
-                status.ToString().c_str());
-        abort();
+        HandleBenchmarkIOError(thread->shared, status, "Get returned an error");
+        return;
       } else {
         // If not existing, then just assume an empty string of data
         value.clear();

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -206,6 +206,7 @@ default_params = {
     "flush_one_in": lambda: random.choice([1000, 1000000]),
     "manual_wal_flush_one_in": lambda: random.choice([0, 1000]),
     "sync_wal_one_in": 0,
+    "tolerate_non_injected_io_errors_for_remote_dbs": 0,
     "file_checksum_impl": lambda: random.choice(["none", "crc32c", "xxh64", "big"]),
     "get_live_files_apis_one_in": lambda: random.choice([10000, 1000000]),
     "checkpoint_atomic_flush": lambda: random.choice([0, 1]),
@@ -975,6 +976,11 @@ def finalize_and_sanitize(src_params):
     # remote --env_uri / --fs_uri is in use.
     if is_remote_db:
         dest_params["enable_blob_direct_write"] = 0
+    
+    # Not to accidentally ignore errors on local dbs
+    # (e.g. errors on IO Uring would be categorized as IO error)
+    if not is_remote_db:
+        dest_params["tolerate_non_injected_io_errors_for_remote_dbs"] = 0
 
     if dest_params.get("enable_blob_direct_write", 0) == 1:
         # Keep blob direct write in its reduced-scope crash-test profile.

--- a/tools/db_crashtest_test.py
+++ b/tools/db_crashtest_test.py
@@ -331,12 +331,47 @@ class DBCrashTestTest(unittest.TestCase):
             {
                 "num_dbs": 1,
                 "clear_column_family_one_in": 10,
+                "tolerate_non_injected_io_errors_for_remote_dbs": 0,
             },
         )
 
         finalized = db_crashtest.finalize_and_sanitize(params)
 
         self.assertEqual(10, finalized["clear_column_family_one_in"])
+        self.assertEqual(0, finalized["tolerate_non_injected_io_errors_for_remote_dbs"])
+
+    def test_finalize_tolerates_non_injected_io_errors_for_remote_db(self):
+        db_crashtest = self.load_db_crashtest()
+        db_crashtest.is_remote_db = True
+        params = self.build_params(
+            db_crashtest.default_params,
+            {
+                "enable_blob_direct_write": 1,
+                "tolerate_non_injected_io_errors_for_remote_dbs": 1,
+            },
+        )
+
+        finalized = db_crashtest.finalize_and_sanitize(params)
+
+        self.assertEqual(0, finalized["enable_blob_direct_write"])
+        # Remote DBs keep the caller-provided value; it is not overridden.
+        self.assertEqual(1, finalized["tolerate_non_injected_io_errors_for_remote_dbs"])
+
+    def test_finalize_disables_tolerate_non_injected_io_errors_for_local_db(self):
+        db_crashtest = self.load_db_crashtest()
+        db_crashtest.is_remote_db = False
+        params = self.build_params(
+            db_crashtest.default_params,
+            {
+                "tolerate_non_injected_io_errors_for_remote_dbs": 1,
+            },
+        )
+
+        finalized = db_crashtest.finalize_and_sanitize(params)
+
+        # Local DBs must never tolerate IO errors, even if requested, so genuine
+        # local IO errors (e.g. io_uring failures) are not silently masked.
+        self.assertEqual(0, finalized["tolerate_non_injected_io_errors_for_remote_dbs"])
 
     def test_build_out_of_space_diagnostics_summarizes_directory_suffixes(self):
         db_crashtest = self.load_db_crashtest()


### PR DESCRIPTION
Summary:

Remote storage reached over `--env_uri` / `--fs_uri` (e.g. Warm Storage) can surface transient infrastructure IO errors that are unrelated to any RocksDB bug. Previously such an error would take down the test/benchmark process, making remote runs unusable. This diff lets both `db_stress` and `db_bench` tolerate non-data-loss IO errors, behind default-off flags that only take effect against a remote backend, so local behavior is unchanged and local IO errors are never masked.

**db_stress:** Add a default-off flag `--tolerate_non_injected_io_errors_for_remote_dbs` that treats non-injected, non-data-loss IO errors as retryable, so remote infrastructure errors do not fail the stress harness through `SharedState::SafeTerminate()`. `IsErrorInjectedAndRetryable` enforces at the binary level that this only applies when a remote backend (`--env_uri` / `--fs_uri`) is in use; `db_crashtest.py` additionally force-disables it for local DBs. Remote crash-test jobs opt in by passing the flag on the command line (see the companion Tupperware config change).

**db_bench:** Add a default-off flag `--tolerate_io_errors_for_remote_dbs`. When set and a remote backend (`--env_uri` / `--fs_uri`) is in use, a non-data-loss IO error surfaced by a benchmark operation ends the run gracefully with an INVALID result through the existing cooperative shutdown path (`SharedState::SetFatal`) instead of calling `abort()` (which previously produced a `Received signal 6 (Aborted)` process crash). All read `Get` / `MultiGet` abort sites and the `BGScan` iterator-error site are routed through a shared `HandleBenchmarkIOError` helper; IO errors on local DBs and data-loss errors are never tolerated. With the flag off (default), the original `abort()` behavior is preserved so local runs still produce a core dump for debugging.

Reviewed By: anand1976

Differential Revision: D112136438


