### PR TITLE
Add compaction delay time statistics

### DIFF
--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -640,6 +640,7 @@ ColumnFamilyData::ColumnFamilyData(
       column_family_set_(column_family_set),
       queued_for_flush_(false),
       queued_for_compaction_(false),
+      compaction_queued_at_micros_(0),
       prev_compaction_needed_bytes_(0),
       allow_2pc_(db_options.allow_2pc),
       last_memtable_id_(0),

--- a/db/column_family.h
+++ b/db/column_family.h
@@ -520,6 +520,12 @@ class ColumnFamilyData {
   void set_queued_for_compaction(bool value) { queued_for_compaction_ = value; }
   bool queued_for_flush() { return queued_for_flush_; }
   bool queued_for_compaction() { return queued_for_compaction_; }
+  void set_compaction_queued_at_micros(uint64_t v) {
+    compaction_queued_at_micros_ = v;
+  }
+  uint64_t compaction_queued_at_micros() const {
+    return compaction_queued_at_micros_;
+  }
 
   int compaction_aborted() const {
     return compaction_aborted_.obj_.load(std::memory_order_acquire);
@@ -741,6 +747,10 @@ class ColumnFamilyData {
   // If true, this ColumnFamily is in DBImpl::compaction_queue_ or its parked
   // compaction set.
   bool queued_for_compaction_;
+
+  // Timestamp (in microseconds) when this CF was added to the compaction queue.
+  // Used to measure compaction queue wait time.
+  uint64_t compaction_queued_at_micros_;
 
   // Read outside the DB mutex by compaction workers (acquire-loaded roughly
   // every 1024 records in ProcessKeyValueCompaction). Given its own cache line

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -6417,6 +6417,88 @@ TEST_F(DBCompactionTest, CompactionHasEmptyOutput) {
   ASSERT_EQ(2, collector->num_ssts_creation_started());
 }
 
+TEST_F(DBCompactionTest, CompactionQueueWaitTime) {
+  // Verify that COMPACTION_QUEUE_WAIT_TIME histogram records nonzero delay
+  // when compactions are queued and blocked by occupied thread pool.
+  const int kNumKeysPerFile = 10;
+
+  Options options = CurrentOptions();
+  options.write_buffer_size = 110 * 1024;  // 110KB
+  options.arena_block_size = 4096;
+  options.num_levels = 3;
+  options.level0_file_num_compaction_trigger = 4;
+  options.level0_slowdown_writes_trigger = 64;
+  options.level0_stop_writes_trigger = 64;
+  options.max_background_jobs = 4;
+  options.statistics = ROCKSDB_NAMESPACE::CreateDBStatistics();
+  options.memtable_factory.reset(
+      test::NewSpecialSkipListFactory(kNumKeysPerFile));
+  options.max_write_buffer_number = 10;
+  DestroyAndReopen(options);
+
+  env_->SetBackgroundThreads(1, Env::HIGH);  // 1 flush thread
+  env_->SetBackgroundThreads(1, Env::LOW);   // 1 compaction thread
+
+  // Block the single compaction thread so queued compactions wait.
+  test::SleepingBackgroundTask sleeping_task;
+  env_->Schedule(&test::SleepingBackgroundTask::DoSleepTask, &sleeping_task,
+                 Env::LOW);
+  sleeping_task.WaitUntilSleeping();
+
+  // Set up a sync point callback to know when compaction is definitely queued.
+  port::Mutex enqueue_mutex;
+  port::CondVar enqueue_cv(&enqueue_mutex);
+  std::atomic<bool> compaction_queued{false};
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::AddToCompactionQueue:Enqueued", [&](void* /* arg */) {
+        enqueue_mutex.Lock();
+        compaction_queued.store(true, std::memory_order_release);
+        enqueue_cv.Signal();
+        enqueue_mutex.Unlock();
+      });
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
+
+  // Write enough L0 files to trigger compaction.
+  for (int n = 0; n < options.level0_file_num_compaction_trigger; n++) {
+    for (int i = 0; i < kNumKeysPerFile; i++) {
+      ASSERT_OK(Put(Key(i), "value"));
+    }
+    ASSERT_OK(Put("", ""));  // extra key to trigger flush
+    ASSERT_OK(dbfull()->TEST_WaitForFlushMemTable());
+  }
+  ASSERT_EQ(NumTableFilesAtLevel(0),
+            options.level0_file_num_compaction_trigger);
+
+  // Wait until compaction is definitely queued before starting the timer.
+  {
+    enqueue_mutex.Lock();
+    while (!compaction_queued.load(std::memory_order_acquire)) {
+      enqueue_cv.Wait();
+    }
+    enqueue_mutex.Unlock();
+  }
+
+  // Now that compaction is queued, sleep to accumulate measurable wait time.
+  env_->SleepForMicroseconds(100000);  // 100ms
+
+  // Unblock the compaction thread.
+  sleeping_task.WakeUp();
+  sleeping_task.WaitUntilDone();
+
+  ASSERT_OK(dbfull()->TEST_WaitForCompact());
+
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->ClearAllCallBacks();
+
+  // Verify the histogram recorded at least one entry with nonzero wait time.
+  HistogramData hist_data;
+  options.statistics->histogramData(COMPACTION_QUEUE_WAIT_TIME, &hist_data);
+  ASSERT_GE(hist_data.count, 1U);
+  ASSERT_GT(hist_data.max, 0.0);
+  // The wait should be at least ~100ms (100000 micros)
+  ASSERT_GE(hist_data.max, 100000.0);
+}
+
 TEST_F(DBCompactionTest, CompactionLimiter) {
   const int kNumKeysPerFile = 10;
   const int kMaxBackgroundThreads = 64;

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -3720,6 +3720,9 @@ void DBImpl::AddToCompactionQueue(ColumnFamilyData* cfd) {
   compaction_queue_.push_back(cfd);
   cfd->set_queued_for_compaction(true);
   ++unscheduled_compactions_;
+  cfd->set_compaction_queued_at_micros(
+      immutable_db_options_.clock->NowMicros());
+  TEST_SYNC_POINT("DBImpl::AddToCompactionQueue:Enqueued");
 }
 
 bool DBImpl::RestoreParkedCompaction(ColumnFamilyData* cfd) {
@@ -4526,6 +4529,7 @@ Status DBImpl::BackgroundCompaction(bool* made_progress,
     }
 
     ColumnFamilyData* cfd = nullptr;
+    uint64_t compaction_queue_wait_micros = 0;
 
     if (!need_repick) {
       auto pick_result = PickCompactionFromQueue(&task_token, log_buffer);
@@ -4540,6 +4544,14 @@ Status DBImpl::BackgroundCompaction(bool* made_progress,
       }
       cfd = std::get<CompactionQueuePicked>(pick_result).cfd;
       assert(cfd != nullptr);
+
+      if (cfd->compaction_queued_at_micros() > 0) {
+        const uint64_t now_micros = immutable_db_options_.clock->NowMicros();
+        compaction_queue_wait_micros =
+            now_micros > cfd->compaction_queued_at_micros()
+                ? now_micros - cfd->compaction_queued_at_micros()
+                : 0;
+      }
 
       // We unreference here because the following code will take a Ref() on
       // this cfd if it is going to use it (Compaction class holds a
@@ -4618,6 +4630,14 @@ Status DBImpl::BackgroundCompaction(bool* made_progress,
             num_files += each_level.files.size();
           }
           RecordInHistogram(stats_, NUM_FILES_IN_SINGLE_COMPACTION, num_files);
+
+          // Record compaction queue wait time (time from enqueue to dequeue)
+          if (compaction_queue_wait_micros > 0) {
+            cfd->internal_stats()->AddCompactionQueueWaitMicros(
+                c->output_level(), compaction_queue_wait_micros);
+            RecordInHistogram(stats_, COMPACTION_QUEUE_WAIT_TIME,
+                              compaction_queue_wait_micros);
+          }
 
           // There are three things that can change compaction score:
           // 1) When flush or compaction finish. This case is covered by

--- a/db/internal_stats.cc
+++ b/db/internal_stats.cc
@@ -61,6 +61,8 @@ const std::map<LevelStatType, LevelStat> InternalStats::compaction_level_stats =
         {LevelStatType::KEY_DROP, LevelStat{"KeyDrop", "KeyDrop"}},
         {LevelStatType::R_BLOB_GB, LevelStat{"RblobGB", "Rblob(GB)"}},
         {LevelStatType::W_BLOB_GB, LevelStat{"WblobGB", "Wblob(GB)"}},
+        {LevelStatType::COMP_QUEUE_WAIT_SEC,
+         LevelStat{"CompQWaitSec", "CompQWait(sec)"}},
 };
 
 const std::map<InternalStats::InternalDBStatsType, DBStatInfo>
@@ -103,6 +105,7 @@ void PrintLevelStatsHeader(char* buf, size_t len, const std::string& cf_name,
       buf + written_size, len - written_size,
       "%s    %s   %s     %s %s  %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s "
       "%s "
+      "%s "
       "%s\n",
       // Note that we skip COMPACTED_FILES and merge it with Files column
       group_by.c_str(), hdr(LevelStatType::NUM_FILES),
@@ -115,7 +118,8 @@ void PrintLevelStatsHeader(char* buf, size_t len, const std::string& cf_name,
       hdr(LevelStatType::COMP_SEC), hdr(LevelStatType::COMP_CPU_SEC),
       hdr(LevelStatType::COMP_COUNT), hdr(LevelStatType::AVG_SEC),
       hdr(LevelStatType::KEY_IN), hdr(LevelStatType::KEY_DROP),
-      hdr(LevelStatType::R_BLOB_GB), hdr(LevelStatType::W_BLOB_GB));
+      hdr(LevelStatType::R_BLOB_GB), hdr(LevelStatType::W_BLOB_GB),
+      hdr(LevelStatType::COMP_QUEUE_WAIT_SEC));
 
   written_size += line_size;
   written_size = std::min(written_size, static_cast<int>(len));
@@ -161,6 +165,8 @@ void PrepareLevelStats(std::map<LevelStatType, double>* level_stats,
       static_cast<double>(stats.num_dropped_records);
   (*level_stats)[LevelStatType::R_BLOB_GB] = stats.bytes_read_blob / kGB;
   (*level_stats)[LevelStatType::W_BLOB_GB] = stats.bytes_written_blob / kGB;
+  (*level_stats)[LevelStatType::COMP_QUEUE_WAIT_SEC] =
+      stats.queue_wait_micros / kMicrosInSec;
 }
 
 void PrintLevelStats(char* buf, size_t len, const std::string& name,
@@ -188,7 +194,8 @@ void PrintLevelStats(char* buf, size_t len, const std::string& name,
       "%7s "      /*  KeyIn */
       "%6s "      /*  KeyDrop */
       "%9.1f "    /*  Rblob(GB) */
-      "%9.1f\n",  /*  Wblob(GB) */
+      "%9.1f "    /*  Wblob(GB) */
+      "%14.2f\n", /*  CompQWait(sec) */
       name.c_str(), static_cast<int>(stat_value.at(LevelStatType::NUM_FILES)),
       static_cast<int>(stat_value.at(LevelStatType::COMPACTED_FILES)),
       BytesToHumanString(
@@ -216,7 +223,8 @@ void PrintLevelStats(char* buf, size_t len, const std::string& name,
           static_cast<std::int64_t>(stat_value.at(LevelStatType::KEY_DROP)))
           .c_str(),
       stat_value.at(LevelStatType::R_BLOB_GB),
-      stat_value.at(LevelStatType::W_BLOB_GB));
+      stat_value.at(LevelStatType::W_BLOB_GB),
+      stat_value.at(LevelStatType::COMP_QUEUE_WAIT_SEC));
 }
 
 void PrintLevelStats(char* buf, size_t len, const std::string& name,
@@ -2072,6 +2080,7 @@ void InternalStats::DumpCFStatsNoFileHistogram(bool is_periodic,
   uint64_t compact_bytes_read = 0;
   uint64_t compact_bytes_write = 0;
   uint64_t compact_micros = 0;
+  uint64_t compact_queue_wait_micros = 0;
   for (int level = 0; level < number_levels_; level++) {
     compact_bytes_read += comp_stats_[level].bytes_read_output_level +
                           comp_stats_[level].bytes_read_non_output_levels +
@@ -2079,16 +2088,19 @@ void InternalStats::DumpCFStatsNoFileHistogram(bool is_periodic,
     compact_bytes_write += comp_stats_[level].bytes_written +
                            comp_stats_[level].bytes_written_blob;
     compact_micros += comp_stats_[level].micros;
+    compact_queue_wait_micros += comp_stats_[level].queue_wait_micros;
   }
 
   snprintf(buf, sizeof(buf),
            "Cumulative compaction: %.2f GB write, %.2f MB/s write, "
-           "%.2f GB read, %.2f MB/s read, %.1f seconds\n",
+           "%.2f GB read, %.2f MB/s read, %.1f seconds, "
+           "%.1f queue wait seconds\n",
            compact_bytes_write / kGB,
            compact_bytes_write / kMB / std::max(seconds_up, 0.001),
            compact_bytes_read / kGB,
            compact_bytes_read / kMB / std::max(seconds_up, 0.001),
-           compact_micros / kMicrosInSec);
+           compact_micros / kMicrosInSec,
+           compact_queue_wait_micros / kMicrosInSec);
   value->append(buf);
 
   // Compaction interval
@@ -2098,16 +2110,20 @@ void InternalStats::DumpCFStatsNoFileHistogram(bool is_periodic,
       compact_bytes_read - cf_stats_snapshot_.compact_bytes_read;
   uint64_t interval_compact_micros =
       compact_micros - cf_stats_snapshot_.compact_micros;
+  uint64_t interval_compact_queue_wait_micros =
+      compact_queue_wait_micros - cf_stats_snapshot_.compact_queue_wait_micros;
 
   snprintf(
       buf, sizeof(buf),
       "Interval compaction: %.2f GB write, %.2f MB/s write, "
-      "%.2f GB read, %.2f MB/s read, %.1f seconds\n",
+      "%.2f GB read, %.2f MB/s read, %.1f seconds, "
+      "%.1f queue wait seconds\n",
       interval_compact_bytes_write / kGB,
       interval_compact_bytes_write / kMB / std::max(interval_seconds_up, 0.001),
       interval_compact_bytes_read / kGB,
       interval_compact_bytes_read / kMB / std::max(interval_seconds_up, 0.001),
-      interval_compact_micros / kMicrosInSec);
+      interval_compact_micros / kMicrosInSec,
+      interval_compact_queue_wait_micros / kMicrosInSec);
   value->append(buf);
 
   snprintf(buf, sizeof(buf),
@@ -2119,6 +2135,7 @@ void InternalStats::DumpCFStatsNoFileHistogram(bool is_periodic,
     cf_stats_snapshot_.compact_bytes_write = compact_bytes_write;
     cf_stats_snapshot_.compact_bytes_read = compact_bytes_read;
     cf_stats_snapshot_.compact_micros = compact_micros;
+    cf_stats_snapshot_.compact_queue_wait_micros = compact_queue_wait_micros;
   }
 
   std::string write_stall_stats;

--- a/db/internal_stats.h
+++ b/db/internal_stats.h
@@ -85,6 +85,7 @@ enum class LevelStatType {
   KEY_DROP,
   R_BLOB_GB,
   W_BLOB_GB,
+  COMP_QUEUE_WAIT_SEC,
   TOTAL  // total number of types
 };
 
@@ -223,6 +224,9 @@ class InternalStats {
     // Number of compactions done
     int count;
 
+    // Time spent waiting in the compaction queue (microseconds)
+    uint64_t queue_wait_micros;
+
     // Number of compactions done per CompactionReason
     int counts[static_cast<int>(CompactionReason::kNumOfReasons)]{};
 
@@ -247,7 +251,8 @@ class InternalStats {
           num_input_records(0),
           num_dropped_records(0),
           num_output_records(0),
-          count(0) {
+          count(0),
+          queue_wait_micros(0) {
       int num_of_reasons = static_cast<int>(CompactionReason::kNumOfReasons);
       for (int i = 0; i < num_of_reasons; i++) {
         counts[i] = 0;
@@ -275,7 +280,8 @@ class InternalStats {
           num_input_records(0),
           num_dropped_records(0),
           num_output_records(0),
-          count(c) {
+          count(c),
+          queue_wait_micros(0) {
       int num_of_reasons = static_cast<int>(CompactionReason::kNumOfReasons);
       for (int i = 0; i < num_of_reasons; i++) {
         counts[i] = 0;
@@ -312,7 +318,8 @@ class InternalStats {
           num_input_records(c.num_input_records),
           num_dropped_records(c.num_dropped_records),
           num_output_records(c.num_output_records),
-          count(c.count) {
+          count(c.count),
+          queue_wait_micros(c.queue_wait_micros) {
       int num_of_reasons = static_cast<int>(CompactionReason::kNumOfReasons);
       for (int i = 0; i < num_of_reasons; i++) {
         counts[i] = c.counts[i];
@@ -344,6 +351,7 @@ class InternalStats {
       num_dropped_records = c.num_dropped_records;
       num_output_records = c.num_output_records;
       count = c.count;
+      queue_wait_micros = c.queue_wait_micros;
 
       int num_of_reasons = static_cast<int>(CompactionReason::kNumOfReasons);
       for (int i = 0; i < num_of_reasons; i++) {
@@ -374,6 +382,7 @@ class InternalStats {
       this->num_dropped_records = 0;
       this->num_output_records = 0;
       this->count = 0;
+      this->queue_wait_micros = 0;
       int num_of_reasons = static_cast<int>(CompactionReason::kNumOfReasons);
       for (int i = 0; i < num_of_reasons; i++) {
         counts[i] = 0;
@@ -407,6 +416,7 @@ class InternalStats {
       this->num_dropped_records += c.num_dropped_records;
       this->num_output_records += c.num_output_records;
       this->count += c.count;
+      this->queue_wait_micros += c.queue_wait_micros;
       int num_of_reasons = static_cast<int>(CompactionReason::kNumOfReasons);
       for (int i = 0; i < num_of_reasons; i++) {
         counts[i] += c.counts[i];
@@ -440,6 +450,7 @@ class InternalStats {
       this->num_dropped_records -= c.num_dropped_records;
       this->num_output_records -= c.num_output_records;
       this->count -= c.count;
+      this->queue_wait_micros -= c.queue_wait_micros;
       int num_of_reasons = static_cast<int>(CompactionReason::kNumOfReasons);
       for (int i = 0; i < num_of_reasons; i++) {
         counts[i] -= c.counts[i];
@@ -582,6 +593,10 @@ class InternalStats {
 
   void IncBytesMoved(int level, uint64_t amount) {
     comp_stats_[level].bytes_moved += amount;
+  }
+
+  void AddCompactionQueueWaitMicros(int level, uint64_t micros) {
+    comp_stats_[level].queue_wait_micros += micros;
   }
 
   void AddCFStats(InternalCFStatsType type, uint64_t value) {
@@ -734,6 +749,7 @@ class InternalStats {
     uint64_t compact_bytes_write;
     uint64_t compact_bytes_read;
     uint64_t compact_micros;
+    uint64_t compact_queue_wait_micros;
     double seconds_up;
 
     // AddFile specific stats
@@ -748,6 +764,7 @@ class InternalStats {
           compact_bytes_write(0),
           compact_bytes_read(0),
           compact_micros(0),
+          compact_queue_wait_micros(0),
           seconds_up(0),
           ingest_bytes_addfile(0),
           ingest_files_addfile(0),
@@ -761,6 +778,7 @@ class InternalStats {
       compact_bytes_write = 0;
       compact_bytes_read = 0;
       compact_micros = 0;
+      compact_queue_wait_micros = 0;
       seconds_up = 0;
       ingest_bytes_addfile = 0;
       ingest_files_addfile = 0;

--- a/include/rocksdb/statistics.h
+++ b/include/rocksdb/statistics.h
@@ -845,6 +845,9 @@ enum Histograms : uint32_t {
   // Time spent opening the secondary DB inside DB::OpenAndCompact().
   OPEN_AND_COMPACT_DB_OPEN_MICROS,
 
+  // Time spent waiting in the compaction queue before compaction starts
+  COMPACTION_QUEUE_WAIT_TIME,
+
   HISTOGRAM_ENUM_MAX
 };
 

--- a/monitoring/statistics.cc
+++ b/monitoring/statistics.cc
@@ -435,6 +435,7 @@ const std::vector<std::pair<Histograms, std::string>> HistogramsNameMap = {
      "rocksdb.flush.write_buffer_manager.memtable.memory.bytes"},
     {OPEN_AND_COMPACT_DB_OPEN_MICROS,
      "rocksdb.open.and.compact.db.open.micros"},
+    {COMPACTION_QUEUE_WAIT_TIME, "rocksdb.compaction.queue.wait.micros"},
 };
 
 std::shared_ptr<Statistics> CreateDBStatistics() {


### PR DESCRIPTION
Adds compaction queue wait-time tracking, exposing it through per-level statistics, CF stats, and the `COMPACTION_QUEUE_WAIT_TIME` histogram. Includes test coverage for delayed queued compactions.