### PR TITLE
feat: set comparator name in PlainTable properties to fix SST ingestion

### DIFF
--- a/db/external_sst_file_basic_test.cc
+++ b/db/external_sst_file_basic_test.cc
@@ -13,6 +13,7 @@
 #include "rocksdb/options.h"
 #include "rocksdb/perf_context.h"
 #include "rocksdb/sst_file_writer.h"
+#include "rocksdb/table.h"
 #include "test_util/testharness.h"
 #include "test_util/testutil.h"
 #include "util/defer.h"
@@ -260,6 +261,43 @@ TEST_F(ExternalSSTFileBasicTest, Basic) {
   ASSERT_NOK(s) << s.ToString();
   s = sst_file_writer.DeleteRange(Key(100), Key(200));
   ASSERT_NOK(s) << s.ToString();
+
+  DestroyAndRecreateExternalSSTFilesDir();
+}
+
+TEST_F(ExternalSSTFileBasicTest, IngestPlainTableFile) {
+  Options options = CurrentOptions();
+
+  PlainTableOptions plain_table_options;
+  plain_table_options.hash_table_ratio = 0;
+  options.table_factory.reset(NewPlainTableFactory(plain_table_options));
+  options.prefix_extractor.reset();
+  options.allow_mmap_reads = true;
+  DestroyAndReopen(options);
+
+  SstFileWriter sst_file_writer(EnvOptions(), options);
+  std::string file = sst_files_dir_ + "plain_table_file.sst";
+  ASSERT_OK(sst_file_writer.Open(file));
+  for (int k = 0; k < 100; k++) {
+    ASSERT_OK(sst_file_writer.Put(Key(k), Key(k) + "_val"));
+  }
+  ExternalSstFileInfo file_info;
+  ASSERT_OK(sst_file_writer.Finish(&file_info));
+  ASSERT_EQ(file_info.num_entries, 100);
+
+  ASSERT_OK(db_->IngestExternalFile({file}, IngestExternalFileOptions()));
+
+  TablePropertiesCollection props;
+  ASSERT_OK(db_->GetPropertiesOfAllTables(&props));
+  ASSERT_EQ(props.size(), 1);
+  for (const auto& file_and_props : props) {
+    ASSERT_EQ(file_and_props.second->comparator_name,
+              options.comparator->Name());
+  }
+
+  for (int k = 0; k < 100; k++) {
+    ASSERT_EQ(Get(Key(k)), Key(k) + "_val");
+  }
 
   DestroyAndRecreateExternalSSTFilesDir();
 }

--- a/table/plain/plain_table_builder.cc
+++ b/table/plain/plain_table_builder.cc
@@ -108,7 +108,9 @@ PlainTableBuilder::PlainTableBuilder(
       moptions_.prefix_extractor != nullptr
           ? moptions_.prefix_extractor->AsString()
           : "nullptr";
-
+  properties_.comparator_name = ioptions_.user_comparator != nullptr
+                                    ? ioptions_.user_comparator->Name()
+                                    : "nullptr";
   std::string val;
   PutFixed32(&val, static_cast<uint32_t>(encoder_.GetEncodingType()));
   properties_


### PR DESCRIPTION
Summary:

PlainTableBuilder was never setting the comparator_name in the table properties, so the SST files written with the plain table format ended with an empty comparator name. Because of that, when we try to ingest one of these files the ingestion fails.

The problem is in the ingestion path. When an external file is ingested, ExternalSstFileIngestionJob validates the comparator of the file against the comparator of the column family (db/external_sst_file_ingestion_job.cc). That job compares the name of the column family comparator with the name stored in the file. When the stored name is empty it does not match the column family comparator, so it returns kInvalidChange and the ingestion is rejected with "InvalidArgument: does not match existing comparator".

The fix is small. We set properties_.comparator_name in the constructor of PlainTableBuilder, the same way that BlockBasedTableBuilder already does it (table/block_based/block_based_table_builder.cc) and external_table.cc. Now the plain table file carries the correct comparator name and the validation passes.

Test Plan:

- Added a new regression test IngestPlainTableFile in db/external_sst_file_basic_test.cc. The test writes a plain table SST file with SstFileWriter, ingests it into a DB that also uses a plain table factory, and then checks two things: that comparator_name is present in the table properties of the ingested file, and that all the keys are readable after the ingestion.
- Confirmed the test catches the bug. Without the fix the ingestion returns "Invalid argument: leveldb.BytewiseComparator: does not match existing comparator". With the fix the test passes.
- Ran make check to make sure there is no regression.