### PR TITLE
Defer obsolete OPTIONS file deletion on open (#15004)

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -5830,7 +5830,7 @@ void DeleteOptionsFilesHelper(const std::map<uint64_t, std::string>& filenames,
 }
 }  // namespace
 
-Status DBImpl::DeleteObsoleteOptionsFiles() {
+Status DBImpl::DeleteObsoleteOptionsFiles(bool schedule_only) {
   std::vector<std::string> filenames;
   // use ordered map to store keep the filenames sorted from the newest
   // to the oldest.
@@ -5855,8 +5855,23 @@ Status DBImpl::DeleteObsoleteOptionsFiles() {
 
   // Keeps the latest 2 Options file
   const size_t kNumOptionsFilesKept = 2;
-  DeleteOptionsFilesHelper(options_filenames, kNumOptionsFilesKept,
-                           immutable_db_options_.info_log, GetEnv());
+  if (options_filenames.size() > kNumOptionsFilesKept) {
+    if (schedule_only) {
+      InstrumentedMutexLock l(&mutex_);
+      for (auto iter =
+               std::next(options_filenames.begin(), kNumOptionsFilesKept);
+           iter != options_filenames.end(); ++iter) {
+        const uint64_t file_number =
+            std::numeric_limits<uint64_t>::max() - iter->first;
+        SchedulePendingPurge(iter->second, GetName(), kOptionsFile, file_number,
+                             /*job_id=*/0);
+      }
+      SchedulePurge();
+    } else {
+      DeleteOptionsFilesHelper(options_filenames, kNumOptionsFilesKept,
+                               immutable_db_options_.info_log, GetEnv());
+    }
+  }
   return Status::OK();
 }
 
@@ -5896,18 +5911,42 @@ Status DBImpl::RenameTempFileToOptionsFile(const std::string& file_name,
   }
 
   if (s.ok()) {
-    int my_disable_delete_obsolete_files;
+    enum class ObsoleteOptionsFileCleanup {
+      kSkip,
+      kDeleteNow,
+      kSchedule,
+    };
+    ObsoleteOptionsFileCleanup obsolete_options_file_cleanup =
+        ObsoleteOptionsFileCleanup::kSkip;
 
     {
       InstrumentedMutexLock l(&mutex_);
       versions_->options_file_number_ = options_file_number;
       versions_->options_file_size_ = options_file_size;
-      my_disable_delete_obsolete_files = disable_delete_obsolete_files_;
+      if (!disable_delete_obsolete_files_ && !is_remote_compaction_enabled) {
+        if (immutable_db_options_.avoid_unnecessary_blocking_io &&
+            !reject_new_background_jobs_) {
+          // DB::Open() sets `opened_successfully_` after WriteOptionsFile()
+          // returns, then schedules the deferred OPTIONS-file purge.
+          obsolete_options_file_cleanup =
+              opened_successfully_ ? ObsoleteOptionsFileCleanup::kSchedule
+                                   : ObsoleteOptionsFileCleanup::kSkip;
+        } else {
+          obsolete_options_file_cleanup =
+              ObsoleteOptionsFileCleanup::kDeleteNow;
+        }
+      }
     }
 
-    if (!my_disable_delete_obsolete_files && !is_remote_compaction_enabled) {
-      // TODO: Should we check for errors here?
-      DeleteObsoleteOptionsFiles().PermitUncheckedError();
+    if (obsolete_options_file_cleanup != ObsoleteOptionsFileCleanup::kSkip) {
+      Status obsolete_options_status =
+          DeleteObsoleteOptionsFiles(obsolete_options_file_cleanup ==
+                                     ObsoleteOptionsFileCleanup::kSchedule);
+      if (!obsolete_options_status.ok()) {
+        ROCKS_LOG_WARN(immutable_db_options_.info_log,
+                       "Unable to delete obsolete OPTIONS files: %s",
+                       obsolete_options_status.ToString().c_str());
+      }
     }
   }
 

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1562,7 +1562,7 @@ class DBImpl : public DB {
   // 2. db_mutex is NOT held
   Status RenameTempFileToOptionsFile(const std::string& file_name,
                                      bool is_remote_compaction_enabled);
-  Status DeleteObsoleteOptionsFiles();
+  Status DeleteObsoleteOptionsFiles(bool schedule_only);
 
   void NotifyOnManualFlushScheduled(autovector<ColumnFamilyData*> cfds,
                                     FlushReason flush_reason);

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -2872,11 +2872,16 @@ Status DBImpl::Open(const DBOptions& db_options, const std::string& dbname,
   }
   TEST_SYNC_POINT("DBImpl::Open:Opened");
   Status persist_options_status;
+  bool cleanup_obsolete_options_files = false;
   if (s.ok()) {
     // Persist RocksDB Options before scheduling the compaction.
     // The WriteOptionsFile() will release and lock the mutex internally.
     persist_options_status =
         impl->WriteOptionsFile(write_options, true /*db_mutex_already_held*/);
+    cleanup_obsolete_options_files =
+        impl->immutable_db_options_.avoid_unnecessary_blocking_io &&
+        impl->immutable_db_options_.compaction_service == nullptr &&
+        !impl->disable_delete_obsolete_files_;
     impl->opened_successfully_ = true;
   } else {
     persist_options_status.PermitUncheckedError();
@@ -2966,6 +2971,17 @@ Status DBImpl::Open(const DBOptions& db_options, const std::string& dbname,
     s = impl->RegisterRecordSeqnoTimeWorker();
   }
   impl->options_mutex_.Unlock();
+  if (cleanup_obsolete_options_files) {
+    Status obsolete_options_status =
+        impl->DeleteObsoleteOptionsFiles(/*schedule_only=*/s.ok());
+    if (!obsolete_options_status.ok()) {
+      ROCKS_LOG_WARN(impl->immutable_db_options_.info_log,
+                     "Unable to %s obsolete OPTIONS files%s: %s",
+                     s.ok() ? "schedule deletion of" : "delete",
+                     s.ok() ? "" : " after DB open failure",
+                     obsolete_options_status.ToString().c_str());
+    }
+  }
   if (s.ok()) {
     *dbptr = std::move(impl);
   } else {

--- a/db/options_file_test.cc
+++ b/db/options_file_test.cc
@@ -3,13 +3,17 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
+#include <atomic>
+#include <memory>
 #include <string>
+#include <utility>
 
 #include "db/db_impl/db_impl.h"
 #include "db/db_test_util.h"
 #include "rocksdb/options.h"
 #include "rocksdb/table.h"
 #include "test_util/testharness.h"
+#include "util/cast_util.h"
 
 namespace ROCKSDB_NAMESPACE {
 class OptionsFileTest : public testing::Test {
@@ -20,6 +24,91 @@ class OptionsFileTest : public testing::Test {
 };
 
 namespace {
+std::string Basename(const std::string& fname) {
+  const size_t basename_pos = fname.find_last_of("/\\");
+  return basename_pos == std::string::npos ? fname
+                                           : fname.substr(basename_pos + 1);
+}
+
+bool IsOptionsFile(const std::string& fname) {
+  return Basename(fname).find(kOptionsFileNamePrefix) == 0;
+}
+
+class FailOptionsDirFsyncFileSystem : public FileSystemWrapper {
+ public:
+  explicit FailOptionsDirFsyncFileSystem(std::shared_ptr<FileSystem> target)
+      : FileSystemWrapper(std::move(target)) {}
+
+  static const char* kClassName() { return "FailOptionsDirFsyncFileSystem"; }
+  const char* Name() const override { return kClassName(); }
+
+  void FailOptionsDirFsyncAfterNextOptionsFile() {
+    observe_options_file_.store(true, std::memory_order_release);
+    fail_options_dir_fsync_.store(false, std::memory_order_release);
+    options_dir_fsync_failures_.store(0, std::memory_order_release);
+  }
+
+  int options_dir_fsync_failures() const {
+    return options_dir_fsync_failures_.load(std::memory_order_acquire);
+  }
+
+  IOStatus NewWritableFile(const std::string& fname,
+                           const FileOptions& file_opts,
+                           std::unique_ptr<FSWritableFile>* result,
+                           IODebugContext* dbg) override {
+    IOStatus s =
+        FileSystemWrapper::NewWritableFile(fname, file_opts, result, dbg);
+    if (!s.ok()) {
+      return s;
+    }
+    if (observe_options_file_.load(std::memory_order_acquire) &&
+        IsOptionsFile(fname)) {
+      fail_options_dir_fsync_.store(true, std::memory_order_release);
+      observe_options_file_.store(false, std::memory_order_release);
+    }
+    return s;
+  }
+
+  IOStatus NewDirectory(const std::string& name, const IOOptions& io_opts,
+                        std::unique_ptr<FSDirectory>* result,
+                        IODebugContext* dbg) override {
+    IOStatus s = FileSystemWrapper::NewDirectory(name, io_opts, result, dbg);
+    if (s.ok()) {
+      *result = std::make_unique<FailOptionsDirFsyncDirectory>(
+          std::move(*result), *this);
+    }
+    return s;
+  }
+
+ private:
+  class FailOptionsDirFsyncDirectory : public FSDirectoryWrapper {
+   public:
+    FailOptionsDirFsyncDirectory(std::unique_ptr<FSDirectory>&& dir,
+                                 FailOptionsDirFsyncFileSystem& fs)
+        : FSDirectoryWrapper(std::move(dir)), fs_(fs) {}
+
+    IOStatus FsyncWithDirOptions(
+        const IOOptions& options, IODebugContext* dbg,
+        const DirFsyncOptions& dir_fsync_options) override {
+      if (fs_.fail_options_dir_fsync_.load(std::memory_order_acquire) &&
+          IsOptionsFile(dir_fsync_options.renamed_new_name)) {
+        fs_.fail_options_dir_fsync_.store(false, std::memory_order_release);
+        fs_.options_dir_fsync_failures_.fetch_add(1, std::memory_order_acq_rel);
+        return IOStatus::IOError("Injected OPTIONS directory fsync failure");
+      }
+      return FSDirectoryWrapper::FsyncWithDirOptions(options, dbg,
+                                                     dir_fsync_options);
+    }
+
+   private:
+    FailOptionsDirFsyncFileSystem& fs_;
+  };
+
+  std::atomic<bool> observe_options_file_{false};
+  std::atomic<bool> fail_options_dir_fsync_{false};
+  std::atomic<int> options_dir_fsync_failures_{0};
+};
+
 void UpdateOptionsFiles(DB* db,
                         std::unordered_set<std::string>* filename_history,
                         int* options_files_count) {
@@ -58,6 +147,34 @@ void VerifyOptionsFileName(
     }
   }
 }
+
+int CountOptionsFiles(Env* env, const std::string& dbname) {
+  std::vector<std::string> filenames;
+  EXPECT_OK(env->GetChildren(dbname, &filenames));
+
+  int options_files_count = 0;
+  uint64_t number;
+  FileType type;
+  for (const auto& filename : filenames) {
+    if (ParseFileName(filename, &number, &type) && type == kOptionsFile) {
+      ++options_files_count;
+    }
+  }
+  return options_files_count;
+}
+
+int CountOptionsFiles(DB* db) {
+  return CountOptionsFiles(db->GetEnv(), db->GetName());
+}
+
+void GenerateStaleOptionsFiles(DB* db, int options_file_count) {
+  ASSERT_OK(db->DisableFileDeletions());
+  for (int i = 0; i < options_file_count; ++i) {
+    ASSERT_OK(db->SetOptions(
+        {{"level0_file_num_compaction_trigger", std::to_string(8 + i)}}));
+  }
+  ASSERT_GT(CountOptionsFiles(db), 2);
+}
 }  // anonymous namespace
 
 TEST_F(OptionsFileTest, NumberOfOptionsFiles) {
@@ -77,6 +194,80 @@ TEST_F(OptionsFileTest, NumberOfOptionsFiles) {
     VerifyOptionsFileName(db.get(), filename_history);
     db.reset();
   }
+}
+
+TEST_F(OptionsFileTest, ObsoleteOptionsFilesPurgedSynchronouslyOnOpen) {
+  Options opt;
+  opt.create_if_missing = true;
+  ASSERT_OK(DestroyDB(dbname_, opt));
+
+  std::unique_ptr<DB> db;
+  ASSERT_OK(DB::Open(opt, dbname_, &db));
+  GenerateStaleOptionsFiles(db.get(), 5);
+  db.reset();
+
+  opt.create_if_missing = false;
+  opt.avoid_unnecessary_blocking_io = false;
+  ASSERT_OK(DB::Open(opt, dbname_, &db));
+  ASSERT_LE(CountOptionsFiles(db.get()), 2);
+}
+
+TEST_F(OptionsFileTest, ObsoleteOptionsFilesPurgedInBackgroundOnOpen) {
+  Options opt;
+  opt.create_if_missing = true;
+  ASSERT_OK(DestroyDB(dbname_, opt));
+
+  std::unique_ptr<DB> db;
+  ASSERT_OK(DB::Open(opt, dbname_, &db));
+  GenerateStaleOptionsFiles(db.get(), 5);
+  db.reset();
+
+  opt.create_if_missing = false;
+  opt.avoid_unnecessary_blocking_io = true;
+
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+  SyncPoint::GetInstance()->LoadDependency(
+      {{"OptionsFileTest::ObsoleteOptionsFilesPurgedInBackgroundOnOpen:"
+        "ReleasePurge",
+        "DBImpl::BGWorkPurge:start"}});
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  ASSERT_OK(DB::Open(opt, dbname_, &db));
+  ASSERT_GT(CountOptionsFiles(db.get()), 2);
+
+  TEST_SYNC_POINT(
+      "OptionsFileTest::ObsoleteOptionsFilesPurgedInBackgroundOnOpen:"
+      "ReleasePurge");
+  ASSERT_OK(static_cast_with_check<DBImpl>(db.get())->TEST_WaitForPurge());
+  ASSERT_LE(CountOptionsFiles(db.get()), 2);
+
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+}
+
+TEST_F(OptionsFileTest, ObsoleteOptionsFilesPurgedSynchronouslyOnOpenFailure) {
+  auto fail_fs =
+      std::make_shared<FailOptionsDirFsyncFileSystem>(FileSystem::Default());
+  std::unique_ptr<Env> env(NewCompositeEnv(fail_fs));
+
+  Options opt;
+  opt.env = env.get();
+  opt.create_if_missing = true;
+  ASSERT_OK(DestroyDB(dbname_, opt));
+
+  std::unique_ptr<DB> db;
+  ASSERT_OK(DB::Open(opt, dbname_, &db));
+  GenerateStaleOptionsFiles(db.get(), 5);
+  db.reset();
+
+  opt.create_if_missing = false;
+  opt.avoid_unnecessary_blocking_io = true;
+
+  fail_fs->FailOptionsDirFsyncAfterNextOptionsFile();
+  ASSERT_NOK(DB::Open(opt, dbname_, &db));
+  ASSERT_EQ(fail_fs->options_dir_fsync_failures(), 1);
+  ASSERT_LE(CountOptionsFiles(opt.env, dbname_), 2);
 }
 
 TEST_F(OptionsFileTest, OptionsFileName) {

--- a/unreleased_history/performance_improvements/delete-obsolete-options-files-background-on-open.md
+++ b/unreleased_history/performance_improvements/delete-obsolete-options-files-background-on-open.md
@@ -1,0 +1,1 @@
+When `DBOptions::avoid_unnecessary_blocking_io` is true, obsolete `OPTIONS-*` files found during DB open are deleted by background purge instead of synchronously on the opening thread.


### PR DESCRIPTION
Summary:

This change reduces DB open latency on remote storage by avoiding foreground deletion of obsolete `OPTIONS-*` files during open when `avoid_unnecessary_blocking_io` is enabled. DB open now avoids foreground deletion of obsolete `OPTIONS-*` files on the pre-open `WriteOptionsFile()` path. `RenameTempFileToOptionsFile()` records the new OPTIONS file and chooses an explicit cleanup mode: skip while open is still in progress, schedule deletion when background work is available, or delete immediately when blocking IO is allowed or background jobs are rejected.

`DBImpl::Open()` makes the deferred cleanup decision once final open status is known. A successful open schedules obsolete OPTIONS files on the purge queue, while a failed open deletes them synchronously before tearing down the partially opened DB. The default synchronous behavior remains unchanged when `avoid_unnecessary_blocking_io` is disabled, and the latest-two OPTIONS retention policy is preserved.

Reviewed By: pdillinger

Differential Revision: D113593680


