### PR TITLE
Add shared backup/checkpoint option bases [1/4] (#14945)

### DIFF
--- a/c_api_gen/c_generated_metadata_structs_auto.cc.inc
+++ b/c_api_gen/c_generated_metadata_structs_auto.cc.inc
@@ -478,6 +478,17 @@ uint64_t rocksdb_compaction_file_info_oldest_blob_file_number(
 
 /* BlobFileAdditionInfo */
 
+const char* rocksdb_blob_file_addition_info_blob_file_path(
+    const rocksdb_blob_file_addition_info_t* info, size_t* size) {
+  *size = info->rep.blob_file_path.size();
+  return info->rep.blob_file_path.data();
+}
+
+uint64_t rocksdb_blob_file_addition_info_blob_file_number(
+    const rocksdb_blob_file_addition_info_t* info) {
+  return info->rep.blob_file_number;
+}
+
 uint64_t rocksdb_blob_file_addition_info_total_blob_count(
     const rocksdb_blob_file_addition_info_t* info) {
   return info->rep.total_blob_count;
@@ -489,6 +500,17 @@ uint64_t rocksdb_blob_file_addition_info_total_blob_bytes(
 }
 
 /* BlobFileGarbageInfo */
+
+const char* rocksdb_blob_file_garbage_info_blob_file_path(
+    const rocksdb_blob_file_garbage_info_t* info, size_t* size) {
+  *size = info->rep.blob_file_path.size();
+  return info->rep.blob_file_path.data();
+}
+
+uint64_t rocksdb_blob_file_garbage_info_blob_file_number(
+    const rocksdb_blob_file_garbage_info_t* info) {
+  return info->rep.blob_file_number;
+}
 
 uint64_t rocksdb_blob_file_garbage_info_garbage_blob_count(
     const rocksdb_blob_file_garbage_info_t* info) {

--- a/c_api_gen/c_generated_metadata_structs_auto.h.inc
+++ b/c_api_gen/c_generated_metadata_structs_auto.h.inc
@@ -342,6 +342,14 @@ rocksdb_compaction_file_info_oldest_blob_file_number(
 
 /* BlobFileAdditionInfo */
 
+extern ROCKSDB_LIBRARY_API const char*
+rocksdb_blob_file_addition_info_blob_file_path(
+    const rocksdb_blob_file_addition_info_t* info, size_t* size);
+
+extern ROCKSDB_LIBRARY_API uint64_t
+rocksdb_blob_file_addition_info_blob_file_number(
+    const rocksdb_blob_file_addition_info_t* info);
+
 extern ROCKSDB_LIBRARY_API uint64_t
 rocksdb_blob_file_addition_info_total_blob_count(
     const rocksdb_blob_file_addition_info_t* info);
@@ -351,6 +359,14 @@ rocksdb_blob_file_addition_info_total_blob_bytes(
     const rocksdb_blob_file_addition_info_t* info);
 
 /* BlobFileGarbageInfo */
+
+extern ROCKSDB_LIBRARY_API const char*
+rocksdb_blob_file_garbage_info_blob_file_path(
+    const rocksdb_blob_file_garbage_info_t* info, size_t* size);
+
+extern ROCKSDB_LIBRARY_API uint64_t
+rocksdb_blob_file_garbage_info_blob_file_number(
+    const rocksdb_blob_file_garbage_info_t* info);
 
 extern ROCKSDB_LIBRARY_API uint64_t
 rocksdb_blob_file_garbage_info_garbage_blob_count(

--- a/c_api_gen/c_generated_option_structs_auto.cc.inc
+++ b/c_api_gen/c_generated_option_structs_auto.cc.inc
@@ -2703,6 +2703,36 @@ uint64_t rocksdb_fifo_compaction_options_get_trivial_copy_buffer_size(
 
 /* BackupEngineOptions */
 
+void rocksdb_backup_engine_options_set_io_buffer_size(
+    rocksdb_backup_engine_options_t* opt, uint64_t v) {
+  opt->rep.io_buffer_size = v;
+}
+
+uint64_t rocksdb_backup_engine_options_get_io_buffer_size(
+    rocksdb_backup_engine_options_t* opt) {
+  return opt->rep.io_buffer_size;
+}
+
+void rocksdb_backup_engine_options_set_backup_rate_limit(
+    rocksdb_backup_engine_options_t* opt, uint64_t v) {
+  opt->rep.backup_rate_limit = v;
+}
+
+uint64_t rocksdb_backup_engine_options_get_backup_rate_limit(
+    rocksdb_backup_engine_options_t* opt) {
+  return opt->rep.backup_rate_limit;
+}
+
+void rocksdb_backup_engine_options_set_max_background_operations(
+    rocksdb_backup_engine_options_t* opt, int v) {
+  opt->rep.max_background_operations = v;
+}
+
+int rocksdb_backup_engine_options_get_max_background_operations(
+    rocksdb_backup_engine_options_t* opt) {
+  return opt->rep.max_background_operations;
+}
+
 void rocksdb_backup_engine_options_set_backup_dir(
     rocksdb_backup_engine_options_t* opt, const char* v) {
   opt->rep.backup_dir = v;
@@ -2754,26 +2784,6 @@ unsigned char rocksdb_backup_engine_options_get_backup_log_files(
   return opt->rep.backup_log_files;
 }
 
-void rocksdb_backup_engine_options_set_io_buffer_size(
-    rocksdb_backup_engine_options_t* opt, uint64_t v) {
-  opt->rep.io_buffer_size = v;
-}
-
-uint64_t rocksdb_backup_engine_options_get_io_buffer_size(
-    rocksdb_backup_engine_options_t* opt) {
-  return opt->rep.io_buffer_size;
-}
-
-void rocksdb_backup_engine_options_set_backup_rate_limit(
-    rocksdb_backup_engine_options_t* opt, uint64_t v) {
-  opt->rep.backup_rate_limit = v;
-}
-
-uint64_t rocksdb_backup_engine_options_get_backup_rate_limit(
-    rocksdb_backup_engine_options_t* opt) {
-  return opt->rep.backup_rate_limit;
-}
-
 void rocksdb_backup_engine_options_set_restore_rate_limit(
     rocksdb_backup_engine_options_t* opt, uint64_t v) {
   opt->rep.restore_rate_limit = v;
@@ -2792,16 +2802,6 @@ void rocksdb_backup_engine_options_set_share_files_with_checksum(
 unsigned char rocksdb_backup_engine_options_get_share_files_with_checksum(
     rocksdb_backup_engine_options_t* opt) {
   return opt->rep.share_files_with_checksum;
-}
-
-void rocksdb_backup_engine_options_set_max_background_operations(
-    rocksdb_backup_engine_options_t* opt, int v) {
-  opt->rep.max_background_operations = v;
-}
-
-int rocksdb_backup_engine_options_get_max_background_operations(
-    rocksdb_backup_engine_options_t* opt) {
-  return opt->rep.max_background_operations;
 }
 
 void rocksdb_backup_engine_options_set_callback_trigger_interval_size(
@@ -2858,16 +2858,6 @@ rocksdb_backup_engine_options_get_current_temperatures_override_manifest(
 
 /* CreateBackupOptions */
 
-void rocksdb_create_backup_options_set_flush_before_backup(
-    rocksdb_create_backup_options_t* opt, unsigned char v) {
-  opt->rep.flush_before_backup = v;
-}
-
-unsigned char rocksdb_create_backup_options_get_flush_before_backup(
-    rocksdb_create_backup_options_t* opt) {
-  return opt->rep.flush_before_backup;
-}
-
 void rocksdb_create_backup_options_set_decrease_background_thread_cpu_priority(
     rocksdb_create_backup_options_t* opt, unsigned char v) {
   opt->rep.decrease_background_thread_cpu_priority = v;
@@ -2888,6 +2878,16 @@ void rocksdb_create_backup_options_set_background_thread_cpu_priority(
 int rocksdb_create_backup_options_get_background_thread_cpu_priority(
     rocksdb_create_backup_options_t* opt) {
   return static_cast<int>(opt->rep.background_thread_cpu_priority);
+}
+
+void rocksdb_create_backup_options_set_flush_before_backup(
+    rocksdb_create_backup_options_t* opt, unsigned char v) {
+  opt->rep.flush_before_backup = v;
+}
+
+unsigned char rocksdb_create_backup_options_get_flush_before_backup(
+    rocksdb_create_backup_options_t* opt) {
+  return opt->rep.flush_before_backup;
 }
 
 void rocksdb_create_backup_options_set_atomic_flush(

--- a/c_api_gen/c_generated_option_structs_auto.h.inc
+++ b/c_api_gen/c_generated_option_structs_auto.h.inc
@@ -1313,6 +1313,30 @@ rocksdb_fifo_compaction_options_get_trivial_copy_buffer_size(
 
 /* BackupEngineOptions */
 
+extern ROCKSDB_LIBRARY_API void
+rocksdb_backup_engine_options_set_io_buffer_size(
+    rocksdb_backup_engine_options_t* opt, uint64_t v);
+
+extern ROCKSDB_LIBRARY_API uint64_t
+rocksdb_backup_engine_options_get_io_buffer_size(
+    rocksdb_backup_engine_options_t* opt);
+
+extern ROCKSDB_LIBRARY_API void
+rocksdb_backup_engine_options_set_backup_rate_limit(
+    rocksdb_backup_engine_options_t* opt, uint64_t v);
+
+extern ROCKSDB_LIBRARY_API uint64_t
+rocksdb_backup_engine_options_get_backup_rate_limit(
+    rocksdb_backup_engine_options_t* opt);
+
+extern ROCKSDB_LIBRARY_API void
+rocksdb_backup_engine_options_set_max_background_operations(
+    rocksdb_backup_engine_options_t* opt, int v);
+
+extern ROCKSDB_LIBRARY_API int
+rocksdb_backup_engine_options_get_max_background_operations(
+    rocksdb_backup_engine_options_t* opt);
+
 extern ROCKSDB_LIBRARY_API void rocksdb_backup_engine_options_set_backup_dir(
     rocksdb_backup_engine_options_t* opt, const char* v);
 
@@ -1351,22 +1375,6 @@ rocksdb_backup_engine_options_get_backup_log_files(
     rocksdb_backup_engine_options_t* opt);
 
 extern ROCKSDB_LIBRARY_API void
-rocksdb_backup_engine_options_set_io_buffer_size(
-    rocksdb_backup_engine_options_t* opt, uint64_t v);
-
-extern ROCKSDB_LIBRARY_API uint64_t
-rocksdb_backup_engine_options_get_io_buffer_size(
-    rocksdb_backup_engine_options_t* opt);
-
-extern ROCKSDB_LIBRARY_API void
-rocksdb_backup_engine_options_set_backup_rate_limit(
-    rocksdb_backup_engine_options_t* opt, uint64_t v);
-
-extern ROCKSDB_LIBRARY_API uint64_t
-rocksdb_backup_engine_options_get_backup_rate_limit(
-    rocksdb_backup_engine_options_t* opt);
-
-extern ROCKSDB_LIBRARY_API void
 rocksdb_backup_engine_options_set_restore_rate_limit(
     rocksdb_backup_engine_options_t* opt, uint64_t v);
 
@@ -1380,14 +1388,6 @@ rocksdb_backup_engine_options_set_share_files_with_checksum(
 
 extern ROCKSDB_LIBRARY_API unsigned char
 rocksdb_backup_engine_options_get_share_files_with_checksum(
-    rocksdb_backup_engine_options_t* opt);
-
-extern ROCKSDB_LIBRARY_API void
-rocksdb_backup_engine_options_set_max_background_operations(
-    rocksdb_backup_engine_options_t* opt, int v);
-
-extern ROCKSDB_LIBRARY_API int
-rocksdb_backup_engine_options_get_max_background_operations(
     rocksdb_backup_engine_options_t* opt);
 
 extern ROCKSDB_LIBRARY_API void
@@ -1432,14 +1432,6 @@ rocksdb_backup_engine_options_get_current_temperatures_override_manifest(
 /* CreateBackupOptions */
 
 extern ROCKSDB_LIBRARY_API void
-rocksdb_create_backup_options_set_flush_before_backup(
-    rocksdb_create_backup_options_t* opt, unsigned char v);
-
-extern ROCKSDB_LIBRARY_API unsigned char
-rocksdb_create_backup_options_get_flush_before_backup(
-    rocksdb_create_backup_options_t* opt);
-
-extern ROCKSDB_LIBRARY_API void
 rocksdb_create_backup_options_set_decrease_background_thread_cpu_priority(
     rocksdb_create_backup_options_t* opt, unsigned char v);
 
@@ -1453,6 +1445,14 @@ rocksdb_create_backup_options_set_background_thread_cpu_priority(
 
 extern ROCKSDB_LIBRARY_API int
 rocksdb_create_backup_options_get_background_thread_cpu_priority(
+    rocksdb_create_backup_options_t* opt);
+
+extern ROCKSDB_LIBRARY_API void
+rocksdb_create_backup_options_set_flush_before_backup(
+    rocksdb_create_backup_options_t* opt, unsigned char v);
+
+extern ROCKSDB_LIBRARY_API unsigned char
+rocksdb_create_backup_options_get_flush_before_backup(
     rocksdb_create_backup_options_t* opt);
 
 extern ROCKSDB_LIBRARY_API void rocksdb_create_backup_options_set_atomic_flush(

--- a/db/c.cc
+++ b/db/c.cc
@@ -5289,6 +5289,17 @@ uint64_t rocksdb_compaction_file_info_oldest_blob_file_number(
 
 /* BlobFileAdditionInfo */
 
+const char* rocksdb_blob_file_addition_info_blob_file_path(
+    const rocksdb_blob_file_addition_info_t* info, size_t* size) {
+  *size = info->rep.blob_file_path.size();
+  return info->rep.blob_file_path.data();
+}
+
+uint64_t rocksdb_blob_file_addition_info_blob_file_number(
+    const rocksdb_blob_file_addition_info_t* info) {
+  return info->rep.blob_file_number;
+}
+
 uint64_t rocksdb_blob_file_addition_info_total_blob_count(
     const rocksdb_blob_file_addition_info_t* info) {
   return info->rep.total_blob_count;
@@ -5300,6 +5311,17 @@ uint64_t rocksdb_blob_file_addition_info_total_blob_bytes(
 }
 
 /* BlobFileGarbageInfo */
+
+const char* rocksdb_blob_file_garbage_info_blob_file_path(
+    const rocksdb_blob_file_garbage_info_t* info, size_t* size) {
+  *size = info->rep.blob_file_path.size();
+  return info->rep.blob_file_path.data();
+}
+
+uint64_t rocksdb_blob_file_garbage_info_blob_file_number(
+    const rocksdb_blob_file_garbage_info_t* info) {
+  return info->rep.blob_file_number;
+}
 
 uint64_t rocksdb_blob_file_garbage_info_garbage_blob_count(
     const rocksdb_blob_file_garbage_info_t* info) {
@@ -11651,6 +11673,36 @@ uint64_t rocksdb_fifo_compaction_options_get_trivial_copy_buffer_size(
 
 /* BackupEngineOptions */
 
+void rocksdb_backup_engine_options_set_io_buffer_size(
+    rocksdb_backup_engine_options_t* opt, uint64_t v) {
+  opt->rep.io_buffer_size = v;
+}
+
+uint64_t rocksdb_backup_engine_options_get_io_buffer_size(
+    rocksdb_backup_engine_options_t* opt) {
+  return opt->rep.io_buffer_size;
+}
+
+void rocksdb_backup_engine_options_set_backup_rate_limit(
+    rocksdb_backup_engine_options_t* opt, uint64_t v) {
+  opt->rep.backup_rate_limit = v;
+}
+
+uint64_t rocksdb_backup_engine_options_get_backup_rate_limit(
+    rocksdb_backup_engine_options_t* opt) {
+  return opt->rep.backup_rate_limit;
+}
+
+void rocksdb_backup_engine_options_set_max_background_operations(
+    rocksdb_backup_engine_options_t* opt, int v) {
+  opt->rep.max_background_operations = v;
+}
+
+int rocksdb_backup_engine_options_get_max_background_operations(
+    rocksdb_backup_engine_options_t* opt) {
+  return opt->rep.max_background_operations;
+}
+
 void rocksdb_backup_engine_options_set_backup_dir(
     rocksdb_backup_engine_options_t* opt, const char* v) {
   opt->rep.backup_dir = v;
@@ -11702,26 +11754,6 @@ unsigned char rocksdb_backup_engine_options_get_backup_log_files(
   return opt->rep.backup_log_files;
 }
 
-void rocksdb_backup_engine_options_set_io_buffer_size(
-    rocksdb_backup_engine_options_t* opt, uint64_t v) {
-  opt->rep.io_buffer_size = v;
-}
-
-uint64_t rocksdb_backup_engine_options_get_io_buffer_size(
-    rocksdb_backup_engine_options_t* opt) {
-  return opt->rep.io_buffer_size;
-}
-
-void rocksdb_backup_engine_options_set_backup_rate_limit(
-    rocksdb_backup_engine_options_t* opt, uint64_t v) {
-  opt->rep.backup_rate_limit = v;
-}
-
-uint64_t rocksdb_backup_engine_options_get_backup_rate_limit(
-    rocksdb_backup_engine_options_t* opt) {
-  return opt->rep.backup_rate_limit;
-}
-
 void rocksdb_backup_engine_options_set_restore_rate_limit(
     rocksdb_backup_engine_options_t* opt, uint64_t v) {
   opt->rep.restore_rate_limit = v;
@@ -11740,16 +11772,6 @@ void rocksdb_backup_engine_options_set_share_files_with_checksum(
 unsigned char rocksdb_backup_engine_options_get_share_files_with_checksum(
     rocksdb_backup_engine_options_t* opt) {
   return opt->rep.share_files_with_checksum;
-}
-
-void rocksdb_backup_engine_options_set_max_background_operations(
-    rocksdb_backup_engine_options_t* opt, int v) {
-  opt->rep.max_background_operations = v;
-}
-
-int rocksdb_backup_engine_options_get_max_background_operations(
-    rocksdb_backup_engine_options_t* opt) {
-  return opt->rep.max_background_operations;
 }
 
 void rocksdb_backup_engine_options_set_callback_trigger_interval_size(
@@ -11806,16 +11828,6 @@ rocksdb_backup_engine_options_get_current_temperatures_override_manifest(
 
 /* CreateBackupOptions */
 
-void rocksdb_create_backup_options_set_flush_before_backup(
-    rocksdb_create_backup_options_t* opt, unsigned char v) {
-  opt->rep.flush_before_backup = v;
-}
-
-unsigned char rocksdb_create_backup_options_get_flush_before_backup(
-    rocksdb_create_backup_options_t* opt) {
-  return opt->rep.flush_before_backup;
-}
-
 void rocksdb_create_backup_options_set_decrease_background_thread_cpu_priority(
     rocksdb_create_backup_options_t* opt, unsigned char v) {
   opt->rep.decrease_background_thread_cpu_priority = v;
@@ -11836,6 +11848,16 @@ void rocksdb_create_backup_options_set_background_thread_cpu_priority(
 int rocksdb_create_backup_options_get_background_thread_cpu_priority(
     rocksdb_create_backup_options_t* opt) {
   return static_cast<int>(opt->rep.background_thread_cpu_priority);
+}
+
+void rocksdb_create_backup_options_set_flush_before_backup(
+    rocksdb_create_backup_options_t* opt, unsigned char v) {
+  opt->rep.flush_before_backup = v;
+}
+
+unsigned char rocksdb_create_backup_options_get_flush_before_backup(
+    rocksdb_create_backup_options_t* opt) {
+  return opt->rep.flush_before_backup;
 }
 
 void rocksdb_create_backup_options_set_atomic_flush(

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -1954,6 +1954,14 @@ rocksdb_compaction_file_info_oldest_blob_file_number(
 
 /* BlobFileAdditionInfo */
 
+extern ROCKSDB_LIBRARY_API const char*
+rocksdb_blob_file_addition_info_blob_file_path(
+    const rocksdb_blob_file_addition_info_t* info, size_t* size);
+
+extern ROCKSDB_LIBRARY_API uint64_t
+rocksdb_blob_file_addition_info_blob_file_number(
+    const rocksdb_blob_file_addition_info_t* info);
+
 extern ROCKSDB_LIBRARY_API uint64_t
 rocksdb_blob_file_addition_info_total_blob_count(
     const rocksdb_blob_file_addition_info_t* info);
@@ -1963,6 +1971,14 @@ rocksdb_blob_file_addition_info_total_blob_bytes(
     const rocksdb_blob_file_addition_info_t* info);
 
 /* BlobFileGarbageInfo */
+
+extern ROCKSDB_LIBRARY_API const char*
+rocksdb_blob_file_garbage_info_blob_file_path(
+    const rocksdb_blob_file_garbage_info_t* info, size_t* size);
+
+extern ROCKSDB_LIBRARY_API uint64_t
+rocksdb_blob_file_garbage_info_blob_file_number(
+    const rocksdb_blob_file_garbage_info_t* info);
 
 extern ROCKSDB_LIBRARY_API uint64_t
 rocksdb_blob_file_garbage_info_garbage_blob_count(
@@ -6239,6 +6255,30 @@ rocksdb_fifo_compaction_options_get_trivial_copy_buffer_size(
 
 /* BackupEngineOptions */
 
+extern ROCKSDB_LIBRARY_API void
+rocksdb_backup_engine_options_set_io_buffer_size(
+    rocksdb_backup_engine_options_t* opt, uint64_t v);
+
+extern ROCKSDB_LIBRARY_API uint64_t
+rocksdb_backup_engine_options_get_io_buffer_size(
+    rocksdb_backup_engine_options_t* opt);
+
+extern ROCKSDB_LIBRARY_API void
+rocksdb_backup_engine_options_set_backup_rate_limit(
+    rocksdb_backup_engine_options_t* opt, uint64_t v);
+
+extern ROCKSDB_LIBRARY_API uint64_t
+rocksdb_backup_engine_options_get_backup_rate_limit(
+    rocksdb_backup_engine_options_t* opt);
+
+extern ROCKSDB_LIBRARY_API void
+rocksdb_backup_engine_options_set_max_background_operations(
+    rocksdb_backup_engine_options_t* opt, int v);
+
+extern ROCKSDB_LIBRARY_API int
+rocksdb_backup_engine_options_get_max_background_operations(
+    rocksdb_backup_engine_options_t* opt);
+
 extern ROCKSDB_LIBRARY_API void rocksdb_backup_engine_options_set_backup_dir(
     rocksdb_backup_engine_options_t* opt, const char* v);
 
@@ -6277,22 +6317,6 @@ rocksdb_backup_engine_options_get_backup_log_files(
     rocksdb_backup_engine_options_t* opt);
 
 extern ROCKSDB_LIBRARY_API void
-rocksdb_backup_engine_options_set_io_buffer_size(
-    rocksdb_backup_engine_options_t* opt, uint64_t v);
-
-extern ROCKSDB_LIBRARY_API uint64_t
-rocksdb_backup_engine_options_get_io_buffer_size(
-    rocksdb_backup_engine_options_t* opt);
-
-extern ROCKSDB_LIBRARY_API void
-rocksdb_backup_engine_options_set_backup_rate_limit(
-    rocksdb_backup_engine_options_t* opt, uint64_t v);
-
-extern ROCKSDB_LIBRARY_API uint64_t
-rocksdb_backup_engine_options_get_backup_rate_limit(
-    rocksdb_backup_engine_options_t* opt);
-
-extern ROCKSDB_LIBRARY_API void
 rocksdb_backup_engine_options_set_restore_rate_limit(
     rocksdb_backup_engine_options_t* opt, uint64_t v);
 
@@ -6306,14 +6330,6 @@ rocksdb_backup_engine_options_set_share_files_with_checksum(
 
 extern ROCKSDB_LIBRARY_API unsigned char
 rocksdb_backup_engine_options_get_share_files_with_checksum(
-    rocksdb_backup_engine_options_t* opt);
-
-extern ROCKSDB_LIBRARY_API void
-rocksdb_backup_engine_options_set_max_background_operations(
-    rocksdb_backup_engine_options_t* opt, int v);
-
-extern ROCKSDB_LIBRARY_API int
-rocksdb_backup_engine_options_get_max_background_operations(
     rocksdb_backup_engine_options_t* opt);
 
 extern ROCKSDB_LIBRARY_API void
@@ -6358,14 +6374,6 @@ rocksdb_backup_engine_options_get_current_temperatures_override_manifest(
 /* CreateBackupOptions */
 
 extern ROCKSDB_LIBRARY_API void
-rocksdb_create_backup_options_set_flush_before_backup(
-    rocksdb_create_backup_options_t* opt, unsigned char v);
-
-extern ROCKSDB_LIBRARY_API unsigned char
-rocksdb_create_backup_options_get_flush_before_backup(
-    rocksdb_create_backup_options_t* opt);
-
-extern ROCKSDB_LIBRARY_API void
 rocksdb_create_backup_options_set_decrease_background_thread_cpu_priority(
     rocksdb_create_backup_options_t* opt, unsigned char v);
 
@@ -6379,6 +6387,14 @@ rocksdb_create_backup_options_set_background_thread_cpu_priority(
 
 extern ROCKSDB_LIBRARY_API int
 rocksdb_create_backup_options_get_background_thread_cpu_priority(
+    rocksdb_create_backup_options_t* opt);
+
+extern ROCKSDB_LIBRARY_API void
+rocksdb_create_backup_options_set_flush_before_backup(
+    rocksdb_create_backup_options_t* opt, unsigned char v);
+
+extern ROCKSDB_LIBRARY_API unsigned char
+rocksdb_create_backup_options_get_flush_before_backup(
     rocksdb_create_backup_options_t* opt);
 
 extern ROCKSDB_LIBRARY_API void rocksdb_create_backup_options_set_atomic_flush(

--- a/include/rocksdb/utilities/backup_engine.h
+++ b/include/rocksdb/utilities/backup_engine.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <climits>
 #include <cstdint>
 #include <forward_list>
 #include <functional>
@@ -21,6 +22,7 @@
 #include "rocksdb/metadata.h"
 #include "rocksdb/options.h"
 #include "rocksdb/status.h"
+#include "rocksdb/utilities/checkpoint.h"
 
 namespace ROCKSDB_NAMESPACE {
 class BackupEngineReadOnlyBase;
@@ -31,7 +33,7 @@ constexpr char kDbFileChecksumFuncName[] = "FileChecksumCrc32c";
 // The default BackupEngine file checksum function name.
 constexpr char kBackupFileChecksumFuncName[] = "crc32c";
 
-struct BackupEngineOptions {
+struct BackupEngineOptions : public CheckpointOrBackupEngineOptions {
   // Where to keep the backup files. Has to be different than dbname_
   // Best to set this to dbname_ + "/backups"
   // Required
@@ -54,11 +56,6 @@ struct BackupEngineOptions {
   // default: true
   bool share_table_files;
 
-  // Backup info and error messages will be written to info_log
-  // if non-nullptr.
-  // Default: nullptr
-  Logger* info_log;
-
   // If sync == true, we can guarantee you'll get consistent backup and
   // restore even on a machine crash/reboot. Backup and restore processes are
   // slower with sync enabled. If sync == false, we can only guarantee that
@@ -76,28 +73,6 @@ struct BackupEngineOptions {
   // memory.
   // Default: true
   bool backup_log_files;
-
-  // Size of the buffer in bytes used for reading files.
-  // Enables optimally configuring the IO size based on the storage backend.
-  // If specified, takes precendence over the rate limiter burst size (if
-  // specified) as well as kDefaultCopyFileBufferSize.
-  // If 0, the rate limiter burst size (if specified) or
-  // kDefaultCopyFileBufferSize will be used.
-  // Default: 0
-  uint64_t io_buffer_size;
-
-  // Max bytes that can be transferred in a second during backup.
-  // If 0, go as fast as you can
-  // This limit only applies to writes. To also limit reads,
-  // a rate limiter able to also limit reads (e.g, its mode = kAllIo)
-  // have to be passed in through the option "backup_rate_limiter"
-  // Default: 0
-  uint64_t backup_rate_limit;
-
-  // Backup rate limiter. Used to control transfer speed for backup. If this is
-  // not null, backup_rate_limit is ignored.
-  // Default: nullptr
-  std::shared_ptr<RateLimiter> backup_rate_limiter{nullptr};
 
   // Max bytes that can be transferred in a second during restore.
   // If 0, go as fast as you can
@@ -125,11 +100,6 @@ struct BackupEngineOptions {
   //
   // Default: true
   bool share_files_with_checksum;
-
-  // Up to this many background threads will be used to copy files & compute
-  // checksums for CreateNewBackup() and RestoreDBFromBackup().
-  // Default: 1
-  int max_background_operations;
 
   // During backup user can get callback every time next
   // callback_trigger_interval_size bytes being copied.
@@ -244,18 +214,18 @@ struct BackupEngineOptions {
       int _max_valid_backups_to_open = INT_MAX,
       ShareFilesNaming _share_files_with_checksum_naming =
           static_cast<ShareFilesNaming>(kUseDbSessionId | kFlagIncludeFileSize))
-      : backup_dir(_backup_dir),
+      : CheckpointOrBackupEngineOptions{_info_log, _io_buffer_size,
+                                        _backup_rate_limit,
+                                        /*backup_rate_limiter=*/nullptr,
+                                        _max_background_operations},
+        backup_dir(_backup_dir),
         backup_env(_backup_env),
         share_table_files(_share_table_files),
-        info_log(_info_log),
         sync(_sync),
         destroy_old_data(_destroy_old_data),
         backup_log_files(_backup_log_files),
-        io_buffer_size(_io_buffer_size),
-        backup_rate_limit(_backup_rate_limit),
         restore_rate_limit(_restore_rate_limit),
         share_files_with_checksum(true),
-        max_background_operations(_max_background_operations),
         callback_trigger_interval_size(_callback_trigger_interval_size),
         max_valid_backups_to_open(_max_valid_backups_to_open),
         share_files_with_checksum_naming(_share_files_with_checksum_naming) {
@@ -305,7 +275,7 @@ struct MaybeExcludeBackupFile {
   bool exclude_decision = false;
 };
 
-struct CreateBackupOptions {
+struct CreateBackupOptions : public CreateCheckpointOrBackupOptions {
   // Flush will always trigger if 2PC is enabled.
   // If write-ahead logs are disabled, set flush_before_backup=true to
   // avoid losing unflushed key/value pairs from the memtable.
@@ -341,14 +311,6 @@ struct CreateBackupOptions {
   std::function<void(MaybeExcludeBackupFile* files_begin,
                      MaybeExcludeBackupFile* files_end)>
       exclude_files_callback = {};
-
-  // If false, background_thread_cpu_priority is ignored.
-  // Otherwise, the cpu priority can be decreased,
-  // if you try to increase the priority, the priority will not change.
-  // The initial priority of the threads is CpuPriority::kNormal,
-  // so you can decrease to priorities lower than kNormal.
-  bool decrease_background_thread_cpu_priority = false;
-  CpuPriority background_thread_cpu_priority = CpuPriority::kNormal;
 
   // If true, use atomic flush to flush all column families atomically
   // before creating the backup. This ensures cross-CF consistency without

--- a/include/rocksdb/utilities/checkpoint.h
+++ b/include/rocksdb/utilities/checkpoint.h
@@ -7,17 +7,80 @@
 
 #pragma once
 
+#include <cstdint>
+#include <functional>
+#include <memory>
 #include <string>
 #include <vector>
 
+#include "rocksdb/env.h"
 #include "rocksdb/status.h"
 
 namespace ROCKSDB_NAMESPACE {
 
 class DB;
 class ColumnFamilyHandle;
+class RateLimiter;
 struct LiveFileMetaData;
 struct ExportImportFilesMetaData;
+
+// Engine-level options shared by BackupEngine and CheckpointEngine.
+struct CheckpointOrBackupEngineOptions {
+  // Info and error messages will be written to info_log if non-nullptr.
+  // Default: nullptr
+  Logger* info_log = nullptr;
+
+  // Size of the buffer in bytes used for reading files.
+  // Enables optimally configuring the IO size based on the storage backend.
+  // If specified, takes precendence over the rate limiter burst size (if
+  // specified) as well as kDefaultCopyFileBufferSize.
+  // If 0, the rate limiter burst size (if specified) or
+  // kDefaultCopyFileBufferSize will be used.
+  // Default: 0
+  uint64_t io_buffer_size = 0;
+
+  // Max copy bytes/second; 0 means unlimited. Ignored when backup_rate_limiter
+  // is set; otherwise, if > 0, a rate limiter is created from this value.
+  // Default: 0
+  uint64_t backup_rate_limit = 0;
+
+  // Rate limiter used to control copy transfer speed. If set, backup_rate_limit
+  // is ignored.
+  // Default: nullptr
+  std::shared_ptr<RateLimiter> backup_rate_limiter{nullptr};
+
+  // Up to this many background threads will be used to copy, hard-link, and
+  // (for backup) checksum files.
+  // Default: 1
+  int max_background_operations = 1;
+};
+
+struct CheckpointEngineOptions : public CheckpointOrBackupEngineOptions {
+  // Whether to hard-link data files when the destination supports it, instead
+  // of copying.
+  // Default: true
+  bool use_link_file_when_available = true;
+};
+
+// Per-operation options common to creating a checkpoint or a backup.
+struct CreateCheckpointOrBackupOptions {
+  // If false, background_thread_cpu_priority is ignored.
+  // Otherwise, the cpu priority can be decreased,
+  // if you try to increase the priority, the priority will not change.
+  // The initial priority of the threads is CpuPriority::kNormal,
+  // so you can decrease to priorities lower than kNormal.
+  bool decrease_background_thread_cpu_priority = false;
+  CpuPriority background_thread_cpu_priority = CpuPriority::kNormal;
+};
+
+struct CreateCheckpointOptions : public CreateCheckpointOrBackupOptions {
+  // If the total live-WAL size is >= this value, all column families are
+  // flushed before the checkpoint; archived logs don't count toward the total.
+  // 0 (default) always flushes. With a non-zero value the checkpoint may miss
+  // recent writes when WAL writing is not always enabled. Always flushes for
+  // 2PC.
+  uint64_t log_size_for_flush = 0;
+};
 
 class Checkpoint {
  public:

--- a/tools/c_api_gen/auto_simple_bindings.py
+++ b/tools/c_api_gen/auto_simple_bindings.py
@@ -776,7 +776,7 @@ def walk_ast(node: dict) -> Iterable[dict]:
         yield from walk_ast(child)
 
 
-def discover_fields(family: FamilyConfig) -> list[tuple[str, str]]:
+def _dump_record(struct_name: str, header: Path) -> dict:
     cmd = [
         get_clang_binary(),
         "-std=c++20",
@@ -788,9 +788,9 @@ def discover_fields(family: FamilyConfig) -> list[tuple[str, str]]:
         "-Xclang",
         "-ast-dump=json",
         "-Xclang",
-        f"-ast-dump-filter={family.struct_name}",
+        f"-ast-dump-filter={struct_name}",
         "-fsyntax-only",
-        str(family.header.relative_to(ROOT)),
+        str(header.relative_to(ROOT)),
     ]
     proc = subprocess.run(
         cmd,
@@ -804,15 +804,48 @@ def discover_fields(family: FamilyConfig) -> list[tuple[str, str]]:
         for node in walk_ast(doc):
             if (
                 node.get("kind") in ("RecordDecl", "CXXRecordDecl")
-                and node.get("name") == family.struct_name
+                and node.get("name") == struct_name
                 and node.get("completeDefinition")
             ):
-                fields = []
-                for child in node.get("inner", []):
-                    if child.get("kind") == "FieldDecl":
-                        fields.append((child["name"], child["type"]["qualType"]))
-                return fields
-    raise RuntimeError(f"Could not find AST definition for {family.struct_name}")
+                return node
+    raise RuntimeError(f"Could not find AST definition for {struct_name}")
+
+
+def _public_base_names(node: dict) -> list[str]:
+    names = []
+    for base in node.get("bases", []):
+        if base.get("access") != "public":
+            continue
+        qual_type = base.get("type", {}).get("qualType", "")
+        simple = qual_type.split()[-1].split("::")[-1] if qual_type else ""
+        if simple:
+            names.append(simple)
+    return names
+
+
+def discover_fields(family: FamilyConfig) -> list[tuple[str, str]]:
+    # Include fields inherited from public base classes that are not themselves
+    # managed families, so a family whose fields live in a shared base (e.g.
+    # BackupEngineOptions : CheckpointOrBackupEngineOptions) still exposes them.
+    # Base fields precede own fields, matching C++ subobject layout. Managed
+    # bases are skipped so each managed family owns exactly its own fields (e.g.
+    # ColumnFamilyOptions does not absorb AdvancedColumnFamilyOptions).
+    fields: list[tuple[str, str]] = []
+    seen_bases: set[str] = set()
+
+    def collect(struct_name: str) -> None:
+        node = _dump_record(struct_name, family.header)
+        for base_name in _public_base_names(node):
+            if base_name in MANAGED_FAMILY_NAMES or base_name in seen_bases:
+                continue
+            seen_bases.add(base_name)
+            collect(base_name)
+        for child in node.get("inner", []):
+            if child.get("kind") == "FieldDecl":
+                fields.append((child["name"], child["type"]["qualType"]))
+
+    collect(family.struct_name)
+    return fields
 
 
 def collect_function_names(root_file: Path, include_re: re.Pattern[str]) -> set[str]:


### PR DESCRIPTION
Summary:

First diff in a stack that lets `Checkpoint` and `BackupEngine` share one parallel copy/link infrastructure. Pure options refactor, no behavior change.

Adds two shared option bases in `rocksdb/utilities/checkpoint.h`: `CheckpointOrBackupEngineOptions` (engine-level config) and `CreateCheckpointOrBackupOptions` (per-operation options). `CheckpointEngineOptions` / `CreateCheckpointOptions` derive from them for checkpoint; `BackupEngineOptions` / `CreateBackupOptions` derive from them for backup and keep their backup-only fields.

Differential Revision: D111387916


