### PR TITLE
Add WriteBatch SliceParts APIs with user-defined timestampadd new apis

### DIFF
--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -1067,14 +1067,44 @@ Status WriteBatch::Put(ColumnFamilyHandle* column_family, const SliceParts& key,
 
   if (ts_sz == 0) {
     s = WriteBatchInternal::Put(this, cf_id, key, value);
-    if (s.ok()) {
-      MaybeTrackTimestampSize(cf_id, ts_sz);
-    }
+  } else {
+    needs_in_place_update_ts_ = true;
+    has_key_with_ts_ = true;
+    std::string dummy_ts(ts_sz, '\0');
+    const int key_with_ts_num_parts = key.num_parts + 1;
+    std::vector<Slice> key_with_ts(key_with_ts_num_parts);
+    std::copy(key.parts, key.parts + key.num_parts, key_with_ts.begin());
+    key_with_ts[key.num_parts] = Slice(dummy_ts);
+    s = WriteBatchInternal::Put(
+        this, cf_id, SliceParts(key_with_ts.data(), key_with_ts_num_parts),
+        value);
+  }
+  if (s.ok()) {
+    MaybeTrackTimestampSize(cf_id, ts_sz);
+  }
+  return s;
+}
+
+Status WriteBatch::Put(ColumnFamilyHandle* column_family, const SliceParts& key,
+                       const Slice& ts, const SliceParts& value) {
+  Status s = CheckColumnFamilyTimestampSize(column_family, ts);
+  if (!s.ok()) {
     return s;
   }
-
-  return Status::InvalidArgument(
-      "Cannot call this method on column family enabling timestamp");
+  has_key_with_ts_ = true;
+  assert(column_family);
+  uint32_t cf_id = column_family->GetID();
+  const int key_with_ts_num_parts = key.num_parts + 1;
+  std::vector<Slice> key_with_ts(key_with_ts_num_parts);
+  std::copy(key.parts, key.parts + key.num_parts, key_with_ts.begin());
+  key_with_ts[key.num_parts] = ts;
+  s = WriteBatchInternal::Put(
+      this, cf_id, SliceParts(key_with_ts.data(), key_with_ts_num_parts),
+      value);
+  if (s.ok()) {
+    MaybeTrackTimestampSize(cf_id, ts.size());
+  }
+  return s;
 }
 
 Status WriteBatchInternal::PutEntity(WriteBatch* b, uint32_t column_family_id,
@@ -1400,14 +1430,42 @@ Status WriteBatch::Delete(ColumnFamilyHandle* column_family,
 
   if (0 == ts_sz) {
     s = WriteBatchInternal::Delete(this, cf_id, key);
-    if (s.ok()) {
-      MaybeTrackTimestampSize(cf_id, ts_sz);
-    }
+  } else {
+    needs_in_place_update_ts_ = true;
+    has_key_with_ts_ = true;
+    std::string dummy_ts(ts_sz, '\0');
+    const int key_with_ts_num_parts = key.num_parts + 1;
+    std::vector<Slice> key_with_ts(key_with_ts_num_parts);
+    std::copy(key.parts, key.parts + key.num_parts, key_with_ts.begin());
+    key_with_ts[key.num_parts] = Slice(dummy_ts);
+    s = WriteBatchInternal::Delete(
+        this, cf_id, SliceParts(key_with_ts.data(), key_with_ts_num_parts));
+  }
+  if (s.ok()) {
+    MaybeTrackTimestampSize(cf_id, ts_sz);
+  }
+  return s;
+}
+
+Status WriteBatch::Delete(ColumnFamilyHandle* column_family,
+                          const SliceParts& key, const Slice& ts) {
+  Status s = CheckColumnFamilyTimestampSize(column_family, ts);
+  if (!s.ok()) {
     return s;
   }
-
-  return Status::InvalidArgument(
-      "Cannot call this method on column family enabling timestamp");
+  assert(column_family);
+  has_key_with_ts_ = true;
+  uint32_t cf_id = column_family->GetID();
+  const int key_with_ts_num_parts = key.num_parts + 1;
+  std::vector<Slice> key_with_ts(key_with_ts_num_parts);
+  std::copy(key.parts, key.parts + key.num_parts, key_with_ts.begin());
+  key_with_ts[key.num_parts] = ts;
+  s = WriteBatchInternal::Delete(
+      this, cf_id, SliceParts(key_with_ts.data(), key_with_ts_num_parts));
+  if (s.ok()) {
+    MaybeTrackTimestampSize(cf_id, ts.size());
+  }
+  return s;
 }
 
 Status WriteBatchInternal::SingleDelete(WriteBatch* b,
@@ -1536,14 +1594,42 @@ Status WriteBatch::SingleDelete(ColumnFamilyHandle* column_family,
 
   if (0 == ts_sz) {
     s = WriteBatchInternal::SingleDelete(this, cf_id, key);
-    if (s.ok()) {
-      MaybeTrackTimestampSize(cf_id, ts_sz);
-    }
+  } else {
+    needs_in_place_update_ts_ = true;
+    has_key_with_ts_ = true;
+    std::string dummy_ts(ts_sz, '\0');
+    const int key_with_ts_num_parts = key.num_parts + 1;
+    std::vector<Slice> key_with_ts(key_with_ts_num_parts);
+    std::copy(key.parts, key.parts + key.num_parts, key_with_ts.begin());
+    key_with_ts[key.num_parts] = Slice(dummy_ts);
+    s = WriteBatchInternal::SingleDelete(
+        this, cf_id, SliceParts(key_with_ts.data(), key_with_ts_num_parts));
+  }
+  if (s.ok()) {
+    MaybeTrackTimestampSize(cf_id, ts_sz);
+  }
+  return s;
+}
+
+Status WriteBatch::SingleDelete(ColumnFamilyHandle* column_family,
+                                const SliceParts& key, const Slice& ts) {
+  Status s = CheckColumnFamilyTimestampSize(column_family, ts);
+  if (!s.ok()) {
     return s;
   }
-
-  return Status::InvalidArgument(
-      "Cannot call this method on column family enabling timestamp");
+  has_key_with_ts_ = true;
+  assert(column_family);
+  uint32_t cf_id = column_family->GetID();
+  const int key_with_ts_num_parts = key.num_parts + 1;
+  std::vector<Slice> key_with_ts(key_with_ts_num_parts);
+  std::copy(key.parts, key.parts + key.num_parts, key_with_ts.begin());
+  key_with_ts[key.num_parts] = ts;
+  s = WriteBatchInternal::SingleDelete(
+      this, cf_id, SliceParts(key_with_ts.data(), key_with_ts_num_parts));
+  if (s.ok()) {
+    MaybeTrackTimestampSize(cf_id, ts.size());
+  }
+  return s;
 }
 
 Status WriteBatchInternal::DeleteRange(WriteBatch* b, uint32_t column_family_id,
@@ -1682,14 +1768,59 @@ Status WriteBatch::DeleteRange(ColumnFamilyHandle* column_family,
 
   if (0 == ts_sz) {
     s = WriteBatchInternal::DeleteRange(this, cf_id, begin_key, end_key);
-    if (s.ok()) {
-      MaybeTrackTimestampSize(cf_id, ts_sz);
-    }
+  } else {
+    needs_in_place_update_ts_ = true;
+    has_key_with_ts_ = true;
+    std::string dummy_ts(ts_sz, '\0');
+    const int begin_key_with_ts_num_parts = begin_key.num_parts + 1;
+    std::vector<Slice> begin_key_with_ts(begin_key_with_ts_num_parts);
+    std::copy(begin_key.parts, begin_key.parts + begin_key.num_parts,
+              begin_key_with_ts.begin());
+    begin_key_with_ts[begin_key.num_parts] = Slice(dummy_ts);
+    const int end_key_with_ts_num_parts = end_key.num_parts + 1;
+    std::vector<Slice> end_key_with_ts(end_key_with_ts_num_parts);
+    std::copy(end_key.parts, end_key.parts + end_key.num_parts,
+              end_key_with_ts.begin());
+    end_key_with_ts[end_key.num_parts] = Slice(dummy_ts);
+    s = WriteBatchInternal::DeleteRange(
+        this, cf_id,
+        SliceParts(begin_key_with_ts.data(), begin_key_with_ts_num_parts),
+        SliceParts(end_key_with_ts.data(), end_key_with_ts_num_parts));
+  }
+  if (s.ok()) {
+    MaybeTrackTimestampSize(cf_id, ts_sz);
+  }
+  return s;
+}
+
+Status WriteBatch::DeleteRange(ColumnFamilyHandle* column_family,
+                               const SliceParts& begin_key,
+                               const SliceParts& end_key, const Slice& ts) {
+  Status s = CheckColumnFamilyTimestampSize(column_family, ts);
+  if (!s.ok()) {
     return s;
   }
-
-  return Status::InvalidArgument(
-      "Cannot call this method on column family enabling timestamp");
+  assert(column_family);
+  has_key_with_ts_ = true;
+  uint32_t cf_id = column_family->GetID();
+  const int begin_key_with_ts_num_parts = begin_key.num_parts + 1;
+  std::vector<Slice> begin_key_with_ts(begin_key_with_ts_num_parts);
+  std::copy(begin_key.parts, begin_key.parts + begin_key.num_parts,
+            begin_key_with_ts.begin());
+  begin_key_with_ts[begin_key.num_parts] = ts;
+  const int end_key_with_ts_num_parts = end_key.num_parts + 1;
+  std::vector<Slice> end_key_with_ts(end_key_with_ts_num_parts);
+  std::copy(end_key.parts, end_key.parts + end_key.num_parts,
+            end_key_with_ts.begin());
+  end_key_with_ts[end_key.num_parts] = ts;
+  s = WriteBatchInternal::DeleteRange(
+      this, cf_id,
+      SliceParts(begin_key_with_ts.data(), begin_key_with_ts_num_parts),
+      SliceParts(end_key_with_ts.data(), end_key_with_ts_num_parts));
+  if (s.ok()) {
+    MaybeTrackTimestampSize(cf_id, ts.size());
+  }
+  return s;
 }
 
 Status WriteBatchInternal::Merge(WriteBatch* b, uint32_t column_family_id,
@@ -1820,14 +1951,45 @@ Status WriteBatch::Merge(ColumnFamilyHandle* column_family,
 
   if (0 == ts_sz) {
     s = WriteBatchInternal::Merge(this, cf_id, key, value);
-    if (s.ok()) {
-      MaybeTrackTimestampSize(cf_id, ts_sz);
-    }
+  } else {
+    needs_in_place_update_ts_ = true;
+    has_key_with_ts_ = true;
+    std::string dummy_ts(ts_sz, '\0');
+    const int key_with_ts_num_parts = key.num_parts + 1;
+    std::vector<Slice> key_with_ts(key_with_ts_num_parts);
+    std::copy(key.parts, key.parts + key.num_parts, key_with_ts.begin());
+    key_with_ts[key.num_parts] = Slice(dummy_ts);
+    s = WriteBatchInternal::Merge(
+        this, cf_id, SliceParts(key_with_ts.data(), key_with_ts_num_parts),
+        value);
+  }
+  if (s.ok()) {
+    MaybeTrackTimestampSize(cf_id, ts_sz);
+  }
+  return s;
+}
+
+Status WriteBatch::Merge(ColumnFamilyHandle* column_family,
+                         const SliceParts& key, const Slice& ts,
+                         const SliceParts& value) {
+  Status s = CheckColumnFamilyTimestampSize(column_family, ts);
+  if (!s.ok()) {
     return s;
   }
-
-  return Status::InvalidArgument(
-      "Cannot call this method on column family enabling timestamp");
+  has_key_with_ts_ = true;
+  assert(column_family);
+  uint32_t cf_id = column_family->GetID();
+  const int key_with_ts_num_parts = key.num_parts + 1;
+  std::vector<Slice> key_with_ts(key_with_ts_num_parts);
+  std::copy(key.parts, key.parts + key.num_parts, key_with_ts.begin());
+  key_with_ts[key.num_parts] = ts;
+  s = WriteBatchInternal::Merge(
+      this, cf_id, SliceParts(key_with_ts.data(), key_with_ts_num_parts),
+      value);
+  if (s.ok()) {
+    MaybeTrackTimestampSize(cf_id, ts.size());
+  }
+  return s;
 }
 
 Status WriteBatchInternal::PutBlobIndex(WriteBatch* b,

--- a/db/write_batch_base.cc
+++ b/db/write_batch_base.cc
@@ -31,6 +31,17 @@ Status WriteBatchBase::Put(const SliceParts& key, const SliceParts& value) {
   return Put(key_slice, value_slice);
 }
 
+Status WriteBatchBase::Put(ColumnFamilyHandle* column_family,
+                           const SliceParts& key, const Slice& ts,
+                           const SliceParts& value) {
+  const int key_with_ts_num_parts = key.num_parts + 1;
+  std::vector<Slice> key_with_ts(key_with_ts_num_parts);
+  std::copy(key.parts, key.parts + key.num_parts, key_with_ts.begin());
+  key_with_ts[key.num_parts] = ts;
+  return Put(column_family,
+             SliceParts(key_with_ts.data(), key_with_ts_num_parts), value);
+}
+
 Status WriteBatchBase::Delete(ColumnFamilyHandle* column_family,
                               const SliceParts& key) {
   std::string key_buf;
@@ -44,6 +55,16 @@ Status WriteBatchBase::Delete(const SliceParts& key) {
   return Delete(key_slice);
 }
 
+Status WriteBatchBase::Delete(ColumnFamilyHandle* column_family,
+                              const SliceParts& key, const Slice& ts) {
+  const int key_with_ts_num_parts = key.num_parts + 1;
+  std::vector<Slice> key_with_ts(key_with_ts_num_parts);
+  std::copy(key.parts, key.parts + key.num_parts, key_with_ts.begin());
+  key_with_ts[key.num_parts] = ts;
+  return Delete(column_family,
+                SliceParts(key_with_ts.data(), key_with_ts_num_parts));
+}
+
 Status WriteBatchBase::SingleDelete(ColumnFamilyHandle* column_family,
                                     const SliceParts& key) {
   std::string key_buf;
@@ -55,6 +76,16 @@ Status WriteBatchBase::SingleDelete(const SliceParts& key) {
   std::string key_buf;
   Slice key_slice(key, &key_buf);
   return SingleDelete(key_slice);
+}
+
+Status WriteBatchBase::SingleDelete(ColumnFamilyHandle* column_family,
+                                    const SliceParts& key, const Slice& ts) {
+  const int key_with_ts_num_parts = key.num_parts + 1;
+  std::vector<Slice> key_with_ts(key_with_ts_num_parts);
+  std::copy(key.parts, key.parts + key.num_parts, key_with_ts.begin());
+  key_with_ts[key.num_parts] = ts;
+  return SingleDelete(column_family,
+                      SliceParts(key_with_ts.data(), key_with_ts_num_parts));
 }
 
 Status WriteBatchBase::DeleteRange(ColumnFamilyHandle* column_family,
@@ -74,6 +105,27 @@ Status WriteBatchBase::DeleteRange(const SliceParts& begin_key,
   return DeleteRange(begin_key_slice, end_key_slice);
 }
 
+Status WriteBatchBase::DeleteRange(ColumnFamilyHandle* column_family,
+                                   const SliceParts& begin_key,
+                                   const SliceParts& end_key, const Slice& ts) {
+  const int begin_key_with_ts_num_parts = begin_key.num_parts + 1;
+  std::vector<Slice> begin_key_with_ts(begin_key_with_ts_num_parts);
+  std::copy(begin_key.parts, begin_key.parts + begin_key.num_parts,
+            begin_key_with_ts.begin());
+  begin_key_with_ts[begin_key.num_parts] = ts;
+
+  const int end_key_with_ts_num_parts = end_key.num_parts + 1;
+  std::vector<Slice> end_key_with_ts(end_key_with_ts_num_parts);
+  std::copy(end_key.parts, end_key.parts + end_key.num_parts,
+            end_key_with_ts.begin());
+  end_key_with_ts[end_key.num_parts] = ts;
+
+  return DeleteRange(
+      column_family,
+      SliceParts(begin_key_with_ts.data(), begin_key_with_ts_num_parts),
+      SliceParts(end_key_with_ts.data(), end_key_with_ts_num_parts));
+}
+
 Status WriteBatchBase::Merge(ColumnFamilyHandle* column_family,
                              const SliceParts& key, const SliceParts& value) {
   std::string key_buf, value_buf;
@@ -89,6 +141,17 @@ Status WriteBatchBase::Merge(const SliceParts& key, const SliceParts& value) {
   Slice value_slice(value, &value_buf);
 
   return Merge(key_slice, value_slice);
+}
+
+Status WriteBatchBase::Merge(ColumnFamilyHandle* column_family,
+                             const SliceParts& key, const Slice& ts,
+                             const SliceParts& value) {
+  const int key_with_ts_num_parts = key.num_parts + 1;
+  std::vector<Slice> key_with_ts(key_with_ts_num_parts);
+  std::copy(key.parts, key.parts + key.num_parts, key_with_ts.begin());
+  key_with_ts[key.num_parts] = ts;
+  return Merge(column_family,
+               SliceParts(key_with_ts.data(), key_with_ts_num_parts), value);
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/write_batch_test.cc
+++ b/db/write_batch_test.cc
@@ -1335,6 +1335,51 @@ TEST_F(WriteBatchTest, SanityChecks) {
   ASSERT_TRUE(wb1.Merge(&cf0, "key", "value").IsInvalidArgument());
   ASSERT_TRUE(
       wb1.DeleteRange(&cf0, "begin_key", "end_key").IsInvalidArgument());
+
+  // Sanity checks for the WriteBatch SliceParts APIs without extra 'ts' arg
+  Slice key_slices[2] = {Slice("key_part1"), Slice("key_part2")};
+  Slice value_slices[2] = {Slice("value_part1"), Slice("value_part2")};
+  // wb has right timestamp size
+  ASSERT_TRUE(
+      wb.Put(&cf0, SliceParts(key_slices, 2), SliceParts(value_slices, 2))
+          .ok());
+  ASSERT_TRUE(wb.Delete(&cf0, SliceParts(key_slices, 2)).ok());
+  ASSERT_TRUE(wb.SingleDelete(&cf0, SliceParts(key_slices, 2)).ok());
+  ASSERT_TRUE(
+      wb.Merge(&cf0, SliceParts(key_slices, 2), SliceParts(value_slices, 2))
+          .ok());
+  ASSERT_TRUE(
+      wb.DeleteRange(&cf0, SliceParts(key_slices, 2), SliceParts(key_slices, 2))
+          .ok());
+
+  // wb1 has wrong timestamp size
+  ASSERT_TRUE(
+      wb1.Put(&cf0, SliceParts(key_slices, 2), SliceParts(value_slices, 2))
+          .IsInvalidArgument());
+  ASSERT_TRUE(wb1.Delete(&cf0, SliceParts(key_slices, 2)).IsInvalidArgument());
+  ASSERT_TRUE(
+      wb1.SingleDelete(&cf0, SliceParts(key_slices, 2)).IsInvalidArgument());
+  ASSERT_TRUE(
+      wb1.Merge(&cf0, SliceParts(key_slices, 2), SliceParts(value_slices, 2))
+          .IsInvalidArgument());
+  ASSERT_TRUE(wb1.DeleteRange(&cf0, SliceParts(key_slices, 2),
+                              SliceParts(key_slices, 2))
+                  .IsInvalidArgument());
+
+  // Sanity checks for the new WriteBatch SliceParts APIs with extra 'ts' arg.
+  ASSERT_TRUE(
+      wb.Put(&cf0, SliceParts(key_slices, 2), "ts", SliceParts(value_slices, 2))
+          .IsInvalidArgument());
+  ASSERT_TRUE(
+      wb.Delete(&cf0, SliceParts(key_slices, 2), "ts").IsInvalidArgument());
+  ASSERT_TRUE(wb.SingleDelete(&cf0, SliceParts(key_slices, 2), "ts")
+                  .IsInvalidArgument());
+  ASSERT_TRUE(wb.Merge(&cf0, SliceParts(key_slices, 2), "ts",
+                       SliceParts(value_slices, 2))
+                  .IsInvalidArgument());
+  ASSERT_TRUE(wb.DeleteRange(&cf0, SliceParts(key_slices, 2),
+                             SliceParts(key_slices, 2), "ts")
+                  .IsInvalidArgument());
 }
 
 TEST_F(WriteBatchTest, UpdateTimestamps) {

--- a/include/rocksdb/write_batch.h
+++ b/include/rocksdb/write_batch.h
@@ -75,10 +75,6 @@ class WriteBatch : public WriteBatchBase {
 
   using WriteBatchBase::Put;
   // Store the mapping "key->value" in the database.
-  // The following Put(..., const Slice& key, ...) API can also be used when
-  // user-defined timestamp is enabled as long as `key` points to a contiguous
-  // buffer with timestamp appended after user key. The caller is responsible
-  // for setting up the memory buffer pointed to by `key`.
   Status Put(ColumnFamilyHandle* column_family, const Slice& key,
              const Slice& value) override;
   Status Put(const Slice& key, const Slice& value) override {
@@ -90,15 +86,13 @@ class WriteBatch : public WriteBatchBase {
   // Variant of Put() that gathers output like writev(2).  The key and value
   // that will be written to the database are concatenations of arrays of
   // slices.
-  // The following Put(..., const SliceParts& key, ...) API can be used when
-  // user-defined timestamp is enabled as long as the timestamp is the last
-  // Slice in `key`, a SliceParts (array of Slices). The caller is responsible
-  // for setting up the `key` SliceParts object.
   Status Put(ColumnFamilyHandle* column_family, const SliceParts& key,
              const SliceParts& value) override;
   Status Put(const SliceParts& key, const SliceParts& value) override {
     return Put(nullptr, key, value);
   }
+  Status Put(ColumnFamilyHandle* column_family, const SliceParts& key,
+             const Slice& ts, const SliceParts& value) override;
 
   using WriteBatchBase::TimedPut;
   // EXPERIMENTAL
@@ -139,6 +133,8 @@ class WriteBatch : public WriteBatchBase {
   Status Delete(ColumnFamilyHandle* column_family,
                 const SliceParts& key) override;
   Status Delete(const SliceParts& key) override { return Delete(nullptr, key); }
+  Status Delete(ColumnFamilyHandle* column_family, const SliceParts& key,
+                const Slice& ts) override;
 
   using WriteBatchBase::SingleDelete;
   // WriteBatch implementation of DB::SingleDelete().  See db.h.
@@ -156,6 +152,8 @@ class WriteBatch : public WriteBatchBase {
   Status SingleDelete(const SliceParts& key) override {
     return SingleDelete(nullptr, key);
   }
+  Status SingleDelete(ColumnFamilyHandle* column_family, const SliceParts& key,
+                      const Slice& ts) override;
 
   using WriteBatchBase::DeleteRange;
   // WriteBatch implementation of DB::DeleteRange().  See db.h.
@@ -176,6 +174,9 @@ class WriteBatch : public WriteBatchBase {
                      const SliceParts& end_key) override {
     return DeleteRange(nullptr, begin_key, end_key);
   }
+  Status DeleteRange(ColumnFamilyHandle* column_family,
+                     const SliceParts& begin_key, const SliceParts& end_key,
+                     const Slice& ts) override;
 
   using WriteBatchBase::Merge;
   // Merge "value" with the existing value of "key" in the database.
@@ -194,6 +195,8 @@ class WriteBatch : public WriteBatchBase {
   Status Merge(const SliceParts& key, const SliceParts& value) override {
     return Merge(nullptr, key, value);
   }
+  Status Merge(ColumnFamilyHandle* column_family, const SliceParts& key,
+               const Slice& ts, const SliceParts& value) override;
 
   using WriteBatchBase::PutLogData;
   // Append a blob of arbitrary size to the records in this batch. The blob will

--- a/include/rocksdb/write_batch_base.h
+++ b/include/rocksdb/write_batch_base.h
@@ -41,6 +41,8 @@ class WriteBatchBase {
   virtual Status Put(ColumnFamilyHandle* column_family, const SliceParts& key,
                      const SliceParts& value);
   virtual Status Put(const SliceParts& key, const SliceParts& value);
+  virtual Status Put(ColumnFamilyHandle* column_family, const SliceParts& key,
+                     const Slice& ts, const SliceParts& value);
 
   // EXPERIMENTAL
   // Store the mapping "key->value" in the database with the specified write
@@ -82,6 +84,8 @@ class WriteBatchBase {
   virtual Status Merge(ColumnFamilyHandle* column_family, const SliceParts& key,
                        const SliceParts& value);
   virtual Status Merge(const SliceParts& key, const SliceParts& value);
+  virtual Status Merge(ColumnFamilyHandle* column_family, const SliceParts& key,
+                       const Slice& ts, const SliceParts& value);
 
   // If the database contains a mapping for "key", erase it.  Else do nothing.
   virtual Status Delete(ColumnFamilyHandle* column_family,
@@ -94,6 +98,8 @@ class WriteBatchBase {
   virtual Status Delete(ColumnFamilyHandle* column_family,
                         const SliceParts& key);
   virtual Status Delete(const SliceParts& key);
+  virtual Status Delete(ColumnFamilyHandle* column_family,
+                        const SliceParts& key, const Slice& ts);
 
   // If the database contains a mapping for "key", erase it. Expects that the
   // key was not overwritten. Else do nothing.
@@ -107,6 +113,8 @@ class WriteBatchBase {
   virtual Status SingleDelete(ColumnFamilyHandle* column_family,
                               const SliceParts& key);
   virtual Status SingleDelete(const SliceParts& key);
+  virtual Status SingleDelete(ColumnFamilyHandle* column_family,
+                              const SliceParts& key, const Slice& ts);
 
   // If the database contains mappings in the range ["begin_key", "end_key"),
   // erase them. Else do nothing.
@@ -123,6 +131,9 @@ class WriteBatchBase {
                              const SliceParts& end_key);
   virtual Status DeleteRange(const SliceParts& begin_key,
                              const SliceParts& end_key);
+  virtual Status DeleteRange(ColumnFamilyHandle* column_family,
+                             const SliceParts& begin_key,
+                             const SliceParts& end_key, const Slice& ts);
 
   // Append a blob of arbitrary size to the records in this batch. The blob will
   // be stored in the transaction log but not in any other file. In particular,


### PR DESCRIPTION
Current WriteBatch SliceParts APIs does not accept user-defined timestamp, and the following description of current APIs is not true because multiple WriteBatch APIs(e.g. Put, delete, etc.) accepting SliceParts args will return `Status::InvalidArgument(
      "Cannot call this method on column family enabling timestamp")` error if I set key as user key + timestamp as described in comment. We need to use SliceParts as argument to avoid temporary buffer usage for concatenating our values. 
```
  // The following Put(..., const Slice& key, ...) API can also be used when
  // user-defined timestamp is enabled as long as `key` points to a contiguous
  // buffer with timestamp appended after user key. The caller is responsible
  // for setting up the memory buffer pointed to by `key`.
```

This patch adds new APIs for SliceParts that accept user-defined timestamp as this [PR](https://github.com/facebook/rocksdb/pull/8946)