### PR TITLE
c: add reusable pinnable slices for point lookups

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -13256,14 +13256,9 @@ void rocksdb_free(void* ptr) { free(ptr); }
 rocksdb_pinnableslice_t* rocksdb_get_pinned(
     rocksdb_t* db, const rocksdb_readoptions_t* options, const char* key,
     size_t keylen, char** errptr) {
-  rocksdb_pinnableslice_t* v = new (rocksdb_pinnableslice_t);
-  Status s = db->rep->Get(options->rep, db->rep->DefaultColumnFamily(),
-                          Slice(key, keylen), &v->rep);
-  if (!s.ok()) {
-    delete (v);
-    if (!s.IsNotFound()) {
-      SaveError(errptr, s);
-    }
+  rocksdb_pinnableslice_t* v = rocksdb_pinnableslice_create();
+  if (!rocksdb_get_pinned_into(db, options, key, keylen, v, errptr)) {
+    rocksdb_pinnableslice_destroy(v);
     return nullptr;
   }
   return v;
@@ -13273,18 +13268,55 @@ rocksdb_pinnableslice_t* rocksdb_get_pinned_cf(
     rocksdb_t* db, const rocksdb_readoptions_t* options,
     rocksdb_column_family_handle_t* column_family, const char* key,
     size_t keylen, char** errptr) {
-  rocksdb_pinnableslice_t* v = new (rocksdb_pinnableslice_t);
-  Status s = db->rep->Get(options->rep, column_family->rep, Slice(key, keylen),
-                          &v->rep);
-  if (!s.ok()) {
-    delete v;
-    if (!s.IsNotFound()) {
-      SaveError(errptr, s);
-    }
+  rocksdb_pinnableslice_t* v = rocksdb_pinnableslice_create();
+  if (!rocksdb_get_pinned_cf_into(db, options, column_family, key, keylen, v,
+                                  errptr)) {
+    rocksdb_pinnableslice_destroy(v);
     return nullptr;
   }
   return v;
 }
+
+unsigned char rocksdb_get_pinned_into(rocksdb_t* db,
+                                      const rocksdb_readoptions_t* options,
+                                      const char* key, size_t keylen,
+                                      rocksdb_pinnableslice_t* value,
+                                      char** errptr) {
+  value->rep.Reset();
+  Status s = db->rep->Get(options->rep, db->rep->DefaultColumnFamily(),
+                          Slice(key, keylen), &value->rep);
+  if (s.ok()) {
+    return 1;
+  }
+  value->rep.Reset();
+  if (!s.IsNotFound()) {
+    SaveError(errptr, s);
+  }
+  return 0;
+}
+
+unsigned char rocksdb_get_pinned_cf_into(
+    rocksdb_t* db, const rocksdb_readoptions_t* options,
+    rocksdb_column_family_handle_t* column_family, const char* key,
+    size_t keylen, rocksdb_pinnableslice_t* value, char** errptr) {
+  value->rep.Reset();
+  Status s = db->rep->Get(options->rep, column_family->rep, Slice(key, keylen),
+                          &value->rep);
+  if (s.ok()) {
+    return 1;
+  }
+  value->rep.Reset();
+  if (!s.IsNotFound()) {
+    SaveError(errptr, s);
+  }
+  return 0;
+}
+
+rocksdb_pinnableslice_t* rocksdb_pinnableslice_create() {
+  return new rocksdb_pinnableslice_t;
+}
+
+void rocksdb_pinnableslice_reset(rocksdb_pinnableslice_t* v) { v->rep.Reset(); }
 
 void rocksdb_pinnableslice_destroy(rocksdb_pinnableslice_t* v) { delete v; }
 

--- a/db/c_test.c
+++ b/db/c_test.c
@@ -2251,6 +2251,54 @@ int main(int argc, char** argv) {
     CheckPinGet(db, roptions, "notfound", NULL);
   }
 
+  StartPhase("pin_get_reuse");
+  {
+    rocksdb_pinnableslice_t* p = rocksdb_pinnableslice_create();
+    size_t val_len;
+    const char* val;
+    unsigned char found;
+
+    found = rocksdb_get_pinned_into(db, roptions, "box", 3, p, &err);
+    CheckNoError(err);
+    CheckCondition(found);
+    val = rocksdb_pinnableslice_value(p, &val_len);
+    CheckEqual("c", val, val_len);
+
+    found = rocksdb_get_pinned_into(db, roptions, "foo", 3, p, &err);
+    CheckNoError(err);
+    CheckCondition(found);
+    val = rocksdb_pinnableslice_value(p, &val_len);
+    CheckEqual("hello", val, val_len);
+
+    found = rocksdb_get_pinned_into(db, roptions, "notfound", 8, p, &err);
+    CheckNoError(err);
+    CheckCondition(!found);
+    rocksdb_pinnableslice_value(p, &val_len);
+    CheckCondition(val_len == 0);
+
+    rocksdb_pinnableslice_destroy(p);
+  }
+
+  StartPhase("pin_reset");
+  {
+    rocksdb_pinnableslice_t* p = rocksdb_pinnableslice_create();
+    size_t val_len;
+    const char* val;
+    unsigned char found;
+
+    found = rocksdb_get_pinned_into(db, roptions, "box", 3, p, &err);
+    CheckNoError(err);
+    CheckCondition(found);
+    val = rocksdb_pinnableslice_value(p, &val_len);
+    CheckEqual("c", val, val_len);
+
+    rocksdb_pinnableslice_reset(p);
+    rocksdb_pinnableslice_value(p, &val_len);
+    CheckCondition(val_len == 0);
+
+    rocksdb_pinnableslice_destroy(p);
+  }
+
   StartPhase("approximate_sizes");
   {
     int i;

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -4555,8 +4555,25 @@ extern ROCKSDB_LIBRARY_API rocksdb_pinnableslice_t* rocksdb_get_pinned_cf(
     rocksdb_t* db, const rocksdb_readoptions_t* options,
     rocksdb_column_family_handle_t* column_family, const char* key,
     size_t keylen, char** errptr);
+/* Stores the value in a caller-owned pinnable slice.
+   Returns 1 if the key was found and 0 on not found or error. Check errptr to
+   distinguish. The slice is empty on return 0. Reusing the slice retains
+   capacity allocated for copied values. */
+extern ROCKSDB_LIBRARY_API unsigned char rocksdb_get_pinned_into(
+    rocksdb_t* db, const rocksdb_readoptions_t* options, const char* key,
+    size_t keylen, rocksdb_pinnableslice_t* value, char** errptr);
+extern ROCKSDB_LIBRARY_API unsigned char rocksdb_get_pinned_cf_into(
+    rocksdb_t* db, const rocksdb_readoptions_t* options,
+    rocksdb_column_family_handle_t* column_family, const char* key,
+    size_t keylen, rocksdb_pinnableslice_t* value, char** errptr);
+extern ROCKSDB_LIBRARY_API rocksdb_pinnableslice_t*
+rocksdb_pinnableslice_create(void);
+extern ROCKSDB_LIBRARY_API void rocksdb_pinnableslice_reset(
+    rocksdb_pinnableslice_t* v);
 extern ROCKSDB_LIBRARY_API void rocksdb_pinnableslice_destroy(
     rocksdb_pinnableslice_t* v);
+/* Returns the data pointer and size from a pinnable slice.
+   The data remains valid until the slice is reset, reused, or destroyed. */
 extern ROCKSDB_LIBRARY_API const char* rocksdb_pinnableslice_value(
     const rocksdb_pinnableslice_t* t, size_t* vlen);
 

--- a/tools/c_api_gen/c_base.cc
+++ b/tools/c_api_gen/c_base.cc
@@ -8378,14 +8378,9 @@ void rocksdb_free(void* ptr) { free(ptr); }
 rocksdb_pinnableslice_t* rocksdb_get_pinned(
     rocksdb_t* db, const rocksdb_readoptions_t* options, const char* key,
     size_t keylen, char** errptr) {
-  rocksdb_pinnableslice_t* v = new (rocksdb_pinnableslice_t);
-  Status s = db->rep->Get(options->rep, db->rep->DefaultColumnFamily(),
-                          Slice(key, keylen), &v->rep);
-  if (!s.ok()) {
-    delete (v);
-    if (!s.IsNotFound()) {
-      SaveError(errptr, s);
-    }
+  rocksdb_pinnableslice_t* v = rocksdb_pinnableslice_create();
+  if (!rocksdb_get_pinned_into(db, options, key, keylen, v, errptr)) {
+    rocksdb_pinnableslice_destroy(v);
     return nullptr;
   }
   return v;
@@ -8395,18 +8390,55 @@ rocksdb_pinnableslice_t* rocksdb_get_pinned_cf(
     rocksdb_t* db, const rocksdb_readoptions_t* options,
     rocksdb_column_family_handle_t* column_family, const char* key,
     size_t keylen, char** errptr) {
-  rocksdb_pinnableslice_t* v = new (rocksdb_pinnableslice_t);
-  Status s = db->rep->Get(options->rep, column_family->rep, Slice(key, keylen),
-                          &v->rep);
-  if (!s.ok()) {
-    delete v;
-    if (!s.IsNotFound()) {
-      SaveError(errptr, s);
-    }
+  rocksdb_pinnableslice_t* v = rocksdb_pinnableslice_create();
+  if (!rocksdb_get_pinned_cf_into(db, options, column_family, key, keylen, v,
+                                  errptr)) {
+    rocksdb_pinnableslice_destroy(v);
     return nullptr;
   }
   return v;
 }
+
+unsigned char rocksdb_get_pinned_into(rocksdb_t* db,
+                                      const rocksdb_readoptions_t* options,
+                                      const char* key, size_t keylen,
+                                      rocksdb_pinnableslice_t* value,
+                                      char** errptr) {
+  value->rep.Reset();
+  Status s = db->rep->Get(options->rep, db->rep->DefaultColumnFamily(),
+                          Slice(key, keylen), &value->rep);
+  if (s.ok()) {
+    return 1;
+  }
+  value->rep.Reset();
+  if (!s.IsNotFound()) {
+    SaveError(errptr, s);
+  }
+  return 0;
+}
+
+unsigned char rocksdb_get_pinned_cf_into(
+    rocksdb_t* db, const rocksdb_readoptions_t* options,
+    rocksdb_column_family_handle_t* column_family, const char* key,
+    size_t keylen, rocksdb_pinnableslice_t* value, char** errptr) {
+  value->rep.Reset();
+  Status s = db->rep->Get(options->rep, column_family->rep, Slice(key, keylen),
+                          &value->rep);
+  if (s.ok()) {
+    return 1;
+  }
+  value->rep.Reset();
+  if (!s.IsNotFound()) {
+    SaveError(errptr, s);
+  }
+  return 0;
+}
+
+rocksdb_pinnableslice_t* rocksdb_pinnableslice_create() {
+  return new rocksdb_pinnableslice_t;
+}
+
+void rocksdb_pinnableslice_reset(rocksdb_pinnableslice_t* v) { v->rep.Reset(); }
 
 void rocksdb_pinnableslice_destroy(rocksdb_pinnableslice_t* v) { delete v; }
 

--- a/tools/c_api_gen/c_base.h
+++ b/tools/c_api_gen/c_base.h
@@ -3455,8 +3455,25 @@ extern ROCKSDB_LIBRARY_API rocksdb_pinnableslice_t* rocksdb_get_pinned_cf(
     rocksdb_t* db, const rocksdb_readoptions_t* options,
     rocksdb_column_family_handle_t* column_family, const char* key,
     size_t keylen, char** errptr);
+/* Stores the value in a caller-owned pinnable slice.
+   Returns 1 if the key was found and 0 on not found or error. Check errptr to
+   distinguish. The slice is empty on return 0. Reusing the slice retains
+   capacity allocated for copied values. */
+extern ROCKSDB_LIBRARY_API unsigned char rocksdb_get_pinned_into(
+    rocksdb_t* db, const rocksdb_readoptions_t* options, const char* key,
+    size_t keylen, rocksdb_pinnableslice_t* value, char** errptr);
+extern ROCKSDB_LIBRARY_API unsigned char rocksdb_get_pinned_cf_into(
+    rocksdb_t* db, const rocksdb_readoptions_t* options,
+    rocksdb_column_family_handle_t* column_family, const char* key,
+    size_t keylen, rocksdb_pinnableslice_t* value, char** errptr);
+extern ROCKSDB_LIBRARY_API rocksdb_pinnableslice_t*
+rocksdb_pinnableslice_create(void);
+extern ROCKSDB_LIBRARY_API void rocksdb_pinnableslice_reset(
+    rocksdb_pinnableslice_t* v);
 extern ROCKSDB_LIBRARY_API void rocksdb_pinnableslice_destroy(
     rocksdb_pinnableslice_t* v);
+/* Returns the data pointer and size from a pinnable slice.
+   The data remains valid until the slice is reset, reused, or destroyed. */
 extern ROCKSDB_LIBRARY_API const char* rocksdb_pinnableslice_value(
     const rocksdb_pinnableslice_t* t, size_t* vlen);
 

--- a/unreleased_history/public_api_changes/c_api_reusable_pinnable_slice.md
+++ b/unreleased_history/public_api_changes/c_api_reusable_pinnable_slice.md
@@ -1,0 +1,1 @@
+Added `rocksdb_pinnableslice_create()`, `rocksdb_pinnableslice_reset()`, `rocksdb_get_pinned_into()`, and `rocksdb_get_pinned_cf_into()` to the C API, allowing callers to reuse pinnable slices across point lookups and reduce allocations.


### PR DESCRIPTION
Add rocksdb_pinnableslice_create(), rocksdb_pinnableslice_reset(), rocksdb_get_pinned_into(), and rocksdb_get_pinned_cf_into().

These APIs let callers reuse slice capacity and avoid allocating a new slice for each lookup.