### PR TITLE
Treat CI timeout as failure

### DIFF
--- a/.github/actions/build-folly/action.yml
+++ b/.github/actions/build-folly/action.yml
@@ -4,6 +4,10 @@ inputs:
   cache-hit:
     description: Whether the folly cache was hit
     required: true
+  timeout-seconds:
+    description: Maximum time for the folly build command
+    required: false
+    default: '21600'
 runs:
   using: composite
   steps:
@@ -18,7 +22,8 @@ runs:
         fi
       done
       export PATH="$(IFS=:; echo "${clean_path[*]}")"
-      make build_folly
+      CI_COMMAND_TIMEOUT_SECONDS=${{ inputs.timeout-seconds }} \
+        .github/scripts/run-with-timeout.sh make build_folly
     shell: bash
   - name: Skip folly build (using cached version)
     if: ${{ inputs.cache-hit == 'true' }}

--- a/.github/actions/build-folly/action.yml
+++ b/.github/actions/build-folly/action.yml
@@ -7,7 +7,7 @@ inputs:
   timeout-seconds:
     description: Maximum time for the folly build command
     required: false
-    default: '21600'
+    default: '3600'
 runs:
   using: composite
   steps:

--- a/.github/actions/install-gflags-on-macos/action.yml
+++ b/.github/actions/install-gflags-on-macos/action.yml
@@ -2,6 +2,6 @@ name: install-gflags-on-macos
 runs:
   using: composite
   steps:
-  - name: Install gflags on macos
-    run: HOMEBREW_NO_AUTO_UPDATE=1 brew install gflags
+  - name: Install CI dependencies on macos
+    run: HOMEBREW_NO_AUTO_UPDATE=1 brew install coreutils gflags
     shell: bash

--- a/.github/actions/windows-build-steps/action.yml
+++ b/.github/actions/windows-build-steps/action.yml
@@ -8,6 +8,10 @@ inputs:
     description: Whether to run Java tests
     required: false
     default: "true"
+  timeout-seconds:
+    description: Maximum time for the Windows build and test commands
+    required: false
+    default: '21600'
 runs:
   using: composite
   steps:
@@ -76,63 +80,12 @@ runs:
       SNAPPY_HOME: ${{ github.workspace }}/thirdparty/snappy-1.2.2
       SNAPPY_INCLUDE: ${{ github.workspace }}/thirdparty/snappy-1.2.2;${{ github.workspace }}/thirdparty/snappy-1.2.2/build
       SNAPPY_LIB_DEBUG: ${{ github.workspace }}/thirdparty/snappy-1.2.2/build/Debug/snappy.lib
+      ROCKSDB_CI_SUITE_RUN: ${{ inputs.suite-run }}
+      ROCKSDB_CI_RUN_JAVA: ${{ inputs.run-java }}
     run: |-
-      # NOTE: if ... Exit $LASTEXITCODE lines needed to exit and report failure
-      echo ===================== Install Dependencies =====================
-      if (!$env:JAVA_HOME -or !(Test-Path (Join-Path $env:JAVA_HOME "bin\javac.exe"))) {
-        $javac = Get-Command javac -ErrorAction SilentlyContinue
-        if (!$javac) {
-          Write-Error "javac was not found on PATH and JAVA_HOME is not set."
-          Exit 1
-        }
-        $env:JAVA_HOME = Split-Path (Split-Path $javac.Source -Parent) -Parent
-      }
-      echo "JAVA_HOME=$env:JAVA_HOME"
-      & "$env:JAVA_HOME\bin\java.exe" -version
-      & "$env:JAVA_HOME\bin\javac.exe" -version
-      mkdir $Env:THIRDPARTY_HOME
-      cd $Env:THIRDPARTY_HOME
-      echo "Building Snappy dependency..."
-      curl -Lo snappy-1.2.2.zip https://github.com/google/snappy/archive/refs/tags/1.2.2.zip
-      if(!$?) { Exit $LASTEXITCODE }
-      unzip -q snappy-1.2.2.zip
-      if(!$?) { Exit $LASTEXITCODE }
-      cd snappy-1.2.2
-      mkdir build
-      cd build
-      & cmake -G "$Env:CMAKE_GENERATOR" .. -DSNAPPY_BUILD_TESTS=OFF -DSNAPPY_BUILD_BENCHMARKS=OFF
-      if(!$?) { Exit $LASTEXITCODE }
-      cmake --build . --config Debug --parallel 32 -- /p:Platform=x64
-      if(!$?) { Exit $LASTEXITCODE }
-      echo ======================== Build RocksDB =========================
-      cd ${{ github.workspace }}
-      $env:Path = "$env:JAVA_HOME\bin;" + $env:Path
-      mkdir build
-      cd build
-      & cmake -G "$Env:CMAKE_GENERATOR" -DCMAKE_BUILD_TYPE=Debug -DWIN_CI=1 -DPORTABLE="$Env:CMAKE_PORTABLE" -DSNAPPY=1 -DXPRESS=1 -DJNI=1 ..
-      if(!$?) { Exit $LASTEXITCODE }
-      cd ..
-      echo "Building with VS version: $Env:CMAKE_GENERATOR"
-      # use more parallel processes than the number of processes available, as most of the compile command would be cache hit
-      cmake --build build --config Debug --parallel 32 -- /p:LinkIncremental=false /p:Platform=x64
-      if(!$?) { Exit $LASTEXITCODE }
-      echo ========================= Test RocksDB =========================
-      $suiteRun = "${{ inputs.suite-run }}"
-      if ($suiteRun -ne "") {
-        $suiteArray = $suiteRun -split ','
-        build_tools\run_ci_db_test.ps1 -SuiteRun $suiteArray -Concurrency 16
-        if(!$?) { Exit $LASTEXITCODE }
-      } else {
-        echo "Skipping C++ tests (suite-run is empty)"
-      }
-      if ("${{ inputs.run-java }}" -eq "true") {
-        echo ======================== Test RocksJava ========================
-        cd build\java
-        & ctest -C Debug -j 16
-        if(!$?) { Exit $LASTEXITCODE }
-      } else {
-        echo "Skipping Java tests"
-      }
+      .github\scripts\run-powershell-with-timeout.ps1 `
+        -TimeoutSeconds ${{ inputs.timeout-seconds }} `
+        -ScriptPath .github\scripts\windows-build.ps1
     shell: pwsh
   - name: Show ccache stats
     shell: pwsh

--- a/.github/scripts/run-powershell-with-timeout.ps1
+++ b/.github/scripts/run-powershell-with-timeout.ps1
@@ -1,0 +1,38 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# This source code is licensed under both the GPLv2 (found in the
+# COPYING file in the root directory) and Apache 2.0 License
+# (found in the LICENSE.Apache file in the root directory).
+
+param(
+  [Parameter(Mandatory = $true)]
+  [ValidateRange(1, 2147483)]
+  [int]$TimeoutSeconds,
+
+  [Parameter(Mandatory = $true)]
+  [string]$ScriptPath
+)
+
+$ErrorActionPreference = "Stop"
+
+$startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+$startInfo.FileName = (Get-Command pwsh -ErrorAction Stop).Source
+$startInfo.UseShellExecute = $false
+$startInfo.ArgumentList.Add("-NoProfile")
+$startInfo.ArgumentList.Add("-File")
+$startInfo.ArgumentList.Add((Resolve-Path $ScriptPath).Path)
+
+$process = [System.Diagnostics.Process]::new()
+$process.StartInfo = $startInfo
+if (!$process.Start()) {
+  Write-Error "Failed to start $ScriptPath"
+  Exit 1
+}
+
+if (!$process.WaitForExit($TimeoutSeconds * 1000)) {
+  taskkill /PID $($process.Id) /T /F | Out-Host
+  $process.WaitForExit()
+  Write-Output "::error::Command timed out after $TimeoutSeconds seconds."
+  Exit 1
+}
+
+Exit $process.ExitCode

--- a/.github/scripts/run-with-timeout.sh
+++ b/.github/scripts/run-with-timeout.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# This source code is licensed under both the GPLv2 (found in the
+# COPYING file in the root directory) and Apache 2.0 License
+# (found in the LICENSE.Apache file in the root directory).
+
+set -euo pipefail
+
+timeout_seconds="${CI_COMMAND_TIMEOUT_SECONDS:-6900}"
+if [[ ! "$timeout_seconds" =~ ^[1-9][0-9]*$ ]]; then
+  echo "::error::CI_COMMAND_TIMEOUT_SECONDS must be a positive integer."
+  exit 1
+fi
+
+if [[ "$#" -eq 0 ]]; then
+  echo "::error::No command was provided."
+  exit 1
+fi
+
+if command -v timeout >/dev/null 2>&1; then
+  timeout_binary=timeout
+elif command -v gtimeout >/dev/null 2>&1; then
+  timeout_binary=gtimeout
+else
+  echo "::error::GNU timeout is required."
+  exit 1
+fi
+
+set +e
+"$timeout_binary" -s TERM -k 30s "${timeout_seconds}s" "$@"
+exit_code=$?
+set -e
+
+if [[ "$exit_code" -eq 124 || "$exit_code" -eq 137 ||
+      "$exit_code" -eq 143 ]]; then
+  echo "::error::Command timed out after ${timeout_seconds} seconds."
+  exit 1
+fi
+
+exit "$exit_code"

--- a/.github/scripts/windows-build.ps1
+++ b/.github/scripts/windows-build.ps1
@@ -1,0 +1,62 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# This source code is licensed under both the GPLv2 (found in the
+# COPYING file in the root directory) and Apache 2.0 License
+# (found in the LICENSE.Apache file in the root directory).
+
+# NOTE: if ... Exit $LASTEXITCODE lines are needed to report failures from
+# native commands.
+echo ===================== Install Dependencies =====================
+if (!$env:JAVA_HOME -or !(Test-Path (Join-Path $env:JAVA_HOME "bin\javac.exe"))) {
+  $javac = Get-Command javac -ErrorAction SilentlyContinue
+  if (!$javac) {
+    Write-Error "javac was not found on PATH and JAVA_HOME is not set."
+    Exit 1
+  }
+  $env:JAVA_HOME = Split-Path (Split-Path $javac.Source -Parent) -Parent
+}
+echo "JAVA_HOME=$env:JAVA_HOME"
+& "$env:JAVA_HOME\bin\java.exe" -version
+& "$env:JAVA_HOME\bin\javac.exe" -version
+mkdir $env:THIRDPARTY_HOME
+cd $env:THIRDPARTY_HOME
+echo "Building Snappy dependency..."
+curl -Lo snappy-1.2.2.zip https://github.com/google/snappy/archive/refs/tags/1.2.2.zip
+if (!$?) { Exit $LASTEXITCODE }
+unzip -q snappy-1.2.2.zip
+if (!$?) { Exit $LASTEXITCODE }
+cd snappy-1.2.2
+mkdir build
+cd build
+& cmake -G "$env:CMAKE_GENERATOR" .. -DSNAPPY_BUILD_TESTS=OFF -DSNAPPY_BUILD_BENCHMARKS=OFF
+if (!$?) { Exit $LASTEXITCODE }
+cmake --build . --config Debug --parallel 32 -- /p:Platform=x64
+if (!$?) { Exit $LASTEXITCODE }
+echo ======================== Build RocksDB =========================
+cd $env:GITHUB_WORKSPACE
+$env:Path = "$env:JAVA_HOME\bin;" + $env:Path
+mkdir build
+cd build
+& cmake -G "$env:CMAKE_GENERATOR" -DCMAKE_BUILD_TYPE=Debug -DWIN_CI=1 -DPORTABLE="$env:CMAKE_PORTABLE" -DSNAPPY=1 -DXPRESS=1 -DJNI=1 ..
+if (!$?) { Exit $LASTEXITCODE }
+cd ..
+echo "Building with VS version: $env:CMAKE_GENERATOR"
+# Use more parallel processes than available processors because most compile
+# commands are expected to be cache hits.
+cmake --build build --config Debug --parallel 32 -- /p:LinkIncremental=false /p:Platform=x64
+if (!$?) { Exit $LASTEXITCODE }
+echo ========================= Test RocksDB =========================
+if ($env:ROCKSDB_CI_SUITE_RUN -ne "") {
+  $suiteArray = $env:ROCKSDB_CI_SUITE_RUN -split ','
+  build_tools\run_ci_db_test.ps1 -SuiteRun $suiteArray -Concurrency 16
+  if (!$?) { Exit $LASTEXITCODE }
+} else {
+  echo "Skipping C++ tests (suite-run is empty)"
+}
+if ($env:ROCKSDB_CI_RUN_JAVA -eq "true") {
+  echo ======================== Test RocksJava ========================
+  cd build\java
+  & ctest -C Debug -j 16
+  if (!$?) { Exit $LASTEXITCODE }
+} else {
+  echo "Skipping Java tests"
+}

--- a/.github/workflows/pr-jobs.yml
+++ b/.github/workflows/pr-jobs.yml
@@ -2,15 +2,16 @@ name: facebook/rocksdb/pr-jobs
 on: [push, pull_request]
 permissions: {}
 env:
-  # Commands fail explicitly before the job timeout, which is retained as a
-  # final safety net for setup and cleanup steps.
-  CI_COMMAND_TIMEOUT_SECONDS: '120'
+  # Commands fail before the outer job timeout, leaving time for failure
+  # reporting and cleanup steps.
+  CI_COMMAND_TIMEOUT_SECONDS: '6900'
+  WINDOWS_CI_COMMAND_TIMEOUT_SECONDS: '10500'
   # Set to a job name to run only that job (on any repo), or leave empty for
   # normal behavior (all jobs on facebook repo only).
   ONLY_JOB: ''
 jobs:
   config:
-    timeout-minutes: 120
+    timeout-minutes: 135
     runs-on: ubuntu-latest
     outputs:
       only_job: ${{ steps.set.outputs.only_job }}
@@ -49,7 +50,7 @@ jobs:
 
   # ======================== Fast Initial Checks ====================== #
   check-format-and-targets:
-    timeout-minutes: 120
+    timeout-minutes: 135
     if: needs.config.outputs.only_job == 'check-format-and-targets' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on: ubuntu-24.04
@@ -90,7 +91,7 @@ jobs:
           tools/check_format_compatible.sh
   # ========================= Linux With Tests ======================== #
   build-linux:
-    timeout-minutes: 120
+    timeout-minutes: 135
     if: needs.config.outputs.only_job == 'build-linux' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -110,7 +111,7 @@ jobs:
       if: always()
     - uses: "./.github/actions/post-steps"
   build-linux-cmake-mingw:
-    timeout-minutes: 120
+    timeout-minutes: 135
     if: needs.config.outputs.only_job == 'build-linux-cmake-mingw' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -143,7 +144,7 @@ jobs:
       if: always()
     - uses: "./.github/actions/post-steps"
   build-linux-make-with-folly:
-    timeout-minutes: 120
+    timeout-minutes: 135
     if: needs.config.outputs.only_job == 'build-linux-make-with-folly' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -170,7 +171,7 @@ jobs:
       if: always()
     - uses: "./.github/actions/post-steps"
   build-linux-make-with-folly-lite-no-test:
-    timeout-minutes: 120
+    timeout-minutes: 135
     if: needs.config.outputs.only_job == 'build-linux-make-with-folly-lite-no-test' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -191,7 +192,7 @@ jobs:
       if: always()
     - uses: "./.github/actions/post-steps"
   build-linux-cmake-with-folly-coroutines:
-    timeout-minutes: 120
+    timeout-minutes: 135
     if: needs.config.outputs.only_job == 'build-linux-cmake-with-folly-coroutines' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -225,7 +226,7 @@ jobs:
       if: always()
     - uses: "./.github/actions/post-steps"
   build-linux-cmake-with-benchmark-no-thread-status:
-    timeout-minutes: 120
+    timeout-minutes: 135
     if: needs.config.outputs.only_job == 'build-linux-cmake-with-benchmark-no-thread-status' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -259,7 +260,7 @@ jobs:
       with:
         artifact-prefix: "${{ github.job }}-shard${{ matrix.shard }}"
   build-linux-encrypted_env-no_compression:
-    timeout-minutes: 120
+    timeout-minutes: 135
     if: needs.config.outputs.only_job == 'build-linux-encrypted_env-no_compression' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -280,7 +281,7 @@ jobs:
     - uses: "./.github/actions/post-steps"
   # ======================== Linux No Test Runs ======================= #
   build-linux-release:
-    timeout-minutes: 120
+    timeout-minutes: 135
     if: needs.config.outputs.only_job == 'build-linux-release' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -313,7 +314,7 @@ jobs:
       if: always()
     - uses: "./.github/actions/post-steps"
   build-linux-clang-13-no_test_run:
-    timeout-minutes: 120
+    timeout-minutes: 135
     if: needs.config.outputs.only_job == 'build-linux-clang-13-no_test_run' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -336,7 +337,7 @@ jobs:
       if: always()
     - uses: "./.github/actions/post-steps"
   build-linux-clang-21-no_test_run:
-    timeout-minutes: 120
+    timeout-minutes: 135
     if: needs.config.outputs.only_job == 'build-linux-clang-21-no_test_run' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -375,7 +376,7 @@ jobs:
       if: always()
     - uses: "./.github/actions/post-steps"
   build-linux-gcc-14-no_test_run:
-    timeout-minutes: 120
+    timeout-minutes: 135
     if: needs.config.outputs.only_job == 'build-linux-gcc-14-no_test_run' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -397,7 +398,7 @@ jobs:
   # ======================== Linux Other Checks ======================= #
 
   build-linux-unity-and-headers:
-    timeout-minutes: 120
+    timeout-minutes: 135
     if: needs.config.outputs.only_job == 'build-linux-unity-and-headers' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -418,7 +419,7 @@ jobs:
       if: always()
     - uses: "./.github/actions/post-steps"
   build-linux-mini-crashtest:
-    timeout-minutes: 120
+    timeout-minutes: 135
     if: needs.config.outputs.only_job == 'build-linux-mini-crashtest' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -453,7 +454,7 @@ jobs:
         artifact-prefix: "${{ github.job }}-${{ matrix.crash_test_target }}"
   # ======================= Linux with Sanitizers ===================== #
   build-linux-clang21-asan-ubsan:
-    timeout-minutes: 120
+    timeout-minutes: 135
     if: needs.config.outputs.only_job == 'build-linux-clang21-asan-ubsan' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -481,7 +482,7 @@ jobs:
       with:
         artifact-prefix: "${{ github.job }}-shard${{ matrix.shard }}"
   build-linux-clang21-mini-tsan:
-    timeout-minutes: 120
+    timeout-minutes: 135
     if: needs.config.outputs.only_job == 'build-linux-clang21-mini-tsan' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -509,7 +510,7 @@ jobs:
       with:
         artifact-prefix: "${{ github.job }}-shard${{ matrix.shard }}"
   build-linux-static_lib-alt_namespace-status_checked:
-    timeout-minutes: 120
+    timeout-minutes: 135
     if: needs.config.outputs.only_job == 'build-linux-static_lib-alt_namespace-status_checked' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -529,7 +530,7 @@ jobs:
     - uses: "./.github/actions/post-steps"
   # ========================= MacOS build only ======================== #
   build-macos:
-    timeout-minutes: 120
+    timeout-minutes: 135
     if: needs.config.outputs.only_job == 'build-macos' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on: macos-15-xlarge
@@ -553,7 +554,7 @@ jobs:
     - uses: "./.github/actions/post-steps"
   # ========================= MacOS with Tests ======================== #
   build-macos-cmake:
-    timeout-minutes: 120
+    timeout-minutes: 135
     if: needs.config.outputs.only_job == 'build-macos-cmake' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on: macos-15-xlarge
@@ -593,7 +594,7 @@ jobs:
   # ======================== Windows with Tests ======================= #
   # NOTE: some windows jobs are in "nightly" to save resources
   build-windows-msvc:
-    timeout-minutes: 120
+    timeout-minutes: 195
     if: needs.config.outputs.only_job == 'build-windows-msvc' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on: windows-8-core
@@ -618,10 +619,10 @@ jobs:
       with:
         suite-run: ${{ matrix.suite_run }}
         run-java: ${{ matrix.run_java }}
-        timeout-seconds: ${{ env.CI_COMMAND_TIMEOUT_SECONDS }}
+        timeout-seconds: ${{ env.WINDOWS_CI_COMMAND_TIMEOUT_SECONDS }}
   # ============================ Java Jobs ============================ #
   build-linux-java:
-    timeout-minutes: 120
+    timeout-minutes: 135
     if: needs.config.outputs.only_job == 'build-linux-java' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -645,7 +646,7 @@ jobs:
     - uses: "./.github/actions/teardown-ccache"
       if: always()
   build-linux-java-static:
-    timeout-minutes: 120
+    timeout-minutes: 135
     if: needs.config.outputs.only_job == 'build-linux-java-static' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -669,7 +670,7 @@ jobs:
     - uses: "./.github/actions/teardown-ccache"
       if: always()
   build-macos-java:
-    timeout-minutes: 120
+    timeout-minutes: 135
     if: needs.config.outputs.only_job == 'build-macos-java' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on: macos-15-xlarge
@@ -698,7 +699,7 @@ jobs:
       if: always()
     - uses: "./.github/actions/post-steps"
   build-macos-java-static:
-    timeout-minutes: 120
+    timeout-minutes: 135
     if: needs.config.outputs.only_job == 'build-macos-java-static' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on: macos-15-xlarge
@@ -725,7 +726,7 @@ jobs:
       if: always()
     - uses: "./.github/actions/post-steps"
   build-macos-java-static-universal:
-    timeout-minutes: 120
+    timeout-minutes: 135
     if: needs.config.outputs.only_job == 'build-macos-java-static-universal' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on: macos-15-xlarge
@@ -752,7 +753,7 @@ jobs:
       if: always()
     - uses: "./.github/actions/post-steps"
   build-linux-java-pmd:
-    timeout-minutes: 120
+    timeout-minutes: 135
     if: needs.config.outputs.only_job == 'build-linux-java-pmd' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -780,7 +781,7 @@ jobs:
         name: maven-site
         path: "${{ github.workspace }}/java/target/site"
   build-linux-arm:
-    timeout-minutes: 120
+    timeout-minutes: 135
     if: needs.config.outputs.only_job == 'build-linux-arm' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -830,7 +831,7 @@ jobs:
     - build-linux-java-pmd
     - build-linux-arm
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 135
     steps:
     - name: Fail if a PR job did not complete successfully
       env:

--- a/.github/workflows/pr-jobs.yml
+++ b/.github/workflows/pr-jobs.yml
@@ -100,23 +100,20 @@ jobs:
     - uses: "./.github/actions/setup-ccache"
       with:
         cache-key-prefix: build-linux
-    - id: build_and_test
-      timeout-minutes: 2
-      continue-on-error: true
-      run: make V=1 J=32 -j32 check
+    - name: Build and test with timeout
+      run: |
+        set +e
+        timeout --signal=TERM --kill-after=30s 2m make V=1 J=32 -j32 check
+        exit_code=$?
+        set -e
+        if [[ "$exit_code" -eq 124 || "$exit_code" -eq 137 ]]; then
+          echo "::error::The build and test command timed out."
+          exit 1
+        fi
+        exit "$exit_code"
     - uses: "./.github/actions/teardown-ccache"
       if: always()
     - uses: "./.github/actions/post-steps"
-    - name: Convert build or test timeout to failure
-      if: always()
-      env:
-        BUILD_AND_TEST_OUTCOME: ${{ steps.build_and_test.outcome }}
-      run: |
-        echo "Build and test outcome: $BUILD_AND_TEST_OUTCOME"
-        if [[ "$BUILD_AND_TEST_OUTCOME" != "success" ]]; then
-          echo "::error::The build and test step failed or timed out."
-          exit 1
-        fi
   build-linux-cmake-mingw:
     timeout-minutes: 2
     if: needs.config.outputs.only_job == 'build-linux-cmake-mingw' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')

--- a/.github/workflows/pr-jobs.yml
+++ b/.github/workflows/pr-jobs.yml
@@ -108,10 +108,15 @@ jobs:
       if: always()
     - uses: "./.github/actions/post-steps"
     - name: Convert build or test timeout to failure
-      if: always() && steps.build_and_test.outcome == 'failure'
+      if: always()
+      env:
+        BUILD_AND_TEST_OUTCOME: ${{ steps.build_and_test.outcome }}
       run: |
-        echo "::error::The build and test step failed or timed out."
-        exit 1
+        echo "Build and test outcome: $BUILD_AND_TEST_OUTCOME"
+        if [[ "$BUILD_AND_TEST_OUTCOME" != "success" ]]; then
+          echo "::error::The build and test step failed or timed out."
+          exit 1
+        fi
   build-linux-cmake-mingw:
     timeout-minutes: 2
     if: needs.config.outputs.only_job == 'build-linux-cmake-mingw' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')

--- a/.github/workflows/pr-jobs.yml
+++ b/.github/workflows/pr-jobs.yml
@@ -165,7 +165,6 @@ jobs:
     - uses: "./.github/actions/build-folly"
       with:
         cache-hit: ${{ steps.cache-folly.outputs.cache-hit }}
-        timeout-seconds: ${{ env.CI_COMMAND_TIMEOUT_SECONDS }}
     - run: .github/scripts/run-with-timeout.sh env USE_FOLLY=1 LIB_MODE=static V=1 make -j64 check
     - uses: "./.github/actions/teardown-ccache"
       if: always()
@@ -213,7 +212,6 @@ jobs:
     - uses: "./.github/actions/build-folly"
       with:
         cache-hit: ${{ steps.cache-folly.outputs.cache-hit }}
-        timeout-seconds: ${{ env.CI_COMMAND_TIMEOUT_SECONDS }}
     - run: |-
         .github/scripts/run-with-timeout.sh bash -euo pipefail -c '
           mkdir build && cd build
@@ -799,51 +797,3 @@ jobs:
         if: always()
         shell: bash
       - uses: "./.github/actions/post-steps"
-  pr-jobs-status:
-    if: always()
-    needs:
-    - config
-    - check-format-and-targets
-    - build-linux
-    - build-linux-cmake-mingw
-    - build-linux-make-with-folly
-    - build-linux-make-with-folly-lite-no-test
-    - build-linux-cmake-with-folly-coroutines
-    - build-linux-cmake-with-benchmark-no-thread-status
-    - build-linux-encrypted_env-no_compression
-    - build-linux-release
-    - build-linux-clang-13-no_test_run
-    - build-linux-clang-21-no_test_run
-    - build-linux-gcc-14-no_test_run
-    - build-linux-unity-and-headers
-    - build-linux-mini-crashtest
-    - build-linux-clang21-asan-ubsan
-    - build-linux-clang21-mini-tsan
-    - build-linux-static_lib-alt_namespace-status_checked
-    - build-macos
-    - build-macos-cmake
-    - build-windows-msvc
-    - build-linux-java
-    - build-linux-java-static
-    - build-macos-java
-    - build-macos-java-static
-    - build-macos-java-static-universal
-    - build-linux-java-pmd
-    - build-linux-arm
-    runs-on: ubuntu-latest
-    timeout-minutes: 135
-    steps:
-    - name: Fail if a PR job did not complete successfully
-      env:
-        NEEDS_CONTEXT: ${{ toJSON(needs) }}
-      run: |
-        failed_jobs="$(jq -r '
-          to_entries[] |
-          select(.value.result == "failure" or .value.result == "cancelled") |
-          "\(.key): \(.value.result)"
-        ' <<< "$NEEDS_CONTEXT")"
-        if [[ -n "$failed_jobs" ]]; then
-          echo "::error::One or more PR jobs failed, timed out, or were cancelled."
-          echo "$failed_jobs"
-          exit 1
-        fi

--- a/.github/workflows/pr-jobs.yml
+++ b/.github/workflows/pr-jobs.yml
@@ -86,7 +86,7 @@ jobs:
         SANITY_CHECK=1 LONG_TEST=1 tools/check_format_compatible.sh
   # ========================= Linux With Tests ======================== #
   build-linux:
-    timeout-minutes: 2
+    timeout-minutes: 10
     if: needs.config.outputs.only_job == 'build-linux' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -100,10 +100,18 @@ jobs:
     - uses: "./.github/actions/setup-ccache"
       with:
         cache-key-prefix: build-linux
-    - run: make V=1 J=32 -j32 check
+    - id: build_and_test
+      timeout-minutes: 2
+      continue-on-error: true
+      run: make V=1 J=32 -j32 check
     - uses: "./.github/actions/teardown-ccache"
       if: always()
     - uses: "./.github/actions/post-steps"
+    - name: Convert build or test timeout to failure
+      if: always() && steps.build_and_test.outcome == 'failure'
+      run: |
+        echo "::error::The build and test step failed or timed out."
+        exit 1
   build-linux-cmake-mingw:
     timeout-minutes: 2
     if: needs.config.outputs.only_job == 'build-linux-cmake-mingw' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')

--- a/.github/workflows/pr-jobs.yml
+++ b/.github/workflows/pr-jobs.yml
@@ -2,12 +2,15 @@ name: facebook/rocksdb/pr-jobs
 on: [push, pull_request]
 permissions: {}
 env:
+  # Commands fail explicitly after 115 minutes. The 120-minute job timeout is
+  # retained as a final safety net for setup and cleanup steps.
+  CI_COMMAND_TIMEOUT_SECONDS: '6900'
   # Set to a job name to run only that job (on any repo), or leave empty for
   # normal behavior (all jobs on facebook repo only).
   ONLY_JOB: ''
 jobs:
   config:
-    timeout-minutes: 2
+    timeout-minutes: 120
     runs-on: ubuntu-latest
     outputs:
       only_job: ${{ steps.set.outputs.only_job }}
@@ -46,7 +49,7 @@ jobs:
 
   # ======================== Fast Initial Checks ====================== #
   check-format-and-targets:
-    timeout-minutes: 2
+    timeout-minutes: 120
     if: needs.config.outputs.only_job == 'check-format-and-targets' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on: ubuntu-24.04
@@ -69,13 +72,13 @@ jobs:
     - name: Download clang-format-diff.py
       run: wget https://rocksdb-deps.s3.us-west-2.amazonaws.com/llvm/llvm-project/release/12.x/clang/tools/clang-format/clang-format-diff.py
     - name: Check format
-      run: VERBOSE_CHECK=1 make check-format
+      run: .github/scripts/run-with-timeout.sh env VERBOSE_CHECK=1 make check-format
     - name: Compare buckify output
-      run: make check-buck-targets
+      run: .github/scripts/run-with-timeout.sh make check-buck-targets
     - name: Simple source code checks
-      run: make check-sources
+      run: .github/scripts/run-with-timeout.sh make check-sources
     - name: Validate GitHub Actions YAML
-      run: make check-workflow-yaml
+      run: .github/scripts/run-with-timeout.sh make check-workflow-yaml
     - name: Sanity check check_format_compatible.sh
       run: |-
         export TEST_TMPDIR=/dev/shm/rocksdb
@@ -83,10 +86,11 @@ jobs:
         mkdir /dev/shm/rocksdb
         git reset --hard
         git config --global --add safe.directory /__w/rocksdb/rocksdb
-        SANITY_CHECK=1 LONG_TEST=1 tools/check_format_compatible.sh
+        .github/scripts/run-with-timeout.sh env SANITY_CHECK=1 LONG_TEST=1 \
+          tools/check_format_compatible.sh
   # ========================= Linux With Tests ======================== #
   build-linux:
-    timeout-minutes: 10
+    timeout-minutes: 120
     if: needs.config.outputs.only_job == 'build-linux' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -101,21 +105,12 @@ jobs:
       with:
         cache-key-prefix: build-linux
     - name: Build and test with timeout
-      run: |
-        set +e
-        timeout --signal=TERM --kill-after=30s 2m make V=1 J=32 -j32 check
-        exit_code=$?
-        set -e
-        if [[ "$exit_code" -eq 124 || "$exit_code" -eq 137 ]]; then
-          echo "::error::The build and test command timed out."
-          exit 1
-        fi
-        exit "$exit_code"
+      run: .github/scripts/run-with-timeout.sh make V=1 J=32 -j32 check
     - uses: "./.github/actions/teardown-ccache"
       if: always()
     - uses: "./.github/actions/post-steps"
   build-linux-cmake-mingw:
-    timeout-minutes: 2
+    timeout-minutes: 120
     if: needs.config.outputs.only_job == 'build-linux-cmake-mingw' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -136,12 +131,19 @@ jobs:
         echo "JAVA_HOME=${JAVA_HOME}"
         which java && java -version
         which javac && javac -version
-        mkdir build && cd build && cmake -DJNI=1 -DWITH_GFLAGS=OFF .. -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++ -DCMAKE_SYSTEM_NAME=Windows && make -j4 rocksdb rocksdbjni
+        .github/scripts/run-with-timeout.sh bash -euo pipefail -c '
+          mkdir build && cd build
+          cmake -DJNI=1 -DWITH_GFLAGS=OFF .. \
+            -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc \
+            -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++ \
+            -DCMAKE_SYSTEM_NAME=Windows
+          make -j4 rocksdb rocksdbjni
+        '
     - uses: "./.github/actions/teardown-ccache"
       if: always()
     - uses: "./.github/actions/post-steps"
   build-linux-make-with-folly:
-    timeout-minutes: 2
+    timeout-minutes: 120
     if: needs.config.outputs.only_job == 'build-linux-make-with-folly' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -162,12 +164,13 @@ jobs:
     - uses: "./.github/actions/build-folly"
       with:
         cache-hit: ${{ steps.cache-folly.outputs.cache-hit }}
-    - run: USE_FOLLY=1 LIB_MODE=static V=1 make -j64 check
+        timeout-seconds: ${{ env.CI_COMMAND_TIMEOUT_SECONDS }}
+    - run: .github/scripts/run-with-timeout.sh env USE_FOLLY=1 LIB_MODE=static V=1 make -j64 check
     - uses: "./.github/actions/teardown-ccache"
       if: always()
     - uses: "./.github/actions/post-steps"
   build-linux-make-with-folly-lite-no-test:
-    timeout-minutes: 2
+    timeout-minutes: 120
     if: needs.config.outputs.only_job == 'build-linux-make-with-folly-lite-no-test' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -183,12 +186,12 @@ jobs:
     - uses: "./.github/actions/setup-ccache"
       with:
         cache-key-prefix: make-folly-lite
-    - run: USE_FOLLY_LITE=1 EXTRA_CXXFLAGS=-DGLOG_USE_GLOG_EXPORT V=1 make -j32 all
+    - run: .github/scripts/run-with-timeout.sh env USE_FOLLY_LITE=1 EXTRA_CXXFLAGS=-DGLOG_USE_GLOG_EXPORT V=1 make -j32 all
     - uses: "./.github/actions/teardown-ccache"
       if: always()
     - uses: "./.github/actions/post-steps"
   build-linux-cmake-with-folly-coroutines:
-    timeout-minutes: 2
+    timeout-minutes: 120
     if: needs.config.outputs.only_job == 'build-linux-cmake-with-folly-coroutines' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -209,12 +212,20 @@ jobs:
     - uses: "./.github/actions/build-folly"
       with:
         cache-hit: ${{ steps.cache-folly.outputs.cache-hit }}
-    - run: "(mkdir build && cd build && cmake -DUSE_COROUTINES=1 -DWITH_GFLAGS=1 -DROCKSDB_BUILD_SHARED=0 -DPORTABLE=ON .. && make VERBOSE=1 -j64 && ctest -j64)"
+        timeout-seconds: ${{ env.CI_COMMAND_TIMEOUT_SECONDS }}
+    - run: |-
+        .github/scripts/run-with-timeout.sh bash -euo pipefail -c '
+          mkdir build && cd build
+          cmake -DUSE_COROUTINES=1 -DWITH_GFLAGS=1 \
+            -DROCKSDB_BUILD_SHARED=0 -DPORTABLE=ON ..
+          make VERBOSE=1 -j64
+          ctest -j64
+        '
     - uses: "./.github/actions/teardown-ccache"
       if: always()
     - uses: "./.github/actions/post-steps"
   build-linux-cmake-with-benchmark-no-thread-status:
-    timeout-minutes: 2
+    timeout-minutes: 120
     if: needs.config.outputs.only_job == 'build-linux-cmake-with-benchmark-no-thread-status' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -233,16 +244,22 @@ jobs:
       with:
         cache-key-prefix: cmake-benchmark
     - name: Build
-      run: mkdir build && cd build && cmake -DWITH_GFLAGS=1 -DWITH_BENCHMARK=1 -DPORTABLE=ON -DCMAKE_CXX_FLAGS=-DNROCKSDB_THREAD_STATUS .. && make VERBOSE=1 -j20
+      run: |-
+        .github/scripts/run-with-timeout.sh bash -euo pipefail -c '
+          mkdir build && cd build
+          cmake -DWITH_GFLAGS=1 -DWITH_BENCHMARK=1 -DPORTABLE=ON \
+            -DCMAKE_CXX_FLAGS=-DNROCKSDB_THREAD_STATUS ..
+          make VERBOSE=1 -j20
+        '
     - name: Test shard ${{ matrix.shard }} of 4
-      run: cd build && ctest -j20 -I ${{ matrix.shard }},,4
+      run: .github/scripts/run-with-timeout.sh bash -c 'cd build && ctest -j20 -I ${{ matrix.shard }},,4'
     - uses: "./.github/actions/teardown-ccache"
       if: always()
     - uses: "./.github/actions/post-steps"
       with:
         artifact-prefix: "${{ github.job }}-shard${{ matrix.shard }}"
   build-linux-encrypted_env-no_compression:
-    timeout-minutes: 2
+    timeout-minutes: 120
     if: needs.config.outputs.only_job == 'build-linux-encrypted_env-no_compression' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -256,14 +273,14 @@ jobs:
     - uses: "./.github/actions/setup-ccache"
       with:
         cache-key-prefix: encrypted-env-no-compression
-    - run: ENCRYPTED_ENV=1 ROCKSDB_DISABLE_SNAPPY=1 ROCKSDB_DISABLE_ZLIB=1 ROCKSDB_DISABLE_BZIP=1 ROCKSDB_DISABLE_LZ4=1 ROCKSDB_DISABLE_ZSTD=1 make V=1 J=32 -j32 check
+    - run: .github/scripts/run-with-timeout.sh env ENCRYPTED_ENV=1 ROCKSDB_DISABLE_SNAPPY=1 ROCKSDB_DISABLE_ZLIB=1 ROCKSDB_DISABLE_BZIP=1 ROCKSDB_DISABLE_LZ4=1 ROCKSDB_DISABLE_ZSTD=1 make V=1 J=32 -j32 check
     - run: "./sst_dump --help | grep -E -q 'Supported built-in compression types: kNoCompression$' # Verify no compiled in compression\n"
     - uses: "./.github/actions/teardown-ccache"
       if: always()
     - uses: "./.github/actions/post-steps"
   # ======================== Linux No Test Runs ======================= #
   build-linux-release:
-    timeout-minutes: 2
+    timeout-minutes: 120
     if: needs.config.outputs.only_job == 'build-linux-release' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -276,27 +293,27 @@ jobs:
     - uses: "./.github/actions/setup-ccache"
       with:
         cache-key-prefix: release
-    - run: make V=1 -j32 LIB_MODE=shared release
+    - run: .github/scripts/run-with-timeout.sh make V=1 -j32 LIB_MODE=shared release
     - run: ls librocksdb.so
     - run: "./trace_analyzer --version" # A tool dependent on gflags that can run in release build
-    - run: make clean
-    - run: USE_RTTI=1 make V=1 -j32 release
+    - run: .github/scripts/run-with-timeout.sh make clean
+    - run: .github/scripts/run-with-timeout.sh env USE_RTTI=1 make V=1 -j32 release
     - run: ls librocksdb.a
     - run: "./trace_analyzer --version"
-    - run: make clean
+    - run: .github/scripts/run-with-timeout.sh make clean
     - run: apt-get remove -y libgflags-dev
-    - run: make V=1 -j32 LIB_MODE=shared release
+    - run: .github/scripts/run-with-timeout.sh make V=1 -j32 LIB_MODE=shared release
     - run: ls librocksdb.so
     - run: if ./trace_analyzer --version; then false; else true; fi
-    - run: make clean
-    - run: USE_RTTI=1 make V=1 -j32 release
+    - run: .github/scripts/run-with-timeout.sh make clean
+    - run: .github/scripts/run-with-timeout.sh env USE_RTTI=1 make V=1 -j32 release
     - run: ls librocksdb.a
     - run: if ./trace_analyzer --version; then false; else true; fi
     - uses: "./.github/actions/teardown-ccache"
       if: always()
     - uses: "./.github/actions/post-steps"
   build-linux-clang-13-no_test_run:
-    timeout-minutes: 2
+    timeout-minutes: 120
     if: needs.config.outputs.only_job == 'build-linux-clang-13-no_test_run' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -311,15 +328,15 @@ jobs:
       with:
         cache-key-prefix: clang-13
     # FIXME: get back to "all microbench" targets
-    - run: CC=clang-13 CXX=clang++-13 USE_CLANG=1 EXTRA_CXXFLAGS=-stdlib=libc++ EXTRA_LDFLAGS=-stdlib=libc++ make -j32 shared_lib
-    - run: make clean
+    - run: .github/scripts/run-with-timeout.sh env CC=clang-13 CXX=clang++-13 USE_CLANG=1 EXTRA_CXXFLAGS=-stdlib=libc++ EXTRA_LDFLAGS=-stdlib=libc++ make -j32 shared_lib
+    - run: .github/scripts/run-with-timeout.sh make clean
     # FIXME: get back to "release" target
-    - run: CC=clang-13 CXX=clang++-13 USE_CLANG=1 EXTRA_CXXFLAGS=-stdlib=libc++ EXTRA_LDFLAGS=-stdlib=libc++ DEBUG_LEVEL=0 make -j32 shared_lib
+    - run: .github/scripts/run-with-timeout.sh env CC=clang-13 CXX=clang++-13 USE_CLANG=1 EXTRA_CXXFLAGS=-stdlib=libc++ EXTRA_LDFLAGS=-stdlib=libc++ DEBUG_LEVEL=0 make -j32 shared_lib
     - uses: "./.github/actions/teardown-ccache"
       if: always()
     - uses: "./.github/actions/post-steps"
   build-linux-clang-21-no_test_run:
-    timeout-minutes: 2
+    timeout-minutes: 120
     if: needs.config.outputs.only_job == 'build-linux-clang-21-no_test_run' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -333,9 +350,9 @@ jobs:
     - uses: "./.github/actions/setup-ccache"
       with:
         cache-key-prefix: clang-21
-    - run: CC=clang-21 CXX=clang++-21 USE_CLANG=1 make -j32 all microbench
-    - run: make clean
-    - run: CC=clang-21 CXX=clang++-21 USE_CLANG=1 DEBUG_LEVEL=0 make -j32 release
+    - run: .github/scripts/run-with-timeout.sh env CC=clang-21 CXX=clang++-21 USE_CLANG=1 make -j32 all microbench
+    - run: .github/scripts/run-with-timeout.sh make clean
+    - run: .github/scripts/run-with-timeout.sh env CC=clang-21 CXX=clang++-21 USE_CLANG=1 DEBUG_LEVEL=0 make -j32 release
     - name: Install clang-format-21 for C API gen checks
       run: apt-get update && apt-get install -y clang-format-21
     - name: Check C API codegen (link-complete, backward-compatible, up to date)
@@ -349,7 +366,8 @@ jobs:
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
         git config --global --add safe.directory '*'
         git fetch --no-tags --depth=1 origin main
-        CXX=clang++-21 make check-c-api-gen \
+        .github/scripts/run-with-timeout.sh env CXX=clang++-21 \
+          make check-c-api-gen \
           CHECK_C_API_GEN_STRICT=1 \
           API_COMPAT_REF=FETCH_HEAD \
           CLANG_FORMAT_BINARY=clang-format-21
@@ -357,7 +375,7 @@ jobs:
       if: always()
     - uses: "./.github/actions/post-steps"
   build-linux-gcc-14-no_test_run:
-    timeout-minutes: 2
+    timeout-minutes: 120
     if: needs.config.outputs.only_job == 'build-linux-gcc-14-no_test_run' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -371,7 +389,7 @@ jobs:
     - uses: "./.github/actions/setup-ccache"
       with:
         cache-key-prefix: gcc-14
-    - run: CC=gcc-14 CXX=g++-14 V=1 make -j32 all microbench
+    - run: .github/scripts/run-with-timeout.sh env CC=gcc-14 CXX=g++-14 V=1 make -j32 all microbench
     - uses: "./.github/actions/teardown-ccache"
       if: always()
     - uses: "./.github/actions/post-steps"
@@ -379,7 +397,7 @@ jobs:
   # ======================== Linux Other Checks ======================= #
 
   build-linux-unity-and-headers:
-    timeout-minutes: 2
+    timeout-minutes: 120
     if: needs.config.outputs.only_job == 'build-linux-unity-and-headers' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -394,13 +412,13 @@ jobs:
       with:
         cache-key-prefix: unity-headers
     - name: Unity build
-      run: make V=1 -j8 unity_test
-    - run: make V=1 -j8 -k check-headers
+      run: .github/scripts/run-with-timeout.sh make V=1 -j8 unity_test
+    - run: .github/scripts/run-with-timeout.sh make V=1 -j8 -k check-headers
     - uses: "./.github/actions/teardown-ccache"
       if: always()
     - uses: "./.github/actions/post-steps"
   build-linux-mini-crashtest:
-    timeout-minutes: 2
+    timeout-minutes: 120
     if: needs.config.outputs.only_job == 'build-linux-mini-crashtest' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -425,7 +443,9 @@ jobs:
     - run: |
         ulimit -S -n $(ulimit -Hn) # Raise open files soft limit to hard limit
         echo "Updated ulimit -Hn: $(ulimit -Hn) -Sn: $(ulimit -Sn)"
-        make V=1 -j8 CRASH_TEST_EXT_ARGS='--duration=${{ matrix.crash_duration }} --max_key=2500000' ${{ matrix.crash_test_target }}
+        .github/scripts/run-with-timeout.sh env \
+          CRASH_TEST_EXT_ARGS='--duration=${{ matrix.crash_duration }} --max_key=2500000' \
+          make V=1 -j8 ${{ matrix.crash_test_target }}
     - uses: "./.github/actions/teardown-ccache"
       if: always()
     - uses: "./.github/actions/post-steps"
@@ -433,7 +453,7 @@ jobs:
         artifact-prefix: "${{ github.job }}-${{ matrix.crash_test_target }}"
   # ======================= Linux with Sanitizers ===================== #
   build-linux-clang21-asan-ubsan:
-    timeout-minutes: 2
+    timeout-minutes: 120
     if: needs.config.outputs.only_job == 'build-linux-clang21-asan-ubsan' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -451,7 +471,7 @@ jobs:
     - uses: "./.github/actions/setup-ccache"
       with:
         cache-key-prefix: clang21-asan-ubsan
-    - run: COMPILE_WITH_ASAN=1 COMPILE_WITH_UBSAN=1 CC=clang-21 CXX=clang++-21 ROCKSDB_DISABLE_ALIGNED_NEW=1 USE_CLANG=1 make V=1 -j40 check
+    - run: .github/scripts/run-with-timeout.sh env COMPILE_WITH_ASAN=1 COMPILE_WITH_UBSAN=1 CC=clang-21 CXX=clang++-21 ROCKSDB_DISABLE_ALIGNED_NEW=1 USE_CLANG=1 make V=1 -j40 check
       env:
         CI_SHARD_INDEX: ${{ matrix.shard }}
         CI_TOTAL_SHARDS: 3
@@ -461,7 +481,7 @@ jobs:
       with:
         artifact-prefix: "${{ github.job }}-shard${{ matrix.shard }}"
   build-linux-clang21-mini-tsan:
-    timeout-minutes: 2
+    timeout-minutes: 120
     if: needs.config.outputs.only_job == 'build-linux-clang21-mini-tsan' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -479,7 +499,7 @@ jobs:
     - uses: "./.github/actions/setup-ccache"
       with:
         cache-key-prefix: clang21-tsan
-    - run: COMPILE_WITH_TSAN=1 CC=clang-21 CXX=clang++-21 ROCKSDB_DISABLE_ALIGNED_NEW=1 USE_CLANG=1 make V=1 -j32 check
+    - run: .github/scripts/run-with-timeout.sh env COMPILE_WITH_TSAN=1 CC=clang-21 CXX=clang++-21 ROCKSDB_DISABLE_ALIGNED_NEW=1 USE_CLANG=1 make V=1 -j32 check
       env:
         CI_SHARD_INDEX: ${{ matrix.shard }}
         CI_TOTAL_SHARDS: 3
@@ -489,7 +509,7 @@ jobs:
       with:
         artifact-prefix: "${{ github.job }}-shard${{ matrix.shard }}"
   build-linux-static_lib-alt_namespace-status_checked:
-    timeout-minutes: 2
+    timeout-minutes: 120
     if: needs.config.outputs.only_job == 'build-linux-static_lib-alt_namespace-status_checked' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -503,13 +523,13 @@ jobs:
     - uses: "./.github/actions/setup-ccache"
       with:
         cache-key-prefix: static-alt-namespace
-    - run: ASSERT_STATUS_CHECKED=1 TEST_UINT128_COMPAT=1 ROCKSDB_MODIFY_NPHASH=1 LIB_MODE=static OPT="-DROCKSDB_USE_STD_SEMAPHORES -DROCKSDB_NAMESPACE=alternative_rocksdb_ns" make V=1 -j24 check
+    - run: .github/scripts/run-with-timeout.sh env ASSERT_STATUS_CHECKED=1 TEST_UINT128_COMPAT=1 ROCKSDB_MODIFY_NPHASH=1 LIB_MODE=static OPT="-DROCKSDB_USE_STD_SEMAPHORES -DROCKSDB_NAMESPACE=alternative_rocksdb_ns" make V=1 -j24 check
     - uses: "./.github/actions/teardown-ccache"
       if: always()
     - uses: "./.github/actions/post-steps"
   # ========================= MacOS build only ======================== #
   build-macos:
-    timeout-minutes: 2
+    timeout-minutes: 120
     if: needs.config.outputs.only_job == 'build-macos' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on: macos-15-xlarge
@@ -527,13 +547,13 @@ jobs:
     - uses: "./.github/actions/install-gflags-on-macos"
     - uses: "./.github/actions/pre-steps-macos"
     - name: Build
-      run: ulimit -S -n `ulimit -H -n` && make V=1 J=16 -j8 all
+      run: ulimit -S -n `ulimit -H -n` && .github/scripts/run-with-timeout.sh make V=1 J=16 -j8 all
     - uses: "./.github/actions/teardown-ccache"
       if: always()
     - uses: "./.github/actions/post-steps"
   # ========================= MacOS with Tests ======================== #
   build-macos-cmake:
-    timeout-minutes: 2
+    timeout-minutes: 120
     if: needs.config.outputs.only_job == 'build-macos-cmake' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on: macos-15-xlarge
@@ -552,20 +572,20 @@ jobs:
     - uses: "./.github/actions/install-gflags-on-macos"
     - uses: "./.github/actions/pre-steps-macos"
     - name: cmake generate project file
-      run: ulimit -S -n `ulimit -H -n` && mkdir build && cd build && cmake -DWITH_GFLAGS=1 ..
+      run: ulimit -S -n `ulimit -H -n` && .github/scripts/run-with-timeout.sh bash -c 'mkdir build && cd build && cmake -DWITH_GFLAGS=1 ..'
     - name: Build tests
-      run: cd build && make VERBOSE=1 -j8
+      run: .github/scripts/run-with-timeout.sh bash -c 'cd build && make VERBOSE=1 -j8'
     - name: Run shard 0 out of 4 test shards
-      run: ulimit -S -n `ulimit -H -n` && cd build && ctest -j8 -I 0,,4
+      run: ulimit -S -n `ulimit -H -n` && .github/scripts/run-with-timeout.sh bash -c 'cd build && ctest -j8 -I 0,,4'
       if: ${{ matrix.run_sharded_tests == 0 }}
     - name: Run shard 1 out of 4 test shards
-      run: ulimit -S -n `ulimit -H -n` && cd build && ctest -j8 -I 1,,4
+      run: ulimit -S -n `ulimit -H -n` && .github/scripts/run-with-timeout.sh bash -c 'cd build && ctest -j8 -I 1,,4'
       if: ${{ matrix.run_sharded_tests == 1 }}
     - name: Run shard 2 out of 4 test shards
-      run: ulimit -S -n `ulimit -H -n` && cd build && ctest -j8 -I 2,,4
+      run: ulimit -S -n `ulimit -H -n` && .github/scripts/run-with-timeout.sh bash -c 'cd build && ctest -j8 -I 2,,4'
       if: ${{ matrix.run_sharded_tests == 2 }}
     - name: Run shard 3 out of 4 test shards
-      run: ulimit -S -n `ulimit -H -n` && cd build && ctest -j8 -I 3,,4
+      run: ulimit -S -n `ulimit -H -n` && .github/scripts/run-with-timeout.sh bash -c 'cd build && ctest -j8 -I 3,,4'
       if: ${{ matrix.run_sharded_tests == 3 }}
     - uses: "./.github/actions/teardown-ccache"
       if: always()
@@ -573,7 +593,7 @@ jobs:
   # ======================== Windows with Tests ======================= #
   # NOTE: some windows jobs are in "nightly" to save resources
   build-windows-msvc:
-    timeout-minutes: 2
+    timeout-minutes: 120
     if: needs.config.outputs.only_job == 'build-windows-msvc' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on: windows-8-core
@@ -598,9 +618,10 @@ jobs:
       with:
         suite-run: ${{ matrix.suite_run }}
         run-java: ${{ matrix.run_java }}
+        timeout-seconds: ${{ env.CI_COMMAND_TIMEOUT_SECONDS }}
   # ============================ Java Jobs ============================ #
   build-linux-java:
-    timeout-minutes: 2
+    timeout-minutes: 120
     if: needs.config.outputs.only_job == 'build-linux-java' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -620,11 +641,11 @@ jobs:
         which java && java -version
         which javac && javac -version
     - name: Test RocksDBJava
-      run: make V=1 J=8 -j8 jtest
+      run: .github/scripts/run-with-timeout.sh make V=1 J=8 -j8 jtest
     - uses: "./.github/actions/teardown-ccache"
       if: always()
   build-linux-java-static:
-    timeout-minutes: 2
+    timeout-minutes: 120
     if: needs.config.outputs.only_job == 'build-linux-java-static' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -644,11 +665,11 @@ jobs:
         which java && java -version
         which javac && javac -version
     - name: Build RocksDBJava Static Library
-      run: make V=1 J=8 -j8 rocksdbjavastatic
+      run: .github/scripts/run-with-timeout.sh make V=1 J=8 -j8 rocksdbjavastatic
     - uses: "./.github/actions/teardown-ccache"
       if: always()
   build-macos-java:
-    timeout-minutes: 2
+    timeout-minutes: 120
     if: needs.config.outputs.only_job == 'build-macos-java' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on: macos-15-xlarge
@@ -672,12 +693,12 @@ jobs:
         which java && java -version
         which javac && javac -version
     - name: Test RocksDBJava
-      run: make V=1 J=16 -j16 jtest
+      run: .github/scripts/run-with-timeout.sh make V=1 J=16 -j16 jtest
     - uses: "./.github/actions/teardown-ccache"
       if: always()
     - uses: "./.github/actions/post-steps"
   build-macos-java-static:
-    timeout-minutes: 2
+    timeout-minutes: 120
     if: needs.config.outputs.only_job == 'build-macos-java-static' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on: macos-15-xlarge
@@ -699,12 +720,12 @@ jobs:
         which java && java -version
         which javac && javac -version
     - name: Build RocksDBJava x86 and ARM Static Libraries
-      run: make V=1 J=16 -j16 rocksdbjavastaticosx
+      run: .github/scripts/run-with-timeout.sh make V=1 J=16 -j16 rocksdbjavastaticosx
     - uses: "./.github/actions/teardown-ccache"
       if: always()
     - uses: "./.github/actions/post-steps"
   build-macos-java-static-universal:
-    timeout-minutes: 2
+    timeout-minutes: 120
     if: needs.config.outputs.only_job == 'build-macos-java-static-universal' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on: macos-15-xlarge
@@ -726,12 +747,12 @@ jobs:
         which java && java -version
         which javac && javac -version
     - name: Build RocksDBJava Universal Binary Static Library
-      run: make V=1 J=16 -j16 rocksdbjavastaticosx_ub
+      run: .github/scripts/run-with-timeout.sh make V=1 J=16 -j16 rocksdbjavastaticosx_ub
     - uses: "./.github/actions/teardown-ccache"
       if: always()
     - uses: "./.github/actions/post-steps"
   build-linux-java-pmd:
-    timeout-minutes: 2
+    timeout-minutes: 120
     if: needs.config.outputs.only_job == 'build-linux-java-pmd' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -749,7 +770,7 @@ jobs:
         which java && java -version
         which javac && javac -version
     - name: PMD RocksDBJava
-      run: make V=1 J=8 -j8 jpmd
+      run: .github/scripts/run-with-timeout.sh make V=1 J=8 -j8 jpmd
     - uses: actions/upload-artifact@v4.0.0
       with:
         name: pmd-report
@@ -759,7 +780,7 @@ jobs:
         name: maven-site
         path: "${{ github.workspace }}/java/target/site"
   build-linux-arm:
-    timeout-minutes: 2
+    timeout-minutes: 120
     if: needs.config.outputs.only_job == 'build-linux-arm' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -771,7 +792,7 @@ jobs:
       - uses: "./.github/actions/setup-ccache"
         with:
           cache-key-prefix: arm
-      - run: ROCKSDBTESTS_PLATFORM_DEPENDENT=only make V=1 J=4 -j4 all_but_some_tests check_some
+      - run: .github/scripts/run-with-timeout.sh env ROCKSDBTESTS_PLATFORM_DEPENDENT=only make V=1 J=4 -j4 all_but_some_tests check_some
       - name: Print ccache stats
         run: ccache -s
         if: always()
@@ -809,7 +830,7 @@ jobs:
     - build-linux-java-pmd
     - build-linux-arm
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: 120
     steps:
     - name: Fail if a PR job did not complete successfully
       env:

--- a/.github/workflows/pr-jobs.yml
+++ b/.github/workflows/pr-jobs.yml
@@ -2,9 +2,9 @@ name: facebook/rocksdb/pr-jobs
 on: [push, pull_request]
 permissions: {}
 env:
-  # Commands fail explicitly after 115 minutes. The 120-minute job timeout is
-  # retained as a final safety net for setup and cleanup steps.
-  CI_COMMAND_TIMEOUT_SECONDS: '6900'
+  # Commands fail explicitly before the job timeout, which is retained as a
+  # final safety net for setup and cleanup steps.
+  CI_COMMAND_TIMEOUT_SECONDS: '120'
   # Set to a job name to run only that job (on any repo), or leave empty for
   # normal behavior (all jobs on facebook repo only).
   ONLY_JOB: ''

--- a/.github/workflows/pr-jobs.yml
+++ b/.github/workflows/pr-jobs.yml
@@ -767,3 +767,51 @@ jobs:
         if: always()
         shell: bash
       - uses: "./.github/actions/post-steps"
+  pr-jobs-status:
+    if: always()
+    needs:
+    - config
+    - check-format-and-targets
+    - build-linux
+    - build-linux-cmake-mingw
+    - build-linux-make-with-folly
+    - build-linux-make-with-folly-lite-no-test
+    - build-linux-cmake-with-folly-coroutines
+    - build-linux-cmake-with-benchmark-no-thread-status
+    - build-linux-encrypted_env-no_compression
+    - build-linux-release
+    - build-linux-clang-13-no_test_run
+    - build-linux-clang-21-no_test_run
+    - build-linux-gcc-14-no_test_run
+    - build-linux-unity-and-headers
+    - build-linux-mini-crashtest
+    - build-linux-clang21-asan-ubsan
+    - build-linux-clang21-mini-tsan
+    - build-linux-static_lib-alt_namespace-status_checked
+    - build-macos
+    - build-macos-cmake
+    - build-windows-msvc
+    - build-linux-java
+    - build-linux-java-static
+    - build-macos-java
+    - build-macos-java-static
+    - build-macos-java-static-universal
+    - build-linux-java-pmd
+    - build-linux-arm
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+    - name: Fail if a PR job did not complete successfully
+      env:
+        NEEDS_CONTEXT: ${{ toJSON(needs) }}
+      run: |
+        failed_jobs="$(jq -r '
+          to_entries[] |
+          select(.value.result == "failure" or .value.result == "cancelled") |
+          "\(.key): \(.value.result)"
+        ' <<< "$NEEDS_CONTEXT")"
+        if [[ -n "$failed_jobs" ]]; then
+          echo "::error::One or more PR jobs failed, timed out, or were cancelled."
+          echo "$failed_jobs"
+          exit 1
+        fi

--- a/.github/workflows/pr-jobs.yml
+++ b/.github/workflows/pr-jobs.yml
@@ -7,6 +7,7 @@ env:
   ONLY_JOB: ''
 jobs:
   config:
+    timeout-minutes: 2
     runs-on: ubuntu-latest
     outputs:
       only_job: ${{ steps.set.outputs.only_job }}
@@ -45,6 +46,7 @@ jobs:
 
   # ======================== Fast Initial Checks ====================== #
   check-format-and-targets:
+    timeout-minutes: 2
     if: needs.config.outputs.only_job == 'check-format-and-targets' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on: ubuntu-24.04
@@ -84,6 +86,7 @@ jobs:
         SANITY_CHECK=1 LONG_TEST=1 tools/check_format_compatible.sh
   # ========================= Linux With Tests ======================== #
   build-linux:
+    timeout-minutes: 2
     if: needs.config.outputs.only_job == 'build-linux' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -102,6 +105,7 @@ jobs:
       if: always()
     - uses: "./.github/actions/post-steps"
   build-linux-cmake-mingw:
+    timeout-minutes: 2
     if: needs.config.outputs.only_job == 'build-linux-cmake-mingw' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -127,6 +131,7 @@ jobs:
       if: always()
     - uses: "./.github/actions/post-steps"
   build-linux-make-with-folly:
+    timeout-minutes: 2
     if: needs.config.outputs.only_job == 'build-linux-make-with-folly' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -152,6 +157,7 @@ jobs:
       if: always()
     - uses: "./.github/actions/post-steps"
   build-linux-make-with-folly-lite-no-test:
+    timeout-minutes: 2
     if: needs.config.outputs.only_job == 'build-linux-make-with-folly-lite-no-test' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -172,6 +178,7 @@ jobs:
       if: always()
     - uses: "./.github/actions/post-steps"
   build-linux-cmake-with-folly-coroutines:
+    timeout-minutes: 2
     if: needs.config.outputs.only_job == 'build-linux-cmake-with-folly-coroutines' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -197,6 +204,7 @@ jobs:
       if: always()
     - uses: "./.github/actions/post-steps"
   build-linux-cmake-with-benchmark-no-thread-status:
+    timeout-minutes: 2
     if: needs.config.outputs.only_job == 'build-linux-cmake-with-benchmark-no-thread-status' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -224,6 +232,7 @@ jobs:
       with:
         artifact-prefix: "${{ github.job }}-shard${{ matrix.shard }}"
   build-linux-encrypted_env-no_compression:
+    timeout-minutes: 2
     if: needs.config.outputs.only_job == 'build-linux-encrypted_env-no_compression' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -244,6 +253,7 @@ jobs:
     - uses: "./.github/actions/post-steps"
   # ======================== Linux No Test Runs ======================= #
   build-linux-release:
+    timeout-minutes: 2
     if: needs.config.outputs.only_job == 'build-linux-release' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -276,6 +286,7 @@ jobs:
       if: always()
     - uses: "./.github/actions/post-steps"
   build-linux-clang-13-no_test_run:
+    timeout-minutes: 2
     if: needs.config.outputs.only_job == 'build-linux-clang-13-no_test_run' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -298,6 +309,7 @@ jobs:
       if: always()
     - uses: "./.github/actions/post-steps"
   build-linux-clang-21-no_test_run:
+    timeout-minutes: 2
     if: needs.config.outputs.only_job == 'build-linux-clang-21-no_test_run' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -335,6 +347,7 @@ jobs:
       if: always()
     - uses: "./.github/actions/post-steps"
   build-linux-gcc-14-no_test_run:
+    timeout-minutes: 2
     if: needs.config.outputs.only_job == 'build-linux-gcc-14-no_test_run' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -356,6 +369,7 @@ jobs:
   # ======================== Linux Other Checks ======================= #
 
   build-linux-unity-and-headers:
+    timeout-minutes: 2
     if: needs.config.outputs.only_job == 'build-linux-unity-and-headers' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -376,6 +390,7 @@ jobs:
       if: always()
     - uses: "./.github/actions/post-steps"
   build-linux-mini-crashtest:
+    timeout-minutes: 2
     if: needs.config.outputs.only_job == 'build-linux-mini-crashtest' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -408,6 +423,7 @@ jobs:
         artifact-prefix: "${{ github.job }}-${{ matrix.crash_test_target }}"
   # ======================= Linux with Sanitizers ===================== #
   build-linux-clang21-asan-ubsan:
+    timeout-minutes: 2
     if: needs.config.outputs.only_job == 'build-linux-clang21-asan-ubsan' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -435,6 +451,7 @@ jobs:
       with:
         artifact-prefix: "${{ github.job }}-shard${{ matrix.shard }}"
   build-linux-clang21-mini-tsan:
+    timeout-minutes: 2
     if: needs.config.outputs.only_job == 'build-linux-clang21-mini-tsan' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -462,6 +479,7 @@ jobs:
       with:
         artifact-prefix: "${{ github.job }}-shard${{ matrix.shard }}"
   build-linux-static_lib-alt_namespace-status_checked:
+    timeout-minutes: 2
     if: needs.config.outputs.only_job == 'build-linux-static_lib-alt_namespace-status_checked' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -481,6 +499,7 @@ jobs:
     - uses: "./.github/actions/post-steps"
   # ========================= MacOS build only ======================== #
   build-macos:
+    timeout-minutes: 2
     if: needs.config.outputs.only_job == 'build-macos' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on: macos-15-xlarge
@@ -504,6 +523,7 @@ jobs:
     - uses: "./.github/actions/post-steps"
   # ========================= MacOS with Tests ======================== #
   build-macos-cmake:
+    timeout-minutes: 2
     if: needs.config.outputs.only_job == 'build-macos-cmake' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on: macos-15-xlarge
@@ -543,6 +563,7 @@ jobs:
   # ======================== Windows with Tests ======================= #
   # NOTE: some windows jobs are in "nightly" to save resources
   build-windows-msvc:
+    timeout-minutes: 2
     if: needs.config.outputs.only_job == 'build-windows-msvc' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on: windows-8-core
@@ -569,6 +590,7 @@ jobs:
         run-java: ${{ matrix.run_java }}
   # ============================ Java Jobs ============================ #
   build-linux-java:
+    timeout-minutes: 2
     if: needs.config.outputs.only_job == 'build-linux-java' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -592,6 +614,7 @@ jobs:
     - uses: "./.github/actions/teardown-ccache"
       if: always()
   build-linux-java-static:
+    timeout-minutes: 2
     if: needs.config.outputs.only_job == 'build-linux-java-static' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -615,6 +638,7 @@ jobs:
     - uses: "./.github/actions/teardown-ccache"
       if: always()
   build-macos-java:
+    timeout-minutes: 2
     if: needs.config.outputs.only_job == 'build-macos-java' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on: macos-15-xlarge
@@ -643,6 +667,7 @@ jobs:
       if: always()
     - uses: "./.github/actions/post-steps"
   build-macos-java-static:
+    timeout-minutes: 2
     if: needs.config.outputs.only_job == 'build-macos-java-static' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on: macos-15-xlarge
@@ -669,6 +694,7 @@ jobs:
       if: always()
     - uses: "./.github/actions/post-steps"
   build-macos-java-static-universal:
+    timeout-minutes: 2
     if: needs.config.outputs.only_job == 'build-macos-java-static-universal' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on: macos-15-xlarge
@@ -695,6 +721,7 @@ jobs:
       if: always()
     - uses: "./.github/actions/post-steps"
   build-linux-java-pmd:
+    timeout-minutes: 2
     if: needs.config.outputs.only_job == 'build-linux-java-pmd' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:
@@ -722,6 +749,7 @@ jobs:
         name: maven-site
         path: "${{ github.workspace }}/java/target/site"
   build-linux-arm:
+    timeout-minutes: 2
     if: needs.config.outputs.only_job == 'build-linux-arm' || (needs.config.outputs.only_job == '' && github.repository_owner == 'facebook')
     needs: config
     runs-on:


### PR DESCRIPTION
## Summary
  GitHub marks native job and step timeouts as cancelled, even with continue-on-error. This change moves timeout enforcement into the executed build/test commands so expiration returns exit code 1 and appears as a normal CI
  failure.

  Timeout Policy

   Scope              | Command timeout    | Job safety timeout
   Standard jobs        | 115 minutes           | 135 minutes
   Windows jobs         | 175 minutes           | 195 minutes
   Folly build           | 60 minutes    | Inherits job limit

  Implementation

  - Added a reusable Unix wrapper using GNU timeout/gtimeout.
  - Normalizes timeout exit codes 124, 137, and 143 to exit code 1.
  - Applied command timeouts to Make, CMake, CTest, Java, sanitizer, crash-test, formatting, and ARM workloads.
  - Installed coreutils on macOS to provide gtimeout.
  - Added a PowerShell wrapper that terminates the Windows child process tree and exits 1.
  - Extracted the Windows build/test workload into a separately timed PowerShell script.
  - Added a configurable Folly build timeout with a 60-minute default.
  - Retained job-level timeout-minutes as protection against checkout, setup, action, artifact, or cleanup hangs.
  - Removed the redundant pr-jobs-status aggregation job.

  Result

  - Build/test command timeout: job reports failure.
  - Failure before timeout: original exit code is preserved.
  - Hang outside wrapped commands: outer job timeout still cancels the job as a final safeguard.

##  Test

  - Confirmed in GitHub Actions that GNU command timeout produces a failed build-linux job.
  - Validated success, ordinary failure, and timeout behavior locally.
  - Validated both timeout and macOS gtimeout paths.
  - Parsed the new PowerShell scripts with PowerShell 7.6.
  - Ran make check-workflow-yaml and make check-sources.
  - Verified timeout coverage across all nontrivial PR jobs.