### PR TITLE
Fix PinnableSlice move construction from pinned slices

### DIFF
--- a/util/slice.cc
+++ b/util/slice.cc
@@ -322,7 +322,7 @@ bool Slice::DecodeHex(std::string* result) const {
   return true;
 }
 
-PinnableSlice::PinnableSlice(PinnableSlice&& other) {
+PinnableSlice::PinnableSlice(PinnableSlice&& other) : PinnableSlice() {
   *this = std::move(other);
 }
 

--- a/util/slice_test.cc
+++ b/util/slice_test.cc
@@ -11,6 +11,8 @@
 
 #include <gtest/gtest.h>
 
+#include <cstring>
+#include <new>
 #include <semaphore>
 
 #include "port/port.h"
@@ -64,6 +66,27 @@ TEST_F(PinnableSliceTest, MoveExternalBuffer) {
   v3 = std::move(v2);
   ASSERT_EQ(buf.data(), v3.data());
   ASSERT_EQ(&buf, v3.GetSelf());
+}
+
+TEST_F(PinnableSliceTest, MoveConstructPinnedThenReuse) {
+  int n2 = 2;
+  int res = 1;
+  Slice s("123");
+  PinnableSlice v1;
+  v1.PinSlice(s, Multiplier, &res, &n2);
+
+  alignas(PinnableSlice) unsigned char storage[sizeof(PinnableSlice)];
+  std::memset(storage, 0xab, sizeof(storage));
+  PinnableSlice* v2 = new (storage) PinnableSlice(std::move(v1));
+  ASSERT_TRUE(v2->IsPinned());
+  AssertSameData("123", *v2);
+
+  v2->Reset();
+  ASSERT_EQ(2, res);
+
+  v2->PinSelf(Slice("456"));
+  AssertSameData("456", *v2);
+  v2->~PinnableSlice();
 }
 
 TEST_F(PinnableSliceTest, Move) {


### PR DESCRIPTION
Summary:
T280925646 reported an ASAN double-free in db_stress' batched prefix scan. The visible free was in VerifyWideColumns(), but WideColumn values are non-owning Slice views, so that destructor should only free the vector element storage. The stack points to prior ownership corruption rather than an intentional verifier free.

The concrete bug is in PinnableSlice's move constructor: it delegates to move assignment without first initializing the target object. When moving from a pinned slice, move assignment does not set buf_ because the target is still pinned. If that moved-to slice is later Reset() and reused with PinSelf(), it writes through an uninitialized buf_ pointer.

This became reachable after D112212266 changed PinnableWideColumns to keep backing buffers in std::forward_list<PinnableSlice> and emplace moved PinnableSlice values into backing nodes.

Fix the move constructor by delegating to the default constructor first, so buf_ is initialized before move assignment. Add a regression that poisons placement-new storage, move-constructs from a pinned slice, resets it, and reuses it with PinSelf(); this crashed before the fix.

Differential Revision: D113480016


