### PR TITLE
Add built-in index factory wrappers

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -205,6 +205,7 @@ cpp_library_wrapper(name="rocksdb_lib", srcs=[
         "table/block_based/block_cache.cc",
         "table/block_based/block_prefetcher.cc",
         "table/block_based/block_prefix_index.cc",
+        "table/block_based/builtin_index_factory.cc",
         "table/block_based/data_block_footer.cc",
         "table/block_based/data_block_hash_index.cc",
         "table/block_based/filter_block_reader_common.cc",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -937,6 +937,7 @@ set(SOURCES
         table/block_based/block_cache.cc
         table/block_based/block_prefetcher.cc
         table/block_based/block_prefix_index.cc
+        table/block_based/builtin_index_factory.cc
         table/block_based/data_block_hash_index.cc
         table/block_based/data_block_footer.cc
         table/block_based/filter_block_reader_common.cc

--- a/include/rocksdb/user_defined_index.h
+++ b/include/rocksdb/user_defined_index.h
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include <cstddef>
+#include <memory>
 #include <string>
 
 #include "rocksdb/advanced_iterator.h"
@@ -66,6 +68,12 @@ class UserDefinedIndexBuilder {
     // Tag (packed sequence number and type) of first_key_in_next_block (valid
     // only when first_key_in_next_block != nullptr).
     uint64_t first_key_tag = 0;
+    // True when block alignment padding put this data block at a
+    // non-sequential offset, so its handle must not be delta encoded
+    // against the previous one. Only meaningful for AddIndexEntry; the
+    // parallel path learns the offset later and receives the same flag as
+    // an explicit FinishAddEntry parameter.
+    bool skip_delta_encoding = false;
   };
 
   virtual ~UserDefinedIndexBuilder() = default;
@@ -116,20 +124,61 @@ class UserDefinedIndexBuilder {
   // snapshots are active). UDI builders that use OnKeyAdded() should be
   // prepared for this.
   //
-  // Thread safety: For a given builder instance, OnKeyAdded() and
-  // AddIndexEntry() are always called from a single thread. Builders do
-  // not need internal synchronization.
+  // Thread safety: Builders that use AddIndexEntry() are called from one
+  // thread. Builders that opt into parallel AddEntry receive OnKeyAdded() and
+  // PrepareAddEntry() on the emit thread and ordered FinishAddEntry() calls on
+  // the background writer thread. Emit-thread calls may overlap
+  // FinishAddEntry(), so implementations must synchronize shared state or keep
+  // the state touched by those callbacks disjoint. Finish() is called only
+  // after all FinishAddEntry() calls complete.
   virtual void OnKeyAdded(const Slice& /*key*/, ValueType /*type*/,
                           const Slice& /*value*/) {}
 
-  // Finish building the index.
-  // Returns a Status and the serialized index contents.
+  // Finish building the complete index into one self-contained byte buffer.
   // The memory backing the contents should not be freed until this builder
   // object is destructed.
   virtual Status Finish(Slice* index_contents) = 0;
 
-  // Returns an estimate of the current serialized index size in bytes.
+  // Returns an estimate of the current serialized index size in bytes: an
+  // upper bound on what Finish() will produce. The table builder adds this to
+  // the estimated SST tail size, and compaction asserts that the final tail
+  // does not exceed the last estimate, so implementations must not
+  // under-report.
   virtual uint64_t EstimatedSize() const = 0;
+
+  // Optional two-phase protocol for builders that can participate in parallel
+  // compression. Builders that do not opt in keep the existing synchronous
+  // AddIndexEntry() path. Builders that return true from
+  // SupportsParallelAddEntry() must provide non-null prepared entries from
+  // CreatePreparedAddEntry(), fill them in PrepareAddEntry(), and commit the
+  // corresponding index entry in FinishAddEntry().
+  //
+  // A prepared entry can be abandoned without a matching FinishAddEntry()
+  // when the SST build fails partway through, so implementations must not
+  // rely on that pairing to release resources.
+  struct PreparedAddEntry {
+    virtual ~PreparedAddEntry() = default;
+  };
+
+  virtual bool SupportsParallelAddEntry() const { return false; }
+
+  virtual std::unique_ptr<PreparedAddEntry> CreatePreparedAddEntry() {
+    return nullptr;
+  }
+
+  // Phase 1, on the emit thread. The key Slices reference table builder
+  // buffers that are overwritten before the matching FinishAddEntry() runs,
+  // so anything needed later must be copied into the prepared entry.
+  virtual void PrepareAddEntry(const Slice& /*last_key_in_current_block*/,
+                               const Slice* /*first_key_in_next_block*/,
+                               const IndexEntryContext& /*context*/,
+                               PreparedAddEntry* /*out*/) {}
+
+  // Phase 2, on the background writer thread, in commit order.
+  virtual void FinishAddEntry(const BlockHandle& /*block_handle*/,
+                              PreparedAddEntry* /*entry*/,
+                              std::string* /*separator_scratch*/,
+                              bool /*skip_delta_encoding*/) {}
 };
 
 // The interface for iterating the user defined index. This will be

--- a/src.mk
+++ b/src.mk
@@ -195,6 +195,7 @@ LIB_SOURCES =                                                   \
   table/block_based/block_cache.cc                              \
   table/block_based/block_prefetcher.cc                         \
   table/block_based/block_prefix_index.cc                       \
+  table/block_based/builtin_index_factory.cc                    \
   table/block_based/data_block_hash_index.cc                    \
   table/block_based/data_block_footer.cc                        \
   table/block_based/filter_block_reader_common.cc               \

--- a/table/block_based/builtin_index_factory.cc
+++ b/table/block_based/builtin_index_factory.cc
@@ -1,0 +1,512 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// This source code is licensed under both the GPLv2 (found in the
+// COPYING file in the root directory) and Apache 2.0 License
+// (found in the LICENSE.Apache file in the root directory).
+
+#include "table/block_based/builtin_index_factory.h"
+
+#include <cassert>
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include "db/dbformat.h"
+#include "rocksdb/comparator.h"
+#include "rocksdb/index_factory.h"
+#include "rocksdb/slice.h"
+#include "rocksdb/status.h"
+#include "table/block_based/index_builder.h"
+#include "util/cast_util.h"
+#include "util/coding.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+// Wrapper around the internal IndexBuilder::PreparedIndexEntry, adapting it
+// to the public IndexFactoryBuilder::PreparedAddEntry interface for parallel
+// compression support.
+struct BuiltinPreparedAddEntry : public IndexFactoryBuilder::PreparedAddEntry {
+  std::unique_ptr<IndexBuilder::PreparedIndexEntry> internal_entry;
+  explicit BuiltinPreparedAddEntry(
+      std::unique_ptr<IndexBuilder::PreparedIndexEntry> e)
+      : internal_entry(std::move(e)) {}
+};
+
+BuiltinIndexFactoryBuilder::BuiltinIndexFactoryBuilder(
+    const InternalKeyComparator* icmp, const BlockBasedTableOptions* table_opts)
+    : icmp_(icmp), table_opts_(table_opts) {
+  assert(icmp_ != nullptr);
+}
+
+BuiltinIndexFactoryBuilder::BuiltinIndexFactoryBuilder(
+    std::unique_ptr<InternalKeyComparator> icmp,
+    const BlockBasedTableOptions* table_opts)
+    : owned_icmp_(std::move(icmp)),
+      icmp_(owned_icmp_.get()),
+      table_opts_(table_opts) {
+  assert(icmp_ != nullptr);
+}
+
+BuiltinIndexFactoryBuilder::~BuiltinIndexFactoryBuilder() = default;
+
+void BuiltinIndexFactoryBuilder::SetInternalBuilder(
+    std::unique_ptr<IndexBuilder> builder,
+    PartitionedIndexBuilder* partitioned) {
+  assert(partitioned == nullptr || partitioned == builder.get());
+  internal_builder_ = std::move(builder);
+  partitioned_builder_ = partitioned;
+}
+
+const InternalKeyComparator* BuiltinIndexFactoryBuilder::GetComparator() const {
+  return icmp_;
+}
+
+const BlockBasedTableOptions& BuiltinIndexFactoryBuilder::GetTableOptions()
+    const {
+  return *table_opts_;
+}
+
+void BuiltinIndexFactoryBuilder::ReconstructInternalKeys(
+    const Slice& last_user_key, const Slice* next_user_key,
+    const IndexEntryContext& ctx) {
+  last_internal_key_.clear();
+  last_internal_key_.append(last_user_key.data(), last_user_key.size());
+  PutFixed64(&last_internal_key_, ctx.last_key_tag);
+
+  if (next_user_key != nullptr) {
+    next_internal_key_.clear();
+    next_internal_key_.append(next_user_key->data(), next_user_key->size());
+    PutFixed64(&next_internal_key_, ctx.first_key_tag);
+  }
+}
+
+Slice BuiltinIndexFactoryBuilder::AddIndexEntry(
+    const Slice& last_key_in_current_block,
+    const Slice* first_key_in_next_block, const BlockHandle& block_handle,
+    std::string* separator_scratch, const IndexEntryContext& context) {
+  // Reconstruct internal keys from user keys + packed tags.
+  // The internal IndexBuilder expects full internal keys:
+  //   [user_key | packed_seq_and_type (8 bytes)]
+  ReconstructInternalKeys(last_key_in_current_block, first_key_in_next_block,
+                          context);
+  Slice last_ik(last_internal_key_);
+
+  Slice next_ik;
+  const Slice* next_ik_ptr = nullptr;
+  if (first_key_in_next_block != nullptr) {
+    next_ik = Slice(next_internal_key_);
+    next_ik_ptr = &next_ik;
+  }
+
+  // Convert the public BlockHandle to the internal BlockHandle.
+  ROCKSDB_NAMESPACE::BlockHandle internal_handle(block_handle.offset,
+                                                 block_handle.size);
+
+  return internal_builder_->AddIndexEntry(last_ik, next_ik_ptr, internal_handle,
+                                          separator_scratch,
+                                          context.skip_delta_encoding);
+}
+
+void BuiltinIndexFactoryBuilder::OnKeyAdded(const Slice& /*key*/,
+                                            ValueType /*type*/,
+                                            const Slice& /*value*/) {
+  // No-op: the internal builder needs the full internal key for
+  // kBinarySearchWithFirstKey, which the table builder supplies via
+  // OnKeyAddedInternal().
+}
+
+Status BuiltinIndexFactoryBuilder::Finish(Slice* index_contents) {
+  IndexBuilder::IndexBlocks index_blocks;
+  Status s = internal_builder_->Finish(&index_blocks);
+  if (!s.ok()) {
+    return s;
+  }
+  // Store the contents -- the internal builder's memory backs this Slice.
+  *index_contents = index_blocks.index_block_contents;
+  return Status::OK();
+}
+
+uint64_t BuiltinIndexFactoryBuilder::EstimatedSize() const {
+  return CurrentIndexSizeEstimate();
+}
+
+uint64_t BuiltinIndexFactoryBuilder::CurrentIndexSizeEstimate() const {
+  return internal_builder_->CurrentIndexSizeEstimate();
+}
+
+Status BuiltinIndexFactoryBuilder::FinishAndWrite(
+    BuiltinIndexBlockWriter* writer, BlockHandle* final_handle, bool compress) {
+  IndexBuilder::IndexBlocks index_blocks;
+  Status s = internal_builder_->Finish(&index_blocks);
+  if (!s.ok() && !s.IsIncomplete()) {
+    return s;
+  }
+
+  // Write any auxiliary meta blocks (e.g., hash index prefix blocks).
+  // The writer callback registers them with the meta index builder.
+  for (const auto& item : index_blocks.meta_blocks) {
+    BlockHandle meta_bh{0, 0};
+    Status ws = writer->WriteBlock(item.second.second, &meta_bh, compress);
+    if (!ws.ok()) {
+      return ws;
+    }
+    writer->AddMetaBlock(item.first, meta_bh);
+  }
+
+  // Write the first (or only) index block.
+  BlockHandle handle{0, 0};
+  Status ws =
+      writer->WriteBlock(index_blocks.index_block_contents, &handle, compress);
+  if (!ws.ok()) {
+    return ws;
+  }
+
+  // For partitioned indexes, the internal builder returns
+  // Status::Incomplete() to signal more partitions remain. Each
+  // subsequent Finish() call receives the handle of the previously
+  // written partition so it can build the top-level index.
+  while (s.IsIncomplete()) {
+    // Convert public BlockHandle to internal BlockHandle for Finish.
+    ROCKSDB_NAMESPACE::BlockHandle internal_handle(handle.offset, handle.size);
+    s = internal_builder_->Finish(&index_blocks, internal_handle);
+    if (!s.ok() && !s.IsIncomplete()) {
+      return s;
+    }
+    ws = writer->WriteBlock(index_blocks.index_block_contents, &handle,
+                            compress);
+    if (!ws.ok()) {
+      return ws;
+    }
+  }
+
+  *final_handle = {handle.offset, handle.size};
+  return Status::OK();
+}
+
+bool BuiltinIndexFactoryBuilder::SupportsParallelAddEntry() const {
+  return true;
+}
+
+std::unique_ptr<IndexFactoryBuilder::PreparedAddEntry>
+BuiltinIndexFactoryBuilder::CreatePreparedAddEntry() {
+  return std::make_unique<BuiltinPreparedAddEntry>(
+      internal_builder_->CreatePreparedIndexEntry());
+}
+
+void BuiltinIndexFactoryBuilder::PrepareAddEntry(const Slice& last_key,
+                                                 const Slice* next_key,
+                                                 const IndexEntryContext& ctx,
+                                                 PreparedAddEntry* out) {
+  auto* entry = static_cast_with_check<BuiltinPreparedAddEntry>(out);
+
+  // Reuses the member buffers rather than allocating per data block.
+  // PrepareIndexEntry copies out what it needs before returning.
+  ReconstructInternalKeys(last_key, next_key, ctx);
+  Slice last_ik(last_internal_key_);
+
+  Slice next_ik;
+  const Slice* next_ik_ptr = nullptr;
+  if (next_key != nullptr) {
+    next_ik = Slice(next_internal_key_);
+    next_ik_ptr = &next_ik;
+  }
+
+  internal_builder_->PrepareIndexEntry(last_ik, next_ik_ptr,
+                                       entry->internal_entry.get());
+}
+
+void BuiltinIndexFactoryBuilder::FinishAddEntry(
+    const BlockHandle& handle, PreparedAddEntry* entry,
+    std::string* /*separator_scratch*/, bool skip_delta_encoding) {
+  auto* builtin_entry = static_cast_with_check<BuiltinPreparedAddEntry>(entry);
+  ROCKSDB_NAMESPACE::BlockHandle internal_handle(handle.offset, handle.size);
+  internal_builder_->FinishIndexEntry(internal_handle,
+                                      builtin_entry->internal_entry.get(),
+                                      skip_delta_encoding);
+}
+
+bool BuiltinIndexFactoryBuilder::separator_is_key_plus_seq() const {
+  return internal_builder_->separator_is_key_plus_seq();
+}
+
+uint64_t BuiltinIndexFactoryBuilder::NumUniformIndexBlocks() const {
+  return internal_builder_->NumUniformIndexBlocks();
+}
+
+size_t BuiltinIndexFactoryBuilder::IndexSize() const {
+  return internal_builder_->IndexSize();
+}
+
+size_t BuiltinIndexFactoryBuilder::NumPartitions() const {
+  return partitioned_builder_ ? partitioned_builder_->NumPartitions() : 0;
+}
+
+size_t BuiltinIndexFactoryBuilder::TopLevelIndexSize(uint64_t offset) const {
+  return partitioned_builder_ ? partitioned_builder_->TopLevelIndexSize(offset)
+                              : 0;
+}
+
+PartitionedIndexBuilder*
+BuiltinIndexFactoryBuilder::GetPartitionedIndexBuilder() {
+  return partitioned_builder_;
+}
+
+IndexBuilder* BuiltinIndexFactoryBuilder::GetInternalBuilder() {
+  return internal_builder_.get();
+}
+
+Slice BuiltinIndexFactoryBuilder::AddIndexEntryDirect(
+    const Slice& last_internal_key, const Slice* first_internal_key_next,
+    const ::ROCKSDB_NAMESPACE::BlockHandle& handle,
+    std::string* separator_scratch, bool skip_delta_encoding) {
+  return internal_builder_->AddIndexEntry(
+      last_internal_key, first_internal_key_next, handle, separator_scratch,
+      skip_delta_encoding);
+}
+
+void BuiltinIndexFactoryBuilder::PrepareAddEntryDirect(
+    const Slice& last_internal_key, const Slice* first_internal_key_next,
+    PreparedAddEntry* out) {
+  auto* entry = static_cast_with_check<BuiltinPreparedAddEntry>(out);
+  // Skip the user-key reconstruction path entirely; pass the caller's
+  // internal keys straight through to the internal builder.
+  internal_builder_->PrepareIndexEntry(
+      last_internal_key, first_internal_key_next, entry->internal_entry.get());
+}
+
+// ============================================================================
+// Factory implementations
+// ============================================================================
+
+// --- BinarySearchIndexFactory ---
+
+static const char* const kBinarySearchName =
+    "rocksdb.builtin.BinarySearchIndex";
+static const char* const kBinarySearchWithFirstKeyName =
+    "rocksdb.builtin.BinarySearchWithFirstKeyIndex";
+
+BinarySearchIndexFactory::BinarySearchIndexFactory(bool with_first_key)
+    : with_first_key_(with_first_key) {}
+
+BinarySearchIndexFactory::BinarySearchIndexFactory(
+    bool with_first_key, const BuiltinIndexFactoryConfig& config)
+    : with_first_key_(with_first_key), has_config_(true), config_(config) {}
+
+const char* BinarySearchIndexFactory::Name() const {
+  return with_first_key_ ? kBinarySearchWithFirstKeyName : kBinarySearchName;
+}
+
+const char* BinarySearchIndexFactory::kClassName() { return kBinarySearchName; }
+
+const char* BinarySearchIndexFactory::kClassNameWithFirstKey() {
+  return kBinarySearchWithFirstKeyName;
+}
+
+Status BinarySearchIndexFactory::NewBuilder(
+    const IndexFactoryOptions& options,
+    std::unique_ptr<IndexFactoryBuilder>& builder) const {
+  if (options.comparator == nullptr) {
+    return Status::InvalidArgument(
+        "BinarySearchIndexFactory::NewBuilder requires a comparator");
+  }
+
+  if (has_config_) {
+    // Full construction path used by the table builder. config_ holds
+    // the per-SST configuration; the table_options pointer remains
+    // valid for the builder's lifetime (Rep owns it).
+    auto index_type = with_first_key_
+                          ? BlockBasedTableOptions::kBinarySearchWithFirstKey
+                          : BlockBasedTableOptions::kBinarySearch;
+    auto wrapper = std::make_unique<BuiltinIndexFactoryBuilder>(
+        config_.internal_comparator, config_.table_options);
+    std::unique_ptr<IndexBuilder> internal(IndexBuilder::CreateIndexBuilder(
+        index_type, wrapper->GetComparator(), config_.internal_prefix_transform,
+        config_.use_delta_encoding_for_index_values, wrapper->GetTableOptions(),
+        config_.ts_sz, config_.persist_user_defined_timestamps, config_.stats));
+    wrapper->SetInternalBuilder(std::move(internal));
+    builder = std::move(wrapper);
+    return Status::OK();
+  }
+
+  // Standalone / test path. Uses a static default BlockBasedTableOptions
+  // since there is no Rep to borrow from.
+  auto icmp = std::make_unique<InternalKeyComparator>(options.comparator);
+  auto index_type = with_first_key_
+                        ? BlockBasedTableOptions::kBinarySearchWithFirstKey
+                        : BlockBasedTableOptions::kBinarySearch;
+  static const BlockBasedTableOptions kDefaultBinarySearchOpts;
+  auto wrapper = std::make_unique<BuiltinIndexFactoryBuilder>(
+      std::move(icmp), &kDefaultBinarySearchOpts);
+  std::unique_ptr<IndexBuilder> internal(IndexBuilder::CreateIndexBuilder(
+      index_type, wrapper->GetComparator(),
+      /*int_key_slice_transform=*/nullptr,
+      /*use_value_delta_encoding=*/true, wrapper->GetTableOptions(),
+      /*ts_sz=*/0, /*persist_user_defined_timestamps=*/true));
+  wrapper->SetInternalBuilder(std::move(internal));
+  builder = std::move(wrapper);
+  return Status::OK();
+}
+
+Status BinarySearchIndexFactory::NewReader(
+    const IndexFactoryOptions& /*options*/, Slice& /*index_contents*/,
+    std::unique_ptr<IndexFactoryReader>& /*reader*/) const {
+  // Built-in reads go through BlockBasedTable::CreateIndexReader directly
+  // (see the asymmetric-API note in include/rocksdb/index_factory.h).
+  return Status::NotSupported(
+      "BinarySearchIndexFactory::NewReader is not used directly. "
+      "The built-in reader is created through "
+      "BlockBasedTable::CreateIndexReader.");
+}
+
+// --- HashIndexFactory ---
+
+static const char* const kHashIndexName = "rocksdb.builtin.HashIndex";
+
+HashIndexFactory::HashIndexFactory(const BuiltinIndexFactoryConfig& config)
+    : has_config_(true), config_(config) {}
+
+const char* HashIndexFactory::Name() const { return kHashIndexName; }
+const char* HashIndexFactory::kClassName() { return kHashIndexName; }
+
+// FinishAndWrite writes and registers hash prefix meta blocks (prefix block and
+// prefix metadata block) through the internal writer callback.
+Status HashIndexFactory::NewBuilder(
+    const IndexFactoryOptions& options,
+    std::unique_ptr<IndexFactoryBuilder>& builder) const {
+  if (options.comparator == nullptr) {
+    return Status::InvalidArgument(
+        "HashIndexFactory::NewBuilder requires a comparator");
+  }
+
+  if (has_config_) {
+    auto wrapper = std::make_unique<BuiltinIndexFactoryBuilder>(
+        config_.internal_comparator, config_.table_options);
+    std::unique_ptr<IndexBuilder> internal(IndexBuilder::CreateIndexBuilder(
+        BlockBasedTableOptions::kHashSearch, wrapper->GetComparator(),
+        config_.internal_prefix_transform,
+        config_.use_delta_encoding_for_index_values, wrapper->GetTableOptions(),
+        config_.ts_sz, config_.persist_user_defined_timestamps, config_.stats));
+    wrapper->SetInternalBuilder(std::move(internal));
+    builder = std::move(wrapper);
+    return Status::OK();
+  }
+
+  // Standalone / test path with a static default BlockBasedTableOptions.
+  auto icmp = std::make_unique<InternalKeyComparator>(options.comparator);
+  static const BlockBasedTableOptions kDefaultHashOpts;
+  auto wrapper = std::make_unique<BuiltinIndexFactoryBuilder>(
+      std::move(icmp), &kDefaultHashOpts);
+  std::unique_ptr<IndexBuilder> internal(IndexBuilder::CreateIndexBuilder(
+      BlockBasedTableOptions::kHashSearch, wrapper->GetComparator(),
+      /*int_key_slice_transform=*/nullptr,
+      /*use_value_delta_encoding=*/true, wrapper->GetTableOptions(),
+      /*ts_sz=*/0, /*persist_user_defined_timestamps=*/true));
+  wrapper->SetInternalBuilder(std::move(internal));
+  builder = std::move(wrapper);
+  return Status::OK();
+}
+
+Status HashIndexFactory::NewReader(
+    const IndexFactoryOptions& /*options*/, Slice& /*index_contents*/,
+    std::unique_ptr<IndexFactoryReader>& /*reader*/) const {
+  return Status::NotSupported(
+      "HashIndexFactory::NewReader is not used directly.");
+}
+
+// --- PartitionedIndexFactory ---
+
+static const char* const kPartitionedIndexName =
+    "rocksdb.builtin.PartitionedIndex";
+
+PartitionedIndexFactory::PartitionedIndexFactory(
+    const BuiltinIndexFactoryConfig& config)
+    : has_config_(true), config_(config) {}
+
+const char* PartitionedIndexFactory::Name() const {
+  return kPartitionedIndexName;
+}
+const char* PartitionedIndexFactory::kClassName() {
+  return kPartitionedIndexName;
+}
+
+// The partitioned index uses a multi-call Finish protocol internally
+// (returning Status::Incomplete() for each partition). The single-call
+// Finish(Slice*) only returns the first partition block. For full
+// partitioned index construction, the table builder uses FinishAndWrite() to
+// drive the multi-call protocol through its internal writer callback.
+Status PartitionedIndexFactory::NewBuilder(
+    const IndexFactoryOptions& options,
+    std::unique_ptr<IndexFactoryBuilder>& builder) const {
+  if (options.comparator == nullptr) {
+    return Status::InvalidArgument(
+        "PartitionedIndexFactory::NewBuilder requires a comparator");
+  }
+
+  if (has_config_) {
+    auto wrapper = std::make_unique<BuiltinIndexFactoryBuilder>(
+        config_.internal_comparator, config_.table_options);
+    PartitionedIndexBuilder* internal =
+        PartitionedIndexBuilder::CreateIndexBuilder(
+            wrapper->GetComparator(),
+            config_.use_delta_encoding_for_index_values,
+            wrapper->GetTableOptions(), config_.ts_sz,
+            config_.persist_user_defined_timestamps, config_.stats);
+    wrapper->SetInternalBuilder(std::unique_ptr<IndexBuilder>(internal),
+                                internal);
+    builder = std::move(wrapper);
+    return Status::OK();
+  }
+
+  // Standalone / test path. PartitionedIndexBuilder holds a const ref to
+  // table_opts_, so the wrapper must be constructed before the builder.
+  auto icmp = std::make_unique<InternalKeyComparator>(options.comparator);
+  static const BlockBasedTableOptions kDefaultPartitionedOpts;
+  auto wrapper = std::make_unique<BuiltinIndexFactoryBuilder>(
+      std::move(icmp), &kDefaultPartitionedOpts);
+  PartitionedIndexBuilder* internal =
+      PartitionedIndexBuilder::CreateIndexBuilder(
+          wrapper->GetComparator(), /*use_value_delta_encoding=*/true,
+          wrapper->GetTableOptions(),
+          /*ts_sz=*/0, /*persist_user_defined_timestamps=*/true);
+  wrapper->SetInternalBuilder(std::unique_ptr<IndexBuilder>(internal),
+                              internal);
+  builder = std::move(wrapper);
+  return Status::OK();
+}
+
+Status PartitionedIndexFactory::NewReader(
+    const IndexFactoryOptions& /*options*/, Slice& /*index_contents*/,
+    std::unique_ptr<IndexFactoryReader>& /*reader*/) const {
+  return Status::NotSupported(
+      "PartitionedIndexFactory::NewReader is not used directly.");
+}
+
+Status NewBuiltinIndexFactoryBuilder(
+    BlockBasedTableOptions::IndexType index_type,
+    const BuiltinIndexFactoryConfig& config, const IndexFactoryOptions& options,
+    std::unique_ptr<IndexFactoryBuilder>& out) {
+  // Stack-local factory objects avoid shared_ptr heap allocation. The factory
+  // is only needed for the duration of NewBuilder(); the builder it produces
+  // is independent.
+  switch (index_type) {
+    case BlockBasedTableOptions::kBinarySearch: {
+      BinarySearchIndexFactory factory(/*with_first_key=*/false, config);
+      return factory.NewBuilder(options, out);
+    }
+    case BlockBasedTableOptions::kBinarySearchWithFirstKey: {
+      BinarySearchIndexFactory factory(/*with_first_key=*/true, config);
+      return factory.NewBuilder(options, out);
+    }
+    case BlockBasedTableOptions::kHashSearch: {
+      HashIndexFactory factory(config);
+      return factory.NewBuilder(options, out);
+    }
+    case BlockBasedTableOptions::kTwoLevelIndexSearch: {
+      PartitionedIndexFactory factory(config);
+      return factory.NewBuilder(options, out);
+    }
+  }
+  // Unreachable for known IndexType values; keep the compiler happy.
+  return Status::InvalidArgument("Unknown BlockBasedTableOptions::IndexType");
+}
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/table/block_based/builtin_index_factory.h
+++ b/table/block_based/builtin_index_factory.h
@@ -1,0 +1,311 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// This source code is licensed under both the GPLv2 (found in the
+// COPYING file in the root directory) and Apache 2.0 License
+// (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+
+#include "rocksdb/index_factory.h"
+#include "rocksdb/table.h"
+#include "table/block_based/index_builder.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+class InternalKeyComparator;
+class InternalKeySliceTransform;
+class Statistics;
+
+// Built-in index factories wrap the internal IndexBuilder / IndexReader
+// behind the public IndexFactory interface. They translate between the
+// public form (user keys, simple BlockHandles) and the internal form
+// (internal keys, IndexValue with first_internal_key).
+
+// Construction parameters used by the built-in factories' NewBuilder()
+// to configure the internal IndexBuilder. Custom factories use only
+// IndexFactoryOptions::comparator and do not need this.
+struct BuiltinIndexFactoryConfig {
+  const InternalKeyComparator* internal_comparator = nullptr;
+  const InternalKeySliceTransform* internal_prefix_transform = nullptr;
+  bool use_delta_encoding_for_index_values = true;
+  // Pointer to the Rep's table_options (which outlives the builder).
+  // Avoids copying the large BlockBasedTableOptions struct per-SST.
+  const BlockBasedTableOptions* table_options = nullptr;
+  size_t ts_sz = 0;
+  bool persist_user_defined_timestamps = true;
+  Statistics* stats = nullptr;
+};
+
+// BinarySearchIndexFactory: the default BlockBasedTable index. Wraps
+// ShortenedIndexBuilder and BinarySearchIndexReader. Handles both
+// kBinarySearch and kBinarySearchWithFirstKey.
+class BinarySearchIndexFactory : public IndexFactory {
+ public:
+  // Lightweight constructor for standalone / test usage.
+  // NewBuilder will use minimal default configuration.
+  // @param with_first_key  If true, creates kBinarySearchWithFirstKey
+  //                        indexes that store the first internal key per
+  //                        block for optimized point lookups.
+  explicit BinarySearchIndexFactory(bool with_first_key = false);
+
+  // Full constructor for use by the table builder.
+  // The factory stores all internal params needed by NewBuilder().
+  BinarySearchIndexFactory(bool with_first_key,
+                           const BuiltinIndexFactoryConfig& config);
+
+  ~BinarySearchIndexFactory() override = default;
+
+  const char* Name() const override;
+  static const char* kClassName();
+  static const char* kClassNameWithFirstKey();
+
+  Status NewBuilder(
+      const IndexFactoryOptions& options,
+      std::unique_ptr<IndexFactoryBuilder>& builder) const override;
+
+  IndexFactoryBuilder* NewBuilder() const override {
+    std::unique_ptr<IndexFactoryBuilder> builder;
+    Status s = NewBuilder(IndexFactoryOptions(), builder);
+    return s.ok() ? builder.release() : nullptr;
+  }
+
+  Status NewReader(const IndexFactoryOptions& options, Slice& index_contents,
+                   std::unique_ptr<IndexFactoryReader>& reader) const override;
+
+  std::unique_ptr<IndexFactoryReader> NewReader(
+      Slice& index_contents) const override {
+    std::unique_ptr<IndexFactoryReader> reader;
+    Status s = NewReader(IndexFactoryOptions(), index_contents, reader);
+    return s.ok() ? std::move(reader) : nullptr;
+  }
+
+ private:
+  bool with_first_key_;
+  bool has_config_ = false;
+  BuiltinIndexFactoryConfig config_;
+};
+
+// HashIndexFactory: prefix-hash index. Wraps HashIndexBuilder and
+// HashIndexReader. Requires a configured prefix_extractor.
+class HashIndexFactory : public IndexFactory {
+ public:
+  // Lightweight constructor for standalone / test usage.
+  HashIndexFactory() = default;
+
+  // Full constructor for use by the table builder.
+  explicit HashIndexFactory(const BuiltinIndexFactoryConfig& config);
+
+  ~HashIndexFactory() override = default;
+
+  const char* Name() const override;
+  static const char* kClassName();
+
+  Status NewBuilder(
+      const IndexFactoryOptions& options,
+      std::unique_ptr<IndexFactoryBuilder>& builder) const override;
+
+  IndexFactoryBuilder* NewBuilder() const override {
+    std::unique_ptr<IndexFactoryBuilder> builder;
+    Status s = NewBuilder(IndexFactoryOptions(), builder);
+    return s.ok() ? builder.release() : nullptr;
+  }
+
+  Status NewReader(const IndexFactoryOptions& options, Slice& index_contents,
+                   std::unique_ptr<IndexFactoryReader>& reader) const override;
+
+  std::unique_ptr<IndexFactoryReader> NewReader(
+      Slice& index_contents) const override {
+    std::unique_ptr<IndexFactoryReader> reader;
+    Status s = NewReader(IndexFactoryOptions(), index_contents, reader);
+    return s.ok() ? std::move(reader) : nullptr;
+  }
+
+ private:
+  bool has_config_ = false;
+  BuiltinIndexFactoryConfig config_;
+};
+
+// PartitionedIndexFactory: two-level partitioned index. Wraps
+// PartitionedIndexBuilder and PartitionIndexReader. Implements the
+// multi-block FinishAndWrite protocol and exposes the underlying
+// PartitionedIndexBuilder for filter <-> index partition alignment.
+class PartitionedIndexFactory : public IndexFactory {
+ public:
+  // Lightweight constructor for standalone / test usage.
+  PartitionedIndexFactory() = default;
+
+  // Full constructor for use by the table builder.
+  explicit PartitionedIndexFactory(const BuiltinIndexFactoryConfig& config);
+
+  ~PartitionedIndexFactory() override = default;
+
+  const char* Name() const override;
+  static const char* kClassName();
+
+  Status NewBuilder(
+      const IndexFactoryOptions& options,
+      std::unique_ptr<IndexFactoryBuilder>& builder) const override;
+
+  IndexFactoryBuilder* NewBuilder() const override {
+    std::unique_ptr<IndexFactoryBuilder> builder;
+    Status s = NewBuilder(IndexFactoryOptions(), builder);
+    return s.ok() ? builder.release() : nullptr;
+  }
+
+  Status NewReader(const IndexFactoryOptions& options, Slice& index_contents,
+                   std::unique_ptr<IndexFactoryReader>& reader) const override;
+
+  std::unique_ptr<IndexFactoryReader> NewReader(
+      Slice& index_contents) const override {
+    std::unique_ptr<IndexFactoryReader> reader;
+    Status s = NewReader(IndexFactoryOptions(), index_contents, reader);
+    return s.ok() ? std::move(reader) : nullptr;
+  }
+
+ private:
+  bool has_config_ = false;
+  BuiltinIndexFactoryConfig config_;
+};
+
+// Dispatch on BlockBasedTableOptions::IndexType and construct the
+// matching built-in factory's builder.
+Status NewBuiltinIndexFactoryBuilder(
+    BlockBasedTableOptions::IndexType index_type,
+    const BuiltinIndexFactoryConfig& config, const IndexFactoryOptions& options,
+    std::unique_ptr<IndexFactoryBuilder>& out);
+
+// BuiltinIndexFactoryBuilder: adapts the internal IndexBuilder to the
+// public IndexFactoryBuilder interface. The table builder uses the
+// *Direct methods to bypass the user-key parse-and-repack on the
+// per-block-boundary hot path.
+//
+// Unqualified BlockHandle inside this class means the public
+// IndexFactoryBuilder::BlockHandle. The internal table/format.h handle is
+// always spelled ::ROCKSDB_NAMESPACE::BlockHandle.
+
+class BuiltinIndexBlockWriter {
+ public:
+  virtual ~BuiltinIndexBlockWriter() = default;
+
+  virtual Status WriteBlock(const Slice& contents,
+                            IndexFactoryBuilder::BlockHandle* handle,
+                            bool compress) = 0;
+  virtual void AddMetaBlock(const std::string& name,
+                            const IndexFactoryBuilder::BlockHandle& handle) = 0;
+};
+
+class BuiltinIndexFactoryBuilder : public IndexFactoryBuilder {
+ public:
+  BuiltinIndexFactoryBuilder(const InternalKeyComparator* icmp,
+                             const BlockBasedTableOptions* table_opts);
+  BuiltinIndexFactoryBuilder(std::unique_ptr<InternalKeyComparator> icmp,
+                             const BlockBasedTableOptions* table_opts);
+  ~BuiltinIndexFactoryBuilder() override;
+
+  // @partitioned: the same object as `builder` when it is a
+  //   PartitionedIndexBuilder, else nullptr. Passed explicitly so the
+  //   partition-specific accessors below never have to infer the concrete
+  //   type from table_opts_->index_type, which the standalone factory
+  //   paths do not set.
+  void SetInternalBuilder(std::unique_ptr<IndexBuilder> builder,
+                          PartitionedIndexBuilder* partitioned = nullptr);
+
+  const InternalKeyComparator* GetComparator() const;
+  const BlockBasedTableOptions& GetTableOptions() const;
+
+  // Forward to the internal builder with the full internal key.
+  // Needed by kBinarySearchWithFirstKey to track first_internal_key.
+  // Inlined because this is called per key from the table builder.
+  inline void OnKeyAddedInternal(const Slice& internal_key,
+                                 const std::optional<Slice>& value) {
+    internal_builder_->OnKeyAdded(internal_key, value);
+  }
+
+  // --- IndexFactoryBuilder overrides ---
+  Slice AddIndexEntry(const Slice& last_key_in_current_block,
+                      const Slice* first_key_in_next_block,
+                      const BlockHandle& block_handle,
+                      std::string* separator_scratch,
+                      const IndexEntryContext& context) override;
+
+  void OnKeyAdded(const Slice& key, ValueType type,
+                  const Slice& value) override;
+
+  Status Finish(Slice* index_contents) override;
+  uint64_t EstimatedSize() const override;
+  uint64_t CurrentIndexSizeEstimate() const;
+
+  Status FinishAndWrite(BuiltinIndexBlockWriter* writer,
+                        BlockHandle* final_handle, bool compress);
+
+  bool SupportsParallelAddEntry() const override;
+  std::unique_ptr<PreparedAddEntry> CreatePreparedAddEntry() override;
+  void PrepareAddEntry(const Slice& last_key, const Slice* next_key,
+                       const IndexEntryContext& ctx,
+                       PreparedAddEntry* out) override;
+  void FinishAddEntry(const BlockHandle& handle, PreparedAddEntry* entry,
+                      std::string* separator_scratch,
+                      bool skip_delta_encoding) override;
+
+  // Metadata the table builder reads back to populate SST properties. These
+  // describe the standard index layout, so they are only meaningful for the
+  // built-in builder and are not part of the public builder interface.
+  bool separator_is_key_plus_seq() const;
+  uint64_t NumUniformIndexBlocks() const;
+  size_t IndexSize() const;
+  size_t NumPartitions() const;
+  size_t TopLevelIndexSize(uint64_t offset) const;
+
+  // Non-null only when the underlying builder is partitioned. The
+  // partitioned filter builder uses it to align filter partitions with
+  // index partitions.
+  PartitionedIndexBuilder* GetPartitionedIndexBuilder();
+
+  IndexBuilder* GetInternalBuilder();
+
+  // Synchronous fast path: pass internal keys straight through to the
+  // underlying IndexBuilder. Avoids the decompose/recompose overhead of
+  // the public AddIndexEntry (which works in user-key form).
+  Slice AddIndexEntryDirect(const Slice& last_internal_key,
+                            const Slice* first_internal_key_next,
+                            const ::ROCKSDB_NAMESPACE::BlockHandle& handle,
+                            std::string* separator_scratch,
+                            bool skip_delta_encoding);
+
+  // Parallel fast path: stages a prepared entry from internal keys
+  // directly, skipping the parse-and-repack the public PrepareAddEntry
+  // performs from user keys + context tags. Caller must later invoke
+  // FinishAddEntry() with the resolved BlockHandle to commit the entry.
+  void PrepareAddEntryDirect(const Slice& last_internal_key,
+                             const Slice* first_internal_key_next,
+                             PreparedAddEntry* out);
+
+ private:
+  std::unique_ptr<InternalKeyComparator> owned_icmp_;
+  const InternalKeyComparator* icmp_;
+  const BlockBasedTableOptions* table_opts_;
+  std::unique_ptr<IndexBuilder> internal_builder_;
+  // Non-owning alias of internal_builder_ when it is a
+  // PartitionedIndexBuilder, else nullptr. Set by SetInternalBuilder.
+  PartitionedIndexBuilder* partitioned_builder_ = nullptr;
+  // ReconstructInternalKeys() and PrepareAddEntry() use these buffers only
+  // on the public user-key path. A table builder uses either the
+  // synchronous add path or the parallel prepare/finish path for one SST,
+  // not both concurrently.
+  std::string last_internal_key_;
+  std::string next_internal_key_;
+
+  // Reconstruct full internal keys from user keys and packed tags.
+  // Writes into last_internal_key_ and (if next_user_key != nullptr)
+  // next_internal_key_ member buffers.
+  void ReconstructInternalKeys(const Slice& last_user_key,
+                               const Slice* next_user_key,
+                               const IndexEntryContext& ctx);
+};
+
+}  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
Let the built-in binary, hash, and partitioned indexes be created through `IndexFactory`. The wrappers preserve the existing internal-key handling and multi-block finish path.

Pass the common-prefix flag to every builder, including both levels of a partitioned index. The regression test checks the prefix encoding and decoded keys with the flag on and off.

The factory tests pass on the original PR plus the fix. Focused tests on the full stack also pass with `ASSERT_STATUS_CHECKED=1` and `COERCE_CONTEXT_SWITCH=1`. Full `make check` runs had test timeouts and hit the 30-minute local limit.

Part 4 of 9. Previous: #14960. Next: #14962. The first three parts have landed.
