### PR TITLE
Update version to 11.8.0 for 11.7 release

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,7 +12,6 @@
 ### Performance Improvements
 * Fixed slow DB open with `best_efforts_recovery`, and slow catch-up of secondary and follower (read-only) instances, in which time and memory grew quadratically with the number of files in the DB (so the slowdown was worst for large DBs with long history).
 
-
 ## 11.6.0 (07/02/2026)
 ### New Features
 * Added EXPERIMENTAL embedded blob SST support through `SstFileWriter::OpenWithEmbeddedBlobs()`, storing eligible large values as same-file blob records in block-based SST files and resolving them transparently for reads. This niche feature currently supports uncompressed embedded blobs only; compression options are placeholders and compression support is deferred to follow-up work.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,18 @@
 # Rocksdb Change Log
 > NOTE: Entries for next release do not go here. Follow instructions in `unreleased_history/README.txt`
 
+## 11.7.0 (07/16/2026)
+### Public API Changes
+* Added `RangeLockManagerHandle::SetIsKilledCallback()`, a `std::function<bool()>` predicate polled during range-lock waits. When it returns true, a blocked `GetRangeLock()` wait returns promptly with `Status::Aborted()` instead of waiting for the lock timeout. Range-lock users that install no callback keep the original wait-until-grant-or-timeout behavior.
+* Added `MultiScanArgs::reverse` to support reverse MultiScan reads over bounded scan ranges.
+
+### Behavior Changes
+* When using `LockWAL()`, live-file capture APIs such as checkpoint and backup now flush WAL-disabled unpersisted data; they can block until `UnlockWAL()` or return `Aborted` when called from the same thread that holds `LockWAL()` to avoid deadlock. `UnlockWAL()` must now also be called from the same thread that called `LockWAL()`.
+
+### Performance Improvements
+* Fixed slow DB open with `best_efforts_recovery`, and slow catch-up of secondary and follower (read-only) instances, in which time and memory grew quadratically with the number of files in the DB (so the slowdown was worst for large DBs with long history).
+
+
 ## 11.6.0 (07/02/2026)
 ### New Features
 * Added EXPERIMENTAL embedded blob SST support through `SstFileWriter::OpenWithEmbeddedBlobs()`, storing eligible large values as same-file blob records in block-based SST files and resolving them transparently for reads. This niche feature currently supports uncompressed embedded blobs only; compression options are placeholders and compression support is deferred to follow-up work.

--- a/include/rocksdb/version.h
+++ b/include/rocksdb/version.h
@@ -12,7 +12,7 @@
 // NOTE: in 'main' development branch, this should be the *next*
 // minor or major version number planned for release.
 #define ROCKSDB_MAJOR 11
-#define ROCKSDB_MINOR 7
+#define ROCKSDB_MINOR 8
 #define ROCKSDB_PATCH 0
 
 // Make it easy to do conditional compilation based on version checks, i.e.

--- a/tools/check_format_compatible.sh
+++ b/tools/check_format_compatible.sh
@@ -161,7 +161,7 @@ EOF
 
 # To check for DB forward compatibility with loading options (old version
 # reading data from new), as well as backward compatibility
-declare -a db_forward_with_options_refs=("10.4.fb" "10.5.fb" "10.6.fb" "10.7.fb" "10.8.fb" "10.9.fb" "10.10.fb" "10.11.fb" "11.0.fb" "11.1.fb" "11.2.fb" "11.3.fb" "11.4.fb" "11.5.fb" "11.6.fb")
+declare -a db_forward_with_options_refs=("10.4.fb" "10.5.fb" "10.6.fb" "10.7.fb" "10.8.fb" "10.9.fb" "10.10.fb" "10.11.fb" "11.0.fb" "11.1.fb" "11.2.fb" "11.3.fb" "11.4.fb" "11.5.fb" "11.6.fb" "11.7.fb")
 # To check for DB forward compatibility without loading options (in addition
 # to the "with loading options" set), as well as backward compatibility
 declare -a db_forward_no_options_refs=() # N/A at the moment

--- a/unreleased_history/behavior_changes/lock_wal_live_file_flush.md
+++ b/unreleased_history/behavior_changes/lock_wal_live_file_flush.md
@@ -1,1 +1,0 @@
-When using `LockWAL()`, live-file capture APIs such as checkpoint and backup now flush WAL-disabled unpersisted data; they can block until `UnlockWAL()` or return `Aborted` when called from the same thread that holds `LockWAL()` to avoid deadlock. `UnlockWAL()` must now also be called from the same thread that called `LockWAL()`.

--- a/unreleased_history/performance_improvements/version_builder_pit_rollback.md
+++ b/unreleased_history/performance_improvements/version_builder_pit_rollback.md
@@ -1,1 +1,0 @@
-Fixed slow DB open with `best_efforts_recovery`, and slow catch-up of secondary and follower (read-only) instances, in which time and memory grew quadratically with the number of files in the DB (so the slowdown was worst for large DBs with long history).

--- a/unreleased_history/public_api_changes/range_lock_kill_callback.md
+++ b/unreleased_history/public_api_changes/range_lock_kill_callback.md
@@ -1,1 +1,0 @@
-Added `RangeLockManagerHandle::SetIsKilledCallback()`, a `std::function<bool()>` predicate polled during range-lock waits. When it returns true, a blocked `GetRangeLock()` wait returns promptly with `Status::Aborted()` instead of waiting for the lock timeout. Range-lock users that install no callback keep the original wait-until-grant-or-timeout behavior.

--- a/unreleased_history/public_api_changes/reverse_multiscan.md
+++ b/unreleased_history/public_api_changes/reverse_multiscan.md
@@ -1,1 +1,0 @@
-Added `MultiScanArgs::reverse` to support reverse MultiScan reads over bounded scan ranges.


### PR DESCRIPTION
## Summary
- Bump version.h from 11.7.0 to 11.8.0
- Add `11.7.fb` to `check_format_compatible.sh`

Part of 11.7 release workflow.