### PR TITLE
Fix blob file path misidentification in SstFileManager during compaction (#15021)

### DIFF
--- a/db/blob/blob_file_builder.cc
+++ b/db/blob/blob_file_builder.cc
@@ -41,14 +41,14 @@ BlobFileBuilder::BlobFileBuilder(
     const std::shared_ptr<IOTracer>& io_tracer,
     BlobFileCompletionCallback* blob_callback,
     BlobFileCreationReason creation_reason,
-    std::vector<std::string>* blob_file_paths,
+    std::vector<std::string>* output_file_paths,
     std::vector<BlobFileAddition>* blob_file_additions)
     : BlobFileBuilder([versions]() { return versions->NewFileNumber(); }, fs,
                       immutable_options, mutable_cf_options, file_options,
                       write_options, db_id, db_session_id, job_id,
                       column_family_id, column_family_name, write_hint,
                       io_tracer, blob_callback, creation_reason,
-                      blob_file_paths, blob_file_additions) {}
+                      output_file_paths, blob_file_additions) {}
 
 BlobFileBuilder::BlobFileBuilder(
     std::function<uint64_t()> file_number_generator, FileSystem* fs,
@@ -60,7 +60,7 @@ BlobFileBuilder::BlobFileBuilder(
     const std::shared_ptr<IOTracer>& io_tracer,
     BlobFileCompletionCallback* blob_callback,
     BlobFileCreationReason creation_reason,
-    std::vector<std::string>* blob_file_paths,
+    std::vector<std::string>* output_file_paths,
     std::vector<BlobFileAddition>* blob_file_additions)
     : file_number_generator_(std::move(file_number_generator)),
       fs_(fs),
@@ -88,7 +88,7 @@ BlobFileBuilder::BlobFileBuilder(
       io_tracer_(io_tracer),
       blob_callback_(blob_callback),
       creation_reason_(creation_reason),
-      blob_file_paths_(blob_file_paths),
+      output_file_paths_(output_file_paths),
       blob_file_additions_(blob_file_additions),
       blob_count_(0),
       blob_bytes_(0) {
@@ -97,13 +97,20 @@ BlobFileBuilder::BlobFileBuilder(
   assert(immutable_options_);
   assert(file_options_);
   assert(write_options_);
-  assert(blob_file_paths_);
-  assert(blob_file_paths_->empty());
+  assert(output_file_paths_);
+  assert(output_file_paths_->empty());
   assert(blob_file_additions_);
   assert(blob_file_additions_->empty());
 }
 
 BlobFileBuilder::~BlobFileBuilder() = default;
+
+std::string BlobFileBuilder::GetBlobFilePath(uint64_t blob_file_number) const {
+  assert(immutable_options_);
+  assert(!immutable_options_->cf_paths.empty());
+  return BlobFileName(immutable_options_->cf_paths.front().path,
+                      blob_file_number);
+}
 
 Status BlobFileBuilder::Add(const Slice& key, const Slice& value,
                             std::string* blob_index) {
@@ -186,10 +193,7 @@ Status BlobFileBuilder::OpenBlobFileIfNeeded() {
   assert(file_number_generator_);
   const uint64_t blob_file_number = file_number_generator_();
 
-  assert(immutable_options_);
-  assert(!immutable_options_->cf_paths.empty());
-  std::string blob_file_path =
-      BlobFileName(immutable_options_->cf_paths.front().path, blob_file_number);
+  std::string blob_file_path = GetBlobFilePath(blob_file_number);
 
   if (blob_callback_) {
     blob_callback_->OnBlobFileCreationStarted(
@@ -214,11 +218,11 @@ Status BlobFileBuilder::OpenBlobFileIfNeeded() {
     }
   }
 
-  // Note: files get added to blob_file_paths_ right after the open, so they
-  // can be cleaned up upon failure. Contrast this with blob_file_additions_,
-  // which only contains successfully written files.
-  assert(blob_file_paths_);
-  blob_file_paths_->emplace_back(std::move(blob_file_path));
+  // Note: blob files get added to output_file_paths_ right after the open, so
+  // they can be cleaned up upon failure. Contrast this with
+  // blob_file_additions_, which only contains successfully written files.
+  assert(output_file_paths_);
+  output_file_paths_->emplace_back(std::move(blob_file_path));
 
   assert(file);
   file->SetIOPriority(write_options_->rate_limiter_priority);
@@ -228,7 +232,7 @@ Status BlobFileBuilder::OpenBlobFileIfNeeded() {
   FileTypeSet tmp_set = immutable_options_->checksum_handoff_file_types;
   Statistics* const statistics = immutable_options_->stats;
   std::unique_ptr<WritableFileWriter> file_writer(new WritableFileWriter(
-      std::move(file), blob_file_paths_->back(), *file_options_,
+      std::move(file), output_file_paths_->back(), *file_options_,
       immutable_options_->clock, io_tracer_, statistics,
       Histograms::BLOB_DB_BLOB_FILE_WRITE_MICROS, immutable_options_->listeners,
       immutable_options_->file_checksum_gen_factory.get(),
@@ -341,7 +345,7 @@ Status BlobFileBuilder::CloseBlobFile() {
 
   if (blob_callback_) {
     s = blob_callback_->OnBlobFileCompleted(
-        blob_file_paths_->back(), column_family_name_, job_id_,
+        GetBlobFilePath(blob_file_number), column_family_name_, job_id_,
         blob_file_number, creation_reason_, s, checksum_value, checksum_method,
         blob_count_, blob_bytes_);
   }
@@ -385,9 +389,10 @@ void BlobFileBuilder::Abandon(const Status& s) {
   if (blob_callback_) {
     // BlobFileBuilder::Abandon() is called because of error while writing to
     // Blob files. So we can ignore the below error.
+    const uint64_t blob_file_number = writer_->get_log_number();
     blob_callback_
-        ->OnBlobFileCompleted(blob_file_paths_->back(), column_family_name_,
-                              job_id_, writer_->get_log_number(),
+        ->OnBlobFileCompleted(GetBlobFilePath(blob_file_number),
+                              column_family_name_, job_id_, blob_file_number,
                               creation_reason_, s, "", "", blob_count_,
                               blob_bytes_)
         .PermitUncheckedError();

--- a/db/blob/blob_file_builder.h
+++ b/db/blob/blob_file_builder.h
@@ -48,7 +48,7 @@ class BlobFileBuilder {
                   const std::shared_ptr<IOTracer>& io_tracer,
                   BlobFileCompletionCallback* blob_callback,
                   BlobFileCreationReason creation_reason,
-                  std::vector<std::string>* blob_file_paths,
+                  std::vector<std::string>* output_file_paths,
                   std::vector<BlobFileAddition>* blob_file_additions);
 
   BlobFileBuilder(std::function<uint64_t()> file_number_generator,
@@ -63,7 +63,7 @@ class BlobFileBuilder {
                   const std::shared_ptr<IOTracer>& io_tracer,
                   BlobFileCompletionCallback* blob_callback,
                   BlobFileCreationReason creation_reason,
-                  std::vector<std::string>* blob_file_paths,
+                  std::vector<std::string>* output_file_paths,
                   std::vector<BlobFileAddition>* blob_file_additions);
 
   BlobFileBuilder(const BlobFileBuilder&) = delete;
@@ -76,6 +76,7 @@ class BlobFileBuilder {
   void Abandon(const Status& s);
 
  private:
+  std::string GetBlobFilePath(uint64_t blob_file_number) const;
   bool IsBlobFileOpen() const;
   Status OpenBlobFileIfNeeded();
   Status CompressBlobIfNeeded(Slice* blob,
@@ -108,7 +109,7 @@ class BlobFileBuilder {
   std::shared_ptr<IOTracer> io_tracer_;
   BlobFileCompletionCallback* blob_callback_;
   BlobFileCreationReason creation_reason_;
-  std::vector<std::string>* blob_file_paths_;
+  std::vector<std::string>* output_file_paths_;
   std::vector<BlobFileAddition>* blob_file_additions_;
   std::unique_ptr<BlobLogWriter> writer_;
   uint64_t blob_count_;

--- a/db/db_sst_test.cc
+++ b/db/db_sst_test.cc
@@ -701,6 +701,44 @@ TEST_F(DBSSTTest, DBWithSstFileManagerForBlobFilesWithGC) {
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->ClearAllCallBacks();
 }
 
+TEST_F(DBSSTTest, SstFileManagerTracksMultipleCompactionBlobOutputs) {
+  constexpr uint64_t kBlobFileSize = 1024;
+  constexpr size_t kValueSize = 600;
+
+  std::shared_ptr<SstFileManager> sst_file_manager(NewSstFileManager(env_));
+  auto* sfm = static_cast<SstFileManagerImpl*>(sst_file_manager.get());
+
+  Options options = CurrentOptions();
+  options.sst_file_manager = sst_file_manager;
+  options.enable_blob_files = true;
+  options.min_blob_size = 0;
+  options.blob_file_size = kBlobFileSize;
+  options.blob_compression_type = kNoCompression;
+  options.disable_auto_compactions = true;
+  options.enable_blob_garbage_collection = true;
+  options.blob_garbage_collection_age_cutoff = 1.0;
+  options.blob_garbage_collection_force_threshold = 0.0;
+  DestroyAndReopen(options);
+
+  const std::string value(kValueSize, 'a');
+  ASSERT_OK(Put("key1", value));
+  ASSERT_OK(Put("key3", value));
+  ASSERT_OK(Flush());
+  ASSERT_OK(Put("key2", value));
+  ASSERT_OK(Put("key4", value));
+  ASSERT_OK(Flush());
+
+  ASSERT_OK(db_->CompactRange(CompactRangeOptions(), nullptr, nullptr));
+  ASSERT_OK(dbfull()->TEST_WaitForCompact());
+  sfm->WaitForEmptyTrash();
+  ASSERT_EQ(2U, GetBlobFileNumbers().size());
+
+  std::unordered_map<std::string, uint64_t> files_in_db;
+  ASSERT_OK(GetAllDataFiles(kTableFile, &files_in_db));
+  ASSERT_OK(GetAllDataFiles(kBlobFile, &files_in_db));
+  ASSERT_EQ(files_in_db, sfm->GetTrackedFiles());
+}
+
 class DBSSTTestRateLimit : public DBSSTTest,
                            public ::testing::WithParamInterface<bool> {
  public:

--- a/unreleased_history/bug_fixes/blob_compaction_wrong_output_path.md
+++ b/unreleased_history/bug_fixes/blob_compaction_wrong_output_path.md
@@ -1,0 +1,1 @@
+Fixed a bug where `BlobFileBuilder` passed an SST path to `OnBlobFileCompleted()` instead of the completed blob path during BlobDB garbage-collection compactions, causing incorrect `SstFileManager` accounting and compaction failures on filesystems where the SST was not yet pathname-visible.


### PR DESCRIPTION
Summary:

The warm storage crash failure in T282626155 exposed a RocksDB bookkeeping bug, not a transient WS error. The regression was introduced by D91480994 / upstream RocksDB PR https://github.com/facebook/rocksdb/pull/14227 (“Support abort background compaction jobs”). That change routed `BlobFileBuilder` output tracking through `CompactionOutputs::output_file_paths_`, which contains both blob and SST paths, while blob completion still assumed `.back()` identified the current blob.

Failure timeline:

1. Compaction job 225 opens `000455.blob`, producing `[000455.blob]`.
2. It opens `000456.sst`, producing `[000455.blob, 000456.sst]`.
3. Blob 455 finishes, but `OnBlobFileCompleted()` receives `.back()`, which is `000456.sst`.
4. `SstFileManager` stats the still-open SST. WS correctly returns non-retryable `NOT_FOUND` because the output is not pathname-visible until close.
5. Compaction fails before installing its outputs in the MANIFEST. Cleanup then deletes `000455.blob` and `000456.sst`; those deletions are consequences of the failure, not its cause.

This change derives callback paths from the blob file number instead of the shared cleanup vector, renames the vector accordingly, and adds a deterministic regression test verifying that `SstFileManager` tracks every blob created during compaction.

Reviewed By: pdillinger

Differential Revision: D114002145


