### PR TITLE
Add UDI index mode API vocabulary

### DIFF
--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -2448,6 +2448,22 @@ struct ReadOptions {
 
   // EXPERIMENTAL
   //
+  // Names which block-based-table index a read should use. This is a
+  // preparatory API for replacing direct table_index_factory selection in a
+  // follow-up change. Until that wiring lands, table_index_factory keeps its
+  // existing behavior and read_index is not consulted by table reading.
+  enum class ReadIndex : uint8_t {
+    // Use the column family's default index routing.
+    kDefault = 0,
+    // Use the standard block-based-table index.
+    kBuiltin = 1,
+    // Prefer the configured custom index when present.
+    kPreferCustom = 2,
+  };
+  ReadIndex read_index = ReadIndex::kDefault;
+
+  // EXPERIMENTAL
+  //
   // Specify an alternate index to use in the SST files instead of the native
   // block based table index. The table_factory used for the column family
   // must support building/reading this index.

--- a/include/rocksdb/table.h
+++ b/include/rocksdb/table.h
@@ -601,6 +601,30 @@ struct BlockBasedTableOptions {
 
   // EXPERIMENTAL
   //
+  // Names the intended relationship between the standard block-based-table
+  // index and a custom index. This is a preparatory API for replacing the
+  // legacy UDI booleans below in a follow-up change. Until that wiring lands,
+  // use_udi_as_primary_index and fail_if_no_udi_on_open keep their existing
+  // behavior and index_mode is not consulted by table building or reading.
+  enum class IndexMode {
+    // Build and read the standard index only.
+    kStandardOnly = 0,
+    // Build both indexes, read the standard index by default, and allow
+    // per-read custom-index selection.
+    kStandardDefault = 1,
+    // Build both indexes and read the custom index by default.
+    kCustomDefault = 2,
+    // Build only the custom index. This requires a later format-safety change
+    // before it can be used by table writing.
+    kCustomOnly = 3,
+    // Build both indexes, read the standard index by default, and require the
+    // custom index block when a factory is configured.
+    kStandardRequired = 4,
+  };
+  IndexMode index_mode = IndexMode::kStandardDefault;
+
+  // EXPERIMENTAL
+  //
   // When true and user_defined_index_factory is set, the UDI becomes the
   // primary index for reads. All reads (including internal operations like
   // compaction and VerifyChecksum) automatically route through the UDI

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -185,6 +185,7 @@ TEST_F(OptionsSettableTest, BlockBasedTableOptionsAllFieldsSettable) {
       "index_block_search_type=kBinary;"
       "data_block_index_type=kDataBlockBinaryAndHash;"
       "index_shortening=kNoShortening;"
+      "index_mode=kCustomDefault;"
       "data_block_hash_table_util_ratio=0.75;"
       "checksum=kxxHash;no_block_cache=1;"
       "block_cache=1M;block_cache_compressed=1k;block_size=1024;"

--- a/table/block_based/block_based_table_factory.cc
+++ b/table/block_based/block_based_table_factory.cc
@@ -214,6 +214,16 @@ static std::unordered_map<std::string,
          BlockBasedTableOptions::IndexShorteningMode::
              kShortenSeparatorsAndSuccessor}};
 
+static const std::unordered_map<std::string, BlockBasedTableOptions::IndexMode>
+    block_base_table_index_mode_string_map = {  // NOLINT(cert-err58-cpp)
+        {"kStandardOnly", BlockBasedTableOptions::IndexMode::kStandardOnly},
+        {"kStandardDefault",
+         BlockBasedTableOptions::IndexMode::kStandardDefault},
+        {"kCustomDefault", BlockBasedTableOptions::IndexMode::kCustomDefault},
+        {"kCustomOnly", BlockBasedTableOptions::IndexMode::kCustomOnly},
+        {"kStandardRequired",
+         BlockBasedTableOptions::IndexMode::kStandardRequired}};
+
 static std::unordered_map<std::string, OptionTypeInfo>
     metadata_cache_options_type_info = {
         {"top_level_index_pinning",
@@ -288,6 +298,9 @@ static struct BlockBasedTableTypeInfo {
          OptionTypeInfo::Enum<BlockBasedTableOptions::IndexShorteningMode>(
              offsetof(struct BlockBasedTableOptions, index_shortening),
              &block_base_table_index_shortening_mode_string_map)},
+        {"index_mode", OptionTypeInfo::Enum<BlockBasedTableOptions::IndexMode>(
+                           offsetof(struct BlockBasedTableOptions, index_mode),
+                           &block_base_table_index_mode_string_map)},
         {"data_block_hash_table_util_ratio",
          {offsetof(struct BlockBasedTableOptions,
                    data_block_hash_table_util_ratio),

--- a/tools/c_api_gen/auto_simple_bindings_blocklist.json
+++ b/tools/c_api_gen/auto_simple_bindings_blocklist.json
@@ -40,6 +40,11 @@
           "reason": "Needs pointer, slice, callback, or other non-trivial C binding policy that the simple generator cannot infer."
         },
         {
+          "field": "read_index",
+          "policy": "manual",
+          "reason": "Uses experimental index-selection compatibility policy that needs explicit legacy C API mapping."
+        },
+        {
           "field": "table_index_factory",
           "policy": "manual",
           "reason": "Needs pointer, slice, callback, or other non-trivial C binding policy that the simple generator cannot infer."
@@ -368,6 +373,11 @@
           "field": "user_defined_index_factory",
           "policy": "manual",
           "reason": "Uses factories, caches, or nested option objects that need explicit ownership or non-scalar marshalling."
+        },
+        {
+          "field": "index_mode",
+          "policy": "manual",
+          "reason": "Uses experimental enum semantics that need explicit C API mapping."
         }
       ]
     },


### PR DESCRIPTION
Part 2 of 9 in the UDI split.

Stack order:
1. #14954 Add IndexFactory compatibility names
2. #14959 Add UDI index mode API vocabulary
3. #14960 Add optional UDI builder protocols
4. #14961 Add built-in index factory wrappers
5. #14962 Promote IndexFactory as UDI SPI
6. #14963 Wire IndexFactory through block-based tables
7. #14965 Account UDI blocks as index blocks
8. #14966 Support parallel AddIndexEntry in trie index
9. #14968 Add IndexFactory stress and benchmark flags

Previous: #14954.
Next: #14960.

What changed:
- Add inert `IndexMode` and `ReadIndex` vocabulary to the public options headers.
- Exclude those experimental enum fields from automatic C API generation until an explicit mapping is available.
- Keep runtime behavior unchanged. The table wiring comes later in the stack.

Validation:
- `git diff --check`
- `make check-sources`
- `python3 tools/c_api_gen/verify_generated_up_to_date.py`
- `AUTO_CLEAN=1 make check-c-api-gen`
- `./c_test`
