### PR TITLE
Simplify ReadOptions plumbing for read-path blob fetchers

### DIFF
--- a/db/blob/blob_fetcher.cc
+++ b/db/blob/blob_fetcher.cc
@@ -26,20 +26,21 @@ Status BlobFetcher::FetchBlob(const Slice& user_key,
   return status;
 }
 
-Status VersionBlobFetcher::FetchBlob(const Slice& user_key,
-                                     const BlobIndex& blob_index,
-                                     FilePrefetchBuffer* prefetch_buffer,
-                                     PinnableSlice* blob_value,
-                                     uint64_t* bytes_read) const {
+Status VersionBlobFetcherBase::FetchBlob(const Slice& user_key,
+                                         const BlobIndex& blob_index,
+                                         FilePrefetchBuffer* prefetch_buffer,
+                                         PinnableSlice* blob_value,
+                                         uint64_t* bytes_read) const {
+  const ReadOptions& read_options = this->read_options();
   if (!allow_write_path_fallback_) {
     assert(version_);
 
-    return version_->GetBlob(read_options_, user_key, blob_index,
+    return version_->GetBlob(read_options, user_key, blob_index,
                              prefetch_buffer, blob_value, bytes_read);
   }
 
   return BlobFilePartitionManager::ResolveBlobDirectWriteIndex(
-      read_options_, user_key, blob_index, version_, blob_file_cache_,
+      read_options, user_key, blob_index, version_, blob_file_cache_,
       prefetch_buffer, blob_value, bytes_read);
 }
 

--- a/db/blob/blob_fetcher.h
+++ b/db/blob/blob_fetcher.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <utility>
+
 #include "rocksdb/options.h"
 #include "rocksdb/status.h"
 
@@ -44,18 +46,15 @@ class BlobFetcher {
   virtual const ReadOptions& read_options() const = 0;
 };
 
-// The default BlobFetcher: reads through a Version, optionally falling back to
-// direct-write blob files that are not yet manifest-visible. Usable by value.
-class VersionBlobFetcher : public BlobFetcher {
+// Shared implementation of the two Version-backed BlobFetchers below. Reads
+// through a Version, optionally falling back to direct-write blob files that
+// are not yet manifest-visible. Everything except the ReadOptions is stored
+// here; the concrete subclass decides whether it references a caller-owned
+// ReadOptions (VersionBlobFetcher) or owns its own copy
+// (OwningVersionBlobFetcher). FetchBlob reads the options via the virtual
+// read_options() so both storage strategies share one implementation.
+class VersionBlobFetcherBase : public BlobFetcher {
  public:
-  VersionBlobFetcher(const Version* version, const ReadOptions& read_options,
-                     BlobFileCache* blob_file_cache = nullptr,
-                     bool allow_write_path_fallback = false)
-      : version_(version),
-        read_options_(read_options),
-        blob_file_cache_(blob_file_cache),
-        allow_write_path_fallback_(allow_write_path_fallback) {}
-
   // Un-hide the base's Slice-based convenience overload.
   using BlobFetcher::FetchBlob;
 
@@ -64,13 +63,75 @@ class VersionBlobFetcher : public BlobFetcher {
                    PinnableSlice* blob_value,
                    uint64_t* bytes_read) const override;
 
+  // True if this fetcher has enough context to resolve a (non-inlined,
+  // non-same-file) blob reference: either a Version to read through, or the
+  // direct-write fallback (a blob file cache) enabled. Callers that may hold a
+  // null Version (e.g. DBIter) can check this to surface a clean Corruption on
+  // an unexpected blob index instead of dereferencing null in FetchBlob.
+  bool CanResolve() const {
+    return version_ != nullptr ||
+           (allow_write_path_fallback_ && blob_file_cache_ != nullptr);
+  }
+
+ protected:
+  VersionBlobFetcherBase(const Version* version, BlobFileCache* blob_file_cache,
+                         bool allow_write_path_fallback)
+      : version_(version),
+        blob_file_cache_(blob_file_cache),
+        allow_write_path_fallback_(allow_write_path_fallback) {}
+
+  const Version* version_;
+  BlobFileCache* blob_file_cache_;
+  bool allow_write_path_fallback_;
+};
+
+// The default BlobFetcher for transient/stack use: holds a reference to a
+// caller-owned ReadOptions rather than a copy, avoiding a per-fetcher copy of
+// the (growing) ReadOptions on the hot path. The referenced ReadOptions must
+// outlive the fetcher, so this is only appropriate for fetchers whose lifetime
+// is bounded by the caller's (e.g. a stack local per Get / per resolution).
+// Use OwningVersionBlobFetcher for lifetime-independent fetchers.
+class VersionBlobFetcher : public VersionBlobFetcherBase {
+ public:
+  VersionBlobFetcher(const Version* version, const ReadOptions& read_options,
+                     BlobFileCache* blob_file_cache = nullptr,
+                     bool allow_write_path_fallback = false)
+      : VersionBlobFetcherBase(version, blob_file_cache,
+                               allow_write_path_fallback),
+        read_options_(read_options) {}
+
+  // Reject binding to a temporary ReadOptions, which would leave a dangling
+  // reference. Callers that cannot guarantee the ReadOptions outlives the
+  // fetcher must use OwningVersionBlobFetcher instead.
+  VersionBlobFetcher(const Version* version, ReadOptions&& read_options,
+                     BlobFileCache* blob_file_cache = nullptr,
+                     bool allow_write_path_fallback = false) = delete;
+
   const ReadOptions& read_options() const override { return read_options_; }
 
  private:
-  const Version* version_;
+  const ReadOptions& read_options_;
+};
+
+// A BlobFetcher that owns its ReadOptions, for fetchers whose lifetime is
+// independent of the caller that created them (the lazy read-path resolver and
+// compaction). Takes ownership of the ReadOptions by rvalue so ownership
+// transfer is explicit and no hidden copy is made on the way in; later reads
+// never touch caller state. Callers holding a borrowed ReadOptions they cannot
+// move must make the copy explicit (e.g. ReadOptions(read_options)).
+class OwningVersionBlobFetcher : public VersionBlobFetcherBase {
+ public:
+  OwningVersionBlobFetcher(const Version* version, ReadOptions&& read_options,
+                           BlobFileCache* blob_file_cache = nullptr,
+                           bool allow_write_path_fallback = false)
+      : VersionBlobFetcherBase(version, blob_file_cache,
+                               allow_write_path_fallback),
+        read_options_(std::move(read_options)) {}
+
+  const ReadOptions& read_options() const override { return read_options_; }
+
+ private:
   ReadOptions read_options_;
-  BlobFileCache* blob_file_cache_;
-  bool allow_write_path_fallback_;
 };
 
 // A BlobFetcher decorator that resolves same-file ("embedded") blob references

--- a/db/compaction/compaction_iterator.cc
+++ b/db/compaction/compaction_iterator.cc
@@ -251,8 +251,9 @@ void CompactionIterator::SetBlobFetcher(const Version* version,
   read_options.io_activity = io_activity;
   read_options.fill_cache = false;
 
-  blob_fetcher_ = std::make_unique<VersionBlobFetcher>(
-      version, read_options, blob_file_cache, allow_write_path_fallback);
+  blob_fetcher_ = std::make_unique<OwningVersionBlobFetcher>(
+      version, std::move(read_options), blob_file_cache,
+      allow_write_path_fallback);
   blob_resolver_.Init(blob_fetcher_.get(), prefetch_buffers_.get(),
                       &iter_stats_);
 }
@@ -2064,8 +2065,9 @@ std::unique_ptr<BlobFetcher> CompactionIterator::CreateBlobFetcherIfNeeded(
     }
   }
 
-  return std::unique_ptr<BlobFetcher>(new VersionBlobFetcher(
-      version, read_options, blob_file_cache, allow_write_path_fallback));
+  return std::unique_ptr<BlobFetcher>(
+      new OwningVersionBlobFetcher(version, std::move(read_options),
+                                   blob_file_cache, allow_write_path_fallback));
 }
 
 std::unique_ptr<PrefetchBufferCollection>

--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -77,10 +77,10 @@ DBIter::DBIter(Env* _env, const ReadOptions& read_options,
       user_comparator_(cmp),
       merge_operator_(ioptions.merge_operator.get()),
       iter_(iter),
-      blob_state_(version, read_options.read_tier,
-                  read_options.verify_checksums, read_options.fill_cache,
-                  read_options.io_activity,
-                  cfd ? cfd->blob_file_cache() : nullptr,
+      // Enable the direct-write blob fallback only when this CF has a
+      // write-path partition manager; otherwise the fetcher stays on the plain
+      // Version::GetBlob fast path.
+      blob_state_(version, read_options, cfd ? cfd->blob_file_cache() : nullptr,
                   cfd != nullptr && cfd->blob_partition_manager() != nullptr),
       read_callback_(read_callback),
       sequence_(s),
@@ -94,8 +94,6 @@ DBIter::DBIter(Env* _env, const ReadOptions& read_options,
       trace_db_(db_impl),
       trace_cf_id_(cfd != nullptr ? cfd->GetID() : 0),
       has_trace_state_(db_impl != nullptr && cfd != nullptr),
-      allow_blob_write_path_fallback_(cfd != nullptr &&
-                                      cfd->blob_partition_manager() != nullptr),
       ingest_sst_lock_(cfd != nullptr ? &cfd->GetIngestSstLock() : nullptr),
       timestamp_ub_(read_options.timestamp),
       timestamp_lb_(read_options.iter_start_ts),
@@ -259,60 +257,25 @@ void DBIter::Next() {
   }
 }
 
-Status DBIter::BlobReader::RetrieveAndSetBlobValue(
-    const Slice& user_key, const Slice& blob_index,
-    bool allow_write_path_fallback) {
+Status DBIter::BlobReader::RetrieveAndSetBlobValue(const Slice& user_key,
+                                                   const Slice& blob_index) {
   assert(blob_value_.empty());
 
-  if (!version_ && (!allow_write_path_fallback || !blob_file_cache_)) {
+  if (!blob_fetcher_.CanResolve()) {
     return Status::Corruption("Encountered unexpected blob index.");
   }
 
-  // TODO: consider moving ReadOptions from ArenaWrappedDBIter to DBIter to
-  // avoid having to copy options back and forth.
   // TODO: plumb Env::IOPriority
-  ReadOptions read_options;
-  read_options.read_tier = read_tier_;
-  read_options.verify_checksums = verify_checksums_;
-  read_options.fill_cache = fill_cache_;
-  read_options.io_activity = io_activity_;
   constexpr FilePrefetchBuffer* prefetch_buffer = nullptr;
   constexpr uint64_t* bytes_read = nullptr;
-
-  if (!allow_write_path_fallback) {
-    assert(version_ != nullptr);
-    return version_->GetBlob(read_options, user_key, blob_index,
-                             prefetch_buffer, &blob_value_, bytes_read);
-  }
-
-  BlobIndex blob_idx;
-  Status s = blob_idx.DecodeFrom(blob_index);
-  if (!s.ok()) {
-    return s;
-  }
-
-  return BlobFilePartitionManager::ResolveBlobDirectWriteIndex(
-      read_options, user_key, blob_idx, version_, blob_file_cache_,
-      prefetch_buffer, &blob_value_, bytes_read);
-}
-
-VersionBlobFetcher DBIter::BlobReader::CreateBlobFetcher() const {
-  ReadOptions read_options;
-  read_options.read_tier = read_tier_;
-  read_options.verify_checksums = verify_checksums_;
-  read_options.fill_cache = fill_cache_;
-  read_options.io_activity = io_activity_;
-  return VersionBlobFetcher(version_, read_options, blob_file_cache_,
-                            allow_write_path_fallback_);
+  return blob_fetcher_.FetchBlob(user_key, blob_index, prefetch_buffer,
+                                 &blob_value_, bytes_read);
 }
 
 bool DBIter::SetValueAndColumnsFromBlobImpl(const Slice& user_key,
                                             const Slice& blob_index) {
-  // Keep the non-BDW iterator path on the pre-existing Version::GetBlob()
-  // fast path. Only enable the direct-write fallback when this CF actually
-  // has a write-path partition manager.
-  const Status s = blob_state_.mut()->reader.RetrieveAndSetBlobValue(
-      user_key, blob_index, allow_blob_write_path_fallback_);
+  const Status s =
+      blob_state_.mut()->reader.RetrieveAndSetBlobValue(user_key, blob_index);
   if (!s.ok()) {
     status_ = s;
     valid_ = false;
@@ -1622,8 +1585,8 @@ bool DBIter::MergeWithBlobBaseValue(const Slice& blob_index,
     return false;
   }
 
-  const Status s = blob_state_.mut()->reader.RetrieveAndSetBlobValue(
-      user_key, blob_index, allow_blob_write_path_fallback_);
+  const Status s =
+      blob_state_.mut()->reader.RetrieveAndSetBlobValue(user_key, blob_index);
   if (!s.ok()) {
     status_ = s;
     valid_ = false;
@@ -1645,12 +1608,11 @@ bool DBIter::MergeWithWideColumnBaseValue(const Slice& entity,
                                           const Slice& user_key) {
   // Resolve V2 entity blob columns if present, since TimedFullMerge only
   // supports V1 format.
-  VersionBlobFetcher blob_fetcher = blob_state_->reader.CreateBlobFetcher();
   std::string resolved_entity;
   Slice effective_entity;
   Status s_resolve = WideColumnSerialization::ResolveEntityForMerge(
-      entity, user_key, &blob_fetcher, nullptr /* prefetch_buffers */,
-      resolved_entity, effective_entity);
+      entity, user_key, &blob_state_->reader.blob_fetcher(),
+      nullptr /* prefetch_buffers */, resolved_entity, effective_entity);
   if (!s_resolve.ok()) {
     status_ = std::move(s_resolve);
     valid_ = false;

--- a/db/db_iter.h
+++ b/db/db_iter.h
@@ -276,38 +276,22 @@ class DBIter final : public Iterator {
 
   class BlobReader {
    public:
-    BlobReader(const Version* version, ReadTier read_tier,
-               bool verify_checksums, bool fill_cache,
-               Env::IOActivity io_activity, BlobFileCache* blob_file_cache,
-               bool allow_write_path_fallback)
-        : version_(version),
-          read_tier_(read_tier),
-          verify_checksums_(verify_checksums),
-          fill_cache_(fill_cache),
-          io_activity_(io_activity),
-          blob_file_cache_(blob_file_cache),
-          allow_write_path_fallback_(allow_write_path_fallback) {}
+    BlobReader(const Version* version, const ReadOptions& read_options,
+               BlobFileCache* blob_file_cache, bool allow_write_path_fallback)
+        : blob_fetcher_(version, ReadOptions(read_options), blob_file_cache,
+                        allow_write_path_fallback) {}
 
     const Slice& GetBlobValue() const { return blob_value_; }
     Status RetrieveAndSetBlobValue(const Slice& user_key,
-                                   const Slice& blob_index,
-                                   bool allow_write_path_fallback);
+                                   const Slice& blob_index);
     void ResetBlobValue() { blob_value_.Reset(); }
-    // Create a VersionBlobFetcher with the same read options as this
-    // BlobReader.
-    VersionBlobFetcher CreateBlobFetcher() const;
+    // The blob fetcher backing this reader, for resolving wide-column entity
+    // blob references (the merge path). Valid for this BlobReader's lifetime.
+    const BlobFetcher& blob_fetcher() const { return blob_fetcher_; }
 
    private:
     PinnableSlice blob_value_;
-    const Version* version_;
-    ReadTier read_tier_;
-    bool verify_checksums_;
-    bool fill_cache_;
-    Env::IOActivity io_activity_;
-    // Cache used by the write-path fallback for in-flight direct-write blob
-    // files that are not yet reachable through Version.
-    BlobFileCache* blob_file_cache_;
-    bool allow_write_path_fallback_;
+    OwningVersionBlobFetcher blob_fetcher_;
   };
   struct BlobState {
     BlobReader reader;
@@ -332,9 +316,7 @@ class DBIter final : public Iterator {
     ValueColumnsState(const Version* version, const ReadOptions& read_options,
                       ColumnFamilyData* cfd)
         : entity_blob_resolver_(
-              version, read_options.read_tier, read_options.verify_checksums,
-              read_options.fill_cache, read_options.io_activity,
-              cfd ? cfd->blob_file_cache() : nullptr,
+              version, read_options, cfd ? cfd->blob_file_cache() : nullptr,
               cfd != nullptr && cfd->blob_partition_manager() != nullptr) {}
 
     Slice& value() { return value_; }
@@ -674,6 +656,14 @@ class DBIter final : public Iterator {
   UserComparatorWrapper user_comparator_;
   const MergeOperator* const merge_operator_;
   IteratorWrapper iter_;
+  // TODO: blob_state_'s BlobReader (whole-value blob reads + the merge entity
+  // path) and value_columns_state_'s ReadPathBlobResolver (lazy per-column
+  // entity resolution) each own a Version-backed blob fetcher with the same
+  // {version, read_options, blob_file_cache, allow_write_path_fallback}, so an
+  // iterator holds two ReadOptions copies. Collapse to a single shared fetcher.
+  // Deferred because the resolver must keep owning its fetcher for the planned
+  // lazy entity read path, where the result outlives the read call and owns the
+  // SuperVersion pin; unifying is best done together with that work.
   DirtyTracked<BlobState> blob_state_;
   ReadCallback* read_callback_;
   // Max visible sequence number. It is normally the snapshot seq unless we have
@@ -720,7 +710,6 @@ class DBIter final : public Iterator {
   DBImpl* trace_db_;
   uint32_t trace_cf_id_;
   bool has_trace_state_;
-  bool allow_blob_write_path_fallback_;
   port::RWMutex* ingest_sst_lock_;
   const Slice* const timestamp_ub_;
   const Slice* const timestamp_lb_;

--- a/db/wide/read_path_blob_resolver.cc
+++ b/db/wide/read_path_blob_resolver.cc
@@ -12,30 +12,12 @@
 
 namespace ROCKSDB_NAMESPACE {
 
-namespace {
-
-ReadOptions BuildReadPathBlobResolverReadOptions(ReadTier read_tier,
-                                                 bool verify_checksums,
-                                                 bool fill_cache,
-                                                 Env::IOActivity io_activity) {
-  ReadOptions read_options;
-  read_options.read_tier = read_tier;
-  read_options.verify_checksums = verify_checksums;
-  read_options.fill_cache = fill_cache;
-  read_options.io_activity = io_activity;
-  return read_options;
-}
-
-}  // namespace
-
-ReadPathBlobResolver::ReadPathBlobResolver(
-    const Version* version, ReadTier read_tier, bool verify_checksums,
-    bool fill_cache, Env::IOActivity io_activity,
-    BlobFileCache* blob_file_cache, bool allow_write_path_fallback)
-    : blob_fetcher_(version,
-                    BuildReadPathBlobResolverReadOptions(
-                        read_tier, verify_checksums, fill_cache, io_activity),
-                    blob_file_cache, allow_write_path_fallback) {}
+ReadPathBlobResolver::ReadPathBlobResolver(const Version* version,
+                                           const ReadOptions& read_options,
+                                           BlobFileCache* blob_file_cache,
+                                           bool allow_write_path_fallback)
+    : blob_fetcher_(version, ReadOptions(read_options), blob_file_cache,
+                    allow_write_path_fallback) {}
 
 void ReadPathBlobResolver::Reset(
     const Slice& user_key, const std::vector<WideColumn>* columns,

--- a/db/wide/read_path_blob_resolver.h
+++ b/db/wide/read_path_blob_resolver.h
@@ -43,9 +43,7 @@ class Version;
 // resolver (ensured by SuperVersion pinning in the caller).
 class ReadPathBlobResolver {
  public:
-  ReadPathBlobResolver(const Version* version, ReadTier read_tier,
-                       bool verify_checksums, bool fill_cache,
-                       Env::IOActivity io_activity,
+  ReadPathBlobResolver(const Version* version, const ReadOptions& read_options,
                        BlobFileCache* blob_file_cache = nullptr,
                        bool allow_write_path_fallback = false);
 
@@ -93,7 +91,10 @@ class ReadPathBlobResolver {
   }
 
  private:
-  VersionBlobFetcher blob_fetcher_;
+  // Owns its ReadOptions: a resolver's lifetime is independent of the caller
+  // that created it (e.g. it may outlive the originating ReadOptions once
+  // returned as part of a lazy result).
+  OwningVersionBlobFetcher blob_fetcher_;
 
   Slice user_key_;
   const std::vector<WideColumn>* columns_ = nullptr;


### PR DESCRIPTION
Summary:
Follow-up cleanup to the embedded (same-file) blob wide-column work (PR #14990): the "ReadOptions usage cleanup/optimization" item.

Split the Version-backed blob fetcher into two variants sharing a common VersionBlobFetcherBase (which implements FetchBlob via a virtual read_options()):
- VersionBlobFetcher now holds a `const ReadOptions&` for transient/stack fetchers (the common case: point Get/MultiGet, DBIter, version_set), so the growing ReadOptions is no longer copied per fetcher on the hot path. A deleted rvalue-ref constructor rejects binding to a temporary.
- OwningVersionBlobFetcher takes `ReadOptions&&` and owns a copy, for fetchers whose lifetime is independent of the caller (the read-path lazy resolver and compaction), making ownership transfer explicit.

DBIter::BlobReader now holds a single blob fetcher instead of decomposed scalar fields (read_tier/verify_checksums/fill_cache/io_activity). This removes the decompose-then-recompose that the old CreateBlobFetcher and RetrieveAndSetBlobValue performed, and closes the field-loss gap: all ReadOptions fields now flow through to blob reads rather than just those four. CreateBlobFetcher is gone; the merge path uses the reader's owned fetcher directly. A CanResolve() predicate on the fetcher preserves the prior "unexpected blob index" Corruption instead of dereferencing a null Version, and the now-redundant allow_blob_write_path_fallback_ member/ parameter (equal to the fetcher's own flag) was dropped.

ReadPathBlobResolver keeps owning its fetcher (now OwningVersionBlobFetcher) so it stays self-contained for the planned lazy entity read path, where the result outlives the read call. A TODO in db_iter.h records the remaining duplication (BlobReader and ReadPathBlobResolver each own a fetcher with the same {version, read_options, blob_file_cache, allow_write_path_fallback}), deferred to that work.

Test Plan:
Pure refactoring with no intended behavior change; Version::GetBlob's Slice overload just decodes and calls the BlobIndex overload, so routing whole-value blob reads through the fetcher is equivalent, and the direct-write fallback flag/read options are unchanged. Covered by existing tests:
- db/blob/db_blob_index_test.cc: embedded/entity blob GetEntity/MultiGetEntity zero-copy, plain Get of an embedded default column, merge over an embedded-blob entity, read_tier == kBlockCacheTier Incomplete, corrupt record Corruption.
- db/blob/db_blob_basic_test.cc and db/wide/db_wide_blob_direct_write_test.cc: separate-file and direct-write blob resolution (the fallback branch).
- db/db_iterator_test.cc (blob) and db/compaction/compaction_iterator_test.cc: DBIter blob/merge paths and the compaction (owning) fetcher.