### PR TITLE
Fix race condition in Java RocksDB.loadLibrary()

### DIFF
--- a/java/src/main/java/org/rocksdb/RocksDB.java
+++ b/java/src/main/java/org/rocksdb/RocksDB.java
@@ -158,6 +158,10 @@ public class RocksDB extends RocksObject {
               "Exceeded timeout whilst trying to load the RocksDB shared library");
         }
       }
+
+      if (libraryLoaded.get() != LibraryState.LOADED) {
+        throw new RuntimeException("RocksDB shared library failed to load due to error on another thread");
+      }
     } catch (final InterruptedException e) {
       // restore interrupted status
       Thread.currentThread().interrupt();


### PR DESCRIPTION
The busy-wait when another thread is already loading the native library didn't check that the library actually loaded successfully, so it was possible for code paths guarded by `loadLibrary()` to proceed without the library present if another thread had failed loading it. This shows up as unexpected `UnsatisfiedLinkError` exceptions in cases that shouldn't otherwise really be possible.

In this case, it seems the best we can reasonably do is provide a less confusing error message, so people who encounter this know they should be looking for an error in other threads rather than e.g. a mismatched or mangled native library which loaded without the expected symbols.