### PR TITLE
Route single-blob reads through BlobFetcher

### DIFF
--- a/db/blob/db_blob_index_test.cc
+++ b/db/blob/db_blob_index_test.cc
@@ -15,6 +15,7 @@
 #include <vector>
 
 #include "db/arena_wrapped_db_iter.h"
+#include "db/blob/blob_fetcher.h"
 #include "db/blob/blob_index.h"
 #include "db/column_family.h"
 #include "db/db_iter.h"
@@ -138,8 +139,11 @@ class DBBlobIndexTest : public DBTestBase {
       bool resolve_direct_write_value, const Version* current,
       PinnableSlice* value, PinnableWideColumns* columns, Status* s,
       bool* is_blob_index, bool* value_found = nullptr) {
+    VersionBlobFetcher blob_fetcher(current, read_options,
+                                    cfd()->blob_file_cache(),
+                                    /*allow_write_path_fallback=*/true);
     return DBImpl::MaybeResolveDirectWriteValue(
-        read_options, key, resolve_direct_write_value, current, cfd(), value,
+        read_options, key, resolve_direct_write_value, blob_fetcher, value,
         columns, s, is_blob_index, value_found);
   }
 

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -2827,9 +2827,10 @@ static Status DecodeDirectWriteBlobIndex(const Slice& blob_index_slice,
   return status;
 }
 
-Status DBImpl::ResolveDirectWritePlainValue(
-    const ReadOptions& read_options, const Slice& key, const Version* current,
-    ColumnFamilyData* cfd, PinnableSlice* value, PinnableWideColumns* columns) {
+Status DBImpl::ResolveDirectWritePlainValue(const Slice& key,
+                                            const BlobFetcher& blob_fetcher,
+                                            PinnableSlice* value,
+                                            PinnableWideColumns* columns) {
   Slice blob_index_slice;
   std::string blob_index_storage;
   if (value != nullptr) {
@@ -2867,9 +2868,9 @@ Status DBImpl::ResolveDirectWritePlainValue(
   BlobIndex blob_idx;
   Status status = DecodeDirectWriteBlobIndex(blob_index_slice, &blob_idx);
   if (status.ok()) {
-    status = BlobFilePartitionManager::ResolveBlobDirectWriteIndex(
-        read_options, key, blob_idx, current, cfd->blob_file_cache(),
-        nullptr /* prefetch_buffer */, target, nullptr /* bytes_read */);
+    status =
+        blob_fetcher.FetchBlob(key, blob_idx, nullptr /* prefetch_buffer */,
+                               target, nullptr /* bytes_read */);
     if (status.ok() && columns != nullptr) {
       columns->SetPlainValue(std::move(*target));
     }
@@ -2877,10 +2878,8 @@ Status DBImpl::ResolveDirectWritePlainValue(
   return status;
 }
 
-Status DBImpl::ResolveDirectWriteWideColumns(const ReadOptions& read_options,
-                                             const Slice& key,
-                                             const Version* current,
-                                             ColumnFamilyData* cfd,
+Status DBImpl::ResolveDirectWriteWideColumns(const Slice& key,
+                                             const BlobFetcher& blob_fetcher,
                                              PinnableWideColumns* columns) {
   assert(columns != nullptr);
 
@@ -2924,9 +2923,8 @@ Status DBImpl::ResolveDirectWriteWideColumns(const ReadOptions& read_options,
     } else {
       extra_buffers.emplace_front();
       PinnableSlice& blob_value = extra_buffers.front();
-      s = BlobFilePartitionManager::ResolveBlobDirectWriteIndex(
-          read_options, key, blob_idx, current, cfd->blob_file_cache(),
-          nullptr /* prefetch_buffer */, &blob_value, nullptr /* bytes_read */);
+      s = blob_fetcher.FetchBlob(key, blob_idx, nullptr /* prefetch_buffer */,
+                                 &blob_value, nullptr /* bytes_read */);
       if (!s.ok()) {
         return s;
       }
@@ -3122,9 +3120,9 @@ Status DBImpl::PostprocessMemtableValueRead(
 
 bool DBImpl::MaybeResolveDirectWriteValue(
     const ReadOptions& read_options, const Slice& key,
-    bool resolve_direct_write_value, const Version* current,
-    ColumnFamilyData* cfd, PinnableSlice* value, PinnableWideColumns* columns,
-    Status* s, bool* is_blob_index, bool* value_found) {
+    bool resolve_direct_write_value, const BlobFetcher& blob_fetcher,
+    PinnableSlice* value, PinnableWideColumns* columns, Status* s,
+    bool* is_blob_index, bool* value_found) {
   if (!s->ok() || !resolve_direct_write_value || (!value && !columns)) {
     return false;
   }
@@ -3169,15 +3167,14 @@ bool DBImpl::MaybeResolveDirectWriteValue(
   }
 
   if (needs_plain_value_resolution) {
-    *s = ResolveDirectWritePlainValue(read_options, key, current, cfd, value,
-                                      columns);
+    *s = ResolveDirectWritePlainValue(key, blob_fetcher, value, columns);
     assert(is_blob_index != nullptr);
     *is_blob_index = false;
     return true;
   }
 
   assert(columns != nullptr);
-  *s = ResolveDirectWriteWideColumns(read_options, key, current, cfd, columns);
+  *s = ResolveDirectWriteWideColumns(key, blob_fetcher, columns);
 
   if (is_blob_index != nullptr) {
     *is_blob_index = false;
@@ -3189,15 +3186,16 @@ bool DBImpl::MaybeResolveDirectWriteValue(
 void DBImpl::PostprocessDirectWriteValueRead(
     const ReadOptions& read_options, const Slice& key,
     const std::string* timestamp, bool resolve_direct_write_value,
-    const Version* current, ColumnFamilyData* cfd, PinnableSlice* value,
+    const BlobFetcher* blob_fetcher, PinnableSlice* value,
     PinnableWideColumns* columns, Status* s, bool* is_blob_index,
     bool* value_found) {
   if (resolve_direct_write_value) {
+    assert(blob_fetcher != nullptr);
     std::string blob_lookup_key_storage;
     const bool value_resolved = MaybeResolveDirectWriteValue(
         read_options,
         GetBlobLookupUserKey(key, timestamp, &blob_lookup_key_storage),
-        resolve_direct_write_value, current, cfd, value, columns, s,
+        resolve_direct_write_value, *blob_fetcher, value, columns, s,
         is_blob_index, value_found);
     if (!value_resolved && value != nullptr) {
       value->PinSelf();

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -3114,39 +3114,34 @@ class DBImpl : public DB {
   // Resolves a plain value whose current payload is an encoded direct-write
   // blob index, either through `value` directly or through the default-column
   // view layered on `columns`.
-  static Status ResolveDirectWritePlainValue(const ReadOptions& read_options,
-                                             const Slice& key,
-                                             const Version* current,
-                                             ColumnFamilyData* cfd,
+  static Status ResolveDirectWritePlainValue(const Slice& key,
+                                             const BlobFetcher& blob_fetcher,
                                              PinnableSlice* value,
                                              PinnableWideColumns* columns);
   // Resolves each unresolved direct-write blob-valued column in `columns` and
   // rebuilds the serialized wide-column entity in place.
-  static Status ResolveDirectWriteWideColumns(const ReadOptions& read_options,
-                                              const Slice& key,
-                                              const Version* current,
-                                              ColumnFamilyData* cfd,
+  static Status ResolveDirectWriteWideColumns(const Slice& key,
+                                              const BlobFetcher& blob_fetcher,
                                               PinnableWideColumns* columns);
   // Dispatches between plain-value and wide-column direct-write resolution for
   // read results observed before flush makes the corresponding blob file
   // visible through normal Version metadata.
   static bool MaybeResolveDirectWriteValue(
       const ReadOptions& read_options, const Slice& key,
-      bool resolve_direct_write_value, const Version* current,
-      ColumnFamilyData* cfd, PinnableSlice* value, PinnableWideColumns* columns,
-      Status* s, bool* is_blob_index, bool* value_found = nullptr);
+      bool resolve_direct_write_value, const BlobFetcher& blob_fetcher,
+      PinnableSlice* value, PinnableWideColumns* columns, Status* s,
+      bool* is_blob_index, bool* value_found = nullptr);
   // Completes primary memtable hits that can still carry direct-write blob
   // references before the blob file is visible in Version metadata.
   static void PostprocessDirectWriteValueRead(
       const ReadOptions& read_options, const Slice& key,
       const std::string* timestamp, bool resolve_direct_write_value,
-      const Version* current, ColumnFamilyData* cfd, PinnableSlice* value,
+      const BlobFetcher* blob_fetcher, PinnableSlice* value,
       PinnableWideColumns* columns, Status* s, bool* is_blob_index,
       bool* value_found = nullptr);
   // Resolves memtable read results that still carry blob references through
   // either a raw blob-index payload in `value` or unresolved blob columns in
-  // `columns`. Unlike the direct-write helper above, this path only depends on
-  // a BlobFetcher and therefore works for read-only/secondary DBs. Sets
+  // `columns`. This generic path is also used by read-only/secondary DBs. Sets
   // *did_resolve to true iff there was a reference to resolve -- in which case
   // this function has finalized `value`/`columns` (populated on success,
   // cleared on error) -- and false iff there was nothing to resolve (the caller

--- a/db/db_impl/db_impl_sync_and_async.h
+++ b/db/db_impl/db_impl_sync_and_async.h
@@ -249,8 +249,9 @@ DEFINE_SYNC_AND_ASYNC(Status, DBImpl::GetImpl)
         done = true;
         PostprocessDirectWriteValueRead(
             read_options, key, timestamp, resolve_direct_write_value,
-            sv->current, cfd, get_impl_options.value, get_impl_options.columns,
-            &s, &is_blob_index, get_impl_options.value_found);
+            memtable_blob_fetcher_ptr, get_impl_options.value,
+            get_impl_options.columns, &s, &is_blob_index,
+            get_impl_options.value_found);
 
         RecordTick(stats_, MEMTABLE_HIT);
       } else if ((s.ok() || s.IsMergeInProgress()) &&
@@ -265,8 +266,9 @@ DEFINE_SYNC_AND_ASYNC(Status, DBImpl::GetImpl)
         done = true;
         PostprocessDirectWriteValueRead(
             read_options, key, timestamp, resolve_direct_write_value,
-            sv->current, cfd, get_impl_options.value, get_impl_options.columns,
-            &s, &is_blob_index, get_impl_options.value_found);
+            memtable_blob_fetcher_ptr, get_impl_options.value,
+            get_impl_options.columns, &s, &is_blob_index,
+            get_impl_options.value_found);
 
         RecordTick(stats_, MEMTABLE_HIT);
       }
@@ -308,12 +310,13 @@ DEFINE_SYNC_AND_ASYNC(Status, DBImpl::GetImpl)
         get_impl_options.get_value ? is_blob_ptr : nullptr,
         get_impl_options.get_value);
     if (get_impl_options.get_value && resolve_direct_write_value) {
+      assert(memtable_blob_fetcher_ptr != nullptr);
       std::string blob_lookup_key_storage;
       MaybeResolveDirectWriteValue(
           read_options,
           GetBlobLookupUserKey(key, timestamp, &blob_lookup_key_storage),
-          resolve_direct_write_value, sv->current, cfd, get_impl_options.value,
-          get_impl_options.columns, &s, &is_blob_index,
+          resolve_direct_write_value, *memtable_blob_fetcher_ptr,
+          get_impl_options.value, get_impl_options.columns, &s, &is_blob_index,
           get_impl_options.value_found);
     }
     RecordTick(stats_, MEMTABLE_MISS);
@@ -573,12 +576,13 @@ DEFINE_SYNC_AND_ASYNC(Status, DBImpl::MultiGetImpl)
         key->is_blob_index = false;
         *key->s = Status::Aborted();
       } else {
+        assert(memtable_blob_fetcher_ptr != nullptr);
         std::string blob_lookup_key_storage;
         MaybeResolveDirectWriteValue(
             read_options,
             GetBlobLookupUserKey(*key->key, key->timestamp,
                                  &blob_lookup_key_storage),
-            /*resolve_direct_write_value=*/true, super_version->current, cfd,
+            /*resolve_direct_write_value=*/true, *memtable_blob_fetcher_ptr,
             key->value, key->columns, key->s, &key->is_blob_index);
       }
     }

--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -79,8 +79,8 @@ DBIter::DBIter(Env* _env, const ReadOptions& read_options,
       merge_operator_(ioptions.merge_operator.get()),
       iter_(iter),
       // Enable the direct-write blob fallback only when this CF has a
-      // write-path partition manager; otherwise the fetcher stays on the plain
-      // Version::GetBlob fast path.
+      // write-path partition manager; otherwise the fetcher stays on the
+      // version-backed path.
       blob_state_(version, read_options, cfd ? cfd->blob_file_cache() : nullptr,
                   cfd != nullptr && cfd->blob_partition_manager() != nullptr),
       read_callback_(read_callback),

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -2771,23 +2771,6 @@ Version::Version(ColumnFamilyData* column_family_data, VersionSet* vset,
 }
 
 Status Version::GetBlob(const ReadOptions& read_options, const Slice& user_key,
-                        const Slice& blob_index_slice,
-                        FilePrefetchBuffer* prefetch_buffer,
-                        PinnableSlice* value, uint64_t* bytes_read) const {
-  BlobIndex blob_index;
-
-  {
-    Status s = blob_index.DecodeFrom(blob_index_slice);
-    if (!s.ok()) {
-      return s;
-    }
-  }
-
-  return GetBlob(read_options, user_key, blob_index, prefetch_buffer, value,
-                 bytes_read);
-}
-
-Status Version::GetBlob(const ReadOptions& read_options, const Slice& user_key,
                         const BlobIndex& blob_index,
                         FilePrefetchBuffer* prefetch_buffer,
                         PinnableSlice* value, uint64_t* bytes_read) const {

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -975,15 +975,6 @@ class Version {
                          MultiGetRange* range,
                          ReadCallback* callback = nullptr);
 
-  // Interprets blob_index_slice as a blob reference, and (assuming the
-  // corresponding blob file is part of this Version) retrieves the blob and
-  // saves it in *value.
-  // REQUIRES: blob_index_slice stores an encoded blob reference
-  Status GetBlob(const ReadOptions& read_options, const Slice& user_key,
-                 const Slice& blob_index_slice,
-                 FilePrefetchBuffer* prefetch_buffer, PinnableSlice* value,
-                 uint64_t* bytes_read) const;
-
   // Retrieves a blob using a blob reference and saves it in *value,
   // assuming the corresponding blob file is part of this Version.
   Status GetBlob(const ReadOptions& read_options, const Slice& user_key,

--- a/db/version_set_sync_and_async.h
+++ b/db/version_set_sync_and_async.h
@@ -143,8 +143,9 @@ DEFINE_SYNC_AND_ASYNC(void, Version::Get)
 
           constexpr uint64_t* bytes_read = nullptr;
 
-          *status = GetBlob(read_options, get_context.ukey_to_get_blob_value(),
-                            blob_index, prefetch_buffer, &result, bytes_read);
+          *status = blob_fetcher.FetchBlob(get_context.ukey_to_get_blob_value(),
+                                           blob_index, prefetch_buffer, &result,
+                                           bytes_read);
           if (!status->ok()) {
             if (status->IsIncomplete()) {
               get_context.MarkKeyMayExist();

--- a/db/wide/read_path_blob_resolver.h
+++ b/db/wide/read_path_blob_resolver.h
@@ -25,9 +25,9 @@ class Version;
 // TODO: ReadPathBlobResolver and CompactionBlobResolver (in
 // compaction_iterator.h) share significant logic for blob column resolution
 // and caching. A refactoring into a common base class or shared utility
-// could reduce duplication. The two classes differ in their blob-fetching
-// backends (Version::GetBlob vs BlobFetcher::FetchBlob) and contexts
-// (read path vs compaction path with stats tracking).
+// could reduce duplication. The two classes differ in fetcher ownership and
+// their surrounding contexts (read path vs compaction path with stats
+// tracking).
 //
 // Enables lazy (on-demand) resolution of blob column values in the read path.
 // When a wide-column entity contains blob references (V2 format), the resolver

--- a/docs/components/read_flow/01_point_lookup.md
+++ b/docs/components/read_flow/01_point_lookup.md
@@ -63,7 +63,7 @@ When integrated BlobDB is enabled, values exceeding `min_blob_size` (see `Advanc
 
 **Phase 1 -- During SST scan (lazy):** When `GetContext::SaveValue()` encounters `kTypeBlobIndex` in the common case (`kNotFound` state), it stores the raw blob index bytes in `pinnable_val_` and sets `is_blob_index = true`. The blob is NOT fetched yet. However, in the merge case (`kMerge` state), the blob IS fetched eagerly via `GetContext::GetBlobValue()` because the merge operator needs the actual value as a base.
 
-**Phase 2 -- Post-scan resolution:** After the SST scan completes with `kFound` state, `Version::Get()` checks `is_blob_index`. If true, it calls `Version::GetBlob()` which decodes the `BlobIndex` (containing file number, offset, size, and compression type), validates the blob file exists, and calls `BlobSource::GetBlob()`. The blob source checks the blob cache first, and on miss reads from the blob file.
+**Phase 2 -- Post-scan resolution:** After the SST scan completes with `kFound` state, `Version::Get()` checks `is_blob_index`. If true, it resolves the encoded index through its `VersionBlobFetcher`. The fetcher decodes the `BlobIndex` (containing file number, offset, size, and compression type) and delegates manifest-visible blobs to `Version::GetBlob()`, which validates that the blob file exists and calls `BlobSource::GetBlob()`. The blob source checks the blob cache first, and on miss reads from the blob file.
 
 This lazy two-phase design avoids reading blob data for keys that would be filtered out by tombstones or superseded by newer versions.
 


### PR DESCRIPTION
Summary:
`BlobFetcher` is the policy boundary for single-blob reads, but
`Version::Get()` and primary direct-write postprocessing still called
lower-level backends directly. This duplicated backend selection and could
bypass future fetcher policy or decorators.

Route those paths through their existing `VersionBlobFetcher` and remove the
redundant Slice-based `Version::GetBlob()` overload. This is behavior-preserving:
each fetcher delegates to the same Version or direct-write backend with the same
`ReadOptions`, cache, and lifetime context.

Differential Revision: D114616978


