### PR TITLE
Release JNI event listener array elements

### DIFF
--- a/java/rocksjni/options.cc
+++ b/java/rocksjni/options.cc
@@ -1752,6 +1752,7 @@ static void rocksdb_set_event_listeners_helper(
             ptr_jlistener_array[i]);
     listener_sptr_vec.push_back(listener_sptr);
   }
+  env->ReleaseLongArrayElements(jlistener_array, ptr_jlistener_array, JNI_ABORT);
 }
 
 /*


### PR DESCRIPTION
## Summary

Fixes #14972 by releasing the `jlongArray` elements acquired while copying Java event listeners into native shared pointers.

## Details

`rocksdb_set_event_listeners_helper` calls `GetLongArrayElements` to read the listener handles, but did not release the returned pointer after copying the values. This adds the matching `ReleaseLongArrayElements` call with `JNI_ABORT`, since the native code does not modify the Java array.

## Validation

I built RocksJava and ran the repository's Java test runner with JNI checking enabled:

```text
JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 make -j8 rocksdbjava
JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 \
  make -C java run_test \
  ALL_JAVA_TESTS='org.rocksdb.OptionsTest org.rocksdb.DBOptionsTest'
```

`OptionsTest` (141 tests), `DBOptionsTest` (84 tests), and the runner's `StatisticsTest` (8 tests) all passed with no failures or errors. Both options test classes exercise `setListeners` and `listeners`, including replacing a non-empty listener list with an empty list.
