### PR TITLE
Add IndexFactory compatibility names

### DIFF
--- a/include/rocksdb/index_factory.h
+++ b/include/rocksdb/index_factory.h
@@ -1,0 +1,24 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+//
+//  *****************************************************************
+//  EXPERIMENTAL - subject to change while under development
+//  *****************************************************************
+
+#pragma once
+
+#include "rocksdb/user_defined_index.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+using IndexFactoryBuilder = UserDefinedIndexBuilder;
+using IndexFactoryIterator = UserDefinedIndexIterator;
+using IndexFactoryReader = UserDefinedIndexReader;
+using IndexFactoryOptions = UserDefinedIndexOption;
+using IndexFactory = UserDefinedIndexFactory;
+
+inline constexpr const char* kIndexFactoryMetaPrefix = kUserDefinedIndexPrefix;
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -20,6 +20,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <type_traits>
 #include <unordered_set>
 #include <vector>
 
@@ -43,6 +44,7 @@
 #include "rocksdb/file_checksum.h"
 #include "rocksdb/file_system.h"
 #include "rocksdb/filter_policy.h"
+#include "rocksdb/index_factory.h"
 #include "rocksdb/iterator.h"
 #include "rocksdb/listener.h"
 #include "rocksdb/memtablerep.h"
@@ -88,6 +90,59 @@
 namespace ROCKSDB_NAMESPACE {
 
 namespace {
+
+static_assert(
+    std::is_same<IndexFactoryIterator, UserDefinedIndexIterator>::value);
+static_assert(std::is_same<IndexFactoryReader, UserDefinedIndexReader>::value);
+
+TEST(IndexFactoryCompatibilityTest, NewNamesPreserveOldSubclassShape) {
+  class LegacyOnlyBuilder : public IndexFactoryBuilder {
+   public:
+    Slice AddIndexEntry(const Slice& last_key_in_current_block,
+                        const Slice* /*first_key_in_next_block*/,
+                        const BlockHandle& /*block_handle*/,
+                        std::string* /*separator_scratch*/,
+                        const IndexEntryContext& /*context*/) override {
+      return last_key_in_current_block;
+    }
+
+    Status Finish(Slice* index_contents) override {
+      *index_contents = Slice();
+      return Status::OK();
+    }
+
+    uint64_t EstimatedSize() const override { return 0; }
+  };
+
+  class LegacyOnlyFactory : public IndexFactory {
+   public:
+    using IndexFactory::NewBuilder;
+    using IndexFactory::NewReader;
+
+    const char* Name() const override { return "legacy_index"; }
+
+    IndexFactoryBuilder* NewBuilder() const override {
+      return new LegacyOnlyBuilder();
+    }
+
+    std::unique_ptr<IndexFactoryReader> NewReader(
+        Slice& /*index_block*/) const override {
+      return nullptr;
+    }
+  };
+
+  LegacyOnlyFactory factory;
+  const IndexFactory* index_factory = &factory;
+  IndexFactoryOptions options;
+  std::unique_ptr<IndexFactoryBuilder> builder;
+  ASSERT_OK(index_factory->NewBuilder(options, builder));
+  ASSERT_NE(builder, nullptr);
+
+  Slice index_contents;
+  ASSERT_OK(builder->Finish(&index_contents));
+  ASSERT_TRUE(index_contents.empty());
+  ASSERT_STREQ(kIndexFactoryMetaPrefix, kUserDefinedIndexPrefix);
+}
 
 const std::string kDummyValue(10000, 'o');
 constexpr auto kVerbose = false;

--- a/unreleased_history/public_api_changes/index_factory_aliases.md
+++ b/unreleased_history/public_api_changes/index_factory_aliases.md
@@ -1,0 +1,1 @@
+Add IndexFactory compatibility names for the existing user-defined index API.


### PR DESCRIPTION
Part 1 of 9 in the UDI split.

Stack order:
1. #14954 Add IndexFactory compatibility names
2. #14959 Add UDI index mode API vocabulary
3. #14960 Add optional UDI builder protocols
4. #14961 Add built-in index factory wrappers
5. #14962 Promote IndexFactory as UDI SPI
6. #14963 Wire IndexFactory through block-based tables
7. #14965 Account UDI blocks as index blocks
8. #14966 Support parallel AddIndexEntry in trie index
9. #14968 Add IndexFactory stress and benchmark flags

Previous: none.
Next: #14959.

This PR adds `include/rocksdb/index_factory.h` as a source-compatible set of new names over the experimental UDI API:

- `IndexFactoryBuilder` -> `UserDefinedIndexBuilder`
- `IndexFactoryIterator` -> `UserDefinedIndexIterator`
- `IndexFactoryReader` -> `UserDefinedIndexReader`
- `IndexFactoryOptions` -> `UserDefinedIndexOption`
- `IndexFactory` -> `UserDefinedIndexFactory`
- `kIndexFactoryMetaPrefix` -> `kUserDefinedIndexPrefix`

This does not change table building, table reading, SST format, OPTIONS parsing, or the C API. Existing `UserDefinedIndexFactory` subclasses that implement the old `NewBuilder()` and `NewReader(Slice&)` shape continue to work through the new `IndexFactory` name.

Validation:
- `build_tools/rockstest.sh table_test --gtest_filter='IndexFactoryCompatibilityTest.*'`
- `make check-sources`
- GitHub Actions PR matrix passed on the PR head

