### PR TITLE
Centralize db_stress validation errors

### DIFF
--- a/db_stress_tool/db_stress_tool.cc
+++ b/db_stress_tool/db_stress_tool.cc
@@ -40,23 +40,25 @@ static std::shared_ptr<ROCKSDB_NAMESPACE::Env> legacy_env_wrapper_guard;
 static std::vector<ROCKSDB_NAMESPACE::FaultInjectionTestFS*>
     fault_fs_for_crash_flush;
 
+template <typename... Args>
+int ReturnValidationError(const Args&... args) {
+  std::cerr << "Error: ";
+  (std::cerr << ... << args) << '\n';
+  return 1;
+}
+
 int ValidateNumDbsFlags() {
   if (FLAGS_num_dbs < 1) {
-    fprintf(stderr, "Error: --num_dbs must be >= 1\n");
-    return 1;
+    return ReturnValidationError("--num_dbs must be >= 1");
   }
   if (FLAGS_num_dbs > 1) {
     if (FLAGS_clear_column_family_one_in > 0) {
-      fprintf(stderr,
-              "Error: --num_dbs > 1 incompatible with "
-              "--clear_column_family_one_in\n");
-      return 1;
+      return ReturnValidationError(
+          "--num_dbs > 1 incompatible with --clear_column_family_one_in");
     }
     if (FLAGS_test_multi_ops_txns) {
-      fprintf(stderr,
-              "Error: --num_dbs > 1 incompatible with "
-              "--test_multi_ops_txns\n");
-      return 1;
+      return ReturnValidationError(
+          "--num_dbs > 1 incompatible with --test_multi_ops_txns");
     }
   }
   return 0;
@@ -108,10 +110,6 @@ void RegisterCrashCallbacks(
   }
 }
 
-int ReturnFlagValidationError(const char* message) {
-  std::cerr << "Error: " << message << '\n';
-  return 1;
-}
 }  // namespace
 
 KeyGenContext key_gen_ctx;
@@ -138,8 +136,8 @@ int db_stress_tool(int argc, char** argv) {
 
   int env_opts = !FLAGS_env_uri.empty() + !FLAGS_fs_uri.empty();
   if (env_opts > 1) {
-    fprintf(stderr, "Error: --env_uri and --fs_uri are mutually exclusive\n");
-    exit(1);  // NOLINT(concurrency-mt-unsafe)
+    return ReturnValidationError(
+        "--env_uri and --fs_uri are mutually exclusive");
   }
 
   Status s = Env::CreateFromUri(ConfigOptions(), FLAGS_env_uri, FLAGS_fs_uri,
@@ -181,9 +179,8 @@ int db_stress_tool(int argc, char** argv) {
     // and injected I/O faults would taint it -- so require --threads=1 and all
     // fault injection off (see the flag's comment).
     if (FLAGS_threads != 1) {
-      fprintf(stderr,
-              "Error: --verify_cpu_corruption_dir requires --threads=1\n");
-      exit(1);  // NOLINT(concurrency-mt-unsafe)
+      return ReturnValidationError(
+          "--verify_cpu_corruption_dir requires --threads=1");
     }
     if (FLAGS_read_fault_one_in != 0 || FLAGS_write_fault_one_in != 0 ||
         FLAGS_metadata_read_fault_one_in != 0 ||
@@ -193,11 +190,9 @@ int db_stress_tool(int argc, char** argv) {
         FLAGS_open_metadata_read_fault_one_in != 0 ||
         FLAGS_open_metadata_write_fault_one_in != 0 ||
         FLAGS_secondary_cache_fault_one_in != 0 || FLAGS_sync_fault_injection) {
-      fprintf(stderr,
-              "Error: --verify_cpu_corruption_dir requires all fault injection "
-              "off (every *_fault_one_in = 0 and sync_fault_injection = "
-              "false)\n");
-      exit(1);  // NOLINT(concurrency-mt-unsafe)
+      return ReturnValidationError(
+          "--verify_cpu_corruption_dir requires all fault injection off "
+          "(every *_fault_one_in = 0 and sync_fault_injection = false)");
     }
     // The read-back compares against the expected-state model, which only the
     // default (state-tracked) stress test maintains. The
@@ -206,12 +201,10 @@ int db_stress_tool(int argc, char** argv) {
     // rather than report false losses.
     if (FLAGS_test_batches_snapshots || FLAGS_test_cf_consistency ||
         FLAGS_test_multi_ops_txns) {
-      fprintf(stderr,
-              "Error: --verify_cpu_corruption_dir requires the default "
-              "state-tracked stress test; it is incompatible with "
-              "--test_batches_snapshots, --test_cf_consistency, and "
-              "--test_multi_ops_txns\n");
-      exit(1);  // NOLINT(concurrency-mt-unsafe)
+      return ReturnValidationError(
+          "--verify_cpu_corruption_dir requires the default state-tracked "
+          "stress test; it is incompatible with --test_batches_snapshots, "
+          "--test_cf_consistency, and --test_multi_ops_txns");
     }
   }
 
@@ -224,72 +217,57 @@ int db_stress_tool(int argc, char** argv) {
   raw_env->SetBackgroundThreads(FLAGS_num_bottom_pri_threads,
                                 ROCKSDB_NAMESPACE::Env::Priority::BOTTOM);
   if (FLAGS_prefixpercent > 0 && FLAGS_prefix_size < 0) {
-    fprintf(stderr,
-            "Error: prefixpercent is non-zero while prefix_size is "
-            "not positive!\n");
-    exit(1);  // NOLINT(concurrency-mt-unsafe)
+    return ReturnValidationError(
+        "prefixpercent is non-zero while prefix_size is not positive!");
   }
   if (FLAGS_test_batches_snapshots && FLAGS_prefix_size <= 0) {
-    fprintf(stderr,
-            "Error: please specify prefix_size for "
-            "test_batches_snapshots test!\n");
-    exit(1);  // NOLINT(concurrency-mt-unsafe)
+    return ReturnValidationError(
+        "please specify prefix_size for test_batches_snapshots test!");
   }
   if (FLAGS_memtable_prefix_bloom_size_ratio > 0.0 && FLAGS_prefix_size < 0 &&
       !FLAGS_memtable_whole_key_filtering) {
-    fprintf(stderr,
-            "Error: please specify positive prefix_size or enable whole key "
-            "filtering in order to use memtable_prefix_bloom_size_ratio\n");
-    exit(1);  // NOLINT(concurrency-mt-unsafe)
+    return ReturnValidationError(
+        "please specify positive prefix_size or enable whole key filtering in "
+        "order to use memtable_prefix_bloom_size_ratio");
   }
   if ((FLAGS_readpercent + FLAGS_prefixpercent + FLAGS_writepercent +
        FLAGS_delpercent + FLAGS_delrangepercent + FLAGS_iterpercent +
        FLAGS_customopspercent) != 100) {
-    fprintf(
-        stderr,
-        "Error: "
-        "Read(-readpercent=%d)+Prefix(-prefixpercent=%d)+Write(-writepercent=%"
-        "d)+Delete(-delpercent=%d)+DeleteRange(-delrangepercent=%d)"
-        "+Iterate(-iterpercent=%d)+CustomOps(-customopspercent=%d) percents != "
-        "100!\n",
-        FLAGS_readpercent, FLAGS_prefixpercent, FLAGS_writepercent,
-        FLAGS_delpercent, FLAGS_delrangepercent, FLAGS_iterpercent,
-        FLAGS_customopspercent);
-    exit(1);  // NOLINT(concurrency-mt-unsafe)
+    return ReturnValidationError(
+        "Read(-readpercent=", FLAGS_readpercent,
+        ")+Prefix(-prefixpercent=", FLAGS_prefixpercent,
+        ")+Write(-writepercent=", FLAGS_writepercent,
+        ")+Delete(-delpercent=", FLAGS_delpercent,
+        ")+DeleteRange(-delrangepercent=", FLAGS_delrangepercent,
+        ")+Iterate(-iterpercent=", FLAGS_iterpercent,
+        ")+CustomOps(-customopspercent=", FLAGS_customopspercent,
+        ") percents != 100!");
   }
   if (FLAGS_disable_wal == 1 && FLAGS_reopen > 0) {
-    fprintf(stderr, "Error: Db cannot reopen safely with disable_wal set!\n");
-    exit(1);  // NOLINT(concurrency-mt-unsafe)
+    return ReturnValidationError(
+        "Db cannot reopen safely with disable_wal set!");
   }
   if ((unsigned)FLAGS_reopen >= FLAGS_ops_per_thread) {
-    fprintf(stderr,
-            "Error: #DB-reopens should be < ops_per_thread\n"
-            "Provided reopens = %d and ops_per_thread = %lu\n",
-            FLAGS_reopen, (unsigned long)FLAGS_ops_per_thread);
-    exit(1);  // NOLINT(concurrency-mt-unsafe)
+    return ReturnValidationError(
+        "#DB-reopens should be < ops_per_thread\nProvided reopens = ",
+        FLAGS_reopen, " and ops_per_thread = ", FLAGS_ops_per_thread);
   }
   if (FLAGS_test_batches_snapshots && FLAGS_delrangepercent > 0) {
-    fprintf(stderr,
-            "Error: nonzero delrangepercent unsupported in "
-            "test_batches_snapshots mode\n");
-    exit(1);  // NOLINT(concurrency-mt-unsafe)
+    return ReturnValidationError(
+        "nonzero delrangepercent unsupported in test_batches_snapshots mode");
   }
   if (FLAGS_active_width > FLAGS_max_key) {
-    fprintf(stderr, "Error: active_width can be at most max_key\n");
-    exit(1);  // NOLINT(concurrency-mt-unsafe)
+    return ReturnValidationError("active_width can be at most max_key");
   } else if (FLAGS_active_width == 0) {
     FLAGS_active_width = FLAGS_max_key;
   }
   if (FLAGS_value_size_mult * kRandomValueMaxFactor > kValueMaxLen) {
-    fprintf(stderr, "Error: value_size_mult can be at most %d\n",
-            kValueMaxLen / kRandomValueMaxFactor);
-    exit(1);  // NOLINT(concurrency-mt-unsafe)
+    return ReturnValidationError("value_size_mult can be at most ",
+                                 kValueMaxLen / kRandomValueMaxFactor);
   }
   if (FLAGS_use_merge && FLAGS_nooverwritepercent == 100) {
-    fprintf(
-        stderr,
-        "Error: nooverwritepercent must not be 100 when using merge operands");
-    exit(1);  // NOLINT(concurrency-mt-unsafe)
+    return ReturnValidationError(
+        "nooverwritepercent must not be 100 when using merge operands");
   }
   if (FLAGS_enable_blob_direct_write) {
     // Blob direct write is intentionally validated as a reduced-scope stress
@@ -299,88 +277,85 @@ int db_stress_tool(int argc, char** argv) {
     // compaction, and APIs/features that depend on active-file snapshotting or
     // unsupported blob option transitions.
     if (!FLAGS_enable_blob_files) {
-      return ReturnFlagValidationError(
+      return ReturnValidationError(
           "enable_blob_direct_write requires enable_blob_files");
     }
     if (FLAGS_allow_concurrent_memtable_write) {
-      return ReturnFlagValidationError(
+      return ReturnValidationError(
           "blob direct write stress requires "
           "allow_concurrent_memtable_write=0");
     }
     if (FLAGS_enable_pipelined_write) {
-      return ReturnFlagValidationError(
+      return ReturnValidationError(
           "blob direct write stress does not support "
           "enable_pipelined_write");
     }
     if (FLAGS_unordered_write) {
-      return ReturnFlagValidationError(
+      return ReturnValidationError(
           "blob direct write stress does not support unordered_write");
     }
     if (FLAGS_two_write_queues) {
-      return ReturnFlagValidationError(
+      return ReturnValidationError(
           "blob direct write stress does not support two_write_queues");
     }
     if (FLAGS_use_blob_db) {
-      return ReturnFlagValidationError(
+      return ReturnValidationError(
           "blob direct write is only supported with integrated BlobDB");
     }
     if (FLAGS_use_merge || FLAGS_use_full_merge_v1) {
-      return ReturnFlagValidationError(
+      return ReturnValidationError(
           "blob direct write stress does not support merge");
     }
     if (FLAGS_experimental_mempurge_threshold > 0.0) {
-      return ReturnFlagValidationError(
+      return ReturnValidationError(
           "blob direct write stress does not support MemPurge");
     }
     if (FLAGS_user_timestamp_size > 0) {
-      return ReturnFlagValidationError(
+      return ReturnValidationError(
           "blob direct write stress does not support user-defined timestamps");
     }
     if (FLAGS_allow_setting_blob_options_dynamically ||
         FLAGS_enable_blob_garbage_collection) {
-      return ReturnFlagValidationError(
+      return ReturnValidationError(
           "blob direct write stress does not support dynamic blob options or "
           "blob GC");
     }
     if (FLAGS_best_efforts_recovery) {
-      return ReturnFlagValidationError(
+      return ReturnValidationError(
           "blob direct write stress supports disable_wal-based crash "
           "testing, not best-efforts recovery");
     }
     if (FLAGS_remote_compaction_worker_threads > 0) {
-      return ReturnFlagValidationError(
+      return ReturnValidationError(
           "blob direct write stress does not support remote compaction");
     }
     if (FLAGS_use_txn || FLAGS_txn_write_policy != 0 ||
         FLAGS_use_optimistic_txn || FLAGS_test_multi_ops_txns ||
         FLAGS_commit_bypass_memtable_one_in > 0) {
-      return ReturnFlagValidationError(
+      return ReturnValidationError(
           "blob direct write stress does not support TransactionDB modes");
     }
     if (FLAGS_test_secondary || FLAGS_backup_one_in > 0 ||
         FLAGS_checkpoint_one_in > 0 || FLAGS_get_live_files_apis_one_in > 0 ||
         FLAGS_ingest_external_file_one_in > 0) {
-      return ReturnFlagValidationError(
+      return ReturnValidationError(
           "blob direct write stress does not support secondary, backup, "
           "checkpoint, get_live_files, or ingest_external_file modes");
     }
     if (FLAGS_ingest_wbwi_one_in > 0) {
-      return ReturnFlagValidationError(
+      return ReturnValidationError(
           "blob direct write stress does not support "
           "IngestWriteBatchWithIndex");
     }
   }
   if (FLAGS_ingest_external_file_one_in > 0 &&
       FLAGS_nooverwritepercent == 100) {
-    fprintf(
-        stderr,
-        "Error: nooverwritepercent must not be 100 when using file ingestion");
-    exit(1);  // NOLINT(concurrency-mt-unsafe)
+    return ReturnValidationError(
+        "nooverwritepercent must not be 100 when using file ingestion");
   }
   if (FLAGS_clear_column_family_one_in > 0 && FLAGS_backup_one_in > 0) {
-    fprintf(stderr,
-            "Error: clear_column_family_one_in must be 0 when using backup\n");
-    exit(1);  // NOLINT(concurrency-mt-unsafe)
+    return ReturnValidationError(
+        "clear_column_family_one_in must be 0 when using backup");
   }
   if (FLAGS_test_cf_consistency && FLAGS_disable_wal) {
     FLAGS_atomic_flush = true;
@@ -389,28 +364,26 @@ int db_stress_tool(int argc, char** argv) {
   // Trie UDI uses zero-copy pointers into block data, which is
   // incompatible with mmap_read.
   if (FLAGS_use_trie_index && FLAGS_mmap_read) {
-    fprintf(stderr,
-            "Error: use_trie_index is incompatible with mmap_read. "
-            "The trie index uses zero-copy pointers into block data "
-            "which is unsafe with mmap'd reads.\n");
-    exit(1);  // NOLINT(concurrency-mt-unsafe)
+    return ReturnValidationError(
+        "use_trie_index is incompatible with mmap_read. The trie index uses "
+        "zero-copy pointers into block data which is unsafe with mmap'd "
+        "reads.");
   }
 
   // TrieIndexFactory requires plain BytewiseComparator, but timestamps use
   // BytewiseComparator.u64ts.
   if (FLAGS_use_trie_index && FLAGS_user_timestamp_size > 0) {
-    fprintf(stderr,
-            "Error: use_trie_index is incompatible with user-defined "
-            "timestamps. TrieIndexFactory requires BytewiseComparator "
-            "but timestamps use BytewiseComparator.u64ts.\n");
-    exit(1);  // NOLINT(concurrency-mt-unsafe)
+    return ReturnValidationError(
+        "use_trie_index is incompatible with user-defined timestamps. "
+        "TrieIndexFactory requires BytewiseComparator but timestamps use "
+        "BytewiseComparator.u64ts.");
   }
 
   if (FLAGS_read_only) {
     if (FLAGS_writepercent != 0 || FLAGS_delpercent != 0 ||
         FLAGS_delrangepercent != 0) {
-      fprintf(stderr, "Error: updates are not supported in read only mode\n");
-      exit(1);  // NOLINT(concurrency-mt-unsafe)
+      return ReturnValidationError(
+          "updates are not supported in read only mode");
     } else if (FLAGS_checkpoint_one_in > 0 &&
                FLAGS_clear_column_family_one_in > 0) {
       fprintf(stdout,
@@ -421,17 +394,15 @@ int db_stress_tool(int argc, char** argv) {
 
   if (FLAGS_open_read_only_one_in > 0) {
     if (FLAGS_read_only) {
-      fprintf(stderr,
-              "Error: open_read_only_one_in needs a read-write primary and is "
-              "incompatible with read_only\n");
-      exit(1);  // NOLINT(concurrency-mt-unsafe)
+      return ReturnValidationError(
+          "open_read_only_one_in needs a read-write primary and is "
+          "incompatible with read_only");
     }
     if (FLAGS_use_txn || FLAGS_use_optimistic_txn || FLAGS_use_blob_db ||
         FLAGS_ttl != -1) {
-      fprintf(stderr,
-              "Error: open_read_only_one_in is not supported with "
-              "transactions, BlobDB, or TTL\n");
-      exit(1);  // NOLINT(concurrency-mt-unsafe)
+      return ReturnValidationError(
+          "open_read_only_one_in is not supported with transactions, BlobDB, "
+          "or TTL");
     }
   }
 
@@ -511,22 +482,19 @@ int db_stress_tool(int argc, char** argv) {
 
   if (FLAGS_best_efforts_recovery &&
       !(FLAGS_skip_verifydb && FLAGS_disable_wal)) {
-    fprintf(stderr,
-            "With best-efforts recovery, skip_verifydb and disable_wal "
-            "should be set to true.\n");
-    exit(1);  // NOLINT(concurrency-mt-unsafe)
+    return ReturnValidationError(
+        "With best-efforts recovery, skip_verifydb and disable_wal should be "
+        "set to true.");
   }
   if (FLAGS_skip_verifydb) {
     if (FLAGS_verify_db_one_in > 0) {
-      fprintf(stderr,
-              "Must set -verify_db_one_in=0 if skip_verifydb is true.\n");
-      exit(1);  // NOLINT(concurrency-mt-unsafe)
+      return ReturnValidationError(
+          "Must set -verify_db_one_in=0 if skip_verifydb is true.");
     }
     if (FLAGS_continuous_verification_interval > 0) {
-      fprintf(stderr,
-              "Must set -continuous_verification_interval=0 if skip_verifydb "
-              "is true.\n");
-      exit(1);  // NOLINT(concurrency-mt-unsafe)
+      return ReturnValidationError(
+          "Must set -continuous_verification_interval=0 if skip_verifydb is "
+          "true.");
     }
   }
   if ((FLAGS_enable_compaction_filter || FLAGS_inplace_update_support) &&
@@ -535,58 +503,50 @@ int db_stress_tool(int argc, char** argv) {
        FLAGS_test_batches_snapshots || FLAGS_test_cf_consistency ||
        FLAGS_check_multiget_consistency ||
        FLAGS_check_multiget_entity_consistency)) {
-    fprintf(
-        stderr,
-        "Error: acquire_snapshot_one_in, compact_range_one_in, iterpercent, "
+    return ReturnValidationError(
+        "acquire_snapshot_one_in, compact_range_one_in, iterpercent, "
         "prefixpercent, test_batches_snapshots, test_cf_consistency, "
         "check_multiget_consistency, check_multiget_entity_consistency must "
-        "all be 0 when using compaction filter or inplace update support\n");
-    exit(1);  // NOLINT(concurrency-mt-unsafe)
+        "all be 0 when using compaction filter or inplace update support");
   }
   if (FLAGS_test_multi_ops_txns) {
     CheckAndSetOptionsForMultiOpsTxnStressTest();
   }
 
   if (!FLAGS_use_txn && FLAGS_use_optimistic_txn) {
-    fprintf(
-        stderr,
+    return ReturnValidationError(
         "You cannot set use_optimistic_txn true while use_txn is false. Please "
-        "set use_txn true if you want to use OptimisticTransactionDB\n");
-    exit(1);  // NOLINT(concurrency-mt-unsafe)
+        "set use_txn true if you want to use OptimisticTransactionDB");
   }
 
   if (FLAGS_create_timestamped_snapshot_one_in > 0) {
     if (!FLAGS_use_txn) {
-      fprintf(stderr, "timestamped snapshot supported only in TransactionDB\n");
-      exit(1);  // NOLINT(concurrency-mt-unsafe)
+      return ReturnValidationError(
+          "timestamped snapshot supported only in TransactionDB");
     } else if (FLAGS_txn_write_policy != 0) {
-      fprintf(stderr,
-              "timestamped snapshot supported only in write-committed\n");
-      exit(1);  // NOLINT(concurrency-mt-unsafe)
+      return ReturnValidationError(
+          "timestamped snapshot supported only in write-committed");
     }
   }
 
   if (FLAGS_preserve_unverified_changes && FLAGS_reopen != 0) {
-    fprintf(stderr,
-            "Reopen DB is incompatible with preserving unverified changes\n");
-    exit(1);  // NOLINT(concurrency-mt-unsafe)
+    return ReturnValidationError(
+        "Reopen DB is incompatible with preserving unverified changes");
   }
 
   if (FLAGS_use_txn && !FLAGS_use_optimistic_txn &&
       FLAGS_sync_fault_injection && FLAGS_txn_write_policy != 0) {
-    fprintf(stderr,
-            "For TransactionDB, correctness testing with unsync data loss is "
-            "currently compatible with only write committed policy\n");
-    exit(1);  // NOLINT(concurrency-mt-unsafe)
+    return ReturnValidationError(
+        "For TransactionDB, correctness testing with unsync data loss is "
+        "currently compatible with only write committed policy");
   }
 
   if (FLAGS_use_put_entity_one_in > 0 &&
       (FLAGS_use_full_merge_v1 || FLAGS_test_multi_ops_txns ||
        FLAGS_user_timestamp_size > 0)) {
-    fprintf(stderr,
-            "Wide columns are incompatible with V1 Merge, the multi-op "
-            "transaction test, and user-defined timestamps\n");
-    exit(1);  // NOLINT(concurrency-mt-unsafe)
+    return ReturnValidationError(
+        "Wide columns are incompatible with V1 Merge, the multi-op "
+        "transaction test, and user-defined timestamps");
   }
 
 #ifndef NDEBUG
@@ -602,10 +562,8 @@ int db_stress_tool(int argc, char** argv) {
   if (!FLAGS_key_len_percent_dist.empty()) {
     weights = SplitString(FLAGS_key_len_percent_dist);
     if (weights.size() != levels) {
-      fprintf(stderr,
-              "Number of weights in key_len_dist should be equal to"
-              " max_key_len");
-      exit(1);  // NOLINT(concurrency-mt-unsafe)
+      return ReturnValidationError(
+          "Number of weights in key_len_dist should be equal to max_key_len");
     }
 
     uint64_t total_weight = 0;
@@ -615,8 +573,8 @@ int db_stress_tool(int argc, char** argv) {
       total_weight += val;
     }
     if (total_weight != 100) {
-      fprintf(stderr, "Sum of all weights in key_len_dist should be 100");
-      exit(1);  // NOLINT(concurrency-mt-unsafe)
+      return ReturnValidationError(
+          "Sum of all weights in key_len_dist should be 100");
     }
   } else {
     uint64_t keys_per_level = key_gen_ctx.window / levels;


### PR DESCRIPTION
Summary:
`db_stress` startup validation had accumulated multiple error-reporting paths, including direct `fprintf`/`exit(1)` pairs. This made invalid configurations inconsistent and bypassed normal unwinding.

Centralize validation failures through `ReturnValidationError`, including diagnostics with runtime values, while leaving operational I/O failures on their existing paths. The variadic stream interface keeps the existing messages without `printf` casts.

Differential Revision: D114384751


