### PR TITLE
Fix wrong pointer check in createColumnFamilyWithImport JNI OOM guard

### DIFF
--- a/java/rocksjni/rocksjni.cc
+++ b/java/rocksjni/rocksjni.cc
@@ -530,7 +530,7 @@ jlong Java_org_rocksdb_RocksDB_createColumnFamilyWithImport(
   std::vector<const ROCKSDB_NAMESPACE::ExportImportFilesMetaData*> metadatas;
   jlong* ptr_metadata_handle_array =
       env->GetLongArrayElements(j_metadata_handle_array, nullptr);
-  if (j_metadata_handle_array == nullptr) {
+  if (ptr_metadata_handle_array == nullptr) {
     // exception thrown: OutOfMemoryError
     return 0;
   }


### PR DESCRIPTION
File: java/rocksjni/rocksjni.cc
Function: Java_org_rocksdb_RocksDB_createColumnFamilyWithImport

The OOM guard after GetLongArrayElements checked the original Java array reference (j_metadata_handle_array) instead of the returned native pointer (ptr_metadata_handle_array). Since the Java array reference is never null at this point, a real GetLongArrayElements OOM failure was never detected, and the code would fall through into a loop dereferencing the null ptr_metadata_handle_array, crashing the JVM with a native null pointer dereference instead of surfacing the pending OutOfMemoryError to Java.

Fix: check ptr_metadata_handle_array instead, matching the pattern used elsewhere in this file for JNI acquisition failures.

Test Plan:
Ran `make jclean rocksdbjava jtest`. All 1240 Java tests passed, including ImportColumnFamilyTest, which exercises createColumnFamilyWithImport directly. Triggering the actual native OOM failure path deterministically in a unit test isn't practical since it would require exhausting JVM heap at the exact JNI call, so this was validated via code review and confirming no regression in the non-OOM path.

Fixes #14973