### PR TITLE
Fix heap-buffer-overflow(read) parsing a corrupted data-block hash index

### DIFF
--- a/table/block_based/block.cc
+++ b/table/block_based/block.cc
@@ -1330,18 +1330,17 @@ Block::Block(BlockContents&& contents, size_t read_amp_bytes_per_bit,
     switch (footer.index_type) {
       case BlockBasedTableOptions::kDataBlockBinarySearch:
         break;
-      case BlockBasedTableOptions::kDataBlockBinaryAndHash:
-        if (input.size() < sizeof(uint16_t) /* NUM_BUCK */) {
-          size = 0;
+      case BlockBasedTableOptions::kDataBlockBinaryAndHash: {
+        uint16_t map_offset;
+        if (!data_block_hash_index_.Initialize(contents_.data.data(),
+                                               input.size(), &map_offset)) {
+          size = 0;  // Corrupted hash index
           break;
         }
-        uint16_t map_offset;
-        data_block_hash_index_.Initialize(contents_.data.data(),
-                                          static_cast<uint16_t>(input.size()),
-                                          &map_offset);
         // Strip the hash index, leaving just data + restarts
         input.remove_suffix(input.size() - map_offset);
         break;
+      }
       default:
         size = 0;  // Error marker
     }

--- a/table/block_based/block_test.cc
+++ b/table/block_based/block_test.cc
@@ -29,6 +29,7 @@
 #include "table/format.h"
 #include "test_util/testharness.h"
 #include "test_util/testutil.h"
+#include "util/coding.h"
 #include "util/random.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -1216,6 +1217,58 @@ TEST_F(BlockPerKVChecksumTest, InitializeProtectionInfo) {
     std::unique_ptr<MetaBlockIter> iter{meta_block->NewMetaIterator(true)};
     ASSERT_TRUE(iter->status().IsCorruption());
   }
+}
+
+TEST_F(BlockPerKVChecksumTest, CorruptHashIndexNumBucketsNoOverRead) {
+  // Regression test for a heap-buffer-overflow(read) reachable from a corrupted
+  // SST. A data block whose footer claims the hash index format but encodes a
+  // NUM_BUCKETS larger than the block would, in release builds (where the
+  // debug-only asserts in DataBlockHashIndex::Initialize are compiled out),
+  // underflow map_offset. That inflated restart_offset_ was then trusted by
+  // Block::GetCorruptionStatus() to size a Slice, driving an out-of-bounds read
+  // in DataBlockFooter::DecodeFrom(). The block must instead be reported as
+  // corrupt without reading past its heap allocation (verified under ASAN).
+  Options options = Options();
+  BlockCreateContext create_context{kTableOptions(),
+                                    nullptr /* ioptions */,
+                                    nullptr /* statistics */,
+                                    kDecompressor(),
+                                    0 /* protection_bytes_per_key */,
+                                    options.comparator};
+
+  // Body bytes followed by a 2-byte NUM_BUCKETS field, then the encoded footer
+  // (values_section_offset + packed). Layout mirrors what DecodeFrom expects.
+  std::string block_body(500, 'x');
+  // NUM_BUCKETS far larger than the block: forces the map_offset underflow.
+  PutFixed16(&block_body, 60000);
+  DataBlockFooter footer;
+  footer.num_restarts = 1;
+  footer.index_type = BlockBasedTableOptions::kDataBlockBinaryAndHash;
+  footer.separated_kv = true;
+  footer.is_uniform = false;
+  // Large offset so the (pre-fix) inflated restart_offset_ path marks size == 0
+  // and routes through GetCorruptionStatus().
+  footer.values_section_offset = 0xFFFFFFFFu;
+  footer.EncodeTo(&block_body);
+
+  // Use a tightly-sized heap allocation so any over-read hits an ASAN redzone.
+  std::unique_ptr<char[]> buf(new char[block_body.size()]);
+  memcpy(buf.get(), block_body.data(), block_body.size());
+  BlockContents contents(std::move(buf), block_body.size());
+
+  std::unique_ptr<Block_kData> data_block;
+  create_context.Create(&data_block, std::move(contents));
+  ASSERT_NE(data_block, nullptr);
+  if (data_block == nullptr) {
+    return;
+  }
+  std::unique_ptr<DataBlockIter> iter{data_block->NewDataIterator(
+      options.comparator, kDisableGlobalSequenceNumber)};
+  ASSERT_NE(iter, nullptr);
+  if (iter == nullptr) {
+    return;
+  }
+  ASSERT_TRUE(iter->status().IsCorruption());
 }
 
 TEST_F(BlockPerKVChecksumTest, ApproximateMemory) {

--- a/table/block_based/data_block_hash_index.cc
+++ b/table/block_based/data_block_hash_index.cc
@@ -73,14 +73,26 @@ void DataBlockHashIndexBuilder::Reset() {
   hash_and_restart_pairs_.clear();
 }
 
-void DataBlockHashIndex::Initialize(const char* data, uint16_t size,
+bool DataBlockHashIndex::Initialize(const char* data, size_t size,
                                     uint16_t* map_offset) {
-  assert(size >= sizeof(uint16_t));  // NUM_BUCKETS
+  num_buckets_ = 0;
+  if (size < sizeof(uint16_t) /* NUM_BUCKETS */ ||
+      size >= kMaxBlockSizeSupportedByHashIndex) {
+    return false;
+  }
   num_buckets_ = DecodeFixed16(data + size - sizeof(uint16_t));
-  assert(num_buckets_ > 0);
-  assert(size > num_buckets_ * sizeof(uint8_t));
+  // The bucket array plus the NUM_BUCKETS field must fit within `size`. A
+  // corrupted block can encode a `num_buckets_` large enough to underflow the
+  // `map_offset` computation below, so reject it here rather than relying on
+  // the debug-only asserts (compiled out in release/ASAN builds).
+  if (num_buckets_ == 0 ||
+      num_buckets_ * sizeof(uint8_t) + sizeof(uint16_t) > size) {
+    num_buckets_ = 0;
+    return false;
+  }
   *map_offset = static_cast<uint16_t>(size - sizeof(uint16_t) -
                                       num_buckets_ * sizeof(uint8_t));
+  return true;
 }
 
 uint8_t DataBlockHashIndex::Lookup(const char* data, uint32_t map_offset,

--- a/table/block_based/data_block_hash_index.h
+++ b/table/block_based/data_block_hash_index.h
@@ -118,7 +118,16 @@ class DataBlockHashIndex {
  public:
   DataBlockHashIndex() : num_buckets_(0) {}
 
-  void Initialize(const char* data, uint16_t size, uint16_t* map_offset);
+  // Parses the serialized hash index at the tail of a data block. `data` points
+  // to the start of the block and `size` is the number of bytes preceding the
+  // hash index footer (i.e. everything up to and including the hash index).
+  // On success, sets `*map_offset` to the offset of the bucket array and
+  // returns true. Returns false (without setting `*map_offset`) if `size` is
+  // not supported or the encoded `num_buckets` is inconsistent with it, which
+  // can happen with corrupted block contents. Callers must treat a false return
+  // as a corrupt block; the debug-only asserts formerly guarding this are
+  // compiled out in release builds, so validation must happen at runtime.
+  bool Initialize(const char* data, size_t size, uint16_t* map_offset);
 
   uint8_t Lookup(const char* data, uint32_t map_offset, const Slice& key) const;
 

--- a/table/block_based/data_block_hash_index_test.cc
+++ b/table/block_based/data_block_hash_index_test.cc
@@ -18,6 +18,7 @@
 #include "table/table_builder.h"
 #include "test_util/testharness.h"
 #include "test_util/testutil.h"
+#include "util/coding.h"
 #include "util/random.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -96,7 +97,7 @@ TEST(DataBlockHashIndex, DataBlockHashTestSmall) {
     Slice s(buffer2);
     DataBlockHashIndex index;
     uint16_t map_offset;
-    index.Initialize(s.data(), static_cast<uint16_t>(s.size()), &map_offset);
+    ASSERT_TRUE(index.Initialize(s.data(), s.size(), &map_offset));
 
     // the additional hash map should start at the end of the buffer
     ASSERT_EQ(original_size, map_offset);
@@ -135,7 +136,7 @@ TEST(DataBlockHashIndex, DataBlockHashTest) {
   Slice s(buffer2);
   DataBlockHashIndex index;
   uint16_t map_offset;
-  index.Initialize(s.data(), static_cast<uint16_t>(s.size()), &map_offset);
+  ASSERT_TRUE(index.Initialize(s.data(), s.size(), &map_offset));
 
   // the additional hash map should start at the end of the buffer
   ASSERT_EQ(original_size, map_offset);
@@ -144,6 +145,57 @@ TEST(DataBlockHashIndex, DataBlockHashTest) {
     uint8_t restart_point = i;
     ASSERT_TRUE(
         SearchForOffset(index, s.data(), map_offset, key, restart_point));
+  }
+}
+
+TEST(DataBlockHashIndex, InitializeRejectsCorruptNumBuckets) {
+  // Build a valid hash index, then corrupt the trailing NUM_BUCKETS field so
+  // that the encoded bucket count exceeds the buffer. Initialize must reject it
+  // instead of underflowing the map_offset computation (which, in a release
+  // build where the debug asserts are compiled out, would later drive an
+  // out-of-bounds read while parsing the block).
+  DataBlockHashIndexBuilder builder;
+  builder.Initialize(0.75 /*util_ratio*/);
+  for (uint8_t i = 0; i < 10; i++) {
+    builder.Add("key" + std::to_string(i), i);
+  }
+  std::string buffer("fake content");
+  builder.Finish(buffer);
+
+  // Sanity check: the unmodified index parses.
+  {
+    Slice s(buffer);
+    DataBlockHashIndex index;
+    uint16_t map_offset = 0;
+    ASSERT_TRUE(index.Initialize(s.data(), s.size(), &map_offset));
+  }
+
+  // Corrupt NUM_BUCKETS (last 2 bytes) to a value larger than the buffer.
+  std::string corrupted = buffer;
+  EncodeFixed16(&corrupted[corrupted.size() - sizeof(uint16_t)],
+                static_cast<uint16_t>(corrupted.size() + 1000));
+  Slice s(corrupted);
+  DataBlockHashIndex index;
+  uint16_t map_offset = 0;
+  ASSERT_FALSE(index.Initialize(s.data(), s.size(), &map_offset));
+  ASSERT_FALSE(index.Valid());
+
+  // A NUM_BUCKETS of zero is also invalid.
+  EncodeFixed16(&corrupted[corrupted.size() - sizeof(uint16_t)], 0);
+  Slice s0(corrupted);
+  DataBlockHashIndex index0;
+  ASSERT_FALSE(index0.Initialize(s0.data(), s0.size(), &map_offset));
+}
+
+TEST(DataBlockHashIndex, InitializeRejectsUnsupportedSize) {
+  for (const size_t size :
+       {size_t{0}, size_t{1}, kMaxBlockSizeSupportedByHashIndex,
+        kMaxBlockSizeSupportedByHashIndex + 1}) {
+    const std::string input(size, 'x');
+    DataBlockHashIndex index;
+    uint16_t map_offset = 0;
+    ASSERT_FALSE(index.Initialize(input.data(), input.size(), &map_offset));
+    ASSERT_FALSE(index.Valid());
   }
 }
 
@@ -172,7 +224,7 @@ TEST(DataBlockHashIndex, DataBlockHashTestCollision) {
   Slice s(buffer2);
   DataBlockHashIndex index;
   uint16_t map_offset;
-  index.Initialize(s.data(), static_cast<uint16_t>(s.size()), &map_offset);
+  ASSERT_TRUE(index.Initialize(s.data(), s.size(), &map_offset));
 
   // the additional hash map should start at the end of the buffer
   ASSERT_EQ(original_size, map_offset);
@@ -213,7 +265,7 @@ TEST(DataBlockHashIndex, DataBlockHashTestLarge) {
   Slice s(buffer2);
   DataBlockHashIndex index;
   uint16_t map_offset;
-  index.Initialize(s.data(), static_cast<uint16_t>(s.size()), &map_offset);
+  ASSERT_TRUE(index.Initialize(s.data(), s.size(), &map_offset));
 
   // the additional hash map should start at the end of the buffer
   ASSERT_EQ(original_size, map_offset);


### PR DESCRIPTION
Summary:
A corrupted RocksDB SST data block whose footer sets the hash-index bit
(`kDataBlockBinaryAndHash`) could drive an out-of-bounds heap read while the
block is being parsed. `DataBlockHashIndex::Initialize` guarded its
`num_buckets` / `map_offset` arithmetic only with `assert()`, which is compiled
out in release and ASAN builds. When the encoded `num_buckets` exceeds the
block, the `uint16_t` `map_offset` computation underflows; that value then
flows into `Block`'s ctor at `input.remove_suffix(input.size() - map_offset)`,
inflating `restart_offset_` far past the real allocation. If `size` is later
zeroed as an error marker (e.g. a corrupted separated-KV footer),
`Block::GetCorruptionStatus` builds a `Slice(data(), restart_offset_)` and
`DataBlockFooter::DecodeFrom` reads `data() + restart_offset_ - 4`, over-reading
the block's heap buffer (reported by agentic fuzzing, T279933950).

Fix:
- `DataBlockHashIndex::Initialize` now returns `bool` and rejects a
  `num_buckets` of 0 or one whose bucket array plus the `NUM_BUCKETS` field does
  not fit within `size`, instead of relying on debug-only asserts.
- `Block`'s ctor checks that return value and also rejects blocks too large for
  the 64KiB `uint16_t`-offset hash-index format, marking the block corrupt
  (`size = 0`) rather than under-flowing `map_offset` and over-reading.

Reviewed By: pdillinger

Differential Revision: D113429299


