### PR TITLE
Tolerate InvalidArgument from full_history_ts_low race when persist_user_defined_timestamps=false

### DIFF
--- a/db_stress_tool/db_stress_common.cc
+++ b/db_stress_tool/db_stress_common.cc
@@ -754,6 +754,19 @@ std::string GetNowNanos() {
   return ret;
 }
 
+std::string GetReadTimestamp() {
+  uint64_t read_timestamp = raw_env->NowNanos();
+  if (!FLAGS_persist_user_defined_timestamps) {
+    // Add 10 seconds of headroom because a concurrent flush can advance
+    // full_history_ts_low making the read timestamp invalid.
+    read_timestamp += 10'000'000'000ULL;
+  }
+
+  std::string ret;
+  PutFixed64(&ret, read_timestamp);
+  return ret;
+}
+
 uint64_t GetWriteUnixTime(ThreadState* thread) {
   static uint64_t kPreserveSeconds =
       std::max(FLAGS_preserve_internal_time_seconds,

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -883,6 +883,8 @@ int64_t GetOneHotKeyID(double rand_seed, int64_t max_key);
 
 std::string GetNowNanos();
 
+std::string GetReadTimestamp();
+
 uint64_t GetWriteUnixTime(ThreadState* thread);
 
 std::shared_ptr<FileChecksumGenFactory> GetFileChecksumImpl(

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -941,13 +941,6 @@ Status StressTest::AssertSame(DB* db, ColumnFamilyHandle* cf,
   PinnableSlice v;
   s = DbStressGet(db, ropt, cf, snap_state.key, &v);
   if (!s.ok() && !s.IsNotFound()) {
-    // When `persist_user_defined_timestamps` is false, a repeated read with
-    // both a read timestamp and an explicitly taken snapshot cannot guarantee
-    // consistent result all the time. When it cannot return consistent result,
-    // it will return an `InvalidArgument` status.
-    if (s.IsInvalidArgument() && !FLAGS_persist_user_defined_timestamps) {
-      return Status::OK();
-    }
     return s;
   }
   if (snap_state.status != s) {
@@ -1107,7 +1100,7 @@ void StressTest::MaybeVerifyCpuCorruption(ThreadState* thread,
   std::string read_ts_str;
   Slice read_ts;
   if (FLAGS_user_timestamp_size > 0) {
-    read_ts_str = GetNowNanos();
+    read_ts_str = GetReadTimestamp();
     read_ts = read_ts_str;
     read_opts.timestamp = &read_ts;
   }
@@ -1941,7 +1934,7 @@ void StressTest::OperateDb(ThreadState* thread) {
       std::string read_ts_str;
       Slice read_ts;
       if (FLAGS_user_timestamp_size > 0) {
-        read_ts_str = GetNowNanos();
+        read_ts_str = GetReadTimestamp();
         read_ts = read_ts_str;
         read_opts.timestamp = &read_ts;
       }
@@ -3385,7 +3378,7 @@ Status StressTest::TestBackupRestore(
     std::string ts_str;
     Slice ts;
     if (FLAGS_user_timestamp_size > 0) {
-      ts_str = GetNowNanos();
+      ts_str = GetReadTimestamp();
       ts = ts_str;
       read_opts.timestamp = &ts;
     }
@@ -3695,7 +3688,7 @@ Status StressTest::TestCheckpoint(ThreadState* thread,
       Slice ts;
       ReadOptions read_opts;
       if (FLAGS_user_timestamp_size > 0) {
-        ts_str = GetNowNanos();
+        ts_str = GetReadTimestamp();
         ts = ts_str;
         read_opts.timestamp = &ts;
       }
@@ -4027,7 +4020,7 @@ void StressTest::TestAcquireSnapshot(ThreadState* thread,
   std::string ts_str;
   Slice ts;
   if (FLAGS_user_timestamp_size > 0) {
-    ts_str = GetNowNanos();
+    ts_str = GetReadTimestamp();
     ts = ts_str;
     ropt.timestamp = &ts;
   }
@@ -4231,7 +4224,7 @@ uint32_t StressTest::GetRangeHash(ThreadState* thread, const Snapshot* snapshot,
   std::string ts_str;
   Slice ts;
   if (FLAGS_user_timestamp_size > 0) {
-    ts_str = GetNowNanos();
+    ts_str = GetReadTimestamp();
     ts = ts_str;
     ro.timestamp = &ts;
   }

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -39,7 +39,7 @@ class NonBatchedOpsStressTest : public StressTest {
     std::string ts_str;
     Slice ts;
     if (FLAGS_user_timestamp_size > 0) {
-      ts_str = GetNowNanos();
+      ts_str = GetReadTimestamp();
       ts = ts_str;
       options.timestamp = &ts;
     }
@@ -515,7 +515,7 @@ class NonBatchedOpsStressTest : public StressTest {
     std::string ts_str;
     Slice ts;
     if (FLAGS_user_timestamp_size > 0) {
-      ts_str = GetNowNanos();
+      ts_str = GetReadTimestamp();
       ts = ts_str;
       read_opts.timestamp = &ts;
     }
@@ -648,7 +648,7 @@ class NonBatchedOpsStressTest : public StressTest {
     std::string read_ts_str;
     Slice read_ts_slice;
     if (FLAGS_user_timestamp_size > 0) {
-      read_ts_str = GetNowNanos();
+      read_ts_str = GetReadTimestamp();
       read_ts_slice = read_ts_str;
       read_opts_copy.timestamp = &read_ts_slice;
     }
@@ -686,7 +686,7 @@ class NonBatchedOpsStressTest : public StressTest {
     std::string read_ts_str;
     Slice read_ts_slice;
     if (FLAGS_user_timestamp_size > 0) {
-      read_ts_str = GetNowNanos();
+      read_ts_str = GetReadTimestamp();
       read_ts_slice = read_ts_str;
       read_opts_copy.timestamp = &read_ts_slice;
     }
@@ -1136,7 +1136,7 @@ class NonBatchedOpsStressTest : public StressTest {
     std::string read_ts_str;
     Slice read_ts_slice;
     if (FLAGS_user_timestamp_size > 0) {
-      read_ts_str = GetNowNanos();
+      read_ts_str = GetReadTimestamp();
       read_ts_slice = read_ts_str;
       read_opts_copy.timestamp = &read_ts_slice;
     }
@@ -2836,7 +2836,7 @@ class NonBatchedOpsStressTest : public StressTest {
     std::string read_ts_str;
     Slice read_ts;
     if (FLAGS_user_timestamp_size > 0) {
-      read_ts_str = GetNowNanos();
+      read_ts_str = GetReadTimestamp();
       read_ts = read_ts_str;
       ro.timestamp = &read_ts;
     }


### PR DESCRIPTION
Summary:
When `persist_user_defined_timestamps=false`, `full_history_ts_low` is automatically advanced by flushes to just above the newest timestamp in the flushed memtable. This creates the following race:

```
Reader                              Concurrent writer / flush
------                              -------------------------
T0: Sample read timestamp:
    892779959679761

                                    T1: Write with a newer timestamp:
                                        892779963289806

                                    T2: Flush the memtable.

                                    T3: Advance full_history_ts_low:
                                        892779963289807

T4: Validate the read:

    892779959679761
      < 892779963289807

    Result: InvalidArgument
```

This is expected RocksDB behavior because history below `full_history_ts_low` is no longer guaranteed to be complete. However, the stress test intends these operations to read the latest value.

This change adds ten seconds of headroom to read timestamps when user-defined timestamps are not persisted. This makes it substantially less likely that a concurrent flush overtakes a read timestamp. Unlike tolerating every `InvalidArgument`, this preserves reporting for genuine timestamp errors. Persisted read timestamps and write timestamps remain unchanged.

The triggering non-default options are `persist_user_defined_timestamps=false` and `user_timestamp_size=8`.

Differential Revision: D114565978


