### PR TITLE
Break include cycle between db.h and multi_scan.h

### DIFF
--- a/include/rocksdb/multi_scan.h
+++ b/include/rocksdb/multi_scan.h
@@ -5,11 +5,13 @@
 
 #pragma once
 
-#include "rocksdb/db.h"
 #include "rocksdb/iterator.h"
 #include "rocksdb/options.h"
 
 namespace ROCKSDB_NAMESPACE {
+
+class ColumnFamilyHandle;
+class DB;
 
 // EXPERIMENTAL
 //


### PR DESCRIPTION
db.h includes multi_scan.h for the inline NewMultiScan(), which needs the complete MultiScan type. multi_scan.h includes db.h back, but only uses DB and ColumnFamilyHandle as pointers and never calls a member inline, so forward declarations are sufficient.
db.h is the only file in the tree that includes multi_scan.h, so the reverse include was already a no-op there. db/multi_scan.cc, the only code that dereferences DB, includes rocksdb/db.h directly and is unaffected.
No functional change.
Found while running my open-source architecture checker ([archcheck](https://github.com/blurman-ai/archcheck)) over the RocksDB include graph.
CLA: I have completed the Contributor License Agreement.