### PR TITLE
Add db_stress coroutine read flag

### DIFF
--- a/db_stress_tool/batched_ops_stress.cc
+++ b/db_stress_tool/batched_ops_stress.cc
@@ -163,7 +163,7 @@ class BatchedOpsStressTest : public StressTest {
     for (int i = 0; i < 10; i++) {
       keys[i] += key.ToString();
       key_slices[i] = keys[i];
-      s = db_->Get(readoptionscopy, cfh, key_slices[i], &from_db);
+      s = DbStressGet(db_, readoptionscopy, cfh, key_slices[i], &from_db);
       if (!s.ok() && !s.IsNotFound()) {
         fprintf(stderr, "get error: %s\n", s.ToString().c_str());
         values[i] = "";
@@ -235,8 +235,8 @@ class BatchedOpsStressTest : public StressTest {
         key_str.emplace_back(keys[key] + Key(rand_keys[rand_key]));
         key_slices.emplace_back(key_str.back());
       }
-      db_->MultiGet(readoptionscopy, cfh, num_prefixes, key_slices.data(),
-                    values.data(), statuses.data());
+      DbStressMultiGet(db_, readoptionscopy, cfh, num_prefixes,
+                       key_slices.data(), values.data(), statuses.data());
       for (size_t i = 0; i < num_prefixes; i++) {
         Status s = statuses[i];
         if (!s.ok() && !s.IsNotFound()) {

--- a/db_stress_tool/cf_consistency_stress.cc
+++ b/db_stress_tool/cf_consistency_stress.cc
@@ -218,7 +218,7 @@ class CfConsistencyStressTest : public StressTest {
           column_families_[rand_column_families[thread->rand.Next() %
                                                 rand_column_families.size()]];
       std::string from_db;
-      s = db_->Get(readoptions, cfh, key, &from_db);
+      s = DbStressGet(db_, readoptions, cfh, key, &from_db);
     } else {
       // 1/2 chance, comparing one key is the same across all CFs
       const Snapshot* snapshot = db_->GetSnapshot();
@@ -226,8 +226,8 @@ class CfConsistencyStressTest : public StressTest {
       readoptionscopy.snapshot = snapshot;
 
       std::string value0;
-      s = db_->Get(readoptionscopy, column_families_[rand_column_families[0]],
-                   key, &value0);
+      s = DbStressGet(db_, readoptionscopy,
+                      column_families_[rand_column_families[0]], key, &value0);
 
       // Temporarily disable error injection for verification
       if (db_fault_injection_fs_) {
@@ -241,8 +241,9 @@ class CfConsistencyStressTest : public StressTest {
         bool found = s.ok();
         for (size_t i = 1; i < rand_column_families.size(); i++) {
           std::string value1;
-          s = db_->Get(readoptionscopy,
-                       column_families_[rand_column_families[i]], key, &value1);
+          s = DbStressGet(db_, readoptionscopy,
+                          column_families_[rand_column_families[i]], key,
+                          &value1);
           if (!s.ok() && !s.IsNotFound()) {
             break;
           }
@@ -326,8 +327,8 @@ class CfConsistencyStressTest : public StressTest {
       key_str.emplace_back(Key(rand_keys[i]));
       keys.emplace_back(key_str.back());
     }
-    db_->MultiGet(readoptionscopy, cfh, num_keys, keys.data(), values.data(),
-                  statuses.data());
+    DbStressMultiGet(db_, readoptionscopy, cfh, num_keys, keys.data(),
+                     values.data(), statuses.data());
     for (const auto& s : statuses) {
       if (s.ok()) {
         // found case
@@ -1477,14 +1478,14 @@ class CfConsistencyStressTest : public StressTest {
           db_->GetEntity(snapshot_read_opts, cfh, key, &snapshot_entity);
       std::string snapshot_value;
       const Status snapshot_value_status =
-          db_->Get(snapshot_read_opts, cfh, key, &snapshot_value);
+          DbStressGet(db_, snapshot_read_opts, cfh, key, &snapshot_value);
 
       PinnableWideColumns latest_entity;
       const Status latest_entity_status =
           db_->GetEntity(latest_read_opts, cfh, key, &latest_entity);
       std::string latest_value;
       const Status latest_value_status =
-          db_->Get(latest_read_opts, cfh, key, &latest_value);
+          DbStressGet(db_, latest_read_opts, cfh, key, &latest_value);
 
       std::string snapshot_verify = "n/a";
       if (snapshot_entity_status.ok()) {

--- a/db_stress_tool/db_stress_common.cc
+++ b/db_stress_tool/db_stress_common.cc
@@ -12,6 +12,8 @@
 #include "db_stress_tool/db_stress_common.h"
 
 #include <cmath>
+#include <condition_variable>
+#include <mutex>
 
 #include "db_stress_tool/db_stress_test_base.h"
 #include "file/file_util.h"
@@ -35,6 +37,83 @@ std::vector<double> sum_probs(100001);
 constexpr int64_t zipf_sum_size = 100000;
 
 namespace ROCKSDB_NAMESPACE {
+
+namespace {
+
+class BlockingAsyncCallback : public DB::AsyncCallback {
+ public:
+  void OnComplete() override {
+    std::lock_guard<std::mutex> lock(mu_);
+    done_ = true;
+    cv_.notify_one();
+  }
+
+  void Wait() {
+    std::unique_lock<std::mutex> lock(mu_);
+    cv_.wait(lock, [this] { return done_; });
+  }
+
+ private:
+  std::mutex mu_;
+  std::condition_variable cv_;
+  bool done_ = false;
+};
+
+}  // namespace
+
+Status DbStressGet(DB* db, const ReadOptions& options,
+                   ColumnFamilyHandle* column_family, const Slice& key,
+                   PinnableSlice* value, std::string* timestamp) {
+#if USE_COROUTINES
+  if (FLAGS_use_async_db_api) {
+    BlockingAsyncCallback callback;
+    Status status;
+    db->GetAsync(options, column_family, key, value, timestamp, status,
+                 callback);
+    callback.Wait();
+    return status;
+  }
+#endif  // USE_COROUTINES
+  return db->Get(options, column_family, key, value, timestamp);
+}
+
+Status DbStressGet(DB* db, const ReadOptions& options,
+                   ColumnFamilyHandle* column_family, const Slice& key,
+                   std::string* value, std::string* timestamp) {
+#if USE_COROUTINES
+  if (FLAGS_use_async_db_api) {
+    BlockingAsyncCallback callback;
+    Status status;
+    db->GetAsync(options, column_family, key, value, timestamp, status,
+                 callback);
+    callback.Wait();
+    return status;
+  }
+#endif  // USE_COROUTINES
+  return db->Get(options, column_family, key, value, timestamp);
+}
+
+Status DbStressGet(DB* db, const ReadOptions& options, const Slice& key,
+                   std::string* value) {
+  return DbStressGet(db, options, db->DefaultColumnFamily(), key, value);
+}
+
+void DbStressMultiGet(DB* db, const ReadOptions& options,
+                      ColumnFamilyHandle* column_family, size_t num_keys,
+                      const Slice* keys, PinnableSlice* values,
+                      Status* statuses) {
+#if USE_COROUTINES
+  if (FLAGS_use_async_db_api) {
+    std::vector<ColumnFamilyHandle*> column_families(num_keys, column_family);
+    BlockingAsyncCallback callback;
+    db->MultiGetAsync(options, num_keys, column_families.data(), keys, values,
+                      statuses, callback);
+    callback.Wait();
+    return;
+  }
+#endif  // USE_COROUTINES
+  db->MultiGet(options, column_family, num_keys, keys, values, statuses);
+}
 
 // Zipfian distribution is generated based on a pre-calculated array.
 // It should be used before start the stress test.

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -250,6 +250,7 @@ DECLARE_bool(compare_full_db_state_snapshot);
 DECLARE_uint64(snapshot_hold_ops);
 DECLARE_bool(long_running_snapshots);
 DECLARE_bool(use_multiget);
+DECLARE_bool(use_async_db_api);
 DECLARE_bool(use_get_entity);
 DECLARE_bool(use_multi_get_entity);
 DECLARE_int32(readpercent);
@@ -844,6 +845,19 @@ bool VerifyIteratorAttributeGroups(
 AttributeGroups GenerateAttributeGroups(
     const std::vector<ColumnFamilyHandle*>& cfhs, uint32_t value_base,
     const Slice& slice);
+
+Status DbStressGet(DB* db, const ReadOptions& options,
+                   ColumnFamilyHandle* column_family, const Slice& key,
+                   PinnableSlice* value, std::string* timestamp = nullptr);
+Status DbStressGet(DB* db, const ReadOptions& options,
+                   ColumnFamilyHandle* column_family, const Slice& key,
+                   std::string* value, std::string* timestamp = nullptr);
+Status DbStressGet(DB* db, const ReadOptions& options, const Slice& key,
+                   std::string* value);
+void DbStressMultiGet(DB* db, const ReadOptions& options,
+                      ColumnFamilyHandle* column_family, size_t num_keys,
+                      const Slice* keys, PinnableSlice* values,
+                      Status* statuses);
 
 StressTest* CreateCfConsistencyStressTest(int db_index,
                                           const std::string& db_path,

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -955,10 +955,13 @@ DEFINE_uint64(snapshot_hold_ops, 0,
 DEFINE_bool(long_running_snapshots, false,
             "If set, hold on some some snapshots for much longer time.");
 
-// The following three options affect both regular read operations during the
+// The following four options affect both regular read operations during the
 // test and initial/final database verification through VerifyDB.
 DEFINE_bool(use_multiget, false,
             "If set, use the batched MultiGet API for reads.");
+
+DEFINE_bool(use_async_db_api, false,
+            "If set, use DB::GetAsync and DB::MultiGetAsync for reads.");
 
 DEFINE_bool(use_get_entity, false, "If set, use the GetEntity API for reads.");
 

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -927,7 +927,7 @@ Status StressTest::AssertSame(DB* db, ColumnFamilyHandle* cf,
   PinnableSlice exp_v(&snap_state.value);
   exp_v.PinSelf();
   PinnableSlice v;
-  s = db->Get(ropt, cf, snap_state.key, &v);
+  s = DbStressGet(db, ropt, cf, snap_state.key, &v);
   if (!s.ok() && !s.IsNotFound()) {
     // When `persist_user_defined_timestamps` is false, a repeated read with
     // both a read timestamp and an explicitly taken snapshot cannot guarantee
@@ -1106,8 +1106,8 @@ void StressTest::MaybeVerifyCpuCorruption(ThreadState* thread,
     for (int64_t key = 0; key < max_key; ++key) {
       const ExpectedValue expected = shared->Get(cf, key);
       db_value.clear();
-      const Status s =
-          db_->Get(read_opts, column_families_[cf], Key(key), &db_value);
+      const Status s = DbStressGet(db_, read_opts, column_families_[cf],
+                                   Key(key), &db_value);
       const std::optional<DataCorruption> corruption =
           ClassifyReadBack(s, db_value, expected, expected_scratch);
       if (corruption.has_value()) {
@@ -3375,9 +3375,9 @@ Status StressTest::TestBackupRestore(
       ts = ts_str;
       read_opts.timestamp = &ts;
     }
-    Status get_status = restored_db->Get(
-        read_opts, restored_cf_handles[rand_column_families[i]], key,
-        &restored_value);
+    Status get_status = DbStressGet(
+        restored_db.get(), read_opts,
+        restored_cf_handles[rand_column_families[i]], key, &restored_value);
     bool exists = thread->shared->Exists(rand_column_families[i], rand_keys[0]);
     if (get_status.ok()) {
       if (!exists && from_latest && ShouldAcquireMutexOnKey()) {
@@ -3677,8 +3677,9 @@ Status StressTest::TestCheckpoint(ThreadState* thread,
         read_opts.timestamp = &ts;
       }
       std::string value;
-      Status get_status = checkpoint_db->Get(
-          read_opts, cf_handles[rand_column_families[i]], key, &value);
+      Status get_status =
+          DbStressGet(checkpoint_db.get(), read_opts,
+                      cf_handles[rand_column_families[i]], key, &value);
       bool exists =
           thread->shared->Exists(rand_column_families[i], rand_keys[0]);
       if (get_status.ok()) {
@@ -4012,7 +4013,7 @@ void StressTest::TestAcquireSnapshot(ThreadState* thread,
   // When taking a snapshot, we also read a key from that snapshot. We
   // will later read the same key before releasing the snapshot and
   // verify that the results are the same.
-  Status status_at = db_->Get(ropt, column_family, key, &value_at);
+  Status status_at = DbStressGet(db_, ropt, column_family, key, &value_at);
   if (!status_at.ok() && IsErrorInjectedAndRetryable(status_at)) {
     db_->ReleaseSnapshot(snapshot);
     return;
@@ -4348,6 +4349,8 @@ void StressTest::PrintEnv() const {
           FLAGS_subcompactions);
   fprintf(stdout, "Use MultiGet              : %s\n",
           FLAGS_use_multiget ? "true" : "false");
+  fprintf(stdout, "Use async DB API          : %s\n",
+          FLAGS_use_async_db_api ? "true" : "false");
   fprintf(stdout, "Use GetEntity             : %s\n",
           FLAGS_use_get_entity ? "true" : "false");
   fprintf(stdout, "Use MultiGetEntity        : %s\n",

--- a/db_stress_tool/multi_ops_txns_stress.cc
+++ b/db_stress_tool/multi_ops_txns_stress.cc
@@ -1180,7 +1180,7 @@ void MultiOpsTxnsStressTest::VerifyDb(ThreadState* thread) const {
       std::reverse(sk_buf + 2 * sizeof(uint32_t), sk_buf + sizeof(sk_buf));
       Slice sk(sk_buf, sizeof(sk_buf));
       std::string value;
-      s = db_->Get(ropts, sk, &value);
+      s = DbStressGet(db_, ropts, sk, &value);
       if (!s.ok()) {
         oss << "Cannot find secondary index entry " << sk.ToString(true)
             << ". Status is " << s.ToString();
@@ -1225,7 +1225,7 @@ void MultiOpsTxnsStressTest::VerifyDb(ThreadState* thread) const {
       // Form a primary key and search in the primary index.
       std::string pk = Record::EncodePrimaryKey(record.a_value());
       std::string value;
-      s = db_->Get(ropts, pk, &value);
+      s = DbStressGet(db_, ropts, pk, &value);
       if (!s.ok()) {
         oss << "Error searching pk " << Slice(pk).ToString(true) << ". "
             << s.ToString() << ". sk " << it->key().ToString(true);
@@ -1323,7 +1323,7 @@ void MultiOpsTxnsStressTest::VerifyPkSkFast(const ReadOptions& read_options,
     // Form a primary key and search in the primary index.
     std::string pk = Record::EncodePrimaryKey(record.a_value());
     std::string value;
-    s = db->Get(ropts, pk, &value);
+    s = DbStressGet(db, ropts, pk, &value);
     if (!s.ok()) {
       oss << "Error searching pk " << Slice(pk).ToString(true) << ". "
           << s.ToString() << ". sk " << it->key().ToString(true);

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -182,7 +182,8 @@ class NonBatchedOpsStressTest : public StressTest {
           const std::string key = Key(i);
           std::string from_db;
 
-          Status s = db_->Get(options, column_families_[cf], key, &from_db);
+          Status s =
+              DbStressGet(db_, options, column_families_[cf], key, &from_db);
 
           VerifyOrSyncValue(static_cast<int>(cf), i, options, shared, from_db,
                             /* msg_prefix */ "Get verification", s);
@@ -276,7 +277,8 @@ class NonBatchedOpsStressTest : public StressTest {
                   FaultInjectionIOType::kMetadataRead);
             }
 
-            s = secondary_db_->Get(options, secondary_cfhs_[cf], key, &from_db);
+            s = DbStressGet(secondary_db_.get(), options, secondary_cfhs_[cf],
+                            key, &from_db);
 
             // Re-enable error injection after verifying the secondary
             if (db_fault_injection_fs_) {
@@ -351,8 +353,8 @@ class NonBatchedOpsStressTest : public StressTest {
             keys[j] = Slice(key_strs[j]);
           }
 
-          db_->MultiGet(options, column_families_[cf], batch_size, keys.data(),
-                        values.data(), statuses.data());
+          DbStressMultiGet(db_, options, column_families_[cf], batch_size,
+                           keys.data(), values.data(), statuses.data());
 
           for (size_t j = 0; j < batch_size; ++j) {
             const std::string from_db = values[j].ToString();
@@ -545,9 +547,8 @@ class NonBatchedOpsStressTest : public StressTest {
         std::string key_str = Key(key);
         std::string value;
         std::string key_ts;
-        s = secondary_db_->Get(
-            read_opts, handle, key_str, &value,
-            FLAGS_user_timestamp_size > 0 ? &key_ts : nullptr);
+        s = DbStressGet(secondary_db_.get(), read_opts, handle, key_str, &value,
+                        FLAGS_user_timestamp_size > 0 ? &key_ts : nullptr);
         s.PermitUncheckedError();
       } else {
         // Use range scan
@@ -702,7 +703,7 @@ class NonBatchedOpsStressTest : public StressTest {
 
     const ExpectedValue pre_read_expected_value =
         thread->shared->Get(rand_column_families[0], rand_keys[0]);
-    Status s = db_->Get(read_opts_copy, cfh, key, &from_db);
+    Status s = DbStressGet(db_, read_opts_copy, cfh, key, &from_db);
     const ExpectedValue post_read_expected_value =
         thread->shared->Get(rand_column_families[0], rand_keys[0]);
 
@@ -861,8 +862,8 @@ class NonBatchedOpsStressTest : public StressTest {
             FaultInjectionIOType::kMetadataRead);
         SharedState::ignore_read_error = false;
       }
-      db_->MultiGet(readoptionscopy, cfh, num_keys, keys.data(), values.data(),
-                    statuses.data());
+      DbStressMultiGet(db_, readoptionscopy, cfh, num_keys, keys.data(),
+                       values.data(), statuses.data());
       if (db_fault_injection_fs_) {
         injected_error_count = GetMinInjectedErrorCount(
             db_fault_injection_fs_->GetAndResetInjectedThreadLocalErrorCount(
@@ -984,7 +985,7 @@ class NonBatchedOpsStressTest : public StressTest {
       } else {
         ThreadStatusUtil::SetThreadOperation(
             ThreadStatus::OperationType::OP_GET);
-        tmp_s = db_->Get(readoptionscopy, cfh, key, &value);
+        tmp_s = DbStressGet(db_, readoptionscopy, cfh, key, &value);
         ThreadStatusUtil::SetThreadOperation(
             ThreadStatus::OperationType::OP_MULTIGET);
       }
@@ -1459,7 +1460,7 @@ class NonBatchedOpsStressTest : public StressTest {
           ThreadStatusUtil::SetThreadOperation(
               ThreadStatus::OperationType::OP_GET);
           cmp_value_s =
-              db_->Get(read_opts_copy, cfh, key_slices[i], &cmp_value);
+              DbStressGet(db_, read_opts_copy, cfh, key_slices[i], &cmp_value);
           ran_cmp_get = true;
           fprintf(stderr,
                   "TestMultiGetEntity mismatch details: cf=%s key=%s "
@@ -1892,7 +1893,7 @@ class NonBatchedOpsStressTest : public StressTest {
       }
 
       std::string from_db;
-      Status s = db_->Get(read_opts, cfh, k, &from_db);
+      Status s = DbStressGet(db_, read_opts, cfh, k, &from_db);
       bool res = VerifyOrSyncValue(
           rand_column_family, rand_key, read_opts, shared,
           /* msg_prefix */ "Pre-Put Get verification", from_db, s);

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -314,6 +314,7 @@ default_params = {
     "separate_key_value_in_data_block": lambda: random.choice([0, 1, 1]),
     "index_block_restart_interval": lambda: random.choice(range(1, 16)),
     "use_multiget": lambda: random.randint(0, 1),
+    "use_async_db_api": lambda: random.choice([0] * 5 + [1]),
     "use_get_entity": lambda: random.choice([0] * 7 + [1]),
     "use_multi_get_entity": lambda: random.choice([0] * 7 + [1]),
     "periodic_compaction_seconds": lambda: random.choice([0, 0, 1, 2, 10, 100, 1000]),


### PR DESCRIPTION
Summary:
Add `--use_async_db_api` to db_stress and route direct `DB::Get` and value `DB::MultiGet` reads through the callback async APIs (`DB::GetAsync` / `DB::MultiGetAsync`) when coroutine support is available. The db_stress helpers block on callback completion and notify waiters while holding the callback lock, so existing stress-test control flow and callback lifetime are preserved. Builds without coroutine support silently keep the existing synchronous path.

Centralize the dispatch in db_stress helpers and use them for workload, verification, secondary, and consistency/debug reads while leaving transaction and entity APIs on their existing paths.

Randomize `use_async_db_api` in `tools/db_crashtest.py` one run in six.

Reviewed By: jaykorean

Differential Revision: D111132477


