### PR TITLE
Add per-column-family compaction abort and resume

### DIFF
--- a/db/column_family.h
+++ b/db/column_family.h
@@ -29,6 +29,7 @@
 #include "trace_replay/block_cache_tracer.h"
 #include "util/cast_util.h"
 #include "util/hash_containers.h"
+#include "util/mutexlock.h"
 #include "util/thread_local.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -520,6 +521,32 @@ class ColumnFamilyData {
   bool queued_for_flush() { return queued_for_flush_; }
   bool queued_for_compaction() { return queued_for_compaction_; }
 
+  int compaction_aborted() const {
+    return compaction_aborted_.obj_.load(std::memory_order_acquire);
+  }
+  void inc_compaction_aborted(InstrumentedMutex* db_mutex) {
+    db_mutex->AssertHeld();
+    compaction_aborted_.obj_.fetch_add(1, std::memory_order_release);
+  }
+  int dec_compaction_aborted(InstrumentedMutex* db_mutex) {
+    db_mutex->AssertHeld();
+    return compaction_aborted_.obj_.fetch_sub(1, std::memory_order_acq_rel) - 1;
+  }
+
+  int num_in_flight_compactions(InstrumentedMutex* db_mutex) const {
+    db_mutex->AssertHeld();
+    return num_in_flight_compactions_;
+  }
+  void inc_num_in_flight_compactions(InstrumentedMutex* db_mutex) {
+    db_mutex->AssertHeld();
+    ++num_in_flight_compactions_;
+  }
+  void dec_num_in_flight_compactions(InstrumentedMutex* db_mutex) {
+    db_mutex->AssertHeld();
+    assert(num_in_flight_compactions_ > 0);
+    --num_in_flight_compactions_;
+  }
+
   static std::pair<WriteStallCondition, WriteStallCause>
   GetWriteStallConditionAndCause(
       int num_unflushed_memtables, int num_l0_files,
@@ -711,9 +738,25 @@ class ColumnFamilyData {
   // If true --> this ColumnFamily is currently present in DBImpl::flush_queue_
   bool queued_for_flush_;
 
-  // If true --> this ColumnFamily is currently present in
-  // DBImpl::compaction_queue_
+  // If true, this ColumnFamily is in DBImpl::compaction_queue_ or its parked
+  // compaction set.
   bool queued_for_compaction_;
+
+  // Read outside the DB mutex by compaction workers (acquire-loaded roughly
+  // every 1024 records in ProcessKeyValueCompaction). Given its own cache line
+  // via CacheAlignedWrapper to avoid false sharing with the DB-mutex-written
+  // fields packed around it.
+  CacheAlignedWrapper<std::atomic<int>> compaction_aborted_{};
+
+  // Per-CF count of compactions "in flight" for AbortCompactions(): a picked
+  // Compaction (or one CompactFiles call), tracked from
+  // BeginInFlightCompaction() until EndInFlightCompaction() at the end of
+  // BackgroundCompaction, so it covers the NotifyOnCompactionCompleted window
+  // that CompactionPicker's compactions_in_progress_ set does not. NOT the same
+  // as DBImpl::num_running_compactions_ (which counts BackgroundCallCompaction
+  // worker invocations, backs the public rocksdb.num-running-compactions
+  // property, and excludes CompactFiles). Protected by the DB mutex.
+  int num_in_flight_compactions_{0};
 
   uint64_t prev_compaction_needed_bytes_;
 

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -1668,8 +1668,12 @@ Status CompactionJob::ProcessKeyValue(
   const uint64_t kCronEveryMask = (1 << 10) - 1;
   [[maybe_unused]] const std::optional<const Slice> end = sub_compact->end;
 
-  // Check for abort signal before starting key processing
-  if (compaction_aborted_.load(std::memory_order_acquire) > 0) {
+  // Check for abort signal before starting key processing. The DB-wide
+  // (AbortAllCompactions) and per-CF (AbortCompactions) counters compose here;
+  // either aborts this job. See DB::AbortCompactions() in db.h for how the
+  // abort knobs relate to each other and to the other compaction controls.
+  if (compaction_aborted_.load(std::memory_order_acquire) > 0 ||
+      cfd->compaction_aborted() > 0) {
     return Status::Incomplete(Status::SubCode::kCompactionAborted);
   }
 
@@ -1691,7 +1695,8 @@ Status CompactionJob::ProcessKeyValue(
     // Periodic cron operations: stats update, abort check.
     if ((num_records & kCronEveryMask) == kCronEveryMask) {
       // Check for abort signal periodically
-      if (compaction_aborted_.load(std::memory_order_acquire) > 0) {
+      if (compaction_aborted_.load(std::memory_order_acquire) > 0 ||
+          cfd->compaction_aborted() > 0) {
         status = Status::Incomplete(Status::SubCode::kCompactionAborted);
         break;
       }

--- a/db/db_compaction_abort_test.cc
+++ b/db/db_compaction_abort_test.cc
@@ -4,6 +4,9 @@
 //  (found in the LICENSE.Apache file in the root directory).
 
 #include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
 #include <set>
 #include <thread>
 #include <unordered_map>
@@ -14,6 +17,7 @@
 #include "options/options_helper.h"
 #include "port/stack_trace.h"
 #include "rocksdb/db.h"
+#include "rocksdb/listener.h"
 #include "rocksdb/sst_file_writer.h"
 #include "test_util/sync_point.h"
 #include "test_util/testharness.h"
@@ -86,6 +90,19 @@ class AbortSynchronizer {
     if (!abort_triggered_.exchange(true)) {
       abort_thread_ = std::thread([this, db]() {
         db->AbortAllCompactions();
+        SignalAbortCompleted();
+      });
+    }
+  }
+
+  void TriggerAbort(DBImpl* db, ColumnFamilyHandle* column_family) {
+    if (abort_triggered_.load() && abort_completed_.load()) {
+      Reset();
+    }
+
+    if (!abort_triggered_.exchange(true)) {
+      abort_thread_ = std::thread([this, db, column_family]() {
+        db->AbortCompactions(column_family);
         SignalAbortCompleted();
       });
     }
@@ -457,6 +474,483 @@ TEST_F(DBCompactionAbortTest, AbortScheduledAutomaticCompactionBeforePick) {
             compact_write_bytes_before_resume);
   ASSERT_LT(NumTableFilesAtLevel(0), kNumL0Files);
   VerifyDataIntegrity(/*num_keys=*/100);
+}
+
+TEST_F(DBCompactionAbortTest, AbortCompactionsIsScopedToColumnFamily) {
+  Options options = CurrentOptions();
+  options.level0_file_num_compaction_trigger = 100;
+  options.max_background_compactions = 2;
+  options.max_subcompactions = 1;
+  options.disable_auto_compactions = true;
+  CreateAndReopenWithCF({"target", "sibling"}, options);
+
+  Random rnd(301);
+  for (int cf = 1; cf <= 2; ++cf) {
+    for (int file = 0; file < 4; ++file) {
+      for (int key = 0; key < 100; ++key) {
+        ASSERT_OK(Put(cf, Key(key), rnd.RandomString(1000)));
+      }
+      ASSERT_OK(Flush(cf));
+    }
+  }
+
+  AbortSynchronizer abort_sync;
+  std::atomic<int> compactions_started{0};
+  std::mutex sibling_mutex;
+  std::condition_variable sibling_cv;
+  bool sibling_started = false;
+  bool allow_sibling_to_finish = false;
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->LoadDependency({
+      {"DBImpl::AbortCompactions:FlagSet",
+       "DBCompactionAbortTest::ScopedAbort:WaitForAbort"},
+  });
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
+      "CompactionJob::ProcessKeyValueCompaction:Start", [&](void* /*arg*/) {
+        if (compactions_started.fetch_add(1) == 0) {
+          std::unique_lock<std::mutex> lock(sibling_mutex);
+          sibling_started = true;
+          sibling_cv.notify_all();
+          sibling_cv.wait(lock, [&]() { return allow_sibling_to_finish; });
+          return;
+        }
+        abort_sync.TriggerAbort(dbfull(), handles_[1]);
+        TEST_SYNC_POINT_CALLBACK(
+            "DBCompactionAbortTest::ScopedAbort:WaitForAbort", nullptr);
+      });
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
+
+  Status sibling_status;
+  std::thread sibling_thread([&]() {
+    sibling_status = dbfull()->CompactRange(CompactRangeOptions(), handles_[2],
+                                            nullptr, nullptr);
+  });
+  {
+    std::unique_lock<std::mutex> lock(sibling_mutex);
+    sibling_cv.wait(lock, [&]() { return sibling_started; });
+  }
+
+  Status target_status = dbfull()->CompactRange(CompactRangeOptions(),
+                                                handles_[1], nullptr, nullptr);
+  abort_sync.WaitForAbortCompletion();
+  {
+    std::lock_guard<std::mutex> guard(sibling_mutex);
+    allow_sibling_to_finish = true;
+  }
+  sibling_cv.notify_all();
+  sibling_thread.join();
+  CleanupSyncPoints();
+
+  ASSERT_TRUE(target_status.IsIncomplete());
+  ASSERT_TRUE(target_status.IsCompactionAborted());
+  ASSERT_OK(sibling_status);
+  target_status = dbfull()->CompactRange(CompactRangeOptions(), handles_[1],
+                                         nullptr, nullptr);
+  ASSERT_TRUE(target_status.IsIncomplete());
+  ASSERT_TRUE(target_status.IsCompactionAborted());
+
+  dbfull()->ResumeCompactions(handles_[1]);
+  ASSERT_OK(dbfull()->CompactRange(CompactRangeOptions(), handles_[1], nullptr,
+                                   nullptr));
+}
+
+TEST_F(DBCompactionAbortTest, PerColumnFamilyAndGlobalAbortCountersCompose) {
+  Options options = CurrentOptions();
+  options.level0_file_num_compaction_trigger = 100;
+  options.disable_auto_compactions = true;
+  CreateAndReopenWithCF({"target", "sibling"}, options);
+
+  for (int cf = 1; cf <= 2; ++cf) {
+    for (int file = 0; file < 2; ++file) {
+      ASSERT_OK(Put(cf, Key(file), "value"));
+      ASSERT_OK(Flush(cf));
+    }
+  }
+
+  dbfull()->AbortAllCompactions();
+  dbfull()->AbortCompactions(handles_[1]);
+  dbfull()->AbortCompactions(handles_[1]);
+  dbfull()->ResumeCompactions(handles_[1]);
+
+  Status sibling_status = dbfull()->CompactRange(CompactRangeOptions(),
+                                                 handles_[2], nullptr, nullptr);
+  ASSERT_TRUE(sibling_status.IsIncomplete());
+  ASSERT_TRUE(sibling_status.IsCompactionAborted());
+
+  dbfull()->ResumeAllCompactions();
+  ASSERT_OK(dbfull()->CompactRange(CompactRangeOptions(), handles_[2], nullptr,
+                                   nullptr));
+  Status target_status = dbfull()->CompactRange(CompactRangeOptions(),
+                                                handles_[1], nullptr, nullptr);
+  ASSERT_TRUE(target_status.IsIncomplete());
+  ASSERT_TRUE(target_status.IsCompactionAborted());
+
+  dbfull()->ResumeCompactions(handles_[1]);
+  ASSERT_OK(dbfull()->CompactRange(CompactRangeOptions(), handles_[1], nullptr,
+                                   nullptr));
+}
+
+TEST_F(DBCompactionAbortTest, AbortCompactionsRejectsCompactFilesTrivialMove) {
+  Options options = CurrentOptions();
+  options.disable_auto_compactions = true;
+  CreateAndReopenWithCF({"target"}, options);
+
+  ASSERT_OK(Put(1, "key", "value"));
+  ASSERT_OK(Flush(1));
+
+  ColumnFamilyMetaData metadata;
+  dbfull()->GetColumnFamilyMetaData(handles_[1], &metadata);
+  ASSERT_EQ(metadata.levels[0].files.size(), 1);
+  const std::vector<std::string> input_files = {
+      metadata.levels[0].files.front().name};
+
+  CompactionOptions compaction_options;
+  compaction_options.allow_trivial_move = true;
+  dbfull()->AbortCompactions(handles_[1]);
+  Status status =
+      dbfull()->CompactFiles(compaction_options, handles_[1], input_files, 1);
+  ASSERT_TRUE(status.IsIncomplete());
+  ASSERT_TRUE(status.IsCompactionAborted());
+
+  dbfull()->ResumeCompactions(handles_[1]);
+  ASSERT_OK(
+      dbfull()->CompactFiles(compaction_options, handles_[1], input_files, 1));
+}
+
+TEST_F(DBCompactionAbortTest, ResumeRestoresParkedAutomaticCompaction) {
+  constexpr int kCompactionTrigger = 4;
+  Options options = CurrentOptions();
+  options.level0_file_num_compaction_trigger = kCompactionTrigger;
+  options.max_background_compactions = 1;
+  options.disable_auto_compactions = false;
+  CreateAndReopenWithCF({"target", "sibling"}, options);
+
+  AbortSynchronizer abort_sync;
+  std::mutex parked_mutex;
+  std::condition_variable parked_cv;
+  bool compaction_parked = false;
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->LoadDependency({
+      {"DBImpl::AbortCompactions:FlagSet",
+       "DBCompactionAbortTest::ParkedCompaction:WaitForAbort"},
+  });
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
+      "BackgroundCallCompaction:0", [&](void* /*arg*/) {
+        abort_sync.TriggerAbort(dbfull(), handles_[1]);
+        TEST_SYNC_POINT_CALLBACK(
+            "DBCompactionAbortTest::ParkedCompaction:WaitForAbort", nullptr);
+      });
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::PickCompactionFromQueue:Parked", [&](void* /*arg*/) {
+        std::lock_guard<std::mutex> guard(parked_mutex);
+        compaction_parked = true;
+        parked_cv.notify_all();
+      });
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
+
+  Random rnd(301);
+  for (int file = 0; file < kCompactionTrigger; ++file) {
+    for (int key = 0; key < 100; ++key) {
+      ASSERT_OK(Put(1, Key(key), rnd.RandomString(1000)));
+    }
+    ASSERT_OK(Flush(1));
+  }
+  {
+    std::unique_lock<std::mutex> lock(parked_mutex);
+    parked_cv.wait(lock, [&]() { return compaction_parked; });
+  }
+
+  CleanupSyncPoints();
+  abort_sync.WaitForAbortCompletion();
+  const int l0_files_before_resume = NumTableFilesAtLevel(0, 1);
+  ASSERT_GE(l0_files_before_resume, kCompactionTrigger);
+
+  WaitForCompactOptions wait_options;
+  wait_options.timeout = std::chrono::milliseconds(1);
+  ASSERT_TRUE(dbfull()->WaitForCompact(wait_options).IsTimedOut());
+
+  for (int file = 0; file < kCompactionTrigger; ++file) {
+    for (int key = 0; key < 100; ++key) {
+      ASSERT_OK(Put(2, Key(key), rnd.RandomString(1000)));
+    }
+    ASSERT_OK(Flush(2));
+  }
+  ASSERT_OK(dbfull()->TEST_WaitForBackgroundWork());
+  ASSERT_LT(NumTableFilesAtLevel(0, 2), kCompactionTrigger);
+  ASSERT_EQ(NumTableFilesAtLevel(0, 1), l0_files_before_resume);
+
+  std::atomic<bool> target_reenqueued{false};
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::RestoreParkedCompaction:cfd", [&](void* arg) {
+        auto* cfd = static_cast<ColumnFamilyData*>(arg);
+        if (cfd->GetName() == "target") {
+          target_reenqueued.store(true);
+        }
+      });
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
+  dbfull()->ResumeCompactions(handles_[1]);
+  ASSERT_TRUE(target_reenqueued.load());
+  CleanupSyncPoints();
+  ASSERT_OK(dbfull()->TEST_WaitForCompact());
+  ASSERT_LT(NumTableFilesAtLevel(0, 1), l0_files_before_resume);
+}
+
+TEST_F(DBCompactionAbortTest, DropColumnFamilyReleasesParkedCompaction) {
+  constexpr int kCompactionTrigger = 4;
+  Options options = CurrentOptions();
+  options.level0_file_num_compaction_trigger = kCompactionTrigger;
+  options.max_background_compactions = 1;
+  options.disable_auto_compactions = false;
+  CreateAndReopenWithCF({"target"}, options);
+
+  AbortSynchronizer abort_sync;
+  std::mutex parked_mutex;
+  std::condition_variable parked_cv;
+  bool compaction_parked = false;
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->LoadDependency({
+      {"DBImpl::AbortCompactions:FlagSet",
+       "DBCompactionAbortTest::DropParkedCompaction:WaitForAbort"},
+  });
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
+      "BackgroundCallCompaction:0", [&](void* /*arg*/) {
+        abort_sync.TriggerAbort(dbfull(), handles_[1]);
+        TEST_SYNC_POINT_CALLBACK(
+            "DBCompactionAbortTest::DropParkedCompaction:WaitForAbort",
+            nullptr);
+      });
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::PickCompactionFromQueue:Parked", [&](void* /*arg*/) {
+        std::lock_guard<std::mutex> guard(parked_mutex);
+        compaction_parked = true;
+        parked_cv.notify_all();
+      });
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
+
+  Random rnd(301);
+  for (int file = 0; file < kCompactionTrigger; ++file) {
+    for (int key = 0; key < 100; ++key) {
+      ASSERT_OK(Put(1, Key(key), rnd.RandomString(1000)));
+    }
+    ASSERT_OK(Flush(1));
+  }
+  {
+    std::unique_lock<std::mutex> lock(parked_mutex);
+    parked_cv.wait(lock, [&]() { return compaction_parked; });
+  }
+
+  CleanupSyncPoints();
+  abort_sync.WaitForAbortCompletion();
+  ASSERT_OK(dbfull()->DropColumnFamily(handles_[1]));
+
+  WaitForCompactOptions wait_options;
+  wait_options.timeout = std::chrono::seconds(10);
+  ASSERT_OK(dbfull()->WaitForCompact(wait_options));
+  dbfull()->ResumeCompactions(handles_[1]);
+}
+
+TEST_F(DBCompactionAbortTest, DropColumnFamilyBeforeAbortedQueueEntryIsParked) {
+  constexpr int kCompactionTrigger = 4;
+  Options options = CurrentOptions();
+  options.level0_file_num_compaction_trigger = kCompactionTrigger;
+  options.max_background_compactions = 1;
+  options.disable_auto_compactions = false;
+  CreateAndReopenWithCF({"target"}, options);
+
+  std::mutex worker_mutex;
+  std::condition_variable worker_cv;
+  bool worker_started = false;
+  bool allow_worker_to_pick = false;
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
+      "BackgroundCallCompaction:0", [&](void* /*arg*/) {
+        std::unique_lock<std::mutex> lock(worker_mutex);
+        worker_started = true;
+        worker_cv.notify_all();
+        worker_cv.wait(lock, [&]() { return allow_worker_to_pick; });
+      });
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
+
+  for (int file = 0; file < kCompactionTrigger; ++file) {
+    ASSERT_OK(Put(1, Key(file), "value"));
+    ASSERT_OK(Flush(1));
+  }
+  {
+    std::unique_lock<std::mutex> lock(worker_mutex);
+    worker_cv.wait(lock, [&]() { return worker_started; });
+  }
+
+  dbfull()->AbortCompactions(handles_[1]);
+  const Status drop_status = dbfull()->DropColumnFamily(handles_[1]);
+  {
+    std::lock_guard<std::mutex> guard(worker_mutex);
+    allow_worker_to_pick = true;
+  }
+  worker_cv.notify_all();
+
+  WaitForCompactOptions wait_options;
+  wait_options.timeout = std::chrono::seconds(10);
+  const Status wait_status = dbfull()->WaitForCompact(wait_options);
+  CleanupSyncPoints();
+  dbfull()->ResumeCompactions(handles_[1]);
+
+  ASSERT_OK(drop_status);
+  ASSERT_OK(wait_status);
+}
+
+TEST_F(DBCompactionAbortTest, NewCompactionWorkWhileAbortedIsParked) {
+  constexpr int kCompactionTrigger = 4;
+  Options options = CurrentOptions();
+  options.level0_file_num_compaction_trigger = kCompactionTrigger;
+  options.max_background_compactions = 1;
+  options.disable_auto_compactions = false;
+  CreateAndReopenWithCF({"target"}, options);
+
+  dbfull()->AbortCompactions(handles_[1]);
+  for (int file = 0; file < kCompactionTrigger; ++file) {
+    ASSERT_OK(Put(1, Key(file), "value"));
+    ASSERT_OK(Flush(1));
+  }
+
+  const int l0_files_before_resume = NumTableFilesAtLevel(0, 1);
+  WaitForCompactOptions wait_options;
+  wait_options.timeout = std::chrono::milliseconds(1);
+  const Status wait_status = dbfull()->WaitForCompact(wait_options);
+
+  dbfull()->ResumeCompactions(handles_[1]);
+  ASSERT_TRUE(wait_status.IsTimedOut());
+  ASSERT_GE(l0_files_before_resume, kCompactionTrigger);
+  ASSERT_OK(dbfull()->TEST_WaitForCompact());
+  ASSERT_LT(NumTableFilesAtLevel(0, 1), l0_files_before_resume);
+}
+
+TEST_F(DBCompactionAbortTest, AbortWaitsForCompactionCompletionCallback) {
+  constexpr int kCompactionTrigger = 4;
+  Options options = CurrentOptions();
+  options.level0_file_num_compaction_trigger = kCompactionTrigger;
+  options.max_background_compactions = 1;
+  options.disable_auto_compactions = false;
+  options.listeners.emplace_back(std::make_shared<EventListener>());
+  CreateAndReopenWithCF({"target"}, options);
+
+  std::mutex callback_mutex;
+  std::condition_variable callback_cv;
+  bool callback_started = false;
+  bool allow_callback_to_finish = false;
+  enum class AbortState { kNotObserved, kWaiting, kComplete };
+  AbortState abort_state = AbortState::kNotObserved;
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::NotifyOnCompactionCompleted::UnlockMutex", [&](void* /*arg*/) {
+        std::unique_lock<std::mutex> lock(callback_mutex);
+        callback_started = true;
+        callback_cv.notify_all();
+        callback_cv.wait(lock, [&]() { return allow_callback_to_finish; });
+      });
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::AbortCompactions:Waiting", [&](void* /*arg*/) {
+        std::lock_guard<std::mutex> guard(callback_mutex);
+        abort_state = AbortState::kWaiting;
+        callback_cv.notify_all();
+      });
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::AbortCompactions:Complete", [&](void* /*arg*/) {
+        std::lock_guard<std::mutex> guard(callback_mutex);
+        abort_state = AbortState::kComplete;
+        callback_cv.notify_all();
+      });
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
+
+  for (int file = 0; file < kCompactionTrigger; ++file) {
+    ASSERT_OK(Put(1, Key(file), "value"));
+    ASSERT_OK(Flush(1));
+  }
+  {
+    std::unique_lock<std::mutex> lock(callback_mutex);
+    callback_cv.wait(lock, [&]() { return callback_started; });
+  }
+
+  std::thread abort_thread([&]() { dbfull()->AbortCompactions(handles_[1]); });
+  bool returned_while_callback_blocked = false;
+  {
+    std::unique_lock<std::mutex> lock(callback_mutex);
+    callback_cv.wait(lock,
+                     [&]() { return abort_state != AbortState::kNotObserved; });
+    returned_while_callback_blocked = abort_state == AbortState::kComplete;
+  }
+
+  {
+    std::lock_guard<std::mutex> guard(callback_mutex);
+    allow_callback_to_finish = true;
+  }
+  callback_cv.notify_all();
+  abort_thread.join();
+  CleanupSyncPoints();
+  dbfull()->ResumeCompactions(handles_[1]);
+
+  ASSERT_FALSE(returned_while_callback_blocked);
+}
+
+TEST_F(DBCompactionAbortTest,
+       DroppedColumnFamilyFilesPurgedAfterTrackedCompaction) {
+  constexpr int kCompactionTrigger = 4;
+  Options options = CurrentOptions();
+  options.level0_file_num_compaction_trigger = kCompactionTrigger;
+  options.max_background_compactions = 1;
+  options.disable_auto_compactions = false;
+  CreateAndReopenWithCF({"target"}, options);
+
+  std::mutex compaction_mutex;
+  std::condition_variable compaction_cv;
+  bool compaction_started = false;
+  bool allow_compaction_to_finish = false;
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
+      "CompactionJob::Run():Start", [&](void* /*arg*/) {
+        std::unique_lock<std::mutex> lock(compaction_mutex);
+        compaction_started = true;
+        compaction_cv.notify_all();
+        compaction_cv.wait(lock, [&]() { return allow_compaction_to_finish; });
+      });
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
+
+  Random rnd(301);
+  for (int file = 0; file < kCompactionTrigger; ++file) {
+    for (int key = 0; key < 100; ++key) {
+      ASSERT_OK(Put(1, Key(key), rnd.RandomString(1000)));
+    }
+    ASSERT_OK(Flush(1));
+  }
+  {
+    std::unique_lock<std::mutex> lock(compaction_mutex);
+    compaction_cv.wait(lock, [&]() { return compaction_started; });
+  }
+
+  const int sst_files_before_drop = GetSstFileCount(dbname_);
+  const Status drop_status = dbfull()->DropColumnFamily(handles_[1]);
+  Status destroy_handle_status;
+  if (drop_status.ok()) {
+    destroy_handle_status = dbfull()->DestroyColumnFamilyHandle(handles_[1]);
+    if (destroy_handle_status.ok()) {
+      handles_.erase(handles_.begin() + 1);
+    }
+  }
+
+  {
+    std::lock_guard<std::mutex> guard(compaction_mutex);
+    allow_compaction_to_finish = true;
+  }
+  compaction_cv.notify_all();
+  const Status wait_status = dbfull()->TEST_WaitForCompact();
+  CleanupSyncPoints();
+
+  ASSERT_OK(drop_status);
+  ASSERT_OK(destroy_handle_status);
+  ASSERT_OK(wait_status);
+  ASSERT_GT(sst_files_before_drop, 0);
+  ASSERT_EQ(0, GetSstFileCount(dbname_));
+}
+
+TEST_F(DBCompactionAbortTest, ResumeCompactionsAfterCloseIsNoOp) {
+  auto* const default_column_family = dbfull()->DefaultColumnFamily();
+  dbfull()->AbortCompactions(default_column_family);
+
+  ASSERT_OK(dbfull()->Close());
+  dbfull()->ResumeCompactions(default_column_family);
 }
 
 TEST_F(DBCompactionAbortTest, AbortAndVerifyNoOutputFiles) {

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -883,6 +883,13 @@ Status DBImpl::CloseHelper() {
     cfd->UnrefAndTryDelete();
   }
 
+  for (auto* cfd : parked_compaction_cfds_) {
+    assert(cfd->queued_for_compaction());
+    cfd->set_queued_for_compaction(false);
+    cfd->UnrefAndTryDelete();
+  }
+  parked_compaction_cfds_.clear();
+
   if (default_cf_handle_ != nullptr || persist_stats_cf_handle_ != nullptr) {
     // we need to delete handle outside of lock because it does its own locking
     mutex_.Unlock();
@@ -4013,6 +4020,9 @@ Status DBImpl::DropColumnFamilyImpl(ColumnFamilyHandle* column_family) {
       write_thread_.ExitUnbatched(&w);
       if (s.ok() && cfd->blob_partition_manager() != nullptr) {
         UnregisterBlobDirectWriteColumnFamily();
+      }
+      if (s.ok()) {
+        RestoreParkedCompaction(cfd);
       }
     }
     if (s.ok()) {

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -21,6 +21,7 @@
 #include <string>
 #include <unordered_map>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include "db/column_family.h"
@@ -478,6 +479,8 @@ class DBImpl : public DB {
   void DisableManualCompaction() override;
   void AbortAllCompactions() override;
   void ResumeAllCompactions() override;
+  void AbortCompactions(ColumnFamilyHandle* column_family) override;
+  void ResumeCompactions(ColumnFamilyHandle* column_family) override;
 
   using DB::SetOptions;
   Status SetOptions(
@@ -2831,9 +2834,24 @@ class DBImpl : public DB {
   ColumnFamilyData* PopFirstFromCompactionQueue();
   FlushRequest PopFirstFromFlushQueue();
 
+  struct CompactionQueueThrottled {};
+  struct CompactionQueueParked {};
+  struct CompactionQueuePicked {
+    ColumnFamilyData* cfd;
+  };
+  using CompactionQueuePickResult =
+      std::variant<CompactionQueuePicked, CompactionQueueThrottled,
+                   CompactionQueueParked>;
+
   // Pick the first unthrottled compaction with task token from queue.
-  ColumnFamilyData* PickCompactionFromQueue(
+  CompactionQueuePickResult PickCompactionFromQueue(
       std::unique_ptr<TaskLimiterToken>* token, LogBuffer* log_buffer);
+  bool IsCompactionAborted(ColumnFamilyData* cfd) const;
+  bool MustWaitForCompaction(ColumnFamilyData* cfd);
+  bool HasPendingManualCompaction(ColumnFamilyData* cfd);
+  bool RestoreParkedCompaction(ColumnFamilyData* cfd);
+  void BeginInFlightCompaction(ColumnFamilyData* cfd);
+  bool EndInFlightCompaction(ColumnFamilyData* cfd);
 
   IOStatus SyncWalImpl(bool include_current_wal,
                        const WriteOptions& write_options,
@@ -3215,6 +3233,10 @@ class DBImpl : public DB {
   // DB mutex in compaction code paths.
   std::atomic<int> compaction_aborted_ = 0;
 
+  // Number of AbortCompactions() callers waiting for a targeted compaction to
+  // finish. Protected by the DB mutex.
+  int per_cf_compaction_abort_waiters_ = 0;
+
   // This condition variable is signaled on these conditions:
   // * whenever bg_compaction_scheduled_ goes down to 0
   // * if AnyManualCompaction, whenever a compaction finishes, even if it hasn't
@@ -3424,7 +3446,7 @@ class DBImpl : public DB {
   // cfd->imm()->IsFlushPending()
   // A column family is inserted into compaction_queue_ when it satisfied
   // condition cfd->NeedsCompaction()
-  // Column families in this list are all Ref()-erenced
+  // Column families in these collections are all Ref()-erenced.
   // TODO(icanadi) Provide some kind of ReferencedColumnFamily class that will
   // do RAII on ColumnFamilyData
   // Column families are in this queue when they need to be flushed or
@@ -3439,9 +3461,23 @@ class DBImpl : public DB {
   // invariant(column family present in flush_queue_ <==>
   // ColumnFamilyData::pending_flush_ == true)
   std::deque<FlushRequest> flush_queue_;
-  // invariant(column family present in compaction_queue_ <==>
-  // ColumnFamilyData::pending_compaction_ == true)
+  // invariant((column family in compaction_queue_ or
+  //            column family in parked_compaction_cfds_)
+  //           <=> queued_for_compaction() == true)
+  //
+  // "Parked" means a column family whose compaction was aborted via
+  // AbortCompactions() while it was queued. When an aborted CF reaches the
+  // front of compaction_queue_, PickCompactionFromQueue() moves it to
+  // parked_compaction_cfds_ instead of scheduling it. The CF does not
+  // immediately lose its place -- only when it reaches the front of the
+  // queue is it parked. This preserves fairness for CFs behind it and
+  // avoids restoring the scheduler credit (which would cause a hot re-pick
+  // loop). On the final ResumeCompactions(), RestoreParkedCompaction()
+  // re-enqueues the CF (or releases its ref if it no longer needs
+  // compaction). Each parked CF carries exactly one Ref() from the
+  // original AddToCompactionQueue() call.
   std::deque<ColumnFamilyData*> compaction_queue_;
+  std::unordered_set<ColumnFamilyData*> parked_compaction_cfds_;
 
   // A map to store file numbers and filenames of the files to be purged
   std::unordered_map<uint64_t, PurgeFileInfo> purge_files_;

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -6,6 +6,7 @@
 // Copyright (c) 2011 The LevelDB Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
+#include <algorithm>
 #include <cinttypes>
 #include <deque>
 #include <unordered_map>
@@ -1195,11 +1196,15 @@ Status DBImpl::CompactRange(const CompactRangeOptions& options,
                             ColumnFamilyHandle* column_family,
                             const Slice* begin_without_ts,
                             const Slice* end_without_ts) {
+  auto* cfd =
+      static_cast_with_check<ColumnFamilyHandleImpl>(column_family)->cfd();
+  assert(cfd);
+
   if (manual_compaction_paused_.load(std::memory_order_acquire) > 0) {
     return Status::Incomplete(Status::SubCode::kManualCompactionPaused);
   }
 
-  if (compaction_aborted_.load(std::memory_order_acquire) > 0) {
+  if (IsCompactionAborted(cfd)) {
     return Status::Incomplete(Status::SubCode::kCompactionAborted);
   }
 
@@ -1610,6 +1615,21 @@ Status DBImpl::CompactFiles(const CompactionOptions& compact_options,
       static_cast_with_check<ColumnFamilyHandleImpl>(column_family)->cfd();
   assert(cfd);
 
+  {
+    InstrumentedMutexLock l(&mutex_);
+    BeginInFlightCompaction(cfd);
+  }
+  Defer end_in_flight_compaction([&]() {
+    InstrumentedMutexLock l(&mutex_);
+    // The caller holds a live handle to this CF, so this can never be the final
+    // unref (the return can only be true when the last reference is dropped).
+    [[maybe_unused]] const bool cfd_deleted = EndInFlightCompaction(cfd);
+    assert(!cfd_deleted);
+    if (per_cf_compaction_abort_waiters_ > 0) {
+      bg_cv_.SignalAll();
+    }
+  });
+
   Status s;
   JobContext job_context(next_job_id_.fetch_add(1), true);
   LogBuffer log_buffer(InfoLogLevel::INFO_LEVEL,
@@ -1738,8 +1758,7 @@ Status DBImpl::CompactFilesImpl(
     return Status::ShutdownInProgress();
   }
 
-  // triggered by AbortAllCompactions
-  if (compaction_aborted_.load(std::memory_order_acquire) > 0) {
+  if (IsCompactionAborted(cfd)) {
     return Status::Incomplete(Status::SubCode::kCompactionAborted);
   }
 
@@ -1866,7 +1885,7 @@ Status DBImpl::CompactFilesImpl(
 
     c.reset();
     bg_compaction_scheduled_--;
-    if (bg_compaction_scheduled_ == 0) {
+    if (bg_compaction_scheduled_ == 0 || per_cf_compaction_abort_waiters_ > 0) {
       bg_cv_.SignalAll();
     }
     MaybeScheduleFlushOrCompaction();
@@ -2001,7 +2020,7 @@ Status DBImpl::CompactFilesImpl(
   c.reset();
 
   bg_compaction_scheduled_--;
-  if (bg_compaction_scheduled_ == 0) {
+  if (bg_compaction_scheduled_ == 0 || per_cf_compaction_abort_waiters_ > 0) {
     bg_cv_.SignalAll();
   }
   MaybeScheduleFlushOrCompaction();
@@ -2471,12 +2490,10 @@ Status DBImpl::RunManualCompaction(
     return manual.status;
   }
 
-  if (compaction_aborted_.load(std::memory_order_acquire) > 0) {
-    // All compactions are being aborted. Return immediately.
-    int counter = compaction_aborted_.load(std::memory_order_acquire);
-    ROCKS_LOG_INFO(
-        immutable_db_options_.info_log,
-        "RunManualCompaction: Aborting due to compaction_aborted_=%d", counter);
+  if (IsCompactionAborted(cfd)) {
+    ROCKS_LOG_INFO(immutable_db_options_.info_log,
+                   "[%s] RunManualCompaction: aborting compaction",
+                   cfd->GetName().c_str());
     manual.status = Status::Incomplete(Status::SubCode::kCompactionAborted);
     manual.done = true;
     return manual.status;
@@ -2506,7 +2523,7 @@ Status DBImpl::RunManualCompaction(
     // and `CompactRangeOptions::canceled` might not work well together.
     while (bg_bottom_compaction_scheduled_ > 0 ||
            bg_compaction_scheduled_ > 0) {
-      if (compaction_aborted_.load(std::memory_order_acquire) > 0) {
+      if (IsCompactionAborted(cfd)) {
         // Pretend the error came from compaction so the below cleanup/error
         // handling code can process it.
         manual.done = true;
@@ -2542,6 +2559,11 @@ Status DBImpl::RunManualCompaction(
   // true.
   while (!manual.done) {
     assert(HasPendingManualCompaction());
+    if (IsCompactionAborted(cfd) && !scheduled && !manual.in_progress) {
+      manual.done = true;
+      manual.status = Status::Incomplete(Status::SubCode::kCompactionAborted);
+      break;
+    }
     manual_conflict = false;
     Compaction* compaction = nullptr;
     if (ShouldntRunManualCompaction(&manual) || (manual.in_progress == true) ||
@@ -2631,7 +2653,7 @@ Status DBImpl::RunManualCompaction(
     if (!scheduled) {
       // There is nothing scheduled to wait on, so any cancellation can end the
       // manual now.
-      if (compaction_aborted_.load(std::memory_order_acquire) > 0) {
+      if (IsCompactionAborted(cfd)) {
         // Stop waiting since it was canceled. Pretend the error came from
         // compaction so the below cleanup/error handling code can process it.
         manual.done = true;
@@ -3299,6 +3321,52 @@ void DBImpl::EnableManualCompaction() {
   manual_compaction_paused_.fetch_sub(1, std::memory_order_release);
 }
 
+bool DBImpl::IsCompactionAborted(ColumnFamilyData* cfd) const {
+  return compaction_aborted_.load(std::memory_order_acquire) > 0 ||
+         cfd->compaction_aborted() > 0;
+}
+
+bool DBImpl::MustWaitForCompaction(ColumnFamilyData* cfd) {
+  mutex_.AssertHeld();
+  // num_in_flight_compactions_ and the picker's compactions_in_progress_ set
+  // cover DIFFERENT windows and neither subsumes the other:
+  //  - the counter covers a picked Compaction from pick through the end of
+  //    BackgroundCompaction (including NotifyOnCompactionCompleted), which the
+  //    picker set does not -- it is cleared during Install's manifest write.
+  //  - the picker set covers the bottom-priority handoff: when a LOW thread
+  //    forwards a bottom compaction, its EndInFlightCompaction() dips the
+  //    counter to 0 while the compaction is still registered and queued for the
+  //    BOTTOM pool, and the picker set keeps AbortCompactions() waiting across
+  //    that gap. (The re-registered "intended" bottom compaction inherits the
+  //    original compaction_reason(), so it is not filtered out below.)
+  if (cfd->num_in_flight_compactions(&mutex_) > 0) {
+    return true;
+  }
+  for (const auto* compaction :
+       *cfd->compaction_picker()->compactions_in_progress()) {
+    const auto reason = compaction->compaction_reason();
+    // These are picker reservations for conflict tracking, not CompactionJobs,
+    // so they never observe the abort atomic in ProcessKeyValue().
+    if (reason != CompactionReason::kExternalSstIngestion &&
+        reason != CompactionReason::kRefitLevel) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void DBImpl::BeginInFlightCompaction(ColumnFamilyData* cfd) {
+  mutex_.AssertHeld();
+  cfd->Ref();
+  cfd->inc_num_in_flight_compactions(&mutex_);
+}
+
+bool DBImpl::EndInFlightCompaction(ColumnFamilyData* cfd) {
+  mutex_.AssertHeld();
+  cfd->dec_num_in_flight_compactions(&mutex_);
+  return cfd->UnrefAndTryDelete();
+}
+
 void DBImpl::AbortAllCompactions() {
   InstrumentedMutexLock l(&mutex_);
 
@@ -3322,6 +3390,83 @@ void DBImpl::AbortAllCompactions() {
   while (bg_bottom_compaction_scheduled_ > 0 || bg_compaction_scheduled_ > 0 ||
          HasPendingManualCompaction()) {
     bg_cv_.Wait();
+  }
+}
+
+void DBImpl::AbortCompactions(ColumnFamilyHandle* column_family) {
+  InstrumentedMutexLock l(&mutex_);
+  if (shutting_down_.load(std::memory_order_acquire)) {
+    return;
+  }
+
+  assert(column_family != nullptr);
+  auto* cfh = static_cast_with_check<ColumnFamilyHandleImpl>(column_family);
+  assert(cfh->db() == this);
+  auto* cfd = cfh->cfd();
+  assert(cfd != nullptr);
+
+  cfd->inc_compaction_aborted(&mutex_);
+  TEST_SYNC_POINT("DBImpl::AbortCompactions:FlagSet");
+
+  for (const auto* manual_compaction : manual_compaction_dequeue_) {
+    if (manual_compaction->cfd == cfd) {
+      manual_compaction->canceled.store(true, std::memory_order_release);
+    }
+  }
+  bg_cv_.SignalAll();
+
+  // Wait for this CF's running compactions to finish or abort. If the DB
+  // is shutting down, return early -- the counter stays incremented but the
+  // CFD and DB will be torn down anyway. Callers that use SCOPE_EXIT for
+  // the matching ResumeCompactions() are safe: the resume is a no-op on a
+  // DB that is already closed.
+  ++per_cf_compaction_abort_waiters_;
+  while (!shutting_down_.load(std::memory_order_acquire) &&
+         (MustWaitForCompaction(cfd) || HasPendingManualCompaction(cfd))) {
+    TEST_SYNC_POINT("DBImpl::AbortCompactions:Waiting");
+    bg_cv_.Wait();
+  }
+  --per_cf_compaction_abort_waiters_;
+  TEST_SYNC_POINT("DBImpl::AbortCompactions:Complete");
+}
+
+void DBImpl::ResumeCompactions(ColumnFamilyHandle* column_family) {
+  InstrumentedMutexLock l(&mutex_);
+  if (shutting_down_.load(std::memory_order_acquire)) {
+    return;
+  }
+
+  assert(column_family != nullptr);
+  auto* cfh = static_cast_with_check<ColumnFamilyHandleImpl>(column_family);
+  assert(cfh->db() == this);
+  auto* cfd = cfh->cfd();
+  assert(cfd != nullptr);
+
+  const int before = cfd->compaction_aborted();
+  if (before <= 0) {
+    ROCKS_LOG_WARN(immutable_db_options_.info_log,
+                   "ResumeCompactions called without prior AbortCompactions "
+                   "for column family %s (counter=%d)",
+                   cfd->GetName().c_str(), before);
+    return;
+  }
+
+  const int current = cfd->dec_compaction_aborted(&mutex_);
+  ROCKS_LOG_INFO(immutable_db_options_.info_log,
+                 "[%s] ResumeCompactions: counter %d -> %d",
+                 cfd->GetName().c_str(), before, current);
+  if (current == 0) {
+    // TODO: Aborting an automatic compaction after PickCompaction()
+    // releases its inputs without recomputing the compaction score, so this
+    // EnqueuePendingCompaction() can observe a stale sub-trigger score and
+    // queue nothing, leaving the CF idle until the next flush. Pre-existing
+    // (ResumeAllCompactions() has the same gap); fix separately for both APIs
+    // by recomputing the score on the abort path.
+    if (!RestoreParkedCompaction(cfd) && !cfd->IsDropped()) {
+      EnqueuePendingCompaction(cfd);
+    }
+    MaybeScheduleFlushOrCompaction();
+    bg_cv_.SignalAll();
   }
 }
 
@@ -3350,6 +3495,7 @@ void DBImpl::ResumeAllCompactions() {
   // If this is the last resume call (abort counter back to 0), schedule
   // compactions that may have been waiting
   if (current == 0) {
+    // The stale-score TODO in ResumeCompactions() also applies here.
     MaybeScheduleFlushOrCompaction();
   }
 }
@@ -3576,6 +3722,27 @@ void DBImpl::AddToCompactionQueue(ColumnFamilyData* cfd) {
   ++unscheduled_compactions_;
 }
 
+bool DBImpl::RestoreParkedCompaction(ColumnFamilyData* cfd) {
+  mutex_.AssertHeld();
+  auto it = parked_compaction_cfds_.find(cfd);
+  if (it == parked_compaction_cfds_.end()) {
+    return false;
+  }
+
+  parked_compaction_cfds_.erase(it);
+  assert(cfd->queued_for_compaction());
+  if (!cfd->IsDropped() && cfd->NeedsCompaction()) {
+    TEST_SYNC_POINT_CALLBACK("DBImpl::RestoreParkedCompaction:cfd",
+                             static_cast<void*>(cfd));
+    compaction_queue_.push_back(cfd);
+    ++unscheduled_compactions_;
+  } else {
+    cfd->set_queued_for_compaction(false);
+    cfd->UnrefAndTryDelete();
+  }
+  return true;
+}
+
 ColumnFamilyData* DBImpl::PopFirstFromCompactionQueue() {
   assert(!compaction_queue_.empty());
   auto cfd = *compaction_queue_.begin();
@@ -3603,22 +3770,37 @@ DBImpl::FlushRequest DBImpl::PopFirstFromFlushQueue() {
   return flush_req;
 }
 
-ColumnFamilyData* DBImpl::PickCompactionFromQueue(
+DBImpl::CompactionQueuePickResult DBImpl::PickCompactionFromQueue(
     std::unique_ptr<TaskLimiterToken>* token, LogBuffer* log_buffer) {
   assert(!compaction_queue_.empty());
   assert(*token == nullptr);
   autovector<ColumnFamilyData*> throttled_candidates;
-  ColumnFamilyData* cfd = nullptr;
+  CompactionQueuePickResult result = CompactionQueueThrottled{};
   while (!compaction_queue_.empty()) {
     auto first_cfd = *compaction_queue_.begin();
     compaction_queue_.pop_front();
     assert(first_cfd->queued_for_compaction());
+    if (first_cfd->IsDropped()) {
+      first_cfd->set_queued_for_compaction(false);
+      result = CompactionQueuePicked{first_cfd};
+      break;
+    }
+    if (first_cfd->compaction_aborted() > 0) {
+      // Parking consumes this worker's credit. Remaining queue entries retain
+      // their own credits and are scheduled when this worker returns.
+      [[maybe_unused]] const bool inserted =
+          parked_compaction_cfds_.insert(first_cfd).second;
+      assert(inserted);
+      TEST_SYNC_POINT("DBImpl::PickCompactionFromQueue:Parked");
+      result = CompactionQueueParked{};
+      break;
+    }
     if (!RequestCompactionToken(first_cfd, false, token, log_buffer)) {
       throttled_candidates.push_back(first_cfd);
       continue;
     }
-    cfd = first_cfd;
-    cfd->set_queued_for_compaction(false);
+    first_cfd->set_queued_for_compaction(false);
+    result = CompactionQueuePicked{first_cfd};
     break;
   }
   // Add throttled compaction candidates back to queue in the original order.
@@ -3626,7 +3808,7 @@ ColumnFamilyData* DBImpl::PickCompactionFromQueue(
        iter != throttled_candidates.rend(); ++iter) {
     compaction_queue_.push_front(*iter);
   }
-  return cfd;
+  return result;
 }
 
 bool DBImpl::EnqueuePendingFlush(const FlushRequest& flush_req) {
@@ -3673,13 +3855,21 @@ bool DBImpl::EnqueuePendingFlush(const FlushRequest& flush_req) {
 
 void DBImpl::EnqueuePendingCompaction(ColumnFamilyData* cfd) {
   mutex_.AssertHeld();
-  if (reject_new_background_jobs_) {
+  if (reject_new_background_jobs_ || cfd->IsDropped()) {
     return;
   }
   if (!cfd->queued_for_compaction() && cfd->NeedsCompaction()) {
     TEST_SYNC_POINT_CALLBACK("EnqueuePendingCompaction::cfd",
                              static_cast<void*>(cfd));
-    AddToCompactionQueue(cfd);
+    if (cfd->compaction_aborted() > 0) {
+      cfd->Ref();
+      cfd->set_queued_for_compaction(true);
+      [[maybe_unused]] const bool inserted =
+          parked_compaction_cfds_.insert(cfd).second;
+      assert(inserted);
+    } else {
+      AddToCompactionQueue(cfd);
+    }
   }
 }
 
@@ -4139,7 +4329,7 @@ void DBImpl::BackgroundCallCompaction(PrepickedCompaction* prepicked_compaction,
       prepicked_compaction->task_token.reset();
     }
 
-    if (made_progress ||
+    if (made_progress || per_cf_compaction_abort_waiters_ > 0 ||
         (bg_compaction_scheduled_ == 0 &&
          bg_bottom_compaction_scheduled_ == 0) ||
         HasPendingManualCompaction() || unscheduled_compactions_ == 0) {
@@ -4181,7 +4371,29 @@ Status DBImpl::BackgroundCompaction(bool* made_progress,
       prepicked_compaction->compaction != nullptr) {
     c.reset(prepicked_compaction->compaction);
   }
+  // Track this CF as having an in-flight compaction for the duration of this
+  // BackgroundCompaction (which covers NotifyOnCompactionCompleted). The Defer
+  // ends tracking on every return path. BeginInFlightCompaction()'s Ref keeps a
+  // dropped CF alive across any c.reset() until then; if this ends the CF's
+  // last reference, the FindObsoleteFiles() pass in BackgroundCallCompaction
+  // cleans up its files.
+  ColumnFamilyData* in_flight_cfd = nullptr;
+  Defer end_in_flight_compaction([&]() {
+    if (in_flight_cfd != nullptr) {
+      EndInFlightCompaction(in_flight_cfd);
+    }
+  });
+  if (c != nullptr) {
+    in_flight_cfd = c->column_family_data();
+    BeginInFlightCompaction(in_flight_cfd);
+  }
   bool is_prepicked = is_manual || c;
+  ColumnFamilyData* prepicked_cfd = nullptr;
+  if (c) {
+    prepicked_cfd = c->column_family_data();
+  } else if (manual_compaction != nullptr) {
+    prepicked_cfd = manual_compaction->cfd;
+  }
 
   // (manual_compaction->in_progress == false);
   bool trivial_move_disallowed =
@@ -4209,6 +4421,9 @@ Status DBImpl::BackgroundCompaction(bool* made_progress,
         // can schedule the still-queued work.
         unscheduled_compactions_++;
       }
+    } else if (prepicked_cfd != nullptr &&
+               prepicked_cfd->compaction_aborted() > 0) {
+      status = Status::Incomplete(Status::SubCode::kCompactionAborted);
     } else if (is_manual &&
                manual_compaction->canceled.load(std::memory_order_acquire)) {
       status = Status::Incomplete(Status::SubCode::kManualCompactionPaused);
@@ -4313,13 +4528,18 @@ Status DBImpl::BackgroundCompaction(bool* made_progress,
     ColumnFamilyData* cfd = nullptr;
 
     if (!need_repick) {
-      cfd = PickCompactionFromQueue(&task_token, log_buffer);
-      if (cfd == nullptr) {
+      auto pick_result = PickCompactionFromQueue(&task_token, log_buffer);
+      if (std::holds_alternative<CompactionQueueThrottled>(pick_result)) {
         // Can't find any executable task from the compaction queue.
         // All tasks have been throttled by compaction thread limiter.
         ++unscheduled_compactions_;
         return Status::Busy();
       }
+      if (std::holds_alternative<CompactionQueueParked>(pick_result)) {
+        return Status::Incomplete(Status::SubCode::kCompactionAborted);
+      }
+      cfd = std::get<CompactionQueuePicked>(pick_result).cfd;
+      assert(cfd != nullptr);
 
       // We unreference here because the following code will take a Ref() on
       // this cfd if it is going to use it (Compaction class holds a
@@ -4360,6 +4580,10 @@ Status DBImpl::BackgroundCompaction(bool* made_progress,
           mutable_cf_options, mutable_db_options_, job_context->snapshot_seqs,
           job_context->snapshot_checker, log_buffer,
           thread_pri == Env::Priority::BOTTOM /* require_max_output_level */));
+      if (c != nullptr && in_flight_cfd == nullptr) {
+        in_flight_cfd = cfd;
+        BeginInFlightCompaction(in_flight_cfd);
+      }
       if (thread_pri == Env::Priority::LOW) {
         TEST_SYNC_POINT("DBImpl::BackgroundCompaction():AfterPickCompaction");
       } else if (thread_pri == Env::Priority::BOTTOM) {
@@ -5082,6 +5306,14 @@ bool DBImpl::HasPendingManualCompaction() {
   return (!manual_compaction_dequeue_.empty());
 }
 
+bool DBImpl::HasPendingManualCompaction(ColumnFamilyData* cfd) {
+  return std::any_of(manual_compaction_dequeue_.begin(),
+                     manual_compaction_dequeue_.end(),
+                     [cfd](const ManualCompactionState* manual) {
+                       return manual->cfd == cfd;
+                     });
+}
+
 void DBImpl::AddManualCompaction(DBImpl::ManualCompactionState* m) {
   assert(manual_compaction_paused_ == 0);
   manual_compaction_dequeue_.push_back(m);
@@ -5432,6 +5664,7 @@ Status DBImpl::WaitForCompact(
     }
     if ((bg_bottom_compaction_scheduled_ || bg_compaction_scheduled_ ||
          bg_flush_scheduled_ || unscheduled_compactions_ ||
+         !parked_compaction_cfds_.empty() ||
          (wait_for_compact_options.wait_for_purge && bg_purge_scheduled_) ||
          unscheduled_flushes_ || error_handler_.IsRecoveryInProgress()) &&
         (error_handler_.GetBGError().ok())) {

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -3725,6 +3725,8 @@ class ModelDB : public DB {
   void DisableManualCompaction() override {}
   void AbortAllCompactions() override {}
   void ResumeAllCompactions() override {}
+  void AbortCompactions(ColumnFamilyHandle* /*column_family*/) override {}
+  void ResumeCompactions(ColumnFamilyHandle* /*column_family*/) override {}
 
   Status WaitForCompact(
       const WaitForCompactOptions& /* wait_for_compact_options */) override {

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -247,6 +247,7 @@ DECLARE_int32(pause_background_one_in);
 DECLARE_int32(disable_file_deletions_one_in);
 DECLARE_int32(disable_manual_compaction_one_in);
 DECLARE_int32(abort_and_resume_compactions_one_in);
+DECLARE_int32(abort_and_resume_cf_compactions_one_in);
 DECLARE_int32(compact_range_width);
 DECLARE_int32(acquire_snapshot_one_in);
 DECLARE_bool(compare_full_db_state_snapshot);

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -950,6 +950,11 @@ DEFINE_int32(abort_and_resume_compactions_one_in, 0,
              "If non-zero, then AbortAllCompactions()+Resume will be called "
              "once for every N ops on average. 0 disables.");
 
+DEFINE_int32(abort_and_resume_cf_compactions_one_in, 0,
+             "If non-zero, then AbortCompactions(cf)+ResumeCompactions(cf) "
+             "will be called on a random column family once for every N ops "
+             "on average. 0 disables.");
+
 DEFINE_int32(compact_range_width, 10000,
              "The width of the ranges passed to CompactRange().");
 

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -1848,6 +1848,11 @@ void StressTest::OperateDb(ThreadState* thread) {
         ProcessStatus(shared, "TestAbortAndResumeCompactions", status);
       }
 
+      if (thread->rand.OneInOpt(FLAGS_abort_and_resume_cf_compactions_one_in)) {
+        Status status = TestAbortAndResumeCfCompactions(thread);
+        ProcessStatus(shared, "TestAbortAndResumeCfCompactions", status);
+      }
+
       if (thread->rand.OneInOpt(FLAGS_verify_checksum_one_in)) {
         ThreadStatusUtil::SetEnableTracking(FLAGS_enable_thread_tracking);
         ThreadStatusUtil::SetThreadOperation(
@@ -4001,6 +4006,17 @@ Status StressTest::TestAbortAndResumeCompactions(ThreadState* thread) {
   clock_->SleepForMicroseconds(1 << pwr2_micros);
   // Resume compactions
   db_->ResumeAllCompactions();
+  return Status::OK();
+}
+
+Status StressTest::TestAbortAndResumeCfCompactions(ThreadState* thread) {
+  int rand_cf = thread->rand.Uniform(static_cast<int>(column_families_.size()));
+  auto* cfh = column_families_[rand_cf];
+  db_->AbortCompactions(cfh);
+  int pwr2_micros =
+      std::min(thread->rand.Uniform(25), thread->rand.Uniform(25));
+  clock_->SleepForMicroseconds(1 << pwr2_micros);
+  db_->ResumeCompactions(cfh);
   return Status::OK();
 }
 

--- a/db_stress_tool/db_stress_test_base.h
+++ b/db_stress_tool/db_stress_test_base.h
@@ -408,6 +408,8 @@ class StressTest {
 
   Status TestAbortAndResumeCompactions(ThreadState* thread);
 
+  Status TestAbortAndResumeCfCompactions(ThreadState* thread);
+
   void TestAcquireSnapshot(ThreadState* thread, int rand_column_family,
                            const std::string& keystr, uint64_t i);
 

--- a/db_stress_tool/db_stress_tool.cc
+++ b/db_stress_tool/db_stress_tool.cc
@@ -357,6 +357,13 @@ int db_stress_tool(int argc, char** argv) {
     return ReturnValidationError(
         "clear_column_family_one_in must be 0 when using backup");
   }
+  if (FLAGS_clear_column_family_one_in > 0 &&
+      FLAGS_abort_and_resume_cf_compactions_one_in > 0) {
+    fprintf(stderr,
+            "Error: clear_column_family_one_in must be 0 when using "
+            "per-column-family compaction abort\n");
+    exit(1);  // NOLINT(concurrency-mt-unsafe)
+  }
   if (FLAGS_test_cf_consistency && FLAGS_disable_wal) {
     FLAGS_atomic_flush = true;
   }

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1895,9 +1895,50 @@ class DB {
   // ResumeAllCompactions().
   virtual void ResumeAllCompactions() = 0;
 
+  // Abort compaction work for `column_family`. Running compactions for the
+  // column family are signaled to abort, and new compactions for it are
+  // rejected until ResumeCompactions() is called. Compactions for other column
+  // families are unaffected. This function blocks until the column family's
+  // running compactions complete or abort, or DB shutdown begins.
+  // Unless DB shutdown has begun, `column_family` must be a live handle owned
+  // by this DB.
+  //
+  // This is the per-column-family counterpart to AbortAllCompactions(). The
+  // global and per-column-family abort counts compose: compaction resumes for
+  // this column family only after matching ResumeAllCompactions() and
+  // ResumeCompactions() calls clear both. Unlike DisableManualCompaction(),
+  // this aborts automatic and manual compactions for the column family. Unlike
+  // PauseBackgroundWork(), it does not pause flushes or work for other column
+  // families.
+  //
+  // Calls are reference counted independently for each column family. The
+  // caller must retain the live handle through all matching
+  // ResumeCompactions() calls while the DB is live, even if the column family
+  // is dropped in the meantime. Flushes and external-ingestion reservations
+  // are unaffected. An already-running level refit is neither signaled nor
+  // waited on; new CompactRange() calls are rejected at entry. Remote
+  // compaction-service work is not actively aborted.
+  // If DB shutdown has begun, this is a no-op and does not inspect
+  // `column_family`.
+  virtual void AbortCompactions(ColumnFamilyHandle* column_family) = 0;
+
+  // Resume compactions for `column_family`. This must be called as many times
+  // as AbortCompactions() for the same column family before work is
+  // rescheduled. While the DB is live, `column_family` must be the live handle
+  // passed to AbortCompactions(). Extra calls log a warning and otherwise have
+  // no effect.
+  // If DB shutdown has begun, this is a no-op and does not inspect
+  // `column_family`.
+  virtual void ResumeCompactions(ColumnFamilyHandle* column_family) = 0;
+
   // Wait for all flush and compactions jobs to finish. Jobs to wait include the
   // unscheduled (queued, but not scheduled yet). If the db is shutting down,
   // Status::ShutdownInProgress will be returned.
+  //
+  // Compaction work parked by AbortCompactions() remains pending. Without a
+  // timeout, this function will not return until matching ResumeCompactions()
+  // calls restore that work and it finishes, the column family is dropped, or
+  // the DB starts shutting down.
   //
   // NOTE: This may also never return if there's sufficient ongoing writes that
   // keeps flush and compaction going without stopping. The user would have to

--- a/include/rocksdb/listener.h
+++ b/include/rocksdb/listener.h
@@ -493,7 +493,8 @@ struct CompactionJobInfo {
   // BlobDB.
   std::vector<BlobFileGarbageInfo> blob_file_garbage_infos;
 
-  // Whether this compaction was aborted via AbortAllCompactions()
+  // Whether this compaction was aborted via AbortAllCompactions() or
+  // AbortCompactions().
   bool aborted = false;
 };
 

--- a/include/rocksdb/statistics.h
+++ b/include/rocksdb/statistics.h
@@ -162,7 +162,8 @@ enum Tickers : uint32_t {
   COMPACTION_OPTIMIZED_DEL_DROP_OBSOLETE,
   // If a compaction was canceled in sfm to prevent ENOSPC
   COMPACTION_CANCELLED,
-  // Number of compactions aborted via AbortAllCompactions()
+  // Number of compactions aborted via AbortAllCompactions() or
+  // AbortCompactions().
   COMPACTION_ABORTED,
 
   // Number of keys written to the database via the Put and Write call's

--- a/include/rocksdb/status.h
+++ b/include/rocksdb/status.h
@@ -493,8 +493,8 @@ class Status {
     return (code() == kIncomplete) && (subcode() == kManualCompactionPaused);
   }
 
-  // Returns true iff the status indicates compaction aborted. This
-  // is caused by a call to AbortAllCompactions
+  // Returns true iff the status indicates compaction aborted by
+  // AbortAllCompactions() or AbortCompactions().
   bool IsCompactionAborted() const {
     MarkChecked();
     return (code() == kIncomplete) && (subcode() == kCompactionAborted);

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -394,6 +394,12 @@ class StackableDB : public DB {
   }
   void AbortAllCompactions() override { return db_->AbortAllCompactions(); }
   void ResumeAllCompactions() override { return db_->ResumeAllCompactions(); }
+  void AbortCompactions(ColumnFamilyHandle* column_family) override {
+    return db_->AbortCompactions(column_family);
+  }
+  void ResumeCompactions(ColumnFamilyHandle* column_family) override {
+    return db_->ResumeCompactions(column_family);
+  }
 
   Status WaitForCompact(
       const WaitForCompactOptions& wait_for_compact_options) override {

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -254,6 +254,7 @@ default_params = {
     "disable_file_deletions_one_in": lambda: random.choice([10000, 1000000]),
     "disable_manual_compaction_one_in": lambda: random.choice([10000, 1000000]),
     "abort_and_resume_compactions_one_in": lambda: random.choice([10000, 1000000]),
+    "abort_and_resume_cf_compactions_one_in": lambda: random.choice([10000, 1000000]),
     "prefix_size": lambda: random.choice([-1, 1, 5, 7, 8]),
     "prefixpercent": 5,
     "progress_reports": 0,

--- a/unreleased_history/new_features/per_cf_compaction_abort.md
+++ b/unreleased_history/new_features/per_cf_compaction_abort.md
@@ -1,0 +1,1 @@
+Added `DB::AbortCompactions()` and `DB::ResumeCompactions()` for per-column-family compaction abort and resume, with the same active-abort semantics as the DB-wide `AbortAllCompactions()`/`ResumeAllCompactions()` but scoped to a single column family. Calls are reference-counted independently per column family and compose with the DB-wide abort.


### PR DESCRIPTION
Summary:
**What**: Add reference-counted `DB::AbortCompactions(cf)` / `DB::ResumeCompactions(cf)` to abort and resume compactions for a single column family without stopping unrelated column families. They compose with the DB-wide `AbortAllCompactions()` / `ResumeAllCompactions()` and are no-ops once DB shutdown has begun.

**How**:
- **Per-CF abort flag.** `ColumnFamilyData` gains `compaction_aborted_`, wrapped in `CacheAlignedWrapper` so the lock-free reads done by compaction workers do not false-share with the DB-mutex-written fields packed around it. A new `IsCompactionAborted(cfd)` helper checks it alongside the DB-wide counter at every entry point (`CompactRange()`, `RunManualCompaction()`, `CompactFilesImpl()`), and `CompactionJob::ProcessKeyValue()` checks both on entry and in its periodic cron check.
- **Parking.** Automatic work for an aborted CF is preserved rather than dropped. `PickCompactionFromQueue()` now returns `std::variant<CompactionQueuePicked, CompactionQueueThrottled, CompactionQueueParked>` and moves an aborted CF into `parked_compaction_cfds_` only once it reaches the front of the queue, so CFs behind it keep their place and the scheduler credit is not restored (which would cause a hot re-pick loop). `EnqueuePendingCompaction()` parks newly needed work for an aborted CF and now early-returns for dropped CFs. `RestoreParkedCompaction()` re-enqueues on the final resume; a CF dropped while parked is handled in `DropColumnFamily()`, and one dropped before its aborted queue entry is reached is handled by a fast path in `PickCompactionFromQueue()`.
- **Knowing when it is safe to return.** `ColumnFamilyData::num_in_flight_compactions_` counts actually-picked work, and `Defer` balances `BeginInFlightCompaction()` / `EndInFlightCompaction()` on every `BackgroundCompaction()` and `CompactFiles()` exit path. That covers the `NotifyOnCompactionCompleted()` window that `CompactionPicker::compactions_in_progress_` does not, since the picker set is cleared during `Install`'s manifest write. `MustWaitForCompaction()` combines the counter with the picker set (filtered to skip `kExternalSstIngestion` / `kRefitLevel` reservations, which are not real jobs) because only the picker set covers the LOW-to-BOTTOM priority handoff, where the counter briefly dips to 0.
- **Waking the waiter.** `AbortCompactions()` cancels matching `manual_compaction_dequeue_` entries and then waits on `bg_cv_`; `per_cf_compaction_abort_waiters_` forces the compaction completion paths to signal, because the picker's `UnregisterCompaction()` does not. `CloseHelper()` drains `parked_compaction_cfds_` and releases their references.
- **API surface.** The two methods are new pure virtuals on `DB`, so `StackableDB` forwards them and the `db_test.cc` DB wrapper stubs them. `db.h` documents how the per-CF API composes with DB-wide abort, `DisableManualCompaction()`, `PauseBackgroundWork()`, shutdown, ingestion reservations, level refit and remote compaction, plus the parked-work caveat on `WaitForCompact()`. Comments in `listener.h`, `statistics.h` and `status.h` now name both abort APIs.
- **Coverage.** 10 new cases in `db_compaction_abort_test.cc` (CF scoping, counter composition, parked-work restore, CF drop both while parked and before parking, trivial-move rejection, waiting for the completion callback, post-close no-op). `db_stress` gains `abort_and_resume_cf_compactions_one_in` and `TestAbortAndResumeCfCompactions()`, rejected in combination with `clear_column_family_one_in` because that would drop the column family out from under an active abort. Also a `db_crashtest.py` knob and one `new_features` release note.
- **Known gap.** A `TODO` records the pre-existing post-pick stale compaction-score problem: aborting after `PickCompaction()` releases the inputs without recomputing the score, so the resume can observe a stale sub-trigger score and re-enqueue nothing. `ResumeAllCompactions()` has the same gap and carries a pointer to the same TODO; fixing it is left to a separate change covering both APIs.

**Why**: Atomic-replace bulk loads only conflict with their target column family, but the DB-wide abort suppresses compaction for every column family colocated in the same RocksDB instance. Scoping the abort keeps unrelated column families compacting for the duration of a bulk load.

Reviewed By: pdillinger

Differential Revision: D113103899


