### PR TITLE
Api to checkpoint only selected set of column families (#15019)

### DIFF
--- a/db/db_filesnapshot.cc
+++ b/db/db_filesnapshot.cc
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 #include "db/db_impl/db_impl.h"
@@ -195,13 +196,63 @@ Status DBImpl::GetCurrentWalFile(std::unique_ptr<WalFile>* current_wal_file) {
   return wal_manager_.GetLiveWalFile(current_logfile_number, current_wal_file);
 }
 
+Status DBImpl::AppendColumnFamilyDropsToManifest(
+    const std::string& manifest_path, uint64_t manifest_size,
+    const std::vector<uint32_t>& cf_ids) {
+  const WriteOptions write_options;
+  // Snapshot manifest_preallocation_size_ under the DB mutex per VersionSet's
+  // contract (the field is mutated by SetDBOptions under this mutex).
+  uint64_t preallocation_size = 0;
+  {
+    InstrumentedMutexLock l(&mutex_);
+    preallocation_size = versions_->manifest_preallocation_size_;
+  }
+  return versions_->AppendColumnFamilyDropsToManifest(
+      manifest_path, manifest_size, cf_ids, write_options, preallocation_size);
+}
+
 Status DBImpl::GetLiveFilesStorageInfo(
     const LiveFilesStorageInfoOptions& opts,
     std::vector<LiveFileStorageInfo>* files) {
+  return GetLiveFilesStorageInfoImpl(opts, /*include_cf_ids=*/{}, files,
+                                     /*excluded_cf_ids=*/nullptr);
+}
+
+Status DBImpl::GetLiveFilesStorageInfoForSubsetCheckpoint(
+    const LiveFilesStorageInfoOptions& opts,
+    const std::vector<uint32_t>& include_cf_ids,
+    std::vector<LiveFileStorageInfo>* files,
+    std::vector<uint32_t>* excluded_cf_ids) {
+  // Internal contract: caller must coalesce ids and always include the default
+  // CF (it cannot be dropped, so a subset checkpoint without it would produce
+  // an unopenable DB). CheckpointImpl enforces this before calling here.
+  assert(!include_cf_ids.empty());
+  assert(std::find(include_cf_ids.begin(), include_cf_ids.end(),
+                   default_cf_handle_->GetID()) != include_cf_ids.end());
+  assert(excluded_cf_ids != nullptr);
+  return GetLiveFilesStorageInfoImpl(opts, include_cf_ids, files,
+                                     excluded_cf_ids);
+}
+
+Status DBImpl::GetLiveFilesStorageInfoImpl(
+    const LiveFilesStorageInfoOptions& opts,
+    const std::vector<uint32_t>& include_cf_ids,
+    std::vector<LiveFileStorageInfo>* files,
+    std::vector<uint32_t>* excluded_cf_ids) {
   // To avoid returning partial results, only move results to files on success.
   assert(files);
   files->clear();
   std::vector<LiveFileStorageInfo> results;
+
+  const bool cf_subset = !include_cf_ids.empty();
+  assert(!cf_subset || excluded_cf_ids != nullptr);
+  const std::unordered_set<uint32_t> include_cf_id_set(include_cf_ids.begin(),
+                                                       include_cf_ids.end());
+  // Tracks which requested ids remain to be observed as live under the DB
+  // mutex; any id still present after the enumeration was either dropped
+  // before or during the checkpoint (race) and must not silently disappear
+  // from the checkpoint.
+  std::unordered_set<uint32_t> unseen_include_cf_ids = include_cf_id_set;
 
   // NOTE: This implementation was largely migrated from Checkpoint.
 
@@ -282,6 +333,14 @@ Status DBImpl::GetLiveFilesStorageInfo(
     if (cfd->IsDropped()) {
       continue;
     }
+    if (cf_subset &&
+        include_cf_id_set.find(cfd->GetID()) == include_cf_id_set.end()) {
+      excluded_cf_ids->push_back(cfd->GetID());
+      continue;
+    }
+    if (cf_subset) {
+      unseen_include_cf_ids.erase(cfd->GetID());
+    }
     VersionStorageInfo& vsi = *cfd->current()->storage_info();
     auto& cf_paths = cfd->ioptions().cf_paths;
 
@@ -341,6 +400,17 @@ Status DBImpl::GetLiveFilesStorageInfo(
       }
       // TODO?: info.temperature
     }
+  }
+
+  // Release-build validation: every id the subset-checkpoint caller asked for
+  // must have been observed as live under the mutex. If any is missing, it was
+  // dropped before we ran (stale handle) or lost a race with a concurrent
+  // drop; either way the checkpoint would silently omit it, violating the
+  // caller's contract that the checkpoint contains the requested CFs.
+  if (cf_subset && !unseen_include_cf_ids.empty()) {
+    mutex_.Unlock();
+    return Status::InvalidArgument(
+        "Requested column family id was not live at checkpoint time");
   }
 
   // Capture some final info before releasing mutex

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -589,6 +589,35 @@ class DBImpl : public DB {
       const LiveFilesStorageInfoOptions& opts,
       std::vector<LiveFileStorageInfo>* files) override;
 
+  // Variant of GetLiveFilesStorageInfo used by subset-CF Checkpoint. Only
+  // table/blob files of the given column families are captured; the rest are
+  // reported in excluded_cf_ids so the caller can reconcile the copied
+  // MANIFEST (typically via AppendColumnFamilyDropsToManifest below). Caller
+  // must supply a non-empty include_cf_ids containing the default CF id and a
+  // non-null excluded_cf_ids; both are internal-contract preconditions.
+  Status GetLiveFilesStorageInfoForSubsetCheckpoint(
+      const LiveFilesStorageInfoOptions& opts,
+      const std::vector<uint32_t>& include_cf_ids,
+      std::vector<LiveFileStorageInfo>* files,
+      std::vector<uint32_t>* excluded_cf_ids);
+
+  // Shared body of GetLiveFilesStorageInfo and its subset-checkpoint variant.
+  // include_cf_ids empty -> no filter; otherwise records skipped CF ids in
+  // *excluded_cf_ids (which must be non-null in that case).
+  Status GetLiveFilesStorageInfoImpl(
+      const LiveFilesStorageInfoOptions& opts,
+      const std::vector<uint32_t>& include_cf_ids,
+      std::vector<LiveFileStorageInfo>* files,
+      std::vector<uint32_t>* excluded_cf_ids);
+
+  // Appends kColumnFamilyDrop records to the MANIFEST file at manifest_path for
+  // the given column family ids. Used by Checkpoint to make a subset-CF
+  // checkpoint's copied MANIFEST consistent with the reduced file set. Operates
+  // only on the given file; does not mutate this DB's live state.
+  Status AppendColumnFamilyDropsToManifest(const std::string& manifest_path,
+                                           uint64_t manifest_size,
+                                           const std::vector<uint32_t>& cf_ids);
+
   Status GetPreparedFileInfoForExternalSstIngestion(
       const std::string& file_path,
       std::shared_ptr<const PreparedFileInfo>* file_info) override;

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -6545,6 +6545,135 @@ Status VersionSet::ReopenManifestForAppend(const std::string& manifest_path) {
   return Status::OK();
 }
 
+Status VersionSet::AppendColumnFamilyDropsToManifest(
+    const std::string& manifest_path, uint64_t manifest_size,
+    const std::vector<uint32_t>& cf_ids, const WriteOptions& write_options,
+    uint64_t manifest_preallocation_size) {
+  if (cf_ids.empty()) {
+    return Status::OK();
+  }
+
+  // Rewrite the checkpoint MANIFEST via a bounded-memory buffered copy into a
+  // .tmp file (append drops, sync, close), then atomically rename over the
+  // original. Avoids depending on FileSystem::ReopenWritableFile (optional,
+  // unsupported on some backends) and avoids reading the whole MANIFEST into
+  // memory (which can reach ~1GB depending on configuration).
+  const std::string tmp_path = manifest_path + ".tmp";
+
+  // Best-effort cleanup of any stale .tmp left by a prior aborted run.
+  fs_->DeleteFile(tmp_path, IOOptions(), /*dbg=*/nullptr)
+      .PermitUncheckedError();
+
+  std::unique_ptr<FSSequentialFile> src_file;
+  {
+    IOStatus io_s = fs_->NewSequentialFile(manifest_path, FileOptions(),
+                                           &src_file, /*dbg=*/nullptr);
+    if (!io_s.ok()) {
+      return io_s;
+    }
+  }
+
+  FileOptions opt_file_opts = GetFileOptionsForManifestWrite();
+  // Buffered writes only: direct writes would need alignment / tail-pad
+  // reasoning that isn't worth the complexity for a checkpoint MANIFEST.
+  opt_file_opts.use_direct_writes = false;
+
+  std::unique_ptr<FSWritableFile> dst_file;
+  {
+    IOStatus io_s = fs_->NewWritableFile(tmp_path, opt_file_opts, &dst_file,
+                                         /*dbg=*/nullptr);
+    if (!io_s.ok()) {
+      return io_s;
+    }
+  }
+
+  // Copy exactly manifest_size bytes through a fixed-size buffer.
+  constexpr size_t kBufSize = 1 * 1024 * 1024;
+  std::string buffer(kBufSize, '\0');
+  uint64_t remaining = manifest_size;
+  while (remaining > 0) {
+    Slice result;
+    const size_t to_read =
+        static_cast<size_t>(std::min<uint64_t>(kBufSize, remaining));
+    IOStatus read_s = src_file->Read(to_read, opt_file_opts.io_options, &result,
+                                     buffer.data(), /*dbg=*/nullptr);
+    if (!read_s.ok()) {
+      return read_s;
+    }
+    if (result.empty()) {
+      return Status::Corruption(
+          "Unexpected EOF reading source checkpoint MANIFEST");
+    }
+    IOStatus write_s = dst_file->Append(result, opt_file_opts.io_options,
+                                        /*dbg=*/nullptr);
+    if (!write_s.ok()) {
+      return write_s;
+    }
+    remaining -= result.size();
+  }
+  src_file.reset();
+
+  // Seeds initial_block_offset = manifest_size % kBlockSize so drop-record
+  // framing continues from where the copied contents left off, matching the
+  // position-based log reader.
+  std::unique_ptr<log::Writer> writer =
+      CreateManifestWriter(std::move(dst_file), tmp_path, opt_file_opts,
+                           manifest_preallocation_size, manifest_size);
+
+  // Always attempt to Close the writer on any exit path, folding any Close
+  // error into the primary status. Guards against dropping the underlying
+  // FSWritableFile with buffered data / no filesystem close hook.
+  Status s;
+  auto close_writer = [&]() {
+    if (writer == nullptr) {
+      return;
+    }
+    Status close_s = writer->Close(write_options);
+    if (s.ok() && !close_s.ok()) {
+      s = close_s;
+    }
+    writer.reset();
+  };
+
+  for (uint32_t cf_id : cf_ids) {
+    VersionEdit edit;
+    edit.SetColumnFamily(cf_id);
+    edit.DropColumnFamily();
+    std::string record;
+    if (!edit.EncodeTo(&record)) {
+      s = Status::Corruption(
+          "Unable to encode column family drop VersionEdit for checkpoint");
+      close_writer();
+      return s;
+    }
+    IOStatus add_s = writer->AddRecord(write_options, record);
+    if (!add_s.ok()) {
+      s = add_s;
+      close_writer();
+      return s;
+    }
+  }
+
+  IOStatus sync_s = SyncManifest(db_options_, write_options, writer->file());
+  if (!sync_s.ok()) {
+    s = sync_s;
+    close_writer();
+    return s;
+  }
+  close_writer();
+  if (!s.ok()) {
+    return s;
+  }
+
+  // Replace the original with the rewritten .tmp.
+  IOStatus rename_s =
+      fs_->RenameFile(tmp_path, manifest_path, IOOptions(), /*dbg=*/nullptr);
+  if (!rename_s.ok()) {
+    return rename_s;
+  }
+  return Status::OK();
+}
+
 Status VersionSet::Recover(
     const std::vector<ColumnFamilyDescriptor>& column_families, bool read_only,
     std::string* db_id, bool no_error_if_files_missing, bool is_retry,

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -1684,6 +1684,16 @@ class VersionSet {
     return manifest_preallocation_size_;
   }
 
+  // Appends a kColumnFamilyDrop record for each id in cf_ids to the MANIFEST
+  // file at manifest_path, whose valid content length is manifest_size bytes.
+  // Intended for post-processing a checkpoint's copied MANIFEST so that column
+  // families whose SST/blob files were not copied are recorded as dropped and
+  // thus not opened during recovery.
+  Status AppendColumnFamilyDropsToManifest(
+      const std::string& manifest_path, uint64_t manifest_size,
+      const std::vector<uint32_t>& cf_ids, const WriteOptions& write_options,
+      uint64_t manifest_preallocation_size);
+
  protected:
   struct ManifestWriter;
 

--- a/include/rocksdb/utilities/checkpoint.h
+++ b/include/rocksdb/utilities/checkpoint.h
@@ -153,6 +153,24 @@ class Checkpoint {
                                   uint64_t log_size_for_flush = 0,
                                   uint64_t* sequence_number_ptr = nullptr);
 
+  // Like CreateCheckpoint above, but the resulting checkpoint contains only the
+  // given column families (plus the default column family, which is always
+  // included). SST and blob files of the other column families are not
+  // hard-linked or copied, and the checkpoint's MANIFEST records those other
+  // column families as dropped, so the checkpoint still opens cleanly under the
+  // default paranoid_checks.
+  // - column_families must be handles from this DB (non-null). Duplicate
+  //   handles (by id) are coalesced. An empty vector is equivalent to the
+  //   overload above (all column families are included).
+  // - The default column family is always included, whether or not it appears
+  //   in column_families (it cannot be dropped).
+  // - The resulting checkpoint must be opened listing exactly these column
+  //   families (plus default); the excluded ones no longer exist in it.
+  virtual Status CreateCheckpoint(
+      const std::string& checkpoint_dir,
+      const std::vector<ColumnFamilyHandle*>& column_families,
+      uint64_t log_size_for_flush = 0, uint64_t* sequence_number_ptr = nullptr);
+
   // Exports all live SST files of a specified Column Family onto export_dir,
   // returning SST files information in metadata.
   // - SST files will be created as hard links when the directory specified

--- a/utilities/checkpoint/checkpoint_impl.cc
+++ b/utilities/checkpoint/checkpoint_impl.cc
@@ -18,6 +18,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "db/db_impl/db_impl.h"
 #include "db/wal_manager.h"
 #include "file/file_util.h"
 #include "file/filename.h"
@@ -274,6 +275,13 @@ Status Checkpoint::CreateCheckpoint(const std::string& /*checkpoint_dir*/,
   return Status::NotSupported("");
 }
 
+Status Checkpoint::CreateCheckpoint(
+    const std::string& /*checkpoint_dir*/,
+    const std::vector<ColumnFamilyHandle*>& /*column_families*/,
+    uint64_t /*log_size_for_flush*/, uint64_t* /*sequence_number_ptr*/) {
+  return Status::NotSupported("");
+}
+
 Status CheckpointImpl::CleanStagingDirectory(
     const std::string& full_private_path, Logger* info_log) {
   std::vector<std::string> subchildren;
@@ -326,11 +334,54 @@ Status CheckpointImpl::CreateCheckpoint(const std::string& checkpoint_dir,
                               /*use_link=*/true, /*copy_rate_limiter=*/nullptr);
 }
 
-Status CheckpointImpl::CreateCheckpointImpl(const std::string& checkpoint_dir,
-                                            uint64_t log_size_for_flush,
-                                            uint64_t* sequence_number_ptr,
-                                            CopyEngine* engine, bool use_link,
-                                            RateLimiter* copy_rate_limiter) {
+Status CheckpointImpl::CreateCheckpoint(
+    const std::string& checkpoint_dir,
+    const std::vector<ColumnFamilyHandle*>& column_families,
+    uint64_t log_size_for_flush, uint64_t* sequence_number_ptr) {
+  // Empty list means "all column families" -- identical to the whole-DB API.
+  if (column_families.empty()) {
+    return CreateCheckpointImpl(checkpoint_dir, log_size_for_flush,
+                                sequence_number_ptr, /*engine=*/nullptr,
+                                /*use_link=*/true,
+                                /*copy_rate_limiter=*/nullptr);
+  }
+
+  // Reject handles that do not belong to this DB. handle->GetID() alone would
+  // silently coerce a foreign CF id into whatever CF in this DB happens to
+  // share that id, producing a wrong-data subset checkpoint.
+  DBImpl* this_db_impl = static_cast_with_check<DBImpl>(db_->GetRootDB());
+  std::unordered_set<uint32_t> id_set;
+  for (auto* handle : column_families) {
+    if (handle == nullptr) {
+      return Status::InvalidArgument("Null column family handle");
+    }
+    auto* cfh = static_cast_with_check<ColumnFamilyHandleImpl>(handle);
+    if (cfh->db() != this_db_impl) {
+      return Status::InvalidArgument(
+          "Column family handle does not belong to this DB");
+    }
+    if (cfh->cfd() != nullptr && cfh->cfd()->IsDropped()) {
+      return Status::InvalidArgument(
+          "Column family handle refers to a dropped column family");
+    }
+    id_set.insert(handle->GetID());
+  }
+  // The default column family cannot be dropped and must exist in every
+  // openable DB, so it is always included and never eligible for exclusion.
+  id_set.insert(db_->DefaultColumnFamily()->GetID());
+
+  std::vector<uint32_t> include_cf_ids(id_set.begin(), id_set.end());
+  return CreateCheckpointImpl(checkpoint_dir, log_size_for_flush,
+                              sequence_number_ptr, /*engine=*/nullptr,
+                              /*use_link=*/true, /*copy_rate_limiter=*/nullptr,
+                              include_cf_ids);
+}
+
+Status CheckpointImpl::CreateCheckpointImpl(
+    const std::string& checkpoint_dir, uint64_t log_size_for_flush,
+    uint64_t* sequence_number_ptr, CopyEngine* engine, bool use_link,
+    RateLimiter* copy_rate_limiter,
+    const std::vector<uint32_t>& include_cf_ids) {
   DBOptions db_options = db_->GetDBOptions();
   Env* env = db_->GetEnv();
   const auto& fs = db_->GetFileSystem();
@@ -387,6 +438,11 @@ Status CheckpointImpl::CreateCheckpointImpl(const std::string& checkpoint_dir,
   // create snapshot directory
   s = env->CreateDir(full_private_path);
   uint64_t sequence_number = 0;
+  // Populated by CreateCustomCheckpoint when include_cf_ids restricts the
+  // checkpoint to a subset of column families.
+  std::vector<uint32_t> excluded_cf_ids;
+  std::string manifest_relative_filename;
+  uint64_t manifest_size = 0;
   if (s.ok()) {
     // enable file deletions
     s = db_->DisableFileDeletions();
@@ -413,7 +469,10 @@ Status CheckpointImpl::CreateCheckpointImpl(const std::string& checkpoint_dir,
             return CreateFile(fs, full_private_path + "/" + fname, contents,
                               db_options.use_fsync);
           } /* create_file_cb */,
-          &sequence_number, log_size_for_flush);
+          &sequence_number, log_size_for_flush,
+          /*get_live_table_checksum=*/false, /*atomic_flush=*/false,
+          include_cf_ids, &excluded_cf_ids, &manifest_relative_filename,
+          &manifest_size);
 
       // Await any deferred work and fold in the first error before committing.
       Status finish_s = mover->Finish();
@@ -421,6 +480,22 @@ Status CheckpointImpl::CreateCheckpointImpl(const std::string& checkpoint_dir,
         s = finish_s;
       } else {
         finish_s.PermitUncheckedError();
+      }
+
+      // All files (including the copied MANIFEST) are now materialized in the
+      // staging dir. If a subset of column families was requested, record the
+      // excluded CFs as dropped in the copied MANIFEST so it is consistent with
+      // the reduced set of SST/blob files and opens under paranoid_checks.
+      if (s.ok() && !excluded_cf_ids.empty()) {
+        if (manifest_relative_filename.empty()) {
+          s = Status::Corruption(
+              "Subset checkpoint did not record a MANIFEST descriptor entry");
+        } else {
+          DBImpl* db_impl = static_cast_with_check<DBImpl>(db_->GetRootDB());
+          s = db_impl->AppendColumnFamilyDropsToManifest(
+              full_private_path + "/" + manifest_relative_filename,
+              manifest_size, excluded_cf_ids);
+        }
       }
 
       // we copied all the files, enable file deletions
@@ -492,7 +567,10 @@ Status CheckpointImpl::CreateCustomCheckpoint(
                          FileType type)>
         create_file_cb,
     uint64_t* sequence_number, uint64_t log_size_for_flush,
-    bool get_live_table_checksum, bool atomic_flush) {
+    bool get_live_table_checksum, bool atomic_flush,
+    const std::vector<uint32_t>& include_cf_ids,
+    std::vector<uint32_t>* excluded_cf_ids,
+    std::string* manifest_relative_filename, uint64_t* manifest_size) {
   *sequence_number = db_->GetLatestSequenceNumber();
 
   LiveFilesStorageInfoOptions opts;
@@ -502,7 +580,15 @@ Status CheckpointImpl::CreateCustomCheckpoint(
 
   std::vector<LiveFileStorageInfo> infos;
   {
-    Status s = db_->GetLiveFilesStorageInfo(opts, &infos);
+    Status s;
+    if (include_cf_ids.empty()) {
+      s = db_->GetLiveFilesStorageInfo(opts, &infos);
+    } else {
+      assert(excluded_cf_ids != nullptr);
+      DBImpl* db_impl = static_cast_with_check<DBImpl>(db_->GetRootDB());
+      s = db_impl->GetLiveFilesStorageInfoForSubsetCheckpoint(
+          opts, include_cf_ids, &infos, excluded_cf_ids);
+    }
     if (!s.ok()) {
       return s;
     }
@@ -525,6 +611,17 @@ Status CheckpointImpl::CreateCustomCheckpoint(
 
   for (auto& info : infos) {
     Status s;
+    // Record the MANIFEST location/size so the caller can post-process it
+    // (append CF-drop records) after all files are materialized.
+    if (info.file_type == kDescriptorFile) {
+      if (manifest_relative_filename != nullptr) {
+        assert(manifest_relative_filename->empty());
+        *manifest_relative_filename = info.relative_filename;
+      }
+      if (manifest_size != nullptr) {
+        *manifest_size = info.size;
+      }
+    }
     if (!info.replacement_contents.empty()) {
       // Currently should only be used for CURRENT file.
       assert(info.file_type == kCurrentFile);

--- a/utilities/checkpoint/checkpoint_impl.h
+++ b/utilities/checkpoint/checkpoint_impl.h
@@ -5,7 +5,10 @@
 
 #pragma once
 
+#include <cstdint>
+#include <functional>
 #include <string>
+#include <vector>
 
 #include "file/filename.h"
 #include "rocksdb/db.h"
@@ -24,13 +27,21 @@ class CheckpointImpl : public Checkpoint {
                           uint64_t log_size_for_flush,
                           uint64_t* sequence_number_ptr) override;
 
+  Status CreateCheckpoint(
+      const std::string& checkpoint_dir,
+      const std::vector<ColumnFamilyHandle*>& column_families,
+      uint64_t log_size_for_flush, uint64_t* sequence_number_ptr) override;
+
   // Shared by the legacy Checkpoint API and CheckpointEngine. engine == nullptr
   // links/copies serially; otherwise work runs on the pool, awaited before the
-  // staging dir is committed.
+  // staging dir is committed. include_cf_ids, when non-empty, restricts the
+  // checkpoint to those column families (plus the default CF); excluded CFs are
+  // recorded as dropped in the checkpoint's MANIFEST.
   Status CreateCheckpointImpl(const std::string& checkpoint_dir,
                               uint64_t log_size_for_flush,
                               uint64_t* sequence_number_ptr, CopyEngine* engine,
-                              bool use_link, RateLimiter* copy_rate_limiter);
+                              bool use_link, RateLimiter* copy_rate_limiter,
+                              const std::vector<uint32_t>& include_cf_ids = {});
 
   Status ExportColumnFamily(ColumnFamilyHandle* handle,
                             const std::string& export_dir,
@@ -53,7 +64,11 @@ class CheckpointImpl : public Checkpoint {
                            const std::string& contents, FileType type)>
           create_file_cb,
       uint64_t* sequence_number, uint64_t log_size_for_flush,
-      bool get_live_table_checksum = false, bool atomic_flush = false);
+      bool get_live_table_checksum = false, bool atomic_flush = false,
+      const std::vector<uint32_t>& include_cf_ids = {},
+      std::vector<uint32_t>* excluded_cf_ids = nullptr,
+      std::string* manifest_relative_filename = nullptr,
+      uint64_t* manifest_size = nullptr);
 
  private:
   Status CleanStagingDirectory(const std::string& path, Logger* info_log);

--- a/utilities/checkpoint/checkpoint_test.cc
+++ b/utilities/checkpoint/checkpoint_test.cc
@@ -555,6 +555,202 @@ TEST_F(CheckpointTest, CheckpointCF) {
   snapshotDB.reset();
 }
 
+namespace {
+int CountSstFiles(Env* env, const std::string& dir) {
+  std::vector<std::string> children;
+  EXPECT_OK(env->GetChildren(dir, &children));
+  int n = 0;
+  for (const auto& c : children) {
+    uint64_t number;
+    FileType type;
+    if (ParseFileName(c, &number, &type) && type == kTableFile) {
+      ++n;
+    }
+  }
+  return n;
+}
+}  // namespace
+
+TEST_F(CheckpointTest, CheckpointSubsetOfCF) {
+  Options options = CurrentOptions();
+  CreateAndReopenWithCF({"one", "two", "three"}, options);
+
+  ASSERT_OK(Put(0, "d_key", "d_val"));
+  ASSERT_OK(Put(1, "one_key", "one_val"));
+  ASSERT_OK(Put(2, "two_key", "two_val"));
+  ASSERT_OK(Put(3, "three_key", "three_val"));
+  // Flush so each column family owns at least one SST file.
+  for (int cf = 0; cf <= 3; ++cf) {
+    ASSERT_OK(Flush(cf));
+  }
+
+  // Checkpoint only {default, two}.
+  Checkpoint* checkpoint;
+  ASSERT_OK(Checkpoint::Create(db_.get(), &checkpoint));
+  std::unique_ptr<Checkpoint> uchk(checkpoint);
+  ASSERT_OK(uchk->CreateCheckpoint(snapshot_name_, {handles_[0], handles_[2]}));
+
+  // Only default's and two's SSTs are present: 4 CFs x 1 SST -> 2 kept.
+  ASSERT_EQ(2, CountSstFiles(env_, snapshot_name_));
+
+  auto verify_all_four_cfs_intact = [&]() {
+    std::string val;
+    ASSERT_OK(db_->Get(ReadOptions(), handles_[0], "d_key", &val));
+    ASSERT_EQ("d_val", val);
+    ASSERT_OK(db_->Get(ReadOptions(), handles_[1], "one_key", &val));
+    ASSERT_EQ("one_val", val);
+    ASSERT_OK(db_->Get(ReadOptions(), handles_[2], "two_key", &val));
+    ASSERT_EQ("two_val", val);
+    ASSERT_OK(db_->Get(ReadOptions(), handles_[3], "three_key", &val));
+    ASSERT_EQ("three_val", val);
+  };
+
+  // The source DB must be untouched: all four CFs and their data are still
+  // present. Guards against accidentally dropping CFs from the live DB when
+  // post-processing the checkpoint MANIFEST.
+  verify_all_four_cfs_intact();
+
+  // Close and reopen the source DB with the full CF list to prove the live
+  // MANIFEST was not mutated by the checkpoint post-processing.
+  ReopenWithColumnFamilies({kDefaultColumnFamilyName, "one", "two", "three"},
+                           options);
+  verify_all_four_cfs_intact();
+
+  options.create_if_missing = false;
+
+  // Opening with exactly {default, two} succeeds and returns the values.
+  {
+    std::vector<ColumnFamilyDescriptor> cfds;
+    cfds.emplace_back(kDefaultColumnFamilyName, options);
+    cfds.emplace_back("two", options);
+    std::vector<ColumnFamilyHandle*> cph;
+    std::unique_ptr<DB> snapshotDB;
+    ASSERT_OK(DB::Open(options, snapshot_name_, cfds, &cph, &snapshotDB));
+    std::string result;
+    ASSERT_OK(snapshotDB->Get(ReadOptions(), cph[0], "d_key", &result));
+    ASSERT_EQ("d_val", result);
+    ASSERT_OK(snapshotDB->Get(ReadOptions(), cph[1], "two_key", &result));
+    ASSERT_EQ("two_val", result);
+    for (auto h : cph) {
+      delete h;
+    }
+    snapshotDB.reset();
+  }
+
+  // The excluded column families no longer exist in the checkpoint: opening
+  // with the full CF list fails.
+  {
+    std::vector<ColumnFamilyDescriptor> cfds;
+    for (const std::string& cf : std::vector<std::string>{
+             kDefaultColumnFamilyName, "one", "two", "three"}) {
+      cfds.emplace_back(cf, options);
+    }
+    std::vector<ColumnFamilyHandle*> cph;
+    std::unique_ptr<DB> snapshotDB;
+    Status s = DB::Open(options, snapshot_name_, cfds, &cph, &snapshotDB);
+    ASSERT_TRUE(s.IsInvalidArgument()) << s.ToString();
+    for (auto h : cph) {
+      delete h;
+    }
+  }
+}
+
+TEST_F(CheckpointTest, CheckpointSubsetEmptyListEqualsAll) {
+  Options options = CurrentOptions();
+  CreateAndReopenWithCF({"one", "two"}, options);
+  ASSERT_OK(Put(0, "d", "0"));
+  ASSERT_OK(Put(1, "a", "1"));
+  ASSERT_OK(Put(2, "b", "2"));
+  for (int cf = 0; cf <= 2; ++cf) {
+    ASSERT_OK(Flush(cf));
+  }
+
+  Checkpoint* checkpoint;
+  ASSERT_OK(Checkpoint::Create(db_.get(), &checkpoint));
+  std::unique_ptr<Checkpoint> uchk(checkpoint);
+  // Empty list is equivalent to a whole-DB checkpoint.
+  ASSERT_OK(uchk->CreateCheckpoint(snapshot_name_,
+                                   std::vector<ColumnFamilyHandle*>{}));
+
+  // All three CFs' SSTs are present.
+  ASSERT_EQ(3, CountSstFiles(env_, snapshot_name_));
+
+  options.create_if_missing = false;
+  std::vector<ColumnFamilyDescriptor> cfds;
+  for (const std::string& cf :
+       std::vector<std::string>{kDefaultColumnFamilyName, "one", "two"}) {
+    cfds.emplace_back(cf, options);
+  }
+  std::vector<ColumnFamilyHandle*> cph;
+  std::unique_ptr<DB> snapshotDB;
+  ASSERT_OK(DB::Open(options, snapshot_name_, cfds, &cph, &snapshotDB));
+  std::string result;
+  ASSERT_OK(snapshotDB->Get(ReadOptions(), cph[1], "a", &result));
+  ASSERT_EQ("1", result);
+  ASSERT_OK(snapshotDB->Get(ReadOptions(), cph[2], "b", &result));
+  ASSERT_EQ("2", result);
+  for (auto h : cph) {
+    delete h;
+  }
+  snapshotDB.reset();
+}
+
+TEST_F(CheckpointTest, CheckpointSubsetNullHandleRejected) {
+  Options options = CurrentOptions();
+  CreateAndReopenWithCF({"one"}, options);
+  ASSERT_OK(Put(1, "a", "1"));
+  Checkpoint* checkpoint;
+  ASSERT_OK(Checkpoint::Create(db_.get(), &checkpoint));
+  std::unique_ptr<Checkpoint> uchk(checkpoint);
+  ASSERT_TRUE(uchk->CreateCheckpoint(snapshot_name_, {handles_[1], nullptr})
+                  .IsInvalidArgument());
+}
+
+TEST_F(CheckpointTest, CheckpointSubsetForeignHandleRejected) {
+  Options options = CurrentOptions();
+  CreateAndReopenWithCF({"one"}, options);
+  ASSERT_OK(Put(1, "a", "1"));
+
+  // Open a second, unrelated DB with its own CF whose id will collide with
+  // "one" from this DB (both are the first non-default CF -> id 1).
+  const std::string other_dbname = test::PerThreadDBPath("other_db_for_ckpt");
+  ASSERT_OK(DestroyDB(other_dbname, options));
+  Options open_opts = options;
+  open_opts.create_if_missing = true;
+  std::unique_ptr<DB> other_db;
+  ASSERT_OK(DB::Open(open_opts, other_dbname, &other_db));
+  ColumnFamilyHandle* other_cf = nullptr;
+  ASSERT_OK(
+      other_db->CreateColumnFamily(ColumnFamilyOptions(), "one", &other_cf));
+
+  Checkpoint* checkpoint;
+  ASSERT_OK(Checkpoint::Create(db_.get(), &checkpoint));
+  std::unique_ptr<Checkpoint> uchk(checkpoint);
+  Status s = uchk->CreateCheckpoint(snapshot_name_, {other_cf});
+  ASSERT_TRUE(s.IsInvalidArgument()) << s.ToString();
+
+  ASSERT_OK(other_db->DestroyColumnFamilyHandle(other_cf));
+  other_db.reset();
+  ASSERT_OK(DestroyDB(other_dbname, options));
+}
+
+TEST_F(CheckpointTest, CheckpointSubsetDroppedHandleRejected) {
+  // A CF handle for a CF that was already dropped must not silently succeed;
+  // GetLiveFilesStorageInfoForSubsetCheckpoint would skip it, producing a
+  // checkpoint missing what the caller asked for.
+  Options options = CurrentOptions();
+  CreateAndReopenWithCF({"one"}, options);
+  ASSERT_OK(Put(1, "a", "1"));
+  ColumnFamilyHandle* dropped_handle = handles_[1];
+  ASSERT_OK(db_->DropColumnFamily(dropped_handle));
+
+  Checkpoint* checkpoint;
+  ASSERT_OK(Checkpoint::Create(db_.get(), &checkpoint));
+  std::unique_ptr<Checkpoint> uchk(checkpoint);
+  Status s = uchk->CreateCheckpoint(snapshot_name_, {dropped_handle});
+  ASSERT_TRUE(s.IsInvalidArgument()) << s.ToString();
+}
+
 TEST_F(CheckpointTest, CheckpointCFNoFlush) {
   Options options = CurrentOptions();
   CreateAndReopenWithCF({"one", "two", "three", "four", "five"}, options);


### PR DESCRIPTION
Summary:

RocksDB's Checkpoint API currently copies all column families. 
For use cases that only need a subset, this is wasteful.

This diff adds a new `CreateCheckpoint(dir, column_families, ...)` overload that:
 - Validates input handles (rejects null/foreign handles, coalesces duplicates, always includes default CF).
 - Filters GetLiveFilesStorageInfo to capture only the requested CFs' table/blob files.
 - Post-processes the copied MANIFEST by appending kColumnFamilyDrop records for excluded CFs, so the checkpoint opens without referencing missing files.
 - An empty column_families vector falls through to the existing whole-DB path.

Reviewed By: xingbowang, pdillinger

Differential Revision: D113963616


