### PR TITLE
Remove read-only Get from MaybeOpenReadOnlyOnPrimary stress test

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -4917,25 +4917,6 @@ void StressTest::MaybeOpenReadOnlyOnPrimary(ThreadState* thread) {
     Status flush_s = db_->Flush(FlushOptions(), column_families_);
     ProcessStatus(thread->shared, "Flush read-only-primary", flush_s);
 
-    ReadOptions read_opts;
-    std::string ts_str;
-    Slice ts;
-    if (FLAGS_user_timestamp_size > 0) {
-      ts_str = GetNowNanos();
-      ts = ts_str;
-      read_opts.timestamp = &ts;
-    }
-    std::string value;
-    for (auto* handle : ro_cfhs) {
-      // Error injection is disabled, so a read is expected to either find the
-      // key or return NotFound; any other status (for example, a missing file
-      // from a wrongly deleted live SST) is a real failure.
-      Status get_s = ro_db->Get(read_opts, handle, Key(0), &value);
-      if (!get_s.IsNotFound()) {
-        ProcessStatus(thread->shared, "Read-only Get", get_s);
-      }
-    }
-
     // Closing the reader runs the read-only close path. If it wrongly purges
     // obsolete files based on its stale snapshot, the primary's live files are
     // deleted and later detected by db_stress's read/verification paths.


### PR DESCRIPTION
Summary:
`MaybeOpenReadOnlyOnPrimary` (added in D111995911) opens a read-only instance on the primary's live directory, flushes the primary, then performed a `Get(Key(0))` on each column family of the read-only instance.

That Get adds no unique test coverage: the scenario under test -- the read-only *close* wrongly deleting the primary's live files -- is detected on the primary's own read/verification paths, not on the read-only Get. Meanwhile the Get races against concurrent primary compaction, which can delete SST files the read-only's frozen MANIFEST still references, so it produces a steady stream of false-positive statuses (IOError, PathNotFound, Corruption) that we kept widening the tolerance list to suppress.

Rather than keep tolerating an ever-growing set of race-induced statuses, remove the read-only Get block entirely. The read-only open and close (the actual behavior under test) are still exercised.

This supersedes the earlier tolerate-statuses approach (and the folded-in D113031321).

Differential Revision: D112987468


