### PR TITLE
Add hard-link support to CopyEngine [3/4] (#14947)

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -4744,6 +4744,12 @@ cpp_unittest_wrapper(name="configurable_test",
             extra_compiler_flags=[])
 
 
+cpp_unittest_wrapper(name="copy_engine_test",
+            srcs=["utilities/copy_engine/copy_engine_test.cc"],
+            deps=[":rocksdb_test_lib"],
+            extra_compiler_flags=[])
+
+
 cpp_unittest_wrapper(name="corruption_test",
             srcs=["db/corruption_test.cc"],
             deps=[":rocksdb_test_lib"],

--- a/BUCK
+++ b/BUCK
@@ -306,6 +306,7 @@ cpp_library_wrapper(name="rocksdb_lib", srcs=[
         "utilities/compaction_filters.cc",
         "utilities/compaction_filters/remove_emptyvalue_compactionfilter.cc",
         "utilities/convenience/info_log_finder.cc",
+        "utilities/copy_engine/copy_engine.cc",
         "utilities/counted_fs.cc",
         "utilities/debug.cc",
         "utilities/env_mirror.cc",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1641,6 +1641,7 @@ if(WITH_TESTS)
         utilities/cassandra/cassandra_row_merge_test.cc
         utilities/cassandra/cassandra_serialize_test.cc
         utilities/checkpoint/checkpoint_test.cc
+        utilities/copy_engine/copy_engine_test.cc
         utilities/sorted_run_builder/sorted_run_builder_test.cc
         utilities/env_timed_test.cc
         utilities/fault_injection_fs_test.cc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1023,6 +1023,7 @@ set(SOURCES
         util/xxhash.cc
         utilities/agg_merge/agg_merge.cc
         utilities/backup/backup_engine.cc
+        utilities/copy_engine/copy_engine.cc
         utilities/blob_db/blob_compaction_filter.cc
         utilities/blob_db/blob_db.cc
         utilities/blob_db/blob_db_impl.cc

--- a/Makefile
+++ b/Makefile
@@ -1816,6 +1816,9 @@ backup_engine_test: $(OBJ_DIR)/utilities/backup/backup_engine_test.o $(TEST_LIBR
 checkpoint_test: $(OBJ_DIR)/utilities/checkpoint/checkpoint_test.o $(TEST_LIBRARY) $(LIBRARY)
 	$(AM_LINK)
 
+copy_engine_test: $(OBJ_DIR)/utilities/copy_engine/copy_engine_test.o $(TEST_LIBRARY) $(LIBRARY)
+	$(AM_LINK)
+
 sorted_run_builder_test: $(OBJ_DIR)/utilities/sorted_run_builder/sorted_run_builder_test.o $(TEST_LIBRARY) $(LIBRARY)
 	$(AM_LINK)
 

--- a/c_api_gen/c_generated_metadata_structs_auto.cc.inc
+++ b/c_api_gen/c_generated_metadata_structs_auto.cc.inc
@@ -482,6 +482,17 @@ uint64_t rocksdb_compaction_file_info_oldest_blob_file_number(
 
 /* BlobFileAdditionInfo */
 
+const char* rocksdb_blob_file_addition_info_blob_file_path(
+    const rocksdb_blob_file_addition_info_t* info, size_t* size) {
+  *size = info->rep.blob_file_path.size();
+  return info->rep.blob_file_path.data();
+}
+
+uint64_t rocksdb_blob_file_addition_info_blob_file_number(
+    const rocksdb_blob_file_addition_info_t* info) {
+  return info->rep.blob_file_number;
+}
+
 uint64_t rocksdb_blob_file_addition_info_total_blob_count(
     const rocksdb_blob_file_addition_info_t* info) {
   return info->rep.total_blob_count;
@@ -493,6 +504,17 @@ uint64_t rocksdb_blob_file_addition_info_total_blob_bytes(
 }
 
 /* BlobFileGarbageInfo */
+
+const char* rocksdb_blob_file_garbage_info_blob_file_path(
+    const rocksdb_blob_file_garbage_info_t* info, size_t* size) {
+  *size = info->rep.blob_file_path.size();
+  return info->rep.blob_file_path.data();
+}
+
+uint64_t rocksdb_blob_file_garbage_info_blob_file_number(
+    const rocksdb_blob_file_garbage_info_t* info) {
+  return info->rep.blob_file_number;
+}
 
 uint64_t rocksdb_blob_file_garbage_info_garbage_blob_count(
     const rocksdb_blob_file_garbage_info_t* info) {

--- a/c_api_gen/c_generated_metadata_structs_auto.h.inc
+++ b/c_api_gen/c_generated_metadata_structs_auto.h.inc
@@ -346,6 +346,14 @@ rocksdb_compaction_file_info_oldest_blob_file_number(
 
 /* BlobFileAdditionInfo */
 
+extern ROCKSDB_LIBRARY_API const char*
+rocksdb_blob_file_addition_info_blob_file_path(
+    const rocksdb_blob_file_addition_info_t* info, size_t* size);
+
+extern ROCKSDB_LIBRARY_API uint64_t
+rocksdb_blob_file_addition_info_blob_file_number(
+    const rocksdb_blob_file_addition_info_t* info);
+
 extern ROCKSDB_LIBRARY_API uint64_t
 rocksdb_blob_file_addition_info_total_blob_count(
     const rocksdb_blob_file_addition_info_t* info);
@@ -355,6 +363,14 @@ rocksdb_blob_file_addition_info_total_blob_bytes(
     const rocksdb_blob_file_addition_info_t* info);
 
 /* BlobFileGarbageInfo */
+
+extern ROCKSDB_LIBRARY_API const char*
+rocksdb_blob_file_garbage_info_blob_file_path(
+    const rocksdb_blob_file_garbage_info_t* info, size_t* size);
+
+extern ROCKSDB_LIBRARY_API uint64_t
+rocksdb_blob_file_garbage_info_blob_file_number(
+    const rocksdb_blob_file_garbage_info_t* info);
 
 extern ROCKSDB_LIBRARY_API uint64_t
 rocksdb_blob_file_garbage_info_garbage_blob_count(

--- a/c_api_gen/c_generated_option_structs_auto.cc.inc
+++ b/c_api_gen/c_generated_option_structs_auto.cc.inc
@@ -2707,6 +2707,36 @@ uint64_t rocksdb_fifo_compaction_options_get_trivial_copy_buffer_size(
 
 /* BackupEngineOptions */
 
+void rocksdb_backup_engine_options_set_io_buffer_size(
+    rocksdb_backup_engine_options_t* opt, uint64_t v) {
+  opt->rep.io_buffer_size = v;
+}
+
+uint64_t rocksdb_backup_engine_options_get_io_buffer_size(
+    rocksdb_backup_engine_options_t* opt) {
+  return opt->rep.io_buffer_size;
+}
+
+void rocksdb_backup_engine_options_set_backup_rate_limit(
+    rocksdb_backup_engine_options_t* opt, uint64_t v) {
+  opt->rep.backup_rate_limit = v;
+}
+
+uint64_t rocksdb_backup_engine_options_get_backup_rate_limit(
+    rocksdb_backup_engine_options_t* opt) {
+  return opt->rep.backup_rate_limit;
+}
+
+void rocksdb_backup_engine_options_set_max_background_operations(
+    rocksdb_backup_engine_options_t* opt, int v) {
+  opt->rep.max_background_operations = v;
+}
+
+int rocksdb_backup_engine_options_get_max_background_operations(
+    rocksdb_backup_engine_options_t* opt) {
+  return opt->rep.max_background_operations;
+}
+
 void rocksdb_backup_engine_options_set_backup_dir(
     rocksdb_backup_engine_options_t* opt, const char* v) {
   opt->rep.backup_dir = v;
@@ -2758,26 +2788,6 @@ unsigned char rocksdb_backup_engine_options_get_backup_log_files(
   return opt->rep.backup_log_files;
 }
 
-void rocksdb_backup_engine_options_set_io_buffer_size(
-    rocksdb_backup_engine_options_t* opt, uint64_t v) {
-  opt->rep.io_buffer_size = v;
-}
-
-uint64_t rocksdb_backup_engine_options_get_io_buffer_size(
-    rocksdb_backup_engine_options_t* opt) {
-  return opt->rep.io_buffer_size;
-}
-
-void rocksdb_backup_engine_options_set_backup_rate_limit(
-    rocksdb_backup_engine_options_t* opt, uint64_t v) {
-  opt->rep.backup_rate_limit = v;
-}
-
-uint64_t rocksdb_backup_engine_options_get_backup_rate_limit(
-    rocksdb_backup_engine_options_t* opt) {
-  return opt->rep.backup_rate_limit;
-}
-
 void rocksdb_backup_engine_options_set_restore_rate_limit(
     rocksdb_backup_engine_options_t* opt, uint64_t v) {
   opt->rep.restore_rate_limit = v;
@@ -2796,16 +2806,6 @@ void rocksdb_backup_engine_options_set_share_files_with_checksum(
 unsigned char rocksdb_backup_engine_options_get_share_files_with_checksum(
     rocksdb_backup_engine_options_t* opt) {
   return opt->rep.share_files_with_checksum;
-}
-
-void rocksdb_backup_engine_options_set_max_background_operations(
-    rocksdb_backup_engine_options_t* opt, int v) {
-  opt->rep.max_background_operations = v;
-}
-
-int rocksdb_backup_engine_options_get_max_background_operations(
-    rocksdb_backup_engine_options_t* opt) {
-  return opt->rep.max_background_operations;
 }
 
 void rocksdb_backup_engine_options_set_callback_trigger_interval_size(
@@ -2862,16 +2862,6 @@ rocksdb_backup_engine_options_get_current_temperatures_override_manifest(
 
 /* CreateBackupOptions */
 
-void rocksdb_create_backup_options_set_flush_before_backup(
-    rocksdb_create_backup_options_t* opt, unsigned char v) {
-  opt->rep.flush_before_backup = v;
-}
-
-unsigned char rocksdb_create_backup_options_get_flush_before_backup(
-    rocksdb_create_backup_options_t* opt) {
-  return opt->rep.flush_before_backup;
-}
-
 void rocksdb_create_backup_options_set_decrease_background_thread_cpu_priority(
     rocksdb_create_backup_options_t* opt, unsigned char v) {
   opt->rep.decrease_background_thread_cpu_priority = v;
@@ -2892,6 +2882,16 @@ void rocksdb_create_backup_options_set_background_thread_cpu_priority(
 int rocksdb_create_backup_options_get_background_thread_cpu_priority(
     rocksdb_create_backup_options_t* opt) {
   return static_cast<int>(opt->rep.background_thread_cpu_priority);
+}
+
+void rocksdb_create_backup_options_set_flush_before_backup(
+    rocksdb_create_backup_options_t* opt, unsigned char v) {
+  opt->rep.flush_before_backup = v;
+}
+
+unsigned char rocksdb_create_backup_options_get_flush_before_backup(
+    rocksdb_create_backup_options_t* opt) {
+  return opt->rep.flush_before_backup;
 }
 
 void rocksdb_create_backup_options_set_atomic_flush(

--- a/c_api_gen/c_generated_option_structs_auto.h.inc
+++ b/c_api_gen/c_generated_option_structs_auto.h.inc
@@ -1317,6 +1317,30 @@ rocksdb_fifo_compaction_options_get_trivial_copy_buffer_size(
 
 /* BackupEngineOptions */
 
+extern ROCKSDB_LIBRARY_API void
+rocksdb_backup_engine_options_set_io_buffer_size(
+    rocksdb_backup_engine_options_t* opt, uint64_t v);
+
+extern ROCKSDB_LIBRARY_API uint64_t
+rocksdb_backup_engine_options_get_io_buffer_size(
+    rocksdb_backup_engine_options_t* opt);
+
+extern ROCKSDB_LIBRARY_API void
+rocksdb_backup_engine_options_set_backup_rate_limit(
+    rocksdb_backup_engine_options_t* opt, uint64_t v);
+
+extern ROCKSDB_LIBRARY_API uint64_t
+rocksdb_backup_engine_options_get_backup_rate_limit(
+    rocksdb_backup_engine_options_t* opt);
+
+extern ROCKSDB_LIBRARY_API void
+rocksdb_backup_engine_options_set_max_background_operations(
+    rocksdb_backup_engine_options_t* opt, int v);
+
+extern ROCKSDB_LIBRARY_API int
+rocksdb_backup_engine_options_get_max_background_operations(
+    rocksdb_backup_engine_options_t* opt);
+
 extern ROCKSDB_LIBRARY_API void rocksdb_backup_engine_options_set_backup_dir(
     rocksdb_backup_engine_options_t* opt, const char* v);
 
@@ -1355,22 +1379,6 @@ rocksdb_backup_engine_options_get_backup_log_files(
     rocksdb_backup_engine_options_t* opt);
 
 extern ROCKSDB_LIBRARY_API void
-rocksdb_backup_engine_options_set_io_buffer_size(
-    rocksdb_backup_engine_options_t* opt, uint64_t v);
-
-extern ROCKSDB_LIBRARY_API uint64_t
-rocksdb_backup_engine_options_get_io_buffer_size(
-    rocksdb_backup_engine_options_t* opt);
-
-extern ROCKSDB_LIBRARY_API void
-rocksdb_backup_engine_options_set_backup_rate_limit(
-    rocksdb_backup_engine_options_t* opt, uint64_t v);
-
-extern ROCKSDB_LIBRARY_API uint64_t
-rocksdb_backup_engine_options_get_backup_rate_limit(
-    rocksdb_backup_engine_options_t* opt);
-
-extern ROCKSDB_LIBRARY_API void
 rocksdb_backup_engine_options_set_restore_rate_limit(
     rocksdb_backup_engine_options_t* opt, uint64_t v);
 
@@ -1384,14 +1392,6 @@ rocksdb_backup_engine_options_set_share_files_with_checksum(
 
 extern ROCKSDB_LIBRARY_API unsigned char
 rocksdb_backup_engine_options_get_share_files_with_checksum(
-    rocksdb_backup_engine_options_t* opt);
-
-extern ROCKSDB_LIBRARY_API void
-rocksdb_backup_engine_options_set_max_background_operations(
-    rocksdb_backup_engine_options_t* opt, int v);
-
-extern ROCKSDB_LIBRARY_API int
-rocksdb_backup_engine_options_get_max_background_operations(
     rocksdb_backup_engine_options_t* opt);
 
 extern ROCKSDB_LIBRARY_API void
@@ -1436,14 +1436,6 @@ rocksdb_backup_engine_options_get_current_temperatures_override_manifest(
 /* CreateBackupOptions */
 
 extern ROCKSDB_LIBRARY_API void
-rocksdb_create_backup_options_set_flush_before_backup(
-    rocksdb_create_backup_options_t* opt, unsigned char v);
-
-extern ROCKSDB_LIBRARY_API unsigned char
-rocksdb_create_backup_options_get_flush_before_backup(
-    rocksdb_create_backup_options_t* opt);
-
-extern ROCKSDB_LIBRARY_API void
 rocksdb_create_backup_options_set_decrease_background_thread_cpu_priority(
     rocksdb_create_backup_options_t* opt, unsigned char v);
 
@@ -1457,6 +1449,14 @@ rocksdb_create_backup_options_set_background_thread_cpu_priority(
 
 extern ROCKSDB_LIBRARY_API int
 rocksdb_create_backup_options_get_background_thread_cpu_priority(
+    rocksdb_create_backup_options_t* opt);
+
+extern ROCKSDB_LIBRARY_API void
+rocksdb_create_backup_options_set_flush_before_backup(
+    rocksdb_create_backup_options_t* opt, unsigned char v);
+
+extern ROCKSDB_LIBRARY_API unsigned char
+rocksdb_create_backup_options_get_flush_before_backup(
     rocksdb_create_backup_options_t* opt);
 
 extern ROCKSDB_LIBRARY_API void rocksdb_create_backup_options_set_atomic_flush(

--- a/db/c.cc
+++ b/db/c.cc
@@ -5289,6 +5289,17 @@ uint64_t rocksdb_compaction_file_info_oldest_blob_file_number(
 
 /* BlobFileAdditionInfo */
 
+const char* rocksdb_blob_file_addition_info_blob_file_path(
+    const rocksdb_blob_file_addition_info_t* info, size_t* size) {
+  *size = info->rep.blob_file_path.size();
+  return info->rep.blob_file_path.data();
+}
+
+uint64_t rocksdb_blob_file_addition_info_blob_file_number(
+    const rocksdb_blob_file_addition_info_t* info) {
+  return info->rep.blob_file_number;
+}
+
 uint64_t rocksdb_blob_file_addition_info_total_blob_count(
     const rocksdb_blob_file_addition_info_t* info) {
   return info->rep.total_blob_count;
@@ -5300,6 +5311,17 @@ uint64_t rocksdb_blob_file_addition_info_total_blob_bytes(
 }
 
 /* BlobFileGarbageInfo */
+
+const char* rocksdb_blob_file_garbage_info_blob_file_path(
+    const rocksdb_blob_file_garbage_info_t* info, size_t* size) {
+  *size = info->rep.blob_file_path.size();
+  return info->rep.blob_file_path.data();
+}
+
+uint64_t rocksdb_blob_file_garbage_info_blob_file_number(
+    const rocksdb_blob_file_garbage_info_t* info) {
+  return info->rep.blob_file_number;
+}
 
 uint64_t rocksdb_blob_file_garbage_info_garbage_blob_count(
     const rocksdb_blob_file_garbage_info_t* info) {
@@ -11651,6 +11673,36 @@ uint64_t rocksdb_fifo_compaction_options_get_trivial_copy_buffer_size(
 
 /* BackupEngineOptions */
 
+void rocksdb_backup_engine_options_set_io_buffer_size(
+    rocksdb_backup_engine_options_t* opt, uint64_t v) {
+  opt->rep.io_buffer_size = v;
+}
+
+uint64_t rocksdb_backup_engine_options_get_io_buffer_size(
+    rocksdb_backup_engine_options_t* opt) {
+  return opt->rep.io_buffer_size;
+}
+
+void rocksdb_backup_engine_options_set_backup_rate_limit(
+    rocksdb_backup_engine_options_t* opt, uint64_t v) {
+  opt->rep.backup_rate_limit = v;
+}
+
+uint64_t rocksdb_backup_engine_options_get_backup_rate_limit(
+    rocksdb_backup_engine_options_t* opt) {
+  return opt->rep.backup_rate_limit;
+}
+
+void rocksdb_backup_engine_options_set_max_background_operations(
+    rocksdb_backup_engine_options_t* opt, int v) {
+  opt->rep.max_background_operations = v;
+}
+
+int rocksdb_backup_engine_options_get_max_background_operations(
+    rocksdb_backup_engine_options_t* opt) {
+  return opt->rep.max_background_operations;
+}
+
 void rocksdb_backup_engine_options_set_backup_dir(
     rocksdb_backup_engine_options_t* opt, const char* v) {
   opt->rep.backup_dir = v;
@@ -11702,26 +11754,6 @@ unsigned char rocksdb_backup_engine_options_get_backup_log_files(
   return opt->rep.backup_log_files;
 }
 
-void rocksdb_backup_engine_options_set_io_buffer_size(
-    rocksdb_backup_engine_options_t* opt, uint64_t v) {
-  opt->rep.io_buffer_size = v;
-}
-
-uint64_t rocksdb_backup_engine_options_get_io_buffer_size(
-    rocksdb_backup_engine_options_t* opt) {
-  return opt->rep.io_buffer_size;
-}
-
-void rocksdb_backup_engine_options_set_backup_rate_limit(
-    rocksdb_backup_engine_options_t* opt, uint64_t v) {
-  opt->rep.backup_rate_limit = v;
-}
-
-uint64_t rocksdb_backup_engine_options_get_backup_rate_limit(
-    rocksdb_backup_engine_options_t* opt) {
-  return opt->rep.backup_rate_limit;
-}
-
 void rocksdb_backup_engine_options_set_restore_rate_limit(
     rocksdb_backup_engine_options_t* opt, uint64_t v) {
   opt->rep.restore_rate_limit = v;
@@ -11740,16 +11772,6 @@ void rocksdb_backup_engine_options_set_share_files_with_checksum(
 unsigned char rocksdb_backup_engine_options_get_share_files_with_checksum(
     rocksdb_backup_engine_options_t* opt) {
   return opt->rep.share_files_with_checksum;
-}
-
-void rocksdb_backup_engine_options_set_max_background_operations(
-    rocksdb_backup_engine_options_t* opt, int v) {
-  opt->rep.max_background_operations = v;
-}
-
-int rocksdb_backup_engine_options_get_max_background_operations(
-    rocksdb_backup_engine_options_t* opt) {
-  return opt->rep.max_background_operations;
 }
 
 void rocksdb_backup_engine_options_set_callback_trigger_interval_size(
@@ -11806,16 +11828,6 @@ rocksdb_backup_engine_options_get_current_temperatures_override_manifest(
 
 /* CreateBackupOptions */
 
-void rocksdb_create_backup_options_set_flush_before_backup(
-    rocksdb_create_backup_options_t* opt, unsigned char v) {
-  opt->rep.flush_before_backup = v;
-}
-
-unsigned char rocksdb_create_backup_options_get_flush_before_backup(
-    rocksdb_create_backup_options_t* opt) {
-  return opt->rep.flush_before_backup;
-}
-
 void rocksdb_create_backup_options_set_decrease_background_thread_cpu_priority(
     rocksdb_create_backup_options_t* opt, unsigned char v) {
   opt->rep.decrease_background_thread_cpu_priority = v;
@@ -11836,6 +11848,16 @@ void rocksdb_create_backup_options_set_background_thread_cpu_priority(
 int rocksdb_create_backup_options_get_background_thread_cpu_priority(
     rocksdb_create_backup_options_t* opt) {
   return static_cast<int>(opt->rep.background_thread_cpu_priority);
+}
+
+void rocksdb_create_backup_options_set_flush_before_backup(
+    rocksdb_create_backup_options_t* opt, unsigned char v) {
+  opt->rep.flush_before_backup = v;
+}
+
+unsigned char rocksdb_create_backup_options_get_flush_before_backup(
+    rocksdb_create_backup_options_t* opt) {
+  return opt->rep.flush_before_backup;
 }
 
 void rocksdb_create_backup_options_set_atomic_flush(

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -1954,6 +1954,14 @@ rocksdb_compaction_file_info_oldest_blob_file_number(
 
 /* BlobFileAdditionInfo */
 
+extern ROCKSDB_LIBRARY_API const char*
+rocksdb_blob_file_addition_info_blob_file_path(
+    const rocksdb_blob_file_addition_info_t* info, size_t* size);
+
+extern ROCKSDB_LIBRARY_API uint64_t
+rocksdb_blob_file_addition_info_blob_file_number(
+    const rocksdb_blob_file_addition_info_t* info);
+
 extern ROCKSDB_LIBRARY_API uint64_t
 rocksdb_blob_file_addition_info_total_blob_count(
     const rocksdb_blob_file_addition_info_t* info);
@@ -1963,6 +1971,14 @@ rocksdb_blob_file_addition_info_total_blob_bytes(
     const rocksdb_blob_file_addition_info_t* info);
 
 /* BlobFileGarbageInfo */
+
+extern ROCKSDB_LIBRARY_API const char*
+rocksdb_blob_file_garbage_info_blob_file_path(
+    const rocksdb_blob_file_garbage_info_t* info, size_t* size);
+
+extern ROCKSDB_LIBRARY_API uint64_t
+rocksdb_blob_file_garbage_info_blob_file_number(
+    const rocksdb_blob_file_garbage_info_t* info);
 
 extern ROCKSDB_LIBRARY_API uint64_t
 rocksdb_blob_file_garbage_info_garbage_blob_count(
@@ -6239,6 +6255,30 @@ rocksdb_fifo_compaction_options_get_trivial_copy_buffer_size(
 
 /* BackupEngineOptions */
 
+extern ROCKSDB_LIBRARY_API void
+rocksdb_backup_engine_options_set_io_buffer_size(
+    rocksdb_backup_engine_options_t* opt, uint64_t v);
+
+extern ROCKSDB_LIBRARY_API uint64_t
+rocksdb_backup_engine_options_get_io_buffer_size(
+    rocksdb_backup_engine_options_t* opt);
+
+extern ROCKSDB_LIBRARY_API void
+rocksdb_backup_engine_options_set_backup_rate_limit(
+    rocksdb_backup_engine_options_t* opt, uint64_t v);
+
+extern ROCKSDB_LIBRARY_API uint64_t
+rocksdb_backup_engine_options_get_backup_rate_limit(
+    rocksdb_backup_engine_options_t* opt);
+
+extern ROCKSDB_LIBRARY_API void
+rocksdb_backup_engine_options_set_max_background_operations(
+    rocksdb_backup_engine_options_t* opt, int v);
+
+extern ROCKSDB_LIBRARY_API int
+rocksdb_backup_engine_options_get_max_background_operations(
+    rocksdb_backup_engine_options_t* opt);
+
 extern ROCKSDB_LIBRARY_API void rocksdb_backup_engine_options_set_backup_dir(
     rocksdb_backup_engine_options_t* opt, const char* v);
 
@@ -6277,22 +6317,6 @@ rocksdb_backup_engine_options_get_backup_log_files(
     rocksdb_backup_engine_options_t* opt);
 
 extern ROCKSDB_LIBRARY_API void
-rocksdb_backup_engine_options_set_io_buffer_size(
-    rocksdb_backup_engine_options_t* opt, uint64_t v);
-
-extern ROCKSDB_LIBRARY_API uint64_t
-rocksdb_backup_engine_options_get_io_buffer_size(
-    rocksdb_backup_engine_options_t* opt);
-
-extern ROCKSDB_LIBRARY_API void
-rocksdb_backup_engine_options_set_backup_rate_limit(
-    rocksdb_backup_engine_options_t* opt, uint64_t v);
-
-extern ROCKSDB_LIBRARY_API uint64_t
-rocksdb_backup_engine_options_get_backup_rate_limit(
-    rocksdb_backup_engine_options_t* opt);
-
-extern ROCKSDB_LIBRARY_API void
 rocksdb_backup_engine_options_set_restore_rate_limit(
     rocksdb_backup_engine_options_t* opt, uint64_t v);
 
@@ -6306,14 +6330,6 @@ rocksdb_backup_engine_options_set_share_files_with_checksum(
 
 extern ROCKSDB_LIBRARY_API unsigned char
 rocksdb_backup_engine_options_get_share_files_with_checksum(
-    rocksdb_backup_engine_options_t* opt);
-
-extern ROCKSDB_LIBRARY_API void
-rocksdb_backup_engine_options_set_max_background_operations(
-    rocksdb_backup_engine_options_t* opt, int v);
-
-extern ROCKSDB_LIBRARY_API int
-rocksdb_backup_engine_options_get_max_background_operations(
     rocksdb_backup_engine_options_t* opt);
 
 extern ROCKSDB_LIBRARY_API void
@@ -6358,14 +6374,6 @@ rocksdb_backup_engine_options_get_current_temperatures_override_manifest(
 /* CreateBackupOptions */
 
 extern ROCKSDB_LIBRARY_API void
-rocksdb_create_backup_options_set_flush_before_backup(
-    rocksdb_create_backup_options_t* opt, unsigned char v);
-
-extern ROCKSDB_LIBRARY_API unsigned char
-rocksdb_create_backup_options_get_flush_before_backup(
-    rocksdb_create_backup_options_t* opt);
-
-extern ROCKSDB_LIBRARY_API void
 rocksdb_create_backup_options_set_decrease_background_thread_cpu_priority(
     rocksdb_create_backup_options_t* opt, unsigned char v);
 
@@ -6379,6 +6387,14 @@ rocksdb_create_backup_options_set_background_thread_cpu_priority(
 
 extern ROCKSDB_LIBRARY_API int
 rocksdb_create_backup_options_get_background_thread_cpu_priority(
+    rocksdb_create_backup_options_t* opt);
+
+extern ROCKSDB_LIBRARY_API void
+rocksdb_create_backup_options_set_flush_before_backup(
+    rocksdb_create_backup_options_t* opt, unsigned char v);
+
+extern ROCKSDB_LIBRARY_API unsigned char
+rocksdb_create_backup_options_get_flush_before_backup(
     rocksdb_create_backup_options_t* opt);
 
 extern ROCKSDB_LIBRARY_API void rocksdb_create_backup_options_set_atomic_flush(

--- a/include/rocksdb/utilities/backup_engine.h
+++ b/include/rocksdb/utilities/backup_engine.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <climits>
 #include <cstdint>
 #include <forward_list>
 #include <functional>
@@ -21,6 +22,7 @@
 #include "rocksdb/metadata.h"
 #include "rocksdb/options.h"
 #include "rocksdb/status.h"
+#include "rocksdb/utilities/checkpoint.h"
 
 namespace ROCKSDB_NAMESPACE {
 class BackupEngineReadOnlyBase;
@@ -31,7 +33,7 @@ constexpr char kDbFileChecksumFuncName[] = "FileChecksumCrc32c";
 // The default BackupEngine file checksum function name.
 constexpr char kBackupFileChecksumFuncName[] = "crc32c";
 
-struct BackupEngineOptions {
+struct BackupEngineOptions : public CheckpointOrBackupEngineOptions {
   // Where to keep the backup files. Has to be different than dbname_
   // Best to set this to dbname_ + "/backups"
   // Required
@@ -54,11 +56,6 @@ struct BackupEngineOptions {
   // default: true
   bool share_table_files;
 
-  // Backup info and error messages will be written to info_log
-  // if non-nullptr.
-  // Default: nullptr
-  Logger* info_log;
-
   // If sync == true, we can guarantee you'll get consistent backup and
   // restore even on a machine crash/reboot. Backup and restore processes are
   // slower with sync enabled. If sync == false, we can only guarantee that
@@ -76,28 +73,6 @@ struct BackupEngineOptions {
   // memory.
   // Default: true
   bool backup_log_files;
-
-  // Size of the buffer in bytes used for reading files.
-  // Enables optimally configuring the IO size based on the storage backend.
-  // If specified, takes precendence over the rate limiter burst size (if
-  // specified) as well as kDefaultCopyFileBufferSize.
-  // If 0, the rate limiter burst size (if specified) or
-  // kDefaultCopyFileBufferSize will be used.
-  // Default: 0
-  uint64_t io_buffer_size;
-
-  // Max bytes that can be transferred in a second during backup.
-  // If 0, go as fast as you can
-  // This limit only applies to writes. To also limit reads,
-  // a rate limiter able to also limit reads (e.g, its mode = kAllIo)
-  // have to be passed in through the option "backup_rate_limiter"
-  // Default: 0
-  uint64_t backup_rate_limit;
-
-  // Backup rate limiter. Used to control transfer speed for backup. If this is
-  // not null, backup_rate_limit is ignored.
-  // Default: nullptr
-  std::shared_ptr<RateLimiter> backup_rate_limiter{nullptr};
 
   // Max bytes that can be transferred in a second during restore.
   // If 0, go as fast as you can
@@ -125,11 +100,6 @@ struct BackupEngineOptions {
   //
   // Default: true
   bool share_files_with_checksum;
-
-  // Up to this many background threads will be used to copy files & compute
-  // checksums for CreateNewBackup() and RestoreDBFromBackup().
-  // Default: 1
-  int max_background_operations;
 
   // During backup user can get callback every time next
   // callback_trigger_interval_size bytes being copied.
@@ -244,18 +214,18 @@ struct BackupEngineOptions {
       int _max_valid_backups_to_open = INT_MAX,
       ShareFilesNaming _share_files_with_checksum_naming =
           static_cast<ShareFilesNaming>(kUseDbSessionId | kFlagIncludeFileSize))
-      : backup_dir(_backup_dir),
+      : CheckpointOrBackupEngineOptions{_info_log, _io_buffer_size,
+                                        _backup_rate_limit,
+                                        /*backup_rate_limiter=*/nullptr,
+                                        _max_background_operations},
+        backup_dir(_backup_dir),
         backup_env(_backup_env),
         share_table_files(_share_table_files),
-        info_log(_info_log),
         sync(_sync),
         destroy_old_data(_destroy_old_data),
         backup_log_files(_backup_log_files),
-        io_buffer_size(_io_buffer_size),
-        backup_rate_limit(_backup_rate_limit),
         restore_rate_limit(_restore_rate_limit),
         share_files_with_checksum(true),
-        max_background_operations(_max_background_operations),
         callback_trigger_interval_size(_callback_trigger_interval_size),
         max_valid_backups_to_open(_max_valid_backups_to_open),
         share_files_with_checksum_naming(_share_files_with_checksum_naming) {
@@ -305,7 +275,7 @@ struct MaybeExcludeBackupFile {
   bool exclude_decision = false;
 };
 
-struct CreateBackupOptions {
+struct CreateBackupOptions : public CreateCheckpointOrBackupOptions {
   // Flush will always trigger if 2PC is enabled.
   // If write-ahead logs are disabled, set flush_before_backup=true to
   // avoid losing unflushed key/value pairs from the memtable.
@@ -341,14 +311,6 @@ struct CreateBackupOptions {
   std::function<void(MaybeExcludeBackupFile* files_begin,
                      MaybeExcludeBackupFile* files_end)>
       exclude_files_callback = {};
-
-  // If false, background_thread_cpu_priority is ignored.
-  // Otherwise, the cpu priority can be decreased,
-  // if you try to increase the priority, the priority will not change.
-  // The initial priority of the threads is CpuPriority::kNormal,
-  // so you can decrease to priorities lower than kNormal.
-  bool decrease_background_thread_cpu_priority = false;
-  CpuPriority background_thread_cpu_priority = CpuPriority::kNormal;
 
   // If true, use atomic flush to flush all column families atomically
   // before creating the backup. This ensures cross-CF consistency without

--- a/include/rocksdb/utilities/checkpoint.h
+++ b/include/rocksdb/utilities/checkpoint.h
@@ -7,17 +7,80 @@
 
 #pragma once
 
+#include <cstdint>
+#include <functional>
+#include <memory>
 #include <string>
 #include <vector>
 
+#include "rocksdb/env.h"
 #include "rocksdb/status.h"
 
 namespace ROCKSDB_NAMESPACE {
 
 class DB;
 class ColumnFamilyHandle;
+class RateLimiter;
 struct LiveFileMetaData;
 struct ExportImportFilesMetaData;
+
+// Engine-level options shared by BackupEngine and CheckpointEngine.
+struct CheckpointOrBackupEngineOptions {
+  // Info and error messages will be written to info_log if non-nullptr.
+  // Default: nullptr
+  Logger* info_log = nullptr;
+
+  // Size of the buffer in bytes used for reading files.
+  // Enables optimally configuring the IO size based on the storage backend.
+  // If specified, takes precendence over the rate limiter burst size (if
+  // specified) as well as kDefaultCopyFileBufferSize.
+  // If 0, the rate limiter burst size (if specified) or
+  // kDefaultCopyFileBufferSize will be used.
+  // Default: 0
+  uint64_t io_buffer_size = 0;
+
+  // Max copy bytes/second; 0 means unlimited. Ignored when backup_rate_limiter
+  // is set; otherwise, if > 0, a rate limiter is created from this value.
+  // Default: 0
+  uint64_t backup_rate_limit = 0;
+
+  // Rate limiter used to control copy transfer speed. If set, backup_rate_limit
+  // is ignored.
+  // Default: nullptr
+  std::shared_ptr<RateLimiter> backup_rate_limiter{nullptr};
+
+  // Up to this many background threads will be used to copy, hard-link, and
+  // (for backup) checksum files.
+  // Default: 1
+  int max_background_operations = 1;
+};
+
+struct CheckpointEngineOptions : public CheckpointOrBackupEngineOptions {
+  // Whether to hard-link data files when the destination supports it, instead
+  // of copying.
+  // Default: true
+  bool use_link_file_when_available = true;
+};
+
+// Per-operation options common to creating a checkpoint or a backup.
+struct CreateCheckpointOrBackupOptions {
+  // If false, background_thread_cpu_priority is ignored.
+  // Otherwise, the cpu priority can be decreased,
+  // if you try to increase the priority, the priority will not change.
+  // The initial priority of the threads is CpuPriority::kNormal,
+  // so you can decrease to priorities lower than kNormal.
+  bool decrease_background_thread_cpu_priority = false;
+  CpuPriority background_thread_cpu_priority = CpuPriority::kNormal;
+};
+
+struct CreateCheckpointOptions : public CreateCheckpointOrBackupOptions {
+  // If the total live-WAL size is >= this value, all column families are
+  // flushed before the checkpoint; archived logs don't count toward the total.
+  // 0 (default) always flushes. With a non-zero value the checkpoint may miss
+  // recent writes when WAL writing is not always enabled. Always flushes for
+  // 2PC.
+  uint64_t log_size_for_flush = 0;
+};
 
 class Checkpoint {
  public:

--- a/src.mk
+++ b/src.mk
@@ -657,6 +657,7 @@ TEST_MAIN_SOURCES =                                                     \
   utilities/cassandra/cassandra_row_merge_test.cc                       \
   utilities/cassandra/cassandra_serialize_test.cc                       \
   utilities/checkpoint/checkpoint_test.cc                               \
+  utilities/copy_engine/copy_engine_test.cc                     \
   utilities/sorted_run_builder/sorted_run_builder_test.cc               \
   utilities/env_timed_test.cc                                           \
   utilities/fault_injection_fs_test.cc                                  \

--- a/src.mk
+++ b/src.mk
@@ -287,6 +287,7 @@ LIB_SOURCES =                                                   \
   utilities/cassandra/format.cc                                 \
   utilities/cassandra/merge_operator.cc                         \
   utilities/checkpoint/checkpoint_impl.cc                       \
+  utilities/copy_engine/copy_engine.cc                         \
   utilities/compaction_filters.cc                               \
   utilities/sorted_run_builder/sorted_run_builder.cc            \
   utilities/compaction_filters/remove_emptyvalue_compactionfilter.cc    \

--- a/tools/c_api_gen/auto_simple_bindings.py
+++ b/tools/c_api_gen/auto_simple_bindings.py
@@ -776,7 +776,7 @@ def walk_ast(node: dict) -> Iterable[dict]:
         yield from walk_ast(child)
 
 
-def discover_fields(family: FamilyConfig) -> list[tuple[str, str]]:
+def _dump_record(struct_name: str, header: Path) -> dict:
     cmd = [
         get_clang_binary(),
         "-std=c++20",
@@ -788,9 +788,9 @@ def discover_fields(family: FamilyConfig) -> list[tuple[str, str]]:
         "-Xclang",
         "-ast-dump=json",
         "-Xclang",
-        f"-ast-dump-filter={family.struct_name}",
+        f"-ast-dump-filter={struct_name}",
         "-fsyntax-only",
-        str(family.header.relative_to(ROOT)),
+        str(header.relative_to(ROOT)),
     ]
     proc = subprocess.run(
         cmd,
@@ -804,15 +804,48 @@ def discover_fields(family: FamilyConfig) -> list[tuple[str, str]]:
         for node in walk_ast(doc):
             if (
                 node.get("kind") in ("RecordDecl", "CXXRecordDecl")
-                and node.get("name") == family.struct_name
+                and node.get("name") == struct_name
                 and node.get("completeDefinition")
             ):
-                fields = []
-                for child in node.get("inner", []):
-                    if child.get("kind") == "FieldDecl":
-                        fields.append((child["name"], child["type"]["qualType"]))
-                return fields
-    raise RuntimeError(f"Could not find AST definition for {family.struct_name}")
+                return node
+    raise RuntimeError(f"Could not find AST definition for {struct_name}")
+
+
+def _public_base_names(node: dict) -> list[str]:
+    names = []
+    for base in node.get("bases", []):
+        if base.get("access") != "public":
+            continue
+        qual_type = base.get("type", {}).get("qualType", "")
+        simple = qual_type.split()[-1].split("::")[-1] if qual_type else ""
+        if simple:
+            names.append(simple)
+    return names
+
+
+def discover_fields(family: FamilyConfig) -> list[tuple[str, str]]:
+    # Include fields inherited from public base classes that are not themselves
+    # managed families, so a family whose fields live in a shared base (e.g.
+    # BackupEngineOptions : CheckpointOrBackupEngineOptions) still exposes them.
+    # Base fields precede own fields, matching C++ subobject layout. Managed
+    # bases are skipped so each managed family owns exactly its own fields (e.g.
+    # ColumnFamilyOptions does not absorb AdvancedColumnFamilyOptions).
+    fields: list[tuple[str, str]] = []
+    seen_bases: set[str] = set()
+
+    def collect(struct_name: str) -> None:
+        node = _dump_record(struct_name, family.header)
+        for base_name in _public_base_names(node):
+            if base_name in MANAGED_FAMILY_NAMES or base_name in seen_bases:
+                continue
+            seen_bases.add(base_name)
+            collect(base_name)
+        for child in node.get("inner", []):
+            if child.get("kind") == "FieldDecl":
+                fields.append((child["name"], child["type"]["qualType"]))
+
+    collect(family.struct_name)
+    return fields
 
 
 def collect_function_names(root_file: Path, include_re: re.Pattern[str]) -> set[str]:

--- a/util/file_checksum_helper.h
+++ b/util/file_checksum_helper.h
@@ -14,6 +14,15 @@
 
 namespace ROCKSDB_NAMESPACE {
 
+// Converts a 32-bit checksum value (e.g. a CRC32C) to its hex string
+// representation, matching the on-disk/backup-metadata encoding. Shared by the
+// backup and copy engines.
+inline std::string ChecksumInt32ToHex(uint32_t checksum_value) {
+  std::string checksum_str;
+  PutFixed32(&checksum_str, EndianSwapValue(checksum_value));
+  return Slice(checksum_str).ToString(/*hex=*/true);
+}
+
 // This is the class to generate the file checksum based on Crc32. It
 // will be used as the default checksum method for SST file checksum
 class FileChecksumGenCrc32c : public FileChecksumGenerator {

--- a/util/rate_limiter_impl.h
+++ b/util/rate_limiter_impl.h
@@ -157,4 +157,23 @@ class GenericRateLimiter : public RateLimiter {
   std::chrono::microseconds tuned_time_;
 };
 
+// Requests `total_bytes_to_request` bytes from `rate_limiter`, split into
+// GetSingleBurstBytes()-sized chunks and blocking until all are granted. Shared
+// by the backup and copy engines.
+inline void LoopRateLimitRequestHelper(size_t total_bytes_to_request,
+                                       RateLimiter* rate_limiter,
+                                       Env::IOPriority pri, Statistics* stats,
+                                       RateLimiter::OpType op_type) {
+  assert(rate_limiter != nullptr);
+  size_t remaining_bytes = total_bytes_to_request;
+  size_t request_bytes = 0;
+  while (remaining_bytes > 0) {
+    request_bytes =
+        std::min(static_cast<size_t>(rate_limiter->GetSingleBurstBytes()),
+                 remaining_bytes);
+    rate_limiter->Request(request_bytes, pri, stats, op_type);
+    remaining_bytes -= request_bytes;
+  }
+}
+
 }  // namespace ROCKSDB_NAMESPACE

--- a/utilities/backup/backup_engine.cc
+++ b/utilities/backup/backup_engine.cc
@@ -47,11 +47,13 @@
 #include "util/channel.h"
 #include "util/coding.h"
 #include "util/crc32c.h"
+#include "util/file_checksum_helper.h"
 #include "util/math.h"
 #include "util/rate_limiter_impl.h"
 #include "util/string_util.h"
 #include "utilities/backup/backup_engine_impl.h"
 #include "utilities/checkpoint/checkpoint_impl.h"
+#include "utilities/copy_engine/copy_engine.h"
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -67,11 +69,6 @@ inline uint32_t ChecksumHexToInt32(const std::string& checksum_hex) {
 }
 inline std::string ChecksumStrToHex(const std::string& checksum_str) {
   return Slice(checksum_str).ToString(true);
-}
-inline std::string ChecksumInt32ToHex(const uint32_t& checksum_value) {
-  std::string checksum_str;
-  PutFixed32(&checksum_str, EndianSwapValue(checksum_value));
-  return ChecksumStrToHex(checksum_str);
 }
 
 const std::string kPrivateDirName = "private";
@@ -248,15 +245,6 @@ class BackupEngineImpl {
       return rv;
     }
   };
-
-  // TODO: deprecate this function once we migrate all BackupEngine's rate
-  // limiting to lower-level ones (i.e, ones in file access wrapper level like
-  // `WritableFileWriter`)
-  static void LoopRateLimitRequestHelper(const size_t total_bytes_to_request,
-                                         RateLimiter* rate_limiter,
-                                         const Env::IOPriority pri,
-                                         Statistics* stats,
-                                         const RateLimiter::OpType op_type);
 
   static inline std::string WithoutTrailingSlash(const std::string& path) {
     if (path.empty() || path.back() != '/') {
@@ -587,34 +575,6 @@ class BackupEngineImpl {
            std::to_string(backup_id) + (tmp ? ".tmp" : "");
   }
 
-  // If size_limit == 0, there is no size limit, copy everything.
-  //
-  // Exactly one of src and contents must be non-empty.
-  //
-  // @param src If non-empty, the file is copied from this pathname.
-  // @param contents If non-empty, the file will be created with these contents.
-  // @param src_temperature Pass in expected temperature of src, return back
-  // temperature reported by FileSystem
-  IOStatus CopyOrCreateFile(const std::string& src, const std::string& dst,
-                            const std::string& contents, uint64_t size_limit,
-                            Env* src_env, Env* dst_env,
-                            const EnvOptions& src_env_options, bool sync,
-                            RateLimiter* rate_limiter,
-                            std::function<void()> progress_callback,
-                            Temperature* src_temperature,
-                            Temperature dst_temperature,
-                            uint64_t* bytes_toward_next_callback,
-                            uint64_t* size, std::string* checksum_hex);
-
-  uint64_t CalculateIOBufferSize(RateLimiter* rate_limiter) const;
-
-  IOStatus ReadFileAndComputeChecksum(const std::string& src,
-                                      const std::shared_ptr<FileSystem>& src_fs,
-                                      const EnvOptions& src_env_options,
-                                      uint64_t size_limit,
-                                      std::string* checksum_hex,
-                                      const Temperature src_temperature) const;
-
   // Helper method to check if backup should be stopped. Can be overridden
   // via sync points for testing.
   bool ShouldStopBackup() const;
@@ -625,152 +585,6 @@ class BackupEngineImpl {
                              Temperature file_temp, RateLimiter* rate_limiter,
                              std::string* db_id,
                              std::string* db_session_id) const;
-
-  struct WorkItemResult {
-    WorkItemResult()
-        : size(0),
-          expected_src_temperature(Temperature::kUnknown),
-          current_src_temperature(Temperature::kUnknown) {}
-
-    WorkItemResult(const WorkItemResult& other) = delete;
-    WorkItemResult& operator=(const WorkItemResult& other) = delete;
-
-    WorkItemResult(WorkItemResult&& o) noexcept { *this = std::move(o); }
-
-    WorkItemResult& operator=(WorkItemResult&& o) noexcept {
-      size = o.size;
-      checksum_hex = std::move(o.checksum_hex);
-      db_id = std::move(o.db_id);
-      db_session_id = std::move(o.db_session_id);
-      io_status = std::move(o.io_status);
-      expected_src_temperature = o.expected_src_temperature;
-      current_src_temperature = o.current_src_temperature;
-      return *this;
-    }
-
-    ~WorkItemResult() {
-      // The Status needs to be ignored here for two reasons.
-      // First, if the BackupEngineImpl shuts down with jobs outstanding, then
-      // it is possible that the Status in the future/promise is never read,
-      // resulting in an unchecked Status. Second, if there are items in the
-      // channel when the BackupEngineImpl is shutdown, these will also have
-      // Status that have not been checked.  This
-      // TODO: Fix those issues so that the Status
-      io_status.PermitUncheckedError();
-    }
-    uint64_t size;
-    std::string checksum_hex;
-    std::string db_id;
-    std::string db_session_id;
-    IOStatus io_status;
-    Temperature expected_src_temperature = Temperature::kUnknown;
-    Temperature current_src_temperature = Temperature::kUnknown;
-  };
-
-  enum WorkItemType : uint64_t {
-    CopyOrCreate = 1U,
-    ComputeChecksum = 2U,
-  };
-
-  // Exactly one of src_path and contents must be non-empty. If src_path is
-  // non-empty, the file is copied from this pathname. Otherwise, if contents is
-  // non-empty, the file will be created at dst_path with these contents.
-  struct WorkItem {
-    std::string src_path;
-    std::string dst_path;
-    Temperature src_temperature;
-    Temperature dst_temperature;
-    std::string contents;
-    Env* src_env;
-    Env* dst_env;
-    EnvOptions src_env_options;
-    bool sync;
-    RateLimiter* rate_limiter;
-    uint64_t size_limit;
-    Statistics* stats;
-    std::promise<WorkItemResult> result;
-    std::function<void()> progress_callback;
-    std::string src_checksum_func_name;
-    std::string src_checksum_hex;
-    std::string db_id;
-    std::string db_session_id;
-    WorkItemType type;
-
-    WorkItem()
-        : src_temperature(Temperature::kUnknown),
-          dst_temperature(Temperature::kUnknown),
-          src_env(nullptr),
-          dst_env(nullptr),
-          src_env_options(),
-          sync(false),
-          rate_limiter(nullptr),
-          size_limit(0),
-          stats(nullptr),
-          src_checksum_func_name(kUnknownFileChecksumFuncName),
-          type(WorkItemType::CopyOrCreate) {}
-
-    WorkItem(const WorkItem&) = delete;
-    WorkItem& operator=(const WorkItem&) = delete;
-
-    WorkItem(WorkItem&& o) noexcept { *this = std::move(o); }
-
-    WorkItem& operator=(WorkItem&& o) noexcept {
-      src_path = std::move(o.src_path);
-      dst_path = std::move(o.dst_path);
-      src_temperature = std::move(o.src_temperature);
-      dst_temperature = std::move(o.dst_temperature);
-      contents = std::move(o.contents);
-      src_env = o.src_env;
-      dst_env = o.dst_env;
-      src_env_options = std::move(o.src_env_options);
-      sync = o.sync;
-      rate_limiter = o.rate_limiter;
-      size_limit = o.size_limit;
-      stats = o.stats;
-      result = std::move(o.result);
-      progress_callback = std::move(o.progress_callback);
-      src_checksum_func_name = std::move(o.src_checksum_func_name);
-      src_checksum_hex = std::move(o.src_checksum_hex);
-      db_id = std::move(o.db_id);
-      db_session_id = std::move(o.db_session_id);
-      src_temperature = o.src_temperature;
-      type = std::move(o.type);
-      return *this;
-    }
-
-    WorkItem(std::string _src_path, std::string _dst_path,
-             const Temperature _src_temperature,
-             const Temperature _dst_temperature, std::string _contents,
-             Env* _src_env, Env* _dst_env, EnvOptions _src_env_options,
-             bool _sync, RateLimiter* _rate_limiter, uint64_t _size_limit,
-             Statistics* _stats, std::function<void()> _progress_callback = {},
-             const std::string& _src_checksum_func_name =
-                 kUnknownFileChecksumFuncName,
-             const std::string& _src_checksum_hex = "",
-             const std::string& _db_id = "",
-             const std::string& _db_session_id = "",
-             WorkItemType _type = WorkItemType::CopyOrCreate)
-        : src_path(std::move(_src_path)),
-          dst_path(std::move(_dst_path)),
-          src_temperature(_src_temperature),
-          dst_temperature(_dst_temperature),
-          contents(std::move(_contents)),
-          src_env(_src_env),
-          dst_env(_dst_env),
-          src_env_options(std::move(_src_env_options)),
-          sync(_sync),
-          rate_limiter(_rate_limiter),
-          size_limit(_size_limit),
-          stats(_stats),
-          progress_callback(_progress_callback),
-          src_checksum_func_name(_src_checksum_func_name),
-          src_checksum_hex(_src_checksum_hex),
-          db_id(_db_id),
-          db_session_id(_db_session_id),
-          type(_type) {}
-
-    ~WorkItem() = default;
-  };
 
   struct BackupAfterCopyOrCreateWorkItem {
     std::future<WorkItemResult> result;
@@ -874,10 +688,7 @@ class BackupEngineImpl {
   };
 
   bool initialized_;
-  std::mutex byte_report_mutex_;
-  mutable channel<WorkItem> work_items_;
-  std::vector<port::Thread> threads_;
-  std::atomic<CpuPriority> threads_cpu_priority_;
+  std::unique_ptr<CopyEngine> copy_engine_;
 
   // Certain operations like PurgeOldBackups and DeleteBackup will trigger
   // automatic GarbageCollect (true) unless we've already done one in this
@@ -929,7 +740,6 @@ class BackupEngineImpl {
   std::unique_ptr<FSDirectory> meta_directory_;
   std::unique_ptr<FSDirectory> private_directory_;
 
-  static const size_t kDefaultCopyFileBufferSize = 5 * 1024 * 1024LL;  // 5MB
   bool read_only_;
   BackupStatistics backup_statistics_;
   std::unordered_set<std::string> reported_ignored_fields_;
@@ -1106,7 +916,6 @@ namespace {
 BackupEngineImpl::BackupEngineImpl(const BackupEngineOptions& options,
                                    Env* db_env, bool read_only)
     : initialized_(false),
-      threads_cpu_priority_(),
       latest_backup_id_(0),
       latest_valid_backup_id_(0),
       stop_backup_(false),
@@ -1129,10 +938,8 @@ BackupEngineImpl::BackupEngineImpl(const BackupEngineOptions& options,
 }
 
 BackupEngineImpl::~BackupEngineImpl() {
-  work_items_.sendEof();
-  for (auto& t : threads_) {
-    t.join();
-  }
+  // copy_engine_'s destructor drains and joins its threads.
+  copy_engine_.reset();
   LogFlush(options_.info_log);
   for (const auto& it : corrupt_backups_) {
     it.second.first.PermitUncheckedError();
@@ -1328,98 +1135,20 @@ IOStatus BackupEngineImpl::Initialize() {
   ROCKS_LOG_INFO(options_.info_log, "Latest valid backup is %u",
                  latest_valid_backup_id_);
 
-  // set up threads to perform file creation / copy or checksum computations
-  // from work_items_ in the background.
-  threads_cpu_priority_ = CpuPriority::kNormal;
-  threads_.reserve(options_.max_background_operations);
-  for (int t = 0; t < options_.max_background_operations; t++) {
-    threads_.emplace_back([this]() {
-#if defined(_GNU_SOURCE) && defined(__GLIBC_PREREQ)
-#if __GLIBC_PREREQ(2, 12)
-      pthread_setname_np(pthread_self(), "backup_engine");
-#endif
-#endif
-      CpuPriority current_priority = CpuPriority::kNormal;
-      WorkItem work_item;
-      uint64_t bytes_toward_next_callback = 0;
-      while (work_items_.read(work_item)) {
-        CpuPriority priority = threads_cpu_priority_;
-        if (current_priority != priority) {
-          TEST_SYNC_POINT_CALLBACK(
-              "BackupEngineImpl::Initialize:SetCpuPriority", &priority);
-          port::SetCpuPriority(0, priority);
-          current_priority = priority;
-        }
-        // `bytes_read` and `bytes_written` stats are enabled based on
-        // compile-time support and cannot be dynamically toggled. So we do not
-        // need to worry about `PerfLevel` here, unlike many other
-        // `IOStatsContext` / `PerfContext` stats.
-        uint64_t prev_bytes_read = IOSTATS(bytes_read);
-        uint64_t prev_bytes_written = IOSTATS(bytes_written);
+  // Create the shared CopyEngine pool now that options_ (incl. rate limiters)
+  // is finalized.
+  CopyEngineOptions copy_options;
+  copy_options.max_background_operations = options_.max_background_operations;
+  copy_options.io_buffer_size = options_.io_buffer_size;
+  copy_options.callback_trigger_interval_size =
+      options_.callback_trigger_interval_size;
+  copy_options.checksum_rate_limiter = options_.backup_rate_limiter.get();
+  copy_options.info_log = options_.info_log;
+  copy_options.thread_name = "backup_engine";
+  copy_options.should_abort = [this]() { return ShouldStopBackup(); };
+  copy_options.abort_status_message = "Backup stopped";
+  copy_engine_ = std::make_unique<CopyEngine>(std::move(copy_options));
 
-        WorkItemResult result;
-        if (work_item.type == WorkItemType::CopyOrCreate) {
-          Temperature temp = work_item.src_temperature;
-          result.io_status = CopyOrCreateFile(
-              work_item.src_path, work_item.dst_path, work_item.contents,
-              work_item.size_limit, work_item.src_env, work_item.dst_env,
-              work_item.src_env_options, work_item.sync, work_item.rate_limiter,
-              work_item.progress_callback, &temp, work_item.dst_temperature,
-              &bytes_toward_next_callback, &result.size, &result.checksum_hex);
-
-          RecordTick(work_item.stats, BACKUP_READ_BYTES,
-                     IOSTATS(bytes_read) - prev_bytes_read);
-          RecordTick(work_item.stats, BACKUP_WRITE_BYTES,
-                     IOSTATS(bytes_written) - prev_bytes_written);
-
-          result.db_id = work_item.db_id;
-          result.db_session_id = work_item.db_session_id;
-          result.expected_src_temperature = work_item.src_temperature;
-          result.current_src_temperature = temp;
-          if (result.io_status.ok() && !work_item.src_checksum_hex.empty()) {
-            // unknown checksum function name implies no db table file checksum
-            // in db manifest; work_item.src_checksum_hex not empty means backup
-            // engine has calculated its crc32c checksum for the table file;
-            // therefore, we are able to compare the checksums.
-            if (work_item.src_checksum_func_name ==
-                    kUnknownFileChecksumFuncName ||
-                work_item.src_checksum_func_name == kDbFileChecksumFuncName) {
-              if (work_item.src_checksum_hex != result.checksum_hex) {
-                std::string checksum_info(
-                    "Expected checksum is " + work_item.src_checksum_hex +
-                    " while computed checksum is " + result.checksum_hex);
-                result.io_status = IOStatus::Corruption(
-                    "Checksum mismatch after copying to " + work_item.dst_path +
-                    ": " + checksum_info);
-              }
-            } else {
-              // FIXME(peterd): dead code?
-              std::string checksum_function_info(
-                  "Existing checksum function is " +
-                  work_item.src_checksum_func_name +
-                  " while provided checksum function is " +
-                  kBackupFileChecksumFuncName);
-              ROCKS_LOG_INFO(
-                  options_.info_log,
-                  "Unable to verify checksum after copying to %s: %s\n",
-                  work_item.dst_path.c_str(), checksum_function_info.c_str());
-            }
-          }
-        } else if (work_item.type == ComputeChecksum) {
-          result.io_status = ReadFileAndComputeChecksum(
-              work_item.src_path, work_item.src_env->GetFileSystem(),
-              work_item.src_env_options, work_item.size_limit,
-              &result.checksum_hex, work_item.src_temperature);
-          result.db_id = work_item.db_id;
-          result.db_session_id = work_item.db_session_id;
-        } else {
-          result.io_status = IOStatus::InvalidArgument(
-              "Unknown work item type: " + std::to_string(work_item.type));
-        }
-        work_item.result.set_value(std::move(result));
-      }
-    });
-  }
   ROCKS_LOG_INFO(options_.info_log, "Initialized BackupEngine");
   return IOStatus::OK();
 }
@@ -1443,9 +1172,8 @@ IOStatus BackupEngineImpl::CreateNewBackupWithMetadata(
   }
 
   if (options.decrease_background_thread_cpu_priority) {
-    if (options.background_thread_cpu_priority < threads_cpu_priority_) {
-      threads_cpu_priority_.store(options.background_thread_cpu_priority);
-    }
+    copy_engine_->MaybeDecreaseCpuPriority(
+        options.background_thread_cpu_priority);
   }
 
   BackupID new_backup_id = latest_backup_id_ + 1;
@@ -1637,7 +1365,7 @@ IOStatus BackupEngineImpl::CreateNewBackupWithMetadata(
         if (maybe_exclude_files[i].exclude_decision) {
           new_backup.get()->AddExcludedFile(e.second.dst_relative);
         } else {
-          work_items_.write(std::move(e.first));
+          copy_engine_->Submit(std::move(e.first));
           backup_items_to_finish.push_back(std::move(e.second));
         }
       }
@@ -2154,7 +1882,7 @@ IOStatus BackupEngineImpl::RestoreDBFromBackup(
     RestoreAfterCopyOrCreateWorkItem after_copy_or_create_work_item(
         copy_or_create_work_item.result.get_future(), file, dst,
         file_info->checksum_hex);
-    work_items_.write(std::move(copy_or_create_work_item));
+    copy_engine_->Submit(std::move(copy_or_create_work_item));
     restore_items_to_finish.push_back(
         std::move(after_copy_or_create_work_item));
   }
@@ -2290,7 +2018,7 @@ IOStatus BackupEngineImpl::VerifyBackup(BackupID backup_id,
       ROCKS_LOG_INFO(options_.info_log,
                      "Scheduling checksum evaluation for %s...\n",
                      abs_path.c_str());
-      work_items_.write(std::move(backup_file_work_item));
+      copy_engine_->Submit(std::move(backup_file_work_item));
       backup_verification_checksum_work_items.push_back(
           std::move(backup_file_checksum_work_item));
     }
@@ -2353,162 +2081,6 @@ IOStatus BackupEngineImpl::VerifyBackup(BackupID backup_id,
   }
 
   return io_s;
-}
-
-IOStatus BackupEngineImpl::CopyOrCreateFile(
-    const std::string& src, const std::string& dst, const std::string& contents,
-    uint64_t size_limit, Env* src_env, Env* dst_env,
-    const EnvOptions& src_env_options, bool sync, RateLimiter* rate_limiter,
-    std::function<void()> progress_callback, Temperature* src_temperature,
-    Temperature dst_temperature, uint64_t* bytes_toward_next_callback,
-    uint64_t* size, std::string* checksum_hex) {
-  assert(src.empty() != contents.empty());
-  if (ShouldStopBackup()) {
-    return status_to_io_status(Status::Incomplete("Backup stopped"));
-  }
-
-  IOStatus io_s;
-  std::unique_ptr<FSWritableFile> dst_file;
-  std::unique_ptr<FSSequentialFile> src_file;
-  FileOptions dst_file_options;
-  dst_file_options.use_mmap_writes = false;
-  dst_file_options.temperature = dst_temperature;
-  // TODO:(gzh) maybe use direct reads/writes here if possible
-  if (size != nullptr) {
-    *size = 0;
-  }
-  uint32_t checksum_value = 0;
-
-  // Check if size limit is set. if not, set it to very big number
-  if (size_limit == 0) {
-    size_limit = std::numeric_limits<uint64_t>::max();
-  }
-
-  io_s = dst_env->GetFileSystem()->NewWritableFile(dst, dst_file_options,
-                                                   &dst_file, nullptr);
-  if (!io_s.ok()) {
-    return io_s;
-  }
-
-  if (!src.empty()) {
-    auto src_file_options = FileOptions(src_env_options);
-    src_file_options.temperature = *src_temperature;
-    io_s = src_env->GetFileSystem()->NewSequentialFile(src, src_file_options,
-                                                       &src_file, nullptr);
-  }
-  if (io_s.IsPathNotFound() && *src_temperature != Temperature::kUnknown) {
-    // Retry without temperature hint in case the FileSystem is strict with
-    // non-kUnknown temperature option
-    io_s = src_env->GetFileSystem()->NewSequentialFile(
-        src, FileOptions(src_env_options), &src_file, nullptr);
-  }
-  if (!io_s.ok()) {
-    return io_s;
-  }
-
-  size_t buf_size = CalculateIOBufferSize(rate_limiter);
-  TEST_SYNC_POINT_CALLBACK(
-      "BackupEngineImpl::CopyOrCreateFile:CalculateIOBufferSize", &buf_size);
-
-  // TODO: pass in Histograms if the destination file is sst or blob
-  std::unique_ptr<WritableFileWriter> dest_writer(
-      new WritableFileWriter(std::move(dst_file), dst, dst_file_options));
-  std::unique_ptr<SequentialFileReader> src_reader;
-  std::unique_ptr<char[]> buf;
-  if (!src.empty()) {
-    // Return back current temperature in FileSystem
-    *src_temperature = src_file->GetTemperature();
-
-    src_reader.reset(new SequentialFileReader(
-        std::move(src_file), src, nullptr /* io_tracer */, {}, rate_limiter));
-    buf.reset(new char[buf_size]);
-  }
-
-  Slice data;
-  const IOOptions opts;
-  do {
-    if (ShouldStopBackup()) {
-      return status_to_io_status(Status::Incomplete("Backup stopped"));
-    }
-    if (!src.empty()) {
-      size_t buffer_to_read =
-          (buf_size < size_limit) ? buf_size : static_cast<size_t>(size_limit);
-      io_s = src_reader->Read(buffer_to_read, &data, buf.get(),
-                              Env::IO_LOW /* rate_limiter_priority */);
-      *bytes_toward_next_callback += data.size();
-    } else {
-      data = contents;
-    }
-    size_limit -= data.size();
-    TEST_SYNC_POINT_CALLBACK(
-        "BackupEngineImpl::CopyOrCreateFile:CorruptionDuringBackup",
-        (src.length() > 4 && src.rfind(".sst") == src.length() - 4) ? &data
-                                                                    : nullptr);
-
-    if (!io_s.ok()) {
-      return io_s;
-    }
-
-    if (size != nullptr) {
-      *size += data.size();
-    }
-    if (checksum_hex != nullptr) {
-      checksum_value = crc32c::Extend(checksum_value, data.data(), data.size());
-    }
-
-    io_s = dest_writer->Append(opts, data);
-
-    if (rate_limiter != nullptr) {
-      if (!src.empty()) {
-        rate_limiter->Request(data.size(), Env::IO_LOW, nullptr /* stats */,
-                              RateLimiter::OpType::kWrite);
-      } else {
-        LoopRateLimitRequestHelper(data.size(), rate_limiter, Env::IO_LOW,
-                                   nullptr /* stats */,
-                                   RateLimiter::OpType::kWrite);
-      }
-    }
-    while (*bytes_toward_next_callback >=
-           options_.callback_trigger_interval_size) {
-      *bytes_toward_next_callback -= options_.callback_trigger_interval_size;
-      if (progress_callback) {
-        std::lock_guard<std::mutex> lock(byte_report_mutex_);
-        try {
-          progress_callback();
-        } catch (const std::exception& exn) {
-          io_s = IOStatus::Aborted("Exception in progress_callback: " +
-                                   std::string(exn.what()));
-          break;
-        } catch (...) {
-          io_s = IOStatus::Aborted("Unknown exception in progress_callback");
-          break;
-        }
-      }
-    }
-  } while (io_s.ok() && contents.empty() && data.size() > 0 && size_limit > 0);
-
-  // Convert uint32_t checksum to hex checksum
-  if (checksum_hex != nullptr) {
-    checksum_hex->assign(ChecksumInt32ToHex(checksum_value));
-  }
-
-  if (io_s.ok() && sync) {
-    io_s = dest_writer->Sync(opts, false);
-  }
-  if (io_s.ok()) {
-    io_s = dest_writer->Close(opts);
-  }
-  return io_s;
-}
-
-uint64_t BackupEngineImpl::CalculateIOBufferSize(
-    RateLimiter* rate_limiter) const {
-  if (options_.io_buffer_size > 0) {
-    return options_.io_buffer_size;
-  }
-  return rate_limiter != nullptr
-             ? static_cast<size_t>(rate_limiter->GetSingleBurstBytes())
-             : kDefaultCopyFileBufferSize;
 }
 
 // fname will always start with "/"
@@ -2577,7 +2149,7 @@ IOStatus BackupEngineImpl::AddBackupFileWorkItem(
     // since the session id should suffice to avoid file name collision in
     // the shared_checksum directory.
     if (checksum_hex.empty() && db_session_id.empty()) {
-      IOStatus io_s = ReadFileAndComputeChecksum(
+      IOStatus io_s = copy_engine_->ReadFileAndComputeChecksum(
           src_path, db_fs_, src_env_options, size_limit, &checksum_hex,
           src_temperature);
       if (!io_s.ok()) {
@@ -2697,7 +2269,7 @@ IOStatus BackupEngineImpl::AddBackupFileWorkItem(
           // ID, but even in that case, we double check the file sizes in
           // BackupMeta::AddFile.
         } else {
-          IOStatus io_s = ReadFileAndComputeChecksum(
+          IOStatus io_s = copy_engine_->ReadFileAndComputeChecksum(
               src_path, db_fs_, src_env_options, size_limit, &checksum_hex,
               src_temperature);
           if (!io_s.ok()) {
@@ -2742,7 +2314,7 @@ IOStatus BackupEngineImpl::AddBackupFileWorkItem(
       // the checkpoint
       ROCKS_LOG_INFO(options_.info_log, "Copying %s to %s", fname.c_str(),
                      copy_dest_path->c_str());
-      work_items_.write(std::move(copy_or_create_work_item));
+      copy_engine_->Submit(std::move(copy_or_create_work_item));
       backup_items_to_finish.push_back(
           std::move(after_copy_or_create_work_item));
     }
@@ -2767,63 +2339,6 @@ bool BackupEngineImpl::ShouldStopBackup() const {
   bool should_stop = stop_backup_.load(std::memory_order_acquire);
   TEST_SYNC_POINT_CALLBACK("BackupEngineImpl::ShouldStopBackup", &should_stop);
   return should_stop;
-}
-
-IOStatus BackupEngineImpl::ReadFileAndComputeChecksum(
-    const std::string& src, const std::shared_ptr<FileSystem>& src_fs,
-    const EnvOptions& src_env_options, uint64_t size_limit,
-    std::string* checksum_hex, const Temperature src_temperature) const {
-  if (checksum_hex == nullptr) {
-    return status_to_io_status(Status::Aborted("Checksum pointer is null"));
-  }
-  if (ShouldStopBackup()) {
-    return status_to_io_status(Status::Incomplete("Backup stopped"));
-  }
-  uint32_t checksum_value = 0;
-  if (size_limit == 0) {
-    size_limit = std::numeric_limits<uint64_t>::max();
-  }
-
-  std::unique_ptr<SequentialFileReader> src_reader;
-  auto file_options = FileOptions(src_env_options);
-  file_options.temperature = src_temperature;
-  RateLimiter* rate_limiter = options_.backup_rate_limiter.get();
-  IOStatus io_s = SequentialFileReader::Create(
-      src_fs, src, file_options, &src_reader, nullptr /* dbg */, rate_limiter);
-  if (io_s.IsPathNotFound() && src_temperature != Temperature::kUnknown) {
-    // Retry without temperature hint in case the FileSystem is strict with
-    // non-kUnknown temperature option
-    file_options.temperature = Temperature::kUnknown;
-    io_s = SequentialFileReader::Create(src_fs, src, file_options, &src_reader,
-                                        nullptr /* dbg */, rate_limiter);
-  }
-  if (!io_s.ok()) {
-    return io_s;
-  }
-
-  size_t buf_size = CalculateIOBufferSize(rate_limiter);
-  std::unique_ptr<char[]> buf(new char[buf_size]);
-  Slice data;
-
-  do {
-    if (ShouldStopBackup()) {
-      return status_to_io_status(Status::Incomplete("Backup stopped"));
-    }
-    size_t buffer_to_read =
-        (buf_size < size_limit) ? buf_size : static_cast<size_t>(size_limit);
-    io_s = src_reader->Read(buffer_to_read, &data, buf.get(),
-                            Env::IO_LOW /* rate_limiter_priority */);
-    if (!io_s.ok()) {
-      return io_s;
-    }
-
-    size_limit -= data.size();
-    checksum_value = crc32c::Extend(checksum_value, data.data(), data.size());
-  } while (data.size() > 0 && size_limit > 0);
-
-  checksum_hex->assign(ChecksumInt32ToHex(checksum_value));
-
-  return io_s;
 }
 
 Status BackupEngineImpl::GetFileDbIdentities(Env* src_env,
@@ -2888,22 +2403,6 @@ Status BackupEngineImpl::GetFileDbIdentities(Env* src_env,
     s = Status::Corruption("Table properties missing in " + file_path);
     ROCKS_LOG_INFO(options_.info_log, "%s", s.ToString().c_str());
     return s;
-  }
-}
-
-void BackupEngineImpl::LoopRateLimitRequestHelper(
-    const size_t total_bytes_to_request, RateLimiter* rate_limiter,
-    const Env::IOPriority pri, Statistics* stats,
-    const RateLimiter::OpType op_type) {
-  assert(rate_limiter != nullptr);
-  size_t remaining_bytes = total_bytes_to_request;
-  size_t request_bytes = 0;
-  while (remaining_bytes > 0) {
-    request_bytes =
-        std::min(static_cast<size_t>(rate_limiter->GetSingleBurstBytes()),
-                 remaining_bytes);
-    rate_limiter->Request(request_bytes, pri, stats, op_type);
-    remaining_bytes -= request_bytes;
   }
 }
 
@@ -3071,7 +2570,7 @@ void BackupEngineImpl::InferDBFilesToRetainInRestore(
             backup_file_work_item.result.get_future(),
             backup_file_info->filename, number);
 
-        work_items_.write(std::move(backup_file_work_item));
+        copy_engine_->Submit(std::move(backup_file_work_item));
         backup_files_compute_checksum_work_items.push_back(
             std::move(backup_file_checksum_work_item));
 
@@ -3103,7 +2602,7 @@ void BackupEngineImpl::InferDBFilesToRetainInRestore(
 
       ComputeChecksumWorkItem db_file_checksum_work_item(
           db_file_work_item.result.get_future(), db_file_path, number);
-      work_items_.write(std::move(db_file_work_item));
+      copy_engine_->Submit(std::move(db_file_work_item));
       db_files_compute_checksum_work_items.push_back(
           std::move(db_file_checksum_work_item));
 

--- a/utilities/copy_engine/copy_engine.cc
+++ b/utilities/copy_engine/copy_engine.cc
@@ -1,0 +1,355 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include "utilities/copy_engine/copy_engine.h"
+
+#include <algorithm>
+#include <exception>
+#include <limits>
+#include <string>
+
+#include "file/sequence_file_reader.h"
+#include "file/writable_file_writer.h"
+#include "logging/logging.h"
+#include "monitoring/iostats_context_imp.h"
+#include "rocksdb/file_system.h"
+#include "rocksdb/slice.h"
+#include "rocksdb/utilities/backup_engine.h"
+#include "test_util/sync_point.h"
+#include "util/crc32c.h"
+#include "util/file_checksum_helper.h"
+#include "util/rate_limiter_impl.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+CopyEngine::CopyEngine(CopyEngineOptions options)
+    : options_(std::move(options)),
+      threads_cpu_priority_(CpuPriority::kNormal) {
+  threads_.reserve(options_.max_background_operations);
+  for (int t = 0; t < options_.max_background_operations; t++) {
+    threads_.emplace_back([this]() { ThreadBody(); });
+  }
+}
+
+CopyEngine::~CopyEngine() {
+  work_items_.sendEof();
+  for (auto& t : threads_) {
+    t.join();
+  }
+}
+
+void CopyEngine::Submit(WorkItem&& item) { work_items_.write(std::move(item)); }
+
+void CopyEngine::MaybeDecreaseCpuPriority(CpuPriority priority) {
+  if (priority < threads_cpu_priority_) {
+    threads_cpu_priority_.store(priority);
+  }
+}
+
+void CopyEngine::ThreadBody() {
+#if defined(_GNU_SOURCE) && defined(__GLIBC_PREREQ)
+#if __GLIBC_PREREQ(2, 12)
+  pthread_setname_np(pthread_self(), options_.thread_name.c_str());
+#endif
+#endif
+  CpuPriority current_priority = CpuPriority::kNormal;
+  WorkItem work_item;
+  uint64_t bytes_toward_next_callback = 0;
+  while (work_items_.read(work_item)) {
+    CpuPriority priority = threads_cpu_priority_;
+    if (current_priority != priority) {
+      TEST_SYNC_POINT_CALLBACK("BackupEngineImpl::Initialize:SetCpuPriority",
+                               &priority);
+      port::SetCpuPriority(0, priority);
+      current_priority = priority;
+    }
+    // `bytes_read` and `bytes_written` stats are enabled based on compile-time
+    // support and cannot be dynamically toggled. So we do not need to worry
+    // about `PerfLevel` here, unlike many other `IOStatsContext` /
+    // `PerfContext` stats.
+    uint64_t prev_bytes_read = IOSTATS(bytes_read);
+    uint64_t prev_bytes_written = IOSTATS(bytes_written);
+
+    WorkItemResult result;
+    if (work_item.type == WorkItemType::CopyOrCreate) {
+      Temperature temp = work_item.src_temperature;
+      result.io_status = CopyOrCreateFile(
+          work_item.src_path, work_item.dst_path, work_item.contents,
+          work_item.size_limit, work_item.src_env, work_item.dst_env,
+          work_item.src_env_options, work_item.sync, work_item.rate_limiter,
+          work_item.progress_callback, &temp, work_item.dst_temperature,
+          &bytes_toward_next_callback, &result.size, &result.checksum_hex);
+
+      RecordTick(work_item.stats, BACKUP_READ_BYTES,
+                 IOSTATS(bytes_read) - prev_bytes_read);
+      RecordTick(work_item.stats, BACKUP_WRITE_BYTES,
+                 IOSTATS(bytes_written) - prev_bytes_written);
+
+      result.db_id = work_item.db_id;
+      result.db_session_id = work_item.db_session_id;
+      result.expected_src_temperature = work_item.src_temperature;
+      result.current_src_temperature = temp;
+      if (result.io_status.ok() && !work_item.src_checksum_hex.empty()) {
+        // unknown checksum function name implies no db table file checksum in
+        // db manifest; work_item.src_checksum_hex not empty means backup engine
+        // has calculated its crc32c checksum for the table file; therefore, we
+        // are able to compare the checksums.
+        if (work_item.src_checksum_func_name == kUnknownFileChecksumFuncName ||
+            work_item.src_checksum_func_name == kDbFileChecksumFuncName) {
+          if (work_item.src_checksum_hex != result.checksum_hex) {
+            std::string checksum_info(
+                "Expected checksum is " + work_item.src_checksum_hex +
+                " while computed checksum is " + result.checksum_hex);
+            result.io_status =
+                IOStatus::Corruption("Checksum mismatch after copying to " +
+                                     work_item.dst_path + ": " + checksum_info);
+          }
+        } else {
+          // FIXME(peterd): dead code?
+          std::string checksum_function_info(
+              "Existing checksum function is " +
+              work_item.src_checksum_func_name +
+              " while provided checksum function is " +
+              kBackupFileChecksumFuncName);
+          ROCKS_LOG_INFO(options_.info_log,
+                         "Unable to verify checksum after copying to %s: %s\n",
+                         work_item.dst_path.c_str(),
+                         checksum_function_info.c_str());
+        }
+      }
+    } else if (work_item.type == ComputeChecksum) {
+      result.io_status = ReadFileAndComputeChecksum(
+          work_item.src_path, work_item.src_env->GetFileSystem(),
+          work_item.src_env_options, work_item.size_limit, &result.checksum_hex,
+          work_item.src_temperature);
+      result.db_id = work_item.db_id;
+      result.db_session_id = work_item.db_session_id;
+    } else {
+      result.io_status = IOStatus::InvalidArgument(
+          "Unknown work item type: " + std::to_string(work_item.type));
+    }
+    work_item.result.set_value(std::move(result));
+  }
+}
+
+IOStatus CopyEngine::CopyOrCreateFile(
+    const std::string& src, const std::string& dst, const std::string& contents,
+    uint64_t size_limit, Env* src_env, Env* dst_env,
+    const EnvOptions& src_env_options, bool sync, RateLimiter* rate_limiter,
+    const std::function<void()>& progress_callback,
+    Temperature* src_temperature, Temperature dst_temperature,
+    uint64_t* bytes_toward_next_callback, uint64_t* size,
+    std::string* checksum_hex) {
+  assert(src.empty() != contents.empty());
+  if (ShouldAbort()) {
+    return status_to_io_status(
+        Status::Incomplete(options_.abort_status_message));
+  }
+
+  IOStatus io_s;
+  std::unique_ptr<FSWritableFile> dst_file;
+  std::unique_ptr<FSSequentialFile> src_file;
+  FileOptions dst_file_options;
+  dst_file_options.use_mmap_writes = false;
+  dst_file_options.temperature = dst_temperature;
+  // TODO:(gzh) maybe use direct reads/writes here if possible
+  if (size != nullptr) {
+    *size = 0;
+  }
+  uint32_t checksum_value = 0;
+
+  // Check if size limit is set. if not, set it to very big number
+  if (size_limit == 0) {
+    size_limit = std::numeric_limits<uint64_t>::max();
+  }
+
+  io_s = dst_env->GetFileSystem()->NewWritableFile(dst, dst_file_options,
+                                                   &dst_file, nullptr);
+  if (!io_s.ok()) {
+    return io_s;
+  }
+
+  auto src_file_options = FileOptions(src_env_options);
+  if (!src.empty()) {
+    src_file_options.temperature = *src_temperature;
+    io_s = src_env->GetFileSystem()->NewSequentialFile(src, src_file_options,
+                                                       &src_file, nullptr);
+  }
+  if (io_s.IsPathNotFound() && *src_temperature != Temperature::kUnknown) {
+    // Retry without temperature hint in case the FileSystem is strict with
+    // non-kUnknown temperature option
+    src_file_options.temperature = Temperature::kUnknown;
+    io_s = src_env->GetFileSystem()->NewSequentialFile(src, src_file_options,
+                                                       &src_file, nullptr);
+  }
+  if (!io_s.ok()) {
+    return io_s;
+  }
+
+  size_t buf_size = CalculateIOBufferSize(rate_limiter);
+  TEST_SYNC_POINT_CALLBACK(
+      "BackupEngineImpl::CopyOrCreateFile:CalculateIOBufferSize", &buf_size);
+
+  // TODO: pass in Histograms if the destination file is sst or blob
+  std::unique_ptr<WritableFileWriter> dest_writer(
+      new WritableFileWriter(std::move(dst_file), dst, dst_file_options));
+  std::unique_ptr<SequentialFileReader> src_reader;
+  std::unique_ptr<char[]> buf;
+  if (!src.empty()) {
+    // Return back current temperature in FileSystem
+    *src_temperature = src_file->GetTemperature();
+
+    src_reader.reset(new SequentialFileReader(
+        std::move(src_file), src, nullptr /* io_tracer */, {}, rate_limiter));
+    buf.reset(new char[buf_size]);
+  }
+
+  Slice data;
+  const IOOptions opts;
+  do {
+    if (ShouldAbort()) {
+      return status_to_io_status(
+          Status::Incomplete(options_.abort_status_message));
+    }
+    if (!src.empty()) {
+      size_t buffer_to_read =
+          (buf_size < size_limit) ? buf_size : static_cast<size_t>(size_limit);
+      io_s = src_reader->Read(buffer_to_read, &data, buf.get(),
+                              Env::IO_LOW /* rate_limiter_priority */);
+      *bytes_toward_next_callback += data.size();
+    } else {
+      data = contents;
+    }
+    size_limit -= data.size();
+    TEST_SYNC_POINT_CALLBACK(
+        "BackupEngineImpl::CopyOrCreateFile:CorruptionDuringBackup",
+        (src.length() > 4 && src.rfind(".sst") == src.length() - 4) ? &data
+                                                                    : nullptr);
+
+    if (!io_s.ok()) {
+      return io_s;
+    }
+
+    if (size != nullptr) {
+      *size += data.size();
+    }
+    if (checksum_hex != nullptr) {
+      checksum_value = crc32c::Extend(checksum_value, data.data(), data.size());
+    }
+
+    io_s = dest_writer->Append(opts, data);
+
+    if (rate_limiter != nullptr) {
+      if (!src.empty()) {
+        rate_limiter->Request(data.size(), Env::IO_LOW, nullptr /* stats */,
+                              RateLimiter::OpType::kWrite);
+      } else {
+        LoopRateLimitRequestHelper(data.size(), rate_limiter, Env::IO_LOW,
+                                   nullptr /* stats */,
+                                   RateLimiter::OpType::kWrite);
+      }
+    }
+    while (*bytes_toward_next_callback >=
+           options_.callback_trigger_interval_size) {
+      *bytes_toward_next_callback -= options_.callback_trigger_interval_size;
+      if (progress_callback) {
+        std::lock_guard<std::mutex> lock(byte_report_mutex_);
+        try {
+          progress_callback();
+        } catch (const std::exception& exn) {
+          io_s = IOStatus::Aborted("Exception in progress_callback: " +
+                                   std::string(exn.what()));
+          break;
+        } catch (...) {
+          io_s = IOStatus::Aborted("Unknown exception in progress_callback");
+          break;
+        }
+      }
+    }
+  } while (io_s.ok() && contents.empty() && data.size() > 0 && size_limit > 0);
+
+  // Convert uint32_t checksum to hex checksum
+  if (checksum_hex != nullptr) {
+    checksum_hex->assign(ChecksumInt32ToHex(checksum_value));
+  }
+
+  if (io_s.ok() && sync) {
+    io_s = dest_writer->Sync(opts, false);
+  }
+  if (io_s.ok()) {
+    io_s = dest_writer->Close(opts);
+  }
+  return io_s;
+}
+
+uint64_t CopyEngine::CalculateIOBufferSize(RateLimiter* rate_limiter) const {
+  if (options_.io_buffer_size > 0) {
+    return options_.io_buffer_size;
+  }
+  return rate_limiter != nullptr
+             ? static_cast<size_t>(rate_limiter->GetSingleBurstBytes())
+             : kDefaultCopyFileBufferSize;
+}
+
+IOStatus CopyEngine::ReadFileAndComputeChecksum(
+    const std::string& src, const std::shared_ptr<FileSystem>& src_fs,
+    const EnvOptions& src_env_options, uint64_t size_limit,
+    std::string* checksum_hex, const Temperature src_temperature) const {
+  if (checksum_hex == nullptr) {
+    return status_to_io_status(Status::Aborted("Checksum pointer is null"));
+  }
+  if (ShouldAbort()) {
+    return status_to_io_status(
+        Status::Incomplete(options_.abort_status_message));
+  }
+  uint32_t checksum_value = 0;
+  if (size_limit == 0) {
+    size_limit = std::numeric_limits<uint64_t>::max();
+  }
+
+  std::unique_ptr<SequentialFileReader> src_reader;
+  auto file_options = FileOptions(src_env_options);
+  file_options.temperature = src_temperature;
+  RateLimiter* rate_limiter = options_.checksum_rate_limiter;
+  IOStatus io_s = SequentialFileReader::Create(
+      src_fs, src, file_options, &src_reader, nullptr /* dbg */, rate_limiter);
+  if (io_s.IsPathNotFound() && src_temperature != Temperature::kUnknown) {
+    // Retry without temperature hint in case the FileSystem is strict with
+    // non-kUnknown temperature option
+    file_options.temperature = Temperature::kUnknown;
+    io_s = SequentialFileReader::Create(src_fs, src, file_options, &src_reader,
+                                        nullptr /* dbg */, rate_limiter);
+  }
+  if (!io_s.ok()) {
+    return io_s;
+  }
+
+  size_t buf_size = CalculateIOBufferSize(rate_limiter);
+  std::unique_ptr<char[]> buf(new char[buf_size]);
+  Slice data;
+
+  do {
+    if (ShouldAbort()) {
+      return status_to_io_status(
+          Status::Incomplete(options_.abort_status_message));
+    }
+    size_t buffer_to_read =
+        (buf_size < size_limit) ? buf_size : static_cast<size_t>(size_limit);
+    io_s = src_reader->Read(buffer_to_read, &data, buf.get(),
+                            Env::IO_LOW /* rate_limiter_priority */);
+    if (!io_s.ok()) {
+      return io_s;
+    }
+
+    size_limit -= data.size();
+    checksum_value = crc32c::Extend(checksum_value, data.data(), data.size());
+  } while (data.size() > 0 && size_limit > 0);
+
+  checksum_hex->assign(ChecksumInt32ToHex(checksum_value));
+
+  return io_s;
+}
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/utilities/copy_engine/copy_engine.cc
+++ b/utilities/copy_engine/copy_engine.cc
@@ -126,6 +126,9 @@ void CopyEngine::ThreadBody() {
           work_item.src_temperature);
       result.db_id = work_item.db_id;
       result.db_session_id = work_item.db_session_id;
+    } else if (work_item.type == Link) {
+      result.io_status =
+          LinkFile(work_item.src_path, work_item.dst_path, work_item.dst_env);
     } else {
       result.io_status = IOStatus::InvalidArgument(
           "Unknown work item type: " + std::to_string(work_item.type));
@@ -282,6 +285,15 @@ IOStatus CopyEngine::CopyOrCreateFile(
     io_s = dest_writer->Close(opts);
   }
   return io_s;
+}
+
+IOStatus CopyEngine::LinkFile(const std::string& src, const std::string& dst,
+                              Env* dst_env) {
+  if (ShouldAbort()) {
+    return status_to_io_status(
+        Status::Incomplete(options_.abort_status_message));
+  }
+  return dst_env->GetFileSystem()->LinkFile(src, dst, IOOptions(), nullptr);
 }
 
 uint64_t CopyEngine::CalculateIOBufferSize(RateLimiter* rate_limiter) const {

--- a/utilities/copy_engine/copy_engine.h
+++ b/utilities/copy_engine/copy_engine.h
@@ -69,6 +69,7 @@ struct WorkItemResult {
 enum WorkItemType : uint64_t {
   CopyOrCreate = 1U,
   ComputeChecksum = 2U,
+  Link = 3U,
 };
 
 // Exactly one of src_path and contents must be non-empty. If src_path is
@@ -173,8 +174,9 @@ struct CopyEngineOptions {
   std::string abort_status_message = "Operation stopped";
 };
 
-// A pool of background threads that copy or checksum files pulled from a shared
-// work queue, so BackupEngine and CheckpointEngine share one implementation.
+// A pool of background threads that copy, hard-link, or checksum files pulled
+// from a shared work queue, so BackupEngine and CheckpointEngine share one
+// implementation.
 class CopyEngine {
  public:
   explicit CopyEngine(CopyEngineOptions options);
@@ -208,6 +210,11 @@ class CopyEngine {
                                       uint64_t size_limit,
                                       std::string* checksum_hex,
                                       Temperature src_temperature) const;
+
+  // Returns the FileSystem's NotSupported when linking is unavailable, so
+  // callers can fall back to copying.
+  IOStatus LinkFile(const std::string& src, const std::string& dst,
+                    Env* dst_env);
 
   uint64_t CalculateIOBufferSize(RateLimiter* rate_limiter) const;
 

--- a/utilities/copy_engine/copy_engine.h
+++ b/utilities/copy_engine/copy_engine.h
@@ -1,0 +1,230 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <functional>
+#include <future>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "port/port.h"
+#include "rocksdb/env.h"
+#include "rocksdb/file_checksum.h"
+#include "rocksdb/io_status.h"
+#include "rocksdb/rate_limiter.h"
+#include "rocksdb/rocksdb_namespace.h"
+#include "rocksdb/statistics.h"
+#include "util/channel.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+class FileSystem;
+
+struct WorkItemResult {
+  WorkItemResult() = default;
+
+  WorkItemResult(const WorkItemResult& other) = delete;
+  WorkItemResult& operator=(const WorkItemResult& other) = delete;
+
+  WorkItemResult(WorkItemResult&& o) noexcept { *this = std::move(o); }
+
+  WorkItemResult& operator=(WorkItemResult&& o) noexcept {
+    size = o.size;
+    checksum_hex = std::move(o.checksum_hex);
+    db_id = std::move(o.db_id);
+    db_session_id = std::move(o.db_session_id);
+    io_status = std::move(o.io_status);
+    expected_src_temperature = o.expected_src_temperature;
+    current_src_temperature = o.current_src_temperature;
+    return *this;
+  }
+
+  ~WorkItemResult() {
+    // The Status needs to be ignored here for two reasons.
+    // First, if the CopyEngine shuts down with jobs outstanding, then
+    // it is possible that the Status in the future/promise is never read,
+    // resulting in an unchecked Status. Second, if there are items in the
+    // channel when the CopyEngine is shutdown, these will also have
+    // Status that have not been checked.  This
+    // TODO: Fix those issues so that the Status
+    io_status.PermitUncheckedError();
+  }
+  uint64_t size = 0;
+  std::string checksum_hex;
+  std::string db_id;
+  std::string db_session_id;
+  IOStatus io_status;
+  Temperature expected_src_temperature = Temperature::kUnknown;
+  Temperature current_src_temperature = Temperature::kUnknown;
+};
+
+enum WorkItemType : uint64_t {
+  CopyOrCreate = 1U,
+  ComputeChecksum = 2U,
+};
+
+// Exactly one of src_path and contents must be non-empty. If src_path is
+// non-empty, the file is copied from this pathname. Otherwise, if contents is
+// non-empty, the file will be created at dst_path with these contents.
+struct WorkItem {
+  std::string src_path;
+  std::string dst_path;
+  Temperature src_temperature = Temperature::kUnknown;
+  Temperature dst_temperature = Temperature::kUnknown;
+  std::string contents;
+  Env* src_env = nullptr;
+  Env* dst_env = nullptr;
+  EnvOptions src_env_options;
+  bool sync = false;
+  RateLimiter* rate_limiter = nullptr;
+  uint64_t size_limit = 0;
+  Statistics* stats = nullptr;
+  std::promise<WorkItemResult> result;
+  std::function<void()> progress_callback;
+  std::string src_checksum_func_name = kUnknownFileChecksumFuncName;
+  std::string src_checksum_hex;
+  std::string db_id;
+  std::string db_session_id;
+  WorkItemType type = WorkItemType::CopyOrCreate;
+
+  WorkItem() = default;
+
+  WorkItem(const WorkItem&) = delete;
+  WorkItem& operator=(const WorkItem&) = delete;
+
+  WorkItem(WorkItem&& o) noexcept { *this = std::move(o); }
+
+  WorkItem& operator=(WorkItem&& o) noexcept {
+    src_path = std::move(o.src_path);
+    dst_path = std::move(o.dst_path);
+    src_temperature = o.src_temperature;
+    dst_temperature = o.dst_temperature;
+    contents = std::move(o.contents);
+    src_env = o.src_env;
+    dst_env = o.dst_env;
+    src_env_options = std::move(o.src_env_options);
+    sync = o.sync;
+    rate_limiter = o.rate_limiter;
+    size_limit = o.size_limit;
+    stats = o.stats;
+    result = std::move(o.result);
+    progress_callback = std::move(o.progress_callback);
+    src_checksum_func_name = std::move(o.src_checksum_func_name);
+    src_checksum_hex = std::move(o.src_checksum_hex);
+    db_id = std::move(o.db_id);
+    db_session_id = std::move(o.db_session_id);
+    type = o.type;
+    return *this;
+  }
+
+  WorkItem(
+      std::string _src_path, std::string _dst_path,
+      const Temperature _src_temperature, const Temperature _dst_temperature,
+      std::string _contents, Env* _src_env, Env* _dst_env,
+      EnvOptions _src_env_options, bool _sync, RateLimiter* _rate_limiter,
+      uint64_t _size_limit, Statistics* _stats,
+      std::function<void()> _progress_callback = {},
+      const std::string& _src_checksum_func_name = kUnknownFileChecksumFuncName,
+      const std::string& _src_checksum_hex = "", const std::string& _db_id = "",
+      const std::string& _db_session_id = "",
+      WorkItemType _type = WorkItemType::CopyOrCreate)
+      : src_path(std::move(_src_path)),
+        dst_path(std::move(_dst_path)),
+        src_temperature(_src_temperature),
+        dst_temperature(_dst_temperature),
+        contents(std::move(_contents)),
+        src_env(_src_env),
+        dst_env(_dst_env),
+        src_env_options(std::move(_src_env_options)),
+        sync(_sync),
+        rate_limiter(_rate_limiter),
+        size_limit(_size_limit),
+        stats(_stats),
+        progress_callback(std::move(_progress_callback)),
+        src_checksum_func_name(_src_checksum_func_name),
+        src_checksum_hex(_src_checksum_hex),
+        db_id(_db_id),
+        db_session_id(_db_session_id),
+        type(_type) {}
+
+  ~WorkItem() = default;
+};
+
+struct CopyEngineOptions {
+  int max_background_operations = 1;
+  uint64_t io_buffer_size = 0;
+  uint64_t callback_trigger_interval_size = 4 * 1024 * 1024;
+  // Rate limiter for standalone ComputeChecksum reads; copies use the
+  // per-WorkItem rate_limiter instead. Not owned; must outlive the CopyEngine.
+  RateLimiter* checksum_rate_limiter = nullptr;
+  Logger* info_log = nullptr;
+  // Pool thread name; must be <= 15 chars on Linux or it is left unnamed.
+  std::string thread_name = "copy_engine";
+  // If set, polled to abort work early (e.g. BackupEngine::StopBackup).
+  std::function<bool()> should_abort = {};
+  std::string abort_status_message = "Operation stopped";
+};
+
+// A pool of background threads that copy or checksum files pulled from a shared
+// work queue, so BackupEngine and CheckpointEngine share one implementation.
+class CopyEngine {
+ public:
+  explicit CopyEngine(CopyEngineOptions options);
+  ~CopyEngine();
+
+  CopyEngine(const CopyEngine&) = delete;
+  CopyEngine& operator=(const CopyEngine&) = delete;
+  CopyEngine(CopyEngine&&) = delete;
+  CopyEngine& operator=(CopyEngine&&) = delete;
+
+  // Enqueues item (moved in); extract item.result's future before calling.
+  void Submit(WorkItem&& item);
+
+  void MaybeDecreaseCpuPriority(CpuPriority priority);
+
+  // Synchronous primitives, usable inline or from the pool.
+  IOStatus CopyOrCreateFile(const std::string& src, const std::string& dst,
+                            const std::string& contents, uint64_t size_limit,
+                            Env* src_env, Env* dst_env,
+                            const EnvOptions& src_env_options, bool sync,
+                            RateLimiter* rate_limiter,
+                            const std::function<void()>& progress_callback,
+                            Temperature* src_temperature,
+                            Temperature dst_temperature,
+                            uint64_t* bytes_toward_next_callback,
+                            uint64_t* size, std::string* checksum_hex);
+
+  IOStatus ReadFileAndComputeChecksum(const std::string& src,
+                                      const std::shared_ptr<FileSystem>& src_fs,
+                                      const EnvOptions& src_env_options,
+                                      uint64_t size_limit,
+                                      std::string* checksum_hex,
+                                      Temperature src_temperature) const;
+
+  uint64_t CalculateIOBufferSize(RateLimiter* rate_limiter) const;
+
+ private:
+  static constexpr size_t kDefaultCopyFileBufferSize =
+      5 * 1024 * 1024LL;  // 5MB
+
+  void ThreadBody();
+  bool ShouldAbort() const {
+    return options_.should_abort && options_.should_abort();
+  }
+
+  CopyEngineOptions options_;
+  std::mutex byte_report_mutex_;
+  mutable channel<WorkItem> work_items_;
+  std::vector<port::Thread> threads_;
+  std::atomic<CpuPriority> threads_cpu_priority_;
+};
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/utilities/copy_engine/copy_engine_test.cc
+++ b/utilities/copy_engine/copy_engine_test.cc
@@ -1,0 +1,192 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include "utilities/copy_engine/copy_engine.h"
+
+#include <future>
+#include <string>
+#include <vector>
+
+#include "file/file_util.h"
+#include "port/stack_trace.h"
+#include "rocksdb/env.h"
+#include "test_util/testharness.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+class CopyEngineTest : public testing::Test {
+ protected:
+  CopyEngineTest() {
+    env_ = Env::Default();
+    dir_ = test::PerThreadDBPath(env_, "copy_engine_test");
+  }
+
+  // PerThreadDBPath is deterministic per (name, pid, thread), so every case in
+  // this fixture maps to the same directory. Destroy it around each case so
+  // files from one case (or a prior/repeated run) cannot leak into the next.
+  void SetUp() override {
+    ASSERT_OK(DestroyDir(env_, dir_));
+    ASSERT_OK(env_->CreateDirIfMissing(dir_));
+  }
+
+  void TearDown() override { ASSERT_OK(DestroyDir(env_, dir_)); }
+
+  std::string SrcPath(int i) const {
+    return dir_ + "/src_" + std::to_string(i);
+  }
+  std::string DstPath(int i) const {
+    return dir_ + "/dst_" + std::to_string(i);
+  }
+
+  void CreateSrc(int i, const std::string& content) {
+    ASSERT_OK(WriteStringToFile(env_, content, SrcPath(i),
+                                /*should_sync=*/false));
+  }
+
+  // Varied sizes exercise the dynamic pull-based pool (not a static split).
+  std::string ContentFor(int i) const {
+    return "file-" + std::to_string(i) + "-" + std::string((i + 1) * 1024, 'x');
+  }
+
+  WorkItem MakeCopyItem(int i) {
+    return WorkItem(SrcPath(i), DstPath(i), Temperature::kUnknown,
+                    Temperature::kUnknown, /*contents=*/"", env_, env_,
+                    EnvOptions(), /*sync=*/false, /*rate_limiter=*/nullptr,
+                    /*size_limit=*/0, /*stats=*/nullptr);
+  }
+
+  WorkItem MakeLinkItem(int i) {
+    WorkItem w = MakeCopyItem(i);
+    w.type = WorkItemType::Link;
+    return w;
+  }
+
+  void VerifyDstMatches(int i, const std::string& expected) {
+    std::string got;
+    ASSERT_OK(ReadFileToString(env_, DstPath(i), &got));
+    ASSERT_EQ(expected, got);
+  }
+
+  Env* env_;
+  std::string dir_;
+};
+
+TEST_F(CopyEngineTest, ParallelCopy) {
+  constexpr int kNumFiles = 16;
+  std::vector<std::string> contents;
+  for (int i = 0; i < kNumFiles; ++i) {
+    contents.push_back(ContentFor(i));
+    CreateSrc(i, contents[i]);
+  }
+
+  CopyEngineOptions options;
+  options.max_background_operations = 4;
+  CopyEngine engine(std::move(options));
+
+  std::vector<std::future<WorkItemResult>> results;
+  for (int i = 0; i < kNumFiles; ++i) {
+    WorkItem w = MakeCopyItem(i);
+    results.push_back(w.result.get_future());
+    engine.Submit(std::move(w));
+  }
+
+  for (int i = 0; i < kNumFiles; ++i) {
+    WorkItemResult r = results[i].get();
+    ASSERT_OK(r.io_status);
+    ASSERT_EQ(contents[i].size(), r.size);
+    VerifyDstMatches(i, contents[i]);
+  }
+}
+
+TEST_F(CopyEngineTest, ParallelLink) {
+  constexpr int kNumFiles = 16;
+  std::vector<std::string> contents;
+  for (int i = 0; i < kNumFiles; ++i) {
+    contents.push_back(ContentFor(i));
+    CreateSrc(i, contents[i]);
+  }
+
+  CopyEngineOptions options;
+  options.max_background_operations = 4;
+  CopyEngine engine(std::move(options));
+
+  std::vector<std::future<WorkItemResult>> results;
+  for (int i = 0; i < kNumFiles; ++i) {
+    WorkItem w = MakeLinkItem(i);
+    results.push_back(w.result.get_future());
+    engine.Submit(std::move(w));
+  }
+
+  bool link_supported = true;
+  for (int i = 0; i < kNumFiles; ++i) {
+    WorkItemResult r = results[i].get();
+    if (r.io_status.IsNotSupported()) {
+      link_supported = false;
+      continue;
+    }
+    ASSERT_OK(r.io_status);
+    VerifyDstMatches(i, contents[i]);
+  }
+  if (!link_supported) {
+    ROCKSDB_GTEST_SKIP("FileSystem does not support hard links");
+  }
+}
+
+TEST_F(CopyEngineTest, SerialCopyMatchesSingleThread) {
+  constexpr int kNumFiles = 5;
+  std::vector<std::string> contents;
+  for (int i = 0; i < kNumFiles; ++i) {
+    contents.push_back(ContentFor(i));
+    CreateSrc(i, contents[i]);
+  }
+
+  CopyEngineOptions options;
+  options.max_background_operations = 1;
+  CopyEngine engine(std::move(options));
+
+  std::vector<std::future<WorkItemResult>> results;
+  for (int i = 0; i < kNumFiles; ++i) {
+    WorkItem w = MakeCopyItem(i);
+    results.push_back(w.result.get_future());
+    engine.Submit(std::move(w));
+  }
+
+  for (int i = 0; i < kNumFiles; ++i) {
+    WorkItemResult r = results[i].get();
+    ASSERT_OK(r.io_status);
+    VerifyDstMatches(i, contents[i]);
+  }
+}
+
+TEST_F(CopyEngineTest, MissingSourceReportsErrorPerItem) {
+  CreateSrc(0, ContentFor(0));
+
+  CopyEngineOptions options;
+  options.max_background_operations = 2;
+  CopyEngine engine(std::move(options));
+
+  WorkItem ok_item = MakeCopyItem(0);
+  auto ok_future = ok_item.result.get_future();
+  engine.Submit(std::move(ok_item));
+
+  WorkItem bad_item = MakeCopyItem(1);  // no source file on disk
+  auto bad_future = bad_item.result.get_future();
+  engine.Submit(std::move(bad_item));
+
+  WorkItemResult ok_result = ok_future.get();
+  ASSERT_OK(ok_result.io_status);
+  VerifyDstMatches(0, ContentFor(0));
+
+  WorkItemResult bad_result = bad_future.get();
+  ASSERT_NOK(bad_result.io_status);
+}
+
+}  // namespace ROCKSDB_NAMESPACE
+
+int main(int argc, char** argv) {
+  ROCKSDB_NAMESPACE::port::InstallStackTraceHandler();
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Summary:

Teaches the shared `CopyEngine` to hard-link files through its background pool: adds `WorkItemType::Link` and `CopyEngine::LinkFile(src, dst, dst_env)`, which returns the FileSystem's `NotSupported` when links are unavailable so callers can fall back to copying. This is what CheckpointEngine (next diff) needs for warm storage, where linking is supported but benefits from parallelism.

No existing caller links through the engine yet (BackupEngine never hard-links), so no behavior change; the path is exercised by a new `copy_engine_test.cc` (parallel copy, parallel link, single-thread copy, per-item error reporting).

Differential Revision: D111387972


