### PR TITLE
Harden MaybeOpenReadOnlyOnPrimary stress test: fix TSAN lock-limit crash + drop false-positive read-only Get

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -4873,16 +4873,18 @@ void StressTest::MaybeOpenReadOnlyOnPrimary(ThreadState* thread) {
 
   // Snapshot the current column family names for the read-only open. Other
   // worker threads can rename families via MaybeClearOneColumnFamily(), which
-  // writes column_family_names_[cf] while holding that family's per-CF lock, so
-  // read each name under the same lock to avoid a data race. This only builds a
-  // local descriptor list; it must not mutate any shared member state.
+  // writes column_family_names_[cf] while holding ALL key locks for that CF.
+  // We only need a single key lock per CF to synchronize with that writer --
+  // using LockColumnFamily would acquire all key locks (potentially hundreds of
+  // thousands) simultaneously, exceeding the number of locks TSAN's
+  // deadlock detector can track as held per thread (128), which aborts with
+  // "sanitizer_deadlock_detector.h ... n_all_locks_ < ... (0x80, 0x80)".
   std::vector<ColumnFamilyDescriptor> cf_descriptors;
   cf_descriptors.reserve(column_family_names_.size());
   for (int cf = 0; cf < static_cast<int>(column_family_names_.size()); ++cf) {
-    thread->shared->LockColumnFamily(cf);
+    MutexLock l(thread->shared->GetMutexForKey(cf, 0));
     cf_descriptors.emplace_back(column_family_names_[cf],
                                 ColumnFamilyOptions(options_));
-    thread->shared->UnlockColumnFamily(cf);
   }
 
   // A read-only instance opened concurrently with the primary can trip over
@@ -4916,25 +4918,6 @@ void StressTest::MaybeOpenReadOnlyOnPrimary(ThreadState* thread) {
     // succeed and any real failure is surfaced via ProcessStatus().
     Status flush_s = db_->Flush(FlushOptions(), column_families_);
     ProcessStatus(thread->shared, "Flush read-only-primary", flush_s);
-
-    ReadOptions read_opts;
-    std::string ts_str;
-    Slice ts;
-    if (FLAGS_user_timestamp_size > 0) {
-      ts_str = GetNowNanos();
-      ts = ts_str;
-      read_opts.timestamp = &ts;
-    }
-    std::string value;
-    for (auto* handle : ro_cfhs) {
-      // Error injection is disabled, so a read is expected to either find the
-      // key or return NotFound; any other status (for example, a missing file
-      // from a wrongly deleted live SST) is a real failure.
-      Status get_s = ro_db->Get(read_opts, handle, Key(0), &value);
-      if (!get_s.IsNotFound()) {
-        ProcessStatus(thread->shared, "Read-only Get", get_s);
-      }
-    }
 
     // Closing the reader runs the read-only close path. If it wrongly purges
     // obsolete files based on its stale snapshot, the primary's live files are


### PR DESCRIPTION
Summary:
`MaybeOpenReadOnlyOnPrimary` (added in D111995911) opens a read-only DB on the primary's live directory while the primary keeps mutating it. Two separate stress-test false positives were observed there; this diff fixes both and consolidates the earlier one-off fixes into a single diff.

1) TSAN deadlock-detector crash in the CF-name snapshot (`fbcode_tsan_blackbox_crash_test`):

    ThreadSanitizer: CHECK failed: sanitizer_deadlock_detector.h:67
    "((n_all_locks_)) < (...)" (0x80, 0x80)

`n_all_locks_` is the number of mutexes a thread holds *simultaneously*; TSAN caps it at 128 (0x80). The snapshot loop called `LockColumnFamily(cf)` to read `column_family_names_[cf]`, and that helper `.Lock()`s ALL per-key mutexes for the CF at once (`ceil(max_key / 2^log2_keys_per_lock)` -- e.g. 25,000 in blackbox with max_key=100000, log2_keys_per_lock=2) without releasing any, so a single call blows past 128. The writer (`MaybeClearOneColumnFamily`) holds all key locks while renaming a CF, so a single key lock is enough to synchronize the read. Fix: take one `MutexLock` on key-lock index 0 per CF instead of `LockColumnFamily`, keeping the simultaneously-held count at 1.

(`LockColumnFamily` is a latent hazard for any caller; the pre-existing caller `MaybeClearOneColumnFamily` never runs in the crash-test config -- `clear_column_family_one_in=0` -- so only this new, ungated caller exposed it.)

2) False-positive read-only Get (folded in from D112987468). After flushing the primary, the test performed a `Get(Key(0))` on each CF of the read-only instance. That Get races against concurrent primary compaction, which can delete SST files the read-only's frozen MANIFEST still references, surfacing as IOError/PathNotFound/Corruption ("truncated block read"). The Get adds no unique coverage -- the scenario under test (the read-only close wrongly deleting primary live files) is detected on the primary's own verification paths -- so remove the Get block entirely instead of widening a tolerated-status list.

Note on D112936376: that diff tried to fix crash (1) by setting `table_cache_numshardbits=0` on the read-only instance, on the theory that the primary's and reader's table caches contribute "128 unique lock objects." That is a misdiagnosis: the failing CHECK counts locks held *simultaneously*, and sharded-cache shard mutexes are held transiently (one at a time; read-path nesting is a constant depth of 2), so shard count does not affect `n_all_locks_`. The real cause is `LockColumnFamily`, fixed in (1), so `table_cache_numshardbits=0` is unnecessary and is not included here.

This diff subsumes and replaces D112936376 and D112987468.

Reviewed By: joshkang97

Differential Revision: D112980148


