### PR TITLE
Add batch-owned pinned MultiGet C API

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -14,6 +14,7 @@
 
 #include <cstdlib>
 #include <iterator>
+#include <limits>
 #include <map>
 #include <memory>
 #include <unordered_set>
@@ -593,6 +594,63 @@ struct rocksdb_perfcontext_t {
 };
 struct rocksdb_pinnableslice_t {
   PinnableSlice rep;
+};
+struct rocksdb_pinnable_multi_get_t {
+  static constexpr size_t kNotFound = std::numeric_limits<size_t>::max();
+
+  explicit rocksdb_pinnable_multi_get_t(size_t result_count)
+      : result_indexes(result_count, kNotFound) {}
+
+  void ReservePayloads(const std::vector<Status>& statuses) {
+    size_t value_count = 0;
+    size_t error_count = 0;
+    for (const Status& status : statuses) {
+      value_count += status.ok();
+      error_count += !status.ok() && !status.IsNotFound();
+    }
+    values.reserve(value_count);
+    errors.reserve(error_count);
+  }
+
+  void StoreResults(std::vector<PinnableSlice>* multi_get_values,
+                    const std::vector<Status>& statuses) {
+    ReservePayloads(statuses);
+    for (size_t i = 0; i < statuses.size(); ++i) {
+      if (statuses[i].ok()) {
+        result_indexes[i] = values.size();
+        values.emplace_back(std::move((*multi_get_values)[i]));
+      } else if (!statuses[i].IsNotFound()) {
+        result_indexes[i] = kNotFound - errors.size() - 1;
+        errors.emplace_back(statuses[i].ToString());
+      }
+    }
+  }
+
+  int GetResult(size_t index, const char** value, size_t* value_size,
+                const char** error, size_t* error_size) const {
+    if (index >= result_indexes.size()) {
+      return rocksdb_pinnable_multi_get_out_of_bounds;
+    }
+    const size_t result_index = result_indexes[index];
+    if (result_index == kNotFound) {
+      return rocksdb_pinnable_multi_get_not_found;
+    }
+    if (result_index < values.size()) {
+      *value = values[result_index].data();
+      *value_size = values[result_index].size();
+      return rocksdb_pinnable_multi_get_found;
+    }
+    const std::string& message = errors[kNotFound - result_index - 1];
+    *error = message.c_str();
+    *error_size = message.size();
+    return rocksdb_pinnable_multi_get_error;
+  }
+
+  // Found entries store a value index. Error entries count back from
+  // kNotFound - 1, leaving kNotFound to represent a missing key.
+  std::vector<size_t> result_indexes;
+  std::vector<PinnableSlice> values;
+  std::vector<std::string> errors;
 };
 struct rocksdb_transactiondb_options_t {
   TransactionDBOptions rep;
@@ -2860,6 +2918,44 @@ void rocksdb_batched_multi_get_cf_slice(
 
   delete[] value_slices;
   delete[] statuses;
+}
+
+rocksdb_pinnable_multi_get_t* rocksdb_batched_multi_get_pinned_cf(
+    rocksdb_t* db, const rocksdb_readoptions_t* options,
+    rocksdb_column_family_handle_t* column_family, size_t num_keys,
+    const rocksdb_slice_t* keys, unsigned char sorted_input) {
+  auto results = std::make_unique<rocksdb_pinnable_multi_get_t>(num_keys);
+  if (num_keys == 0) {
+    return results.release();
+  }
+  const Slice* key_slices = reinterpret_cast<const Slice*>(keys);
+  std::vector<PinnableSlice> values(num_keys);
+  std::vector<Status> statuses(num_keys);
+  db->rep->MultiGet(options->rep, column_family->rep, num_keys, key_slices,
+                    values.data(), statuses.data(), sorted_input != 0);
+  results->StoreResults(&values, statuses);
+  return results.release();
+}
+
+size_t rocksdb_pinnable_multi_get_count(
+    const rocksdb_pinnable_multi_get_t* multi_get) {
+  return multi_get->result_indexes.size();
+}
+
+int rocksdb_pinnable_multi_get_result(
+    const rocksdb_pinnable_multi_get_t* multi_get, size_t index,
+    const char** value, size_t* value_size, const char** error,
+    size_t* error_size) {
+  *value = nullptr;
+  *value_size = 0;
+  *error = nullptr;
+  *error_size = 0;
+  return multi_get->GetResult(index, value, value_size, error, error_size);
+}
+
+void rocksdb_pinnable_multi_get_destroy(
+    rocksdb_pinnable_multi_get_t* multi_get) {
+  delete multi_get;
 }
 
 unsigned char rocksdb_key_may_exist(rocksdb_t* db,

--- a/db/c_test.c
+++ b/db/c_test.c
@@ -189,6 +189,57 @@ static void CheckMultiGetValues(size_t num_keys, char** values,
   }
 }
 
+static void CheckPinnableMultiGetFound(
+    const rocksdb_pinnable_multi_get_t* multi_get, size_t index,
+    const char* expected, size_t expected_size) {
+  const char* value;
+  const char* error;
+  size_t value_size;
+  size_t error_size;
+  int result = rocksdb_pinnable_multi_get_result(
+      multi_get, index, &value, &value_size, &error, &error_size);
+  CheckCondition(result == rocksdb_pinnable_multi_get_found);
+  CheckCondition(value_size == expected_size);
+  CheckCondition(error == NULL);
+  CheckCondition(error_size == 0);
+  if (expected_size > 0) {
+    CheckCondition(value != NULL);
+    CheckCondition(memcmp(value, expected, expected_size) == 0);
+  }
+}
+
+static void CheckPinnableMultiGetNotFound(
+    const rocksdb_pinnable_multi_get_t* multi_get, size_t index) {
+  const char* value;
+  const char* error;
+  size_t value_size;
+  size_t error_size;
+  int result = rocksdb_pinnable_multi_get_result(
+      multi_get, index, &value, &value_size, &error, &error_size);
+  CheckCondition(result == rocksdb_pinnable_multi_get_not_found);
+  CheckCondition(value == NULL);
+  CheckCondition(value_size == 0);
+  CheckCondition(error == NULL);
+  CheckCondition(error_size == 0);
+}
+
+static void CheckPinnableMultiGetError(
+    const rocksdb_pinnable_multi_get_t* multi_get, size_t index,
+    const char* expected) {
+  const char* value;
+  const char* error;
+  size_t value_size;
+  size_t error_size;
+  int result = rocksdb_pinnable_multi_get_result(
+      multi_get, index, &value, &value_size, &error, &error_size);
+  CheckCondition(result == rocksdb_pinnable_multi_get_error);
+  CheckCondition(value == NULL);
+  CheckCondition(value_size == 0);
+  CheckCondition(error != NULL);
+  CheckCondition(error_size == strlen(error));
+  CheckCondition(strstr(error, expected) != NULL);
+}
+
 static void CheckIter(rocksdb_iterator_t* iter, const char* key,
                       const char* val) {
   size_t len;
@@ -832,6 +883,39 @@ static char* MergeOperatorPartialMerge(void* arg, const char* key,
   char* result = malloc(4);
   memcpy(result, "fake", 4);
   return result;
+}
+
+static char* FailingMergeOperatorFullMerge(
+    void* arg, const char* key, size_t key_length, const char* existing_value,
+    size_t existing_value_length, const char* const* operands_list,
+    const size_t* operands_list_length, int num_operands,
+    unsigned char* success, size_t* new_value_length) {
+  (void)arg;
+  (void)key;
+  (void)key_length;
+  (void)existing_value;
+  (void)existing_value_length;
+  (void)operands_list;
+  (void)operands_list_length;
+  (void)num_operands;
+  *success = 0;
+  *new_value_length = 0;
+  return NULL;
+}
+
+static char* FailingMergeOperatorPartialMerge(
+    void* arg, const char* key, size_t key_length,
+    const char* const* operands_list, const size_t* operands_list_length,
+    int num_operands, unsigned char* success, size_t* new_value_length) {
+  (void)arg;
+  (void)key;
+  (void)key_length;
+  (void)operands_list;
+  (void)operands_list_length;
+  (void)num_operands;
+  *success = 0;
+  *new_value_length = 0;
+  return NULL;
 }
 
 static void CheckTxnGet(rocksdb_transaction_t* txn,
@@ -2639,12 +2723,17 @@ int main(int argc, char** argv) {
     // use dbpathname2 as the cf_path for "cf1"
     rocksdb_dbpath_t* dbpath2;
     char dbpathname2[200];
+    rocksdb_mergeoperator_t* failing_merge_operator;
     snprintf(dbpathname2, sizeof(dbpathname2),
              "%s/rocksdb_c_test-%" PRIu64 "-dbpath2", GetTempDir(),
              GetTestId());
     dbpath2 = rocksdb_dbpath_create(dbpathname2, 1024 * 1024);
     const rocksdb_dbpath_t* cf_paths[1] = {dbpath2};
     rocksdb_options_set_cf_paths(cf_options_2, cf_paths, 1);
+    failing_merge_operator = rocksdb_mergeoperator_create(
+        NULL, MergeOperatorDestroy, FailingMergeOperatorFullMerge,
+        FailingMergeOperatorPartialMerge, NULL, MergeOperatorName);
+    rocksdb_options_set_merge_operator(cf_options_2, failing_merge_operator);
 
     const char* cf_names[2] = {"default", "cf1"};
     const rocksdb_options_t* cf_opts[2] = {cf_options_1, cf_options_2};
@@ -3166,6 +3255,95 @@ int main(int argc, char** argv) {
         }
       }
     }
+
+    {
+      rocksdb_slice_t pinned_keys[6] = {{"box", 3},   {"missing", 7},
+                                        {"empty", 5}, {"merge-error", 11},
+                                        {"box", 3},   {"owned", 5}};
+      rocksdb_pinnable_multi_get_t* multi_get;
+      const char* value;
+      const char* error;
+      size_t value_size;
+      size_t error_size;
+      int result;
+
+      rocksdb_put_cf(db, woptions, handles[1], "empty", 5, "", 0, &err);
+      CheckNoError(err);
+      rocksdb_put_cf(db, woptions, handles[1], "merge-error", 11, "base", 4,
+                     &err);
+      CheckNoError(err);
+      rocksdb_merge_cf(db, woptions, handles[1], "merge-error", 11, "operand",
+                       7, &err);
+      CheckNoError(err);
+      rocksdb_put_cf(db, woptions, handles[1], "owned", 5, "before", 6, &err);
+      CheckNoError(err);
+
+      multi_get = rocksdb_batched_multi_get_pinned_cf(db, roptions, handles[1],
+                                                      6, pinned_keys, 0);
+      CheckCondition(rocksdb_pinnable_multi_get_count(multi_get) == 6);
+      CheckPinnableMultiGetFound(multi_get, 0, "c", 1);
+      CheckPinnableMultiGetNotFound(multi_get, 1);
+      CheckPinnableMultiGetFound(multi_get, 2, "", 0);
+      CheckPinnableMultiGetError(multi_get, 3, "Merge operator failed");
+      CheckPinnableMultiGetFound(multi_get, 4, "c", 1);
+      CheckPinnableMultiGetFound(multi_get, 5, "before", 6);
+
+      value = "unchanged";
+      error = "unchanged";
+      value_size = 9;
+      error_size = 9;
+      result = rocksdb_pinnable_multi_get_result(
+          multi_get, 6, &value, &value_size, &error, &error_size);
+      CheckCondition(result == rocksdb_pinnable_multi_get_out_of_bounds);
+      CheckCondition(value == NULL);
+      CheckCondition(value_size == 0);
+      CheckCondition(error == NULL);
+      CheckCondition(error_size == 0);
+
+      result = rocksdb_pinnable_multi_get_result(
+          multi_get, 5, &value, &value_size, &error, &error_size);
+      CheckCondition(result == rocksdb_pinnable_multi_get_found);
+      const char* borrowed_value = value;
+      size_t borrowed_value_size = value_size;
+      result = rocksdb_pinnable_multi_get_result(
+          multi_get, 3, &value, &value_size, &error, &error_size);
+      CheckCondition(result == rocksdb_pinnable_multi_get_error);
+      const char* borrowed_error = error;
+      size_t borrowed_error_size = error_size;
+      rocksdb_put_cf(db, woptions, handles[1], "owned", 5, "after", 5, &err);
+      CheckNoError(err);
+      CheckCondition(borrowed_value_size == 6);
+      CheckCondition(memcmp(borrowed_value, "before", 6) == 0);
+      CheckCondition(borrowed_error_size == strlen(borrowed_error));
+      CheckCondition(strstr(borrowed_error, "Merge operator failed") != NULL);
+      rocksdb_pinnable_multi_get_destroy(multi_get);
+    }
+
+    {
+      rocksdb_slice_t sorted_keys[4] = {
+          {"box", 3}, {"box", 3}, {"empty", 5}, {"missing", 7}};
+      rocksdb_pinnable_multi_get_t* multi_get =
+          rocksdb_batched_multi_get_pinned_cf(db, roptions, handles[1], 4,
+                                              sorted_keys, 1);
+      CheckCondition(rocksdb_pinnable_multi_get_count(multi_get) == 4);
+      CheckPinnableMultiGetFound(multi_get, 0, "c", 1);
+      CheckPinnableMultiGetFound(multi_get, 1, "c", 1);
+      CheckPinnableMultiGetFound(multi_get, 2, "", 0);
+      CheckPinnableMultiGetNotFound(multi_get, 3);
+      rocksdb_pinnable_multi_get_destroy(multi_get);
+
+      multi_get = rocksdb_batched_multi_get_pinned_cf(db, roptions, handles[1],
+                                                      0, sorted_keys, 1);
+      CheckCondition(rocksdb_pinnable_multi_get_count(multi_get) == 0);
+      rocksdb_pinnable_multi_get_destroy(multi_get);
+    }
+
+    rocksdb_delete_cf(db, woptions, handles[1], "empty", 5, &err);
+    CheckNoError(err);
+    rocksdb_delete_cf(db, woptions, handles[1], "merge-error", 11, &err);
+    CheckNoError(err);
+    rocksdb_delete_cf(db, woptions, handles[1], "owned", 5, &err);
+    CheckNoError(err);
 
     {
       unsigned char value_found = 0;

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -157,6 +157,7 @@ typedef struct rocksdb_sstfilewriter_t rocksdb_sstfilewriter_t;
 typedef struct rocksdb_ratelimiter_t rocksdb_ratelimiter_t;
 typedef struct rocksdb_perfcontext_t rocksdb_perfcontext_t;
 typedef struct rocksdb_pinnableslice_t rocksdb_pinnableslice_t;
+typedef struct rocksdb_pinnable_multi_get_t rocksdb_pinnable_multi_get_t;
 typedef struct rocksdb_transactiondb_options_t rocksdb_transactiondb_options_t;
 typedef struct rocksdb_transactiondb_t rocksdb_transactiondb_t;
 typedef struct rocksdb_transaction_options_t rocksdb_transaction_options_t;
@@ -724,6 +725,52 @@ extern ROCKSDB_LIBRARY_API void rocksdb_batched_multi_get_cf_slice(
     rocksdb_column_family_handle_t* column_family, size_t num_keys,
     const rocksdb_slice_t* keys_list, rocksdb_pinnableslice_t** values,
     char** errs, const bool sorted_input);
+
+/*
+ * Result states returned by rocksdb_pinnable_multi_get_result().
+ */
+enum {
+  rocksdb_pinnable_multi_get_not_found = 0,
+  rocksdb_pinnable_multi_get_found = 1,
+  rocksdb_pinnable_multi_get_error = 2,
+  rocksdb_pinnable_multi_get_out_of_bounds = 3,
+};
+
+/*
+ * Runs a batched MultiGet for one column family and returns one owner for all
+ * pinned values and error messages. Result indexes match the input key order,
+ * including duplicate keys.
+ *
+ * If sorted_input is nonzero, keys must be sorted using the column family's
+ * comparator.
+ */
+extern ROCKSDB_LIBRARY_API rocksdb_pinnable_multi_get_t*
+rocksdb_batched_multi_get_pinned_cf(
+    rocksdb_t* db, const rocksdb_readoptions_t* options,
+    rocksdb_column_family_handle_t* column_family, size_t num_keys,
+    const rocksdb_slice_t* keys, unsigned char sorted_input);
+
+extern ROCKSDB_LIBRARY_API size_t
+rocksdb_pinnable_multi_get_count(const rocksdb_pinnable_multi_get_t* multi_get);
+
+/*
+ * Returns the result state at index. For a found value, value and value_size
+ * describe borrowed value bytes. For an error, error and error_size describe a
+ * borrowed null-terminated error message. The borrowed data remains valid until
+ * rocksdb_pinnable_multi_get_destroy() is called. The batch must be destroyed
+ * before closing the DB used to create it.
+ *
+ * Unused outputs are set to NULL and zero. An index greater than or equal to
+ * rocksdb_pinnable_multi_get_count() returns
+ * rocksdb_pinnable_multi_get_out_of_bounds.
+ */
+extern ROCKSDB_LIBRARY_API int rocksdb_pinnable_multi_get_result(
+    const rocksdb_pinnable_multi_get_t* multi_get, size_t index,
+    const char** value, size_t* value_size, const char** error,
+    size_t* error_size);
+
+extern ROCKSDB_LIBRARY_API void rocksdb_pinnable_multi_get_destroy(
+    rocksdb_pinnable_multi_get_t* multi_get);
 
 // The value is only allocated (using malloc) and returned if it is found and
 // value_found isn't NULL. In that case the user is responsible for freeing it.

--- a/tools/c_api_gen/c_base.cc
+++ b/tools/c_api_gen/c_base.cc
@@ -10,6 +10,7 @@
 
 #include <cstdlib>
 #include <iterator>
+#include <limits>
 #include <map>
 #include <memory>
 #include <unordered_set>
@@ -589,6 +590,63 @@ struct rocksdb_perfcontext_t {
 };
 struct rocksdb_pinnableslice_t {
   PinnableSlice rep;
+};
+struct rocksdb_pinnable_multi_get_t {
+  static constexpr size_t kNotFound = std::numeric_limits<size_t>::max();
+
+  explicit rocksdb_pinnable_multi_get_t(size_t result_count)
+      : result_indexes(result_count, kNotFound) {}
+
+  void ReservePayloads(const std::vector<Status>& statuses) {
+    size_t value_count = 0;
+    size_t error_count = 0;
+    for (const Status& status : statuses) {
+      value_count += status.ok();
+      error_count += !status.ok() && !status.IsNotFound();
+    }
+    values.reserve(value_count);
+    errors.reserve(error_count);
+  }
+
+  void StoreResults(std::vector<PinnableSlice>* multi_get_values,
+                    const std::vector<Status>& statuses) {
+    ReservePayloads(statuses);
+    for (size_t i = 0; i < statuses.size(); ++i) {
+      if (statuses[i].ok()) {
+        result_indexes[i] = values.size();
+        values.emplace_back(std::move((*multi_get_values)[i]));
+      } else if (!statuses[i].IsNotFound()) {
+        result_indexes[i] = kNotFound - errors.size() - 1;
+        errors.emplace_back(statuses[i].ToString());
+      }
+    }
+  }
+
+  int GetResult(size_t index, const char** value, size_t* value_size,
+                const char** error, size_t* error_size) const {
+    if (index >= result_indexes.size()) {
+      return rocksdb_pinnable_multi_get_out_of_bounds;
+    }
+    const size_t result_index = result_indexes[index];
+    if (result_index == kNotFound) {
+      return rocksdb_pinnable_multi_get_not_found;
+    }
+    if (result_index < values.size()) {
+      *value = values[result_index].data();
+      *value_size = values[result_index].size();
+      return rocksdb_pinnable_multi_get_found;
+    }
+    const std::string& message = errors[kNotFound - result_index - 1];
+    *error = message.c_str();
+    *error_size = message.size();
+    return rocksdb_pinnable_multi_get_error;
+  }
+
+  // Found entries store a value index. Error entries count back from
+  // kNotFound - 1, leaving kNotFound to represent a missing key.
+  std::vector<size_t> result_indexes;
+  std::vector<PinnableSlice> values;
+  std::vector<std::string> errors;
 };
 struct rocksdb_transactiondb_options_t {
   TransactionDBOptions rep;
@@ -2666,6 +2724,44 @@ void rocksdb_batched_multi_get_cf_slice(
 
   delete[] value_slices;
   delete[] statuses;
+}
+
+rocksdb_pinnable_multi_get_t* rocksdb_batched_multi_get_pinned_cf(
+    rocksdb_t* db, const rocksdb_readoptions_t* options,
+    rocksdb_column_family_handle_t* column_family, size_t num_keys,
+    const rocksdb_slice_t* keys, unsigned char sorted_input) {
+  auto results = std::make_unique<rocksdb_pinnable_multi_get_t>(num_keys);
+  if (num_keys == 0) {
+    return results.release();
+  }
+  const Slice* key_slices = reinterpret_cast<const Slice*>(keys);
+  std::vector<PinnableSlice> values(num_keys);
+  std::vector<Status> statuses(num_keys);
+  db->rep->MultiGet(options->rep, column_family->rep, num_keys, key_slices,
+                    values.data(), statuses.data(), sorted_input != 0);
+  results->StoreResults(&values, statuses);
+  return results.release();
+}
+
+size_t rocksdb_pinnable_multi_get_count(
+    const rocksdb_pinnable_multi_get_t* multi_get) {
+  return multi_get->result_indexes.size();
+}
+
+int rocksdb_pinnable_multi_get_result(
+    const rocksdb_pinnable_multi_get_t* multi_get, size_t index,
+    const char** value, size_t* value_size, const char** error,
+    size_t* error_size) {
+  *value = nullptr;
+  *value_size = 0;
+  *error = nullptr;
+  *error_size = 0;
+  return multi_get->GetResult(index, value, value_size, error, error_size);
+}
+
+void rocksdb_pinnable_multi_get_destroy(
+    rocksdb_pinnable_multi_get_t* multi_get) {
+  delete multi_get;
 }
 
 unsigned char rocksdb_key_may_exist(rocksdb_t* db,

--- a/tools/c_api_gen/c_base.h
+++ b/tools/c_api_gen/c_base.h
@@ -155,6 +155,7 @@ typedef struct rocksdb_sstfilewriter_t rocksdb_sstfilewriter_t;
 typedef struct rocksdb_ratelimiter_t rocksdb_ratelimiter_t;
 typedef struct rocksdb_perfcontext_t rocksdb_perfcontext_t;
 typedef struct rocksdb_pinnableslice_t rocksdb_pinnableslice_t;
+typedef struct rocksdb_pinnable_multi_get_t rocksdb_pinnable_multi_get_t;
 typedef struct rocksdb_transactiondb_options_t rocksdb_transactiondb_options_t;
 typedef struct rocksdb_transactiondb_t rocksdb_transactiondb_t;
 typedef struct rocksdb_transaction_options_t rocksdb_transaction_options_t;
@@ -595,6 +596,52 @@ extern ROCKSDB_LIBRARY_API void rocksdb_batched_multi_get_cf_slice(
     rocksdb_column_family_handle_t* column_family, size_t num_keys,
     const rocksdb_slice_t* keys_list, rocksdb_pinnableslice_t** values,
     char** errs, const bool sorted_input);
+
+/*
+ * Result states returned by rocksdb_pinnable_multi_get_result().
+ */
+enum {
+  rocksdb_pinnable_multi_get_not_found = 0,
+  rocksdb_pinnable_multi_get_found = 1,
+  rocksdb_pinnable_multi_get_error = 2,
+  rocksdb_pinnable_multi_get_out_of_bounds = 3,
+};
+
+/*
+ * Runs a batched MultiGet for one column family and returns one owner for all
+ * pinned values and error messages. Result indexes match the input key order,
+ * including duplicate keys.
+ *
+ * If sorted_input is nonzero, keys must be sorted using the column family's
+ * comparator.
+ */
+extern ROCKSDB_LIBRARY_API rocksdb_pinnable_multi_get_t*
+rocksdb_batched_multi_get_pinned_cf(
+    rocksdb_t* db, const rocksdb_readoptions_t* options,
+    rocksdb_column_family_handle_t* column_family, size_t num_keys,
+    const rocksdb_slice_t* keys, unsigned char sorted_input);
+
+extern ROCKSDB_LIBRARY_API size_t
+rocksdb_pinnable_multi_get_count(const rocksdb_pinnable_multi_get_t* multi_get);
+
+/*
+ * Returns the result state at index. For a found value, value and value_size
+ * describe borrowed value bytes. For an error, error and error_size describe a
+ * borrowed null-terminated error message. The borrowed data remains valid until
+ * rocksdb_pinnable_multi_get_destroy() is called. The batch must be destroyed
+ * before closing the DB used to create it.
+ *
+ * Unused outputs are set to NULL and zero. An index greater than or equal to
+ * rocksdb_pinnable_multi_get_count() returns
+ * rocksdb_pinnable_multi_get_out_of_bounds.
+ */
+extern ROCKSDB_LIBRARY_API int rocksdb_pinnable_multi_get_result(
+    const rocksdb_pinnable_multi_get_t* multi_get, size_t index,
+    const char** value, size_t* value_size, const char** error,
+    size_t* error_size);
+
+extern ROCKSDB_LIBRARY_API void rocksdb_pinnable_multi_get_destroy(
+    rocksdb_pinnable_multi_get_t* multi_get);
 
 // The value is only allocated (using malloc) and returned if it is found and
 // value_found isn't NULL. In that case the user is responsible for freeing it.

--- a/unreleased_history/public_api_changes/pinnable_multi_get_batch.md
+++ b/unreleased_history/public_api_changes/pinnable_multi_get_batch.md
@@ -1,0 +1,1 @@
+Added `rocksdb_batched_multi_get_pinned_cf()` to return batch-owned pinned MultiGet values and per-key errors without allocating one wrapper per found value.


### PR DESCRIPTION
## Summary

- add `rocksdb_batched_multi_get_pinned_cf` for batched reads using `rocksdb_slice_t` keys
- return one `rocksdb_pinnable_multi_get_t` owner for all values and per-key errors
- preserve input ordering, duplicates, misses, and sorted-input behavior
- expose indexed borrowed results plus count and destroy functions

## Why

`rocksdb_batched_multi_get_cf_slice` returns one separately allocated `rocksdb_pinnableslice_t` wrapper for every found key. Language bindings that want to retain a full batch have to manage and destroy each wrapper independently.

The new API keeps successful `PinnableSlice` values in one owner. It stores only compact value and error payloads, while a result index maps them back to the original key order. Found values and error messages remain borrowed until the batch is destroyed.

The batch must be destroyed before closing the DB that created it because pinned values can retain DB-owned cache state.

## Compatibility

This is additive. Existing MultiGet APIs and ownership rules are unchanged.

## Testing

`c_test` covers:

- found and missing keys
- duplicate keys and input ordering
- empty values
- per-key merge errors
- sorted and unsorted input
- empty batches
- out-of-bounds access
- borrowed value and error lifetimes

Validation run locally:

- `make -j8 check-c-api-c_test`
- `CXX=clang++ make check-c-api-gen CHECK_C_API_GEN_STRICT=1 CLANG_FORMAT_BINARY=clang-format`
- C API link-completeness and backward-compatibility checks

This API is intended to replace a temporary compatibility extension in `rust-rocksdb` once it is available in a RocksDB release.