### PR TITLE
Add compact_target_level flag to db_bench

### DIFF
--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -422,6 +422,11 @@ static const bool FLAGS_subcompactions_dummy
     __attribute__((__unused__)) = RegisterFlagValidator(&FLAGS_subcompactions,
                                                     &ValidateUint32Range);
 
+DEFINE_int32(compact_target_level, -1,
+             "For CompactRange in compact benchmarks, set "
+             "CompactRangeOptions::target_level (requires change_level). "
+             "-1 keeps the default behavior.");
+
 DEFINE_int32(max_background_flushes,
              ROCKSDB_NAMESPACE::Options().max_background_flushes,
              "The maximum number of concurrent background flushes"
@@ -4889,6 +4894,10 @@ class Benchmark {
       // auto compactionOptions = CompactionOptions();
       // db->CompactFiles(compactionOptions, file_names, 0);
       auto compactionOptions = CompactRangeOptions();
+      if (FLAGS_compact_target_level >= 0) {
+        compactionOptions.change_level = true;
+        compactionOptions.target_level = FLAGS_compact_target_level;
+      }
       db->CompactRange(compactionOptions, nullptr, nullptr);
     } else {
       fprintf(stdout,
@@ -7284,15 +7293,24 @@ class Benchmark {
     CompactRangeOptions cro;
     cro.bottommost_level_compaction =
         BottommostLevelCompaction::kForceOptimized;
+    if (FLAGS_compact_target_level >= 0) {
+      cro.change_level = true;
+      cro.target_level = FLAGS_compact_target_level;
+    }
     db->CompactRange(cro, nullptr, nullptr);
   }
 
   void CompactAll() {
+    CompactRangeOptions cro;
+    if (FLAGS_compact_target_level >= 0) {
+      cro.change_level = true;
+      cro.target_level = FLAGS_compact_target_level;
+    }
     if (db_.db != nullptr) {
-      db_.db->CompactRange(CompactRangeOptions(), nullptr, nullptr);
+      db_.db->CompactRange(cro, nullptr, nullptr);
     }
     for (const auto& db_with_cfh : multi_dbs_) {
-      db_with_cfh.db->CompactRange(CompactRangeOptions(), nullptr, nullptr);
+      db_with_cfh.db->CompactRange(cro, nullptr, nullptr);
     }
   }
 


### PR DESCRIPTION
## Summary

- Add `-compact_target_level` gflag to `db_bench` (default `-1`, preserving current behavior).
- When set to a non-negative level, manual `CompactRange` in `compact` / `filldeterministic` benchmarks sets `CompactRangeOptions::change_level` and `CompactRangeOptions::target_level`.
- Refactor `CompactAll()` to reuse one `CompactRangeOptions` instance so the flag applies to all DBs.

## Motivation

Bench workflows that call `CompactRange` across all levels may leave files on intermediate levels via trivial move; forcing a target bottom level after manual compaction makes space usage in benchmarks more representative of a fully compacted DB.

## Test plan

- [ ] `make db_bench -j$(nproc)`
- [ ] `./db_bench -benchmarks=compact -compact_target_level=6 ...` (level-based CF, sufficient `num_levels`)