### PR TITLE
Add error-reporting WriteBatch slice-part C APIs

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -16,6 +16,7 @@
 #include <iterator>
 #include <map>
 #include <memory>
+#include <string>
 #include <unordered_set>
 #include <vector>
 
@@ -246,6 +247,47 @@ static rocksdb_wal_file_t CaptureWalFile(const WalFile& wal_file) {
   result.size_file_bytes = wal_file.SizeFileBytes();
   return result;
 }
+
+static Status CheckWriteBatchSliceParts(const char* parts_name, int num_parts,
+                                        const rocksdb_slice_t* parts) {
+  if (num_parts < 0) {
+    return Status::InvalidArgument(
+        std::string(parts_name) +
+        " part count must be non-negative: " + std::to_string(num_parts));
+  }
+  if (num_parts > 0 && parts == nullptr) {
+    return Status::InvalidArgument(
+        std::string(parts_name) +
+        " parts must not be null when part count is positive: " +
+        std::to_string(num_parts));
+  }
+  for (int i = 0; i < num_parts; ++i) {
+    if (parts[i].data == nullptr && parts[i].size != 0) {
+      return Status::InvalidArgument(std::string(parts_name) + " part " +
+                                     std::to_string(i) +
+                                     " has null data with non-zero size: " +
+                                     std::to_string(parts[i].size));
+    }
+  }
+  return Status::OK();
+}
+
+class CWriteBatchSliceParts {
+ public:
+  CWriteBatchSliceParts(int num_parts, const rocksdb_slice_t* parts) {
+    slices_.reserve(num_parts);
+    for (int i = 0; i < num_parts; ++i) {
+      slices_.emplace_back(parts[i].data, parts[i].size);
+    }
+  }
+
+  SliceParts Get() const {
+    return SliceParts(slices_.data(), static_cast<int>(slices_.size()));
+  }
+
+ private:
+  std::vector<Slice> slices_;
+};
 
 extern "C" {
 
@@ -666,6 +708,7 @@ struct rocksdb_compactionservice_scheduleresponse_t {
 struct rocksdb_compactionservice_jobinfo_t {
   CompactionServiceJobInfo rep;
 };
+
 // Layout assertions: these structs must be reinterpret_cast-compatible
 // with their rep field (single-member struct, standard-layout).
 static_assert(sizeof(rocksdb_writebatch_t) == sizeof(WriteBatch),
@@ -3586,6 +3629,40 @@ void rocksdb_writebatch_putv_cf(rocksdb_writebatch_t* b,
              SliceParts(value_slices.get(), num_values));
 }
 
+void rocksdb_writebatch_put_slice_parts(rocksdb_writebatch_t* b,
+                                        int num_key_parts,
+                                        const rocksdb_slice_t* key_parts,
+                                        int num_value_parts,
+                                        const rocksdb_slice_t* value_parts,
+                                        char** errptr) {
+  Status s = CheckWriteBatchSliceParts("key", num_key_parts, key_parts);
+  if (s.ok()) {
+    s = CheckWriteBatchSliceParts("value", num_value_parts, value_parts);
+  }
+  if (s.ok()) {
+    CWriteBatchSliceParts keys(num_key_parts, key_parts);
+    CWriteBatchSliceParts values(num_value_parts, value_parts);
+    s = b->rep.Put(keys.Get(), values.Get());
+  }
+  SaveError(errptr, s);
+}
+
+void rocksdb_writebatch_put_slice_parts_cf(
+    rocksdb_writebatch_t* b, rocksdb_column_family_handle_t* column_family,
+    int num_key_parts, const rocksdb_slice_t* key_parts, int num_value_parts,
+    const rocksdb_slice_t* value_parts, char** errptr) {
+  Status s = CheckWriteBatchSliceParts("key", num_key_parts, key_parts);
+  if (s.ok()) {
+    s = CheckWriteBatchSliceParts("value", num_value_parts, value_parts);
+  }
+  if (s.ok()) {
+    CWriteBatchSliceParts keys(num_key_parts, key_parts);
+    CWriteBatchSliceParts values(num_value_parts, value_parts);
+    s = b->rep.Put(column_family->rep, keys.Get(), values.Get());
+  }
+  SaveError(errptr, s);
+}
+
 void rocksdb_writebatch_merge(rocksdb_writebatch_t* b, const char* key,
                               size_t klen, const char* val, size_t vlen) {
   b->rep.Merge(Slice(key, klen), Slice(val, vlen));
@@ -3635,6 +3712,40 @@ void rocksdb_writebatch_mergev_cf(rocksdb_writebatch_t* b,
   }
   b->rep.Merge(column_family->rep, SliceParts(key_slices.get(), num_keys),
                SliceParts(value_slices.get(), num_values));
+}
+
+void rocksdb_writebatch_merge_slice_parts(rocksdb_writebatch_t* b,
+                                          int num_key_parts,
+                                          const rocksdb_slice_t* key_parts,
+                                          int num_value_parts,
+                                          const rocksdb_slice_t* value_parts,
+                                          char** errptr) {
+  Status s = CheckWriteBatchSliceParts("key", num_key_parts, key_parts);
+  if (s.ok()) {
+    s = CheckWriteBatchSliceParts("value", num_value_parts, value_parts);
+  }
+  if (s.ok()) {
+    CWriteBatchSliceParts keys(num_key_parts, key_parts);
+    CWriteBatchSliceParts values(num_value_parts, value_parts);
+    s = b->rep.Merge(keys.Get(), values.Get());
+  }
+  SaveError(errptr, s);
+}
+
+void rocksdb_writebatch_merge_slice_parts_cf(
+    rocksdb_writebatch_t* b, rocksdb_column_family_handle_t* column_family,
+    int num_key_parts, const rocksdb_slice_t* key_parts, int num_value_parts,
+    const rocksdb_slice_t* value_parts, char** errptr) {
+  Status s = CheckWriteBatchSliceParts("key", num_key_parts, key_parts);
+  if (s.ok()) {
+    s = CheckWriteBatchSliceParts("value", num_value_parts, value_parts);
+  }
+  if (s.ok()) {
+    CWriteBatchSliceParts keys(num_key_parts, key_parts);
+    CWriteBatchSliceParts values(num_value_parts, value_parts);
+    s = b->rep.Merge(column_family->rep, keys.Get(), values.Get());
+  }
+  SaveError(errptr, s);
 }
 
 void rocksdb_writebatch_singledelete(rocksdb_writebatch_t* b, const char* key,
@@ -3690,6 +3801,29 @@ void rocksdb_writebatch_deletev_cf(
   b->rep.Delete(column_family->rep, SliceParts(key_slices.get(), num_keys));
 }
 
+void rocksdb_writebatch_delete_slice_parts(rocksdb_writebatch_t* b,
+                                           int num_key_parts,
+                                           const rocksdb_slice_t* key_parts,
+                                           char** errptr) {
+  Status s = CheckWriteBatchSliceParts("key", num_key_parts, key_parts);
+  if (s.ok()) {
+    CWriteBatchSliceParts keys(num_key_parts, key_parts);
+    s = b->rep.Delete(keys.Get());
+  }
+  SaveError(errptr, s);
+}
+
+void rocksdb_writebatch_delete_slice_parts_cf(
+    rocksdb_writebatch_t* b, rocksdb_column_family_handle_t* column_family,
+    int num_key_parts, const rocksdb_slice_t* key_parts, char** errptr) {
+  Status s = CheckWriteBatchSliceParts("key", num_key_parts, key_parts);
+  if (s.ok()) {
+    CWriteBatchSliceParts keys(num_key_parts, key_parts);
+    s = b->rep.Delete(column_family->rep, keys.Get());
+  }
+  SaveError(errptr, s);
+}
+
 void rocksdb_writebatch_delete_range(rocksdb_writebatch_t* b,
                                      const char* start_key,
                                      size_t start_key_len, const char* end_key,
@@ -3739,6 +3873,41 @@ void rocksdb_writebatch_delete_rangev_cf(
   b->rep.DeleteRange(column_family->rep,
                      SliceParts(start_key_slices.get(), num_keys),
                      SliceParts(end_key_slices.get(), num_keys));
+}
+
+void rocksdb_writebatch_delete_range_slice_parts(
+    rocksdb_writebatch_t* b, int num_begin_key_parts,
+    const rocksdb_slice_t* begin_key_parts, int num_end_key_parts,
+    const rocksdb_slice_t* end_key_parts, char** errptr) {
+  Status s = CheckWriteBatchSliceParts("begin key", num_begin_key_parts,
+                                       begin_key_parts);
+  if (s.ok()) {
+    s = CheckWriteBatchSliceParts("end key", num_end_key_parts, end_key_parts);
+  }
+  if (s.ok()) {
+    CWriteBatchSliceParts begin_key(num_begin_key_parts, begin_key_parts);
+    CWriteBatchSliceParts end_key(num_end_key_parts, end_key_parts);
+    s = b->rep.DeleteRange(begin_key.Get(), end_key.Get());
+  }
+  SaveError(errptr, s);
+}
+
+void rocksdb_writebatch_delete_range_slice_parts_cf(
+    rocksdb_writebatch_t* b, rocksdb_column_family_handle_t* column_family,
+    int num_begin_key_parts, const rocksdb_slice_t* begin_key_parts,
+    int num_end_key_parts, const rocksdb_slice_t* end_key_parts,
+    char** errptr) {
+  Status s = CheckWriteBatchSliceParts("begin key", num_begin_key_parts,
+                                       begin_key_parts);
+  if (s.ok()) {
+    s = CheckWriteBatchSliceParts("end key", num_end_key_parts, end_key_parts);
+  }
+  if (s.ok()) {
+    CWriteBatchSliceParts begin_key(num_begin_key_parts, begin_key_parts);
+    CWriteBatchSliceParts end_key(num_end_key_parts, end_key_parts);
+    s = b->rep.DeleteRange(column_family->rep, begin_key.Get(), end_key.Get());
+  }
+  SaveError(errptr, s);
 }
 
 class H : public WriteBatch::Handler {

--- a/db/c_test.c
+++ b/db/c_test.c
@@ -104,6 +104,12 @@ static void Free(char** ptr) {
   }
 }
 
+static void CheckErrorContains(char** err, const char* expected) {
+  CheckCondition(*err != NULL);
+  CheckCondition(strstr(*err, expected) != NULL);
+  Free(err);
+}
+
 static long GetLocalFileSize(const char* path) {
   FILE* file = fopen(path, "rb");
   long size;
@@ -334,6 +340,48 @@ static int CmpCompare(void* arg, const char* a, size_t alen, const char* b,
     }
   }
   return r;
+}
+
+static int TimestampCmpCompare(void* arg, const char* a, size_t alen,
+                               const char* b, size_t blen) {
+  const size_t timestamp_size = 8;
+  if (alen < timestamp_size || blen < timestamp_size) {
+    return CmpCompare(arg, a, alen, b, blen);
+  }
+  int result =
+      CmpCompare(arg, a, alen - timestamp_size, b, blen - timestamp_size);
+  if (result != 0) {
+    return result;
+  }
+  return CmpCompare(arg, b + blen - timestamp_size, timestamp_size,
+                    a + alen - timestamp_size, timestamp_size);
+}
+
+static int TimestampCmpCompareTimestamp(void* arg, const char* a, size_t alen,
+                                        const char* b, size_t blen) {
+  return CmpCompare(arg, b, blen, a, alen);
+}
+
+static int TimestampCmpCompareWithoutTimestamp(void* arg, const char* a,
+                                               size_t alen,
+                                               unsigned char a_has_ts,
+                                               const char* b, size_t blen,
+                                               unsigned char b_has_ts) {
+  const size_t timestamp_size = 8;
+  if (a_has_ts) {
+    CheckCondition(alen >= timestamp_size);
+    alen -= timestamp_size;
+  }
+  if (b_has_ts) {
+    CheckCondition(blen >= timestamp_size);
+    blen -= timestamp_size;
+  }
+  return CmpCompare(arg, a, alen, b, blen);
+}
+
+static const char* TimestampCmpName(void* arg) {
+  (void)arg;
+  return "c_test.TimestampComparator";
 }
 
 static const char* CmpName(void* arg) {
@@ -2597,6 +2645,193 @@ int main(int argc, char** argv) {
     rocksdb_merge(db, woptions, "bar", 3, "barvalue", 8, &err);
     CheckNoError(err);
     CheckGet(db, roptions, "bar", "fake");
+  }
+
+  StartPhase("writebatch_slice_parts");
+  {
+    rocksdb_column_family_handle_t* slices_cf = rocksdb_create_column_family(
+        db, options, "writebatch_slice_parts", &err);
+    CheckNoError(err);
+
+    rocksdb_put(db, woptions, "slices-merge", 12, "base", 4, &err);
+    CheckNoError(err);
+    rocksdb_put(db, woptions, "slices-delete", 13, "old", 3, &err);
+    CheckNoError(err);
+    rocksdb_put(db, woptions, "slices-range-a", 14, "a", 1, &err);
+    CheckNoError(err);
+    rocksdb_put(db, woptions, "slices-range-b", 14, "b", 1, &err);
+    CheckNoError(err);
+    rocksdb_put(db, woptions, "slices-range-c", 14, "c", 1, &err);
+    CheckNoError(err);
+
+    rocksdb_writebatch_t* wb = rocksdb_writebatch_create();
+    const rocksdb_slice_t put_key[] = {{"slices-", 7}, {"", 0}, {"put", 3}};
+    const rocksdb_slice_t put_value[] = {{"v", 1}, {"", 0}, {"alue", 4}};
+    const rocksdb_slice_t merge_key[] = {{"slices-", 7}, {"merge", 5}};
+    const rocksdb_slice_t merge_value[] = {{"oper", 4}, {"and", 3}};
+    const rocksdb_slice_t delete_key[] = {{"slices-", 7}, {"delete", 6}};
+    const rocksdb_slice_t range_begin[] = {{"slices-", 7}, {"range-a", 7}};
+    const rocksdb_slice_t range_end[] = {
+        {"slices", 6}, {"-range-", 7}, {"c", 1}};
+    const rocksdb_slice_t null_empty_key[] = {{NULL, 0}, {"null-key", 8}};
+
+    rocksdb_writebatch_put_slice_parts(wb, 3, put_key, 3, put_value, &err);
+    CheckNoError(err);
+    rocksdb_writebatch_put_slice_parts(wb, 0, NULL, 0, NULL, &err);
+    CheckNoError(err);
+    rocksdb_writebatch_put_slice_parts(wb, 2, null_empty_key, 3, put_value,
+                                       &err);
+    CheckNoError(err);
+    rocksdb_writebatch_merge_slice_parts(wb, 2, merge_key, 2, merge_value,
+                                         &err);
+    CheckNoError(err);
+    rocksdb_writebatch_delete_slice_parts(wb, 2, delete_key, &err);
+    CheckNoError(err);
+    rocksdb_writebatch_delete_range_slice_parts(wb, 2, range_begin, 3,
+                                                range_end, &err);
+    CheckNoError(err);
+    CheckCondition(rocksdb_writebatch_count(wb) == 6);
+
+    rocksdb_write(db, woptions, wb, &err);
+    CheckNoError(err);
+    CheckGet(db, roptions, "slices-put", "value");
+    CheckGet(db, roptions, "", "");
+    CheckGet(db, roptions, "null-key", "value");
+    CheckGet(db, roptions, "slices-merge", "fake");
+    CheckGet(db, roptions, "slices-delete", NULL);
+    CheckGet(db, roptions, "slices-range-a", NULL);
+    CheckGet(db, roptions, "slices-range-b", NULL);
+    CheckGet(db, roptions, "slices-range-c", "c");
+
+    int count = rocksdb_writebatch_count(wb);
+    rocksdb_writebatch_put_slice_parts(wb, -1, NULL, 0, NULL, &err);
+    CheckErrorContains(&err, "key part count must be non-negative: -1");
+    CheckCondition(rocksdb_writebatch_count(wb) == count);
+    rocksdb_writebatch_delete_range_slice_parts(wb, 0, NULL, -1, NULL, &err);
+    CheckErrorContains(&err, "end key part count must be non-negative: -1");
+    CheckCondition(rocksdb_writebatch_count(wb) == count);
+    rocksdb_writebatch_delete_slice_parts(wb, 1, NULL, &err);
+    CheckErrorContains(
+        &err, "key parts must not be null when part count is positive: 1");
+    CheckCondition(rocksdb_writebatch_count(wb) == count);
+
+    const rocksdb_slice_t null_data[] = {{NULL, 1}};
+    rocksdb_writebatch_delete_slice_parts(wb, 1, null_data, &err);
+    CheckErrorContains(&err, "key part 0 has null data with non-zero size: 1");
+    CheckCondition(rocksdb_writebatch_count(wb) == count);
+
+    const rocksdb_slice_t oversized_key[] = {{"x", (size_t)UINT32_MAX}};
+    rocksdb_writebatch_delete_slice_parts(wb, 1, oversized_key, &err);
+    CheckErrorContains(&err, "key is too large");
+    CheckCondition(rocksdb_writebatch_count(wb) == count);
+    const rocksdb_slice_t small_key[] = {{"k", 1}};
+    const rocksdb_slice_t overflowing_value[] = {{"v", SIZE_MAX}, {"x", 1}};
+    rocksdb_writebatch_put_slice_parts(wb, 1, small_key, 2, overflowing_value,
+                                       &err);
+    CheckErrorContains(&err, "value is too large");
+    CheckCondition(rocksdb_writebatch_count(wb) == count);
+    rocksdb_writebatch_delete_range_slice_parts(wb, 1, small_key, 1,
+                                                oversized_key, &err);
+    CheckErrorContains(&err, "end key is too large");
+    CheckCondition(rocksdb_writebatch_count(wb) == count);
+
+    if (sizeof(size_t) > sizeof(uint32_t)) {
+      const rocksdb_slice_t oversized_value[] = {
+          {"v", (size_t)UINT32_MAX + (size_t)1}};
+      rocksdb_writebatch_put_slice_parts(wb, 1, small_key, 1, oversized_value,
+                                         &err);
+      CheckErrorContains(&err, "value is too large");
+      CheckCondition(rocksdb_writebatch_count(wb) == count);
+    }
+    rocksdb_writebatch_destroy(wb);
+
+    rocksdb_put_cf(db, woptions, slices_cf, "cf-merge", 8, "base", 4, &err);
+    CheckNoError(err);
+    rocksdb_put_cf(db, woptions, slices_cf, "cf-delete", 9, "old", 3, &err);
+    CheckNoError(err);
+    rocksdb_put_cf(db, woptions, slices_cf, "cf-range-a", 10, "a", 1, &err);
+    CheckNoError(err);
+    rocksdb_put_cf(db, woptions, slices_cf, "cf-range-b", 10, "b", 1, &err);
+    CheckNoError(err);
+    rocksdb_put_cf(db, woptions, slices_cf, "cf-range-c", 10, "c", 1, &err);
+    CheckNoError(err);
+
+    wb = rocksdb_writebatch_create();
+    const rocksdb_slice_t cf_put_key[] = {{"cf-", 3}, {"put", 3}};
+    const rocksdb_slice_t cf_put_value[] = {{"v", 1}, {"", 0}, {"alue", 4}};
+    const rocksdb_slice_t cf_merge_key[] = {{"cf-", 3}, {"merge", 5}};
+    const rocksdb_slice_t cf_delete_key[] = {{"cf-", 3}, {"delete", 6}};
+    const rocksdb_slice_t cf_range_begin[] = {
+        {"cf-", 3}, {"range-", 6}, {"a", 1}};
+    const rocksdb_slice_t cf_range_end[] = {{"cf-range-", 9}, {"c", 1}};
+
+    rocksdb_writebatch_put_slice_parts_cf(wb, slices_cf, 2, cf_put_key, 3,
+                                          cf_put_value, &err);
+    CheckNoError(err);
+    rocksdb_writebatch_merge_slice_parts_cf(wb, slices_cf, 2, cf_merge_key, 2,
+                                            merge_value, &err);
+    CheckNoError(err);
+    rocksdb_writebatch_delete_slice_parts_cf(wb, slices_cf, 2, cf_delete_key,
+                                             &err);
+    CheckNoError(err);
+    rocksdb_writebatch_delete_range_slice_parts_cf(
+        wb, slices_cf, 3, cf_range_begin, 2, cf_range_end, &err);
+    CheckNoError(err);
+    CheckCondition(rocksdb_writebatch_count(wb) == 4);
+
+    rocksdb_write(db, woptions, wb, &err);
+    CheckNoError(err);
+    CheckGetCF(db, roptions, slices_cf, "cf-put", "value");
+    CheckGetCF(db, roptions, slices_cf, "cf-merge", "fake");
+    CheckGetCF(db, roptions, slices_cf, "cf-delete", NULL);
+    CheckGetCF(db, roptions, slices_cf, "cf-range-a", NULL);
+    CheckGetCF(db, roptions, slices_cf, "cf-range-b", NULL);
+    CheckGetCF(db, roptions, slices_cf, "cf-range-c", "c");
+
+    rocksdb_writebatch_destroy(wb);
+    rocksdb_drop_column_family(db, slices_cf, &err);
+    CheckNoError(err);
+    rocksdb_column_family_handle_destroy(slices_cf);
+  }
+
+  StartPhase("writebatch_slice_parts_timestamp_cf");
+  {
+    rocksdb_comparator_t* timestamp_cmp = rocksdb_comparator_with_ts_create(
+        NULL, CmpDestroy, TimestampCmpCompare, TimestampCmpCompareTimestamp,
+        TimestampCmpCompareWithoutTimestamp, TimestampCmpName, 8);
+    rocksdb_options_t* timestamp_options = rocksdb_options_create();
+    rocksdb_options_set_comparator(timestamp_options, timestamp_cmp);
+    rocksdb_column_family_handle_t* timestamp_cf = rocksdb_create_column_family(
+        db, timestamp_options, "writebatch_slice_parts_timestamp", &err);
+    CheckNoError(err);
+
+    rocksdb_writebatch_t* wb = rocksdb_writebatch_create();
+    const rocksdb_slice_t key[] = {{"k", 1}, {"ey", 2}};
+    const rocksdb_slice_t value[] = {{"v", 1}, {"alue", 4}};
+    int count = rocksdb_writebatch_count(wb);
+
+    rocksdb_writebatch_put_slice_parts_cf(wb, timestamp_cf, 2, key, 2, value,
+                                          &err);
+    CheckErrorContains(&err, "column family enabling timestamp");
+    CheckCondition(rocksdb_writebatch_count(wb) == count);
+    rocksdb_writebatch_merge_slice_parts_cf(wb, timestamp_cf, 2, key, 2, value,
+                                            &err);
+    CheckErrorContains(&err, "column family enabling timestamp");
+    CheckCondition(rocksdb_writebatch_count(wb) == count);
+    rocksdb_writebatch_delete_slice_parts_cf(wb, timestamp_cf, 2, key, &err);
+    CheckErrorContains(&err, "column family enabling timestamp");
+    CheckCondition(rocksdb_writebatch_count(wb) == count);
+    rocksdb_writebatch_delete_range_slice_parts_cf(wb, timestamp_cf, 1, key, 2,
+                                                   value, &err);
+    CheckErrorContains(&err, "column family enabling timestamp");
+    CheckCondition(rocksdb_writebatch_count(wb) == count);
+
+    rocksdb_writebatch_destroy(wb);
+    rocksdb_drop_column_family(db, timestamp_cf, &err);
+    CheckNoError(err);
+    rocksdb_column_family_handle_destroy(timestamp_cf);
+    rocksdb_options_destroy(timestamp_options);
+    rocksdb_comparator_destroy(timestamp_cmp);
   }
 
   StartPhase("columnfamilies");

--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -99,6 +99,18 @@ enum ContentFlags : uint32_t {
 constexpr size_t kMaxWriteBatchKeySize =
     size_t{std::numeric_limits<uint32_t>::max()} - kNumInternalBytes;
 
+Status CheckSlicePartsSize(const SliceParts& parts, size_t limit,
+                           const char* name) {
+  size_t total_bytes = 0;
+  for (int i = 0; i < parts.num_parts; ++i) {
+    if (parts.parts[i].size() > limit - total_bytes) {
+      return Status::InvalidArgument(std::string(name) + " is too large");
+    }
+    total_bytes += parts.parts[i].size();
+  }
+  return Status::OK();
+}
+
 struct BatchContentClassifier : public WriteBatch::Handler {
   uint32_t content_flags = 0;
 
@@ -1003,22 +1015,12 @@ Status WriteBatch::Put(ColumnFamilyHandle* column_family, const Slice& key,
 
 Status WriteBatchInternal::CheckSlicePartsLength(const SliceParts& key,
                                                  const SliceParts& value) {
-  size_t total_key_bytes = 0;
-  for (int i = 0; i < key.num_parts; ++i) {
-    total_key_bytes += key.parts[i].size();
+  Status s = CheckSlicePartsSize(key, kMaxWriteBatchKeySize, "key");
+  if (!s.ok()) {
+    return s;
   }
-  if (total_key_bytes > kMaxWriteBatchKeySize) {
-    return Status::InvalidArgument("key is too large");
-  }
-
-  size_t total_value_bytes = 0;
-  for (int i = 0; i < value.num_parts; ++i) {
-    total_value_bytes += value.parts[i].size();
-  }
-  if (total_value_bytes > size_t{std::numeric_limits<uint32_t>::max()}) {
-    return Status::InvalidArgument("value is too large");
-  }
-  return Status::OK();
+  return CheckSlicePartsSize(
+      value, size_t{std::numeric_limits<uint32_t>::max()}, "value");
 }
 
 Status WriteBatchInternal::Put(WriteBatch* b, uint32_t column_family_id,
@@ -1636,7 +1638,10 @@ Status WriteBatch::DeleteRange(ColumnFamilyHandle* column_family,
 Status WriteBatchInternal::DeleteRange(WriteBatch* b, uint32_t column_family_id,
                                        const SliceParts& begin_key,
                                        const SliceParts& end_key) {
-  Status s = CheckSlicePartsLength(begin_key, end_key);
+  Status s = CheckSlicePartsSize(begin_key, kMaxWriteBatchKeySize, "begin key");
+  if (s.ok()) {
+    s = CheckSlicePartsSize(end_key, kMaxWriteBatchKeySize, "end key");
+  }
   if (!s.ok()) {
     return s;
   }

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -1042,6 +1042,19 @@ extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_putv_cf(
     int num_keys, const char* const* keys_list, const size_t* keys_list_sizes,
     int num_values, const char* const* values_list,
     const size_t* values_list_sizes);
+/* Slice-part variants concatenate each rocksdb_slice_t array into one key or
+ * value and report errors through errptr. Part counts must be non-negative,
+ * an array may be NULL only when its part count is zero, and a part may have
+ * NULL data only when its size is zero. The column-family variants report an
+ * error when the column family uses user-defined timestamps. */
+extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_put_slice_parts(
+    rocksdb_writebatch_t* b, int num_key_parts,
+    const rocksdb_slice_t* key_parts, int num_value_parts,
+    const rocksdb_slice_t* value_parts, char** errptr);
+extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_put_slice_parts_cf(
+    rocksdb_writebatch_t* b, rocksdb_column_family_handle_t* column_family,
+    int num_key_parts, const rocksdb_slice_t* key_parts, int num_value_parts,
+    const rocksdb_slice_t* value_parts, char** errptr);
 extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_merge(rocksdb_writebatch_t*,
                                                          const char* key,
                                                          size_t klen,
@@ -1059,6 +1072,14 @@ extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_mergev_cf(
     int num_keys, const char* const* keys_list, const size_t* keys_list_sizes,
     int num_values, const char* const* values_list,
     const size_t* values_list_sizes);
+extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_merge_slice_parts(
+    rocksdb_writebatch_t* b, int num_key_parts,
+    const rocksdb_slice_t* key_parts, int num_value_parts,
+    const rocksdb_slice_t* value_parts, char** errptr);
+extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_merge_slice_parts_cf(
+    rocksdb_writebatch_t* b, rocksdb_column_family_handle_t* column_family,
+    int num_key_parts, const rocksdb_slice_t* key_parts, int num_value_parts,
+    const rocksdb_slice_t* value_parts, char** errptr);
 extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_singledelete(
     rocksdb_writebatch_t* b, const char* key, size_t klen);
 extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_delete_cf(
@@ -1079,6 +1100,12 @@ extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_deletev(
 extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_deletev_cf(
     rocksdb_writebatch_t* b, rocksdb_column_family_handle_t* column_family,
     int num_keys, const char* const* keys_list, const size_t* keys_list_sizes);
+extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_delete_slice_parts(
+    rocksdb_writebatch_t* b, int num_key_parts,
+    const rocksdb_slice_t* key_parts, char** errptr);
+extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_delete_slice_parts_cf(
+    rocksdb_writebatch_t* b, rocksdb_column_family_handle_t* column_family,
+    int num_key_parts, const rocksdb_slice_t* key_parts, char** errptr);
 extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_delete_range(
     rocksdb_writebatch_t* b, const char* start_key, size_t start_key_len,
     const char* end_key, size_t end_key_len);
@@ -1095,6 +1122,14 @@ extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_delete_rangev_cf(
     int num_keys, const char* const* start_keys_list,
     const size_t* start_keys_list_sizes, const char* const* end_keys_list,
     const size_t* end_keys_list_sizes);
+extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_delete_range_slice_parts(
+    rocksdb_writebatch_t* b, int num_begin_key_parts,
+    const rocksdb_slice_t* begin_key_parts, int num_end_key_parts,
+    const rocksdb_slice_t* end_key_parts, char** errptr);
+extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_delete_range_slice_parts_cf(
+    rocksdb_writebatch_t* b, rocksdb_column_family_handle_t* column_family,
+    int num_begin_key_parts, const rocksdb_slice_t* begin_key_parts,
+    int num_end_key_parts, const rocksdb_slice_t* end_key_parts, char** errptr);
 extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_iterate(
     rocksdb_writebatch_t*, void* state,
     void (*put)(void*, const char* k, size_t klen, const char* v, size_t vlen),

--- a/tools/c_api_gen/c_base.cc
+++ b/tools/c_api_gen/c_base.cc
@@ -12,6 +12,7 @@
 #include <iterator>
 #include <map>
 #include <memory>
+#include <string>
 #include <unordered_set>
 #include <vector>
 
@@ -242,6 +243,47 @@ static rocksdb_wal_file_t CaptureWalFile(const WalFile& wal_file) {
   result.size_file_bytes = wal_file.SizeFileBytes();
   return result;
 }
+
+static Status CheckWriteBatchSliceParts(const char* parts_name, int num_parts,
+                                        const rocksdb_slice_t* parts) {
+  if (num_parts < 0) {
+    return Status::InvalidArgument(
+        std::string(parts_name) +
+        " part count must be non-negative: " + std::to_string(num_parts));
+  }
+  if (num_parts > 0 && parts == nullptr) {
+    return Status::InvalidArgument(
+        std::string(parts_name) +
+        " parts must not be null when part count is positive: " +
+        std::to_string(num_parts));
+  }
+  for (int i = 0; i < num_parts; ++i) {
+    if (parts[i].data == nullptr && parts[i].size != 0) {
+      return Status::InvalidArgument(std::string(parts_name) + " part " +
+                                     std::to_string(i) +
+                                     " has null data with non-zero size: " +
+                                     std::to_string(parts[i].size));
+    }
+  }
+  return Status::OK();
+}
+
+class CWriteBatchSliceParts {
+ public:
+  CWriteBatchSliceParts(int num_parts, const rocksdb_slice_t* parts) {
+    slices_.reserve(num_parts);
+    for (int i = 0; i < num_parts; ++i) {
+      slices_.emplace_back(parts[i].data, parts[i].size);
+    }
+  }
+
+  SliceParts Get() const {
+    return SliceParts(slices_.data(), static_cast<int>(slices_.size()));
+  }
+
+ private:
+  std::vector<Slice> slices_;
+};
 
 extern "C" {
 
@@ -662,6 +704,7 @@ struct rocksdb_compactionservice_scheduleresponse_t {
 struct rocksdb_compactionservice_jobinfo_t {
   CompactionServiceJobInfo rep;
 };
+
 // Layout assertions: these structs must be reinterpret_cast-compatible
 // with their rep field (single-member struct, standard-layout).
 static_assert(sizeof(rocksdb_writebatch_t) == sizeof(WriteBatch),
@@ -3333,6 +3376,40 @@ void rocksdb_writebatch_putv_cf(rocksdb_writebatch_t* b,
              SliceParts(value_slices.get(), num_values));
 }
 
+void rocksdb_writebatch_put_slice_parts(rocksdb_writebatch_t* b,
+                                        int num_key_parts,
+                                        const rocksdb_slice_t* key_parts,
+                                        int num_value_parts,
+                                        const rocksdb_slice_t* value_parts,
+                                        char** errptr) {
+  Status s = CheckWriteBatchSliceParts("key", num_key_parts, key_parts);
+  if (s.ok()) {
+    s = CheckWriteBatchSliceParts("value", num_value_parts, value_parts);
+  }
+  if (s.ok()) {
+    CWriteBatchSliceParts keys(num_key_parts, key_parts);
+    CWriteBatchSliceParts values(num_value_parts, value_parts);
+    s = b->rep.Put(keys.Get(), values.Get());
+  }
+  SaveError(errptr, s);
+}
+
+void rocksdb_writebatch_put_slice_parts_cf(
+    rocksdb_writebatch_t* b, rocksdb_column_family_handle_t* column_family,
+    int num_key_parts, const rocksdb_slice_t* key_parts, int num_value_parts,
+    const rocksdb_slice_t* value_parts, char** errptr) {
+  Status s = CheckWriteBatchSliceParts("key", num_key_parts, key_parts);
+  if (s.ok()) {
+    s = CheckWriteBatchSliceParts("value", num_value_parts, value_parts);
+  }
+  if (s.ok()) {
+    CWriteBatchSliceParts keys(num_key_parts, key_parts);
+    CWriteBatchSliceParts values(num_value_parts, value_parts);
+    s = b->rep.Put(column_family->rep, keys.Get(), values.Get());
+  }
+  SaveError(errptr, s);
+}
+
 void rocksdb_writebatch_merge(rocksdb_writebatch_t* b, const char* key,
                               size_t klen, const char* val, size_t vlen) {
   b->rep.Merge(Slice(key, klen), Slice(val, vlen));
@@ -3382,6 +3459,40 @@ void rocksdb_writebatch_mergev_cf(rocksdb_writebatch_t* b,
   }
   b->rep.Merge(column_family->rep, SliceParts(key_slices.get(), num_keys),
                SliceParts(value_slices.get(), num_values));
+}
+
+void rocksdb_writebatch_merge_slice_parts(rocksdb_writebatch_t* b,
+                                          int num_key_parts,
+                                          const rocksdb_slice_t* key_parts,
+                                          int num_value_parts,
+                                          const rocksdb_slice_t* value_parts,
+                                          char** errptr) {
+  Status s = CheckWriteBatchSliceParts("key", num_key_parts, key_parts);
+  if (s.ok()) {
+    s = CheckWriteBatchSliceParts("value", num_value_parts, value_parts);
+  }
+  if (s.ok()) {
+    CWriteBatchSliceParts keys(num_key_parts, key_parts);
+    CWriteBatchSliceParts values(num_value_parts, value_parts);
+    s = b->rep.Merge(keys.Get(), values.Get());
+  }
+  SaveError(errptr, s);
+}
+
+void rocksdb_writebatch_merge_slice_parts_cf(
+    rocksdb_writebatch_t* b, rocksdb_column_family_handle_t* column_family,
+    int num_key_parts, const rocksdb_slice_t* key_parts, int num_value_parts,
+    const rocksdb_slice_t* value_parts, char** errptr) {
+  Status s = CheckWriteBatchSliceParts("key", num_key_parts, key_parts);
+  if (s.ok()) {
+    s = CheckWriteBatchSliceParts("value", num_value_parts, value_parts);
+  }
+  if (s.ok()) {
+    CWriteBatchSliceParts keys(num_key_parts, key_parts);
+    CWriteBatchSliceParts values(num_value_parts, value_parts);
+    s = b->rep.Merge(column_family->rep, keys.Get(), values.Get());
+  }
+  SaveError(errptr, s);
 }
 
 void rocksdb_writebatch_singledelete(rocksdb_writebatch_t* b, const char* key,
@@ -3437,6 +3548,29 @@ void rocksdb_writebatch_deletev_cf(
   b->rep.Delete(column_family->rep, SliceParts(key_slices.get(), num_keys));
 }
 
+void rocksdb_writebatch_delete_slice_parts(rocksdb_writebatch_t* b,
+                                           int num_key_parts,
+                                           const rocksdb_slice_t* key_parts,
+                                           char** errptr) {
+  Status s = CheckWriteBatchSliceParts("key", num_key_parts, key_parts);
+  if (s.ok()) {
+    CWriteBatchSliceParts keys(num_key_parts, key_parts);
+    s = b->rep.Delete(keys.Get());
+  }
+  SaveError(errptr, s);
+}
+
+void rocksdb_writebatch_delete_slice_parts_cf(
+    rocksdb_writebatch_t* b, rocksdb_column_family_handle_t* column_family,
+    int num_key_parts, const rocksdb_slice_t* key_parts, char** errptr) {
+  Status s = CheckWriteBatchSliceParts("key", num_key_parts, key_parts);
+  if (s.ok()) {
+    CWriteBatchSliceParts keys(num_key_parts, key_parts);
+    s = b->rep.Delete(column_family->rep, keys.Get());
+  }
+  SaveError(errptr, s);
+}
+
 void rocksdb_writebatch_delete_range(rocksdb_writebatch_t* b,
                                      const char* start_key,
                                      size_t start_key_len, const char* end_key,
@@ -3486,6 +3620,41 @@ void rocksdb_writebatch_delete_rangev_cf(
   b->rep.DeleteRange(column_family->rep,
                      SliceParts(start_key_slices.get(), num_keys),
                      SliceParts(end_key_slices.get(), num_keys));
+}
+
+void rocksdb_writebatch_delete_range_slice_parts(
+    rocksdb_writebatch_t* b, int num_begin_key_parts,
+    const rocksdb_slice_t* begin_key_parts, int num_end_key_parts,
+    const rocksdb_slice_t* end_key_parts, char** errptr) {
+  Status s = CheckWriteBatchSliceParts("begin key", num_begin_key_parts,
+                                       begin_key_parts);
+  if (s.ok()) {
+    s = CheckWriteBatchSliceParts("end key", num_end_key_parts, end_key_parts);
+  }
+  if (s.ok()) {
+    CWriteBatchSliceParts begin_key(num_begin_key_parts, begin_key_parts);
+    CWriteBatchSliceParts end_key(num_end_key_parts, end_key_parts);
+    s = b->rep.DeleteRange(begin_key.Get(), end_key.Get());
+  }
+  SaveError(errptr, s);
+}
+
+void rocksdb_writebatch_delete_range_slice_parts_cf(
+    rocksdb_writebatch_t* b, rocksdb_column_family_handle_t* column_family,
+    int num_begin_key_parts, const rocksdb_slice_t* begin_key_parts,
+    int num_end_key_parts, const rocksdb_slice_t* end_key_parts,
+    char** errptr) {
+  Status s = CheckWriteBatchSliceParts("begin key", num_begin_key_parts,
+                                       begin_key_parts);
+  if (s.ok()) {
+    s = CheckWriteBatchSliceParts("end key", num_end_key_parts, end_key_parts);
+  }
+  if (s.ok()) {
+    CWriteBatchSliceParts begin_key(num_begin_key_parts, begin_key_parts);
+    CWriteBatchSliceParts end_key(num_end_key_parts, end_key_parts);
+    s = b->rep.DeleteRange(column_family->rep, begin_key.Get(), end_key.Get());
+  }
+  SaveError(errptr, s);
 }
 
 class H : public WriteBatch::Handler {

--- a/tools/c_api_gen/c_base.h
+++ b/tools/c_api_gen/c_base.h
@@ -865,6 +865,19 @@ extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_putv_cf(
     int num_keys, const char* const* keys_list, const size_t* keys_list_sizes,
     int num_values, const char* const* values_list,
     const size_t* values_list_sizes);
+/* Slice-part variants concatenate each rocksdb_slice_t array into one key or
+ * value and report errors through errptr. Part counts must be non-negative,
+ * an array may be NULL only when its part count is zero, and a part may have
+ * NULL data only when its size is zero. The column-family variants report an
+ * error when the column family uses user-defined timestamps. */
+extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_put_slice_parts(
+    rocksdb_writebatch_t* b, int num_key_parts,
+    const rocksdb_slice_t* key_parts, int num_value_parts,
+    const rocksdb_slice_t* value_parts, char** errptr);
+extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_put_slice_parts_cf(
+    rocksdb_writebatch_t* b, rocksdb_column_family_handle_t* column_family,
+    int num_key_parts, const rocksdb_slice_t* key_parts, int num_value_parts,
+    const rocksdb_slice_t* value_parts, char** errptr);
 extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_merge(rocksdb_writebatch_t*,
                                                          const char* key,
                                                          size_t klen,
@@ -882,6 +895,14 @@ extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_mergev_cf(
     int num_keys, const char* const* keys_list, const size_t* keys_list_sizes,
     int num_values, const char* const* values_list,
     const size_t* values_list_sizes);
+extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_merge_slice_parts(
+    rocksdb_writebatch_t* b, int num_key_parts,
+    const rocksdb_slice_t* key_parts, int num_value_parts,
+    const rocksdb_slice_t* value_parts, char** errptr);
+extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_merge_slice_parts_cf(
+    rocksdb_writebatch_t* b, rocksdb_column_family_handle_t* column_family,
+    int num_key_parts, const rocksdb_slice_t* key_parts, int num_value_parts,
+    const rocksdb_slice_t* value_parts, char** errptr);
 extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_singledelete(
     rocksdb_writebatch_t* b, const char* key, size_t klen);
 extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_delete_cf(
@@ -902,6 +923,12 @@ extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_deletev(
 extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_deletev_cf(
     rocksdb_writebatch_t* b, rocksdb_column_family_handle_t* column_family,
     int num_keys, const char* const* keys_list, const size_t* keys_list_sizes);
+extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_delete_slice_parts(
+    rocksdb_writebatch_t* b, int num_key_parts,
+    const rocksdb_slice_t* key_parts, char** errptr);
+extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_delete_slice_parts_cf(
+    rocksdb_writebatch_t* b, rocksdb_column_family_handle_t* column_family,
+    int num_key_parts, const rocksdb_slice_t* key_parts, char** errptr);
 extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_delete_range(
     rocksdb_writebatch_t* b, const char* start_key, size_t start_key_len,
     const char* end_key, size_t end_key_len);
@@ -918,6 +945,14 @@ extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_delete_rangev_cf(
     int num_keys, const char* const* start_keys_list,
     const size_t* start_keys_list_sizes, const char* const* end_keys_list,
     const size_t* end_keys_list_sizes);
+extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_delete_range_slice_parts(
+    rocksdb_writebatch_t* b, int num_begin_key_parts,
+    const rocksdb_slice_t* begin_key_parts, int num_end_key_parts,
+    const rocksdb_slice_t* end_key_parts, char** errptr);
+extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_delete_range_slice_parts_cf(
+    rocksdb_writebatch_t* b, rocksdb_column_family_handle_t* column_family,
+    int num_begin_key_parts, const rocksdb_slice_t* begin_key_parts,
+    int num_end_key_parts, const rocksdb_slice_t* end_key_parts, char** errptr);
 extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_iterate(
     rocksdb_writebatch_t*, void* state,
     void (*put)(void*, const char* k, size_t klen, const char* v, size_t vlen),

--- a/unreleased_history/bug_fixes/write_batch_slice_parts_size_validation.md
+++ b/unreleased_history/bug_fixes/write_batch_slice_parts_size_validation.md
@@ -1,0 +1,1 @@
+Fixed overflow in WriteBatch SliceParts size validation and checked both DeleteRange endpoints against the key size limit.

--- a/unreleased_history/public_api_changes/writebatch_slice_parts_c_api.md
+++ b/unreleased_history/public_api_changes/writebatch_slice_parts_c_api.md
@@ -1,0 +1,1 @@
+Added slice-part C WriteBatch put, merge, delete, and range delete APIs that accept `rocksdb_slice_t` arrays and report rejected operations through `errptr`.


### PR DESCRIPTION
## Summary

- add slice-part C APIs for WriteBatch put, merge, delete, and range delete operations
- provide default and column-family variants using `rocksdb_slice_t` arrays
- report rejected operations through `errptr`
- keep all existing WriteBatch C API signatures unchanged
- make SliceParts size validation overflow-safe
- validate both DeleteRange endpoints against the key size limit

## Why

The existing `putv`, `mergev`, and delete-vector APIs require separate pointer and length arrays and discard the `Status` returned by `WriteBatch`. A rejected operation, such as a write to a timestamp-enabled column family without a timestamp, can therefore be silently omitted.

The new APIs accept `rocksdb_slice_t` parts, build real `Slice` descriptors for the call, and return errors through the normal C API `errptr` convention. Range endpoints have independent part counts.

While adding the API, tests exposed two existing SliceParts validation problems. Aggregate size addition could overflow, and `DeleteRange` treated the end key as a value for size validation. Both checks are fixed in this change.

## Compatibility

This is additive. The existing vector and scalar WriteBatch APIs are unchanged. This overlaps in purpose with the older #10528 proposal, but does not change existing function signatures.

## Testing

`c_test` covers:

- default and column-family operations
- multi-part and empty-part inputs
- unequal range endpoint part counts
- null arrays and null part data
- negative part counts
- single-part and aggregate size errors
- oversized range end keys
- timestamp-enabled column-family errors

Additional validation:

- `write_batch_test`
- `make -j8 check-c-api-c_test`
- `CXX=clang++ make check-c-api-gen CHECK_C_API_GEN_STRICT=1 CLANG_FORMAT_BINARY=clang-format`
- C API link-completeness and backward-compatibility checks

These APIs are intended to replace temporary compatibility extensions in `rust-rocksdb` once they are available in a RocksDB release.