### PR TITLE
Fsync destination files in parallel CheckpointEngine copies (#15035)

### DIFF
--- a/utilities/backup/backup_engine.cc
+++ b/utilities/backup/backup_engine.cc
@@ -1877,8 +1877,8 @@ IOStatus BackupEngineImpl::RestoreDBFromBackup(
         absolute_file, dst, Temperature::kUnknown /* src_temp */,
         file_info->temp, "" /* contents */, src_env, db_env_,
         EnvOptions() /* src_env_options */, options_.sync,
-        options_.restore_rate_limiter.get(), file_info->size,
-        nullptr /* stats */);
+        false /* use_fsync */, options_.restore_rate_limiter.get(),
+        file_info->size, nullptr /* stats */);
     RestoreAfterCopyOrCreateWorkItem after_copy_or_create_work_item(
         copy_or_create_work_item.result.get_future(), file, dst,
         file_info->checksum_hex);
@@ -2007,8 +2007,8 @@ IOStatus BackupEngineImpl::VerifyBackup(BackupID backup_id,
           abs_path, "" /* dst_path */, Temperature::kUnknown,
           Temperature::kUnknown /* dst_temperature */, "" /* contents */,
           backup_env_, nullptr /* dst_env */, EnvOptions(), false /* sync */,
-          options_.backup_rate_limiter.get(), 0 /* size_limit */,
-          nullptr /* stats */, {} /* progress_callback */,
+          false /* use_fsync */, options_.backup_rate_limiter.get(),
+          0 /* size_limit */, nullptr /* stats */, {} /* progress_callback */,
           kUnknownFileChecksumFuncName /* src_checksum_func_name */,
           "" /* src_checksum_hex */, "" /* db_id */, "" /* db_session_id*/,
           WorkItemType::ComputeChecksum);
@@ -2297,9 +2297,9 @@ IOStatus BackupEngineImpl::AddBackupFileWorkItem(
     WorkItem copy_or_create_work_item(
         src_dir.empty() ? "" : src_path, *copy_dest_path, src_temperature,
         Temperature::kUnknown /*dst_temp*/, contents, db_env_, backup_env_,
-        src_env_options, options_.sync, rate_limiter, size_limit, stats,
-        progress_callback, src_checksum_func_name, checksum_hex, db_id,
-        db_session_id);
+        src_env_options, options_.sync, false /* use_fsync */, rate_limiter,
+        size_limit, stats, progress_callback, src_checksum_func_name,
+        checksum_hex, db_id, db_session_id);
     BackupAfterCopyOrCreateWorkItem after_copy_or_create_work_item(
         copy_or_create_work_item.result.get_future(), shared, need_to_copy,
         backup_env_, temp_dest_path, final_dest_path, dst_relative);
@@ -2559,7 +2559,7 @@ void BackupEngineImpl::InferDBFilesToRetainInRestore(
             backup_file_path, "" /* dst_path */, backup_file_info->temp,
             Temperature::kUnknown /* dst_temperature */, "" /* contents */,
             backup_engine_impl->backup_env_, nullptr /* dst_env */,
-            backup_env_options, false /* sync */,
+            backup_env_options, false /* sync */, false /* use_fsync */,
             options_.restore_rate_limiter.get(), 0 /* size_limit */,
             nullptr /* stats */, {} /* progress_callback */,
             kUnknownFileChecksumFuncName /* src_checksum_func_name */,
@@ -2594,8 +2594,8 @@ void BackupEngineImpl::InferDBFilesToRetainInRestore(
           db_file_path, "" /* dst_path */, backup_file_info->temp,
           Temperature::kUnknown /* dst_temperature */, "" /* contents */,
           db_env_, nullptr /* dst_env */, db_env_options, false /* sync */,
-          options_.restore_rate_limiter.get(), 0 /* size_limit */,
-          nullptr /* stats */, {} /* progress_callback */,
+          false /* use_fsync */, options_.restore_rate_limiter.get(),
+          0 /* size_limit */, nullptr /* stats */, {} /* progress_callback */,
           kUnknownFileChecksumFuncName /* src_checksum_func_name */,
           "" /* src_checksum_hex */, "" /* db_id */, "" /* db_session_id*/,
           WorkItemType::ComputeChecksum);

--- a/utilities/checkpoint/checkpoint_impl.cc
+++ b/utilities/checkpoint/checkpoint_impl.cc
@@ -180,8 +180,9 @@ class ParallelFileMover : public CheckpointFileMover {
     // Linking moves no data, so the WorkItem carries no temperature; it is kept
     // in PendingLink for the copy fallback in Finish().
     WorkItem w(src, dst, Temperature::kUnknown, Temperature::kUnknown,
-               /*contents=*/"", env_, env_, EnvOptions(), use_fsync_,
-               /*rate_limiter=*/nullptr, /*size_limit=*/0, /*stats=*/nullptr);
+               /*contents=*/"", env_, env_, EnvOptions(), /*sync=*/true,
+               /*use_fsync=*/use_fsync_, /*rate_limiter=*/nullptr,
+               /*size_limit=*/0, /*stats=*/nullptr);
     w.type = WorkItemType::Link;
     link_pendings_.push_back({w.result.get_future(), src, dst, temperature});
     engine_->Submit(std::move(w));
@@ -192,8 +193,8 @@ class ParallelFileMover : public CheckpointFileMover {
               uint64_t size_limit, Temperature temperature) override {
     ROCKS_LOG_INFO(info_log_, "Copying %s", dst.c_str());
     WorkItem w(src, dst, temperature, temperature, /*contents=*/"", env_, env_,
-               EnvOptions(), use_fsync_, copy_rate_limiter_, size_limit,
-               stats_);
+               EnvOptions(), /*sync=*/true, /*use_fsync=*/use_fsync_,
+               copy_rate_limiter_, size_limit, stats_);
     copy_futures_.push_back(w.result.get_future());
     engine_->Submit(std::move(w));
     return Status::OK();
@@ -223,8 +224,9 @@ class ParallelFileMover : public CheckpointFileMover {
         // size_limit 0 copies the whole file; only immutable (non-trim_to_size)
         // files are linked, so this matches the serial path's info.size bound.
         WorkItem w(p.src, p.dst, p.temperature, p.temperature,
-                   /*contents=*/"", env_, env_, EnvOptions(), use_fsync_,
-                   copy_rate_limiter_, /*size_limit=*/0, stats_);
+                   /*contents=*/"", env_, env_, EnvOptions(), /*sync=*/true,
+                   /*use_fsync=*/use_fsync_, copy_rate_limiter_,
+                   /*size_limit=*/0, stats_);
         fallback_copies.push_back(w.result.get_future());
         engine_->Submit(std::move(w));
       } else {

--- a/utilities/copy_engine/copy_engine.cc
+++ b/utilities/copy_engine/copy_engine.cc
@@ -78,9 +78,10 @@ void CopyEngine::ThreadBody() {
       result.io_status = CopyOrCreateFile(
           work_item.src_path, work_item.dst_path, work_item.contents,
           work_item.size_limit, work_item.src_env, work_item.dst_env,
-          work_item.src_env_options, work_item.sync, work_item.rate_limiter,
-          work_item.progress_callback, &temp, work_item.dst_temperature,
-          &bytes_toward_next_callback, &result.size, &result.checksum_hex);
+          work_item.src_env_options, work_item.sync, work_item.use_fsync,
+          work_item.rate_limiter, work_item.progress_callback, &temp,
+          work_item.dst_temperature, &bytes_toward_next_callback, &result.size,
+          &result.checksum_hex);
 
       RecordTick(work_item.stats, options_.read_bytes_ticker,
                  IOSTATS(bytes_read) - prev_bytes_read);
@@ -140,8 +141,8 @@ void CopyEngine::ThreadBody() {
 IOStatus CopyEngine::CopyOrCreateFile(
     const std::string& src, const std::string& dst, const std::string& contents,
     uint64_t size_limit, Env* src_env, Env* dst_env,
-    const EnvOptions& src_env_options, bool sync, RateLimiter* rate_limiter,
-    const std::function<void()>& progress_callback,
+    const EnvOptions& src_env_options, bool sync, bool use_fsync,
+    RateLimiter* rate_limiter, const std::function<void()>& progress_callback,
     Temperature* src_temperature, Temperature dst_temperature,
     uint64_t* bytes_toward_next_callback, uint64_t* size,
     std::string* checksum_hex) {
@@ -278,8 +279,8 @@ IOStatus CopyEngine::CopyOrCreateFile(
     checksum_hex->assign(ChecksumInt32ToHex(checksum_value));
   }
 
-  if (io_s.ok() && sync) {
-    io_s = dest_writer->Sync(opts, false);
+  if (io_s.ok() && (sync || use_fsync)) {
+    io_s = dest_writer->Sync(opts, use_fsync);
   }
   if (io_s.ok()) {
     io_s = dest_writer->Close(opts);

--- a/utilities/copy_engine/copy_engine.h
+++ b/utilities/copy_engine/copy_engine.h
@@ -85,6 +85,7 @@ struct WorkItem {
   Env* dst_env = nullptr;
   EnvOptions src_env_options;
   bool sync = false;
+  bool use_fsync = false;
   RateLimiter* rate_limiter = nullptr;
   uint64_t size_limit = 0;
   Statistics* stats = nullptr;
@@ -113,6 +114,7 @@ struct WorkItem {
     dst_env = o.dst_env;
     src_env_options = std::move(o.src_env_options);
     sync = o.sync;
+    use_fsync = o.use_fsync;
     rate_limiter = o.rate_limiter;
     size_limit = o.size_limit;
     stats = o.stats;
@@ -130,8 +132,8 @@ struct WorkItem {
       std::string _src_path, std::string _dst_path,
       const Temperature _src_temperature, const Temperature _dst_temperature,
       std::string _contents, Env* _src_env, Env* _dst_env,
-      EnvOptions _src_env_options, bool _sync, RateLimiter* _rate_limiter,
-      uint64_t _size_limit, Statistics* _stats,
+      EnvOptions _src_env_options, bool _sync, bool _use_fsync,
+      RateLimiter* _rate_limiter, uint64_t _size_limit, Statistics* _stats,
       std::function<void()> _progress_callback = {},
       const std::string& _src_checksum_func_name = kUnknownFileChecksumFuncName,
       const std::string& _src_checksum_hex = "", const std::string& _db_id = "",
@@ -146,6 +148,7 @@ struct WorkItem {
         dst_env(_dst_env),
         src_env_options(std::move(_src_env_options)),
         sync(_sync),
+        use_fsync(_use_fsync),
         rate_limiter(_rate_limiter),
         size_limit(_size_limit),
         stats(_stats),
@@ -201,7 +204,7 @@ class CopyEngine {
                             const std::string& contents, uint64_t size_limit,
                             Env* src_env, Env* dst_env,
                             const EnvOptions& src_env_options, bool sync,
-                            RateLimiter* rate_limiter,
+                            bool use_fsync, RateLimiter* rate_limiter,
                             const std::function<void()>& progress_callback,
                             Temperature* src_temperature,
                             Temperature dst_temperature,

--- a/utilities/copy_engine/copy_engine_test.cc
+++ b/utilities/copy_engine/copy_engine_test.cc
@@ -53,7 +53,8 @@ class CopyEngineTest : public testing::Test {
   WorkItem MakeCopyItem(int i) {
     return WorkItem(SrcPath(i), DstPath(i), Temperature::kUnknown,
                     Temperature::kUnknown, /*contents=*/"", env_, env_,
-                    EnvOptions(), /*sync=*/false, /*rate_limiter=*/nullptr,
+                    EnvOptions(), /*sync=*/false, /*use_fsync=*/false,
+                    /*rate_limiter=*/nullptr,
                     /*size_limit=*/0, /*stats=*/nullptr);
   }
 


### PR DESCRIPTION
Summary:

Parallel checkpoint copies were never fsynced. `CopyEngine::CopyOrCreateFile`
gated the destination sync on `use_fsync` (wired to `db_options.use_fsync`) --
but `use_fsync` means "fsync vs fdatasync", not "whether to sync". With the
default `use_fsync=false`, the parallel path skipped the sync, so a copied
MANIFEST/SST stayed in the unsynced buffer and was dropped by
`TestFSWritableFile::Close` under `sync_fault_injection`, leaving a 0-byte file
and checkpoint corruption:

  Corruption: no log_file_number, next_file_number, last_sequence entry in MANIFEST
  Corruption: Sst file size mismatch between expected N and file system 0

Serial `CopyFile` always syncs (using `use_fsync` only to pick the flavor), so
it never hit this.

Fix: split `WorkItem` / `CopyOrCreateFile` into `sync` (whether to sync) and
`use_fsync` (fsync vs fdatasync). CheckpointEngine now passes `sync=true,
use_fsync=db_options.use_fsync`, matching serial. BackupEngine is unchanged --
`sync=options_.sync` with the new `use_fsync=false` default reproduces the prior
behavior.

Differential Revision: D114393892


