### PR TITLE
Speed up Slice::ToString(bool hex=true)

### DIFF
--- a/util/slice.cc
+++ b/util/slice.cc
@@ -238,16 +238,11 @@ std::string SliceTransform::AsString() const {
   return GetId();
 }
 
-// 2 small internal utility functions, for efficient hex conversions
+// a small internal utility function, for efficient hex conversion
 // and no need for snprintf, toupper etc...
 // Originally from wdt/util/EncryptionUtils.cpp - for
-// std::to_string(true)/DecodeHex:
-char toHex(unsigned char v) {
-  if (v <= 9) {
-    return '0' + v;
-  }
-  return 'A' + v - 10;
-}
+// DecodeHex:
+
 // most of the code is for validation/error check
 int fromHex(char c) {
   // toupper:
@@ -280,19 +275,21 @@ Slice::Slice(const SliceParts& parts, std::string* buf) {
 
 // Return a string that contains the copy of the referenced data.
 std::string Slice::ToString(bool hex) const {
-  std::string result;  // RVO/NRVO/move
-  if (hex) {
-    result.reserve(2 * size_);
-    for (size_t i = 0; i < size_; ++i) {
-      unsigned char c = data_[i];
-      result.push_back(toHex(c >> 4));
-      result.push_back(toHex(c & 0xf));
-    }
-    return result;
-  } else {
-    result.assign(data_, size_);
-    return result;
+  if (!hex) {
+    return {data_, size_};
   }
+  static constexpr char kHexChars[] = "0123456789ABCDEF";
+  std::string result(2 * size_, '\0');
+  char* p = result.data();
+  const unsigned char* src = reinterpret_cast<const unsigned char*>(data_);
+  const unsigned char* end = src + size_;
+
+  while (src != end) {
+    const unsigned char c = *src++;
+    *p++ = kHexChars[c >> 4];
+    *p++ = kHexChars[c & 0xF];
+  }
+  return result;
 }
 
 // Originally from rocksdb/utilities/ldb_cmd.h

--- a/util/slice.cc
+++ b/util/slice.cc
@@ -16,6 +16,7 @@
 #include "rocksdb/slice_transform.h"
 #include "rocksdb/utilities/object_registry.h"
 #include "rocksdb/utilities/options_type.h"
+#include "util/cast_util.h"
 #include "util/string_util.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -280,7 +281,7 @@ std::string Slice::ToString(bool hex) const {
   static constexpr char kHexChars[] = "0123456789ABCDEF";
   std::string result(2 * size_, '\0');
   char* p = result.data();
-  const unsigned char* src = reinterpret_cast<const unsigned char*>(data_);
+  const unsigned char* src = lossless_cast<const unsigned char*>(data_);
   const unsigned char* end = src + size_;
 
   while (src != end) {

--- a/util/slice.cc
+++ b/util/slice.cc
@@ -240,8 +240,7 @@ std::string SliceTransform::AsString() const {
 
 // A small internal utility function, for efficient hex conversion
 // and no need for snprintf, toupper etc...
-// Originally from wdt/util/EncryptionUtils.cpp - for
-// DecodeHex:
+// Originally from wdt/util/EncryptionUtils.cpp - for DecodeHex:
 
 // most of the code is for validation/error check
 int fromHex(char c) {

--- a/util/slice.cc
+++ b/util/slice.cc
@@ -238,7 +238,7 @@ std::string SliceTransform::AsString() const {
   return GetId();
 }
 
-// a small internal utility function, for efficient hex conversion
+// A small internal utility function, for efficient hex conversion
 // and no need for snprintf, toupper etc...
 // Originally from wdt/util/EncryptionUtils.cpp - for
 // DecodeHex:

--- a/util/slice.cc
+++ b/util/slice.cc
@@ -242,7 +242,6 @@ std::string SliceTransform::AsString() const {
 // A small internal utility function, for efficient hex conversion
 // and no need for snprintf, toupper etc...
 // Originally from wdt/util/EncryptionUtils.cpp - for DecodeHex:
-
 // most of the code is for validation/error check
 int fromHex(char c) {
   // toupper:

--- a/util/slice.cc
+++ b/util/slice.cc
@@ -239,6 +239,7 @@ std::string SliceTransform::AsString() const {
   return GetId();
 }
 
+namespace {
 // A small internal utility function, for efficient hex conversion
 // and no need for snprintf, toupper etc...
 // Originally from wdt/util/EncryptionUtils.cpp - for DecodeHex:
@@ -257,6 +258,7 @@ int fromHex(char c) {
   }
   return c - 'A' + 10;
 }
+}  // end namespace
 
 Slice::Slice(const SliceParts& parts, std::string* buf) {
   size_t length = 0;

--- a/util/slice_test.cc
+++ b/util/slice_test.cc
@@ -708,34 +708,32 @@ TEST(BitFieldsTest, BitFields) {
 }
 
 void VerifyHexRoundTrip(const std::string& input) {
-    Slice slice(input);
+  Slice slice(input);
 
-    // Verify non-hex ToString matches original input
-    std::string normal_str = slice.ToString(false);
-    ASSERT_EQ(normal_str, input);
+  // Verify non-hex ToString matches original input
+  std::string normal_str = slice.ToString(false);
+  ASSERT_EQ(normal_str, input);
 
-    // Encode to hex
-    std::string hex_str = slice.ToString(true);
+  // Encode to hex
+  std::string hex_str = slice.ToString(true);
 
-    // Hex string should be exactly twice the length of the input
-    ASSERT_EQ(hex_str.size(), input.size() * 2);
+  // Hex string should be exactly twice the length of the input
+  ASSERT_EQ(hex_str.size(), input.size() * 2);
 
-    // Verify all characters in hex string are valid hex digits
-    for (char c : hex_str) {
-        ASSERT_TRUE(
-            (c >= '0' && c <= '9') ||
-            (c >= 'A' && c <= 'F')
-        ) << "Invalid hex character: " << c;
-    }
+  // Verify all characters in hex string are valid hex digits
+  for (char c : hex_str) {
+    ASSERT_TRUE((c >= '0' && c <= '9') || (c >= 'A' && c <= 'F'))
+        << "Invalid hex character: " << c;
+  }
 
-    // Decode hex back to original
-    Slice hex_slice(hex_str);
-    std::string decoded;
-    ASSERT_TRUE(hex_slice.DecodeHex(&decoded));
+  // Decode hex back to original
+  Slice hex_slice(hex_str);
+  std::string decoded;
+  ASSERT_TRUE(hex_slice.DecodeHex(&decoded));
 
-    // Verify decoded output matches original input
-    ASSERT_EQ(decoded, input);
-    ASSERT_EQ(decoded.size(), input.size());
+  // Verify decoded output matches original input
+  ASSERT_EQ(decoded, input);
+  ASSERT_EQ(decoded.size(), input.size());
 }
 
 TEST(SliceHexTest, HexAndToStringRoundTrip) {
@@ -789,7 +787,7 @@ TEST(SliceHexTest, HexAndToStringRoundTrip) {
     std::string all_bytes;
     all_bytes.reserve(256);
     for (int i = 0; i < 256; ++i) {
-        all_bytes.push_back(static_cast<char>(i));
+      all_bytes.push_back(static_cast<char>(i));
     }
 
     VerifyHexRoundTrip(all_bytes);

--- a/util/slice_test.cc
+++ b/util/slice_test.cc
@@ -707,9 +707,7 @@ TEST(BitFieldsTest, BitFields) {
   }
 }
 
-class SliceHexTest : public testing::Test {};
-
-TEST_F(SliceHexTest, HexAndToStringRoundTrip) {
+TEST(SliceHexTest, HexAndToStringRoundTrip) {
   {
     Slice empty_slice("");
     std::string normal_str = empty_slice.ToString(false);

--- a/util/slice_test.cc
+++ b/util/slice_test.cc
@@ -725,7 +725,7 @@ TEST_F(SliceHexTest, HexAndToStringRoundTrip) {
   {
     Slice single_byte_slice("A");
     ASSERT_EQ(single_byte_slice.ToString(false), "A");
-    ASSERT_EQ(single_byte_slice.ToString(true), "41"); // Hex for 'A'
+    ASSERT_EQ(single_byte_slice.ToString(true), "41");  // Hex for 'A'
     Slice hex_slice("41");
     std::string decoded;
     ASSERT_TRUE(hex_slice.DecodeHex(&decoded));
@@ -739,15 +739,15 @@ TEST_F(SliceHexTest, HexAndToStringRoundTrip) {
       all_bytes.push_back(static_cast<char>(i));
     }
     Slice all_bytes_slice(all_bytes);
-    
+
     // Verify non-hex ToString matches original binary data
     std::string non_hex_out = all_bytes_slice.ToString(false);
     ASSERT_EQ(non_hex_out, all_bytes);
-    
+
     // Verify hex ToString output length (2 hex chars per byte)
     std::string hex_out = all_bytes_slice.ToString(true);
     ASSERT_EQ(hex_out.size(), 512);
-    
+
     // Round-trip: Wrap the hex string in a Slice, then decode it
     Slice hex_slice(hex_out);
     std::string decoded_bytes;

--- a/util/slice_test.cc
+++ b/util/slice_test.cc
@@ -707,6 +707,56 @@ TEST(BitFieldsTest, BitFields) {
   }
 }
 
+class SliceHexTest : public testing::Test {};
+
+TEST_F(SliceHexTest, HexAndToStringRoundTrip) {
+  {
+    Slice empty_slice("");
+    std::string normal_str = empty_slice.ToString(false);
+    std::string hex_str = empty_slice.ToString(true);
+    ASSERT_TRUE(normal_str.empty());
+    ASSERT_TRUE(hex_str.empty());
+    Slice hex_slice(hex_str);
+    std::string decoded;
+    ASSERT_TRUE(hex_slice.DecodeHex(&decoded));
+    ASSERT_TRUE(decoded.empty());
+  }
+
+  {
+    Slice single_byte_slice("A");
+    ASSERT_EQ(single_byte_slice.ToString(false), "A");
+    ASSERT_EQ(single_byte_slice.ToString(true), "41"); // Hex for 'A'
+    Slice hex_slice("41");
+    std::string decoded;
+    ASSERT_TRUE(hex_slice.DecodeHex(&decoded));
+    ASSERT_EQ(decoded, "A");
+  }
+
+  {
+    std::string all_bytes;
+    all_bytes.reserve(256);
+    for (int i = 0; i < 256; ++i) {
+      all_bytes.push_back(static_cast<char>(i));
+    }
+    Slice all_bytes_slice(all_bytes);
+    
+    // Verify non-hex ToString matches original binary data
+    std::string non_hex_out = all_bytes_slice.ToString(false);
+    ASSERT_EQ(non_hex_out, all_bytes);
+    
+    // Verify hex ToString output length (2 hex chars per byte)
+    std::string hex_out = all_bytes_slice.ToString(true);
+    ASSERT_EQ(hex_out.size(), 512);
+    
+    // Round-trip: Wrap the hex string in a Slice, then decode it
+    Slice hex_slice(hex_out);
+    std::string decoded_bytes;
+    ASSERT_TRUE(hex_slice.DecodeHex(&decoded_bytes));
+    ASSERT_EQ(decoded_bytes, all_bytes);
+    ASSERT_EQ(decoded_bytes.size(), 256);
+  }
+}
+
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {

--- a/util/slice_test.cc
+++ b/util/slice_test.cc
@@ -707,23 +707,56 @@ TEST(BitFieldsTest, BitFields) {
   }
 }
 
-TEST(SliceHexTest, HexAndToStringRoundTrip) {
-  {
-    Slice empty_slice("");
-    std::string normal_str = empty_slice.ToString(false);
-    std::string hex_str = empty_slice.ToString(true);
-    ASSERT_TRUE(normal_str.empty());
-    ASSERT_TRUE(hex_str.empty());
+void VerifyHexRoundTrip(const std::string& input) {
+    Slice slice(input);
+
+    // Verify non-hex ToString matches original input
+    std::string normal_str = slice.ToString(false);
+    ASSERT_EQ(normal_str, input);
+
+    // Encode to hex
+    std::string hex_str = slice.ToString(true);
+
+    // Hex string should be exactly twice the length of the input
+    ASSERT_EQ(hex_str.size(), input.size() * 2);
+
+    // Verify all characters in hex string are valid hex digits
+    for (char c : hex_str) {
+        ASSERT_TRUE(
+            (c >= '0' && c <= '9') ||
+            (c >= 'A' && c <= 'F')
+        ) << "Invalid hex character: " << c;
+    }
+
+    // Decode hex back to original
     Slice hex_slice(hex_str);
     std::string decoded;
     ASSERT_TRUE(hex_slice.DecodeHex(&decoded));
+
+    // Verify decoded output matches original input
+    ASSERT_EQ(decoded, input);
+    ASSERT_EQ(decoded.size(), input.size());
+}
+
+TEST(SliceHexTest, HexAndToStringRoundTrip) {
+  {
+    VerifyHexRoundTrip("");
+
+    // Additionally verify that decoding an empty hex string yields empty output
+    Slice empty_hex("");
+    std::string decoded;
+    ASSERT_TRUE(empty_hex.DecodeHex(&decoded));
     ASSERT_TRUE(decoded.empty());
   }
 
   {
+    VerifyHexRoundTrip("A");
+
+    // Additionally verify the specific hex encoding of 'A'
     Slice single_byte_slice("A");
-    ASSERT_EQ(single_byte_slice.ToString(false), "A");
-    ASSERT_EQ(single_byte_slice.ToString(true), "41");  // Hex for 'A'
+    ASSERT_EQ(single_byte_slice.ToString(true), "41");
+
+    // Verify decoding the known hex value yields the original character
     Slice hex_slice("41");
     std::string decoded;
     ASSERT_TRUE(hex_slice.DecodeHex(&decoded));
@@ -731,27 +764,39 @@ TEST(SliceHexTest, HexAndToStringRoundTrip) {
   }
 
   {
+    Slice hex_slice("deadbeef");
+    std::string decoded;
+    ASSERT_TRUE(hex_slice.DecodeHex(&decoded));
+    ASSERT_EQ(decoded.size(), 4);
+
+    // Verify the decoded bytes match expected values
+    ASSERT_EQ(static_cast<unsigned char>(decoded[0]), 0xDE);
+    ASSERT_EQ(static_cast<unsigned char>(decoded[1]), 0xAD);
+    ASSERT_EQ(static_cast<unsigned char>(decoded[2]), 0xBE);
+    ASSERT_EQ(static_cast<unsigned char>(decoded[3]), 0xEF);
+
+    // Round-trip the decoded bytes back through VerifyHexRoundTrip
+    VerifyHexRoundTrip(decoded);
+
+    // Verify uppercase hex input also decodes correctly
+    Slice upper_hex_slice("DEADBEEF");
+    std::string upper_decoded;
+    ASSERT_TRUE(upper_hex_slice.DecodeHex(&upper_decoded));
+    ASSERT_EQ(upper_decoded, decoded);
+  }
+
+  {
     std::string all_bytes;
     all_bytes.reserve(256);
     for (int i = 0; i < 256; ++i) {
-      all_bytes.push_back(static_cast<char>(i));
+        all_bytes.push_back(static_cast<char>(i));
     }
+
+    VerifyHexRoundTrip(all_bytes);
+
+    // Additionally verify the exact output size for all-bytes case
     Slice all_bytes_slice(all_bytes);
-
-    // Verify non-hex ToString matches original binary data
-    std::string non_hex_out = all_bytes_slice.ToString(false);
-    ASSERT_EQ(non_hex_out, all_bytes);
-
-    // Verify hex ToString output length (2 hex chars per byte)
-    std::string hex_out = all_bytes_slice.ToString(true);
-    ASSERT_EQ(hex_out.size(), 512);
-
-    // Round-trip: Wrap the hex string in a Slice, then decode it
-    Slice hex_slice(hex_out);
-    std::string decoded_bytes;
-    ASSERT_TRUE(hex_slice.DecodeHex(&decoded_bytes));
-    ASSERT_EQ(decoded_bytes, all_bytes);
-    ASSERT_EQ(decoded_bytes.size(), 256);
+    ASSERT_EQ(all_bytes_slice.ToString(true).size(), 512);
   }
 }
 


### PR DESCRIPTION
- Replace branching with a single indexed load from constexpr lookup table.
- Instead of reserve + push_back, one allocation sets final size immediately, avoiding repeated size updates and bounds checks.
- Raw pointer skips repeated operator[] overhead and internal index tracking.
- When `hex=false`, construct the string directly, avoiding assign + return copy.

Noticed when using `ldb --value_hex scan`:

Before:

```
perf stat -e branches,branch-misses tools/ldb --value_hex scan --db=test_db | dd of=/dev/null
 Performance counter stats for 'tools/ldb --value_hex scan --db=test_db':
     2,983,373,019      branches:u
       101,288,380      branch-misses:u           #    3.40% of all branches
       4.365280485 seconds time elapsed
       2.854659000 seconds user
       0.741348000 seconds sys
884520+1 records in
884520+1 records out
452874563 bytes (453 MB, 432 MiB) copied, 4.40603 s, 103 MB/s
```

After:

```
perf stat -e branches,branch-misses tools/ldb --value_hex scan --db=test_db | dd of=/dev/null
 Performance counter stats for 'tools/ldb --value_hex scan --db=test_db':
       275,719,553      branches:u
           797,887      branch-misses:u           #    0.29% of all branches
       1.922297831 seconds time elapsed
       0.346486000 seconds user
       0.785366000 seconds sys
884520+1 records in
884520+1 records out
452874563 bytes (453 MB, 432 MiB) copied, 1.97187 s, 230 MB/s
```

Built with `DEBUG_LEVEL=0`.  `gcc 8.5.0`

Also see https://github.com/facebook/rocksdb/pull/15070 which incorporates the changes from this PR and also speeds up `Slice::DecodeHex` .