### PR TITLE
Add db_stress coverage for WriteBufferManager flush policies (#15048)

### DIFF
--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -834,6 +834,9 @@ void ColumnFamilyData::SetDropped() {
   // can't drop default CF
   assert(id_ != 0);
   dropped_ = true;
+  if (mem_ != nullptr) {
+    mem_->StopWBMTracking();
+  }
   write_controller_token_.reset();
 
   // remove from column_family_set
@@ -1246,7 +1249,10 @@ uint64_t ColumnFamilyData::GetLiveSstFilesSize() const {
 MemTable* ColumnFamilyData::ConstructNewMemtable(
     const MutableCFOptions& mutable_cf_options, SequenceNumber earliest_seq) {
   return new MemTable(internal_comparator_, ioptions_, mutable_cf_options,
-                      write_buffer_manager_, earliest_seq, id_);
+                      write_buffer_manager_, earliest_seq, id_,
+                      column_family_set_ != nullptr
+                          ? column_family_set_->flush_initiator()
+                          : nullptr);
 }
 
 void ColumnFamilyData::CreateNewMemtable(SequenceNumber earliest_seq) {
@@ -1899,6 +1905,34 @@ size_t ColumnFamilySet::NumberOfColumnFamilies() const {
   return column_families_.size();
 }
 
+void ColumnFamilySet::RefreshLargestMutableCFMem() {
+  if (flush_initiator_ == nullptr || flush_initiator_->UsesTotalMutableMem()) {
+    return;
+  }
+
+  constexpr int kMaxRefreshAttempts = 3;
+  for (int attempt = 0; attempt < kMaxRefreshAttempts; ++attempt) {
+    const uint64_t update_seq =
+        flush_initiator_->GetLargestMutableCFUpdateSequence();
+    size_t largest = 0;
+    for (auto cfd : *this) {
+      if (!cfd->IsDropped() && cfd->initialized() && !cfd->mem()->IsEmpty()) {
+        largest = std::max(largest, cfd->mem()->WBMTrackedMemoryUsage());
+      }
+    }
+    if (flush_initiator_->TrySetLargestMutableCFMem(largest, update_seq)) {
+      if (write_buffer_manager_ != nullptr) {
+        write_buffer_manager_->NotifyFlushInitiatorChanged();
+      }
+      return;
+    }
+  }
+  flush_initiator_->InvalidateLargestMutableCFMem();
+  if (write_buffer_manager_ != nullptr) {
+    write_buffer_manager_->NotifyFlushInitiatorChanged();
+  }
+}
+
 // under a DB mutex AND write thread
 ColumnFamilyData* ColumnFamilySet::CreateColumnFamily(
     const std::string& name, uint32_t id, Version* dummy_versions,
@@ -1939,6 +1973,7 @@ void ColumnFamilySet::RemoveColumnFamily(ColumnFamilyData* cfd) {
   column_families_.erase(cfd->GetName());
   running_ts_sz_.erase(cf_id);
   ts_sz_for_record_.erase(cf_id);
+  RefreshLargestMutableCFMem();
 }
 
 // under a DB mutex OR from a write thread

--- a/db/column_family.h
+++ b/db/column_family.h
@@ -52,6 +52,7 @@ struct SuperVersionContext;
 class BlobFileCache;
 class BlobFilePartitionManager;
 class BlobSource;
+class FlushInitiator;
 
 extern const double kIncSlowdownRatio;
 // This file contains a list of data structures for managing column family
@@ -871,6 +872,14 @@ class ColumnFamilySet {
 
   WriteBufferManager* write_buffer_manager() { return write_buffer_manager_; }
 
+  void SetFlushInitiator(FlushInitiator* flush_initiator) {
+    flush_initiator_ = flush_initiator;
+  }
+
+  FlushInitiator* flush_initiator() const { return flush_initiator_; }
+
+  void RefreshLargestMutableCFMem();
+
   WriteController* write_controller() { return write_controller_; }
 
  private:
@@ -912,6 +921,7 @@ class ColumnFamilySet {
   const ImmutableDBOptions* const db_options_;
   Cache* table_cache_;
   WriteBufferManager* write_buffer_manager_;
+  FlushInitiator* flush_initiator_ = nullptr;
   WriteController* write_controller_;
   BlockCacheTracer* const block_cache_tracer_;
   std::shared_ptr<IOTracer> io_tracer_;

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -300,6 +300,8 @@ DBImpl::DBImpl(const DBOptions& options, const std::string& dbname,
                             std::memory_order_relaxed);
   if (write_buffer_manager_) {
     wbm_stall_.reset(new WBMStallInterface());
+    wbm_flush_initiator_.reset(new WBMFlushInitiator(this));
+    write_buffer_manager_->RegisterFlushInitiator(wbm_flush_initiator_.get());
   }
 }
 
@@ -506,7 +508,8 @@ Status DBImpl::ResumeImpl(DBRecoverContext context,
 void DBImpl::WaitForBackgroundWork() {
   // Wait for background work to finish
   while (bg_bottom_compaction_scheduled_ || bg_compaction_scheduled_ ||
-         bg_flush_scheduled_ || bg_pressure_callback_in_progress_) {
+         bg_flush_scheduled_ || bg_wbm_flush_scheduled_ ||
+         bg_pressure_callback_in_progress_) {
     bg_cv_.Wait();
   }
 }
@@ -807,6 +810,15 @@ Status DBImpl::CloseHelper() {
   }
   mutex_.Unlock();
 
+  // Deregister from the shared WriteBufferManager before any teardown so no
+  // cross-DB flush selection can query this DB's (soon-to-be-destroyed) column
+  // families. Done without holding mutex_ to respect the registry -> mutex_
+  // lock order. Deregister waits for any in-flight selection; already-scheduled
+  // cross-DB flush jobs are drained below via bg_wbm_flush_scheduled_.
+  if (write_buffer_manager_ && wbm_flush_initiator_) {
+    write_buffer_manager_->DeregisterFlushInitiator(wbm_flush_initiator_.get());
+  }
+
   // Below check is added as recovery_error_ is not checked and it causes crash
   // in DBSSTTest.DBWithMaxSpaceAllowedWithBlobFiles when space limit is
   // reached.
@@ -833,7 +845,7 @@ Status DBImpl::CloseHelper() {
 
   // Wait for background work to finish
   while (bg_bottom_compaction_scheduled_ || bg_compaction_scheduled_ ||
-         bg_flush_scheduled_ || bg_purge_scheduled_ ||
+         bg_flush_scheduled_ || bg_wbm_flush_scheduled_ || bg_purge_scheduled_ ||
          bg_pressure_callback_in_progress_ ||
          bg_async_file_open_state_ == AsyncFileOpenState::kScheduled ||
          async_wal_precreate_state_ == AsyncWALPrecreateState::kScheduled ||

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -273,6 +273,11 @@ DBImpl::DBImpl(const DBOptions& options, const std::string& dbname,
   SetDbSessionId();
   assert(!db_session_id_.empty());
 
+  if (write_buffer_manager_ != nullptr && !read_only_) {
+    wbm_flush_initiator_ = std::make_unique<WBMFlushInitiator>(
+        this, immutable_db_options_.atomic_flush);
+  }
+
   periodic_task_functions_.emplace(PeriodicTaskType::kDumpStats,
                                    [this]() { this->DumpStats(); });
   periodic_task_functions_.emplace(PeriodicTaskType::kPersistStats,
@@ -291,6 +296,8 @@ DBImpl::DBImpl(const DBOptions& options, const std::string& dbname,
       table_cache_.get(), write_buffer_manager_, &write_controller_,
       &block_cache_tracer_, io_tracer_, db_id_, db_session_id_,
       options.daily_offpeak_time_utc, &error_handler_, read_only));
+  versions_->GetColumnFamilySet()->SetFlushInitiator(
+      wbm_flush_initiator_.get());
   column_family_memtables_.reset(
       new ColumnFamilyMemTablesImpl(versions_->GetColumnFamilySet()));
 
@@ -525,7 +532,8 @@ Status DBImpl::ResumeImpl(DBRecoverContext context,
 void DBImpl::WaitForBackgroundWork() {
   // Wait for background work to finish
   while (bg_bottom_compaction_scheduled_ || bg_compaction_scheduled_ ||
-         bg_flush_scheduled_ || bg_pressure_callback_in_progress_) {
+         bg_flush_scheduled_ || bg_wbm_flush_scheduled_ ||
+         bg_pressure_callback_in_progress_) {
     bg_cv_.Wait();
   }
 }
@@ -816,6 +824,19 @@ Status DBImpl::MaybeWriteWalMarkersToManifestOnClose() {
                                 /*new_descriptor_log=*/false);
 }
 
+void DBImpl::MaybeRegisterFlushInitiator() {
+  // Register only fully opened read-write DBs. Do not hold mutex_: the lock
+  // order is registry mutex before DB mutex.
+  if (write_buffer_manager_ == nullptr || read_only_ || !opened_successfully_) {
+    return;
+  }
+  assert(wbm_flush_initiator_ != nullptr);
+  if (wbm_flush_initiator_ == nullptr || wbm_flush_initiator_->IsRegistered()) {
+    return;
+  }
+  write_buffer_manager_->RegisterFlushInitiator(wbm_flush_initiator_.get());
+}
+
 Status DBImpl::CloseHelper() {
   // Guarantee that there is no background error recovery in progress before
   // continuing with the shutdown
@@ -826,6 +847,13 @@ Status DBImpl::CloseHelper() {
     bg_cv_.Wait();
   }
   mutex_.Unlock();
+
+  // Deregister before teardown and without mutex_ to preserve registry-to-DB
+  // lock ordering.
+  if (write_buffer_manager_ && wbm_flush_initiator_ &&
+      wbm_flush_initiator_->IsRegistered()) {
+    write_buffer_manager_->DeregisterFlushInitiator(wbm_flush_initiator_.get());
+  }
 
   // Below check is added as recovery_error_ is not checked and it causes crash
   // in DBSSTTest.DBWithMaxSpaceAllowedWithBlobFiles when space limit is
@@ -853,8 +881,8 @@ Status DBImpl::CloseHelper() {
 
   // Wait for background work to finish
   while (bg_bottom_compaction_scheduled_ || bg_compaction_scheduled_ ||
-         bg_flush_scheduled_ || bg_purge_scheduled_ ||
-         bg_pressure_callback_in_progress_ ||
+         bg_flush_scheduled_ || bg_wbm_flush_scheduled_ ||
+         bg_purge_scheduled_ || bg_pressure_callback_in_progress_ ||
          bg_async_file_open_state_ == AsyncFileOpenState::kScheduled ||
          async_wal_precreate_state_ == AsyncWALPrecreateState::kScheduled ||
          pending_purge_obsolete_files_ ||

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1443,6 +1443,23 @@ class DBImpl : public DB {
     State state_;
   };
 
+  // Adapter that lets a WriteBufferManager shared across DBs (under the
+  // kFlushLargestAcrossDBs policy) query this DB's memtable memory and initiate
+  // a flush on it. Owned by DBImpl; forwards to DBImpl methods.
+  class WBMFlushInitiator : public FlushInitiator {
+   public:
+    explicit WBMFlushInitiator(DBImpl* db) : db_(db) {}
+
+    size_t GetFlushableMemUsage() override {
+      return db_->GetFlushableMemUsage();
+    }
+
+    void ScheduleFlush() override { db_->ScheduleWriteBufferManagerFlush(); }
+
+   private:
+    DBImpl* const db_;
+  };
+
   static void TEST_ResetDbSessionIdGen();
   static std::string GenerateDbSessionId(Env* env);
 
@@ -2634,6 +2651,23 @@ class DBImpl : public DB {
   // REQUIRES: mutex locked and in write thread.
   Status HandleWriteBufferManagerFlush(WriteContext* write_context);
 
+  // Support for the kFlushLargestAcrossDBs WriteBufferManager policy. These are
+  // invoked by the shared WriteBufferManager (via WBMFlushInitiator) so it can
+  // pick the highest-memory DB and flush it, possibly from another DB's thread.
+
+  // Sum of the flushable mutable memtable memory across this DB's column
+  // families. Returns 0 for DBs that cannot participate (read-only, not yet
+  // opened, or atomic_flush). Acquires mutex_ internally.
+  size_t GetFlushableMemUsage();
+
+  // Schedules a background job that flushes this DB's largest flushable column
+  // family without waiting. Safe to call from another DB's thread.
+  void ScheduleWriteBufferManagerFlush();
+
+  static void BGWorkWBMFlush(void* arg);
+  static void UnscheduleWBMFlushCallback(void* arg);
+  void BackgroundCallWBMFlush();
+
   // REQUIRES: mutex locked
   Status PreprocessWrite(const WriteOptions& write_options,
                          WalContext* log_context, WriteContext* write_context);
@@ -3475,6 +3509,11 @@ class DBImpl : public DB {
   // number of background memtable flush jobs, submitted to the HIGH pool
   int bg_flush_scheduled_ = 0;
 
+  // number of outstanding background jobs scheduled by a shared
+  // WriteBufferManager (kFlushLargestAcrossDBs) to flush this DB's largest CF.
+  // Tracked so DB shutdown drains them just like bg_flush_scheduled_.
+  int bg_wbm_flush_scheduled_ = 0;
+
   // stores the number of flushes are currently running
   int num_running_flushes_ = 0;
 
@@ -3661,6 +3700,10 @@ class DBImpl : public DB {
 
   // Pointer to WriteBufferManager stalling interface.
   std::unique_ptr<StallInterface> wbm_stall_;
+
+  // Registered with the WriteBufferManager for the kFlushLargestAcrossDBs
+  // policy so a shared WBM can flush this DB when it holds the most memory.
+  std::unique_ptr<FlushInitiator> wbm_flush_initiator_;
 
   // seqno_to_time_mapping_ stores the sequence number to time mapping, it's not
   // thread safe, both read and write need db mutex hold.

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1314,7 +1314,10 @@ class DBImpl : public DB
   // finishes. For example in CompactRange.
   Status TEST_AtomicFlushMemTables(
       const autovector<ColumnFamilyData*>& provided_candidate_cfds,
-      const FlushOptions& flush_opts);
+      const FlushOptions& flush_opts, bool non_blocking_write_thread = false);
+
+  void TEST_BeginWriteStall();
+  void TEST_EndWriteStall();
 
   // Wait for background threads to complete scheduled work.
   Status TEST_WaitForBackgroundWork();
@@ -1527,6 +1530,20 @@ class DBImpl : public DB
     State state_;
   };
 
+  // Adapts DBImpl to the shared WriteBufferManager flush registry.
+  class WBMFlushInitiator : public FlushInitiator {
+   public:
+    WBMFlushInitiator(DBImpl* db, bool atomic_flush)
+        : FlushInitiator(atomic_flush), db_(db) {}
+
+    bool ScheduleFlush() override {
+      return db_->ScheduleWriteBufferManagerFlush();
+    }
+
+   private:
+    DBImpl* const db_;
+  };
+
   static void TEST_ResetDbSessionIdGen();
   static std::string GenerateDbSessionId(Env* env);
 
@@ -1544,6 +1561,9 @@ class DBImpl : public DB
   // db_session_id_ is an identifier that gets reset
   // every time the DB is opened
   std::string db_session_id_;
+  // Declared before versions_ so memtables cannot outlive their allocation
+  // accounting target during destruction.
+  std::unique_ptr<FlushInitiator> wbm_flush_initiator_;
   std::unique_ptr<VersionSet> versions_;
   // Flag to check whether we allocated and own the info log file
   bool own_info_log_;
@@ -2635,6 +2655,19 @@ class DBImpl : public DB
       const autovector<ColumnFamilyData*>& provided_candidate_cfds = {},
       bool entered_write_thread = false);
 
+  enum class WriteThreadJoinMode { kBlocking, kNonBlocking };
+
+  Status FlushMemTableImpl(ColumnFamilyData* cfd, const FlushOptions& options,
+                           FlushReason flush_reason, bool entered_write_thread,
+                           WriteThreadJoinMode join_mode,
+                           bool* switched_memtable);
+
+  Status AtomicFlushMemTablesImpl(
+      const FlushOptions& options, FlushReason flush_reason,
+      const autovector<ColumnFamilyData*>& provided_candidate_cfds,
+      bool entered_write_thread, WriteThreadJoinMode join_mode,
+      bool* switched_memtable);
+
   // REQUIRES: mutex locked and write queues drained up to the recovery flush
   // fence that is about to switch memtables.
   void MaybeSyncLastSequenceWithAllocatedForRecovery(FlushReason flush_reason);
@@ -2721,6 +2754,15 @@ class DBImpl : public DB
     return static_cast<uint8_t*>(static_cast<void*>(this)) + type;
   }
 
+  // Checks DB-local write queues; manager-wide stall state would reject healthy
+  // DBs. REQUIRES: mutex_ held.
+  bool WouldBlockJoiningWriteThread() {
+    mutex_.AssertHeld();
+    return write_thread_.GetBegunCountOfOutstandingStall() != 0 ||
+           (two_write_queues_ &&
+            nonmem_write_thread_.GetBegunCountOfOutstandingStall() != 0);
+  }
+
   // REQUIRES: mutex locked and in write thread.
   void AssignAtomicFlushSeq(const autovector<ColumnFamilyData*>& cfds);
 
@@ -2729,6 +2771,31 @@ class DBImpl : public DB
 
   // REQUIRES: mutex locked and in write thread.
   Status HandleWriteBufferManagerFlush(WriteContext* write_context);
+
+  // Column families and memory eligible for a WriteBufferManager flush.
+  struct FlushableCFs {
+    ColumnFamilyData* largest = nullptr;  // most mutable memtable memory
+    ColumnFamilyData* oldest = nullptr;   // smallest memtable creation seq
+    size_t largest_mem = 0;
+    size_t total_mem = 0;
+  };
+
+  // Shared selection for bidding and flushing. REQUIRES: mutex_ held.
+  FlushableCFs CollectFlushableCFs();
+
+  // Registers an opened read-write DB without holding mutex_.
+  void MaybeRegisterFlushInitiator();
+
+  // Refreshes the published maximum after mutable memtables change.
+  // REQUIRES: mutex_ held and pending memtable writes drained.
+  void RefreshLargestMutableCFMem();
+
+  // Queues one WBM flush; false makes the requesting DB flush locally.
+  bool ScheduleWriteBufferManagerFlush();
+
+  static void BGWorkWBMFlush(void* arg);
+  static void UnscheduleWBMFlushCallback(void* arg);
+  void BackgroundCallWBMFlush();
 
   // REQUIRES: mutex locked
   Status PreprocessWrite(const WriteOptions& write_options,
@@ -3614,6 +3681,16 @@ class DBImpl : public DB
 
   // number of background memtable flush jobs, submitted to the HIGH pool
   int bg_flush_scheduled_ = 0;
+
+  // LOW avoids consuming a flush worker while joining the target write thread.
+  static constexpr Env::Priority kWBMFlushPriority = Env::Priority::LOW;
+
+  // Outstanding cross-DB WBM flush jobs, drained during shutdown.
+  int bg_wbm_flush_scheduled_ = 0;
+
+  // A handoff that could not switch a memtable makes the next requester flush
+  // locally. Protected by mutex_.
+  bool wbm_flush_needs_local_fallback_ = false;
 
   // stores the number of flushes are currently running
   int num_running_flushes_ = 0;

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -3775,6 +3775,102 @@ void DBImpl::UnscheduleFlushCallback(void* arg) {
   TEST_SYNC_POINT("DBImpl::UnscheduleFlushCallback");
 }
 
+size_t DBImpl::GetFlushableMemUsage() {
+  InstrumentedMutexLock l(&mutex_);
+  // DBs that cannot honor a cross-DB flush request must not be selected.
+  if (!opened_successfully_ || read_only_ ||
+      immutable_db_options_.atomic_flush) {
+    return 0;
+  }
+  size_t total = 0;
+  for (auto cfd : *versions_->GetColumnFamilySet()) {
+    if (!cfd->IsDropped() && !cfd->mem()->IsEmpty() &&
+        !cfd->imm()->IsFlushPendingOrRunning()) {
+      total += cfd->mem()->ApproximateMemoryUsageFast();
+    }
+  }
+  return total;
+}
+
+void DBImpl::ScheduleWriteBufferManagerFlush() {
+  InstrumentedMutexLock l(&mutex_);
+  if (shutdown_initiated_.load(std::memory_order_acquire) ||
+      shutting_down_.load(std::memory_order_acquire) ||
+      reject_new_background_jobs_ || !opened_successfully_ || read_only_ ||
+      immutable_db_options_.atomic_flush) {
+    return;
+  }
+  // Coalesce: keep at most one outstanding WBM-driven flush job per DB.
+  if (bg_wbm_flush_scheduled_ > 0) {
+    return;
+  }
+  ++bg_wbm_flush_scheduled_;
+  env_->Schedule(&DBImpl::BGWorkWBMFlush, this, Env::Priority::HIGH,
+                 this /* tag */, &DBImpl::UnscheduleWBMFlushCallback);
+}
+
+void DBImpl::BGWorkWBMFlush(void* arg) {
+  IOSTATS_SET_THREAD_POOL_ID(Env::Priority::HIGH);
+  TEST_SYNC_POINT("DBImpl::BGWorkWBMFlush");
+  static_cast<DBImpl*>(arg)->BackgroundCallWBMFlush();
+  TEST_SYNC_POINT("DBImpl::BGWorkWBMFlush:done");
+}
+
+void DBImpl::UnscheduleWBMFlushCallback(void* arg) {
+  // Invoked by the thread pool (with mutex_ held by CloseHelper's UnSchedule)
+  // when a still-queued task is cancelled. Mirror UnscheduleFlushCallback: only
+  // decrement the counter here; do not re-lock mutex_.
+  static_cast<DBImpl*>(arg)->bg_wbm_flush_scheduled_--;
+  TEST_SYNC_POINT("DBImpl::UnscheduleWBMFlushCallback");
+}
+
+void DBImpl::BackgroundCallWBMFlush() {
+  ColumnFamilyData* cfd_to_flush = nullptr;
+  {
+    InstrumentedMutexLock l(&mutex_);
+    if (!shutting_down_.load(std::memory_order_acquire) &&
+        !reject_new_background_jobs_ && opened_successfully_ && !read_only_ &&
+        !immutable_db_options_.atomic_flush) {
+      size_t max_mem = 0;
+      for (auto cfd : *versions_->GetColumnFamilySet()) {
+        if (!cfd->IsDropped() && !cfd->mem()->IsEmpty() &&
+            !cfd->imm()->IsFlushPendingOrRunning()) {
+          size_t mem = cfd->mem()->ApproximateMemoryUsageFast();
+          if (cfd_to_flush == nullptr || mem > max_mem) {
+            cfd_to_flush = cfd;
+            max_mem = mem;
+          }
+        }
+      }
+      if (cfd_to_flush != nullptr) {
+        cfd_to_flush->Ref();
+      }
+    }
+  }
+
+  if (cfd_to_flush != nullptr) {
+    FlushOptions flush_options;
+    flush_options.wait = false;
+    flush_options.allow_write_stall = true;
+    // FlushMemTable self-acquires mutex_ and enters the write thread, then
+    // schedules a bg_flush_scheduled_-tracked flush. bg_wbm_flush_scheduled_
+    // stays > 0 across this call, so shutdown cannot tear down the DB in the
+    // window before that flush becomes tracked.
+    Status s =
+        FlushMemTable(cfd_to_flush, flush_options,
+                      FlushReason::kWriteBufferManager,
+                      false /* entered_write_thread */);
+    s.PermitUncheckedError();
+  }
+
+  InstrumentedMutexLock l(&mutex_);
+  if (cfd_to_flush != nullptr) {
+    cfd_to_flush->UnrefAndTryDelete();
+  }
+  --bg_wbm_flush_scheduled_;
+  bg_cv_.SignalAll();
+}
+
 Status DBImpl::BackgroundFlush(bool* made_progress, JobContext* job_context,
                                LogBuffer* log_buffer, FlushReason* reason,
                                bool* flush_rescheduled_to_retain_udt,

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <cinttypes>
 #include <deque>
+#include <memory>
 #include <unordered_map>
 
 #include "db/blob/blob_file_partition_manager.h"
@@ -2033,7 +2034,7 @@ Status DBImpl::PauseBackgroundWork() {
   InstrumentedMutexLock guard_lock(&mutex_);
   bg_compaction_paused_++;
   while (bg_bottom_compaction_scheduled_ > 0 || bg_compaction_scheduled_ > 0 ||
-         bg_flush_scheduled_ > 0) {
+         bg_flush_scheduled_ > 0 || bg_wbm_flush_scheduled_ > 0) {
     bg_cv_.Wait();
   }
   bg_work_paused_++;
@@ -2728,6 +2729,20 @@ Status DBImpl::FlushMemTable(ColumnFamilyData* cfd,
                              const FlushOptions& flush_options,
                              FlushReason flush_reason,
                              bool entered_write_thread) {
+  return FlushMemTableImpl(cfd, flush_options, flush_reason,
+                           entered_write_thread, WriteThreadJoinMode::kBlocking,
+                           nullptr /* switched_memtable */);
+}
+
+Status DBImpl::FlushMemTableImpl(ColumnFamilyData* cfd,
+                                 const FlushOptions& flush_options,
+                                 FlushReason flush_reason,
+                                 bool entered_write_thread,
+                                 WriteThreadJoinMode join_mode,
+                                 bool* switched_memtable) {
+  if (switched_memtable != nullptr) {
+    *switched_memtable = false;
+  }
   // This method should not be called if atomic_flush is true.
   assert(!immutable_db_options_.atomic_flush);
   if (!flush_options.wait && write_controller_.IsStopped()) {
@@ -2763,10 +2778,39 @@ Status DBImpl::FlushMemTable(ColumnFamilyData* cfd,
     WriteThread::Writer w;
     WriteThread::Writer nonmem_w;
     if (needs_to_join_write_thread) {
-      write_thread_.EnterUnbatched(&w, &mutex_);
-      if (two_write_queues_) {
-        nonmem_write_thread_.EnterUnbatched(&nonmem_w, &mutex_);
+      if (join_mode == WriteThreadJoinMode::kNonBlocking) {
+        // Refuse stalls because this job may be needed to release their memory.
+        bool entered = write_thread_.EnterUnbatchedNonBlocking(&w, &mutex_);
+        if (entered && two_write_queues_) {
+          entered = nonmem_write_thread_.EnterUnbatchedNonBlocking(&nonmem_w,
+                                                                   &mutex_);
+          if (!entered) {
+            write_thread_.ExitUnbatched(&w);
+          }
+        }
+        if (!entered) {
+          s.PermitUncheckedOk();
+          return Status::Incomplete(
+              "Write stall in progress, unable to join the write thread to "
+              "switch memtables");
+        }
+      } else {
+        write_thread_.EnterUnbatched(&w, &mutex_);
+        if (two_write_queues_) {
+          nonmem_write_thread_.EnterUnbatched(&nonmem_w, &mutex_);
+        }
       }
+    }
+    if (cfd->IsDropped()) {
+      TEST_SYNC_POINT("DBImpl::FlushMemTableImpl:Dropped");
+      if (needs_to_join_write_thread) {
+        write_thread_.ExitUnbatched(&w);
+        if (two_write_queues_) {
+          nonmem_write_thread_.ExitUnbatched(&nonmem_w);
+        }
+      }
+      s.PermitUncheckedOk();
+      return Status::ColumnFamilyDropped();
     }
     WaitForPendingWrites();
 
@@ -2779,6 +2823,9 @@ Status DBImpl::FlushMemTable(ColumnFamilyData* cfd,
     if (!cfd->mem()->IsEmpty() || !cached_recoverable_state_empty_.load() ||
         IsRecoveryFlush(flush_reason)) {
       s = SwitchMemtable(cfd, &context);
+      if (s.ok() && switched_memtable != nullptr) {
+        *switched_memtable = true;
+      }
     }
     const uint64_t flush_memtable_id = std::numeric_limits<uint64_t>::max();
     if (s.ok()) {
@@ -2895,6 +2942,20 @@ Status DBImpl::AtomicFlushMemTables(
     const FlushOptions& flush_options, FlushReason flush_reason,
     const autovector<ColumnFamilyData*>& provided_candidate_cfds,
     bool entered_write_thread) {
+  return AtomicFlushMemTablesImpl(flush_options, flush_reason,
+                                  provided_candidate_cfds, entered_write_thread,
+                                  WriteThreadJoinMode::kBlocking,
+                                  nullptr /* switched_memtable */);
+}
+
+Status DBImpl::AtomicFlushMemTablesImpl(
+    const FlushOptions& flush_options, FlushReason flush_reason,
+    const autovector<ColumnFamilyData*>& provided_candidate_cfds,
+    bool entered_write_thread, WriteThreadJoinMode join_mode,
+    bool* switched_memtable) {
+  if (switched_memtable != nullptr) {
+    *switched_memtable = false;
+  }
   if (!flush_options.wait && write_controller_.IsStopped()) {
     std::ostringstream oss;
     oss << "Writes have been stopped, thus unable to perform manual flush. "
@@ -2925,32 +2986,30 @@ Status DBImpl::AtomicFlushMemTables(
     candidate_cfds = provided_candidate_cfds;
   }
 
+  const auto unref_generated_candidates = [&]() {
+    if (!provided_candidate_cfds.empty()) {
+      return;
+    }
+    for (auto candidate_cfd : candidate_cfds) {
+      candidate_cfd->UnrefAndTryDelete();
+    }
+    candidate_cfds.clear();
+  };
+
   if (!flush_options.allow_write_stall) {
     int num_cfs_to_flush = 0;
     for (auto cfd : candidate_cfds) {
       bool flush_needed = true;
       s = WaitUntilFlushWouldNotStallWrites(cfd, &flush_needed);
       if (!s.ok()) {
-        // Unref the newly generated candidate cfds (when not provided) in
-        // `candidate_cfds`
-        if (provided_candidate_cfds.empty()) {
-          for (auto candidate_cfd : candidate_cfds) {
-            candidate_cfd->UnrefAndTryDelete();
-          }
-        }
+        unref_generated_candidates();
         return s;
       } else if (flush_needed) {
         ++num_cfs_to_flush;
       }
     }
     if (0 == num_cfs_to_flush) {
-      // Unref the newly generated candidate cfds (when not provided) in
-      // `candidate_cfds`
-      if (provided_candidate_cfds.empty()) {
-        for (auto candidate_cfd : candidate_cfds) {
-          candidate_cfd->UnrefAndTryDelete();
-        }
-      }
+      unref_generated_candidates();
       return s;
     }
   }
@@ -2965,9 +3024,28 @@ Status DBImpl::AtomicFlushMemTables(
     WriteThread::Writer w;
     WriteThread::Writer nonmem_w;
     if (needs_to_join_write_thread) {
-      write_thread_.EnterUnbatched(&w, &mutex_);
-      if (two_write_queues_) {
-        nonmem_write_thread_.EnterUnbatched(&nonmem_w, &mutex_);
+      if (join_mode == WriteThreadJoinMode::kNonBlocking) {
+        // Refuse stalls because this job may be needed to release their memory.
+        bool entered = write_thread_.EnterUnbatchedNonBlocking(&w, &mutex_);
+        if (entered && two_write_queues_) {
+          entered = nonmem_write_thread_.EnterUnbatchedNonBlocking(&nonmem_w,
+                                                                   &mutex_);
+          if (!entered) {
+            write_thread_.ExitUnbatched(&w);
+          }
+        }
+        if (!entered) {
+          unref_generated_candidates();
+          s.PermitUncheckedOk();
+          return Status::Incomplete(
+              "Write stall in progress, unable to join the write thread to "
+              "switch memtables");
+        }
+      } else {
+        write_thread_.EnterUnbatched(&w, &mutex_);
+        if (two_write_queues_) {
+          nonmem_write_thread_.EnterUnbatched(&nonmem_w, &mutex_);
+        }
       }
     }
     WaitForPendingWrites();
@@ -2979,13 +3057,7 @@ Status DBImpl::AtomicFlushMemTables(
 
     SelectColumnFamiliesForAtomicFlush(&cfds, candidate_cfds, flush_reason);
 
-    // Unref the newly generated candidate cfds (when not provided) in
-    // `candidate_cfds`
-    if (provided_candidate_cfds.empty()) {
-      for (auto candidate_cfd : candidate_cfds) {
-        candidate_cfd->UnrefAndTryDelete();
-      }
-    }
+    unref_generated_candidates();
 
     for (auto cfd : cfds) {
       if (cfd->mem()->IsEmpty() && cached_recoverable_state_empty_.load() &&
@@ -2997,6 +3069,9 @@ Status DBImpl::AtomicFlushMemTables(
       cfd->UnrefAndTryDelete();
       if (!s.ok()) {
         break;
+      }
+      if (switched_memtable != nullptr) {
+        *switched_memtable = true;
       }
     }
     if (s.ok()) {
@@ -3962,6 +4037,160 @@ void DBImpl::UnscheduleFlushCallback(void* arg) {
   }
   delete static_cast<FlushThreadArg*>(arg);
   TEST_SYNC_POINT("DBImpl::UnscheduleFlushCallback");
+}
+
+void DBImpl::RefreshLargestMutableCFMem() {
+  mutex_.AssertHeld();
+  versions_->GetColumnFamilySet()->RefreshLargestMutableCFMem();
+}
+
+DBImpl::FlushableCFs DBImpl::CollectFlushableCFs() {
+  mutex_.AssertHeld();
+  FlushableCFs result;
+  SequenceNumber oldest_seq = kMaxSequenceNumber;
+  for (auto cfd : *versions_->GetColumnFamilySet()) {
+    if (cfd->IsDropped() || !cfd->initialized() || cfd->mem()->IsEmpty()) {
+      continue;
+    }
+    const size_t mem = cfd->mem()->WBMTrackedMemoryUsage();
+    result.total_mem += mem;
+    // Non-atomic flushes skip CFs already flushing.
+    if (cfd->imm()->IsFlushPendingOrRunning()) {
+      continue;
+    }
+    if (result.largest == nullptr || mem > result.largest_mem) {
+      result.largest = cfd;
+      result.largest_mem = mem;
+    }
+    const SequenceNumber seq = cfd->mem()->GetCreationSeq();
+    if (result.oldest == nullptr || seq < oldest_seq) {
+      result.oldest = cfd;
+      oldest_seq = seq;
+    }
+  }
+  return result;
+}
+
+bool DBImpl::ScheduleWriteBufferManagerFlush() {
+  std::unique_ptr<FlushThreadArg> fta;
+  {
+    if (!mutex_.TryLock()) {
+      return false;
+    }
+    Defer unlock_mutex([this] { mutex_.Unlock(); });
+    // Recheck bid eligibility because DB state may have changed.
+    if (shutdown_initiated_.load(std::memory_order_acquire) ||
+        shutting_down_.load(std::memory_order_acquire) ||
+        reject_new_background_jobs_ || !opened_successfully_ || read_only_ ||
+        write_controller_.IsStopped() ||
+        // Reject both the pause drain and fully paused states.
+        bg_work_paused_ > 0 || bg_compaction_paused_ > 0 ||
+        // Never queue work that would wait behind this DB's stall.
+        WouldBlockJoiningWriteThread()) {
+      return false;
+    }
+    if (wbm_flush_needs_local_fallback_) {
+      wbm_flush_needs_local_fallback_ = false;
+      return false;
+    }
+    // A queued or running job does not count as new progress. Returning false
+    // makes this writer seal locally instead of repeatedly deferring while the
+    // LOW pool is busy.
+    if (bg_wbm_flush_scheduled_ > 0) {
+      return false;
+    }
+    fta = std::make_unique<FlushThreadArg>();
+    fta->db_ = this;
+    fta->thread_pri_ = kWBMFlushPriority;
+    ++bg_wbm_flush_scheduled_;
+  }
+
+  // Scheduling outside mutex_ avoids nesting it with the Env thread-pool lock.
+  // Deregistration keeps this DB alive until this callback returns; afterwards
+  // the background-job counter protects it through execution or cancellation.
+  env_->Schedule(&DBImpl::BGWorkWBMFlush, fta.release(), kWBMFlushPriority,
+                 GetTaskTag(TaskType::kDefault) /* tag */,
+                 &DBImpl::UnscheduleWBMFlushCallback);
+  return true;
+}
+
+void DBImpl::BGWorkWBMFlush(void* arg) {
+  const std::unique_ptr<FlushThreadArg> fta(static_cast<FlushThreadArg*>(arg));
+
+  IOSTATS_SET_THREAD_POOL_ID(fta->thread_pri_);
+  TEST_SYNC_POINT("DBImpl::BGWorkWBMFlush");
+  static_cast_with_check<DBImpl>(fta->db_)->BackgroundCallWBMFlush();
+  TEST_SYNC_POINT("DBImpl::BGWorkWBMFlush:done");
+}
+
+void DBImpl::UnscheduleWBMFlushCallback(void* arg) {
+  const std::unique_ptr<FlushThreadArg> fta(static_cast<FlushThreadArg*>(arg));
+  fta->db_->mutex_.AssertHeld();
+  fta->db_->bg_wbm_flush_scheduled_--;
+  fta->db_->bg_cv_.SignalAll();
+  TEST_SYNC_POINT("DBImpl::UnscheduleWBMFlushCallback");
+}
+
+void DBImpl::BackgroundCallWBMFlush() {
+  const bool atomic_flush = immutable_db_options_.atomic_flush;
+  ColumnFamilyData* cfd_to_flush = nullptr;
+  bool has_flushable_cf = false;
+  {
+    InstrumentedMutexLock l(&mutex_);
+    if (!shutdown_initiated_.load(std::memory_order_acquire) &&
+        !shutting_down_.load(std::memory_order_acquire) &&
+        !reject_new_background_jobs_ && opened_successfully_ && !read_only_ &&
+        !write_controller_.IsStopped() && bg_work_paused_ == 0 &&
+        bg_compaction_paused_ == 0 && !WouldBlockJoiningWriteThread()) {
+      const FlushableCFs flushable = CollectFlushableCFs();
+      has_flushable_cf =
+          atomic_flush ? flushable.total_mem > 0 : flushable.largest != nullptr;
+      if (!atomic_flush) {
+        cfd_to_flush = flushable.largest;
+        if (cfd_to_flush != nullptr) {
+          cfd_to_flush->Ref();
+        }
+      }
+    }
+  }
+  TEST_SYNC_POINT("DBImpl::BackgroundCallWBMFlush:AfterPick");
+
+  FlushOptions flush_options;
+  flush_options.wait = false;
+  flush_options.allow_write_stall = true;
+  bool made_progress = false;
+  if (has_flushable_cf) {
+    Status s;
+    if (atomic_flush) {
+      s = AtomicFlushMemTablesImpl(
+          flush_options, FlushReason::kWriteBufferManager,
+          {} /* provided_candidate_cfds */, false /* entered_write_thread */,
+          WriteThreadJoinMode::kNonBlocking, &made_progress);
+    } else {
+      s = FlushMemTableImpl(cfd_to_flush, flush_options,
+                            FlushReason::kWriteBufferManager,
+                            false /* entered_write_thread */,
+                            WriteThreadJoinMode::kNonBlocking, &made_progress);
+    }
+    if (!s.ok()) {
+      made_progress = false;
+      ROCKS_LOG_WARN(
+          immutable_db_options_.info_log,
+          "Flush on behalf of a shared WriteBufferManager failed: %s",
+          s.ToString().c_str());
+    }
+    s.PermitUncheckedError();
+  }
+  TEST_SYNC_POINT_CALLBACK("DBImpl::BackgroundCallWBMFlush:MadeProgress",
+                           &made_progress);
+
+  InstrumentedMutexLock l(&mutex_);
+  if (cfd_to_flush != nullptr) {
+    cfd_to_flush->UnrefAndTryDelete();
+  }
+  wbm_flush_needs_local_fallback_ = !made_progress;
+  --bg_wbm_flush_scheduled_;
+  bg_cv_.SignalAll();
 }
 
 Status DBImpl::BackgroundFlush(bool* made_progress, JobContext* job_context,
@@ -5664,9 +5893,10 @@ Status DBImpl::WaitForCompact(
     if (bg_work_paused_ && wait_for_compact_options.abort_on_pause) {
       return Status::Aborted();
     }
+    // A WBM job can enqueue a regular flush, so wait for both to quiesce.
     if ((bg_bottom_compaction_scheduled_ || bg_compaction_scheduled_ ||
-         bg_flush_scheduled_ || unscheduled_compactions_ ||
-         !parked_compaction_cfds_.empty() ||
+         bg_flush_scheduled_ || bg_wbm_flush_scheduled_ ||
+         unscheduled_compactions_ || !parked_compaction_cfds_.empty() ||
          (wait_for_compact_options.wait_for_purge && bg_purge_scheduled_) ||
          unscheduled_flushes_ || error_handler_.IsRecoveryInProgress()) &&
         (error_handler_.GetBGError().ok())) {

--- a/db/db_impl/db_impl_debug.cc
+++ b/db/db_impl/db_impl_debug.cc
@@ -182,9 +182,30 @@ Status DBImpl::TEST_FlushMemTableWithListenerWait(bool allow_write_stall,
 
 Status DBImpl::TEST_AtomicFlushMemTables(
     const autovector<ColumnFamilyData*>& provided_candidate_cfds,
-    const FlushOptions& flush_opts) {
-  return AtomicFlushMemTables(flush_opts, FlushReason::kTest,
-                              provided_candidate_cfds);
+    const FlushOptions& flush_opts, bool non_blocking_write_thread) {
+  const auto join_mode = non_blocking_write_thread
+                             ? WriteThreadJoinMode::kNonBlocking
+                             : WriteThreadJoinMode::kBlocking;
+  return AtomicFlushMemTablesImpl(flush_opts, FlushReason::kTest,
+                                  provided_candidate_cfds,
+                                  false /* entered_write_thread */, join_mode,
+                                  nullptr /* switched_memtable */);
+}
+
+void DBImpl::TEST_BeginWriteStall() {
+  InstrumentedMutexLock l(&mutex_);
+  write_thread_.BeginWriteStall();
+  if (wbm_flush_initiator_ != nullptr) {
+    wbm_flush_initiator_->SetFlushable(false);
+  }
+}
+
+void DBImpl::TEST_EndWriteStall() {
+  InstrumentedMutexLock l(&mutex_);
+  write_thread_.EndWriteStall();
+  if (wbm_flush_initiator_ != nullptr) {
+    wbm_flush_initiator_->SetFlushable(true);
+  }
 }
 
 Status DBImpl::TEST_WaitForBackgroundWork() {

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -3013,6 +3013,8 @@ Status DBImpl::Open(const DBOptions& db_options, const std::string& dbname,
     }
   }
   if (s.ok()) {
+    // Register only after open succeeds and without holding the DB mutex.
+    impl->MaybeRegisterFlushInitiator();
     *dbptr = std::move(impl);
   } else {
     for (auto* h : *handles) {

--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -2132,9 +2132,23 @@ Status DBImpl::PreprocessWrite(const WriteOptions& write_options,
     // thread is writing to another DB with the same write buffer, they may also
     // be flushed. We may end up with flushing much more DBs than needed. It's
     // suboptimal but still correct.
-    InstrumentedMutexLock l(&mutex_);
-    WaitForPendingWrites();
-    status = HandleWriteBufferManagerFlush(write_context);
+    //
+    // Under kFlushLargestAcrossDBs, first give the shared WriteBufferManager a
+    // chance to flush whichever DB (possibly a different one) holds the most
+    // memtable memory. If it initiates a flush on another DB, this DB defers
+    // instead of flushing itself. Called without holding mutex_ to respect the
+    // registry -> mutex_ lock order.
+    if (write_buffer_manager_->flush_policy() ==
+            WriteBufferFlushPolicy::kFlushLargestAcrossDBs &&
+        !immutable_db_options_.atomic_flush &&
+        write_buffer_manager_->InitiateFlushOnLargestDB(
+            wbm_flush_initiator_.get())) {
+      // A larger DB sharing this WriteBufferManager will flush asynchronously.
+    } else {
+      InstrumentedMutexLock l(&mutex_);
+      WaitForPendingWrites();
+      status = HandleWriteBufferManagerFlush(write_context);
+    }
   }
 
   if (UNLIKELY(status.ok() && !trim_history_scheduler_.Empty())) {
@@ -2722,8 +2736,16 @@ Status DBImpl::HandleWriteBufferManagerFlush(WriteContext* write_context) {
   if (immutable_db_options_.atomic_flush) {
     SelectColumnFamiliesForAtomicFlush(&cfds);
   } else {
+    const WriteBufferFlushPolicy policy = write_buffer_manager_->flush_policy();
+    const bool flush_largest =
+        policy == WriteBufferFlushPolicy::kFlushLargest ||
+        policy == WriteBufferFlushPolicy::kFlushLargestAcrossDBs;
     ColumnFamilyData* cfd_picked = nullptr;
+    // Only one of these keys is used, depending on the policy: the smallest
+    // creation seq for kFlushOldest, or the largest memtable memory usage for
+    // kFlushLargest.
     SequenceNumber seq_num_for_cf_picked = kMaxSequenceNumber;
+    size_t mem_for_cf_picked = 0;
 
     for (auto cfd : *versions_->GetColumnFamilySet()) {
       if (cfd->IsDropped()) {
@@ -2734,10 +2756,21 @@ Status DBImpl::HandleWriteBufferManagerFlush(WriteContext* write_context) {
         // and no immutable memtables for which flush has yet to finish. If
         // we triggered flush on CFs already trying to flush, we would risk
         // creating too many immutable memtables leading to write stalls.
-        uint64_t seq = cfd->mem()->GetCreationSeq();
-        if (cfd_picked == nullptr || seq < seq_num_for_cf_picked) {
-          cfd_picked = cfd;
-          seq_num_for_cf_picked = seq;
+        if (flush_largest) {
+          // Pick the CF using the most memory so that a single flush frees as
+          // much as possible. ApproximateMemoryUsageFast() is a cheap relaxed
+          // load that needs no external synchronization.
+          const size_t mem = cfd->mem()->ApproximateMemoryUsageFast();
+          if (cfd_picked == nullptr || mem > mem_for_cf_picked) {
+            cfd_picked = cfd;
+            mem_for_cf_picked = mem;
+          }
+        } else {
+          const uint64_t seq = cfd->mem()->GetCreationSeq();
+          if (cfd_picked == nullptr || seq < seq_num_for_cf_picked) {
+            cfd_picked = cfd;
+            seq_num_for_cf_picked = seq;
+          }
         }
       }
     }

--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -2126,12 +2126,31 @@ Status DBImpl::PreprocessWrite(const WriteOptions& write_options,
     }
   }
 
+  bool deferred_flush_to_another_db = false;
   if (UNLIKELY(status.ok() && write_buffer_manager_->ShouldFlush())) {
     // Before a new memtable is added in SwitchMemtable(),
     // write_buffer_manager_->ShouldFlush() will keep returning true. If another
     // thread is writing to another DB with the same write buffer, they may also
     // be flushed. We may end up with flushing much more DBs than needed. It's
     // suboptimal but still correct.
+    // Let a larger DB flush first. Do not hold mutex_: registry locks precede
+    // DB locks.
+    deferred_flush_to_another_db =
+        write_buffer_manager_->flush_policy() ==
+            WriteBufferFlushPolicy::kFlushLargestAcrossDBs &&
+        write_buffer_manager_->InitiateFlushOnLargestDB(
+            wbm_flush_initiator_.get());
+    if (!deferred_flush_to_another_db) {
+      InstrumentedMutexLock l(&mutex_);
+      WaitForPendingWrites();
+      status = HandleWriteBufferManagerFlush(write_context);
+    }
+  }
+
+  // Before parking, seal locally so a failed deferred flush cannot deadlock the
+  // shared WBM stall.
+  if (UNLIKELY(status.ok() && deferred_flush_to_another_db &&
+               write_buffer_manager_->ShouldStall())) {
     InstrumentedMutexLock l(&mutex_);
     WaitForPendingWrites();
     status = HandleWriteBufferManagerFlush(write_context);
@@ -2722,25 +2741,14 @@ Status DBImpl::HandleWriteBufferManagerFlush(WriteContext* write_context) {
   if (immutable_db_options_.atomic_flush) {
     SelectColumnFamiliesForAtomicFlush(&cfds);
   } else {
-    ColumnFamilyData* cfd_picked = nullptr;
-    SequenceNumber seq_num_for_cf_picked = kMaxSequenceNumber;
-
-    for (auto cfd : *versions_->GetColumnFamilySet()) {
-      if (cfd->IsDropped()) {
-        continue;
-      }
-      if (!cfd->mem()->IsEmpty() && !cfd->imm()->IsFlushPendingOrRunning()) {
-        // We only consider flush on CFs with bytes in the mutable memtable,
-        // and no immutable memtables for which flush has yet to finish. If
-        // we triggered flush on CFs already trying to flush, we would risk
-        // creating too many immutable memtables leading to write stalls.
-        uint64_t seq = cfd->mem()->GetCreationSeq();
-        if (cfd_picked == nullptr || seq < seq_num_for_cf_picked) {
-          cfd_picked = cfd;
-          seq_num_for_cf_picked = seq;
-        }
-      }
-    }
+    const WriteBufferFlushPolicy policy = write_buffer_manager_->flush_policy();
+    // Cross-DB selection still flushes the largest CF within the chosen DB.
+    const bool flush_largest =
+        policy == WriteBufferFlushPolicy::kFlushLargest ||
+        policy == WriteBufferFlushPolicy::kFlushLargestAcrossDBs;
+    const FlushableCFs flushable = CollectFlushableCFs();
+    ColumnFamilyData* cfd_picked =
+        flush_largest ? flushable.largest : flushable.oldest;
     if (cfd_picked != nullptr) {
       cfds.push_back(cfd_picked);
     }
@@ -2919,6 +2927,9 @@ void DBImpl::WriteBufferManagerStallWrites() {
   // First block future writer threads who want to add themselves to the queue
   // of WriteThread.
   write_thread_.BeginWriteStall();
+  if (wbm_flush_initiator_ != nullptr) {
+    wbm_flush_initiator_->SetFlushable(false);
+  }
   mutex_.Unlock();
 
   // Change the state to State::Blocked.
@@ -2933,6 +2944,9 @@ void DBImpl::WriteBufferManagerStallWrites() {
   // Stall has ended. Signal writer threads so that they can add
   // themselves to the WriteThread queue for writes.
   write_thread_.EndWriteStall();
+  if (wbm_flush_initiator_ != nullptr) {
+    wbm_flush_initiator_->SetFlushable(true);
+  }
 }
 
 Status DBImpl::ThrottleLowPriWritesIfNeeded(const WriteOptions& write_options,
@@ -3120,6 +3134,7 @@ Status DBImpl::SwitchMemtable(ColumnFamilyData* cfd, WriteContext* context,
                               SequenceNumber last_seqno) {
   mutex_.AssertHeld();
   assert(lock_wal_owner_thread_id_counts_.empty());
+  bool refresh_largest_mutable_cf = false;
 
   // TODO: plumb Env::IOActivity, Env::IOPriority
   const WriteOptions write_options;
@@ -3261,6 +3276,11 @@ Status DBImpl::SwitchMemtable(ColumnFamilyData* cfd, WriteContext* context,
   cfd->mem()->ConstructFragmentedRangeTombstones();
 
   mutex_.Lock();
+  const size_t switched_mem = cfd->mem()->WBMTrackedMemoryUsage();
+  refresh_largest_mutable_cf =
+      wbm_flush_initiator_ != nullptr &&
+      !wbm_flush_initiator_->UsesTotalMutableMem() && switched_mem > 0 &&
+      switched_mem >= wbm_flush_initiator_->GetLargestMutableCFMem();
   if (recycle_log_number != 0) {
     // Since renaming the file is done outside DB mutex, we need to ensure
     // concurrent full purges don't delete the file while we're recycling it.
@@ -3409,6 +3429,9 @@ Status DBImpl::SwitchMemtable(ColumnFamilyData* cfd, WriteContext* context,
   }
   new_mem->Ref();
   cfd->SetMemtable(new_mem);
+  if (refresh_largest_mutable_cf) {
+    RefreshLargestMutableCFMem();
+  }
   InstallSuperVersionAndScheduleWork(cfd, &context->superversion_context);
   MaybeScheduleAsyncWALPrecreate(preallocate_block_size);
 

--- a/db/db_memtable_test.cc
+++ b/db/db_memtable_test.cc
@@ -140,7 +140,8 @@ TEST_F(DBMemTableTest, DuplicateSeq) {
   ImmutableOptions ioptions(options);
   WriteBufferManager wb(options.db_write_buffer_size);
   MemTable* mem = new MemTable(cmp, ioptions, MutableCFOptions(options), &wb,
-                               kMaxSequenceNumber, 0 /* column_family_id */);
+                               kMaxSequenceNumber, 0 /* column_family_id */,
+                               nullptr /* flush_initiator */);
 
   // Write some keys and make sure it returns false on duplicates
   ASSERT_OK(
@@ -188,7 +189,8 @@ TEST_F(DBMemTableTest, DuplicateSeq) {
       new TestPrefixExtractor());  // which uses _ to extract the prefix
   ioptions = ImmutableOptions(options);
   mem = new MemTable(cmp, ioptions, MutableCFOptions(options), &wb,
-                     kMaxSequenceNumber, 0 /* column_family_id */);
+                     kMaxSequenceNumber, 0 /* column_family_id */,
+                     nullptr /* flush_initiator */);
   // Insert a duplicate key with _ in it
   ASSERT_OK(
       mem->Add(seq, kTypeValue, "key_1", "value", nullptr /* kv_prot_info */));
@@ -201,7 +203,8 @@ TEST_F(DBMemTableTest, DuplicateSeq) {
   options.allow_concurrent_memtable_write = true;
   ioptions = ImmutableOptions(options);
   mem = new MemTable(cmp, ioptions, MutableCFOptions(options), &wb,
-                     kMaxSequenceNumber, 0 /* column_family_id */);
+                     kMaxSequenceNumber, 0 /* column_family_id */,
+                     nullptr /* flush_initiator */);
   MemTablePostProcessInfo post_process_info;
   ASSERT_OK(mem->Add(seq, kTypeValue, "key", "value",
                      nullptr /* kv_prot_info */, true, &post_process_info));
@@ -234,7 +237,8 @@ TEST_F(DBMemTableTest, ConcurrentMergeWrite) {
   ImmutableOptions ioptions(options);
   WriteBufferManager wb(options.db_write_buffer_size);
   MemTable* mem = new MemTable(cmp, ioptions, MutableCFOptions(options), &wb,
-                               kMaxSequenceNumber, 0 /* column_family_id */);
+                               kMaxSequenceNumber, 0 /* column_family_id */,
+                               nullptr /* flush_initiator */);
 
   // Put 0 as the base
   PutFixed64(&value, static_cast<uint64_t>(0));

--- a/db/db_write_buffer_manager_test.cc
+++ b/db/db_write_buffer_manager_test.cc
@@ -845,6 +845,139 @@ TEST_P(DBWriteBufferManagerTest, StopSwitchingMemTablesOnceFlushing) {
   shared_wbm_db.reset();
 }
 
+// Verifies that with WriteBufferFlushPolicy::kFlushLargest, the column family
+// whose mutable memtable is using the most memory is the one selected for
+// flushing -- regardless of creation order or which CF received the write that
+// crossed the limit. The default policy (kFlushOldest) would instead pick the
+// default CF here.
+//
+// Not supported in LITE mode due to `GetProperty()` unavailable.
+TEST_P(DBWriteBufferManagerTest, FlushLargestMemtablePolicy) {
+  Options options = CurrentOptions();
+  options.arena_block_size = 4 << 10;   // 4KB
+  options.write_buffer_size = 1 << 20;  // 1MB, so per-CF flush is never hit
+  std::shared_ptr<Cache> cache =
+      NewLRUCache(4 << 20 /* capacity (4MB) */, 2 /* num_shard_bits */);
+  cost_cache_ = GetParam();
+  options.write_buffer_manager.reset(new WriteBufferManager(
+      512 << 10 /* buffer_size (512KB) */, cost_cache_ ? cache : nullptr,
+      false /* allow_stall */, WriteBufferFlushPolicy::kFlushLargest));
+
+  // "default" (oldest), "cf1" (largest), and "cf2" all share the same WBM.
+  CreateAndReopenWithCF({"cf1", "cf2"}, options);
+
+  // Block the flush background thread so switched memtables stay pending and
+  // remain observable via the num-immutable-mem-table property.
+  test::SleepingBackgroundTask sleeping_task_high;
+  env_->Schedule(&test::SleepingBackgroundTask::DoSleepTask, &sleeping_task_high,
+                 Env::Priority::HIGH);
+
+  // Make cf1 the largest mutable memtable while keeping the total under the WBM
+  // limit (512KB * 7/8 = 448KB) so no flush is triggered yet.
+  ASSERT_OK(
+      Put(0 /* default */, Key(1), DummyString(200 << 10), WriteOptions()));
+  ASSERT_OK(Put(1 /* cf1 */, Key(1), DummyString(300 << 10), WriteOptions()));
+  ASSERT_TRUE(options.write_buffer_manager->ShouldFlush());
+
+  // This write crosses the WBM limit and triggers a flush. Even though it
+  // targets cf2, kFlushLargest must pick cf1, the largest memtable.
+  ASSERT_OK(Put(2 /* cf2 */, Key(1), DummyString(1), WriteOptions()));
+
+  auto num_immutable = [&](int cf) {
+    std::string prop;
+    EXPECT_TRUE(db_->GetProperty(
+        handles_[cf], "rocksdb.num-immutable-mem-table", &prop));
+    return prop;
+  };
+  EXPECT_EQ("1", num_immutable(1));  // cf1 (largest) was flushed
+  EXPECT_EQ("0", num_immutable(0));  // default was not
+  EXPECT_EQ("0", num_immutable(2));  // cf2 was not
+
+  sleeping_task_high.WakeUp();
+  sleeping_task_high.WaitUntilDone();
+}
+
+namespace {
+// Records which DB instances have completed a flush, so a test can wait for and
+// assert on cross-DB flush behavior deterministically.
+class FlushedDBRecorder : public EventListener {
+ public:
+  void OnFlushCompleted(DB* db, const FlushJobInfo& /*info*/) override {
+    InstrumentedMutexLock l(&mu_);
+    flushed_.insert(db);
+    cv_.SignalAll();
+  }
+  void WaitForFlush(DB* db) {
+    InstrumentedMutexLock l(&mu_);
+    while (flushed_.find(db) == flushed_.end()) {
+      cv_.Wait();
+    }
+  }
+  bool HasFlushed(DB* db) {
+    InstrumentedMutexLock l(&mu_);
+    return flushed_.find(db) != flushed_.end();
+  }
+  void Reset() {
+    InstrumentedMutexLock l(&mu_);
+    flushed_.clear();
+  }
+
+ private:
+  InstrumentedMutex mu_;
+  InstrumentedCondVar cv_{&mu_};
+  std::set<DB*> flushed_;
+};
+}  // anonymous namespace
+
+// Verifies WriteBufferFlushPolicy::kFlushLargestAcrossDBs: when multiple DBs
+// share a single WriteBufferManager, the DB using the most mutable memtable
+// memory is the one flushed -- even when a write to a *different* (smaller) DB
+// is what crosses the shared memory limit. The smaller DB defers instead of
+// flushing itself.
+//
+// Not supported in LITE mode due to `GetProperty()` unavailable.
+TEST_P(DBWriteBufferManagerTest, FlushLargestAcrossDBsPolicy) {
+  auto recorder = std::make_shared<FlushedDBRecorder>();
+  Options options = CurrentOptions();
+  options.arena_block_size = 4 << 10;   // 4KB
+  options.write_buffer_size = 1 << 20;  // 1MB, so per-CF flush is never hit
+  options.listeners.push_back(recorder);
+  std::shared_ptr<Cache> cache =
+      NewLRUCache(4 << 20 /* capacity (4MB) */, 2 /* num_shard_bits */);
+  cost_cache_ = GetParam();
+  options.write_buffer_manager.reset(new WriteBufferManager(
+      512 << 10 /* buffer_size (512KB) */, cost_cache_ ? cache : nullptr,
+      false /* allow_stall */, WriteBufferFlushPolicy::kFlushLargestAcrossDBs));
+
+  // db_ (the fixture's DB) shares the WBM with a second DB, other_db.
+  Reopen(options);
+  std::string other_dbname = test::PerThreadDBPath("wbm_across_dbs_other");
+  ASSERT_OK(DestroyDB(other_dbname, options));
+  std::unique_ptr<DB> other_db;
+  ASSERT_OK(DB::Open(options, other_dbname, &other_db));
+
+  // Make other_db the larger DB (300KB) and db_ smaller (200KB). The total
+  // (500KB) exceeds the mutable limit (512KB * 7/8 = 448KB), but neither Put
+  // trips the trigger at its start.
+  ASSERT_OK(other_db->Put(WriteOptions(), Key(1), DummyString(300 << 10)));
+  ASSERT_OK(Put(Key(1), DummyString(200 << 10), WriteOptions()));
+  ASSERT_TRUE(options.write_buffer_manager->ShouldFlush());
+
+  // Ignore any flush that may have happened during open/setup.
+  recorder->Reset();
+
+  // This crossing write targets db_, but kFlushLargestAcrossDBs must flush
+  // other_db (the larger one) instead, and db_ must defer.
+  ASSERT_OK(Put(Key(2), DummyString(1), WriteOptions()));
+
+  recorder->WaitForFlush(other_db.get());
+  EXPECT_FALSE(recorder->HasFlushed(db_.get()));
+
+  ASSERT_OK(other_db->Close());
+  other_db.reset();
+  ASSERT_OK(DestroyDB(other_dbname, options));
+}
+
 TEST_F(DBWriteBufferManagerTest, RuntimeChangeableAllowStall) {
   constexpr int kBigValue = 10000;
 

--- a/db/db_write_buffer_manager_test.cc
+++ b/db/db_write_buffer_manager_test.cc
@@ -7,9 +7,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+
 #include "db/db_test_util.h"
 #include "db/write_thread.h"
 #include "port/stack_trace.h"
+#include "util/defer.h"
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -843,6 +848,959 @@ TEST_P(DBWriteBufferManagerTest, StopSwitchingMemTablesOnceFlushing) {
   ASSERT_OK(shared_wbm_db->Close());
   ASSERT_OK(DestroyDB(dbname, options));
   shared_wbm_db.reset();
+}
+
+// kFlushLargest must select by mutable memory rather than creation order.
+// Not supported in LITE mode because GetProperty() is unavailable.
+TEST_P(DBWriteBufferManagerTest, FlushLargestMemtablePolicy) {
+  Options options = CurrentOptions();
+  options.arena_block_size = 4 << 10;   // 4KB
+  options.write_buffer_size = 1 << 20;  // 1MB, so per-CF flush is never hit
+  std::shared_ptr<Cache> cache =
+      NewLRUCache(4 << 20 /* capacity (4MB) */, 2 /* num_shard_bits */);
+  cost_cache_ = GetParam();
+  options.write_buffer_manager = std::make_shared<WriteBufferManager>(
+      512 << 10 /* buffer_size (512KB) */, cost_cache_ ? cache : nullptr,
+      false /* allow_stall */, WriteBufferFlushPolicy::kFlushLargest);
+
+  CreateAndReopenWithCF({"cf1", "cf2"}, options);
+
+  // Block the flush background thread so switched memtables stay pending and
+  // remain observable via the num-immutable-mem-table property.
+  test::SleepingBackgroundTask sleeping_task_high;
+  env_->Schedule(&test::SleepingBackgroundTask::DoSleepTask,
+                 &sleeping_task_high, Env::Priority::HIGH);
+
+  // Make cf1 the largest mutable memtable while keeping the total under the WBM
+  // limit (512KB * 7/8 = 448KB) so no flush is triggered yet.
+  ASSERT_OK(
+      Put(0 /* default */, Key(1), DummyString(200 << 10), WriteOptions()));
+  ASSERT_OK(Put(1 /* cf1 */, Key(1), DummyString(300 << 10), WriteOptions()));
+  ASSERT_TRUE(options.write_buffer_manager->ShouldFlush());
+
+  // This write crosses the WBM limit and triggers a flush. Even though it
+  // targets cf2, kFlushLargest must pick cf1, the largest memtable.
+  ASSERT_OK(Put(2 /* cf2 */, Key(1), DummyString(1), WriteOptions()));
+
+  auto num_immutable = [&](int cf) {
+    std::string prop;
+    EXPECT_TRUE(db_->GetProperty(handles_[cf],
+                                 "rocksdb.num-immutable-mem-table", &prop));
+    return prop;
+  };
+  EXPECT_EQ("1", num_immutable(1));  // cf1 (largest) was flushed
+  EXPECT_EQ("0", num_immutable(0));  // default was not
+  EXPECT_EQ("0", num_immutable(2));  // cf2 was not
+
+  sleeping_task_high.WakeUp();
+  sleeping_task_high.WaitUntilDone();
+}
+
+namespace {
+// Records which DB instances have completed a flush, so a test can wait for and
+// assert on cross-DB flush behavior deterministically.
+class FlushedDBRecorder : public EventListener {
+ public:
+  void OnFlushCompleted(DB* db, const FlushJobInfo& info) override {
+    InstrumentedMutexLock l(&mu_);
+    flushed_.insert(db);
+    cf_flushes_[db].insert(info.cf_name);
+    cv_.SignalAll();
+  }
+  void WaitForFlush(DB* db) {
+    InstrumentedMutexLock l(&mu_);
+    while (flushed_.find(db) == flushed_.end()) {
+      cv_.Wait();
+    }
+  }
+  // Waits until `db` has flushed at least `n` distinct column families.
+  void WaitForColumnFamilies(DB* db, size_t n) {
+    InstrumentedMutexLock l(&mu_);
+    while (cf_flushes_[db].size() < n) {
+      cv_.Wait();
+    }
+  }
+  bool HasFlushed(DB* db) {
+    InstrumentedMutexLock l(&mu_);
+    return flushed_.find(db) != flushed_.end();
+  }
+  void Reset() {
+    InstrumentedMutexLock l(&mu_);
+    flushed_.clear();
+    cf_flushes_.clear();
+  }
+
+ private:
+  InstrumentedMutex mu_;
+  InstrumentedCondVar cv_{&mu_};
+  std::set<DB*> flushed_;
+  std::map<DB*, std::set<std::string>> cf_flushes_;
+};
+}  // anonymous namespace
+
+// A write on a smaller DB must flush the largest DB sharing the WBM.
+// Not supported in LITE mode because GetProperty() is unavailable.
+TEST_P(DBWriteBufferManagerTest, FlushLargestAcrossDBsPolicy) {
+  auto recorder = std::make_shared<FlushedDBRecorder>();
+  Options options = CurrentOptions();
+  options.arena_block_size = 4 << 10;   // 4KB
+  options.write_buffer_size = 1 << 20;  // 1MB, so per-CF flush is never hit
+  options.listeners.push_back(recorder);
+  std::shared_ptr<Cache> cache =
+      NewLRUCache(4 << 20 /* capacity (4MB) */, 2 /* num_shard_bits */);
+  cost_cache_ = GetParam();
+  options.write_buffer_manager = std::make_shared<WriteBufferManager>(
+      512 << 10 /* buffer_size (512KB) */, cost_cache_ ? cache : nullptr,
+      false /* allow_stall */, WriteBufferFlushPolicy::kFlushLargestAcrossDBs);
+
+  Reopen(options);
+  std::string other_dbname = test::PerThreadDBPath("wbm_across_dbs_other");
+  ASSERT_OK(DestroyDB(other_dbname, options));
+  std::unique_ptr<DB> other_db;
+  ASSERT_OK(DB::Open(options, other_dbname, &other_db));
+
+  ASSERT_OK(other_db->Put(WriteOptions(), Key(1), DummyString(300 << 10)));
+  ASSERT_OK(Put(Key(1), DummyString(200 << 10), WriteOptions()));
+  ASSERT_TRUE(options.write_buffer_manager->ShouldFlush());
+  options.write_buffer_manager->TEST_RefreshFlushInitiatorCandidate();
+
+  // Ignore any flush that may have happened during open/setup.
+  recorder->Reset();
+
+  // This crossing write targets db_, but kFlushLargestAcrossDBs must flush
+  // other_db (the larger one) instead, and db_ must defer.
+  ASSERT_OK(Put(Key(2), DummyString(1), WriteOptions()));
+
+  recorder->WaitForFlush(other_db.get());
+  EXPECT_FALSE(recorder->HasFlushed(db_.get()));
+
+  ASSERT_OK(other_db->Close());
+  other_db.reset();
+  ASSERT_OK(DestroyDB(other_dbname, options));
+}
+
+TEST_F(DBWriteBufferManagerTest,
+       FlushLargestAcrossDBsDoesNotWaitForForeignMutex) {
+  Options options = CurrentOptions();
+  options.arena_block_size = 4 << 10;
+  options.write_buffer_size = 1 << 20;
+  options.write_buffer_manager = std::make_shared<WriteBufferManager>(
+      512 << 10, nullptr, false,
+      WriteBufferFlushPolicy::kFlushLargestAcrossDBs);
+
+  Reopen(options);
+  std::string other_dbname =
+      test::PerThreadDBPath("wbm_busy_foreign_mutex_other");
+  ASSERT_OK(DestroyDB(other_dbname, options));
+  std::unique_ptr<DB> other_db;
+  ASSERT_OK(DB::Open(options, other_dbname, &other_db));
+
+  ASSERT_OK(other_db->Put(WriteOptions(), Key(1), DummyString(300 << 10)));
+  ASSERT_OK(Put(Key(1), DummyString(200 << 10), WriteOptions()));
+  ASSERT_TRUE(options.write_buffer_manager->ShouldFlush());
+  options.write_buffer_manager->TEST_RefreshFlushInitiatorCandidate();
+
+  auto* other_dbimpl = static_cast_with_check<DBImpl>(other_db.get());
+  other_dbimpl->TEST_LockMutex();
+
+  std::mutex completion_mu;
+  std::condition_variable completion_cv;
+  bool write_finished = false;
+  Status write_status;
+  port::Thread writer([&] {
+    write_status = Put(Key(2), DummyString(1), WriteOptions());
+    {
+      std::lock_guard<std::mutex> lock(completion_mu);
+      write_finished = true;
+    }
+    completion_cv.notify_one();
+  });
+
+  bool completed_while_foreign_mutex_locked;
+  {
+    std::unique_lock<std::mutex> lock(completion_mu);
+    completed_while_foreign_mutex_locked = completion_cv.wait_for(
+        lock, std::chrono::seconds(5), [&] { return write_finished; });
+  }
+  other_dbimpl->TEST_UnlockMutex();
+  writer.join();
+
+  EXPECT_TRUE(completed_while_foreign_mutex_locked);
+  ASSERT_OK(write_status);
+  ASSERT_OK(other_db->Close());
+  other_db.reset();
+  ASSERT_OK(DestroyDB(other_dbname, options));
+}
+
+TEST_F(DBWriteBufferManagerTest,
+       AtomicFlushNonBlockingJoinReleasesGeneratedCandidates) {
+  Options options = CurrentOptions();
+  options.atomic_flush = true;
+  CreateAndReopenWithCF({"cf1"}, options);
+
+  auto* impl = dbfull();
+  {
+    impl->TEST_BeginWriteStall();
+    Defer end_stall([&] { impl->TEST_EndWriteStall(); });
+
+    FlushOptions flush_options;
+    flush_options.wait = false;
+    flush_options.allow_write_stall = true;
+    const Status s = impl->TEST_AtomicFlushMemTables(
+        {} /* provided_candidate_cfds */, flush_options,
+        true /* non_blocking_write_thread */);
+    ASSERT_TRUE(s.IsIncomplete());
+  }
+
+  // Closing destroys the ColumnFamilySet and verifies that the failed flush
+  // did not retain a reference to either column family.
+  Close();
+}
+
+// A cross-DB WBM flush must run even when the high-priority pool is empty.
+TEST_P(DBWriteBufferManagerTest, FlushLargestAcrossDBsWithEmptyHighPriPool) {
+  auto recorder = std::make_shared<FlushedDBRecorder>();
+  Options options = CurrentOptions();
+  options.arena_block_size = 4 << 10;   // 4KB
+  options.write_buffer_size = 1 << 20;  // 1MB, so per-CF flush is never hit
+  options.listeners.push_back(recorder);
+  cost_cache_ = GetParam();
+  std::shared_ptr<Cache> cache =
+      NewLRUCache(4 << 20 /* capacity (4MB) */, 2 /* num_shard_bits */);
+  options.write_buffer_manager = std::make_shared<WriteBufferManager>(
+      512 << 10 /* buffer_size (512KB) */, cost_cache_ ? cache : nullptr,
+      false /* allow_stall */, WriteBufferFlushPolicy::kFlushLargestAcrossDBs);
+
+  Reopen(options);
+  std::string other_dbname = test::PerThreadDBPath("wbm_empty_high_pri_other");
+  ASSERT_OK(DestroyDB(other_dbname, options));
+  std::unique_ptr<DB> other_db;
+  ASSERT_OK(DB::Open(options, other_dbname, &other_db));
+
+  ASSERT_OK(other_db->Put(WriteOptions(), Key(1), DummyString(300 << 10)));
+  ASSERT_OK(Put(Key(1), DummyString(200 << 10), WriteOptions()));
+  ASSERT_TRUE(options.write_buffer_manager->ShouldFlush());
+  options.write_buffer_manager->TEST_RefreshFlushInitiatorCandidate();
+  recorder->Reset();
+
+  // Empty the shared high-priority pool after DB open, and restore it on exit.
+  const int saved_high = env_->GetBackgroundThreads(Env::Priority::HIGH);
+  Defer restore_high_pool(
+      [&] { env_->SetBackgroundThreads(saved_high, Env::Priority::HIGH); });
+  env_->SetBackgroundThreads(0, Env::Priority::HIGH);
+  ASSERT_EQ(0, env_->GetBackgroundThreads(Env::Priority::HIGH));
+
+  ASSERT_OK(Put(Key(2), DummyString(1), WriteOptions()));
+  recorder->WaitForFlush(other_db.get());
+
+  ASSERT_OK(other_db->Close());
+  other_db.reset();
+  ASSERT_OK(DestroyDB(other_dbname, options));
+}
+
+// A write-stopped DB cannot honor a flush and must not win selection.
+TEST_P(DBWriteBufferManagerTest, FlushLargestAcrossDBsSkipsWriteStoppedDB) {
+  Options options = CurrentOptions();
+  options.arena_block_size = 4 << 10;   // 4KB
+  options.write_buffer_size = 1 << 20;  // 1MB, so per-CF flush is never hit
+  cost_cache_ = GetParam();
+  std::shared_ptr<Cache> cache =
+      NewLRUCache(4 << 20 /* capacity (4MB) */, 2 /* num_shard_bits */);
+  options.write_buffer_manager = std::make_shared<WriteBufferManager>(
+      512 << 10 /* buffer_size (512KB) */, cost_cache_ ? cache : nullptr,
+      false /* allow_stall */, WriteBufferFlushPolicy::kFlushLargestAcrossDBs);
+
+  Reopen(options);
+  std::string other_dbname = test::PerThreadDBPath("wbm_write_stopped_other");
+  ASSERT_OK(DestroyDB(other_dbname, options));
+  std::unique_ptr<DB> other_db;
+  ASSERT_OK(DB::Open(options, other_dbname, &other_db));
+
+  ASSERT_OK(other_db->Put(WriteOptions(), Key(1), DummyString(300 << 10)));
+  ASSERT_OK(Put(Key(1), DummyString(200 << 10), WriteOptions()));
+  ASSERT_TRUE(options.write_buffer_manager->ShouldFlush());
+  options.write_buffer_manager->TEST_RefreshFlushInitiatorCandidate();
+
+  auto* other_dbimpl = static_cast_with_check<DBImpl>(other_db.get());
+  auto stop_token = other_dbimpl->TEST_write_controler().GetStopToken();
+  ASSERT_TRUE(other_dbimpl->TEST_write_controler().IsStopped());
+
+  // Block the flush thread so the memtable switch stays observable.
+  test::SleepingBackgroundTask sleeping_task_high;
+  env_->Schedule(&test::SleepingBackgroundTask::DoSleepTask,
+                 &sleeping_task_high, Env::Priority::HIGH);
+
+  ASSERT_OK(Put(Key(2), DummyString(1), WriteOptions()));
+
+  std::string prop;
+  ASSERT_TRUE(db_->GetProperty("rocksdb.num-immutable-mem-table", &prop));
+  EXPECT_EQ("1", prop) << "db_ should have flushed itself";
+
+  sleeping_task_high.WakeUp();
+  sleeping_task_high.WaitUntilDone();
+  stop_token.reset();
+  ASSERT_OK(other_db->Close());
+  other_db.reset();
+  ASSERT_OK(DestroyDB(other_dbname, options));
+}
+
+// Skip a stalled DB so the selected flush can run and release shared memory.
+TEST_F(DBWriteBufferManagerTest, FlushLargestAcrossDBsSkipsStalledDB) {
+  Options options = CurrentOptions();
+  options.arena_block_size = 4 << 10;
+  options.write_buffer_size = 4 << 20;  // per-CF flush is never hit
+  options.create_if_missing = true;
+  options.create_missing_column_families = true;
+  options.write_buffer_manager = std::make_shared<WriteBufferManager>(
+      1 << 20 /* buffer_size (1MB) */, nullptr /* cache */,
+      true /* allow_stall */, WriteBufferFlushPolicy::kFlushLargestAcrossDBs);
+
+  Reopen(options);
+
+  // Keep mutable memory in other_db after it enters the stall.
+  std::string other_dbname = test::PerThreadDBPath("wbm_stalled_other");
+  ASSERT_OK(DestroyDB(other_dbname, options));
+  std::vector<ColumnFamilyDescriptor> cf_descs = {
+      {kDefaultColumnFamilyName, ColumnFamilyOptions(options)},
+      {"cf1", ColumnFamilyOptions(options)}};
+  std::vector<ColumnFamilyHandle*> other_handles;
+  std::unique_ptr<DB> other_db;
+  ASSERT_OK(
+      DB::Open(options, other_dbname, cf_descs, &other_handles, &other_db));
+
+  // Freeze flushes so the stall remains active for the test.
+  InstrumentedMutex mu;
+  InstrumentedCondVar cv(&mu);
+  bool blocked = false;
+  bool job_done = false;
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->LoadDependency(
+      {{"DBWriteBufferManagerTest::SkipsStalledDB:Done",
+        "DBImpl::BackgroundCallFlush:start"}});
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
+      "WBMStallInterface::BlockDB", [&](void*) {
+        InstrumentedMutexLock l(&mu);
+        blocked = true;
+        cv.SignalAll();
+      });
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::BGWorkWBMFlush:done", [&](void*) {
+        InstrumentedMutexLock l(&mu);
+        job_done = true;
+        cv.SignalAll();
+      });
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
+
+  // Stay below both thresholds until the dedicated staller crosses them.
+  ASSERT_OK(other_db->Put(WriteOptions(), other_handles[1], Key(1),
+                          DummyString(300 << 10)));
+  ASSERT_OK(other_db->Put(WriteOptions(), other_handles[0], Key(1),
+                          DummyString(250 << 10)));
+  ASSERT_OK(Put(Key(1), DummyString(200 << 10), WriteOptions()));
+  ASSERT_FALSE(options.write_buffer_manager->ShouldFlush());
+  ASSERT_FALSE(options.write_buffer_manager->IsStallActive());
+
+  // The first write crosses the limit; the second observes it and parks.
+  port::Thread staller([&] {
+    other_db
+        ->Put(WriteOptions(), other_handles[0], Key(2), DummyString(500 << 10))
+        .PermitUncheckedError();
+    other_db->Put(WriteOptions(), other_handles[0], Key(3), DummyString(1))
+        .PermitUncheckedError();
+  });
+  {
+    InstrumentedMutexLock l(&mu);
+    while (!blocked) {
+      cv.Wait();
+    }
+  }
+  ASSERT_TRUE(options.write_buffer_manager->IsStallActive());
+  options.write_buffer_manager->TEST_RefreshFlushInitiatorCandidate();
+
+  // The smaller, non-stalled DB must win despite other_db's larger bid.
+  EXPECT_TRUE(options.write_buffer_manager->InitiateFlushOnLargestDB(nullptr));
+  {
+    InstrumentedMutexLock l(&mu);
+    while (!job_done) {
+      cv.Wait();
+    }
+  }
+
+  std::string prop;
+  ASSERT_TRUE(db_->GetProperty("rocksdb.num-immutable-mem-table", &prop));
+  EXPECT_EQ("1", prop) << "the non-stalled DB should have been flushed";
+  ASSERT_TRUE(other_db->GetProperty(other_handles[1],
+                                    "rocksdb.num-immutable-mem-table", &prop));
+  EXPECT_EQ("0", prop) << "a stalled DB must not be handed a cross-DB job";
+
+  options.write_buffer_manager->SetAllowStall(false);
+  staller.join();
+
+  TEST_SYNC_POINT("DBWriteBufferManagerTest::SkipsStalledDB:Done");
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->ClearAllCallBacks();
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();
+  for (auto* handle : other_handles) {
+    ASSERT_OK(other_db->DestroyColumnFamilyHandle(handle));
+  }
+  ASSERT_OK(other_db->Close());
+  other_db.reset();
+  ASSERT_OK(DestroyDB(other_dbname, options));
+}
+
+// A DB that deferred must still seal locally before entering a shared stall.
+TEST_F(DBWriteBufferManagerTest, FlushLargestAcrossDBsSelfFlushesBeforeStall) {
+  Options options = CurrentOptions();
+  options.arena_block_size = 4 << 10;
+  options.write_buffer_size = 4 << 20;  // per-CF flush is never hit
+  options.create_if_missing = true;
+  options.write_buffer_manager = std::make_shared<WriteBufferManager>(
+      1 << 20 /* buffer_size (1MB) */, nullptr /* cache */,
+      true /* allow_stall */, WriteBufferFlushPolicy::kFlushLargestAcrossDBs);
+
+  Reopen(options);
+  std::string other_dbname = test::PerThreadDBPath("wbm_selfflush_other");
+  ASSERT_OK(DestroyDB(other_dbname, options));
+  std::unique_ptr<DB> other_db;
+  ASSERT_OK(DB::Open(options, other_dbname, &other_db));
+
+  // Freeze the larger DB's job so only db_ can release memory.
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->LoadDependency(
+      {{"DBWriteBufferManagerTest::SelfFlushesBeforeStall:Release",
+        "DBImpl::BGWorkWBMFlush"}});
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
+
+  ASSERT_OK(other_db->Put(WriteOptions(), Key(1), DummyString(700 << 10)));
+  ASSERT_OK(Put(Key(1), DummyString(350 << 10), WriteOptions()));
+  ASSERT_TRUE(options.write_buffer_manager->ShouldFlush());
+  ASSERT_TRUE(options.write_buffer_manager->ShouldStall());
+  options.write_buffer_manager->TEST_RefreshFlushInitiatorCandidate();
+
+  // This write defers to other_db and then has to stall. It can only return if
+  // it sealed its own memtable on the way in.
+  InstrumentedMutex mu;
+  InstrumentedCondVar cv(&mu);
+  bool write_done = false;
+  port::Thread writer([&] {
+    Status s = Put(Key(2), DummyString(1), WriteOptions());
+    InstrumentedMutexLock l(&mu);
+    write_done = true;
+    s.PermitUncheckedError();
+    cv.SignalAll();
+  });
+
+  bool timed_out = false;
+  {
+    InstrumentedMutexLock l(&mu);
+    const uint64_t deadline = env_->NowMicros() + 30 * 1000 * 1000;
+    while (!write_done) {
+      if (cv.TimedWait(deadline)) {
+        timed_out = !write_done;
+        break;
+      }
+    }
+  }
+  EXPECT_FALSE(timed_out)
+      << "writer never came back: it deferred to an idle DB and then parked "
+         "with no flush in flight, so nothing can ever call FreeMem()";
+
+  if (!timed_out) {
+    EXPECT_GT(NumTableFilesAtLevel(0), 0)
+        << "the deferring DB must seal its own memtable rather than rely on "
+           "the other DB's job";
+  }
+
+  options.write_buffer_manager->SetAllowStall(false);
+  TEST_SYNC_POINT("DBWriteBufferManagerTest::SelfFlushesBeforeStall:Release");
+  writer.join();
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->ClearAllCallBacks();
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();
+  ASSERT_OK(other_db->Close());
+  other_db.reset();
+  ASSERT_OK(DestroyDB(other_dbname, options));
+}
+
+// A queued LOW-pool handoff can defer one write, but subsequent writes must
+// fall back locally until that handoff has switched a memtable.
+TEST_P(DBWriteBufferManagerTest,
+       FlushLargestAcrossDBsPendingJobFallsBackLocally) {
+  Options options = CurrentOptions();
+  options.arena_block_size = 4 << 10;
+  options.write_buffer_size = 1 << 20;
+  cost_cache_ = GetParam();
+  std::shared_ptr<Cache> cache =
+      NewLRUCache(4 << 20 /* capacity (4MB) */, 2 /* num_shard_bits */);
+  options.write_buffer_manager = std::make_shared<WriteBufferManager>(
+      512 << 10 /* buffer_size (512KB) */, cost_cache_ ? cache : nullptr,
+      false /* allow_stall */, WriteBufferFlushPolicy::kFlushLargestAcrossDBs);
+
+  Reopen(options);
+  std::string other_dbname = test::PerThreadDBPath("wbm_pending_handoff_other");
+  ASSERT_OK(DestroyDB(other_dbname, options));
+  std::unique_ptr<DB> other_db;
+  ASSERT_OK(DB::Open(options, other_dbname, &other_db));
+
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->LoadDependency(
+      {{"DBWriteBufferManagerTest::PendingHandoff:ReleaseWBM",
+        "DBImpl::BGWorkWBMFlush"},
+       {"DBWriteBufferManagerTest::PendingHandoff:ReleaseFlush",
+        "DBImpl::BackgroundCallFlush:start"}});
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
+  bool released = false;
+  auto release_background_work = [&] {
+    if (released) {
+      return;
+    }
+    TEST_SYNC_POINT("DBWriteBufferManagerTest::PendingHandoff:ReleaseWBM");
+    TEST_SYNC_POINT("DBWriteBufferManagerTest::PendingHandoff:ReleaseFlush");
+    ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->ClearAllCallBacks();
+    ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();
+    released = true;
+  };
+  Defer release_on_exit([&] { release_background_work(); });
+
+  ASSERT_OK(other_db->Put(WriteOptions(), Key(1), DummyString(300 << 10)));
+  ASSERT_OK(Put(Key(1), DummyString(200 << 10), WriteOptions()));
+  ASSERT_TRUE(options.write_buffer_manager->ShouldFlush());
+  options.write_buffer_manager->TEST_RefreshFlushInitiatorCandidate();
+
+  // The first write queues a handoff to other_db. The second observes that the
+  // handoff is still pending and must seal db_ instead of deferring again.
+  ASSERT_OK(Put(Key(2), DummyString(1), WriteOptions()));
+  ASSERT_OK(Put(Key(3), DummyString(1), WriteOptions()));
+
+  std::string prop;
+  ASSERT_TRUE(db_->GetProperty("rocksdb.num-immutable-mem-table", &prop));
+  EXPECT_EQ("1", prop) << "a pending handoff must trigger local fallback";
+  ASSERT_TRUE(other_db->GetProperty("rocksdb.num-immutable-mem-table", &prop));
+  EXPECT_EQ("0", prop) << "the LOW-pool handoff should still be blocked";
+
+  release_background_work();
+  ASSERT_OK(other_db->Close());
+  other_db.reset();
+  ASSERT_OK(DestroyDB(other_dbname, options));
+}
+
+// A handoff that finds no flushable CF must force the next requester to seal
+// locally instead of repeatedly accepting stale bids.
+TEST_P(DBWriteBufferManagerTest,
+       FlushLargestAcrossDBsNoProgressFallsBackLocally) {
+  Options options = CurrentOptions();
+  options.arena_block_size = 4 << 10;
+  options.write_buffer_size = 2 << 20;
+  cost_cache_ = GetParam();
+  std::shared_ptr<Cache> cache =
+      NewLRUCache(4 << 20 /* capacity (4MB) */, 2 /* num_shard_bits */);
+  options.write_buffer_manager = std::make_shared<WriteBufferManager>(
+      1 << 20 /* buffer_size (1MB) */, cost_cache_ ? cache : nullptr,
+      false /* allow_stall */, WriteBufferFlushPolicy::kFlushLargestAcrossDBs);
+
+  Reopen(options);
+  std::string other_dbname =
+      test::PerThreadDBPath("wbm_no_progress_handoff_other");
+  ASSERT_OK(DestroyDB(other_dbname, options));
+  std::unique_ptr<DB> other_db;
+  ASSERT_OK(DB::Open(options, other_dbname, &other_db));
+
+  test::SleepingBackgroundTask sleeping_task_high;
+  const int saved_high = env_->GetBackgroundThreads(Env::Priority::HIGH);
+  env_->SetBackgroundThreads(1, Env::Priority::HIGH);
+  env_->Schedule(&test::SleepingBackgroundTask::DoSleepTask,
+                 &sleeping_task_high, Env::Priority::HIGH);
+  sleeping_task_high.WaitUntilSleeping();
+  bool high_pool_restored = false;
+  auto restore_high_pool = [&] {
+    if (high_pool_restored) {
+      return;
+    }
+    sleeping_task_high.WakeUp();
+    sleeping_task_high.WaitUntilDone();
+    env_->SetBackgroundThreads(saved_high, Env::Priority::HIGH);
+    high_pool_restored = true;
+  };
+  Defer restore_high_pool_on_exit([&] { restore_high_pool(); });
+
+  ASSERT_OK(other_db->Put(WriteOptions(), Key(1), DummyString(100 << 10)));
+  FlushOptions flush_options;
+  flush_options.wait = false;
+  ASSERT_OK(other_db->Flush(flush_options));
+  ASSERT_OK(other_db->Put(WriteOptions(), Key(2), DummyString(600 << 10)));
+  ASSERT_OK(Put(Key(1), DummyString(100 << 10), WriteOptions()));
+  ASSERT_FALSE(options.write_buffer_manager->ShouldFlush());
+
+  InstrumentedMutex mu;
+  InstrumentedCondVar cv(&mu);
+  bool handoff_done = false;
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::BGWorkWBMFlush:done", [&](void*) {
+        InstrumentedMutexLock l(&mu);
+        handoff_done = true;
+        cv.SignalAll();
+      });
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
+  Defer cleanup_sync_points([] {
+    ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->ClearAllCallBacks();
+    ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();
+  });
+
+  options.write_buffer_manager->TEST_RefreshFlushInitiatorCandidate();
+  ASSERT_OK(Put(Key(2), DummyString(200 << 10), WriteOptions()));
+  ASSERT_TRUE(options.write_buffer_manager->ShouldFlush());
+  ASSERT_OK(Put(Key(3), DummyString(1), WriteOptions()));
+  {
+    InstrumentedMutexLock l(&mu);
+    const uint64_t deadline = env_->NowMicros() + 30 * 1000 * 1000;
+    while (!handoff_done) {
+      ASSERT_FALSE(cv.TimedWait(deadline));
+    }
+  }
+
+  ASSERT_OK(Put(Key(4), DummyString(1), WriteOptions()));
+  std::string prop;
+  ASSERT_TRUE(db_->GetProperty("rocksdb.num-immutable-mem-table", &prop));
+  EXPECT_EQ("1", prop);
+
+  restore_high_pool();
+  ASSERT_OK(other_db->Close());
+  other_db.reset();
+  ASSERT_OK(DestroyDB(other_dbname, options));
+}
+
+TEST_F(DBWriteBufferManagerTest,
+       FlushLargestAcrossDBsDetectsNoOpAfterSelection) {
+  Options options = CurrentOptions();
+  options.arena_block_size = 4 << 10;
+  options.write_buffer_size = 2 << 20;
+  options.write_buffer_manager = std::make_shared<WriteBufferManager>(
+      1 << 20, nullptr, false, WriteBufferFlushPolicy::kFlushLargestAcrossDBs);
+
+  Reopen(options);
+  std::string other_dbname =
+      test::PerThreadDBPath("wbm_no_op_after_selection_other");
+  ASSERT_OK(DestroyDB(other_dbname, options));
+  std::unique_ptr<DB> other_db;
+  ASSERT_OK(DB::Open(options, other_dbname, &other_db));
+
+  InstrumentedMutex mu;
+  InstrumentedCondVar cv(&mu);
+  bool candidate_picked = false;
+  bool release_handoff = false;
+  bool handoff_done = false;
+  bool made_progress = true;
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::BackgroundCallWBMFlush:AfterPick", [&](void*) {
+        InstrumentedMutexLock l(&mu);
+        candidate_picked = true;
+        cv.SignalAll();
+        while (!release_handoff) {
+          cv.Wait();
+        }
+      });
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::BackgroundCallWBMFlush:MadeProgress", [&](void* arg) {
+        InstrumentedMutexLock l(&mu);
+        made_progress = *static_cast<bool*>(arg);
+      });
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::BGWorkWBMFlush:done", [&](void*) {
+        InstrumentedMutexLock l(&mu);
+        handoff_done = true;
+        cv.SignalAll();
+      });
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
+  Defer cleanup_sync_points([&] {
+    {
+      InstrumentedMutexLock l(&mu);
+      release_handoff = true;
+      cv.SignalAll();
+    }
+    ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->ClearAllCallBacks();
+    ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();
+  });
+
+  ASSERT_OK(other_db->Put(WriteOptions(), Key(1), DummyString(600 << 10)));
+  ASSERT_OK(Put(Key(1), DummyString(400 << 10), WriteOptions()));
+  ASSERT_TRUE(options.write_buffer_manager->ShouldFlush());
+  options.write_buffer_manager->TEST_RefreshFlushInitiatorCandidate();
+  ASSERT_OK(Put(Key(2), DummyString(1), WriteOptions()));
+  {
+    InstrumentedMutexLock l(&mu);
+    const uint64_t deadline = env_->NowMicros() + 30 * 1000 * 1000;
+    while (!candidate_picked) {
+      ASSERT_FALSE(cv.TimedWait(deadline));
+    }
+  }
+
+  FlushOptions flush_options;
+  flush_options.wait = false;
+  ASSERT_OK(other_db->Flush(flush_options));
+  {
+    InstrumentedMutexLock l(&mu);
+    release_handoff = true;
+    cv.SignalAll();
+    const uint64_t deadline = env_->NowMicros() + 30 * 1000 * 1000;
+    while (!handoff_done) {
+      ASSERT_FALSE(cv.TimedWait(deadline));
+    }
+  }
+  EXPECT_FALSE(made_progress);
+
+  ASSERT_OK(other_db->Close());
+  other_db.reset();
+  ASSERT_OK(DestroyDB(other_dbname, options));
+}
+
+TEST_F(DBWriteBufferManagerTest,
+       FlushLargestAcrossDBsSkipsDroppedCandidateAfterSelection) {
+  Options options = CurrentOptions();
+  options.arena_block_size = 4 << 10;
+  options.write_buffer_size = 2 << 20;
+  options.write_buffer_manager = std::make_shared<WriteBufferManager>(
+      1 << 20, nullptr, false, WriteBufferFlushPolicy::kFlushLargestAcrossDBs);
+
+  Reopen(options);
+  std::string other_dbname =
+      test::PerThreadDBPath("wbm_dropped_after_selection_other");
+  ASSERT_OK(DestroyDB(other_dbname, options));
+  std::unique_ptr<DB> other_db;
+  ASSERT_OK(DB::Open(options, other_dbname, &other_db));
+  ColumnFamilyHandle* other_cfh = nullptr;
+  ASSERT_OK(other_db->CreateColumnFamily(ColumnFamilyOptions(), "victim",
+                                         &other_cfh));
+
+  InstrumentedMutex mu;
+  InstrumentedCondVar cv(&mu);
+  bool candidate_picked = false;
+  bool release_handoff = false;
+  bool handoff_done = false;
+  bool dropped_candidate_rejected = false;
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::BackgroundCallWBMFlush:AfterPick", [&](void*) {
+        InstrumentedMutexLock l(&mu);
+        candidate_picked = true;
+        cv.SignalAll();
+        while (!release_handoff) {
+          cv.Wait();
+        }
+      });
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::FlushMemTableImpl:Dropped", [&](void*) {
+        InstrumentedMutexLock l(&mu);
+        dropped_candidate_rejected = true;
+      });
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::BGWorkWBMFlush:done", [&](void*) {
+        InstrumentedMutexLock l(&mu);
+        handoff_done = true;
+        cv.SignalAll();
+      });
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
+  Defer cleanup_sync_points([&] {
+    {
+      InstrumentedMutexLock l(&mu);
+      release_handoff = true;
+      cv.SignalAll();
+    }
+    ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->ClearAllCallBacks();
+    ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();
+  });
+
+  ASSERT_OK(
+      other_db->Put(WriteOptions(), other_cfh, Key(1), DummyString(600 << 10)));
+  ASSERT_OK(Put(Key(1), DummyString(400 << 10), WriteOptions()));
+  ASSERT_TRUE(options.write_buffer_manager->ShouldFlush());
+  options.write_buffer_manager->TEST_RefreshFlushInitiatorCandidate();
+  ASSERT_OK(Put(Key(2), DummyString(1), WriteOptions()));
+  {
+    InstrumentedMutexLock l(&mu);
+    const uint64_t deadline = env_->NowMicros() + 30 * 1000 * 1000;
+    while (!candidate_picked) {
+      ASSERT_FALSE(cv.TimedWait(deadline));
+    }
+  }
+
+  ASSERT_OK(other_db->DropColumnFamily(other_cfh));
+  ASSERT_OK(other_db->DestroyColumnFamilyHandle(other_cfh));
+  {
+    InstrumentedMutexLock l(&mu);
+    release_handoff = true;
+    cv.SignalAll();
+    const uint64_t deadline = env_->NowMicros() + 30 * 1000 * 1000;
+    while (!handoff_done) {
+      ASSERT_FALSE(cv.TimedWait(deadline));
+    }
+  }
+  EXPECT_TRUE(dropped_candidate_rejected);
+
+  ASSERT_OK(other_db->Close());
+  other_db.reset();
+  ASSERT_OK(DestroyDB(other_dbname, options));
+}
+
+// Closing must cancel a queued WBM job and balance its scheduled counter.
+TEST_P(DBWriteBufferManagerTest, FlushLargestAcrossDBsCancelsQueuedJobOnClose) {
+  Options options = CurrentOptions();
+  options.arena_block_size = 4 << 10;
+  options.write_buffer_size = 1 << 20;
+  cost_cache_ = GetParam();
+  std::shared_ptr<Cache> cache =
+      NewLRUCache(4 << 20 /* capacity (4MB) */, 2 /* num_shard_bits */);
+  options.write_buffer_manager = std::make_shared<WriteBufferManager>(
+      512 << 10 /* buffer_size (512KB) */, cost_cache_ ? cache : nullptr,
+      false /* allow_stall */, WriteBufferFlushPolicy::kFlushLargestAcrossDBs);
+
+  std::atomic<int> cancellations{0};
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::UnscheduleWBMFlushCallback",
+      [&](void*) { cancellations.fetch_add(1); });
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
+  Defer cleanup_sync_points([] {
+    ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->ClearAllCallBacks();
+    ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();
+  });
+
+  Reopen(options);
+  std::string other_dbname = test::PerThreadDBPath("wbm_cancel_on_close_other");
+  ASSERT_OK(DestroyDB(other_dbname, options));
+  std::unique_ptr<DB> other_db;
+  ASSERT_OK(DB::Open(options, other_dbname, &other_db));
+
+  test::SleepingBackgroundTask sleeping_task_low;
+  const int saved_low = env_->GetBackgroundThreads(Env::Priority::LOW);
+  env_->SetBackgroundThreads(1, Env::Priority::LOW);
+  env_->Schedule(&test::SleepingBackgroundTask::DoSleepTask, &sleeping_task_low,
+                 Env::Priority::LOW);
+  sleeping_task_low.WaitUntilSleeping();
+  Defer restore_low_pool([&] {
+    sleeping_task_low.WakeUp();
+    sleeping_task_low.WaitUntilDone();
+    env_->SetBackgroundThreads(saved_low, Env::Priority::LOW);
+  });
+
+  ASSERT_OK(other_db->Put(WriteOptions(), Key(1), DummyString(300 << 10)));
+  ASSERT_OK(Put(Key(1), DummyString(200 << 10), WriteOptions()));
+  ASSERT_TRUE(options.write_buffer_manager->ShouldFlush());
+  options.write_buffer_manager->TEST_RefreshFlushInitiatorCandidate();
+  ASSERT_OK(Put(Key(2), DummyString(1), WriteOptions()));
+
+  ASSERT_OK(other_db->Close());
+  other_db.reset();
+  EXPECT_GT(cancellations.load(), 0);
+
+  ASSERT_OK(DestroyDB(other_dbname, options));
+}
+
+// A read-only DB consumes shared WBM memory but cannot honor a flush request.
+TEST_P(DBWriteBufferManagerTest, FlushLargestAcrossDBsSkipsReadOnlyDB) {
+  Options options = CurrentOptions();
+  options.arena_block_size = 4 << 10;   // 4KB
+  options.write_buffer_size = 1 << 20;  // 1MB, so per-CF flush is never hit
+  cost_cache_ = GetParam();
+  std::shared_ptr<Cache> cache =
+      NewLRUCache(4 << 20 /* capacity (4MB) */, 2 /* num_shard_bits */);
+
+  // Stage a DB whose data lives only in the WAL, so opening it read-only
+  // rebuilds that data into memtables.
+  std::string ro_dbname = test::PerThreadDBPath("wbm_read_only_db");
+  {
+    Options staging = options;
+    staging.create_if_missing = true;
+    staging.avoid_flush_during_shutdown = true;  // keep the data in the WAL
+    ASSERT_OK(DestroyDB(ro_dbname, staging));
+    std::unique_ptr<DB> staging_db;
+    ASSERT_OK(DB::Open(staging, ro_dbname, &staging_db));
+    ASSERT_OK(staging_db->Put(WriteOptions(), Key(1), DummyString(300 << 10)));
+    ASSERT_OK(staging_db->Close());
+  }
+
+  options.write_buffer_manager = std::make_shared<WriteBufferManager>(
+      512 << 10 /* buffer_size (512KB) */, cost_cache_ ? cache : nullptr,
+      false /* allow_stall */, WriteBufferFlushPolicy::kFlushLargestAcrossDBs);
+  Reopen(options);
+
+  const size_t mem_before = options.write_buffer_manager->memory_usage();
+  std::unique_ptr<DB> read_only_db;
+  ASSERT_OK(DB::OpenForReadOnly(options, ro_dbname, &read_only_db));
+  EXPECT_GT(options.write_buffer_manager->memory_usage(), mem_before);
+
+  // Block the flush thread so the memtable switch stays observable.
+  test::SleepingBackgroundTask sleeping_task_high;
+  env_->Schedule(&test::SleepingBackgroundTask::DoSleepTask,
+                 &sleeping_task_high, Env::Priority::HIGH);
+
+  ASSERT_OK(Put(Key(1), DummyString(200 << 10), WriteOptions()));
+  ASSERT_TRUE(options.write_buffer_manager->ShouldFlush());
+  options.write_buffer_manager->TEST_RefreshFlushInitiatorCandidate();
+
+  // db_ holds less than the read-only DB, so without the read-only exclusion
+  // the selector would pick a DB that cannot flush and db_ would defer.
+  ASSERT_OK(Put(Key(2), DummyString(1), WriteOptions()));
+
+  std::string prop;
+  ASSERT_TRUE(db_->GetProperty("rocksdb.num-immutable-mem-table", &prop));
+  EXPECT_EQ("1", prop) << "db_ should have flushed itself";
+
+  sleeping_task_high.WakeUp();
+  sleeping_task_high.WaitUntilDone();
+  ASSERT_OK(read_only_db->Close());
+  read_only_db.reset();
+  ASSERT_OK(DestroyDB(ro_dbname, options));
+}
+
+// Rank an atomic-flush DB by the memory reclaimed across all its CFs.
+TEST_P(DBWriteBufferManagerTest, FlushLargestAcrossDBsPicksAtomicFlushDB) {
+  auto recorder = std::make_shared<FlushedDBRecorder>();
+  Options options = CurrentOptions();
+  options.arena_block_size = 4 << 10;   // 4KB
+  options.write_buffer_size = 1 << 20;  // 1MB, so per-CF flush is never hit
+  options.listeners.push_back(recorder);
+  std::shared_ptr<Cache> cache =
+      NewLRUCache(4 << 20 /* capacity (4MB) */, 2 /* num_shard_bits */);
+  cost_cache_ = GetParam();
+  options.write_buffer_manager = std::make_shared<WriteBufferManager>(
+      512 << 10 /* buffer_size (512KB) */, cost_cache_ ? cache : nullptr,
+      false /* allow_stall */, WriteBufferFlushPolicy::kFlushLargestAcrossDBs);
+
+  Reopen(options);
+
+  Options atomic_options = options;
+  atomic_options.atomic_flush = true;
+  atomic_options.create_if_missing = true;
+  atomic_options.create_missing_column_families = true;
+
+  std::string atomic_dbname = test::PerThreadDBPath("wbm_atomic_db");
+  ASSERT_OK(DestroyDB(atomic_dbname, atomic_options));
+  std::vector<ColumnFamilyDescriptor> cf_descs = {
+      {kDefaultColumnFamilyName, ColumnFamilyOptions(atomic_options)},
+      {"cf1", ColumnFamilyOptions(atomic_options)}};
+  std::vector<ColumnFamilyHandle*> atomic_handles;
+  std::unique_ptr<DB> atomic_db;
+  ASSERT_OK(DB::Open(atomic_options, atomic_dbname, cf_descs, &atomic_handles,
+                     &atomic_db));
+
+  // atomic_db reclaims 300KB across two CFs versus db_'s single 200KB CF.
+  ASSERT_OK(atomic_db->Put(WriteOptions(), atomic_handles[0], Key(1),
+                           DummyString(150 << 10)));
+  ASSERT_OK(atomic_db->Put(WriteOptions(), atomic_handles[1], Key(1),
+                           DummyString(150 << 10)));
+  ASSERT_OK(Put(Key(1), DummyString(200 << 10), WriteOptions()));
+  ASSERT_TRUE(options.write_buffer_manager->ShouldFlush());
+  options.write_buffer_manager->TEST_RefreshFlushInitiatorCandidate();
+
+  // Ignore any flush that may have happened during open/setup.
+  recorder->Reset();
+
+  // The crossing write targets db_, but atomic_db reclaims more, so it is the
+  // one flushed -- and atomically, i.e. both of its column families.
+  ASSERT_OK(Put(Key(2), DummyString(1), WriteOptions()));
+
+  recorder->WaitForColumnFamilies(atomic_db.get(), 2);
+  EXPECT_FALSE(recorder->HasFlushed(db_.get()));
+
+  for (auto* handle : atomic_handles) {
+    ASSERT_OK(atomic_db->DestroyColumnFamilyHandle(handle));
+  }
+  ASSERT_OK(atomic_db->Close());
+  atomic_db.reset();
+  ASSERT_OK(DestroyDB(atomic_dbname, atomic_options));
 }
 
 TEST_F(DBWriteBufferManagerTest, RuntimeChangeableAllowStall) {

--- a/db/db_write_test.cc
+++ b/db/db_write_test.cc
@@ -1075,6 +1075,185 @@ INSTANTIATE_TEST_CASE_P(DBWriteTestInstance, DBWriteTest,
                                         DBTestBase::kConcurrentWALWrites,
                                         DBTestBase::kPipelinedWrite));
 
+// A non-blocking unbatched join must refuse an active write stall.
+TEST(WriteThreadTest, EnterUnbatchedNonBlockingRefusesDuringStall) {
+  Options options;
+  ImmutableDBOptions db_options(options);
+  WriteThread write_thread(db_options);
+  InstrumentedMutex mu;
+
+  // No stall: joining succeeds and must be paired with ExitUnbatched().
+  {
+    WriteThread::Writer w;
+    InstrumentedMutexLock l(&mu);
+    ASSERT_TRUE(write_thread.EnterUnbatchedNonBlocking(&w, &mu));
+    ASSERT_OK(w.status);
+    EXPECT_FALSE(w.no_slowdown);
+    EXPECT_FALSE(w.non_blocking_join);
+    write_thread.ExitUnbatched(&w);
+  }
+
+  // Stalled: refuses rather than parking on stall_cv_. Reaching the assertion
+  // at all is the point -- EnterUnbatched() would never have returned.
+  {
+    InstrumentedMutexLock l(&mu);
+    write_thread.BeginWriteStall();
+    ASSERT_NE(0, write_thread.GetBegunCountOfOutstandingStall());
+
+    WriteThread::Writer w;
+    ASSERT_FALSE(write_thread.EnterUnbatchedNonBlocking(&w, &mu));
+    ASSERT_TRUE(w.status.IsIncomplete());
+    EXPECT_FALSE(w.no_slowdown);
+    EXPECT_FALSE(w.non_blocking_join);
+
+    // Not linked, so ExitUnbatched() must not be called; ending the stall is
+    // enough to leave the queue clean.
+    write_thread.EndWriteStall();
+    ASSERT_EQ(0, write_thread.GetBegunCountOfOutstandingStall());
+  }
+
+  {
+    WriteThread::Writer w;
+    InstrumentedMutexLock l(&mu);
+    ASSERT_TRUE(write_thread.EnterUnbatchedNonBlocking(&w, &mu));
+    write_thread.ExitUnbatched(&w);
+  }
+}
+
+TEST(WriteThreadTest, EnterUnbatchedNonBlockingFinishesAfterLeadershipStall) {
+  Options options;
+  ImmutableDBOptions db_options(options);
+  WriteThread write_thread(db_options);
+  InstrumentedMutex mu;
+  InstrumentedMutex signal_mu;
+  InstrumentedCondVar signal_cv(&signal_mu);
+  bool before_lock = false;
+  bool release_joiner = false;
+  bool entered = true;
+
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
+      "WriteThread::EnterUnbatchedNonBlocking:BeforeLock", [&](void*) {
+        InstrumentedMutexLock l(&signal_mu);
+        before_lock = true;
+        signal_cv.SignalAll();
+        while (!release_joiner) {
+          signal_cv.Wait();
+        }
+      });
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
+  Defer cleanup_sync_points([] {
+    ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->ClearAllCallBacks();
+    ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();
+  });
+
+  port::Thread joiner([&] {
+    WriteThread::Writer w;
+    InstrumentedMutexLock l(&mu);
+    entered = write_thread.EnterUnbatchedNonBlocking(&w, &mu);
+    if (entered) {
+      write_thread.ExitUnbatched(&w);
+    }
+  });
+
+  {
+    InstrumentedMutexLock l(&signal_mu);
+    while (!before_lock) {
+      signal_cv.Wait();
+    }
+  }
+  {
+    InstrumentedMutexLock l(&mu);
+    write_thread.BeginWriteStall();
+  }
+  {
+    InstrumentedMutexLock l(&signal_mu);
+    release_joiner = true;
+    signal_cv.SignalAll();
+  }
+
+  joiner.join();
+  EXPECT_TRUE(entered);
+  {
+    InstrumentedMutexLock l(&mu);
+    write_thread.EndWriteStall();
+  }
+}
+
+// A newly started stall must wake and remove a queued non-blocking join.
+TEST(WriteThreadTest, EnterUnbatchedNonBlockingSweptOutByLaterStall) {
+  Options options;
+  ImmutableDBOptions db_options(options);
+  WriteThread write_thread(db_options);
+  InstrumentedMutex mu;
+
+  // Occupy the write thread so the writer under test queues behind it rather
+  // than being linked as leader.
+  WriteThread::Writer leader;
+  mu.Lock();
+  write_thread.EnterUnbatched(&leader, &mu);
+  mu.Unlock();
+
+  InstrumentedMutex signal_mu;
+  InstrumentedCondVar signal_cv(&signal_mu);
+  bool queued = false;
+  bool finished = false;
+  bool entered = true;
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
+      "WriteThread::EnterUnbatched:Wait", [&](void*) {
+        InstrumentedMutexLock l(&signal_mu);
+        queued = true;
+        signal_cv.SignalAll();
+      });
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
+
+  port::Thread follower([&] {
+    WriteThread::Writer w;
+    InstrumentedMutexLock l(&mu);
+    entered = write_thread.EnterUnbatchedNonBlocking(&w, &mu);
+    if (entered) {
+      write_thread.ExitUnbatched(&w);
+    }
+    InstrumentedMutexLock sl(&signal_mu);
+    finished = true;
+    signal_cv.SignalAll();
+  });
+
+  {
+    InstrumentedMutexLock l(&signal_mu);
+    while (!queued) {
+      signal_cv.Wait();
+    }
+  }
+
+  mu.Lock();
+  write_thread.BeginWriteStall();
+  mu.Unlock();
+
+  bool timed_out = false;
+  {
+    InstrumentedMutexLock l(&signal_mu);
+    const uint64_t deadline = Env::Default()->NowMicros() + 30 * 1000 * 1000;
+    while (!finished) {
+      if (signal_cv.TimedWait(deadline)) {
+        timed_out = !finished;
+        break;
+      }
+    }
+  }
+  EXPECT_FALSE(timed_out) << "swept-out writer never woke: it is waiting for a "
+                             "leadership handoff that cannot arrive";
+  EXPECT_FALSE(entered) << "a swept-out writer must report failure, since it "
+                           "is no longer linked and must not be exited";
+
+  follower.join();
+  mu.Lock();
+  write_thread.EndWriteStall();
+  write_thread.ExitUnbatched(&leader);
+  mu.Unlock();
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->ClearAllCallBacks();
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();
+}
+
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {

--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -502,9 +502,13 @@ Status FlushJob::MemPurge() {
       }
     }
 
+    // MemPurge output is installed directly into the immutable list, so it
+    // must not advertise memory that can be reclaimed by switching a mutable
+    // memtable.
     new_mem = new MemTable(cfd_->internal_comparator(), cfd_->ioptions(),
                            mutable_cf_options_, cfd_->write_buffer_mgr(),
-                           earliest_seqno, cfd_->GetID());
+                           earliest_seqno, cfd_->GetID(),
+                           nullptr /* flush_initiator */);
     assert(new_mem != nullptr);
 
     Env* env = db_options_.env;

--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -189,11 +189,12 @@ MemTable::MemTable(const InternalKeyComparator& cmp,
                    const ImmutableOptions& ioptions,
                    const MutableCFOptions& mutable_cf_options,
                    WriteBufferManager* write_buffer_manager,
-                   SequenceNumber latest_seq, uint32_t column_family_id)
+                   SequenceNumber latest_seq, uint32_t column_family_id,
+                   FlushInitiator* flush_initiator)
     : comparator_(cmp),
       moptions_(ioptions, mutable_cf_options),
       kArenaBlockSize(Arena::OptimizeBlockSize(moptions_.arena_block_size)),
-      mem_tracker_(write_buffer_manager),
+      mem_tracker_(write_buffer_manager, flush_initiator),
       arena_(moptions_.arena_block_size,
              (write_buffer_manager != nullptr &&
               (write_buffer_manager->enabled() ||
@@ -1187,7 +1188,9 @@ Status MemTable::Add(SequenceNumber s, ValueType type,
     // (non-concurrent), these counters may be concurrently modified by
     // BatchPostProcess() (e.g., from AddLogicallyRedundantRangeTombstone
     // called on a read path).
-    num_entries_.FetchAddRelaxed(1);
+    if (num_entries_.FetchAddRelaxed(1) == 0) {
+      mem_tracker_.ActivateFlushInitiator();
+    }
     data_size_.FetchAddRelaxed(encoded_len);
     if (type == kTypeDeletion || type == kTypeSingleDeletion ||
         type == kTypeDeletionWithTimestamp) {
@@ -1274,7 +1277,6 @@ Status MemTable::Add(SequenceNumber s, ValueType type,
     is_range_del_table_empty_.StoreRelaxed(false);
   }
   UpdateOldestKeyTime();
-
   TEST_SYNC_POINT_CALLBACK("MemTable::Add:BeforeReturn:Encoded", &encoded);
   return Status::OK();
 }

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -597,7 +597,8 @@ class MemTable final : public ReadOnlyMemTable {
                     const ImmutableOptions& ioptions,
                     const MutableCFOptions& mutable_cf_options,
                     WriteBufferManager* write_buffer_manager,
-                    SequenceNumber earliest_seq, uint32_t column_family_id);
+                    SequenceNumber earliest_seq, uint32_t column_family_id,
+                    FlushInitiator* flush_initiator);
   // No copying allowed
   MemTable(const MemTable&) = delete;
   MemTable& operator=(const MemTable&) = delete;
@@ -618,6 +619,13 @@ class MemTable final : public ReadOnlyMemTable {
     return table_->ApproximateMemoryUsage() +
            range_del_table_->ApproximateMemoryUsage() +
            arena_.MemoryAllocatedBytes();
+  }
+
+  size_t WBMTrackedMemoryUsage() const { return mem_tracker_.tracked_bytes(); }
+
+  void StopWBMTracking() {
+    WriteLock wl(&immutable_mutex_);
+    mem_tracker_.DeactivateFlushInitiator();
   }
 
   void UniqueRandomSample(const uint64_t& target_sample_size,
@@ -739,7 +747,11 @@ class MemTable final : public ReadOnlyMemTable {
   // Used in concurrent memtable inserts.
   void BatchPostProcess(const MemTablePostProcessInfo& update_counters) {
     table_->BatchPostProcess();
-    num_entries_.FetchAddRelaxed(update_counters.num_entries);
+    const uint64_t old_num_entries =
+        num_entries_.FetchAddRelaxed(update_counters.num_entries);
+    if (old_num_entries == 0 && update_counters.num_entries != 0) {
+      mem_tracker_.ActivateFlushInitiator();
+    }
     data_size_.FetchAddRelaxed(update_counters.data_size);
     if (update_counters.num_deletes != 0) {
       num_deletes_.FetchAddRelaxed(update_counters.num_deletes);

--- a/db/memtable_list_test.cc
+++ b/db/memtable_list_test.cc
@@ -267,7 +267,8 @@ TEST_F(MemTableListTest, GetTest) {
 
   WriteBufferManager wb(options.db_write_buffer_size);
   MemTable* mem = new MemTable(cmp, ioptions, MutableCFOptions(options), &wb,
-                               kMaxSequenceNumber, 0 /* column_family_id */);
+                               kMaxSequenceNumber, 0 /* column_family_id */,
+                               nullptr /* flush_initiator */);
   mem->Ref();
 
   // Write some keys to this memtable.
@@ -335,7 +336,8 @@ TEST_F(MemTableListTest, GetTest) {
   // Create another memtable and write some keys to it
   WriteBufferManager wb2(options.db_write_buffer_size);
   MemTable* mem2 = new MemTable(cmp, ioptions, MutableCFOptions(options), &wb2,
-                                kMaxSequenceNumber, 0 /* column_family_id */);
+                                kMaxSequenceNumber, 0 /* column_family_id */,
+                                nullptr /* flush_initiator */);
   mem2->SetID(2);
   mem2->Ref();
 
@@ -432,7 +434,8 @@ TEST_F(MemTableListTest, GetFromHistoryTest) {
 
   WriteBufferManager wb(options.db_write_buffer_size);
   MemTable* mem = new MemTable(cmp, ioptions, MutableCFOptions(options), &wb,
-                               kMaxSequenceNumber, 0 /* column_family_id */);
+                               kMaxSequenceNumber, 0 /* column_family_id */,
+                               nullptr /* flush_initiator */);
   mem->Ref();
 
   // Write some keys to this memtable.
@@ -536,7 +539,8 @@ TEST_F(MemTableListTest, GetFromHistoryTest) {
   // Create another memtable and write some keys to it
   WriteBufferManager wb2(options.db_write_buffer_size);
   MemTable* mem2 = new MemTable(cmp, ioptions, MutableCFOptions(options), &wb2,
-                                kMaxSequenceNumber, 0 /* column_family_id */);
+                                kMaxSequenceNumber, 0 /* column_family_id */,
+                                nullptr /* flush_initiator */);
   mem2->Ref();
 
   ASSERT_OK(
@@ -566,7 +570,8 @@ TEST_F(MemTableListTest, GetFromHistoryTest) {
   // Add a third memtable to push the first memtable out of the history
   WriteBufferManager wb3(options.db_write_buffer_size);
   MemTable* mem3 = new MemTable(cmp, ioptions, MutableCFOptions(options), &wb3,
-                                kMaxSequenceNumber, 0 /* column_family_id */);
+                                kMaxSequenceNumber, 0 /* column_family_id */,
+                                nullptr /* flush_initiator */);
   mem3->Ref();
   // This is to make assert(memtable->IsFragmentedRangeTombstonesConstructed())
   // in MemTableListVersion::GetFromList work.
@@ -660,8 +665,9 @@ TEST_F(MemTableListTest, FlushPendingTest) {
   std::vector<MemTable*> tables;
   MutableCFOptions mutable_cf_options(options);
   for (int i = 0; i < num_tables; i++) {
-    MemTable* mem = new MemTable(cmp, ioptions, mutable_cf_options, &wb,
-                                 kMaxSequenceNumber, 0 /* column_family_id */);
+    MemTable* mem =
+        new MemTable(cmp, ioptions, mutable_cf_options, &wb, kMaxSequenceNumber,
+                     0 /* column_family_id */, nullptr /* flush_initiator */);
     mem->SetID(memtable_id++);
     mem->Ref();
 
@@ -935,8 +941,9 @@ TEST_F(MemTableListTest, FlushRequestPersistsAfterPartialPick) {
                     0 /* max_write_buffer_size_to_maintain */);
 
   for (uint64_t memtable_id = 0; memtable_id < 2; ++memtable_id) {
-    MemTable* mem = new MemTable(cmp, ioptions, mutable_cf_options, &wb,
-                                 kMaxSequenceNumber, 0 /* column_family_id */);
+    MemTable* mem =
+        new MemTable(cmp, ioptions, mutable_cf_options, &wb, kMaxSequenceNumber,
+                     0 /* column_family_id */, nullptr /* flush_initiator */);
     mem->SetID(memtable_id);
     mem->Ref();
     ASSERT_OK(mem->Add(++seq, kTypeValue, "key" + std::to_string(memtable_id),
@@ -991,8 +998,9 @@ TEST_F(MemTableListTest, RemoveOldMemTablesTest) {
   // WAL 20.
   SequenceNumber seq = 1;
   for (uint64_t next_log_number : {10, 20}) {
-    MemTable* mem = new MemTable(cmp, ioptions, mutable_cf_options, &wb,
-                                 kMaxSequenceNumber, 0 /* column_family_id */);
+    MemTable* mem =
+        new MemTable(cmp, ioptions, mutable_cf_options, &wb, kMaxSequenceNumber,
+                     0 /* column_family_id */, nullptr /* flush_initiator */);
     mem->Ref();
     ASSERT_OK(mem->Add(++seq, kTypeValue, "key", "value",
                        nullptr /* kv_prot_info */));
@@ -1065,9 +1073,9 @@ TEST_F(MemTableListTest, AtomicFlushTest) {
     mutable_cf_options_list.emplace_back(new MutableCFOptions(options));
     uint64_t memtable_id = 0;
     for (int i = 0; i != num_tables_per_cf; ++i) {
-      MemTable* mem =
-          new MemTable(cmp, ioptions, *(mutable_cf_options_list.back()), &wb,
-                       kMaxSequenceNumber, cf_id);
+      MemTable* mem = new MemTable(
+          cmp, ioptions, *(mutable_cf_options_list.back()), &wb,
+          kMaxSequenceNumber, cf_id, nullptr /* flush_initiator */);
       mem->SetID(memtable_id++);
       mem->Ref();
 
@@ -1218,8 +1226,9 @@ TEST_F(MemTableListWithTimestampTest, GetTableNewestUDT) {
   std::string key;
   std::string write_ts;
   for (int i = 0; i < num_tables; i++) {
-    MemTable* mem = new MemTable(cmp, ioptions, mutable_cf_options, &wb,
-                                 kMaxSequenceNumber, 0 /* column_family_id */);
+    MemTable* mem =
+        new MemTable(cmp, ioptions, mutable_cf_options, &wb, kMaxSequenceNumber,
+                     0 /* column_family_id */, nullptr /* flush_initiator */);
     mem->SetID(memtable_id++);
     mem->Ref();
 
@@ -1271,8 +1280,9 @@ TEST_F(MemTableListWithTimestampTest, ConcurrentGetTableNewestUDT) {
   WriteBufferManager wb(options.db_write_buffer_size);
   MutableCFOptions mutable_cf_options(options);
 
-  MemTable* mem = new MemTable(cmp, ioptions, mutable_cf_options, &wb,
-                               kMaxSequenceNumber, 0 /* column_family_id */);
+  MemTable* mem =
+      new MemTable(cmp, ioptions, mutable_cf_options, &wb, kMaxSequenceNumber,
+                   0 /* column_family_id */, nullptr /* flush_initiator */);
   mem->Ref();
 
   std::atomic<uint64_t> next_seq{1};

--- a/db/write_batch_test.cc
+++ b/db/write_batch_test.cc
@@ -43,7 +43,8 @@ static std::string PrintContents(WriteBatch* b,
   ImmutableOptions ioptions(options);
   WriteBufferManager wb(options.db_write_buffer_size);
   MemTable* mem = new MemTable(cmp, ioptions, MutableCFOptions(options), &wb,
-                               kMaxSequenceNumber, 0 /* column_family_id */);
+                               kMaxSequenceNumber, 0 /* column_family_id */,
+                               nullptr /* flush_initiator */);
   mem->Ref();
   std::string state;
   ColumnFamilyMemTablesDefault cf_mems_default(mem);

--- a/db/write_thread.cc
+++ b/db/write_thread.cc
@@ -229,11 +229,10 @@ bool WriteThread::LinkOne(Writer* w, std::atomic<Writer*>* newest_writer) {
   Writer* writers = newest_writer->load(std::memory_order_relaxed);
   while (true) {
     assert(writers != w);
-    // If write stall in effect, and w->no_slowdown is not true,
-    // block here until stall is cleared. If its true, then return
-    // immediately
+    // If a write stall is in effect, fail fast when requested. Otherwise,
+    // block here until the stall is cleared.
     if (writers == &write_stall_dummy_) {
-      if (w->no_slowdown) {
+      if (w->no_slowdown || w->non_blocking_join) {
         w->status = Status::Incomplete("Write stall");
         SetState(w, STATE_COMPLETED);
         return false;
@@ -335,7 +334,10 @@ void WriteThread::BeginWriteStall() {
   Writer* w = write_stall_dummy_.link_older;
   Writer* prev = &write_stall_dummy_;
   while (w != nullptr && w->write_group == nullptr) {
-    if (w->no_slowdown) {
+    // The oldest writer already owns leadership. It must finish and hand off
+    // to the stall barrier; unlinking it would strand newer writers.
+    const bool is_leader = w->link_older == nullptr;
+    if (!is_leader && (w->no_slowdown || w->non_blocking_join)) {
       prev->link_older = w->link_older;
       w->status = Status::Incomplete("Write stall");
       SetState(w, STATE_COMPLETED);
@@ -903,6 +905,31 @@ void WriteThread::EnterUnbatched(Writer* w, InstrumentedMutex* mu) {
     WaitForMemTableWriters();
   }
   mu->Lock();
+}
+
+bool WriteThread::EnterUnbatchedNonBlocking(Writer* w, InstrumentedMutex* mu) {
+  assert(w != nullptr && w->batch == nullptr);
+  w->non_blocking_join = true;
+  mu->Unlock();
+  const bool linked_as_leader = LinkOne(w, &newest_writer_);
+  if (!linked_as_leader) {
+    TEST_SYNC_POINT("WriteThread::EnterUnbatched:Wait");
+    // A new stall may sweep this queued writer and mark it completed.
+    AwaitState(w, STATE_GROUP_LEADER | STATE_COMPLETED, &eu_ctx);
+  }
+  TEST_SYNC_POINT("WriteThread::EnterUnbatchedNonBlocking:BeforeLock");
+  mu->Lock();
+  w->non_blocking_join = false;
+  if (w->state.load(std::memory_order_acquire) == STATE_COMPLETED) {
+    assert(!w->status.ok());
+    return false;
+  }
+  if (enable_pipelined_write_) {
+    mu->Unlock();
+    WaitForMemTableWriters();
+    mu->Lock();
+  }
+  return true;
 }
 
 void WriteThread::ExitUnbatched(Writer* w) {

--- a/db/write_thread.h
+++ b/db/write_thread.h
@@ -129,6 +129,7 @@ class WriteThread {
     WriteBatch* trace_batch;
     bool sync;
     bool no_slowdown;
+    bool non_blocking_join;
     bool disable_wal;
     Env::IOPriority rate_limiter_priority;
     bool disable_memtable;
@@ -159,6 +160,7 @@ class WriteThread {
           trace_batch(nullptr),
           sync(false),
           no_slowdown(false),
+          non_blocking_join(false),
           disable_wal(false),
           rate_limiter_priority(Env::IOPriority::IO_TOTAL),
           disable_memtable(false),
@@ -189,6 +191,7 @@ class WriteThread {
           // members
           sync(write_options.sync),
           no_slowdown(write_options.no_slowdown),
+          non_blocking_join(false),
           disable_wal(write_options.disableWAL),
           rate_limiter_priority(write_options.rate_limiter_priority),
           disable_memtable(_disable_memtable),
@@ -383,6 +386,10 @@ class WriteThread {
   // InstrumentedMutex* mu:  The db mutex, to unlock while waiting
   // REQUIRES: db mutex held
   void EnterUnbatched(Writer* w, InstrumentedMutex* mu);
+
+  // Refuses an existing or newly started stall. Call ExitUnbatched() only when
+  // this returns true; false leaves `w` unlinked with Incomplete status.
+  bool EnterUnbatchedNonBlocking(Writer* w, InstrumentedMutex* mu);
 
   // Completes a Writer begun with EnterUnbatched, unblocking subsequent
   // writers.

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -113,6 +113,7 @@ DECLARE_int32(max_write_buffer_number);
 DECLARE_int32(min_write_buffer_number_to_merge);
 DECLARE_int64(max_write_buffer_size_to_maintain);
 DECLARE_bool(use_write_buffer_manager);
+DECLARE_int32(wbm_flush_policy);
 DECLARE_double(memtable_prefix_bloom_size_ratio);
 DECLARE_bool(memtable_whole_key_filtering);
 DECLARE_int32(open_files);

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -112,6 +112,7 @@ DECLARE_int32(max_write_buffer_number);
 DECLARE_int32(min_write_buffer_number_to_merge);
 DECLARE_int64(max_write_buffer_size_to_maintain);
 DECLARE_bool(use_write_buffer_manager);
+DECLARE_int32(wbm_flush_policy);
 DECLARE_double(memtable_prefix_bloom_size_ratio);
 DECLARE_bool(memtable_whole_key_filtering);
 DECLARE_int32(open_files);

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -164,6 +164,14 @@ DEFINE_bool(use_write_buffer_manager, false,
             "Charge WriteBufferManager memory to the block cache");
 
 DEFINE_int32(
+    wbm_flush_policy,
+    static_cast<int32_t>(
+        ROCKSDB_NAMESPACE::WriteBufferFlushPolicy::kFlushOldest),
+    "Which memtable the WriteBufferManager flushes to free memory (see `enum "
+    "class WriteBufferFlushPolicy` in write_buffer_manager.h): 0 = oldest, 1 = "
+    "largest in the same DB, 2 = largest across all DBs sharing the manager");
+
+DEFINE_int32(
     write_buffer_size,
     static_cast<int32_t>(ROCKSDB_NAMESPACE::Options().write_buffer_size),
     "Number of bytes to buffer in memtable before compacting");

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -12,6 +12,7 @@
 #include "rocksdb/utilities/backup_engine.h"
 #ifdef GFLAGS
 #include "db_stress_tool/db_stress_common.h"
+#include "util/cast_util.h"
 
 static bool ValidateUint32Range(const char* flagname, uint64_t value) {
   if (value > std::numeric_limits<uint32_t>::max()) {
@@ -172,6 +173,14 @@ DEFINE_uint64(db_write_buffer_size,
 
 DEFINE_bool(use_write_buffer_manager, false,
             "Charge WriteBufferManager memory to the block cache");
+
+DEFINE_int32(
+    wbm_flush_policy,
+    ROCKSDB_NAMESPACE::lossless_cast<int32_t>(
+        ROCKSDB_NAMESPACE::WriteBufferFlushPolicy::kFlushOldest),
+    "Which memtable the WriteBufferManager flushes to free memory (see `enum "
+    "class WriteBufferFlushPolicy` in write_buffer_manager.h): 0 = oldest, 1 = "
+    "largest in the same DB, 2 = largest across all DBs sharing the manager");
 
 DEFINE_int32(
     write_buffer_size,

--- a/db_stress_tool/db_stress_tool.cc
+++ b/db_stress_tool/db_stress_tool.cc
@@ -590,8 +590,9 @@ int db_stress_tool(int argc, char** argv) {
   block_cache =
       StressTest::NewCache(FLAGS_cache_size, FLAGS_cache_numshardbits);
   if (FLAGS_use_write_buffer_manager) {
-    wbm = std::make_shared<WriteBufferManager>(FLAGS_db_write_buffer_size,
-                                               block_cache);
+    wbm = std::make_shared<WriteBufferManager>(
+        FLAGS_db_write_buffer_size, block_cache, false /* allow_stall */,
+        static_cast<WriteBufferFlushPolicy>(FLAGS_wbm_flush_policy));
   }
   if (FLAGS_rate_limiter_bytes_per_sec > 0) {
     rate_limiter.reset(NewGenericRateLimiter(

--- a/db_stress_tool/db_stress_tool.cc
+++ b/db_stress_tool/db_stress_tool.cc
@@ -30,6 +30,7 @@
 #include "port/stack_trace.h"
 #include "rocksdb/convenience.h"
 #include "table/format.h"
+#include "util/cast_util.h"
 #include "utilities/fault_injection_fs.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -120,6 +121,14 @@ int db_stress_tool(int argc, char** argv) {
                   " [OPTIONS]...");
   RegisterDbStressBdwFlagValidators();
   ParseCommandLineFlags(&argc, &argv, true);
+
+  if (FLAGS_wbm_flush_policy <
+          lossless_cast<int32_t>(WriteBufferFlushPolicy::kFlushOldest) ||
+      FLAGS_wbm_flush_policy >
+          lossless_cast<int32_t>(
+              WriteBufferFlushPolicy::kFlushLargestAcrossDBs)) {
+    return ReturnValidationError("--wbm_flush_policy must be 0, 1, or 2");
+  }
 
   SanitizeDoubleParam(&FLAGS_bloom_bits);
   SanitizeDoubleParam(&FLAGS_memtable_prefix_bloom_size_ratio);
@@ -628,8 +637,9 @@ int db_stress_tool(int argc, char** argv) {
   block_cache =
       StressTest::NewCache(FLAGS_cache_size, FLAGS_cache_numshardbits);
   if (FLAGS_use_write_buffer_manager) {
-    wbm = std::make_shared<WriteBufferManager>(FLAGS_db_write_buffer_size,
-                                               block_cache);
+    wbm = std::make_shared<WriteBufferManager>(
+        FLAGS_db_write_buffer_size, block_cache, false /* allow_stall */,
+        lossless_cast<WriteBufferFlushPolicy>(FLAGS_wbm_flush_policy));
   }
   if (FLAGS_rate_limiter_bytes_per_sec > 0) {
     rate_limiter.reset(NewGenericRateLimiter(

--- a/include/rocksdb/write_buffer_manager.h
+++ b/include/rocksdb/write_buffer_manager.h
@@ -23,6 +23,29 @@
 namespace ROCKSDB_NAMESPACE {
 class CacheReservationManager;
 
+// Policy that decides, when the WriteBufferManager triggers a flush to free
+// memory, which column family's mutable memtable should be flushed. The
+// WriteBufferManager itself only signals that a flush is needed; the actual
+// selection happens in the DB, which consults this policy.
+enum class WriteBufferFlushPolicy {
+  // Flush the column family whose mutable memtable was created earliest. This
+  // is the historical default.
+  kFlushOldest,
+  // Flush the column family whose mutable memtable is currently using the most
+  // memory. Freeing the largest memtable reclaims the most memory per flush,
+  // which reduces how often the WriteBufferManager has to trigger a flush when
+  // many column families share a single write buffer -- avoiding a stream of
+  // small, back-to-back flushes.
+  kFlushLargest,
+  // Like kFlushLargest, but the selection spans every DB that shares this
+  // WriteBufferManager: the DB using the most mutable memtable memory flushes
+  // its largest column family, even if a different DB's write triggered the
+  // flush. A DB that is not the largest defers instead of flushing itself, so a
+  // single flush of the biggest memory holder replaces many small flushes
+  // scattered across DBs. Only applies to non-atomic-flush DBs.
+  kFlushLargestAcrossDBs,
+};
+
 // Interface to block and signal DB instances, intended for RocksDB
 // internal use only. Each DB instance contains ptr to StallInterface.
 class StallInterface {
@@ -32,6 +55,27 @@ class StallInterface {
   virtual void Block() = 0;
 
   virtual void Signal() = 0;
+};
+
+// Interface implemented by each DB (DBImpl) so that a WriteBufferManager shared
+// across multiple DBs can, under the kFlushLargestAcrossDBs policy, find the DB
+// using the most mutable memtable memory and initiate a flush on it. Intended
+// for RocksDB internal use only.
+class FlushInitiator {
+ public:
+  virtual ~FlushInitiator() {}
+
+  // Best-effort estimate of the bytes held by this DB's flushable mutable
+  // memtables. Called by the WriteBufferManager while holding its registry
+  // mutex; the implementation may briefly lock the DB mutex but must not
+  // acquire the registry mutex.
+  virtual size_t GetFlushableMemUsage() = 0;
+
+  // Schedules a non-blocking background flush of this DB's largest flushable
+  // column family. Must be safe to call from another DB's thread: it must not
+  // block on this DB's write thread and must not acquire the registry mutex.
+  // Called by the WriteBufferManager while holding its registry mutex.
+  virtual void ScheduleFlush() = 0;
 };
 
 class WriteBufferManager final {
@@ -47,9 +91,13 @@ class WriteBufferManager final {
   // allow_stall: if set true, it will enable stalling of writes when
   // memory_usage() exceeds buffer_size. It will wait for flush to complete and
   // memory usage to drop down.
-  explicit WriteBufferManager(size_t _buffer_size,
-                              std::shared_ptr<Cache> cache = {},
-                              bool allow_stall = false);
+  //
+  // flush_policy: decides which column family is flushed when a flush is
+  // triggered to free memory. See WriteBufferFlushPolicy.
+  explicit WriteBufferManager(
+      size_t _buffer_size, std::shared_ptr<Cache> cache = {},
+      bool allow_stall = false,
+      WriteBufferFlushPolicy flush_policy = WriteBufferFlushPolicy::kFlushOldest);
   // No copying allowed
   WriteBufferManager(const WriteBufferManager&) = delete;
   WriteBufferManager& operator=(const WriteBufferManager&) = delete;
@@ -93,6 +141,16 @@ class WriteBufferManager final {
   void SetAllowStall(bool new_allow_stall) {
     allow_stall_.store(new_allow_stall, std::memory_order_relaxed);
     MaybeEndWriteStall();
+  }
+
+  // Returns the policy used to pick which column family to flush when a flush
+  // is triggered to free memory.
+  WriteBufferFlushPolicy flush_policy() const {
+    return flush_policy_.load(std::memory_order_relaxed);
+  }
+
+  void SetFlushPolicy(WriteBufferFlushPolicy new_flush_policy) {
+    flush_policy_.store(new_flush_policy, std::memory_order_relaxed);
   }
 
   // Below functions should be called by RocksDB internally.
@@ -159,6 +217,20 @@ class WriteBufferManager final {
 
   void RemoveDBFromQueue(StallInterface* wbm_stall);
 
+  // Registry of DBs sharing this WriteBufferManager, used only by the
+  // kFlushLargestAcrossDBs policy. Registration lasts for the DB's lifetime.
+  // Should only be called by RocksDB internally.
+  void RegisterFlushInitiator(FlushInitiator* initiator);
+  void DeregisterFlushInitiator(FlushInitiator* initiator);
+
+  // Across all registered DBs, if one other than `self` is using more flushable
+  // memtable memory, initiate a background flush on it and return true (the
+  // caller should then NOT flush itself). Returns false when `self` is (one of)
+  // the largest or there are no other candidates, in which case the caller
+  // should fall back to flushing itself. Should only be called by RocksDB
+  // internally, and NOT while holding the caller's DB mutex.
+  bool InitiateFlushOnLargestDB(FlushInitiator* self);
+
  private:
   std::atomic<size_t> buffer_size_;
   std::atomic<size_t> mutable_limit_;
@@ -176,6 +248,12 @@ class WriteBufferManager final {
   // Value should only be changed by BeginWriteStall() and MaybeEndWriteStall()
   // while holding mu_, but it can be read without a lock.
   std::atomic<bool> stall_active_;
+  std::atomic<WriteBufferFlushPolicy> flush_policy_;
+
+  // Registry of DBs sharing this WriteBufferManager (kFlushLargestAcrossDBs).
+  std::list<FlushInitiator*> flush_initiators_;
+  // Protects flush_initiators_.
+  std::mutex flush_initiators_mu_;
 
   void ReserveMemWithCache(size_t mem);
   void FreeMemWithCache(size_t mem);

--- a/include/rocksdb/write_buffer_manager.h
+++ b/include/rocksdb/write_buffer_manager.h
@@ -15,13 +15,25 @@
 #include <atomic>
 #include <condition_variable>
 #include <cstddef>
+#include <limits>
 #include <list>
 #include <mutex>
+#include <vector>
 
 #include "rocksdb/cache.h"
 
 namespace ROCKSDB_NAMESPACE {
 class CacheReservationManager;
+
+// Selects which mutable memtable to flush when the WBM exceeds its limit.
+enum class WriteBufferFlushPolicy {
+  // Flush the oldest mutable memtable; this is the historical default.
+  kFlushOldest,
+  // Flush the largest mutable memtable in the current DB.
+  kFlushLargest,
+  // Flush the DB that would reclaim the most memory among all sharing this WBM.
+  kFlushLargestAcrossDBs,
+};
 
 // Interface to block and signal DB instances, intended for RocksDB
 // internal use only. Each DB instance contains ptr to StallInterface.
@@ -32,6 +44,71 @@ class StallInterface {
   virtual void Block() = 0;
 
   virtual void Signal() = 0;
+};
+
+// Internal adapter for selecting and flushing a DB sharing a WBM.
+class FlushInitiator {
+ public:
+  explicit FlushInitiator(bool atomic_flush);
+  virtual ~FlushInitiator();
+
+  // The stable registration state is published independently of this object,
+  // so initiators must not move while registered.
+  FlushInitiator(const FlushInitiator&) = delete;
+  FlushInitiator& operator=(const FlushInitiator&) = delete;
+  FlushInitiator(FlushInitiator&&) = delete;
+  FlushInitiator& operator=(FlushInitiator&&) = delete;
+
+  // Updates this DB's WBM-visible counters from a memtable allocation.
+  // `memtable_mem` is that memtable's total allocation after adding `mem`.
+  void ReserveMem(size_t mem, size_t memtable_mem);
+
+  // Removes a sealed memtable from the mutable-memory total. The owner
+  // refreshes the largest-CF counter after installing its replacement.
+  void ScheduleFreeMem(size_t mem);
+
+  void SetLargestMutableCFMem(size_t mem);
+
+  // Replaces the cached maximum only if no allocation update overlapped the
+  // caller's scan.
+  bool TrySetLargestMutableCFMem(size_t mem, uint64_t update_seq);
+
+  // Excludes an uncertain cached maximum from cross-DB selection.
+  void InvalidateLargestMutableCFMem();
+
+  void UpdateLargestMutableCFMem(size_t mem);
+
+  uint64_t GetLargestMutableCFUpdateSequence() const;
+
+  size_t GetTotalMutableMem() const;
+
+  size_t GetLargestMutableCFMem() const;
+
+  size_t GetFlushableMemUsage() const;
+
+  // Total-memory accounting is always exact; a max-CF rebuild can be invalid.
+  bool HasAccurateFlushableMemUsage() const;
+
+  bool UsesTotalMutableMem() const;
+
+  void SetFlushable(bool flushable);
+
+  bool IsRegistered() const;
+
+  // Queues one asynchronous flush. Must not block on the DB write thread or
+  // reacquire the registry mutex. A pending request returns false so the
+  // caller makes local progress instead of deferring repeatedly.
+  virtual bool ScheduleFlush() = 0;
+
+ private:
+  friend class WriteBufferManager;
+
+  struct RegistrationState;
+
+  static constexpr size_t kInvalidRegistryIndex =
+      std::numeric_limits<size_t>::max();
+
+  std::shared_ptr<RegistrationState> registration_state_;
 };
 
 class WriteBufferManager final {
@@ -47,9 +124,14 @@ class WriteBufferManager final {
   // allow_stall: if set true, it will enable stalling of writes when
   // memory_usage() exceeds buffer_size. It will wait for flush to complete and
   // memory usage to drop down.
+  //
   explicit WriteBufferManager(size_t _buffer_size,
                               std::shared_ptr<Cache> cache = {},
                               bool allow_stall = false);
+
+  // flush_policy belongs to this shared manager, not serialized DBOptions.
+  WriteBufferManager(size_t _buffer_size, std::shared_ptr<Cache> cache,
+                     bool allow_stall, WriteBufferFlushPolicy flush_policy);
   // No copying allowed
   WriteBufferManager(const WriteBufferManager&) = delete;
   WriteBufferManager& operator=(const WriteBufferManager&) = delete;
@@ -94,6 +176,13 @@ class WriteBufferManager final {
     allow_stall_.store(new_allow_stall, std::memory_order_relaxed);
     MaybeEndWriteStall();
   }
+
+  // Returns the policy used for WBM-triggered flushes.
+  WriteBufferFlushPolicy flush_policy() const {
+    return flush_policy_.load(std::memory_order_relaxed);
+  }
+
+  void SetFlushPolicy(WriteBufferFlushPolicy new_flush_policy);
 
   // Below functions should be called by RocksDB internally.
 
@@ -159,6 +248,23 @@ class WriteBufferManager final {
 
   void RemoveDBFromQueue(StallInterface* wbm_stall);
 
+  // Internal registry for DBs sharing this manager.
+  void RegisterFlushInitiator(FlushInitiator* initiator);
+  void DeregisterFlushInitiator(FlushInitiator* initiator);
+  void NotifyFlushInitiatorChanged();
+
+  // Reads the asynchronously maintained candidate and flushes it if it is
+  // larger than `self`. This path does not take the registry mutex or scan the
+  // registry. False means `self` must flush.
+  bool InitiateFlushOnLargestDB(FlushInitiator* self);
+
+  // Rebuilds the cached candidate synchronously for deterministic tests.
+  void TEST_RefreshFlushInitiatorCandidate();
+
+  size_t TEST_GetFlushInitiatorRegistrySize() const;
+
+  bool TEST_HasFlushInitiatorSorter() const;
+
  private:
   std::atomic<size_t> buffer_size_;
   std::atomic<size_t> mutable_limit_;
@@ -176,6 +282,11 @@ class WriteBufferManager final {
   // Value should only be changed by BeginWriteStall() and MaybeEndWriteStall()
   // while holding mu_, but it can be read without a lock.
   std::atomic<bool> stall_active_;
+  std::atomic<WriteBufferFlushPolicy> flush_policy_;
+  std::mutex flush_policy_mu_;
+
+  struct FlushInitiatorRegistry;
+  std::unique_ptr<FlushInitiatorRegistry> flush_initiator_registry_;
 
   void ReserveMemWithCache(size_t mem);
   void FreeMemWithCache(size_t mem);

--- a/java/rocksjni/write_batch_test.cc
+++ b/java/rocksjni/write_batch_test.cc
@@ -49,7 +49,8 @@ jbyteArray Java_org_rocksdb_WriteBatchTest_getContents(JNIEnv* env,
   ROCKSDB_NAMESPACE::MemTable* mem = new ROCKSDB_NAMESPACE::MemTable(
       cmp, ROCKSDB_NAMESPACE::ImmutableOptions(options),
       ROCKSDB_NAMESPACE::MutableCFOptions(options), &wb,
-      ROCKSDB_NAMESPACE::kMaxSequenceNumber, 0 /* column_family_id */);
+      ROCKSDB_NAMESPACE::kMaxSequenceNumber, 0 /* column_family_id */,
+      nullptr /* flush_initiator */);
   mem->Ref();
   std::string state;
   ROCKSDB_NAMESPACE::ColumnFamilyMemTablesDefault cf_mems_default(mem);

--- a/memory/allocator.h
+++ b/memory/allocator.h
@@ -33,13 +33,23 @@ class Allocator {
 
 class AllocTracker {
  public:
-  explicit AllocTracker(WriteBufferManager* write_buffer_manager);
+  explicit AllocTracker(WriteBufferManager* write_buffer_manager,
+                        FlushInitiator* flush_initiator);
   // No copying allowed
   AllocTracker(const AllocTracker&) = delete;
   void operator=(const AllocTracker&) = delete;
 
   ~AllocTracker();
   void Allocate(size_t bytes);
+
+  // Starts publishing this memtable's allocation to its DB-level counters.
+  // Safe to call repeatedly and concurrently after successful inserts.
+  void ActivateFlushInitiator();
+
+  // Stops publishing this memtable as mutable without changing the WBM's
+  // global allocation accounting.
+  void DeactivateFlushInitiator();
+
   // Call when we're finished allocating memory so we can free it from
   // the write buffer's limit.
   void DoneAllocating();
@@ -48,9 +58,18 @@ class AllocTracker {
 
   bool is_freed() const { return write_buffer_manager_ == nullptr || freed_; }
 
+  size_t tracked_bytes() const {
+    return bytes_reported_.load(std::memory_order_relaxed);
+  }
+
  private:
+  void ReportAllocations(size_t bytes_allocated);
+
   WriteBufferManager* write_buffer_manager_;
+  FlushInitiator* flush_initiator_;
   std::atomic<size_t> bytes_allocated_;
+  std::atomic<size_t> bytes_reported_;
+  std::atomic<bool> flush_initiator_active_;
   bool done_allocating_;
   bool freed_;
 };

--- a/memtable/alloc_tracker.cc
+++ b/memtable/alloc_tracker.cc
@@ -15,9 +15,13 @@
 
 namespace ROCKSDB_NAMESPACE {
 
-AllocTracker::AllocTracker(WriteBufferManager* write_buffer_manager)
+AllocTracker::AllocTracker(WriteBufferManager* write_buffer_manager,
+                           FlushInitiator* flush_initiator)
     : write_buffer_manager_(write_buffer_manager),
+      flush_initiator_(flush_initiator),
       bytes_allocated_(0),
+      bytes_reported_(0),
+      flush_initiator_active_(false),
       done_allocating_(false),
       freed_(false) {}
 
@@ -27,8 +31,46 @@ void AllocTracker::Allocate(size_t bytes) {
   assert(write_buffer_manager_ != nullptr);
   if (write_buffer_manager_->enabled() ||
       write_buffer_manager_->cost_to_cache()) {
-    bytes_allocated_.fetch_add(bytes, std::memory_order_relaxed);
+    const size_t memtable_mem =
+        bytes_allocated_.fetch_add(bytes, std::memory_order_relaxed) + bytes;
+    if (flush_initiator_ != nullptr &&
+        flush_initiator_active_.load(std::memory_order_acquire)) {
+      ReportAllocations(memtable_mem);
+    }
+    // Publish the DB-local counters before ReserveMem() wakes the WBM's
+    // candidate-refresh thread on a threshold crossing.
     write_buffer_manager_->ReserveMem(bytes);
+  }
+}
+
+void AllocTracker::ActivateFlushInitiator() {
+  if (write_buffer_manager_ == nullptr || flush_initiator_ == nullptr) {
+    return;
+  }
+  flush_initiator_active_.store(true, std::memory_order_release);
+  ReportAllocations(bytes_allocated_.load(std::memory_order_relaxed));
+  write_buffer_manager_->NotifyFlushInitiatorChanged();
+}
+
+void AllocTracker::DeactivateFlushInitiator() {
+  if (flush_initiator_ != nullptr &&
+      flush_initiator_active_.exchange(false, std::memory_order_acq_rel)) {
+    const size_t mem = bytes_allocated_.load(std::memory_order_relaxed);
+    ReportAllocations(mem);
+    flush_initiator_->ScheduleFreeMem(
+        bytes_reported_.load(std::memory_order_relaxed));
+  }
+}
+
+void AllocTracker::ReportAllocations(size_t bytes_allocated) {
+  size_t bytes_reported = bytes_reported_.load(std::memory_order_relaxed);
+  while (bytes_reported < bytes_allocated) {
+    if (bytes_reported_.compare_exchange_weak(bytes_reported, bytes_allocated,
+                                              std::memory_order_relaxed)) {
+      flush_initiator_->ReserveMem(bytes_allocated - bytes_reported,
+                                   bytes_allocated);
+      return;
+    }
   }
 }
 
@@ -36,11 +78,12 @@ void AllocTracker::DoneAllocating() {
   if (write_buffer_manager_ != nullptr && !done_allocating_) {
     if (write_buffer_manager_->enabled() ||
         write_buffer_manager_->cost_to_cache()) {
-      write_buffer_manager_->ScheduleFreeMem(
-          bytes_allocated_.load(std::memory_order_relaxed));
+      const size_t mem = bytes_allocated_.load(std::memory_order_relaxed);
+      write_buffer_manager_->ScheduleFreeMem(mem);
     } else {
       assert(bytes_allocated_.load(std::memory_order_relaxed) == 0);
     }
+    DeactivateFlushInitiator();
     done_allocating_ = true;
   }
 }

--- a/memtable/write_buffer_manager.cc
+++ b/memtable/write_buffer_manager.cc
@@ -20,14 +20,16 @@
 namespace ROCKSDB_NAMESPACE {
 WriteBufferManager::WriteBufferManager(size_t _buffer_size,
                                        std::shared_ptr<Cache> cache,
-                                       bool allow_stall)
+                                       bool allow_stall,
+                                       WriteBufferFlushPolicy flush_policy)
     : buffer_size_(_buffer_size),
       mutable_limit_(buffer_size_ * 7 / 8),
       memory_used_(0),
       memory_active_(0),
       cache_res_mgr_(nullptr),
       allow_stall_(allow_stall),
-      stall_active_(false) {
+      stall_active_(false),
+      flush_policy_(flush_policy) {
   if (cache) {
     // Memtable's memory usage tends to fluctuate frequently
     // therefore we set delayed_decrease = true to save some dummy entry
@@ -180,6 +182,38 @@ void WriteBufferManager::RemoveDBFromQueue(StallInterface* wbm_stall) {
     }
   }
   wbm_stall->Signal();
+}
+
+void WriteBufferManager::RegisterFlushInitiator(FlushInitiator* initiator) {
+  std::lock_guard<std::mutex> lock(flush_initiators_mu_);
+  flush_initiators_.push_back(initiator);
+}
+
+void WriteBufferManager::DeregisterFlushInitiator(FlushInitiator* initiator) {
+  std::lock_guard<std::mutex> lock(flush_initiators_mu_);
+  flush_initiators_.remove(initiator);
+}
+
+bool WriteBufferManager::InitiateFlushOnLargestDB(FlushInitiator* self) {
+  // Holding flush_initiators_mu_ across the whole selection keeps every
+  // registered DB alive for the GetFlushableMemUsage()/ScheduleFlush() calls
+  // (DeregisterFlushInitiator() takes the same lock). Each of those calls locks
+  // at most one DB mutex at a time, so two DB mutexes are never held at once.
+  std::lock_guard<std::mutex> lock(flush_initiators_mu_);
+  FlushInitiator* best = nullptr;
+  size_t best_mem = 0;
+  for (FlushInitiator* initiator : flush_initiators_) {
+    size_t mem = initiator->GetFlushableMemUsage();
+    if (best == nullptr || mem > best_mem) {
+      best = initiator;
+      best_mem = mem;
+    }
+  }
+  if (best == nullptr || best == self) {
+    return false;
+  }
+  best->ScheduleFlush();
+  return true;
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/memtable/write_buffer_manager.cc
+++ b/memtable/write_buffer_manager.cc
@@ -9,25 +9,303 @@
 
 #include "rocksdb/write_buffer_manager.h"
 
+#include <chrono>
+#include <condition_variable>
 #include <memory>
+#include <vector>
 
 #include "cache/cache_entry_roles.h"
 #include "cache/cache_reservation_manager.h"
 #include "db/db_impl/db_impl.h"
+#include "port/port.h"
 #include "rocksdb/status.h"
+#include "util/atomic.h"
 #include "util/coding.h"
 
 namespace ROCKSDB_NAMESPACE {
+struct FlushInitiator::RegistrationState {
+  RegistrationState(FlushInitiator* owner_arg, bool atomic_flush_arg)
+      : initiator(owner_arg), atomic_flush(atomic_flush_arg) {}
+
+  size_t GetFlushableMemUsage() const {
+    if (!flushable.load(std::memory_order_relaxed)) {
+      return 0;
+    }
+    if (!atomic_flush &&
+        !largest_mutable_cf_mem_accurate.load(std::memory_order_acquire)) {
+      return 0;
+    }
+    return atomic_flush
+               ? total_mutable_mem.load(std::memory_order_relaxed)
+               : largest_mutable_cf_mem.load(std::memory_order_relaxed);
+  }
+
+  FlushInitiator* Pin() {
+    callbacks_in_progress.fetch_add(1, std::memory_order_acq_rel);
+    FlushInitiator* const result = initiator.load(std::memory_order_acquire);
+    if (result == nullptr) {
+      Unpin();
+    }
+    return result;
+  }
+
+  void Unpin() {
+    const size_t previous =
+        callbacks_in_progress.fetch_sub(1, std::memory_order_acq_rel);
+    assert(previous > 0);
+    if (previous == 1) {
+      std::lock_guard<std::mutex> lock(callbacks_mu);
+      callbacks_cv.notify_all();
+    }
+  }
+
+  void Detach() {
+    initiator.store(nullptr, std::memory_order_release);
+    std::unique_lock<std::mutex> lock(callbacks_mu);
+    callbacks_cv.wait(lock, [this] {
+      return callbacks_in_progress.load(std::memory_order_acquire) == 0;
+    });
+  }
+
+  std::atomic<FlushInitiator*> initiator;
+  const bool atomic_flush;
+  std::atomic<size_t> total_mutable_mem{0};
+  std::atomic<size_t> largest_mutable_cf_mem{0};
+  std::atomic<uint64_t> largest_mutable_cf_update_seq{0};
+  std::atomic<bool> largest_mutable_cf_mem_accurate{true};
+  std::atomic<bool> flushable{true};
+  std::atomic<size_t> registry_index{kInvalidRegistryIndex};
+  std::atomic<size_t> callbacks_in_progress{0};
+  std::mutex callbacks_mu;
+  std::condition_variable callbacks_cv;
+};
+
+struct WriteBufferManager::FlushInitiatorRegistry {
+  explicit FlushInitiatorRegistry(WriteBufferManager* owner_arg)
+      : owner(owner_arg) {}
+
+  FlushInitiatorRegistry(const FlushInitiatorRegistry&) = delete;
+  FlushInitiatorRegistry& operator=(const FlushInitiatorRegistry&) = delete;
+  FlushInitiatorRegistry(FlushInitiatorRegistry&&) = delete;
+  FlushInitiatorRegistry& operator=(FlushInitiatorRegistry&&) = delete;
+
+  ~FlushInitiatorRegistry() { Stop(); }
+
+  void Register(
+      const std::shared_ptr<FlushInitiator::RegistrationState>& state) {
+    {
+      std::lock_guard<std::mutex> lock(mu);
+      assert(state->registry_index.load(std::memory_order_relaxed) ==
+             FlushInitiator::kInvalidRegistryIndex);
+      state->registry_index.store(active.size(), std::memory_order_release);
+      active.push_back(state);
+    }
+    if (owner->flush_policy() ==
+        WriteBufferFlushPolicy::kFlushLargestAcrossDBs) {
+      StartSorter();
+    }
+    RequestRefresh();
+  }
+
+  void Deregister(
+      const std::shared_ptr<FlushInitiator::RegistrationState>& state) {
+    {
+      std::lock_guard<std::mutex> lock(mu);
+      const size_t index =
+          state->registry_index.load(std::memory_order_acquire);
+      assert(index < active.size());
+      assert(active[index] == state);
+      const std::shared_ptr<FlushInitiator::RegistrationState> last =
+          active.back();
+      active[index] = last;
+      last->registry_index.store(index, std::memory_order_release);
+      active.pop_back();
+      state->registry_index.store(FlushInitiator::kInvalidRegistryIndex,
+                                  std::memory_order_release);
+
+      if (AtomicSharedPtrLoad(&largest, std::memory_order_acquire) == state) {
+        AtomicSharedPtrStore(
+            &largest, std::shared_ptr<FlushInitiator::RegistrationState>{},
+            std::memory_order_release);
+      }
+    }
+
+    state->Detach();
+    RequestRefresh();
+  }
+
+  void PolicyChanged(WriteBufferFlushPolicy policy) {
+    if (policy != WriteBufferFlushPolicy::kFlushLargestAcrossDBs) {
+      StopSorter();
+      return;
+    }
+    StartSorter();
+    RequestRefresh();
+  }
+
+  void RequestRefresh() {
+    refresh_requested.store(true, std::memory_order_release);
+    cv.notify_one();
+  }
+
+  void Refresh() {
+    std::lock_guard<std::mutex> refresh_lock(refresh_mu);
+    {
+      std::lock_guard<std::mutex> lock(mu);
+      refresh_snapshot.assign(active.begin(), active.end());
+    }
+
+    std::shared_ptr<FlushInitiator::RegistrationState> best;
+    size_t best_mem = 0;
+    if (owner->flush_policy() ==
+        WriteBufferFlushPolicy::kFlushLargestAcrossDBs) {
+      for (const auto& candidate : refresh_snapshot) {
+        if (candidate->registry_index.load(std::memory_order_acquire) ==
+            FlushInitiator::kInvalidRegistryIndex) {
+          continue;
+        }
+        const size_t mem = candidate->GetFlushableMemUsage();
+        if (best == nullptr || mem > best_mem) {
+          best = candidate;
+          best_mem = mem;
+        }
+      }
+    }
+    {
+      std::lock_guard<std::mutex> lock(mu);
+      if (owner->flush_policy() ==
+              WriteBufferFlushPolicy::kFlushLargestAcrossDBs &&
+          best != nullptr && best_mem > 0 &&
+          best->registry_index.load(std::memory_order_acquire) !=
+              FlushInitiator::kInvalidRegistryIndex) {
+        AtomicSharedPtrStore(&largest, best, std::memory_order_release);
+      } else {
+        AtomicSharedPtrStore(
+            &largest, std::shared_ptr<FlushInitiator::RegistrationState>{},
+            std::memory_order_release);
+      }
+    }
+    refresh_snapshot.clear();
+  }
+
+  std::shared_ptr<FlushInitiator::RegistrationState> PinLargest(
+      FlushInitiator** initiator) {
+    std::shared_ptr<FlushInitiator::RegistrationState> state =
+        AtomicSharedPtrLoad(&largest, std::memory_order_acquire);
+    *initiator = state == nullptr ? nullptr : state->Pin();
+    if (*initiator == nullptr) {
+      state.reset();
+    }
+    return state;
+  }
+
+  void Stop() {
+    StopSorter();
+    AtomicSharedPtrStore(&largest,
+                         std::shared_ptr<FlushInitiator::RegistrationState>{},
+                         std::memory_order_release);
+  }
+
+  bool Empty() const {
+    std::lock_guard<std::mutex> lock(mu);
+    return active.empty();
+  }
+
+  size_t TEST_Size() const {
+    std::lock_guard<std::mutex> lock(mu);
+    return active.size();
+  }
+
+  bool TEST_HasSorter() const {
+    std::lock_guard<std::mutex> lifecycle_lock(sorter_lifecycle_mu);
+    return sorter != nullptr;
+  }
+
+ private:
+  void StartSorter() {
+    std::lock_guard<std::mutex> lifecycle_lock(sorter_lifecycle_mu);
+    {
+      std::lock_guard<std::mutex> lock(mu);
+      if (owner->flush_policy() !=
+              WriteBufferFlushPolicy::kFlushLargestAcrossDBs ||
+          active.empty() || sorter != nullptr) {
+        return;
+      }
+      stopping = false;
+      sorter = std::make_unique<port::Thread>([this] { Run(); });
+    }
+  }
+
+  void StopSorter() {
+    std::lock_guard<std::mutex> lifecycle_lock(sorter_lifecycle_mu);
+    std::unique_ptr<port::Thread> sorter_to_join;
+    {
+      std::lock_guard<std::mutex> lock(mu);
+      stopping = true;
+      sorter_to_join = std::move(sorter);
+      AtomicSharedPtrStore(&largest,
+                           std::shared_ptr<FlushInitiator::RegistrationState>{},
+                           std::memory_order_release);
+    }
+    cv.notify_all();
+    if (sorter_to_join != nullptr) {
+      sorter_to_join->join();
+    }
+  }
+
+  void Run() {
+    constexpr auto kPressureRefreshInterval = std::chrono::milliseconds(10);
+    constexpr auto kIdleRefreshInterval = std::chrono::seconds(1);
+    for (;;) {
+      Refresh();
+      std::unique_lock<std::mutex> lock(mu);
+      const auto refresh_interval = owner->ShouldFlush()
+                                        ? kPressureRefreshInterval
+                                        : kIdleRefreshInterval;
+      cv.wait_for(lock, refresh_interval, [this] {
+        return stopping ||
+               refresh_requested.exchange(false, std::memory_order_acq_rel);
+      });
+      if (stopping) {
+        return;
+      }
+    }
+  }
+
+  WriteBufferManager* const owner;
+  mutable std::mutex mu;
+  std::condition_variable cv;
+  bool stopping = false;
+  std::atomic<bool> refresh_requested{false};
+  mutable std::mutex sorter_lifecycle_mu;
+  std::unique_ptr<port::Thread> sorter;
+  std::mutex refresh_mu;
+  std::vector<std::shared_ptr<FlushInitiator::RegistrationState>>
+      refresh_snapshot;
+  std::vector<std::shared_ptr<FlushInitiator::RegistrationState>> active;
+  std::shared_ptr<FlushInitiator::RegistrationState> largest;
+};
+
 WriteBufferManager::WriteBufferManager(size_t _buffer_size,
                                        std::shared_ptr<Cache> cache,
                                        bool allow_stall)
+    : WriteBufferManager(_buffer_size, cache, allow_stall,
+                         WriteBufferFlushPolicy::kFlushOldest) {}
+
+WriteBufferManager::WriteBufferManager(size_t _buffer_size,
+                                       std::shared_ptr<Cache> cache,
+                                       bool allow_stall,
+                                       WriteBufferFlushPolicy flush_policy)
     : buffer_size_(_buffer_size),
       mutable_limit_(buffer_size_ * 7 / 8),
       memory_used_(0),
       memory_active_(0),
       cache_res_mgr_(nullptr),
       allow_stall_(allow_stall),
-      stall_active_(false) {
+      stall_active_(false),
+      flush_policy_(flush_policy),
+      flush_initiator_registry_(
+          std::make_unique<FlushInitiatorRegistry>(this)) {
   if (cache) {
     // Memtable's memory usage tends to fluctuate frequently
     // therefore we set delayed_decrease = true to save some dummy entry
@@ -39,10 +317,21 @@ WriteBufferManager::WriteBufferManager(size_t _buffer_size,
 }
 
 WriteBufferManager::~WriteBufferManager() {
+  flush_initiator_registry_->Stop();
 #ifndef NDEBUG
-  std::unique_lock<std::mutex> lock(mu_);
-  assert(queue_.empty());
+  {
+    std::unique_lock<std::mutex> lock(mu_);
+    assert(queue_.empty());
+  }
+  assert(flush_initiator_registry_->Empty());
 #endif
+}
+
+void WriteBufferManager::SetFlushPolicy(
+    WriteBufferFlushPolicy new_flush_policy) {
+  std::lock_guard<std::mutex> lock(flush_policy_mu_);
+  flush_policy_.store(new_flush_policy, std::memory_order_relaxed);
+  flush_initiator_registry_->PolicyChanged(new_flush_policy);
 }
 
 std::size_t WriteBufferManager::dummy_entries_in_cache_usage() const {
@@ -60,7 +349,12 @@ void WriteBufferManager::ReserveMem(size_t mem) {
     memory_used_.fetch_add(mem, std::memory_order_relaxed);
   }
   if (enabled()) {
-    memory_active_.fetch_add(mem, std::memory_order_relaxed);
+    const size_t previous =
+        memory_active_.fetch_add(mem, std::memory_order_relaxed);
+    const size_t mutable_limit = mutable_limit_.load(std::memory_order_relaxed);
+    if (previous <= mutable_limit && previous + mem > mutable_limit) {
+      flush_initiator_registry_->RequestRefresh();
+    }
   }
 }
 
@@ -126,7 +420,7 @@ void WriteBufferManager::BeginWriteStall(StallInterface* wbm_stall) {
     // Verify if the stall conditions are stil active.
     if (ShouldStall()) {
       stall_active_.store(true, std::memory_order_relaxed);
-      queue_.splice(queue_.end(), std::move(new_node));
+      queue_.splice(queue_.end(), new_node);
     }
   }
 
@@ -180,6 +474,173 @@ void WriteBufferManager::RemoveDBFromQueue(StallInterface* wbm_stall) {
     }
   }
   wbm_stall->Signal();
+}
+
+FlushInitiator::FlushInitiator(bool atomic_flush)
+    : registration_state_(
+          std::make_shared<RegistrationState>(this, atomic_flush)) {}
+
+FlushInitiator::~FlushInitiator() {
+  assert(!IsRegistered());
+  registration_state_->Detach();
+}
+
+void FlushInitiator::ReserveMem(size_t mem, size_t memtable_mem) {
+  registration_state_->total_mutable_mem.fetch_add(mem,
+                                                   std::memory_order_relaxed);
+  if (!registration_state_->atomic_flush) {
+    UpdateLargestMutableCFMem(memtable_mem);
+  }
+}
+
+void FlushInitiator::SetLargestMutableCFMem(size_t mem) {
+  registration_state_->largest_mutable_cf_mem.store(mem,
+                                                    std::memory_order_seq_cst);
+  registration_state_->largest_mutable_cf_mem_accurate.store(
+      true, std::memory_order_release);
+}
+
+bool FlushInitiator::TrySetLargestMutableCFMem(size_t mem,
+                                               uint64_t update_seq) {
+  if (registration_state_->largest_mutable_cf_update_seq.load(
+          std::memory_order_seq_cst) != update_seq) {
+    return false;
+  }
+
+  size_t previous = registration_state_->largest_mutable_cf_mem.load(
+      std::memory_order_seq_cst);
+  if (!registration_state_->largest_mutable_cf_mem.compare_exchange_strong(
+          previous, mem, std::memory_order_seq_cst)) {
+    return false;
+  }
+  if (registration_state_->largest_mutable_cf_update_seq.load(
+          std::memory_order_seq_cst) == update_seq) {
+    registration_state_->largest_mutable_cf_mem_accurate.store(
+        true, std::memory_order_release);
+    return true;
+  }
+
+  // Preserve the old upper bound when an allocation overlapped the rebuild.
+  // The allocator might have skipped its max update based on that value.
+  size_t current = registration_state_->largest_mutable_cf_mem.load(
+      std::memory_order_seq_cst);
+  while (current < previous &&
+         !registration_state_->largest_mutable_cf_mem.compare_exchange_weak(
+             current, previous, std::memory_order_seq_cst)) {
+  }
+  return false;
+}
+
+void FlushInitiator::InvalidateLargestMutableCFMem() {
+  registration_state_->largest_mutable_cf_mem_accurate.store(
+      false, std::memory_order_release);
+}
+
+void FlushInitiator::UpdateLargestMutableCFMem(size_t mem) {
+  registration_state_->largest_mutable_cf_update_seq.fetch_add(
+      1, std::memory_order_seq_cst);
+  size_t largest = registration_state_->largest_mutable_cf_mem.load(
+      std::memory_order_seq_cst);
+  while (largest < mem &&
+         !registration_state_->largest_mutable_cf_mem.compare_exchange_weak(
+             largest, mem, std::memory_order_seq_cst)) {
+  }
+}
+
+uint64_t FlushInitiator::GetLargestMutableCFUpdateSequence() const {
+  return registration_state_->largest_mutable_cf_update_seq.load(
+      std::memory_order_seq_cst);
+}
+
+void FlushInitiator::ScheduleFreeMem(size_t mem) {
+  [[maybe_unused]] const size_t previous =
+      registration_state_->total_mutable_mem.fetch_sub(
+          mem, std::memory_order_relaxed);
+  assert(previous >= mem);
+}
+
+size_t FlushInitiator::GetTotalMutableMem() const {
+  return registration_state_->total_mutable_mem.load(std::memory_order_relaxed);
+}
+
+size_t FlushInitiator::GetLargestMutableCFMem() const {
+  return registration_state_->largest_mutable_cf_mem.load(
+      std::memory_order_relaxed);
+}
+
+size_t FlushInitiator::GetFlushableMemUsage() const {
+  return registration_state_->GetFlushableMemUsage();
+}
+
+bool FlushInitiator::HasAccurateFlushableMemUsage() const {
+  return registration_state_->atomic_flush ||
+         registration_state_->largest_mutable_cf_mem_accurate.load(
+             std::memory_order_acquire);
+}
+
+bool FlushInitiator::UsesTotalMutableMem() const {
+  return registration_state_->atomic_flush;
+}
+
+void FlushInitiator::SetFlushable(bool flushable) {
+  registration_state_->flushable.store(flushable, std::memory_order_relaxed);
+}
+
+bool FlushInitiator::IsRegistered() const {
+  return registration_state_->registry_index.load(std::memory_order_acquire) !=
+         kInvalidRegistryIndex;
+}
+
+void WriteBufferManager::RegisterFlushInitiator(FlushInitiator* initiator) {
+  assert(initiator != nullptr);
+  flush_initiator_registry_->Register(initiator->registration_state_);
+}
+
+void WriteBufferManager::DeregisterFlushInitiator(FlushInitiator* initiator) {
+  assert(initiator != nullptr);
+  flush_initiator_registry_->Deregister(initiator->registration_state_);
+}
+
+void WriteBufferManager::NotifyFlushInitiatorChanged() {
+  flush_initiator_registry_->RequestRefresh();
+}
+
+bool WriteBufferManager::InitiateFlushOnLargestDB(FlushInitiator* self) {
+  if (self != nullptr && !self->HasAccurateFlushableMemUsage()) {
+    return false;
+  }
+  FlushInitiator* initiator = nullptr;
+  const std::shared_ptr<FlushInitiator::RegistrationState> best =
+      flush_initiator_registry_->PinLargest(&initiator);
+  if (best == nullptr ||
+      (self != nullptr && best.get() == self->registration_state_.get())) {
+    if (best != nullptr) {
+      best->Unpin();
+    }
+    return false;
+  }
+  const size_t best_mem = best->GetFlushableMemUsage();
+  if (best_mem == 0 ||
+      (self != nullptr && best_mem <= self->GetFlushableMemUsage())) {
+    best->Unpin();
+    return false;
+  }
+
+  const bool scheduled = initiator->ScheduleFlush();
+  best->Unpin();
+  return scheduled;
+}
+
+size_t WriteBufferManager::TEST_GetFlushInitiatorRegistrySize() const {
+  return flush_initiator_registry_->TEST_Size();
+}
+
+bool WriteBufferManager::TEST_HasFlushInitiatorSorter() const {
+  return flush_initiator_registry_->TEST_HasSorter();
+}
+
+void WriteBufferManager::TEST_RefreshFlushInitiatorCandidate() {
+  flush_initiator_registry_->Refresh();
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/memtable/write_buffer_manager_test.cc
+++ b/memtable/write_buffer_manager_test.cc
@@ -9,6 +9,12 @@
 
 #include "rocksdb/write_buffer_manager.h"
 
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+
+#include "memory/allocator.h"
 #include "rocksdb/advanced_cache.h"
 #include "test_util/testharness.h"
 
@@ -293,6 +299,305 @@ TEST_F(ChargeWriteBufferTest, BasicWithCacheFull) {
   ASSERT_GE(cache->GetPinnedUsage(), 46 * kSizeDummyEntry);
   ASSERT_LT(cache->GetPinnedUsage(),
             46 * kSizeDummyEntry + kMetaDataChargeOverhead);
+}
+
+namespace {
+// Test double for a DB in the cross-DB flush registry.
+class FakeFlushInitiator : public FlushInitiator {
+ public:
+  FakeFlushInitiator(size_t mem, bool can_flush, bool atomic_flush = false)
+      : FlushInitiator(atomic_flush), can_flush_(can_flush) {
+    ReserveMem(mem, mem);
+  }
+
+  bool ScheduleFlush() override {
+    ++schedule_calls_;
+    return can_flush_;
+  }
+
+  void SetLargestMem(size_t mem) { SetLargestMutableCFMem(mem); }
+
+  bool can_flush_;
+  int schedule_calls_ = 0;
+};
+
+class RegistryReentrantFlushInitiator : public FlushInitiator {
+ public:
+  RegistryReentrantFlushInitiator(WriteBufferManager* wbm,
+                                  FlushInitiator* nested)
+      : FlushInitiator(false), wbm_(wbm), nested_(nested) {
+    ReserveMem(100, 100);
+  }
+
+  bool ScheduleFlush() override {
+    wbm_->RegisterFlushInitiator(nested_);
+    wbm_->DeregisterFlushInitiator(nested_);
+    return true;
+  }
+
+ private:
+  WriteBufferManager* const wbm_;
+  FlushInitiator* const nested_;
+};
+
+class BlockingFlushInitiator : public FlushInitiator {
+ public:
+  BlockingFlushInitiator() : FlushInitiator(false) { ReserveMem(100, 100); }
+
+  bool ScheduleFlush() override {
+    std::unique_lock<std::mutex> lock(mu_);
+    entered_ = true;
+    cv_.notify_all();
+    cv_.wait(lock, [this] { return released_; });
+    return true;
+  }
+
+  void WaitUntilEntered() {
+    std::unique_lock<std::mutex> lock(mu_);
+    cv_.wait(lock, [this] { return entered_; });
+  }
+
+  void Release() {
+    std::lock_guard<std::mutex> lock(mu_);
+    released_ = true;
+    cv_.notify_all();
+  }
+
+ private:
+  std::mutex mu_;
+  std::condition_variable cv_;
+  bool entered_ = false;
+  bool released_ = false;
+};
+}  // anonymous namespace
+
+// InitiateFlushOnLargestDB() must report true only when a flush is genuinely in
+// flight somewhere else, because the caller skips its own flush when it does.
+TEST_F(WriteBufferManagerTest, InitiateFlushOnLargestDBContract) {
+  WriteBufferManager wbf(100 * 1024 * 1024, nullptr /* cache */,
+                         false /* allow_stall */,
+                         WriteBufferFlushPolicy::kFlushLargestAcrossDBs);
+
+  FakeFlushInitiator self(/*mem=*/100, /*can_flush=*/true);
+  FakeFlushInitiator bigger(/*mem=*/200, /*can_flush=*/true);
+  wbf.RegisterFlushInitiator(&self);
+  wbf.RegisterFlushInitiator(&bigger);
+  wbf.TEST_RefreshFlushInitiatorCandidate();
+
+  // The larger DB accepts, so the caller may defer to it.
+  ASSERT_TRUE(wbf.InitiateFlushOnLargestDB(&self));
+  ASSERT_EQ(1, bigger.schedule_calls_);
+  ASSERT_EQ(0, self.schedule_calls_);
+
+  // The larger DB's state changed after it won the bid and it now declines.
+  // The caller must be told so, otherwise nothing would flush at all.
+  bigger.can_flush_ = false;
+  ASSERT_FALSE(wbf.InitiateFlushOnLargestDB(&self));
+  ASSERT_EQ(2, bigger.schedule_calls_);
+  ASSERT_EQ(0, self.schedule_calls_);
+
+  // Caller is itself the largest: it flushes itself rather than deferring.
+  bigger.SetLargestMem(1);
+  bigger.can_flush_ = true;
+  wbf.TEST_RefreshFlushInitiatorCandidate();
+  ASSERT_FALSE(wbf.InitiateFlushOnLargestDB(&self));
+  ASSERT_EQ(2, bigger.schedule_calls_);
+
+  // Nobody has anything to reclaim: there is no one to defer to.
+  self.SetLargestMem(0);
+  bigger.SetLargestMem(0);
+  wbf.TEST_RefreshFlushInitiatorCandidate();
+  ASSERT_FALSE(wbf.InitiateFlushOnLargestDB(&self));
+  ASSERT_EQ(2, bigger.schedule_calls_);
+
+  wbf.DeregisterFlushInitiator(&self);
+  wbf.DeregisterFlushInitiator(&bigger);
+}
+
+TEST_F(WriteBufferManagerTest, FlushInitiatorTracksMutableMemory) {
+  FakeFlushInitiator normal(/*mem=*/0, /*can_flush=*/true);
+  normal.ReserveMem(/*mem=*/100, /*memtable_mem=*/100);
+  normal.ReserveMem(/*mem=*/50, /*memtable_mem=*/50);
+
+  EXPECT_EQ(150, normal.GetTotalMutableMem());
+  EXPECT_EQ(100, normal.GetLargestMutableCFMem());
+  EXPECT_EQ(100, normal.GetFlushableMemUsage());
+
+  normal.ScheduleFreeMem(100);
+  normal.SetLargestMutableCFMem(50);
+  EXPECT_EQ(50, normal.GetTotalMutableMem());
+  EXPECT_EQ(50, normal.GetFlushableMemUsage());
+
+  FakeFlushInitiator atomic(/*mem=*/0, /*can_flush=*/true,
+                            /*atomic_flush=*/true);
+  atomic.ReserveMem(/*mem=*/100, /*memtable_mem=*/100);
+  atomic.ReserveMem(/*mem=*/50, /*memtable_mem=*/50);
+  EXPECT_EQ(150, atomic.GetFlushableMemUsage());
+}
+
+TEST_F(WriteBufferManagerTest, LargestMutableCFRebuildRejectsStaleUpdate) {
+  FakeFlushInitiator initiator(/*mem=*/100, /*can_flush=*/true);
+  const uint64_t update_seq = initiator.GetLargestMutableCFUpdateSequence();
+
+  initiator.UpdateLargestMutableCFMem(200);
+
+  EXPECT_FALSE(initiator.TrySetLargestMutableCFMem(50, update_seq));
+  EXPECT_EQ(200, initiator.GetLargestMutableCFMem());
+}
+
+TEST_F(WriteBufferManagerTest, InaccurateLargestMutableCFIsNotSelected) {
+  WriteBufferManager wbf(1024, nullptr, false,
+                         WriteBufferFlushPolicy::kFlushLargestAcrossDBs);
+  FakeFlushInitiator stale(/*mem=*/200, /*can_flush=*/true);
+  FakeFlushInitiator current(/*mem=*/100, /*can_flush=*/true);
+  wbf.RegisterFlushInitiator(&stale);
+  wbf.RegisterFlushInitiator(&current);
+
+  stale.InvalidateLargestMutableCFMem();
+  EXPECT_FALSE(stale.HasAccurateFlushableMemUsage());
+  wbf.TEST_RefreshFlushInitiatorCandidate();
+  EXPECT_FALSE(wbf.InitiateFlushOnLargestDB(&stale));
+  EXPECT_EQ(0, stale.schedule_calls_);
+  EXPECT_EQ(0, current.schedule_calls_);
+  EXPECT_TRUE(wbf.InitiateFlushOnLargestDB(nullptr));
+  EXPECT_EQ(1, current.schedule_calls_);
+
+  stale.SetLargestMutableCFMem(200);
+  EXPECT_TRUE(stale.HasAccurateFlushableMemUsage());
+  wbf.TEST_RefreshFlushInitiatorCandidate();
+  EXPECT_TRUE(wbf.InitiateFlushOnLargestDB(nullptr));
+  EXPECT_EQ(1, stale.schedule_calls_);
+
+  wbf.DeregisterFlushInitiator(&stale);
+  wbf.DeregisterFlushInitiator(&current);
+}
+
+TEST_F(WriteBufferManagerTest, AllocTrackerPublishesOnlyActiveMemtables) {
+  WriteBufferManager wbf(1024);
+  FakeFlushInitiator initiator(/*mem=*/0, /*can_flush=*/true);
+  AllocTracker tracker(&wbf, &initiator);
+
+  tracker.Allocate(100);
+  EXPECT_EQ(0, initiator.GetFlushableMemUsage());
+
+  tracker.ActivateFlushInitiator();
+  EXPECT_EQ(100, initiator.GetFlushableMemUsage());
+
+  tracker.Allocate(50);
+  EXPECT_EQ(150, initiator.GetTotalMutableMem());
+  EXPECT_EQ(150, initiator.GetLargestMutableCFMem());
+
+  tracker.DeactivateFlushInitiator();
+  EXPECT_EQ(0, initiator.GetTotalMutableMem());
+  tracker.DoneAllocating();
+  EXPECT_EQ(0, initiator.GetTotalMutableMem());
+}
+
+TEST_F(WriteBufferManagerTest, AllocTrackerWithoutManagerDoesNotPublish) {
+  FakeFlushInitiator initiator(/*mem=*/0, /*can_flush=*/true);
+  AllocTracker tracker(nullptr, &initiator);
+
+  tracker.ActivateFlushInitiator();
+
+  EXPECT_EQ(0, initiator.GetFlushableMemUsage());
+}
+
+TEST_F(WriteBufferManagerTest, FlushPolicyStopsAndRestartsSorter) {
+  WriteBufferManager wbf(1024, nullptr /* cache */, false /* allow_stall */,
+                         WriteBufferFlushPolicy::kFlushLargestAcrossDBs);
+  FakeFlushInitiator initiator(/*mem=*/100, /*can_flush=*/true);
+  wbf.RegisterFlushInitiator(&initiator);
+  EXPECT_TRUE(wbf.TEST_HasFlushInitiatorSorter());
+
+  wbf.SetFlushPolicy(WriteBufferFlushPolicy::kFlushOldest);
+  EXPECT_FALSE(wbf.TEST_HasFlushInitiatorSorter());
+  EXPECT_FALSE(wbf.InitiateFlushOnLargestDB(nullptr));
+
+  wbf.SetFlushPolicy(WriteBufferFlushPolicy::kFlushLargestAcrossDBs);
+  EXPECT_TRUE(wbf.TEST_HasFlushInitiatorSorter());
+  wbf.TEST_RefreshFlushInitiatorCandidate();
+  EXPECT_TRUE(wbf.InitiateFlushOnLargestDB(nullptr));
+
+  wbf.DeregisterFlushInitiator(&initiator);
+}
+
+TEST_F(WriteBufferManagerTest, DeregistrationReclaimsRegistryState) {
+  WriteBufferManager wbf(1024, nullptr /* cache */, false /* allow_stall */,
+                         WriteBufferFlushPolicy::kFlushLargestAcrossDBs);
+
+  for (size_t i = 0; i < 1000; ++i) {
+    auto initiator =
+        std::make_unique<FakeFlushInitiator>(i + 1, /*can_flush=*/true);
+    wbf.RegisterFlushInitiator(initiator.get());
+    wbf.DeregisterFlushInitiator(initiator.get());
+  }
+
+  EXPECT_EQ(0, wbf.TEST_GetFlushInitiatorRegistrySize());
+}
+
+TEST_F(WriteBufferManagerTest, LargeFlushInitiatorRegistry) {
+  constexpr size_t kNumDBs = 10000;
+  WriteBufferManager wbf(100 * 1024 * 1024, nullptr /* cache */,
+                         false /* allow_stall */,
+                         WriteBufferFlushPolicy::kFlushLargestAcrossDBs);
+  std::vector<std::unique_ptr<FakeFlushInitiator>> initiators;
+  initiators.reserve(kNumDBs);
+  for (size_t i = 0; i < kNumDBs; ++i) {
+    initiators.emplace_back(std::make_unique<FakeFlushInitiator>(i + 1, true));
+    wbf.RegisterFlushInitiator(initiators.back().get());
+  }
+  wbf.TEST_RefreshFlushInitiatorCandidate();
+
+  EXPECT_TRUE(wbf.InitiateFlushOnLargestDB(nullptr));
+  EXPECT_EQ(1, initiators.back()->schedule_calls_);
+
+  // Forward-order removal repeatedly exercises the swap-with-last index fixup.
+  for (const auto& initiator : initiators) {
+    wbf.DeregisterFlushInitiator(initiator.get());
+  }
+}
+
+TEST_F(WriteBufferManagerTest, ScheduleFlushRunsOutsideRegistryLock) {
+  WriteBufferManager wbf(1024, nullptr /* cache */, false /* allow_stall */,
+                         WriteBufferFlushPolicy::kFlushLargestAcrossDBs);
+  FakeFlushInitiator nested(/*mem=*/1, /*can_flush=*/true);
+  RegistryReentrantFlushInitiator initiator(&wbf, &nested);
+  wbf.RegisterFlushInitiator(&initiator);
+  wbf.TEST_RefreshFlushInitiatorCandidate();
+
+  EXPECT_TRUE(wbf.InitiateFlushOnLargestDB(nullptr));
+
+  wbf.DeregisterFlushInitiator(&initiator);
+}
+
+TEST_F(WriteBufferManagerTest, DeregistrationWaitsForCachedCandidateReader) {
+  WriteBufferManager wbf(1024, nullptr /* cache */, false /* allow_stall */,
+                         WriteBufferFlushPolicy::kFlushLargestAcrossDBs);
+  BlockingFlushInitiator initiator;
+  wbf.RegisterFlushInitiator(&initiator);
+  wbf.TEST_RefreshFlushInitiatorCandidate();
+
+  std::thread selector(
+      [&] { EXPECT_TRUE(wbf.InitiateFlushOnLargestDB(nullptr)); });
+  initiator.WaitUntilEntered();
+
+  std::atomic<bool> deregistration_started{false};
+  std::atomic<bool> deregistration_finished{false};
+  std::thread deregister([&] {
+    deregistration_started.store(true, std::memory_order_release);
+    wbf.DeregisterFlushInitiator(&initiator);
+    deregistration_finished.store(true, std::memory_order_release);
+  });
+  while (!deregistration_started.load(std::memory_order_acquire)) {
+    std::this_thread::yield();
+  }
+  EXPECT_FALSE(deregistration_finished.load(std::memory_order_acquire));
+
+  initiator.Release();
+  selector.join();
+  deregister.join();
+  EXPECT_TRUE(deregistration_finished.load(std::memory_order_acquire));
+  EXPECT_FALSE(wbf.InitiateFlushOnLargestDB(nullptr));
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/monitoring/instrumented_mutex.h
+++ b/monitoring/instrumented_mutex.h
@@ -44,6 +44,8 @@ class InstrumentedMutex {
 
   void Lock();
 
+  bool TryLock() { return mutex_.TryLock(); }
+
   void Unlock() { mutex_.Unlock(); }
 
   void AssertHeld() const { mutex_.AssertHeld(); }

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -573,7 +573,8 @@ class MemTableConstructor : public Constructor {
     ImmutableOptions ioptions(options_);
     memtable_ =
         new MemTable(internal_comparator_, ioptions, MutableCFOptions(options_),
-                     wb, kMaxSequenceNumber, 0 /* column_family_id */);
+                     wb, kMaxSequenceNumber, 0 /* column_family_id */,
+                     nullptr /* flush_initiator */);
     memtable_->Ref();
   }
   ~MemTableConstructor() override { delete memtable_->Unref(); }
@@ -586,7 +587,8 @@ class MemTableConstructor : public Constructor {
     ImmutableOptions mem_ioptions(ioptions);
     memtable_ = new MemTable(internal_comparator_, mem_ioptions,
                              MutableCFOptions(options_), write_buffer_manager_,
-                             kMaxSequenceNumber, 0 /* column_family_id */);
+                             kMaxSequenceNumber, 0 /* column_family_id */,
+                             nullptr /* flush_initiator */);
     memtable_->Ref();
     int seq = 1;
     for (const auto& kv : kv_map) {
@@ -5563,7 +5565,8 @@ class MemTableTest : public testing::Test {
     ImmutableOptions ioptions(options_);
     wb_ = new WriteBufferManager(options_.db_write_buffer_size);
     memtable_ = new MemTable(cmp, ioptions, MutableCFOptions(options_), wb_,
-                             kMaxSequenceNumber, 0 /* column_family_id */);
+                             kMaxSequenceNumber, 0 /* column_family_id */,
+                             nullptr /* flush_initiator */);
     memtable_->Ref();
   }
 

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -511,6 +511,19 @@ DEFINE_bool(verify_manifest_content_on_close,
 DEFINE_bool(cost_write_buffer_to_cache, false,
             "The usage of memtable is costed to the block cache");
 
+DEFINE_bool(write_buffer_manager_allow_stall, false,
+            "If true, the WriteBufferManager stalls writes when total memtable "
+            "memory exceeds db_write_buffer_size");
+
+DEFINE_string(
+    write_buffer_manager_flush_policy, "oldest",
+    "Which memtable the WriteBufferManager flushes when it needs to free "
+    "memory. Allowed values are oldest, largest, and largest_across_dbs. "
+    "Requires db_write_buffer_size or cost_write_buffer_to_cache to be set, "
+    "since otherwise no WriteBufferManager is created. largest_across_dbs is "
+    "only meaningful with num_multi_db > 1, which shares one "
+    "WriteBufferManager across all DBs.");
+
 DEFINE_int64(arena_block_size, ROCKSDB_NAMESPACE::Options().arena_block_size,
              "The size, in bytes, of one block in arena memory allocation.");
 
@@ -1552,6 +1565,23 @@ static enum ROCKSDB_NAMESPACE::TieredAdmissionPolicy StringToAdmissionPolicy(
     return ROCKSDB_NAMESPACE::kAdmPolicyAllowAll;
   } else {
     fprintf(stderr, "Cannot parse admission policy %s\n", policy);
+    db_bench_exit(1);
+  }
+}
+
+static enum ROCKSDB_NAMESPACE::WriteBufferFlushPolicy
+StringToWriteBufferFlushPolicy(const char* policy) {
+  assert(policy);
+
+  if (!strcasecmp(policy, "oldest")) {
+    return ROCKSDB_NAMESPACE::WriteBufferFlushPolicy::kFlushOldest;
+  } else if (!strcasecmp(policy, "largest")) {
+    return ROCKSDB_NAMESPACE::WriteBufferFlushPolicy::kFlushLargest;
+  } else if (!strcasecmp(policy, "largest_across_dbs")) {
+    return ROCKSDB_NAMESPACE::WriteBufferFlushPolicy::kFlushLargestAcrossDBs;
+  } else {
+    fprintf(stderr, "Cannot parse write buffer manager flush policy %s\n",
+            policy);
     db_bench_exit(1);
   }
 }
@@ -5168,8 +5198,11 @@ class Benchmark {
 
     options.max_open_files = FLAGS_open_files;
     if (FLAGS_cost_write_buffer_to_cache || FLAGS_db_write_buffer_size != 0) {
-      options.write_buffer_manager.reset(
-          new WriteBufferManager(FLAGS_db_write_buffer_size, cache_));
+      options.write_buffer_manager.reset(new WriteBufferManager(
+          FLAGS_db_write_buffer_size, cache_,
+          FLAGS_write_buffer_manager_allow_stall,
+          StringToWriteBufferFlushPolicy(
+              FLAGS_write_buffer_manager_flush_policy.c_str())));
     }
     options.max_manifest_file_size = FLAGS_max_manifest_file_size;
     options.max_manifest_space_amp_pct = FLAGS_max_manifest_space_amp_pct;

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -360,6 +360,9 @@ default_params = {
         [0, 0, 0, 1024 * 1024, 8 * 1024 * 1024, 128 * 1024 * 1024]
     ),
     "use_write_buffer_manager": lambda: random.randint(0, 1),
+    # 0 = flush oldest memtable, 1 = flush largest in the same DB,
+    # 2 = flush largest across all DBs sharing the WriteBufferManager.
+    "wbm_flush_policy": lambda: random.choice([0, 1, 2]),
     "avoid_unnecessary_blocking_io": random.randint(0, 1),
     "write_dbid_to_manifest": random.randint(0, 1),
     "write_identity_file": random.randint(0, 1),
@@ -1382,6 +1385,9 @@ def finalize_and_sanitize(src_params):
     if dest_params["use_write_buffer_manager"]:
         if dest_params["cache_size"] <= 0 or dest_params["db_write_buffer_size"] <= 0:
             dest_params["use_write_buffer_manager"] = 0
+    if not dest_params["use_write_buffer_manager"]:
+        # No WriteBufferManager is created, so the policy would be a no-op.
+        dest_params["wbm_flush_policy"] = 0
     if (
         dest_params["user_timestamp_size"] > 0
         and dest_params["persist_user_defined_timestamps"] == 0

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -54,6 +54,8 @@ REMOTE_DB_LIVENESS_TIMEOUT_MULTIPLIER = 2
 _FAULT_INJECTION_LOG_DIR_NAME = "fault_injection_logs"
 _REMOTE_DB_URI_FLAGS = ("--env_uri", "--fs_uri")
 _MIN_WRITE_BUFFER_SIZE = 64 * 1024
+_WBM_FLUSH_POLICIES = (0, 1, 2)
+_WBM_FLUSH_LARGEST_ACROSS_DBS = 2
 
 
 def get_random_seed(override):
@@ -442,6 +444,7 @@ default_params = {
         [0, 0, 0, 1024 * 1024, 8 * 1024 * 1024, 128 * 1024 * 1024]
     ),
     "use_write_buffer_manager": lambda: random.randint(0, 1),
+    "wbm_flush_policy": lambda: random.choice(_WBM_FLUSH_POLICIES),
     "avoid_unnecessary_blocking_io": random.randint(0, 1),
     "write_dbid_to_manifest": random.randint(0, 1),
     "write_identity_file": random.randint(0, 1),
@@ -1533,6 +1536,8 @@ def finalize_and_sanitize(src_params):
     if dest_params["use_write_buffer_manager"]:
         if dest_params["cache_size"] <= 0 or dest_params["db_write_buffer_size"] <= 0:
             dest_params["use_write_buffer_manager"] = 0
+    if not dest_params["use_write_buffer_manager"]:
+        dest_params["wbm_flush_policy"] = 0
     if (
         dest_params["user_timestamp_size"] > 0
         and dest_params["persist_user_defined_timestamps"] == 0
@@ -1841,6 +1846,18 @@ def gen_cmd_params(args):
     if args.test_type == "liveness":
         apply_liveness_remote_defaults(params, args)
         params.update(liveness_fault_injection_params)
+
+    # DB paths must not change between the crash and recovery processes.
+    wbm_flush_policy = params["wbm_flush_policy"]
+    if callable(wbm_flush_policy):
+        wbm_flush_policy = wbm_flush_policy()
+        params["wbm_flush_policy"] = wbm_flush_policy
+    use_write_buffer_manager = params["use_write_buffer_manager"]
+    if (
+        wbm_flush_policy == _WBM_FLUSH_LARGEST_ACROSS_DBS
+        and (callable(use_write_buffer_manager) or use_write_buffer_manager)
+    ):
+        params["num_dbs"] = max(params.get("num_dbs", 1), 2)
     return params
 
 

--- a/tools/db_crashtest_test.py
+++ b/tools/db_crashtest_test.py
@@ -97,6 +97,7 @@ class DBCrashTestTest(unittest.TestCase):
     def build_params(self, base_params, overrides=None):
         params = dict(base_params)
         params["db"] = self.test_tmpdir
+        params["wbm_flush_policy"] = 0
         if overrides:
             params.update(overrides)
         return params
@@ -178,6 +179,73 @@ class DBCrashTestTest(unittest.TestCase):
                 for arg in first_command
             )
         )
+
+    def test_wbm_flush_policy_coverage(self):
+        db_crashtest = self.load_db_crashtest()
+        for policy in db_crashtest._WBM_FLUSH_POLICIES:
+            params = db_crashtest.gen_cmd_params(
+                self.build_mode_args(
+                    cache_size=8 * 1024 * 1024,
+                    db=self.test_tmpdir,
+                    db_write_buffer_size=1024 * 1024,
+                    num_dbs=1,
+                    use_write_buffer_manager=1,
+                    wbm_flush_policy=policy,
+                )
+            )
+
+            command, _ = db_crashtest.gen_cmd(params, [])
+
+            self.assertIn(f"--wbm_flush_policy={policy}", command)
+            expected_num_dbs = (
+                2
+                if policy == db_crashtest._WBM_FLUSH_LARGEST_ACROSS_DBS
+                else 1
+            )
+            self.assertIn(f"--num_dbs={expected_num_dbs}", command)
+
+    def test_cross_db_wbm_policy_keeps_db_topology_stable(self):
+        db_crashtest = self.load_db_crashtest()
+        policies = iter([db_crashtest._WBM_FLUSH_LARGEST_ACROSS_DBS, 0])
+        params = db_crashtest.gen_cmd_params(
+            self.build_mode_args(
+                cache_size=8 * 1024 * 1024,
+                db=self.test_tmpdir,
+                db_write_buffer_size=1024 * 1024,
+                num_dbs=1,
+                use_write_buffer_manager=1,
+                wbm_flush_policy=lambda: next(policies),
+            )
+        )
+
+        first_command, _ = db_crashtest.gen_cmd(params, [])
+        second_command, _ = db_crashtest.gen_cmd(params, [])
+
+        self.assertEqual(
+            db_crashtest._WBM_FLUSH_LARGEST_ACROSS_DBS,
+            params["wbm_flush_policy"],
+        )
+        self.assertEqual(2, params["num_dbs"])
+        for command in (first_command, second_command):
+            self.assertIn("--wbm_flush_policy=2", command)
+            self.assertIn("--num_dbs=2", command)
+
+    def test_cross_db_wbm_policy_does_not_force_two_dbs_when_disabled(self):
+        db_crashtest = self.load_db_crashtest()
+        params = db_crashtest.gen_cmd_params(
+            self.build_mode_args(
+                db=self.test_tmpdir,
+                num_dbs=1,
+                use_write_buffer_manager=0,
+                wbm_flush_policy=db_crashtest._WBM_FLUSH_LARGEST_ACROSS_DBS,
+            )
+        )
+
+        command, _ = db_crashtest.gen_cmd(params, [])
+
+        self.assertEqual(1, params["num_dbs"])
+        self.assertIn("--wbm_flush_policy=0", command)
+        self.assertIn("--num_dbs=1", command)
 
     def test_cache_and_write_buffer_size_multiplier_respects_write_buffer_minimum(
         self,

--- a/unreleased_history/public_api_changes/write_buffer_manager_flush_policy.md
+++ b/unreleased_history/public_api_changes/write_buffer_manager_flush_policy.md
@@ -1,0 +1,1 @@
+Added `WriteBufferFlushPolicy` and `WriteBufferManager` policy selection for flushing the oldest or largest column family, including the largest column family across DBs sharing a manager.


### PR DESCRIPTION
Summary:

Adds a validated db_stress flag for selecting the WriteBufferManager flush policy and randomizes it in db_crashtest. Crash-test generation covers all three policies; kFlushLargestAcrossDBs automatically uses two DBs sharing one manager so the cross-DB path is exercised.

Differential Revision: D114638570
