### PR TITLE
cmake: discover gtest tests at ctest time to fix macOS CMake CI build (#14951)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1707,7 +1707,21 @@ if(WITH_TESTS)
       )
       target_link_libraries(${exename}${ARTIFACT_SUFFIX} testutillib${ARTIFACT_SUFFIX} testharness gtest ${THIRDPARTY_LIBS} ${ROCKSDB_LIB})
       if(NOT "${exename}" MATCHES "db_sanity_test")
-        gtest_discover_tests(${exename} DISCOVERY_TIMEOUT 120)
+        if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.18)
+          # Discover tests at ctest time instead of during the parallel build.
+          # POST_BUILD discovery (the default) runs each freshly-built test
+          # binary while the -j build is still compiling; on resource-constrained
+          # CI (notably the arm64 macOS runners) that discovery run can yield
+          # empty output, and CMake's JSON parser then aborts the whole build
+          # with "Syntax error: value, object or array expected". PRE_TEST moves
+          # discovery out of the build phase so a slow/empty enumeration no
+          # longer fails the build.
+          gtest_discover_tests(${exename}
+                               DISCOVERY_TIMEOUT 120
+                               DISCOVERY_MODE PRE_TEST)
+        else()
+          gtest_discover_tests(${exename} DISCOVERY_TIMEOUT 120)
+        endif()
         add_dependencies(rocksdb_check ${exename}${ARTIFACT_SUFFIX})
       endif()
   endforeach(sourcefile ${TESTS})


### PR DESCRIPTION
Summary:

The `build-macos-cmake` CI job intermittently but persistently fails during `make` with:

  GoogleTestAddTests.cmake:... (parse_tests_from_json)
  * Line 1, Column 1
  Syntax error: value, object or array expected.
  make: *** [all] Error 2

This is `gtest_discover_tests` running in its default POST_BUILD mode: it executes each freshly-built test binary during the parallel `-j` build to enumerate test cases as JSON. On the resource-constrained arm64 macOS runners, that discovery run competes with the in-flight compile jobs and can produce empty output, which CMake's JSON parser then rejects, aborting the whole build. The failing targets (e.g. `cache_reservation_manager_test`, `lru_cache_test`) are unrelated to whatever change is under test -- other test binaries in the same run discover fine -- confirming it is a build-phase discovery race, not a code defect.

Switch discovery to `DISCOVERY_MODE PRE_TEST` so enumeration happens at ctest time (serially, after the build) instead of during the parallel build. This keeps the build green while preserving full test discovery. `PRE_TEST` requires CMake >= 3.18, so it is guarded by a version check; on older CMake (the project's declared minimum is 3.12) behavior is unchanged.

Differential Revision: D112478854


