### PR TITLE
Fix same-sequence range tombstone visibility

### DIFF
--- a/table/merger_test.cc
+++ b/table/merger_test.cc
@@ -3,9 +3,13 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
+#include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
+#include "db/range_tombstone_fragmenter.h"
+#include "memory/arena.h"
 #include "table/merging_iterator.h"
 #include "test_util/testharness.h"
 #include "test_util/testutil.h"
@@ -112,6 +116,57 @@ class MergerTest : public testing::Test {
     single_iterator_.reset(new VectorIterator(all_keys_, all_keys_, &icomp_));
   }
 
+  std::string IKey(const Slice& user_key, SequenceNumber seq,
+                   ValueType value_type) {
+    return InternalKey(user_key, seq, value_type).Encode().ToString();
+  }
+
+  VectorIterator* NewArenaVectorIterator(Arena* arena,
+                                         std::vector<std::string> keys,
+                                         std::vector<std::string> values) {
+    auto mem = arena->AllocateAligned(sizeof(VectorIterator));
+    return new (mem)
+        VectorIterator(std::move(keys), std::move(values), &icomp_);
+  }
+
+  std::unique_ptr<TruncatedRangeDelIterator> NewRangeTombstoneIter(
+      const std::vector<RangeTombstone>& range_dels) {
+    std::vector<std::string> keys, values;
+    for (const auto& range_del : range_dels) {
+      auto key_and_value = range_del.Serialize();
+      keys.push_back(key_and_value.first.Encode().ToString());
+      values.push_back(key_and_value.second.ToString());
+    }
+    auto range_del_iter = std::unique_ptr<VectorIterator>(
+        new VectorIterator(keys, values, &icomp_));
+    auto fragment_list = std::make_shared<FragmentedRangeTombstoneList>(
+        std::move(range_del_iter), icomp_);
+    auto fragment_iter = std::unique_ptr<FragmentedRangeTombstoneIterator>(
+        new FragmentedRangeTombstoneIterator(fragment_list, icomp_,
+                                             kMaxSequenceNumber));
+    return std::unique_ptr<TruncatedRangeDelIterator>(
+        new TruncatedRangeDelIterator(std::move(fragment_iter), &icomp_,
+                                      nullptr, nullptr));
+  }
+
+  InternalIterator* NewSameReadSeqRangeTombstoneIterator(Arena* arena) {
+    constexpr SequenceNumber kReadSeq = 10;
+
+    MergeIteratorBuilder builder(&icomp_, arena, false /* prefix_seek_mode */);
+    builder.AddPointAndTombstoneIterator(
+        NewArenaVectorIterator(arena, {}, {}),
+        NewRangeTombstoneIter({RangeTombstone("b", "e", kReadSeq)}));
+    builder.AddPointAndTombstoneIterator(
+        NewArenaVectorIterator(
+            arena,
+            {IKey("c", 9, kTypeDeletion), IKey("d", kReadSeq, kTypeDeletion)},
+            {"", ""}),
+        std::unique_ptr<TruncatedRangeDelIterator>());
+    InternalIterator* iter = builder.Finish();
+    iter->SetRangeDelReadSeqno(kReadSeq);
+    return iter;
+  }
+
   InternalKeyComparator icomp_;
   Random rnd_;
   std::unique_ptr<InternalIterator> merging_iterator_;
@@ -170,6 +225,52 @@ TEST_F(MergerTest, SeekToLastTest) {
     SeekToLast();
     AssertEquivalence();
     Prev(50000);
+  }
+}
+
+TEST_F(MergerTest, SameReadSeqRangeTombstoneDoesNotHideSameSeqPointDelete) {
+  constexpr SequenceNumber kReadSeq = 10;
+
+  {
+    Arena arena;
+    InternalIterator* iter = NewSameReadSeqRangeTombstoneIterator(&arena);
+    iter->SeekToFirst();
+    ASSERT_TRUE(iter->Valid());
+    EXPECT_EQ(IKey("d", kReadSeq, kTypeDeletion), iter->key().ToString());
+    iter->Next();
+    EXPECT_FALSE(iter->Valid());
+    EXPECT_OK(iter->status());
+    iter->~InternalIterator();
+  }
+
+  {
+    Arena arena;
+    InternalIterator* iter = NewSameReadSeqRangeTombstoneIterator(&arena);
+    iter->Seek(IKey("d", kReadSeq, kValueTypeForSeek));
+    ASSERT_TRUE(iter->Valid());
+    EXPECT_EQ(IKey("d", kReadSeq, kTypeDeletion), iter->key().ToString());
+    iter->~InternalIterator();
+  }
+
+  {
+    Arena arena;
+    InternalIterator* iter = NewSameReadSeqRangeTombstoneIterator(&arena);
+    iter->SeekToLast();
+    ASSERT_TRUE(iter->Valid());
+    EXPECT_EQ(IKey("d", kReadSeq, kTypeDeletion), iter->key().ToString());
+    iter->Prev();
+    EXPECT_FALSE(iter->Valid());
+    EXPECT_OK(iter->status());
+    iter->~InternalIterator();
+  }
+
+  {
+    Arena arena;
+    InternalIterator* iter = NewSameReadSeqRangeTombstoneIterator(&arena);
+    iter->SeekForPrev(IKey("e", 0, kValueTypeForSeekForPrev));
+    ASSERT_TRUE(iter->Valid());
+    EXPECT_EQ(IKey("d", kReadSeq, kTypeDeletion), iter->key().ToString());
+    iter->~InternalIterator();
   }
 }
 

--- a/table/merging_iterator.cc
+++ b/table/merging_iterator.cc
@@ -27,8 +27,9 @@ namespace ROCKSDB_NAMESPACE {
 // for example. Level j is in active_ if its current range tombstone has its
 // start_key popped from minHeap_ and its end_key in minHeap_. If the top of
 // minHeap_ is a point key from level L, we can determine if the point key is
-// covered by any range tombstone by checking if there is an l <= L in active_.
-// The case of l == L also involves checking range tombstone's sequence number.
+// covered by any range tombstone by checking if there is an l <= L in active_
+// whose tombstone sequence number is greater than the point key sequence
+// number.
 //
 // The following (non-exhaustive) list of invariants are maintained by
 // MergingIterator during forward scanning. After each InternalIterator API,
@@ -61,6 +62,7 @@ class MergingIterator : public InternalIterator {
         prefix_seek_mode_(prefix_seek_mode),
         direction_(kForward),
         comparator_(comparator),
+        range_del_read_seqno_(kMaxSequenceNumber),
         current_(nullptr),
         minHeap_(MinHeapItemComparator(comparator_)),
         pinned_iters_mgr_(nullptr),
@@ -137,6 +139,7 @@ class MergingIterator : public InternalIterator {
   }
 
   void SetRangeDelReadSeqno(SequenceNumber read_seqno) override {
+    range_del_read_seqno_ = read_seqno;
     for (auto& child : children_) {
       // This should only be needed for LevelIterator (iterators from L1+).
       child.iter.SetRangeDelReadSeqno(read_seqno);
@@ -146,6 +149,36 @@ class MergingIterator : public InternalIterator {
         child->SetRangeDelReadSeqno(read_seqno);
       }
     }
+  }
+
+  bool RangeTombstoneCoversPointKey(size_t level,
+                                    const ParsedInternalKey& pik) const {
+    assert(range_tombstone_iters_[level]);
+    assert(range_tombstone_iters_[level]->Valid());
+    assert(comparator_->Compare(range_tombstone_iters_[level]->start_key(),
+                                pik) <= 0);
+    assert(comparator_->Compare(pik, range_tombstone_iters_[level]->end_key()) <
+           0);
+    return pik.sequence < range_tombstone_iters_[level]->seq();
+  }
+
+  std::set<size_t>::const_iterator FindActiveRangeTombstoneCoveringPointKey(
+      const ParsedInternalKey& pik, size_t max_level) const {
+    for (auto i = active_.begin(); i != active_.end() && *i <= max_level; ++i) {
+      if (RangeTombstoneCoversPointKey(*i, pik)) {
+        return i;
+      }
+    }
+    return active_.end();
+  }
+
+  bool CanUseLevelOrderRangeTombstoneSkip(size_t level) const {
+    assert(range_tombstone_iters_[level]);
+    assert(range_tombstone_iters_[level]->Valid());
+    // Read-path range conversion materializes tombstones at the iterator read
+    // sequence. Such a tombstone can be in a newer iterator level without being
+    // newer than every lower-level point key.
+    return range_tombstone_iters_[level]->seq() != range_del_read_seqno_;
   }
 
   bool Valid() const override { return current_ != nullptr && status_.ok(); }
@@ -607,6 +640,7 @@ class MergingIterator : public InternalIterator {
   enum Direction : uint8_t { kForward, kReverse };
   Direction direction_;
   const InternalKeyComparator* comparator_;
+  SequenceNumber range_del_read_seqno_;
   // HeapItem for all child point iterators.
   // Invariant(children_): children_[i] is in minHeap_ iff
   // children_[i].iter.Valid(), and at most one children_[i] is in minHeap_.
@@ -761,10 +795,11 @@ class MergingIterator : public InternalIterator {
 //  - range_tombstone_iters_[i]->Valid()
 //  - range_tombstone_iters_[i]->start_key().user_key <= k1.user_key
 //  - k2 = range_tombstone_iters_[i]->end_key()
-// We assume that range_tombstone_iters_[i]->start_key() has a higher sequence
-// number compared to any key from levels > i that has the same user key. So no
-// point key from levels > i in range [k1, k2) is visible. So
-// children_[i].iter.key() <= LevelNextVisible(i, target).
+// CanUseLevelOrderRangeTombstoneSkip(i) ensures the range tombstone is not a
+// read-sequence tombstone. For other range tombstones, level order implies the
+// tombstone has a higher sequence number than any key from levels > i with the
+// same user key. So no point key from levels > i in range [k1, k2) is visible.
+// Thus children_[i].iter.key() <= LevelNextVisible(i, target).
 //
 // Post-condition (**) target < pinned_heap_item_[i].tombstone_pik for i >=
 // starting_level if range_tombstone_iters_[i].Valid(). This follows from that
@@ -863,9 +898,9 @@ void MergingIterator::SeekImpl(const Slice& target, size_t starting_level,
               level, comparator_->Compare(range_tombstone_iter->start_key(),
                                           pik) > 0 /* start_key */);
           // current_search_key < end_key guaranteed by the SeekInternalKey()
-          // and Valid() calls above. Here we only need to compare user_key
-          // since if target.user_key ==
-          // range_tombstone_iter->start_key().user_key and target <
+          // and Valid() calls above. When level-order tombstone skipping is
+          // allowed, we only need to compare user_key since if target.user_key
+          // == range_tombstone_iter->start_key().user_key and target <
           // range_tombstone_iter->start_key(), no older level would have any
           // key in range [target, range_tombstone_iter->start_key()], so no
           // keys in range [target, range_tombstone_iter->end_key()) from older
@@ -874,7 +909,8 @@ void MergingIterator::SeekImpl(const Slice& target, size_t starting_level,
           //
           // TODO: range_tombstone_iter->Seek() finds the max covering
           //  sequence number, can make it cheaper by not looking for max.
-          if (comparator_->user_comparator()->Compare(
+          if (CanUseLevelOrderRangeTombstoneSkip(level) &&
+              comparator_->user_comparator()->Compare(
                   range_tombstone_iter->start_key().user_key,
                   current_search_key.GetUserKey()) <= 0) {
             range_tombstone_reseek = true;
@@ -1032,45 +1068,27 @@ bool MergingIterator::SkipNextDeleted() {
   ParsedInternalKey pik;
   ParseInternalKey(current->iter.key(), &pik, false).PermitUncheckedError();
   if (!active_.empty()) {
-    auto i = *active_.begin();
-    if (i < current->level) {
-      // range tombstone is from a newer level, definitely covers
-      assert(comparator_->Compare(range_tombstone_iters_[i]->start_key(),
-                                  pik) <= 0);
-      assert(comparator_->Compare(pik, range_tombstone_iters_[i]->end_key()) <
-             0);
+    auto covering_iter =
+        FindActiveRangeTombstoneCoveringPointKey(pik, current->level);
+    if (covering_iter == active_.end()) {
+      return false /* current key not deleted */;
+    }
+    auto i = *covering_iter;
+    if (i < current->level && CanUseLevelOrderRangeTombstoneSkip(i)) {
       std::string target;
       AppendInternalKey(&target, range_tombstone_iters_[i]->end_key());
       SeekImpl(target, current->level, true);
       return true /* current key deleted */;
-    } else if (i == current->level) {
-      // range tombstone is from the same level as current, check sequence
-      // number. By `active_` we know current key is between start key and end
-      // key.
-      assert(comparator_->Compare(range_tombstone_iters_[i]->start_key(),
-                                  pik) <= 0);
-      assert(comparator_->Compare(pik, range_tombstone_iters_[i]->end_key()) <
-             0);
-      if (pik.sequence < range_tombstone_iters_[current->level]->seq()) {
-        // covered by range tombstone
-        current->iter.Next();
-        // Invariant (children_)
-        if (current->iter.Valid()) {
-          minHeap_.replace_top(current);
-        } else {
-          considerStatus(current->iter.status());
-          minHeap_.pop();
-        }
-        return true /* current key deleted */;
-      } else {
-        return false /* current key not deleted */;
-      }
     } else {
-      return false /* current key not deleted */;
-      // range tombstone from an older sorted run with current key < end key.
-      // current key is not deleted and the older sorted run will have its range
-      // tombstone updated when the range tombstone's end key are popped from
-      // minHeap_.
+      current->iter.Next();
+      // Invariant (children_)
+      if (current->iter.Valid()) {
+        minHeap_.replace_top(current);
+      } else {
+        considerStatus(current->iter.status());
+        minHeap_.pop();
+      }
+      return true /* current key deleted */;
     }
   }
   // we can reach here only if active_ is empty
@@ -1143,9 +1161,8 @@ void MergingIterator::SeekForPrevImpl(const Slice& target,
               level, comparator_->Compare(range_tombstone_iter->end_key(),
                                           pik) <= 0 /* end_key */);
           // start key <= current_search_key guaranteed by the Seek() call above
-          // Only interested in user key coverage since older sorted runs must
-          // have smaller sequence numbers than this tombstone.
-          if (comparator_->user_comparator()->Compare(
+          if (CanUseLevelOrderRangeTombstoneSkip(level) &&
+              comparator_->user_comparator()->Compare(
                   current_search_key.GetUserKey(),
                   range_tombstone_iter->end_key().user_key) < 0) {
             range_tombstone_reseek = true;
@@ -1246,13 +1263,13 @@ bool MergingIterator::SkipPrevDeleted() {
   ParsedInternalKey pik;
   ParseInternalKey(current->iter.key(), &pik, false).PermitUncheckedError();
   if (!active_.empty()) {
-    auto i = *active_.begin();
-    if (i < current->level) {
-      // range tombstone is from a newer level, definitely covers
-      assert(comparator_->Compare(range_tombstone_iters_[i]->start_key(),
-                                  pik) <= 0);
-      assert(comparator_->Compare(pik, range_tombstone_iters_[i]->end_key()) <
-             0);
+    auto covering_iter =
+        FindActiveRangeTombstoneCoveringPointKey(pik, current->level);
+    if (covering_iter == active_.end()) {
+      return false /* current key not deleted */;
+    }
+    auto i = *covering_iter;
+    if (i < current->level && CanUseLevelOrderRangeTombstoneSkip(i)) {
       std::string target;
       AppendInternalKey(&target, range_tombstone_iters_[i]->start_key());
       // This is different from SkipNextDeleted() which does reseek at sorted
@@ -1264,26 +1281,15 @@ bool MergingIterator::SkipPrevDeleted() {
       // which might still be the same user key.
       SeekForPrevImpl(target, i + 1, true);
       return true /* current key deleted */;
-    } else if (i == current->level) {
-      // By `active_` we know current key is between start key and end key.
-      assert(comparator_->Compare(range_tombstone_iters_[i]->start_key(),
-                                  pik) <= 0);
-      assert(comparator_->Compare(pik, range_tombstone_iters_[i]->end_key()) <
-             0);
-      if (pik.sequence < range_tombstone_iters_[current->level]->seq()) {
-        current->iter.Prev();
-        if (current->iter.Valid()) {
-          maxHeap_->replace_top(current);
-        } else {
-          considerStatus(current->iter.status());
-          maxHeap_->pop();
-        }
-        return true /* current key deleted */;
-      } else {
-        return false /* current key not deleted */;
-      }
     } else {
-      return false /* current key not deleted */;
+      current->iter.Prev();
+      if (current->iter.Valid()) {
+        maxHeap_->replace_top(current);
+      } else {
+        considerStatus(current->iter.status());
+        maxHeap_->pop();
+      }
+      return true /* current key deleted */;
     }
   }
 


### PR DESCRIPTION
## Summary

Root cause:
`min_tombstones_for_range_conversion` can make `DBIter` convert a discovered
run of visible point tombstones into a logically redundant range tombstone on
the read path. The converted tombstone is inserted into the active memtable at
the iterator snapshot sequence, i.e. `insert_seq = sequence_`.

That means the converted range tombstone can have the same sequence number as
the last point tombstone in the run. It cannot legitimately span across a live
same-sequence value: when forward iteration sees a live value, `DBIter` flushes
the pending tombstone run using that live key as the exclusive end bound. The
same-sequence internal key inside the converted range is a point tombstone, not
a live value.

Concrete read/write sequence:

1. Start with live keys and flush them to an older sorted run:

   ```
   seq 1: Put(b)
   seq 2: Put(c)
   seq 3: Put(d)
   seq 4: Put(e)
   Flush
   ```

   At this point `b`, `c`, `d`, and `e` are live in an SST.

2. Write point deletes for the first three keys and flush them to a lower sorted
   run that a later merge iterator can still read independently of the active
   memtable:

   ```
   seq 8:  Delete(b)
   seq 9:  Delete(c)
   seq 10: Delete(d)
   Flush
   ```

   The lower sorted run now contains point tombstones such as `c@9` and
   `d@10`. Key `e` remains the next live key after the delete run.

3. A snapshot/prefix scan reads at sequence `10` with range conversion enabled.
   As `DBIter` scans forward, it observes:

   ```
   b -> deleted by point tombstone b@8
   c -> deleted by point tombstone c@9
   d -> deleted by point tombstone d@10
   e -> live
   ```

   `DBIter` tracks `b`, `c`, and `d` as a contiguous tombstone run. When it sees
   live key `e`, it terminates the run at exclusive bound `e`. If the run length
   reaches `min_tombstones_for_range_conversion`, it inserts the synthetic range
   tombstone `[b,e)@10` into the active memtable.

4. In a batched snapshot prefix scan, a later prepared range can reuse the same
   logical iterator after its memtable range-tombstone iterator is refreshed or
   rebuilt. The merge layer can then see both of these internal records:

   ```
   newer memtable range tombstone: [b,e)@10
   lower sorted-run point tombstone: d@10
   ```

   That state is valid because the converted tombstone is redundant read-path
   metadata. It does not remove the original point tombstones.

`MergingIterator` treats lower numeric iterator levels as newer sorted runs. Its
range-tombstone logic assumed that an active range tombstone from a newer run
must also have a strictly newer sequence number than any point key from older
runs. That assumption showed up in two places:

* `SkipNextDeleted()` / `SkipPrevDeleted()` treated an active tombstone from a
  newer level as definitely covering the current lower-level point key.
* The cascading seek optimization treated a covering tombstone in level `i` as
  proof that all lower levels could be seeked directly to the tombstone end
  key, or to the start key for reverse scans.

That is valid only when level order implies sequence order. It is not valid for
read-path-converted tombstones. In the example above, `[b,e)@10` must hide
`c@9`, but it must not hide the internal point tombstone `d@10`, because range
tombstones cover only point keys with smaller sequence numbers. User-visible
`d` is still deleted due to the point tombstone itself; the important invariant
is that the merge iterator must not drop the same-sequence internal key before
`DBIter` can process it.

The old code could skip the whole lower iterator to `e`, or treat the active
tombstone as "definitely covers" when `d@10` reached the heap top. That can
remove an internal key that is not covered by the range tombstone and can leave
`DBIter` with non-monotonic user-key skipping / tombstone-run state, matching
the T279867049 failure mode.

Fix:

Track the range-delete read sequence in `MergingIterator` via
`SetRangeDelReadSeqno()`. When deciding whether an active range tombstone covers
a point key, require the explicit sequence-number relation
`tombstone_seq > point_seq`, regardless of iterator level.

For the range-wide cascading seek optimization, keep the fast path for normal
range tombstones but disable it for tombstones whose sequence is the iterator
read sequence. Those are the read-path-conversion case where level order is not
enough to prove sequence order for every lower-level point in the range. After a
read-sequence tombstone is confirmed to cover the current point key, advance only
that point iterator one key at a time so same-sequence point tombstones later in
the range remain visible to `DBIter`.

The lookup over `active_` now searches active tombstones at levels up to the
current point level and picks one that actually has `seq > point_seq`. This also
avoids returning visible too early if the first active tombstone is not new
enough but a later active tombstone is.

## Test Plan

Add `MergerTest.SameReadSeqRangeTombstoneDoesNotHideSameSeqPointDelete`, which
builds an in-memory merging iterator with `[b,e)@10` in a newer run and point
tombstones `c@9`, `d@10` in an older run. The test verifies forward seek/scan
and reverse seek/scan hide `c@9` but preserve same-seq point tombstone `d@10`.

Validated with:

* `AUTO_CLEAN=1 build_tools/rockstest.sh merger_test --gtest_filter=MergerTest.SameReadSeqRangeTombstoneDoesNotHideSameSeqPointDelete`
* `COERCE_CONTEXT_SWITCH=1 AUTO_CLEAN=1 build_tools/rockstest.sh merger_test -r100 --gtest_filter=MergerTest.SameReadSeqRangeTombstoneDoesNotHideSameSeqPointDelete`
* `AUTO_CLEAN=1 build_tools/rockstest.sh db_iterator_test --gtest_filter='*ReadPathRangeTombstoneTest.NewerPointInOlderFileStillVisible*:*ReadPathRangeTombstoneTest.ReseekDiscoveredDeleteRunPreservesOlderSnapshots*:*ReadPathRangeTombstoneTest.BasicInsertion*'`
* `AUTO_CLEAN=1 build_tools/rockstest.sh merger_test`
* `AUTO_CLEAN=1 make check-sources`
* `make format-auto`
* `git diff --check`
