### PR TITLE
Add built-in index factory tests

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -205,6 +205,7 @@ cpp_library_wrapper(name="rocksdb_lib", srcs=[
         "table/block_based/block_cache.cc",
         "table/block_based/block_prefetcher.cc",
         "table/block_based/block_prefix_index.cc",
+        "table/block_based/builtin_index_factory.cc",
         "table/block_based/data_block_footer.cc",
         "table/block_based/data_block_hash_index.cc",
         "table/block_based/filter_block_reader_common.cc",

--- a/BUCK
+++ b/BUCK
@@ -4614,6 +4614,12 @@ cpp_unittest_wrapper(name="bloom_test",
             extra_compiler_flags=[])
 
 
+cpp_unittest_wrapper(name="builtin_index_factory_test",
+            srcs=["table/block_based/builtin_index_factory_test.cc"],
+            deps=[":rocksdb_test_lib"],
+            extra_compiler_flags=[])
+
+
 cpp_unittest_wrapper(name="cache_reservation_manager_test",
             srcs=["cache/cache_reservation_manager_test.cc"],
             deps=[":rocksdb_test_lib"],

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -937,6 +937,7 @@ set(SOURCES
         table/block_based/block_cache.cc
         table/block_based/block_prefetcher.cc
         table/block_based/block_prefix_index.cc
+        table/block_based/builtin_index_factory.cc
         table/block_based/data_block_hash_index.cc
         table/block_based/data_block_footer.cc
         table/block_based/filter_block_reader_common.cc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1595,6 +1595,7 @@ if(WITH_TESTS)
         options/options_test.cc
         table/block_based/block_based_table_reader_test.cc
         table/block_based/block_test.cc
+        table/block_based/builtin_index_factory_test.cc
         table/block_based/data_block_hash_index_test.cc
         table/block_based/full_filter_block_test.cc
         table/block_based/partitioned_filter_block_test.cc

--- a/Makefile
+++ b/Makefile
@@ -2018,6 +2018,9 @@ block_fetcher_test: table/block_fetcher_test.o $(TEST_LIBRARY) $(LIBRARY)
 block_test: $(OBJ_DIR)/table/block_based/block_test.o $(TEST_LIBRARY) $(LIBRARY)
 	$(AM_LINK)
 
+builtin_index_factory_test: $(OBJ_DIR)/table/block_based/builtin_index_factory_test.o $(TEST_LIBRARY) $(LIBRARY)
+	$(AM_LINK)
+
 data_block_hash_index_test: $(OBJ_DIR)/table/block_based/data_block_hash_index_test.o $(TEST_LIBRARY) $(LIBRARY)
 	$(AM_LINK)
 

--- a/include/rocksdb/user_defined_index.h
+++ b/include/rocksdb/user_defined_index.h
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include <cstddef>
+#include <memory>
 #include <string>
 
 #include "rocksdb/advanced_iterator.h"
@@ -66,6 +68,12 @@ class UserDefinedIndexBuilder {
     // Tag (packed sequence number and type) of first_key_in_next_block (valid
     // only when first_key_in_next_block != nullptr).
     uint64_t first_key_tag = 0;
+    // True when block alignment padding put this data block at a
+    // non-sequential offset, so its handle must not be delta encoded
+    // against the previous one. Only meaningful for AddIndexEntry; the
+    // parallel path learns the offset later and receives the same flag as
+    // an explicit FinishAddEntry parameter.
+    bool skip_delta_encoding = false;
   };
 
   virtual ~UserDefinedIndexBuilder() = default;
@@ -116,20 +124,61 @@ class UserDefinedIndexBuilder {
   // snapshots are active). UDI builders that use OnKeyAdded() should be
   // prepared for this.
   //
-  // Thread safety: For a given builder instance, OnKeyAdded() and
-  // AddIndexEntry() are always called from a single thread. Builders do
-  // not need internal synchronization.
+  // Thread safety: Builders that use AddIndexEntry() are called from one
+  // thread. Builders that opt into parallel AddEntry receive OnKeyAdded() and
+  // PrepareAddEntry() on the emit thread and ordered FinishAddEntry() calls on
+  // the background writer thread. Emit-thread calls may overlap
+  // FinishAddEntry(), so implementations must synchronize shared state or keep
+  // the state touched by those callbacks disjoint. Finish() is called only
+  // after all FinishAddEntry() calls complete.
   virtual void OnKeyAdded(const Slice& /*key*/, ValueType /*type*/,
                           const Slice& /*value*/) {}
 
-  // Finish building the index.
-  // Returns a Status and the serialized index contents.
+  // Finish building the complete index into one self-contained byte buffer.
   // The memory backing the contents should not be freed until this builder
   // object is destructed.
   virtual Status Finish(Slice* index_contents) = 0;
 
-  // Returns an estimate of the current serialized index size in bytes.
+  // Returns an estimate of the current serialized index size in bytes: an
+  // upper bound on what Finish() will produce. The table builder adds this to
+  // the estimated SST tail size, and compaction asserts that the final tail
+  // does not exceed the last estimate, so implementations must not
+  // under-report.
   virtual uint64_t EstimatedSize() const = 0;
+
+  // Optional two-phase protocol for builders that can participate in parallel
+  // compression. Builders that do not opt in keep the existing synchronous
+  // AddIndexEntry() path. Builders that return true from
+  // SupportsParallelAddEntry() must provide non-null prepared entries from
+  // CreatePreparedAddEntry(), fill them in PrepareAddEntry(), and commit the
+  // corresponding index entry in FinishAddEntry().
+  //
+  // A prepared entry can be abandoned without a matching FinishAddEntry()
+  // when the SST build fails partway through, so implementations must not
+  // rely on that pairing to release resources.
+  struct PreparedAddEntry {
+    virtual ~PreparedAddEntry() = default;
+  };
+
+  virtual bool SupportsParallelAddEntry() const { return false; }
+
+  virtual std::unique_ptr<PreparedAddEntry> CreatePreparedAddEntry() {
+    return nullptr;
+  }
+
+  // Phase 1, on the emit thread. The key Slices reference table builder
+  // buffers that are overwritten before the matching FinishAddEntry() runs,
+  // so anything needed later must be copied into the prepared entry.
+  virtual void PrepareAddEntry(const Slice& /*last_key_in_current_block*/,
+                               const Slice* /*first_key_in_next_block*/,
+                               const IndexEntryContext& /*context*/,
+                               PreparedAddEntry* /*out*/) {}
+
+  // Phase 2, on the background writer thread, in commit order.
+  virtual void FinishAddEntry(const BlockHandle& /*block_handle*/,
+                              PreparedAddEntry* /*entry*/,
+                              std::string* /*separator_scratch*/,
+                              bool /*skip_delta_encoding*/) {}
 };
 
 // The interface for iterating the user defined index. This will be

--- a/src.mk
+++ b/src.mk
@@ -195,6 +195,7 @@ LIB_SOURCES =                                                   \
   table/block_based/block_cache.cc                              \
   table/block_based/block_prefetcher.cc                         \
   table/block_based/block_prefix_index.cc                       \
+  table/block_based/builtin_index_factory.cc                    \
   table/block_based/data_block_hash_index.cc                    \
   table/block_based/data_block_footer.cc                        \
   table/block_based/filter_block_reader_common.cc               \

--- a/src.mk
+++ b/src.mk
@@ -610,6 +610,7 @@ TEST_MAIN_SOURCES =                                                     \
   options/options_test.cc                                               \
   table/block_based/block_based_table_reader_test.cc                    \
   table/block_based/block_test.cc                                       \
+  table/block_based/builtin_index_factory_test.cc                       \
   table/block_based/data_block_hash_index_test.cc                       \
   table/block_based/full_filter_block_test.cc                           \
   table/block_based/partitioned_filter_block_test.cc                    \

--- a/table/block_based/builtin_index_factory.cc
+++ b/table/block_based/builtin_index_factory.cc
@@ -1,0 +1,512 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// This source code is licensed under both the GPLv2 (found in the
+// COPYING file in the root directory) and Apache 2.0 License
+// (found in the LICENSE.Apache file in the root directory).
+
+#include "table/block_based/builtin_index_factory.h"
+
+#include <cassert>
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include "db/dbformat.h"
+#include "rocksdb/comparator.h"
+#include "rocksdb/index_factory.h"
+#include "rocksdb/slice.h"
+#include "rocksdb/status.h"
+#include "table/block_based/index_builder.h"
+#include "util/cast_util.h"
+#include "util/coding.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+// Wrapper around the internal IndexBuilder::PreparedIndexEntry, adapting it
+// to the public IndexFactoryBuilder::PreparedAddEntry interface for parallel
+// compression support.
+struct BuiltinPreparedAddEntry : public IndexFactoryBuilder::PreparedAddEntry {
+  std::unique_ptr<IndexBuilder::PreparedIndexEntry> internal_entry;
+  explicit BuiltinPreparedAddEntry(
+      std::unique_ptr<IndexBuilder::PreparedIndexEntry> e)
+      : internal_entry(std::move(e)) {}
+};
+
+BuiltinIndexFactoryBuilder::BuiltinIndexFactoryBuilder(
+    const InternalKeyComparator* icmp, const BlockBasedTableOptions* table_opts)
+    : icmp_(icmp), table_opts_(table_opts) {
+  assert(icmp_ != nullptr);
+}
+
+BuiltinIndexFactoryBuilder::BuiltinIndexFactoryBuilder(
+    std::unique_ptr<InternalKeyComparator> icmp,
+    const BlockBasedTableOptions* table_opts)
+    : owned_icmp_(std::move(icmp)),
+      icmp_(owned_icmp_.get()),
+      table_opts_(table_opts) {
+  assert(icmp_ != nullptr);
+}
+
+BuiltinIndexFactoryBuilder::~BuiltinIndexFactoryBuilder() = default;
+
+void BuiltinIndexFactoryBuilder::SetInternalBuilder(
+    std::unique_ptr<IndexBuilder> builder,
+    PartitionedIndexBuilder* partitioned) {
+  assert(partitioned == nullptr || partitioned == builder.get());
+  internal_builder_ = std::move(builder);
+  partitioned_builder_ = partitioned;
+}
+
+const InternalKeyComparator* BuiltinIndexFactoryBuilder::GetComparator() const {
+  return icmp_;
+}
+
+const BlockBasedTableOptions& BuiltinIndexFactoryBuilder::GetTableOptions()
+    const {
+  return *table_opts_;
+}
+
+void BuiltinIndexFactoryBuilder::ReconstructInternalKeys(
+    const Slice& last_user_key, const Slice* next_user_key,
+    const IndexEntryContext& ctx) {
+  last_internal_key_.clear();
+  last_internal_key_.append(last_user_key.data(), last_user_key.size());
+  PutFixed64(&last_internal_key_, ctx.last_key_tag);
+
+  if (next_user_key != nullptr) {
+    next_internal_key_.clear();
+    next_internal_key_.append(next_user_key->data(), next_user_key->size());
+    PutFixed64(&next_internal_key_, ctx.first_key_tag);
+  }
+}
+
+Slice BuiltinIndexFactoryBuilder::AddIndexEntry(
+    const Slice& last_key_in_current_block,
+    const Slice* first_key_in_next_block, const BlockHandle& block_handle,
+    std::string* separator_scratch, const IndexEntryContext& context) {
+  // Reconstruct internal keys from user keys + packed tags.
+  // The internal IndexBuilder expects full internal keys:
+  //   [user_key | packed_seq_and_type (8 bytes)]
+  ReconstructInternalKeys(last_key_in_current_block, first_key_in_next_block,
+                          context);
+  Slice last_ik(last_internal_key_);
+
+  Slice next_ik;
+  const Slice* next_ik_ptr = nullptr;
+  if (first_key_in_next_block != nullptr) {
+    next_ik = Slice(next_internal_key_);
+    next_ik_ptr = &next_ik;
+  }
+
+  // Convert the public BlockHandle to the internal BlockHandle.
+  ROCKSDB_NAMESPACE::BlockHandle internal_handle(block_handle.offset,
+                                                 block_handle.size);
+
+  return internal_builder_->AddIndexEntry(last_ik, next_ik_ptr, internal_handle,
+                                          separator_scratch,
+                                          context.skip_delta_encoding);
+}
+
+void BuiltinIndexFactoryBuilder::OnKeyAdded(const Slice& /*key*/,
+                                            ValueType /*type*/,
+                                            const Slice& /*value*/) {
+  // No-op: the internal builder needs the full internal key for
+  // kBinarySearchWithFirstKey, which the table builder supplies via
+  // OnKeyAddedInternal().
+}
+
+Status BuiltinIndexFactoryBuilder::Finish(Slice* index_contents) {
+  IndexBuilder::IndexBlocks index_blocks;
+  Status s = internal_builder_->Finish(&index_blocks);
+  if (!s.ok()) {
+    return s;
+  }
+  // Store the contents -- the internal builder's memory backs this Slice.
+  *index_contents = index_blocks.index_block_contents;
+  return Status::OK();
+}
+
+uint64_t BuiltinIndexFactoryBuilder::EstimatedSize() const {
+  return CurrentIndexSizeEstimate();
+}
+
+uint64_t BuiltinIndexFactoryBuilder::CurrentIndexSizeEstimate() const {
+  return internal_builder_->CurrentIndexSizeEstimate();
+}
+
+Status BuiltinIndexFactoryBuilder::FinishAndWrite(
+    BuiltinIndexBlockWriter* writer, BlockHandle* final_handle, bool compress) {
+  IndexBuilder::IndexBlocks index_blocks;
+  Status s = internal_builder_->Finish(&index_blocks);
+  if (!s.ok() && !s.IsIncomplete()) {
+    return s;
+  }
+
+  // Write any auxiliary meta blocks (e.g., hash index prefix blocks).
+  // The writer callback registers them with the meta index builder.
+  for (const auto& item : index_blocks.meta_blocks) {
+    BlockHandle meta_bh{0, 0};
+    Status ws = writer->WriteBlock(item.second.second, &meta_bh, compress);
+    if (!ws.ok()) {
+      return ws;
+    }
+    writer->AddMetaBlock(item.first, meta_bh);
+  }
+
+  // Write the first (or only) index block.
+  BlockHandle handle{0, 0};
+  Status ws =
+      writer->WriteBlock(index_blocks.index_block_contents, &handle, compress);
+  if (!ws.ok()) {
+    return ws;
+  }
+
+  // For partitioned indexes, the internal builder returns
+  // Status::Incomplete() to signal more partitions remain. Each
+  // subsequent Finish() call receives the handle of the previously
+  // written partition so it can build the top-level index.
+  while (s.IsIncomplete()) {
+    // Convert public BlockHandle to internal BlockHandle for Finish.
+    ROCKSDB_NAMESPACE::BlockHandle internal_handle(handle.offset, handle.size);
+    s = internal_builder_->Finish(&index_blocks, internal_handle);
+    if (!s.ok() && !s.IsIncomplete()) {
+      return s;
+    }
+    ws = writer->WriteBlock(index_blocks.index_block_contents, &handle,
+                            compress);
+    if (!ws.ok()) {
+      return ws;
+    }
+  }
+
+  *final_handle = {handle.offset, handle.size};
+  return Status::OK();
+}
+
+bool BuiltinIndexFactoryBuilder::SupportsParallelAddEntry() const {
+  return true;
+}
+
+std::unique_ptr<IndexFactoryBuilder::PreparedAddEntry>
+BuiltinIndexFactoryBuilder::CreatePreparedAddEntry() {
+  return std::make_unique<BuiltinPreparedAddEntry>(
+      internal_builder_->CreatePreparedIndexEntry());
+}
+
+void BuiltinIndexFactoryBuilder::PrepareAddEntry(const Slice& last_key,
+                                                 const Slice* next_key,
+                                                 const IndexEntryContext& ctx,
+                                                 PreparedAddEntry* out) {
+  auto* entry = static_cast_with_check<BuiltinPreparedAddEntry>(out);
+
+  // Reuses the member buffers rather than allocating per data block.
+  // PrepareIndexEntry copies out what it needs before returning.
+  ReconstructInternalKeys(last_key, next_key, ctx);
+  Slice last_ik(last_internal_key_);
+
+  Slice next_ik;
+  const Slice* next_ik_ptr = nullptr;
+  if (next_key != nullptr) {
+    next_ik = Slice(next_internal_key_);
+    next_ik_ptr = &next_ik;
+  }
+
+  internal_builder_->PrepareIndexEntry(last_ik, next_ik_ptr,
+                                       entry->internal_entry.get());
+}
+
+void BuiltinIndexFactoryBuilder::FinishAddEntry(
+    const BlockHandle& handle, PreparedAddEntry* entry,
+    std::string* /*separator_scratch*/, bool skip_delta_encoding) {
+  auto* builtin_entry = static_cast_with_check<BuiltinPreparedAddEntry>(entry);
+  ROCKSDB_NAMESPACE::BlockHandle internal_handle(handle.offset, handle.size);
+  internal_builder_->FinishIndexEntry(internal_handle,
+                                      builtin_entry->internal_entry.get(),
+                                      skip_delta_encoding);
+}
+
+bool BuiltinIndexFactoryBuilder::separator_is_key_plus_seq() const {
+  return internal_builder_->separator_is_key_plus_seq();
+}
+
+uint64_t BuiltinIndexFactoryBuilder::NumUniformIndexBlocks() const {
+  return internal_builder_->NumUniformIndexBlocks();
+}
+
+size_t BuiltinIndexFactoryBuilder::IndexSize() const {
+  return internal_builder_->IndexSize();
+}
+
+size_t BuiltinIndexFactoryBuilder::NumPartitions() const {
+  return partitioned_builder_ ? partitioned_builder_->NumPartitions() : 0;
+}
+
+size_t BuiltinIndexFactoryBuilder::TopLevelIndexSize(uint64_t offset) const {
+  return partitioned_builder_ ? partitioned_builder_->TopLevelIndexSize(offset)
+                              : 0;
+}
+
+PartitionedIndexBuilder*
+BuiltinIndexFactoryBuilder::GetPartitionedIndexBuilder() {
+  return partitioned_builder_;
+}
+
+IndexBuilder* BuiltinIndexFactoryBuilder::GetInternalBuilder() {
+  return internal_builder_.get();
+}
+
+Slice BuiltinIndexFactoryBuilder::AddIndexEntryDirect(
+    const Slice& last_internal_key, const Slice* first_internal_key_next,
+    const ::ROCKSDB_NAMESPACE::BlockHandle& handle,
+    std::string* separator_scratch, bool skip_delta_encoding) {
+  return internal_builder_->AddIndexEntry(
+      last_internal_key, first_internal_key_next, handle, separator_scratch,
+      skip_delta_encoding);
+}
+
+void BuiltinIndexFactoryBuilder::PrepareAddEntryDirect(
+    const Slice& last_internal_key, const Slice* first_internal_key_next,
+    PreparedAddEntry* out) {
+  auto* entry = static_cast_with_check<BuiltinPreparedAddEntry>(out);
+  // Skip the user-key reconstruction path entirely; pass the caller's
+  // internal keys straight through to the internal builder.
+  internal_builder_->PrepareIndexEntry(
+      last_internal_key, first_internal_key_next, entry->internal_entry.get());
+}
+
+// ============================================================================
+// Factory implementations
+// ============================================================================
+
+// --- BinarySearchIndexFactory ---
+
+static const char* const kBinarySearchName =
+    "rocksdb.builtin.BinarySearchIndex";
+static const char* const kBinarySearchWithFirstKeyName =
+    "rocksdb.builtin.BinarySearchWithFirstKeyIndex";
+
+BinarySearchIndexFactory::BinarySearchIndexFactory(bool with_first_key)
+    : with_first_key_(with_first_key) {}
+
+BinarySearchIndexFactory::BinarySearchIndexFactory(
+    bool with_first_key, const BuiltinIndexFactoryConfig& config)
+    : with_first_key_(with_first_key), has_config_(true), config_(config) {}
+
+const char* BinarySearchIndexFactory::Name() const {
+  return with_first_key_ ? kBinarySearchWithFirstKeyName : kBinarySearchName;
+}
+
+const char* BinarySearchIndexFactory::kClassName() { return kBinarySearchName; }
+
+const char* BinarySearchIndexFactory::kClassNameWithFirstKey() {
+  return kBinarySearchWithFirstKeyName;
+}
+
+Status BinarySearchIndexFactory::NewBuilder(
+    const IndexFactoryOptions& options,
+    std::unique_ptr<IndexFactoryBuilder>& builder) const {
+  if (options.comparator == nullptr) {
+    return Status::InvalidArgument(
+        "BinarySearchIndexFactory::NewBuilder requires a comparator");
+  }
+
+  if (has_config_) {
+    // Full construction path used by the table builder. config_ holds
+    // the per-SST configuration; the table_options pointer remains
+    // valid for the builder's lifetime (Rep owns it).
+    auto index_type = with_first_key_
+                          ? BlockBasedTableOptions::kBinarySearchWithFirstKey
+                          : BlockBasedTableOptions::kBinarySearch;
+    auto wrapper = std::make_unique<BuiltinIndexFactoryBuilder>(
+        config_.internal_comparator, config_.table_options);
+    std::unique_ptr<IndexBuilder> internal(IndexBuilder::CreateIndexBuilder(
+        index_type, wrapper->GetComparator(), config_.internal_prefix_transform,
+        config_.use_delta_encoding_for_index_values, wrapper->GetTableOptions(),
+        config_.ts_sz, config_.persist_user_defined_timestamps, config_.stats));
+    wrapper->SetInternalBuilder(std::move(internal));
+    builder = std::move(wrapper);
+    return Status::OK();
+  }
+
+  // Standalone / test path. Uses a static default BlockBasedTableOptions
+  // since there is no Rep to borrow from.
+  auto icmp = std::make_unique<InternalKeyComparator>(options.comparator);
+  auto index_type = with_first_key_
+                        ? BlockBasedTableOptions::kBinarySearchWithFirstKey
+                        : BlockBasedTableOptions::kBinarySearch;
+  static const BlockBasedTableOptions kDefaultBinarySearchOpts;
+  auto wrapper = std::make_unique<BuiltinIndexFactoryBuilder>(
+      std::move(icmp), &kDefaultBinarySearchOpts);
+  std::unique_ptr<IndexBuilder> internal(IndexBuilder::CreateIndexBuilder(
+      index_type, wrapper->GetComparator(),
+      /*int_key_slice_transform=*/nullptr,
+      /*use_value_delta_encoding=*/true, wrapper->GetTableOptions(),
+      /*ts_sz=*/0, /*persist_user_defined_timestamps=*/true));
+  wrapper->SetInternalBuilder(std::move(internal));
+  builder = std::move(wrapper);
+  return Status::OK();
+}
+
+Status BinarySearchIndexFactory::NewReader(
+    const IndexFactoryOptions& /*options*/, Slice& /*index_contents*/,
+    std::unique_ptr<IndexFactoryReader>& /*reader*/) const {
+  // Built-in reads go through BlockBasedTable::CreateIndexReader directly
+  // (see the asymmetric-API note in include/rocksdb/index_factory.h).
+  return Status::NotSupported(
+      "BinarySearchIndexFactory::NewReader is not used directly. "
+      "The built-in reader is created through "
+      "BlockBasedTable::CreateIndexReader.");
+}
+
+// --- HashIndexFactory ---
+
+static const char* const kHashIndexName = "rocksdb.builtin.HashIndex";
+
+HashIndexFactory::HashIndexFactory(const BuiltinIndexFactoryConfig& config)
+    : has_config_(true), config_(config) {}
+
+const char* HashIndexFactory::Name() const { return kHashIndexName; }
+const char* HashIndexFactory::kClassName() { return kHashIndexName; }
+
+// FinishAndWrite writes and registers hash prefix meta blocks (prefix block and
+// prefix metadata block) through the internal writer callback.
+Status HashIndexFactory::NewBuilder(
+    const IndexFactoryOptions& options,
+    std::unique_ptr<IndexFactoryBuilder>& builder) const {
+  if (options.comparator == nullptr) {
+    return Status::InvalidArgument(
+        "HashIndexFactory::NewBuilder requires a comparator");
+  }
+
+  if (has_config_) {
+    auto wrapper = std::make_unique<BuiltinIndexFactoryBuilder>(
+        config_.internal_comparator, config_.table_options);
+    std::unique_ptr<IndexBuilder> internal(IndexBuilder::CreateIndexBuilder(
+        BlockBasedTableOptions::kHashSearch, wrapper->GetComparator(),
+        config_.internal_prefix_transform,
+        config_.use_delta_encoding_for_index_values, wrapper->GetTableOptions(),
+        config_.ts_sz, config_.persist_user_defined_timestamps, config_.stats));
+    wrapper->SetInternalBuilder(std::move(internal));
+    builder = std::move(wrapper);
+    return Status::OK();
+  }
+
+  // Standalone / test path with a static default BlockBasedTableOptions.
+  auto icmp = std::make_unique<InternalKeyComparator>(options.comparator);
+  static const BlockBasedTableOptions kDefaultHashOpts;
+  auto wrapper = std::make_unique<BuiltinIndexFactoryBuilder>(
+      std::move(icmp), &kDefaultHashOpts);
+  std::unique_ptr<IndexBuilder> internal(IndexBuilder::CreateIndexBuilder(
+      BlockBasedTableOptions::kHashSearch, wrapper->GetComparator(),
+      /*int_key_slice_transform=*/nullptr,
+      /*use_value_delta_encoding=*/true, wrapper->GetTableOptions(),
+      /*ts_sz=*/0, /*persist_user_defined_timestamps=*/true));
+  wrapper->SetInternalBuilder(std::move(internal));
+  builder = std::move(wrapper);
+  return Status::OK();
+}
+
+Status HashIndexFactory::NewReader(
+    const IndexFactoryOptions& /*options*/, Slice& /*index_contents*/,
+    std::unique_ptr<IndexFactoryReader>& /*reader*/) const {
+  return Status::NotSupported(
+      "HashIndexFactory::NewReader is not used directly.");
+}
+
+// --- PartitionedIndexFactory ---
+
+static const char* const kPartitionedIndexName =
+    "rocksdb.builtin.PartitionedIndex";
+
+PartitionedIndexFactory::PartitionedIndexFactory(
+    const BuiltinIndexFactoryConfig& config)
+    : has_config_(true), config_(config) {}
+
+const char* PartitionedIndexFactory::Name() const {
+  return kPartitionedIndexName;
+}
+const char* PartitionedIndexFactory::kClassName() {
+  return kPartitionedIndexName;
+}
+
+// The partitioned index uses a multi-call Finish protocol internally
+// (returning Status::Incomplete() for each partition). The single-call
+// Finish(Slice*) only returns the first partition block. For full
+// partitioned index construction, the table builder uses FinishAndWrite() to
+// drive the multi-call protocol through its internal writer callback.
+Status PartitionedIndexFactory::NewBuilder(
+    const IndexFactoryOptions& options,
+    std::unique_ptr<IndexFactoryBuilder>& builder) const {
+  if (options.comparator == nullptr) {
+    return Status::InvalidArgument(
+        "PartitionedIndexFactory::NewBuilder requires a comparator");
+  }
+
+  if (has_config_) {
+    auto wrapper = std::make_unique<BuiltinIndexFactoryBuilder>(
+        config_.internal_comparator, config_.table_options);
+    PartitionedIndexBuilder* internal =
+        PartitionedIndexBuilder::CreateIndexBuilder(
+            wrapper->GetComparator(),
+            config_.use_delta_encoding_for_index_values,
+            wrapper->GetTableOptions(), config_.ts_sz,
+            config_.persist_user_defined_timestamps, config_.stats);
+    wrapper->SetInternalBuilder(std::unique_ptr<IndexBuilder>(internal),
+                                internal);
+    builder = std::move(wrapper);
+    return Status::OK();
+  }
+
+  // Standalone / test path. PartitionedIndexBuilder holds a const ref to
+  // table_opts_, so the wrapper must be constructed before the builder.
+  auto icmp = std::make_unique<InternalKeyComparator>(options.comparator);
+  static const BlockBasedTableOptions kDefaultPartitionedOpts;
+  auto wrapper = std::make_unique<BuiltinIndexFactoryBuilder>(
+      std::move(icmp), &kDefaultPartitionedOpts);
+  PartitionedIndexBuilder* internal =
+      PartitionedIndexBuilder::CreateIndexBuilder(
+          wrapper->GetComparator(), /*use_value_delta_encoding=*/true,
+          wrapper->GetTableOptions(),
+          /*ts_sz=*/0, /*persist_user_defined_timestamps=*/true);
+  wrapper->SetInternalBuilder(std::unique_ptr<IndexBuilder>(internal),
+                              internal);
+  builder = std::move(wrapper);
+  return Status::OK();
+}
+
+Status PartitionedIndexFactory::NewReader(
+    const IndexFactoryOptions& /*options*/, Slice& /*index_contents*/,
+    std::unique_ptr<IndexFactoryReader>& /*reader*/) const {
+  return Status::NotSupported(
+      "PartitionedIndexFactory::NewReader is not used directly.");
+}
+
+Status NewBuiltinIndexFactoryBuilder(
+    BlockBasedTableOptions::IndexType index_type,
+    const BuiltinIndexFactoryConfig& config, const IndexFactoryOptions& options,
+    std::unique_ptr<IndexFactoryBuilder>& out) {
+  // Stack-local factory objects avoid shared_ptr heap allocation. The factory
+  // is only needed for the duration of NewBuilder(); the builder it produces
+  // is independent.
+  switch (index_type) {
+    case BlockBasedTableOptions::kBinarySearch: {
+      BinarySearchIndexFactory factory(/*with_first_key=*/false, config);
+      return factory.NewBuilder(options, out);
+    }
+    case BlockBasedTableOptions::kBinarySearchWithFirstKey: {
+      BinarySearchIndexFactory factory(/*with_first_key=*/true, config);
+      return factory.NewBuilder(options, out);
+    }
+    case BlockBasedTableOptions::kHashSearch: {
+      HashIndexFactory factory(config);
+      return factory.NewBuilder(options, out);
+    }
+    case BlockBasedTableOptions::kTwoLevelIndexSearch: {
+      PartitionedIndexFactory factory(config);
+      return factory.NewBuilder(options, out);
+    }
+  }
+  // Unreachable for known IndexType values; keep the compiler happy.
+  return Status::InvalidArgument("Unknown BlockBasedTableOptions::IndexType");
+}
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/table/block_based/builtin_index_factory.h
+++ b/table/block_based/builtin_index_factory.h
@@ -1,0 +1,311 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// This source code is licensed under both the GPLv2 (found in the
+// COPYING file in the root directory) and Apache 2.0 License
+// (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+
+#include "rocksdb/index_factory.h"
+#include "rocksdb/table.h"
+#include "table/block_based/index_builder.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+class InternalKeyComparator;
+class InternalKeySliceTransform;
+class Statistics;
+
+// Built-in index factories wrap the internal IndexBuilder / IndexReader
+// behind the public IndexFactory interface. They translate between the
+// public form (user keys, simple BlockHandles) and the internal form
+// (internal keys, IndexValue with first_internal_key).
+
+// Construction parameters used by the built-in factories' NewBuilder()
+// to configure the internal IndexBuilder. Custom factories use only
+// IndexFactoryOptions::comparator and do not need this.
+struct BuiltinIndexFactoryConfig {
+  const InternalKeyComparator* internal_comparator = nullptr;
+  const InternalKeySliceTransform* internal_prefix_transform = nullptr;
+  bool use_delta_encoding_for_index_values = true;
+  // Pointer to the Rep's table_options (which outlives the builder).
+  // Avoids copying the large BlockBasedTableOptions struct per-SST.
+  const BlockBasedTableOptions* table_options = nullptr;
+  size_t ts_sz = 0;
+  bool persist_user_defined_timestamps = true;
+  Statistics* stats = nullptr;
+};
+
+// BinarySearchIndexFactory: the default BlockBasedTable index. Wraps
+// ShortenedIndexBuilder and BinarySearchIndexReader. Handles both
+// kBinarySearch and kBinarySearchWithFirstKey.
+class BinarySearchIndexFactory : public IndexFactory {
+ public:
+  // Lightweight constructor for standalone / test usage.
+  // NewBuilder will use minimal default configuration.
+  // @param with_first_key  If true, creates kBinarySearchWithFirstKey
+  //                        indexes that store the first internal key per
+  //                        block for optimized point lookups.
+  explicit BinarySearchIndexFactory(bool with_first_key = false);
+
+  // Full constructor for use by the table builder.
+  // The factory stores all internal params needed by NewBuilder().
+  BinarySearchIndexFactory(bool with_first_key,
+                           const BuiltinIndexFactoryConfig& config);
+
+  ~BinarySearchIndexFactory() override = default;
+
+  const char* Name() const override;
+  static const char* kClassName();
+  static const char* kClassNameWithFirstKey();
+
+  Status NewBuilder(
+      const IndexFactoryOptions& options,
+      std::unique_ptr<IndexFactoryBuilder>& builder) const override;
+
+  IndexFactoryBuilder* NewBuilder() const override {
+    std::unique_ptr<IndexFactoryBuilder> builder;
+    Status s = NewBuilder(IndexFactoryOptions(), builder);
+    return s.ok() ? builder.release() : nullptr;
+  }
+
+  Status NewReader(const IndexFactoryOptions& options, Slice& index_contents,
+                   std::unique_ptr<IndexFactoryReader>& reader) const override;
+
+  std::unique_ptr<IndexFactoryReader> NewReader(
+      Slice& index_contents) const override {
+    std::unique_ptr<IndexFactoryReader> reader;
+    Status s = NewReader(IndexFactoryOptions(), index_contents, reader);
+    return s.ok() ? std::move(reader) : nullptr;
+  }
+
+ private:
+  bool with_first_key_;
+  bool has_config_ = false;
+  BuiltinIndexFactoryConfig config_;
+};
+
+// HashIndexFactory: prefix-hash index. Wraps HashIndexBuilder and
+// HashIndexReader. Requires a configured prefix_extractor.
+class HashIndexFactory : public IndexFactory {
+ public:
+  // Lightweight constructor for standalone / test usage.
+  HashIndexFactory() = default;
+
+  // Full constructor for use by the table builder.
+  explicit HashIndexFactory(const BuiltinIndexFactoryConfig& config);
+
+  ~HashIndexFactory() override = default;
+
+  const char* Name() const override;
+  static const char* kClassName();
+
+  Status NewBuilder(
+      const IndexFactoryOptions& options,
+      std::unique_ptr<IndexFactoryBuilder>& builder) const override;
+
+  IndexFactoryBuilder* NewBuilder() const override {
+    std::unique_ptr<IndexFactoryBuilder> builder;
+    Status s = NewBuilder(IndexFactoryOptions(), builder);
+    return s.ok() ? builder.release() : nullptr;
+  }
+
+  Status NewReader(const IndexFactoryOptions& options, Slice& index_contents,
+                   std::unique_ptr<IndexFactoryReader>& reader) const override;
+
+  std::unique_ptr<IndexFactoryReader> NewReader(
+      Slice& index_contents) const override {
+    std::unique_ptr<IndexFactoryReader> reader;
+    Status s = NewReader(IndexFactoryOptions(), index_contents, reader);
+    return s.ok() ? std::move(reader) : nullptr;
+  }
+
+ private:
+  bool has_config_ = false;
+  BuiltinIndexFactoryConfig config_;
+};
+
+// PartitionedIndexFactory: two-level partitioned index. Wraps
+// PartitionedIndexBuilder and PartitionIndexReader. Implements the
+// multi-block FinishAndWrite protocol and exposes the underlying
+// PartitionedIndexBuilder for filter <-> index partition alignment.
+class PartitionedIndexFactory : public IndexFactory {
+ public:
+  // Lightweight constructor for standalone / test usage.
+  PartitionedIndexFactory() = default;
+
+  // Full constructor for use by the table builder.
+  explicit PartitionedIndexFactory(const BuiltinIndexFactoryConfig& config);
+
+  ~PartitionedIndexFactory() override = default;
+
+  const char* Name() const override;
+  static const char* kClassName();
+
+  Status NewBuilder(
+      const IndexFactoryOptions& options,
+      std::unique_ptr<IndexFactoryBuilder>& builder) const override;
+
+  IndexFactoryBuilder* NewBuilder() const override {
+    std::unique_ptr<IndexFactoryBuilder> builder;
+    Status s = NewBuilder(IndexFactoryOptions(), builder);
+    return s.ok() ? builder.release() : nullptr;
+  }
+
+  Status NewReader(const IndexFactoryOptions& options, Slice& index_contents,
+                   std::unique_ptr<IndexFactoryReader>& reader) const override;
+
+  std::unique_ptr<IndexFactoryReader> NewReader(
+      Slice& index_contents) const override {
+    std::unique_ptr<IndexFactoryReader> reader;
+    Status s = NewReader(IndexFactoryOptions(), index_contents, reader);
+    return s.ok() ? std::move(reader) : nullptr;
+  }
+
+ private:
+  bool has_config_ = false;
+  BuiltinIndexFactoryConfig config_;
+};
+
+// Dispatch on BlockBasedTableOptions::IndexType and construct the
+// matching built-in factory's builder.
+Status NewBuiltinIndexFactoryBuilder(
+    BlockBasedTableOptions::IndexType index_type,
+    const BuiltinIndexFactoryConfig& config, const IndexFactoryOptions& options,
+    std::unique_ptr<IndexFactoryBuilder>& out);
+
+// BuiltinIndexFactoryBuilder: adapts the internal IndexBuilder to the
+// public IndexFactoryBuilder interface. The table builder uses the
+// *Direct methods to bypass the user-key parse-and-repack on the
+// per-block-boundary hot path.
+//
+// Unqualified BlockHandle inside this class means the public
+// IndexFactoryBuilder::BlockHandle. The internal table/format.h handle is
+// always spelled ::ROCKSDB_NAMESPACE::BlockHandle.
+
+class BuiltinIndexBlockWriter {
+ public:
+  virtual ~BuiltinIndexBlockWriter() = default;
+
+  virtual Status WriteBlock(const Slice& contents,
+                            IndexFactoryBuilder::BlockHandle* handle,
+                            bool compress) = 0;
+  virtual void AddMetaBlock(const std::string& name,
+                            const IndexFactoryBuilder::BlockHandle& handle) = 0;
+};
+
+class BuiltinIndexFactoryBuilder : public IndexFactoryBuilder {
+ public:
+  BuiltinIndexFactoryBuilder(const InternalKeyComparator* icmp,
+                             const BlockBasedTableOptions* table_opts);
+  BuiltinIndexFactoryBuilder(std::unique_ptr<InternalKeyComparator> icmp,
+                             const BlockBasedTableOptions* table_opts);
+  ~BuiltinIndexFactoryBuilder() override;
+
+  // @partitioned: the same object as `builder` when it is a
+  //   PartitionedIndexBuilder, else nullptr. Passed explicitly so the
+  //   partition-specific accessors below never have to infer the concrete
+  //   type from table_opts_->index_type, which the standalone factory
+  //   paths do not set.
+  void SetInternalBuilder(std::unique_ptr<IndexBuilder> builder,
+                          PartitionedIndexBuilder* partitioned = nullptr);
+
+  const InternalKeyComparator* GetComparator() const;
+  const BlockBasedTableOptions& GetTableOptions() const;
+
+  // Forward to the internal builder with the full internal key.
+  // Needed by kBinarySearchWithFirstKey to track first_internal_key.
+  // Inlined because this is called per key from the table builder.
+  inline void OnKeyAddedInternal(const Slice& internal_key,
+                                 const std::optional<Slice>& value) {
+    internal_builder_->OnKeyAdded(internal_key, value);
+  }
+
+  // --- IndexFactoryBuilder overrides ---
+  Slice AddIndexEntry(const Slice& last_key_in_current_block,
+                      const Slice* first_key_in_next_block,
+                      const BlockHandle& block_handle,
+                      std::string* separator_scratch,
+                      const IndexEntryContext& context) override;
+
+  void OnKeyAdded(const Slice& key, ValueType type,
+                  const Slice& value) override;
+
+  Status Finish(Slice* index_contents) override;
+  uint64_t EstimatedSize() const override;
+  uint64_t CurrentIndexSizeEstimate() const;
+
+  Status FinishAndWrite(BuiltinIndexBlockWriter* writer,
+                        BlockHandle* final_handle, bool compress);
+
+  bool SupportsParallelAddEntry() const override;
+  std::unique_ptr<PreparedAddEntry> CreatePreparedAddEntry() override;
+  void PrepareAddEntry(const Slice& last_key, const Slice* next_key,
+                       const IndexEntryContext& ctx,
+                       PreparedAddEntry* out) override;
+  void FinishAddEntry(const BlockHandle& handle, PreparedAddEntry* entry,
+                      std::string* separator_scratch,
+                      bool skip_delta_encoding) override;
+
+  // Metadata the table builder reads back to populate SST properties. These
+  // describe the standard index layout, so they are only meaningful for the
+  // built-in builder and are not part of the public builder interface.
+  bool separator_is_key_plus_seq() const;
+  uint64_t NumUniformIndexBlocks() const;
+  size_t IndexSize() const;
+  size_t NumPartitions() const;
+  size_t TopLevelIndexSize(uint64_t offset) const;
+
+  // Non-null only when the underlying builder is partitioned. The
+  // partitioned filter builder uses it to align filter partitions with
+  // index partitions.
+  PartitionedIndexBuilder* GetPartitionedIndexBuilder();
+
+  IndexBuilder* GetInternalBuilder();
+
+  // Synchronous fast path: pass internal keys straight through to the
+  // underlying IndexBuilder. Avoids the decompose/recompose overhead of
+  // the public AddIndexEntry (which works in user-key form).
+  Slice AddIndexEntryDirect(const Slice& last_internal_key,
+                            const Slice* first_internal_key_next,
+                            const ::ROCKSDB_NAMESPACE::BlockHandle& handle,
+                            std::string* separator_scratch,
+                            bool skip_delta_encoding);
+
+  // Parallel fast path: stages a prepared entry from internal keys
+  // directly, skipping the parse-and-repack the public PrepareAddEntry
+  // performs from user keys + context tags. Caller must later invoke
+  // FinishAddEntry() with the resolved BlockHandle to commit the entry.
+  void PrepareAddEntryDirect(const Slice& last_internal_key,
+                             const Slice* first_internal_key_next,
+                             PreparedAddEntry* out);
+
+ private:
+  std::unique_ptr<InternalKeyComparator> owned_icmp_;
+  const InternalKeyComparator* icmp_;
+  const BlockBasedTableOptions* table_opts_;
+  std::unique_ptr<IndexBuilder> internal_builder_;
+  // Non-owning alias of internal_builder_ when it is a
+  // PartitionedIndexBuilder, else nullptr. Set by SetInternalBuilder.
+  PartitionedIndexBuilder* partitioned_builder_ = nullptr;
+  // ReconstructInternalKeys() and PrepareAddEntry() use these buffers only
+  // on the public user-key path. A table builder uses either the
+  // synchronous add path or the parallel prepare/finish path for one SST,
+  // not both concurrently.
+  std::string last_internal_key_;
+  std::string next_internal_key_;
+
+  // Reconstruct full internal keys from user keys and packed tags.
+  // Writes into last_internal_key_ and (if next_user_key != nullptr)
+  // next_internal_key_ member buffers.
+  void ReconstructInternalKeys(const Slice& last_user_key,
+                               const Slice* next_user_key,
+                               const IndexEntryContext& ctx);
+};
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/table/block_based/builtin_index_factory_test.cc
+++ b/table/block_based/builtin_index_factory_test.cc
@@ -1,0 +1,949 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// This source code is licensed under both the GPLv2 (found in the
+// COPYING file in the root directory) and Apache 2.0 License
+// (found in the LICENSE.Apache file in the root directory).
+
+#include "table/block_based/builtin_index_factory.h"
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "db/dbformat.h"
+#include "rocksdb/comparator.h"
+#include "rocksdb/index_factory.h"
+#include "rocksdb/slice.h"
+#include "rocksdb/user_defined_index.h"
+#include "table/block_based/block_based_table_reader.h"
+#include "table/block_based/index_builder.h"
+#include "test_util/testharness.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+// ============================================================================
+// Backward compatibility aliases test
+// ============================================================================
+
+TEST(BackwardCompatTest, UserDefinedIndexAliasesCompile) {
+  // Verify backward-compatible type aliases in user_defined_index.h
+  static_assert(std::is_same_v<UserDefinedIndexBuilder, IndexFactoryBuilder>);
+  static_assert(std::is_same_v<UserDefinedIndexIterator, IndexFactoryIterator>);
+  static_assert(std::is_same_v<UserDefinedIndexReader, IndexFactoryReader>);
+  static_assert(std::is_same_v<UserDefinedIndexFactory, IndexFactory>);
+  static_assert(std::is_same_v<UserDefinedIndexOption, IndexFactoryOptions>);
+  ASSERT_STREQ(kUserDefinedIndexPrefix, kIndexFactoryMetaPrefix);
+}
+
+// CRITICAL: This test pins the exact string value of the meta block prefix
+// used by user-defined indexes on disk. Changing this value breaks all SSTs
+// written by previous RocksDB versions that use the UserDefinedIndex feature.
+//
+// Note that this test deliberately uses a hardcoded string literal rather
+// than the constants -- that way an accidental change to either constant is
+// caught here. If you find yourself updating this assertion, stop: you are
+// introducing a backward-incompatible on-disk change that requires a
+// deliberate format-version bump and a migration path.
+TEST(OnDiskFormatTest, UserDefinedIndexMetaPrefix) {
+  ASSERT_STREQ(kIndexFactoryMetaPrefix, "rocksdb.user_defined_index.");
+  ASSERT_STREQ(kUserDefinedIndexPrefix, "rocksdb.user_defined_index.");
+}
+
+// Helper to build IndexFactoryOptions with BytewiseComparator.
+static IndexFactoryOptions MakeOptions() {
+  IndexFactoryOptions opts;
+  opts.comparator = BytewiseComparator();
+  return opts;
+}
+
+// The internal IndexBuilder uses delta encoding for block handles and expects
+// consecutive blocks laid out as: offset_i = offset_{i-1} + size_{i-1} +
+// kBlockTrailerSize (5 bytes: 1-byte compression type + 32-bit checksum).
+static constexpr uint64_t kBlockTrailerSize =
+    BlockBasedTable::kBlockTrailerSize;
+static constexpr uint64_t kBlockSize = 100;
+
+// Helper to add a few index entries to a builder. Simulates block boundaries
+// for keys "aaa", "bbb", "ccc" at consecutive offsets.
+static void AddSampleEntries(IndexFactoryBuilder* builder) {
+  std::string scratch;
+  IndexFactoryBuilder::IndexEntryContext ctx;
+  ctx.last_key_tag = 0;
+  ctx.first_key_tag = 0;
+
+  Slice key_a("aaa");
+  Slice key_b("bbb");
+  Slice key_c("ccc");
+  IndexFactoryBuilder::BlockHandle bh{0, 0};
+
+  // Block 0: [0, 100)
+  bh = {0, kBlockSize};
+  builder->AddIndexEntry(key_a, &key_b, bh, &scratch, ctx);
+
+  // Block 1: starts at 0 + 100 + 5 = 105
+  bh = {kBlockSize + kBlockTrailerSize, kBlockSize};
+  builder->AddIndexEntry(key_b, &key_c, bh, &scratch, ctx);
+
+  // Block 2 (last): starts at 105 + 100 + 5 = 210
+  bh = {2 * (kBlockSize + kBlockTrailerSize), kBlockSize};
+  builder->AddIndexEntry(key_c, nullptr, bh, &scratch, ctx);
+}
+
+static std::string GeneratedKey(size_t index) {
+  return "key" + std::to_string(100000 + index);
+}
+
+static void AddGeneratedEntries(IndexFactoryBuilder* builder, size_t count) {
+  std::string scratch;
+  for (size_t i = 0; i < count; ++i) {
+    const std::string key = GeneratedKey(i);
+    const std::string next_key = GeneratedKey(i + 1);
+    const Slice key_slice(key);
+    const Slice next_key_slice(next_key);
+    const Slice* next_key_ptr = i + 1 == count ? nullptr : &next_key_slice;
+
+    IndexFactoryBuilder::IndexEntryContext ctx;
+    ctx.last_key_tag =
+        PackSequenceAndType(static_cast<SequenceNumber>(count - i), kTypeValue);
+    ctx.first_key_tag =
+        next_key_ptr == nullptr
+            ? 0
+            : PackSequenceAndType(static_cast<SequenceNumber>(count - i - 1),
+                                  kTypeValue);
+    const IndexFactoryBuilder::BlockHandle handle{
+        i * (kBlockSize + kBlockTrailerSize), kBlockSize};
+    builder->AddIndexEntry(key_slice, next_key_ptr, handle, &scratch, ctx);
+  }
+}
+
+// ============================================================================
+// BinarySearchIndexFactory tests
+// ============================================================================
+
+class BinarySearchIndexFactoryTest : public ::testing::Test {};
+
+TEST_F(BinarySearchIndexFactoryTest, Name) {
+  BinarySearchIndexFactory factory(/*with_first_key=*/false);
+  ASSERT_STREQ(factory.Name(), "rocksdb.builtin.BinarySearchIndex");
+}
+
+TEST_F(BinarySearchIndexFactoryTest, NameWithFirstKey) {
+  BinarySearchIndexFactory factory(/*with_first_key=*/true);
+  ASSERT_STREQ(factory.Name(), "rocksdb.builtin.BinarySearchWithFirstKeyIndex");
+}
+
+TEST_F(BinarySearchIndexFactoryTest, KClassName) {
+  ASSERT_STREQ(BinarySearchIndexFactory::kClassName(),
+               "rocksdb.builtin.BinarySearchIndex");
+}
+
+TEST_F(BinarySearchIndexFactoryTest, KClassNameWithFirstKey) {
+  ASSERT_STREQ(BinarySearchIndexFactory::kClassNameWithFirstKey(),
+               "rocksdb.builtin.BinarySearchWithFirstKeyIndex");
+}
+
+TEST_F(BinarySearchIndexFactoryTest, NewBuilderSucceeds) {
+  BinarySearchIndexFactory factory(/*with_first_key=*/false);
+  auto opts = MakeOptions();
+  std::unique_ptr<IndexFactoryBuilder> builder;
+  ASSERT_OK(factory.NewBuilder(opts, builder));
+  ASSERT_NE(builder, nullptr);
+}
+
+TEST_F(BinarySearchIndexFactoryTest, NewBuilderRequiresComparator) {
+  BinarySearchIndexFactory factory(/*with_first_key=*/false);
+  IndexFactoryOptions opts;
+  opts.comparator = nullptr;
+  std::unique_ptr<IndexFactoryBuilder> builder;
+  Status s = factory.NewBuilder(opts, builder);
+  ASSERT_TRUE(s.IsInvalidArgument());
+}
+
+TEST_F(BinarySearchIndexFactoryTest, BuilderAddAndFinish) {
+  BinarySearchIndexFactory factory(/*with_first_key=*/false);
+  auto opts = MakeOptions();
+  std::unique_ptr<IndexFactoryBuilder> builder;
+  ASSERT_OK(factory.NewBuilder(opts, builder));
+
+  AddSampleEntries(builder.get());
+
+  ASSERT_GT(builder->EstimatedSize(), static_cast<uint64_t>(0));
+
+  Slice contents;
+  ASSERT_OK(builder->Finish(&contents));
+  ASSERT_GT(contents.size(), static_cast<size_t>(0));
+}
+
+TEST_F(BinarySearchIndexFactoryTest, NewBuilderWithFirstKeySucceeds) {
+  BinarySearchIndexFactory factory(/*with_first_key=*/true);
+  auto opts = MakeOptions();
+  std::unique_ptr<IndexFactoryBuilder> builder;
+  ASSERT_OK(factory.NewBuilder(opts, builder));
+  ASSERT_NE(builder, nullptr);
+}
+
+TEST_F(BinarySearchIndexFactoryTest, NewReaderReturnsNotSupported) {
+  BinarySearchIndexFactory factory(/*with_first_key=*/false);
+  auto opts = MakeOptions();
+  Slice dummy_contents("dummy");
+  std::unique_ptr<IndexFactoryReader> reader;
+  Status s = factory.NewReader(opts, dummy_contents, reader);
+  ASSERT_TRUE(s.IsNotSupported());
+  ASSERT_EQ(reader, nullptr);
+}
+
+// ============================================================================
+// HashIndexFactory tests
+// ============================================================================
+
+class HashIndexFactoryTest : public ::testing::Test {};
+
+TEST_F(HashIndexFactoryTest, Name) {
+  HashIndexFactory factory;
+  ASSERT_STREQ(factory.Name(), "rocksdb.builtin.HashIndex");
+}
+
+TEST_F(HashIndexFactoryTest, KClassName) {
+  ASSERT_STREQ(HashIndexFactory::kClassName(), "rocksdb.builtin.HashIndex");
+}
+
+TEST_F(HashIndexFactoryTest, NewBuilderSucceeds) {
+  HashIndexFactory factory;
+  auto opts = MakeOptions();
+  std::unique_ptr<IndexFactoryBuilder> builder;
+  ASSERT_OK(factory.NewBuilder(opts, builder));
+  ASSERT_NE(builder, nullptr);
+}
+
+TEST_F(HashIndexFactoryTest, NewBuilderRequiresComparator) {
+  HashIndexFactory factory;
+  IndexFactoryOptions opts;
+  opts.comparator = nullptr;
+  std::unique_ptr<IndexFactoryBuilder> builder;
+  Status s = factory.NewBuilder(opts, builder);
+  ASSERT_TRUE(s.IsInvalidArgument());
+}
+
+TEST_F(HashIndexFactoryTest, BuilderAddAndFinish) {
+  HashIndexFactory factory;
+  auto opts = MakeOptions();
+  std::unique_ptr<IndexFactoryBuilder> builder;
+  ASSERT_OK(factory.NewBuilder(opts, builder));
+
+  AddSampleEntries(builder.get());
+
+  // HashIndexBuilder::CurrentIndexSizeEstimate() always returns 0 by design.
+  // The hash builder tracks size differently from the binary search builder.
+
+  Slice contents;
+  ASSERT_OK(builder->Finish(&contents));
+  ASSERT_GT(contents.size(), static_cast<size_t>(0));
+}
+
+TEST_F(HashIndexFactoryTest, NewReaderReturnsNotSupported) {
+  HashIndexFactory factory;
+  auto opts = MakeOptions();
+  Slice dummy_contents("dummy");
+  std::unique_ptr<IndexFactoryReader> reader;
+  Status s = factory.NewReader(opts, dummy_contents, reader);
+  ASSERT_TRUE(s.IsNotSupported());
+  ASSERT_EQ(reader, nullptr);
+}
+
+// ============================================================================
+// PartitionedIndexFactory tests
+// ============================================================================
+
+class PartitionedIndexFactoryTest : public ::testing::Test {};
+
+TEST_F(PartitionedIndexFactoryTest, Name) {
+  PartitionedIndexFactory factory;
+  ASSERT_STREQ(factory.Name(), "rocksdb.builtin.PartitionedIndex");
+}
+
+TEST_F(PartitionedIndexFactoryTest, KClassName) {
+  ASSERT_STREQ(PartitionedIndexFactory::kClassName(),
+               "rocksdb.builtin.PartitionedIndex");
+}
+
+TEST_F(PartitionedIndexFactoryTest, NewBuilderSucceeds) {
+  PartitionedIndexFactory factory;
+  auto opts = MakeOptions();
+  std::unique_ptr<IndexFactoryBuilder> builder;
+  ASSERT_OK(factory.NewBuilder(opts, builder));
+  ASSERT_NE(builder, nullptr);
+}
+
+TEST_F(PartitionedIndexFactoryTest, NewBuilderRequiresComparator) {
+  PartitionedIndexFactory factory;
+  IndexFactoryOptions opts;
+  opts.comparator = nullptr;
+  std::unique_ptr<IndexFactoryBuilder> builder;
+  Status s = factory.NewBuilder(opts, builder);
+  ASSERT_TRUE(s.IsInvalidArgument());
+}
+
+TEST_F(PartitionedIndexFactoryTest, BuilderAddEntries) {
+  PartitionedIndexFactory factory;
+  auto opts = MakeOptions();
+  std::unique_ptr<IndexFactoryBuilder> builder;
+  ASSERT_OK(factory.NewBuilder(opts, builder));
+
+  // AddIndexEntry should succeed without crashing.
+  AddSampleEntries(builder.get());
+
+  // EstimatedSize should be non-zero after adding entries.
+  ASSERT_GT(builder->EstimatedSize(), static_cast<uint64_t>(0));
+
+  // Note: PartitionedIndexBuilder::Finish() requires a multi-step protocol
+  // with partition block handles provided by the table builder. Testing the
+  // full Finish flow requires integration with BlockBasedTableBuilder and is
+  // covered by higher-level tests (e.g., table_test).
+}
+
+TEST_F(PartitionedIndexFactoryTest, NewReaderReturnsNotSupported) {
+  PartitionedIndexFactory factory;
+  auto opts = MakeOptions();
+  Slice dummy_contents("dummy");
+  std::unique_ptr<IndexFactoryReader> reader;
+  Status s = factory.NewReader(opts, dummy_contents, reader);
+  ASSERT_TRUE(s.IsNotSupported());
+  ASSERT_EQ(reader, nullptr);
+}
+
+// ============================================================================
+// InternalKeyReconstruction test: verify that BuiltinIndexFactoryBuilder's
+// AddIndexEntry (which reconstructs internal keys from user keys + tags)
+// produces the same output as calling the raw ShortenedIndexBuilder directly
+// with pre-built internal keys.
+// ============================================================================
+
+TEST_F(BinarySearchIndexFactoryTest, InternalKeyReconstruction) {
+  // Create factory with full config so we exercise the has_config_ path.
+  BuiltinIndexFactoryConfig config;
+  InternalKeyComparator icmp(BytewiseComparator());
+  config.internal_comparator = &icmp;
+  config.use_delta_encoding_for_index_values = true;
+  BlockBasedTableOptions table_opts;
+  config.table_options = &table_opts;
+
+  BinarySearchIndexFactory factory(/*with_first_key=*/false, config);
+  IndexFactoryOptions opts;
+  opts.comparator = BytewiseComparator();
+  std::unique_ptr<IndexFactoryBuilder> builder;
+  ASSERT_OK(factory.NewBuilder(opts, builder));
+  ASSERT_EQ(
+      static_cast<BuiltinIndexFactoryBuilder*>(builder.get())->GetComparator(),
+      &icmp);
+
+  // Add entries with known user keys and tags via the public interface.
+  IndexFactoryBuilder::BlockHandle h1{0, kBlockSize};
+  IndexFactoryBuilder::BlockHandle h2{kBlockSize + kBlockTrailerSize,
+                                      kBlockSize};
+  IndexFactoryBuilder::IndexEntryContext ctx1;
+  ctx1.last_key_tag = PackSequenceAndType(100, kTypeValue);
+  ctx1.first_key_tag = PackSequenceAndType(50, kTypeValue);
+  IndexFactoryBuilder::IndexEntryContext ctx2;
+  ctx2.last_key_tag = PackSequenceAndType(50, kTypeValue);
+  ctx2.first_key_tag = 0;
+
+  std::string scratch;
+  Slice next1("bbb");
+  builder->AddIndexEntry(Slice("aaa"), &next1, h1, &scratch, ctx1);
+  builder->AddIndexEntry(Slice("bbb"), nullptr, h2, &scratch, ctx2);
+
+  // Verify Finish produces valid output.
+  Slice contents;
+  ASSERT_OK(builder->Finish(&contents));
+  ASSERT_GT(contents.size(), static_cast<size_t>(0));
+
+  // Also create a raw ShortenedIndexBuilder with the same parameters and
+  // pass pre-built internal keys. The outputs should be identical.
+  std::unique_ptr<IndexBuilder> raw_builder(IndexBuilder::CreateIndexBuilder(
+      BlockBasedTableOptions::kBinarySearch, &icmp,
+      /*int_key_slice_transform=*/nullptr,
+      /*use_value_delta_encoding=*/true, table_opts,
+      /*ts_sz=*/0, /*persist_user_defined_timestamps=*/true));
+
+  // Construct internal keys: user_key + PutFixed64(PackSequenceAndType(...))
+  std::string ik1;
+  ik1.append("aaa");
+  PutFixed64(&ik1, PackSequenceAndType(100, kTypeValue));
+  std::string ik2;
+  ik2.append("bbb");
+  PutFixed64(&ik2, PackSequenceAndType(50, kTypeValue));
+  Slice ik1_slice(ik1);
+  Slice ik2_slice(ik2);
+
+  BlockHandle bh1(0, kBlockSize);
+  BlockHandle bh2(kBlockSize + kBlockTrailerSize, kBlockSize);
+  raw_builder->AddIndexEntry(ik1_slice, &ik2_slice, bh1, &scratch,
+                             /*skip_delta_encoding=*/false);
+  raw_builder->AddIndexEntry(ik2_slice, nullptr, bh2, &scratch,
+                             /*skip_delta_encoding=*/false);
+
+  IndexBuilder::IndexBlocks raw_blocks;
+  ASSERT_OK(raw_builder->Finish(&raw_blocks));
+
+  // Both should produce the same index block content.
+  ASSERT_EQ(contents.ToString(), raw_blocks.index_block_contents.ToString());
+}
+
+// ============================================================================
+// GetPartitionedIndexBuilder test: partitioned builders return a non-null
+// builder; non-partitioned builders return null.
+// ============================================================================
+
+TEST_F(PartitionedIndexFactoryTest, GetPartitionedIndexBuilder) {
+  // Create factory with full config (needed for partitioned builder).
+  BuiltinIndexFactoryConfig config;
+  InternalKeyComparator icmp(BytewiseComparator());
+  config.internal_comparator = &icmp;
+  config.use_delta_encoding_for_index_values = true;
+  BlockBasedTableOptions table_opts;
+  table_opts.index_type = BlockBasedTableOptions::kTwoLevelIndexSearch;
+  table_opts.metadata_block_size = 4096;
+  config.table_options = &table_opts;
+
+  PartitionedIndexFactory factory(config);
+  IndexFactoryOptions opts;
+  opts.comparator = BytewiseComparator();
+  std::unique_ptr<IndexFactoryBuilder> builder;
+  ASSERT_OK(factory.NewBuilder(opts, builder));
+
+  auto* builtin_builder =
+      static_cast<BuiltinIndexFactoryBuilder*>(builder.get());
+  ASSERT_NE(builtin_builder->GetPartitionedIndexBuilder(), nullptr);
+
+  // Non-partitioned builders should return null.
+  BinarySearchIndexFactory bs_factory(/*with_first_key=*/false);
+  std::unique_ptr<IndexFactoryBuilder> bs_builder;
+  ASSERT_OK(bs_factory.NewBuilder(opts, bs_builder));
+  auto* bs_builtin = static_cast<BuiltinIndexFactoryBuilder*>(bs_builder.get());
+  ASSERT_EQ(bs_builtin->GetPartitionedIndexBuilder(), nullptr);
+
+  HashIndexFactory hash_factory;
+  std::unique_ptr<IndexFactoryBuilder> hash_builder;
+  ASSERT_OK(hash_factory.NewBuilder(opts, hash_builder));
+  auto* hash_builtin =
+      static_cast<BuiltinIndexFactoryBuilder*>(hash_builder.get());
+  ASSERT_EQ(hash_builtin->GetPartitionedIndexBuilder(), nullptr);
+
+  // The standalone (no config) path also produces a PartitionedIndexBuilder,
+  // even though its default BlockBasedTableOptions say kBinarySearch. The
+  // partition accessors must follow the builder, not the options.
+  PartitionedIndexFactory standalone_factory;
+  std::unique_ptr<IndexFactoryBuilder> standalone_builder;
+  ASSERT_OK(standalone_factory.NewBuilder(opts, standalone_builder));
+  auto* standalone_builtin =
+      static_cast<BuiltinIndexFactoryBuilder*>(standalone_builder.get());
+  ASSERT_NE(standalone_builtin->GetPartitionedIndexBuilder(), nullptr);
+}
+
+// ============================================================================
+// Built-in FinishAndWrite writes a single binary-search index block through
+// the internal writer callback.
+// ============================================================================
+
+class MockIndexBlockWriter : public BuiltinIndexBlockWriter {
+ public:
+  Status WriteBlock(const Slice& contents,
+                    IndexFactoryBuilder::BlockHandle* handle,
+                    bool /*compress*/) override {
+    if (write_count == fail_on_write) {
+      ++write_count;
+      return Status::IOError("mock WriteBlock failed");
+    }
+    blocks_written.push_back(contents.ToString());
+    handle->offset = next_offset;
+    handle->size = contents.size();
+    next_offset += contents.size() + kBlockTrailerSize;
+    ++write_count;
+    return Status::OK();
+  }
+  void AddMetaBlock(const std::string& name,
+                    const IndexFactoryBuilder::BlockHandle& handle) override {
+    meta_blocks.emplace_back(name, handle);
+  }
+
+  std::vector<std::string> blocks_written;
+  std::vector<std::pair<std::string, IndexFactoryBuilder::BlockHandle>>
+      meta_blocks;
+  uint64_t next_offset = 0;
+  int write_count = 0;
+  int fail_on_write = -1;
+};
+
+TEST_F(BinarySearchIndexFactoryTest, FinishAndWriteSingleBlock) {
+  auto factory = BinarySearchIndexFactory(/*with_first_key=*/false);
+  IndexFactoryOptions opts;
+  opts.comparator = BytewiseComparator();
+  std::unique_ptr<IndexFactoryBuilder> builder;
+  ASSERT_OK(factory.NewBuilder(opts, builder));
+
+  // Add some entries.
+  AddSampleEntries(builder.get());
+
+  MockIndexBlockWriter writer;
+  IndexFactoryBuilder::BlockHandle final_handle{0, 0};
+  ASSERT_OK(static_cast<BuiltinIndexFactoryBuilder*>(builder.get())
+                ->FinishAndWrite(&writer, &final_handle, /*compress=*/true));
+
+  // Should have written exactly one block.
+  ASSERT_EQ(writer.blocks_written.size(), static_cast<size_t>(1));
+  ASSERT_GT(writer.blocks_written[0].size(), static_cast<size_t>(0));
+  ASSERT_EQ(final_handle.offset, static_cast<uint64_t>(0));
+  ASSERT_EQ(final_handle.size, writer.blocks_written[0].size());
+}
+
+TEST_F(BinarySearchIndexFactoryTest, FinishAndWritePropagatesWriteBlockError) {
+  auto factory = BinarySearchIndexFactory(/*with_first_key=*/false);
+  IndexFactoryOptions opts;
+  opts.comparator = BytewiseComparator();
+  std::unique_ptr<IndexFactoryBuilder> builder;
+  ASSERT_OK(factory.NewBuilder(opts, builder));
+
+  AddSampleEntries(builder.get());
+
+  MockIndexBlockWriter writer;
+  writer.fail_on_write = 0;
+  IndexFactoryBuilder::BlockHandle final_handle{0, 0};
+  Status s = static_cast<BuiltinIndexFactoryBuilder*>(builder.get())
+                 ->FinishAndWrite(&writer, &final_handle, /*compress=*/true);
+  ASSERT_TRUE(s.IsIOError());
+  ASSERT_TRUE(writer.blocks_written.empty());
+}
+
+// ============================================================================
+// Helpers for parallel-compression API surface tests.
+// ============================================================================
+
+// Build a configured BuiltinIndexFactoryBuilder for a given index_type.
+// The internal_comparator and table_options are owned by the caller and
+// must outlive the returned builder.
+static std::unique_ptr<IndexFactoryBuilder> MakeConfiguredBuiltinBuilder(
+    BlockBasedTableOptions::IndexType index_type,
+    const InternalKeyComparator& icmp, const BlockBasedTableOptions& topts) {
+  BuiltinIndexFactoryConfig config;
+  config.internal_comparator = &icmp;
+  config.use_delta_encoding_for_index_values = true;
+  config.table_options = &topts;
+  IndexFactoryOptions opts;
+  opts.comparator = BytewiseComparator();
+
+  std::unique_ptr<IndexFactoryBuilder> builder;
+  Status s = NewBuiltinIndexFactoryBuilder(index_type, config, opts, builder);
+  EXPECT_OK(s);
+  return builder;
+}
+
+// Build an internal-key string of the form `user_key | PackSequenceAndType`.
+static std::string MakeInternalKey(const std::string& user_key,
+                                   SequenceNumber seq, ValueType vt) {
+  std::string out(user_key);
+  PutFixed64(&out, PackSequenceAndType(seq, vt));
+  return out;
+}
+
+// ============================================================================
+// NewBuiltinIndexFactoryBuilder helper: dispatches on IndexType to the
+// appropriate built-in factory and returns a usable IndexFactoryBuilder.
+// ============================================================================
+
+class NewBuiltinIndexFactoryBuilderTest : public ::testing::Test {};
+
+TEST_F(NewBuiltinIndexFactoryBuilderTest, DispatchesAllIndexTypes) {
+  InternalKeyComparator icmp(BytewiseComparator());
+  BlockBasedTableOptions topts;
+
+  for (auto t : {BlockBasedTableOptions::kBinarySearch,
+                 BlockBasedTableOptions::kBinarySearchWithFirstKey,
+                 BlockBasedTableOptions::kHashSearch,
+                 BlockBasedTableOptions::kTwoLevelIndexSearch}) {
+    SCOPED_TRACE("index_type=" + std::to_string(static_cast<int>(t)));
+    BlockBasedTableOptions per_type = topts;
+    per_type.index_type = t;
+    if (t == BlockBasedTableOptions::kTwoLevelIndexSearch) {
+      per_type.metadata_block_size = 4096;
+    }
+    auto builder = MakeConfiguredBuiltinBuilder(t, icmp, per_type);
+    ASSERT_NE(builder, nullptr);
+  }
+}
+
+TEST_F(NewBuiltinIndexFactoryBuilderTest, BinarySearchProducesUsableBuilder) {
+  InternalKeyComparator icmp(BytewiseComparator());
+  BlockBasedTableOptions topts;
+  topts.index_type = BlockBasedTableOptions::kBinarySearch;
+
+  auto builder = MakeConfiguredBuiltinBuilder(
+      BlockBasedTableOptions::kBinarySearch, icmp, topts);
+  ASSERT_NE(builder, nullptr);
+
+  AddSampleEntries(builder.get());
+
+  Slice contents;
+  ASSERT_OK(builder->Finish(&contents));
+  ASSERT_GT(contents.size(), static_cast<size_t>(0));
+}
+
+TEST_F(NewBuiltinIndexFactoryBuilderTest,
+       BinarySearchWithFirstKeyProducesUsableBuilder) {
+  InternalKeyComparator icmp(BytewiseComparator());
+  BlockBasedTableOptions topts;
+  topts.index_type = BlockBasedTableOptions::kBinarySearchWithFirstKey;
+
+  auto builder = MakeConfiguredBuiltinBuilder(
+      BlockBasedTableOptions::kBinarySearchWithFirstKey, icmp, topts);
+  auto* builtin = static_cast<BuiltinIndexFactoryBuilder*>(builder.get());
+
+  std::string scratch;
+  const std::string ik_a = MakeInternalKey("aaa", 100, kTypeValue);
+  const std::string ik_b = MakeInternalKey("bbb", 50, kTypeValue);
+  const std::string ik_c = MakeInternalKey("ccc", 25, kTypeValue);
+  const Slice ik_a_s(ik_a);
+  const Slice ik_b_s(ik_b);
+  const Slice ik_c_s(ik_c);
+  const BlockHandle bh1(0, kBlockSize);
+  const BlockHandle bh2(kBlockSize + kBlockTrailerSize, kBlockSize);
+  const BlockHandle bh3(2 * (kBlockSize + kBlockTrailerSize), kBlockSize);
+
+  builtin->OnKeyAddedInternal(ik_a_s, std::nullopt);
+  builtin->AddIndexEntryDirect(ik_a_s, &ik_b_s, bh1, &scratch,
+                               /*skip_delta_encoding=*/false);
+  builtin->OnKeyAddedInternal(ik_b_s, std::nullopt);
+  builtin->AddIndexEntryDirect(ik_b_s, &ik_c_s, bh2, &scratch,
+                               /*skip_delta_encoding=*/false);
+  builtin->OnKeyAddedInternal(ik_c_s, std::nullopt);
+  builtin->AddIndexEntryDirect(ik_c_s, nullptr, bh3, &scratch,
+                               /*skip_delta_encoding=*/false);
+
+  Slice contents;
+  ASSERT_OK(builder->Finish(&contents));
+  ASSERT_GT(contents.size(), static_cast<size_t>(0));
+}
+
+TEST_F(NewBuiltinIndexFactoryBuilderTest, PartitionedFinishAndWrite) {
+  InternalKeyComparator icmp(BytewiseComparator());
+  BlockBasedTableOptions topts;
+  topts.index_type = BlockBasedTableOptions::kTwoLevelIndexSearch;
+  topts.metadata_block_size = 128;
+
+  auto builder = MakeConfiguredBuiltinBuilder(
+      BlockBasedTableOptions::kTwoLevelIndexSearch, icmp, topts);
+  auto* builtin = static_cast<BuiltinIndexFactoryBuilder*>(builder.get());
+
+  AddGeneratedEntries(builder.get(), 64);
+
+  MockIndexBlockWriter writer;
+  IndexFactoryBuilder::BlockHandle final_handle{0, 0};
+  ASSERT_OK(builtin->FinishAndWrite(&writer, &final_handle,
+                                    /*compress=*/false));
+  ASSERT_GT(writer.blocks_written.size(), static_cast<size_t>(1));
+  ASSERT_GT(final_handle.size, static_cast<uint64_t>(0));
+  ASSERT_GT(builtin->NumPartitions(), static_cast<size_t>(0));
+}
+
+// ============================================================================
+// Parallel compression API surface on BuiltinIndexFactoryBuilder.
+//
+// Verifies that the SupportsParallelAddEntry / CreatePreparedAddEntry /
+// PrepareAddEntry / FinishAddEntry contract works end-to-end and produces
+// the same index block as the synchronous AddIndexEntry path. This is the
+// path used by EmitBlockForParallel + BGWorker; if it ever drifts from the
+// synchronous path, parallel compression with the built-in index produces
+// silently corrupt output.
+// ============================================================================
+
+class BuiltinParallelCompressionApiTest : public ::testing::Test {};
+
+TEST_F(BuiltinParallelCompressionApiTest, SupportsParallelAddEntry) {
+  // All built-in IndexBuilder subclasses implement PrepareIndexEntry /
+  // FinishIndexEntry, so BuiltinIndexFactoryBuilder reports support for
+  // the parallel protocol regardless of index_type. Whether the table
+  // builder *uses* parallel compression is a separate decision driven by
+  // partition_filters / decouple_partitioned_filters settings.
+  InternalKeyComparator icmp(BytewiseComparator());
+  BlockBasedTableOptions topts;
+
+  for (auto t : {BlockBasedTableOptions::kBinarySearch,
+                 BlockBasedTableOptions::kBinarySearchWithFirstKey,
+                 BlockBasedTableOptions::kHashSearch,
+                 BlockBasedTableOptions::kTwoLevelIndexSearch}) {
+    SCOPED_TRACE("index_type=" + std::to_string(static_cast<int>(t)));
+    BlockBasedTableOptions per_type = topts;
+    per_type.index_type = t;
+    if (t == BlockBasedTableOptions::kTwoLevelIndexSearch) {
+      per_type.metadata_block_size = 4096;
+    }
+    auto builder = MakeConfiguredBuiltinBuilder(t, icmp, per_type);
+    EXPECT_TRUE(builder->SupportsParallelAddEntry());
+  }
+}
+
+TEST_F(BuiltinParallelCompressionApiTest, PrepareFinishMatchesAddIndexEntry) {
+  // Drive both the synchronous and parallel paths with identical input and
+  // verify they produce byte-identical index blocks.
+  InternalKeyComparator icmp(BytewiseComparator());
+  BlockBasedTableOptions topts;
+  topts.index_type = BlockBasedTableOptions::kBinarySearch;
+
+  // --- Synchronous path ---
+  auto sync_builder = MakeConfiguredBuiltinBuilder(
+      BlockBasedTableOptions::kBinarySearch, icmp, topts);
+  std::string scratch_a;
+  IndexFactoryBuilder::IndexEntryContext ctx_ab;
+  ctx_ab.last_key_tag = PackSequenceAndType(100, kTypeValue);
+  ctx_ab.first_key_tag = PackSequenceAndType(50, kTypeValue);
+  Slice key_a("aaa");
+  Slice key_b("bbb");
+  Slice key_c("ccc");
+  IndexFactoryBuilder::BlockHandle h1{0, kBlockSize};
+  IndexFactoryBuilder::BlockHandle h2{kBlockSize + kBlockTrailerSize,
+                                      kBlockSize};
+  IndexFactoryBuilder::BlockHandle h3{2 * (kBlockSize + kBlockTrailerSize),
+                                      kBlockSize};
+  IndexFactoryBuilder::IndexEntryContext ctx_bc;
+  ctx_bc.last_key_tag = PackSequenceAndType(50, kTypeValue);
+  ctx_bc.first_key_tag = PackSequenceAndType(25, kTypeValue);
+  IndexFactoryBuilder::IndexEntryContext ctx_c;
+  ctx_c.last_key_tag = PackSequenceAndType(25, kTypeValue);
+  ctx_c.first_key_tag = 0;
+  sync_builder->AddIndexEntry(key_a, &key_b, h1, &scratch_a, ctx_ab);
+  sync_builder->AddIndexEntry(key_b, &key_c, h2, &scratch_a, ctx_bc);
+  sync_builder->AddIndexEntry(key_c, nullptr, h3, &scratch_a, ctx_c);
+  Slice sync_contents;
+  ASSERT_OK(sync_builder->Finish(&sync_contents));
+
+  // --- Parallel path: stage prepares first, then commit in order ---
+  auto par_builder = MakeConfiguredBuiltinBuilder(
+      BlockBasedTableOptions::kBinarySearch, icmp, topts);
+  ASSERT_TRUE(par_builder->SupportsParallelAddEntry());
+  auto p1 = par_builder->CreatePreparedAddEntry();
+  auto p2 = par_builder->CreatePreparedAddEntry();
+  auto p3 = par_builder->CreatePreparedAddEntry();
+  par_builder->PrepareAddEntry(key_a, &key_b, ctx_ab, p1.get());
+  par_builder->PrepareAddEntry(key_b, &key_c, ctx_bc, p2.get());
+  par_builder->PrepareAddEntry(key_c, nullptr, ctx_c, p3.get());
+  std::string scratch_b;
+  par_builder->FinishAddEntry(h1, p1.get(), &scratch_b,
+                              /*skip_delta_encoding=*/false);
+  par_builder->FinishAddEntry(h2, p2.get(), &scratch_b,
+                              /*skip_delta_encoding=*/false);
+  par_builder->FinishAddEntry(h3, p3.get(), &scratch_b,
+                              /*skip_delta_encoding=*/false);
+  Slice par_contents;
+  ASSERT_OK(par_builder->Finish(&par_contents));
+
+  EXPECT_EQ(sync_contents.ToString(), par_contents.ToString());
+}
+
+TEST_F(BuiltinParallelCompressionApiTest,
+       PrepareAddEntryDirectMatchesPrepareAddEntry) {
+  // Compare PrepareAddEntryDirect (fast path used by EmitBlockForParallel,
+  // takes internal keys) to PrepareAddEntry (the public path that takes
+  // user keys + tags). Both must produce identical staged entries and,
+  // after FinishAddEntry, identical index blocks.
+  InternalKeyComparator icmp(BytewiseComparator());
+  BlockBasedTableOptions topts;
+  topts.index_type = BlockBasedTableOptions::kBinarySearch;
+
+  // Sequence/type tags chosen distinct so any leakage shows up.
+  const SequenceNumber seq_a = 1000;
+  const SequenceNumber seq_b = 500;
+  const SequenceNumber seq_c = 250;
+
+  std::string ik_a = MakeInternalKey("aaa", seq_a, kTypeValue);
+  std::string ik_b = MakeInternalKey("bbb", seq_b, kTypeValue);
+  std::string ik_c = MakeInternalKey("ccc", seq_c, kTypeValue);
+  Slice ik_a_s(ik_a);
+  Slice ik_b_s(ik_b);
+  Slice ik_c_s(ik_c);
+
+  IndexFactoryBuilder::BlockHandle h1{0, kBlockSize};
+  IndexFactoryBuilder::BlockHandle h2{kBlockSize + kBlockTrailerSize,
+                                      kBlockSize};
+  IndexFactoryBuilder::BlockHandle h3{2 * (kBlockSize + kBlockTrailerSize),
+                                      kBlockSize};
+
+  // --- Public path: PrepareAddEntry with user keys + context tags ---
+  auto pub_builder = MakeConfiguredBuiltinBuilder(
+      BlockBasedTableOptions::kBinarySearch, icmp, topts);
+  IndexFactoryBuilder::IndexEntryContext ctx_ab;
+  ctx_ab.last_key_tag = PackSequenceAndType(seq_a, kTypeValue);
+  ctx_ab.first_key_tag = PackSequenceAndType(seq_b, kTypeValue);
+  IndexFactoryBuilder::IndexEntryContext ctx_bc;
+  ctx_bc.last_key_tag = PackSequenceAndType(seq_b, kTypeValue);
+  ctx_bc.first_key_tag = PackSequenceAndType(seq_c, kTypeValue);
+  IndexFactoryBuilder::IndexEntryContext ctx_c;
+  ctx_c.last_key_tag = PackSequenceAndType(seq_c, kTypeValue);
+  ctx_c.first_key_tag = 0;
+  Slice key_a("aaa");
+  Slice key_b("bbb");
+  Slice key_c("ccc");
+  auto p1 = pub_builder->CreatePreparedAddEntry();
+  auto p2 = pub_builder->CreatePreparedAddEntry();
+  auto p3 = pub_builder->CreatePreparedAddEntry();
+  pub_builder->PrepareAddEntry(key_a, &key_b, ctx_ab, p1.get());
+  pub_builder->PrepareAddEntry(key_b, &key_c, ctx_bc, p2.get());
+  pub_builder->PrepareAddEntry(key_c, nullptr, ctx_c, p3.get());
+  std::string scratch_pub;
+  pub_builder->FinishAddEntry(h1, p1.get(), &scratch_pub, false);
+  pub_builder->FinishAddEntry(h2, p2.get(), &scratch_pub, false);
+  pub_builder->FinishAddEntry(h3, p3.get(), &scratch_pub, false);
+  Slice pub_contents;
+  ASSERT_OK(pub_builder->Finish(&pub_contents));
+
+  // --- Direct path: PrepareAddEntryDirect with internal keys ---
+  auto dir_builder = MakeConfiguredBuiltinBuilder(
+      BlockBasedTableOptions::kBinarySearch, icmp, topts);
+  // The direct path is on BuiltinIndexFactoryBuilder, not the base interface.
+  auto* dir = static_cast<BuiltinIndexFactoryBuilder*>(dir_builder.get());
+  auto d1 = dir->CreatePreparedAddEntry();
+  auto d2 = dir->CreatePreparedAddEntry();
+  auto d3 = dir->CreatePreparedAddEntry();
+  dir->PrepareAddEntryDirect(ik_a_s, &ik_b_s, d1.get());
+  dir->PrepareAddEntryDirect(ik_b_s, &ik_c_s, d2.get());
+  dir->PrepareAddEntryDirect(ik_c_s, nullptr, d3.get());
+  std::string scratch_dir;
+  dir->FinishAddEntry(h1, d1.get(), &scratch_dir, false);
+  dir->FinishAddEntry(h2, d2.get(), &scratch_dir, false);
+  dir->FinishAddEntry(h3, d3.get(), &scratch_dir, false);
+  Slice dir_contents;
+  ASSERT_OK(dir_builder->Finish(&dir_contents));
+
+  EXPECT_EQ(pub_contents.ToString(), dir_contents.ToString());
+}
+
+TEST_F(BuiltinParallelCompressionApiTest, AddIndexEntryDirectMatchesPublic) {
+  // Same equivalence guarantee for the synchronous fast path used by
+  // ForwardAddIndexEntryToAll.
+  InternalKeyComparator icmp(BytewiseComparator());
+  BlockBasedTableOptions topts;
+  topts.index_type = BlockBasedTableOptions::kBinarySearch;
+
+  const SequenceNumber seq_a = 100;
+  const SequenceNumber seq_b = 50;
+  const SequenceNumber seq_c = 25;
+  std::string ik_a = MakeInternalKey("aaa", seq_a, kTypeValue);
+  std::string ik_b = MakeInternalKey("bbb", seq_b, kTypeValue);
+  std::string ik_c = MakeInternalKey("ccc", seq_c, kTypeValue);
+  Slice ik_a_s(ik_a);
+  Slice ik_b_s(ik_b);
+  Slice ik_c_s(ik_c);
+
+  BlockHandle bh1(0, kBlockSize);
+  BlockHandle bh2(kBlockSize + kBlockTrailerSize, kBlockSize);
+  BlockHandle bh3(2 * (kBlockSize + kBlockTrailerSize), kBlockSize);
+
+  // --- Public path: AddIndexEntry (user keys + context tags) ---
+  auto pub_builder = MakeConfiguredBuiltinBuilder(
+      BlockBasedTableOptions::kBinarySearch, icmp, topts);
+  std::string scratch_pub;
+  IndexFactoryBuilder::IndexEntryContext ctx_ab;
+  ctx_ab.last_key_tag = PackSequenceAndType(seq_a, kTypeValue);
+  ctx_ab.first_key_tag = PackSequenceAndType(seq_b, kTypeValue);
+  IndexFactoryBuilder::IndexEntryContext ctx_bc;
+  ctx_bc.last_key_tag = PackSequenceAndType(seq_b, kTypeValue);
+  ctx_bc.first_key_tag = PackSequenceAndType(seq_c, kTypeValue);
+  IndexFactoryBuilder::IndexEntryContext ctx_c;
+  ctx_c.last_key_tag = PackSequenceAndType(seq_c, kTypeValue);
+  ctx_c.first_key_tag = 0;
+  Slice key_a("aaa");
+  Slice key_b("bbb");
+  Slice key_c("ccc");
+  IndexFactoryBuilder::BlockHandle ph1{bh1.offset(), bh1.size()};
+  IndexFactoryBuilder::BlockHandle ph2{bh2.offset(), bh2.size()};
+  IndexFactoryBuilder::BlockHandle ph3{bh3.offset(), bh3.size()};
+  pub_builder->AddIndexEntry(key_a, &key_b, ph1, &scratch_pub, ctx_ab);
+  pub_builder->AddIndexEntry(key_b, &key_c, ph2, &scratch_pub, ctx_bc);
+  pub_builder->AddIndexEntry(key_c, nullptr, ph3, &scratch_pub, ctx_c);
+  Slice pub_contents;
+  ASSERT_OK(pub_builder->Finish(&pub_contents));
+
+  // --- Direct path: AddIndexEntryDirect (internal keys) ---
+  auto dir_builder = MakeConfiguredBuiltinBuilder(
+      BlockBasedTableOptions::kBinarySearch, icmp, topts);
+  auto* dir = static_cast<BuiltinIndexFactoryBuilder*>(dir_builder.get());
+  std::string scratch_dir;
+  dir->AddIndexEntryDirect(ik_a_s, &ik_b_s, bh1, &scratch_dir, false);
+  dir->AddIndexEntryDirect(ik_b_s, &ik_c_s, bh2, &scratch_dir, false);
+  dir->AddIndexEntryDirect(ik_c_s, nullptr, bh3, &scratch_dir, false);
+  Slice dir_contents;
+  ASSERT_OK(dir_builder->Finish(&dir_contents));
+
+  EXPECT_EQ(pub_contents.ToString(), dir_contents.ToString());
+}
+
+TEST_F(BuiltinParallelCompressionApiTest, ContextSkipDeltaEncodingApplies) {
+  InternalKeyComparator icmp(BytewiseComparator());
+  BlockBasedTableOptions topts;
+  topts.index_type = BlockBasedTableOptions::kBinarySearch;
+
+  const SequenceNumber seq_a = 100;
+  const SequenceNumber seq_b = 50;
+  const SequenceNumber seq_c = 25;
+  std::string ik_a = MakeInternalKey("aaa", seq_a, kTypeValue);
+  std::string ik_b = MakeInternalKey("bbb", seq_b, kTypeValue);
+  std::string ik_c = MakeInternalKey("ccc", seq_c, kTypeValue);
+  Slice ik_a_s(ik_a);
+  Slice ik_b_s(ik_b);
+  Slice ik_c_s(ik_c);
+
+  BlockHandle bh1(0, kBlockSize);
+  BlockHandle bh2(kBlockSize + kBlockTrailerSize + 17, kBlockSize);
+  BlockHandle bh3(bh2.offset() + kBlockSize + kBlockTrailerSize, kBlockSize);
+
+  auto public_builder = MakeConfiguredBuiltinBuilder(
+      BlockBasedTableOptions::kBinarySearch, icmp, topts);
+  std::string scratch_public;
+  IndexFactoryBuilder::IndexEntryContext ctx_ab;
+  ctx_ab.last_key_tag = PackSequenceAndType(seq_a, kTypeValue);
+  ctx_ab.first_key_tag = PackSequenceAndType(seq_b, kTypeValue);
+  // Block alignment padding left a gap before bh2, so the delta encoding
+  // assumption does not hold for this entry.
+  IndexFactoryBuilder::IndexEntryContext ctx_bc;
+  ctx_bc.last_key_tag = PackSequenceAndType(seq_b, kTypeValue);
+  ctx_bc.first_key_tag = PackSequenceAndType(seq_c, kTypeValue);
+  ctx_bc.skip_delta_encoding = true;
+  IndexFactoryBuilder::IndexEntryContext ctx_c;
+  ctx_c.last_key_tag = PackSequenceAndType(seq_c, kTypeValue);
+  ctx_c.first_key_tag = 0;
+  Slice key_a("aaa");
+  Slice key_b("bbb");
+  Slice key_c("ccc");
+  IndexFactoryBuilder::BlockHandle ph1{bh1.offset(), bh1.size()};
+  IndexFactoryBuilder::BlockHandle ph2{bh2.offset(), bh2.size()};
+  IndexFactoryBuilder::BlockHandle ph3{bh3.offset(), bh3.size()};
+  public_builder->AddIndexEntry(key_a, &key_b, ph1, &scratch_public, ctx_ab);
+  public_builder->AddIndexEntry(key_b, &key_c, ph2, &scratch_public, ctx_bc);
+  public_builder->AddIndexEntry(key_c, nullptr, ph3, &scratch_public, ctx_c);
+  Slice public_contents;
+  ASSERT_OK(public_builder->Finish(&public_contents));
+
+  auto direct_builder = MakeConfiguredBuiltinBuilder(
+      BlockBasedTableOptions::kBinarySearch, icmp, topts);
+  auto* direct = static_cast<BuiltinIndexFactoryBuilder*>(direct_builder.get());
+  std::string scratch_direct;
+  direct->AddIndexEntryDirect(ik_a_s, &ik_b_s, bh1, &scratch_direct,
+                              /*skip_delta_encoding=*/false);
+  direct->AddIndexEntryDirect(ik_b_s, &ik_c_s, bh2, &scratch_direct,
+                              /*skip_delta_encoding=*/true);
+  direct->AddIndexEntryDirect(ik_c_s, nullptr, bh3, &scratch_direct,
+                              /*skip_delta_encoding=*/false);
+  Slice direct_contents;
+  ASSERT_OK(direct_builder->Finish(&direct_contents));
+
+  EXPECT_EQ(public_contents.ToString(), direct_contents.ToString());
+}
+
+}  // namespace ROCKSDB_NAMESPACE
+
+int main(int argc, char** argv) {
+  ROCKSDB_NAMESPACE::port::InstallStackTraceHandler();
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Superseded by #14961.

The built-in IndexFactory tests are now included with the wrapper implementation so the behavior and coverage can be reviewed together. This test-only branch is no longer part of the UDI stack.
