### PR TITLE
Release TransactionDB path string after multi-CF open

### DIFF
--- a/java/rocksjni/transaction_db.cc
+++ b/java/rocksjni/transaction_db.cc
@@ -113,6 +113,7 @@ jlongArray Java_org_rocksdb_TransactionDB_open__JJLjava_lang_String_2_3_3B_3J(
   ROCKSDB_NAMESPACE::TransactionDB* tdb = nullptr;
   const ROCKSDB_NAMESPACE::Status s = ROCKSDB_NAMESPACE::TransactionDB::Open(
       *db_options, *txn_db_options, db_path, column_families, &handles, &tdb);
+  env->ReleaseStringUTFChars(jdb_path, db_path);
 
   // check if open operation was successful
   if (s.ok()) {


### PR DESCRIPTION
## Summary

Release the database path returned by `GetStringUTFChars` after the multi-column-family `TransactionDB::Open` call.

This matches the resource handling in the single-column-family and `OptimisticTransactionDB` implementations.

Fixes #14893

## Test plan

- Built the RocksJava JNI library and Java tests.
- Ran `TransactionDBTest` with `-Xcheck:jni`: 11 tests passed.
- Ran the complete RocksJava test suite: 1,248 tests passed.
- Repeated the focused test under macOS `leaks` and confirmed the original `GetStringUTFChars` leak stack is no longer present.
- Ran `make check-format` and `git diff --check`.