### PR TITLE
Add OpenAndCompact DB open latency histogram (#14986)

### DIFF
--- a/db/db_impl/db_impl_secondary.cc
+++ b/db/db_impl/db_impl_secondary.cc
@@ -1596,9 +1596,13 @@ Status DB::OpenAndCompact(
   //    needs LSM state from MANIFEST, not memtable data from WAL replay)
   std::unique_ptr<DB> db;
   std::vector<ColumnFamilyHandle*> handles;
+  const uint64_t db_open_start_micros = db_options.env->NowMicros();
   s = DBImplSecondary::OpenAsSecondaryImpl(db_options, name, output_directory,
                                            column_families, &handles, &db,
                                            /*recover_wal=*/false);
+  RecordTimeToHistogram(db_options.statistics.get(),
+                        OPEN_AND_COMPACT_DB_OPEN_MICROS,
+                        db_options.env->NowMicros() - db_open_start_micros);
   if (!s.ok()) {
     return s;
   }

--- a/include/rocksdb/statistics.h
+++ b/include/rocksdb/statistics.h
@@ -825,6 +825,9 @@ enum Histograms : uint32_t {
   // Distribution of total memtable memory usage for WBM-triggered flushes.
   FLUSH_WRITE_BUFFER_MANAGER_MEMTABLE_MEMORY_BYTES,
 
+  // Time spent opening the secondary DB inside DB::OpenAndCompact().
+  OPEN_AND_COMPACT_DB_OPEN_MICROS,
+
   HISTOGRAM_ENUM_MAX
 };
 

--- a/java/rocksjni/portal.h
+++ b/java/rocksjni/portal.h
@@ -6084,6 +6084,8 @@ class HistogramTypeJni {
       case ROCKSDB_NAMESPACE::Histograms::
           FLUSH_WRITE_BUFFER_MANAGER_MEMTABLE_MEMORY_BYTES:
         return 0x4A;
+      case ROCKSDB_NAMESPACE::Histograms::OPEN_AND_COMPACT_DB_OPEN_MICROS:
+        return 0x4B;
       case ROCKSDB_NAMESPACE::Histograms::HISTOGRAM_ENUM_MAX:
         // 0x3E is reserved for backwards compatibility on current minor
         // version.
@@ -6255,6 +6257,8 @@ class HistogramTypeJni {
       case 0x4A:
         return ROCKSDB_NAMESPACE::Histograms::
             FLUSH_WRITE_BUFFER_MANAGER_MEMTABLE_MEMORY_BYTES;
+      case 0x4B:
+        return ROCKSDB_NAMESPACE::Histograms::OPEN_AND_COMPACT_DB_OPEN_MICROS;
       case 0x3E:
         // 0x3E is reserved for backwards compatibility on current minor
         // version.

--- a/java/src/main/java/org/rocksdb/HistogramType.java
+++ b/java/src/main/java/org/rocksdb/HistogramType.java
@@ -271,6 +271,11 @@ public enum HistogramType {
    */
   FLUSH_WRITE_BUFFER_MANAGER_MEMTABLE_MEMORY_BYTES((byte) 0x4A),
 
+  /**
+   * Time spent opening the secondary DB inside DB::OpenAndCompact().
+   */
+  OPEN_AND_COMPACT_DB_OPEN_MICROS((byte) 0x4B),
+
   // 0x3E is reserved for backwards compatibility on current minor version.
   HISTOGRAM_ENUM_MAX((byte) 0x3E);
 

--- a/monitoring/statistics.cc
+++ b/monitoring/statistics.cc
@@ -423,6 +423,8 @@ const std::vector<std::pair<Histograms, std::string>> HistogramsNameMap = {
      "rocksdb.flush.write_buffer_full.memtable.memory.bytes"},
     {FLUSH_WRITE_BUFFER_MANAGER_MEMTABLE_MEMORY_BYTES,
      "rocksdb.flush.write_buffer_manager.memtable.memory.bytes"},
+    {OPEN_AND_COMPACT_DB_OPEN_MICROS,
+     "rocksdb.open.and.compact.db.open.micros"},
 };
 
 std::shared_ptr<Statistics> CreateDBStatistics() {


### PR DESCRIPTION
Summary:

Why: We want to measure the DB open time during offloaded compactions.

What: Add a histogram for the DB open time in `DB::OpenAndCompact()`.

Differential Revision: D113136652


