### PR TITLE
Log failed Status values in db_stress assertions (#15054)

### DIFF
--- a/db_stress_tool/batched_ops_stress.cc
+++ b/db_stress_tool/batched_ops_stress.cc
@@ -687,7 +687,7 @@ class BatchedOpsStressTest : public StressTest {
       // if the first iterator finished, they should have all finished
       assert(!iters[i]->Valid() ||
              !iters[i]->key().starts_with(prefix_slices[i]));
-      assert(iters[i]->status().ok());
+      DB_STRESS_ASSERT_OK(iters[i]->status());
     }
 
     db_->ReleaseSnapshot(snapshot);

--- a/db_stress_tool/cf_consistency_stress.cc
+++ b/db_stress_tool/cf_consistency_stress.cc
@@ -680,7 +680,7 @@ class CfConsistencyStressTest : public StressTest {
             continue;
           }
 
-          assert(s.ok());
+          DB_STRESS_ASSERT_OK(s);
           if (cmp_s.IsNotFound()) {
             fprintf(stderr,
                     "MultiGetEntity (AttributeGroup) returns different results "
@@ -793,7 +793,7 @@ class CfConsistencyStressTest : public StressTest {
             continue;
           }
 
-          assert(s.ok());
+          DB_STRESS_ASSERT_OK(s);
           if (cmp_s.IsNotFound()) {
             fprintf(
                 stderr,

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -41,6 +41,7 @@
 #include "db_stress_tool/db_stress_env_wrapper.h"
 #include "db_stress_tool/db_stress_listener.h"
 #include "db_stress_tool/db_stress_shared_state.h"
+#include "db_stress_tool/db_stress_status.h"
 #include "db_stress_tool/db_stress_test_base.h"
 #include "logging/logging.h"
 #include "monitoring/histogram.h"

--- a/db_stress_tool/db_stress_driver.cc
+++ b/db_stress_tool/db_stress_driver.cc
@@ -78,11 +78,8 @@ bool RunStressTestImpl(SharedState* shared) {
     if (s.ok() && !ev_dir.empty()) {
       s = InitUnverifiedSubdir(ev_dir);
     }
-    if (!s.ok()) {
-      fprintf(stderr, "%sFailed to setup unverified state dir: %s\n",
-              db_label.c_str(), s.ToString().c_str());
-      exit(1);
-    }
+    DB_STRESS_ASSERT_OK_MSG(s, "%sFailed to setup unverified state dir",
+                            db_label.c_str());
   }
 
   stress->InitDb(shared);
@@ -177,11 +174,8 @@ bool RunStressTestImpl(SharedState* shared) {
         if (s.ok() && !ev_dir.empty()) {
           s = DestroyUnverifiedSubdir(ev_dir);
         }
-        if (!s.ok()) {
-          fprintf(stderr, "%sFailed to cleanup unverified state dir: %s\n",
-                  db_label.c_str(), s.ToString().c_str());
-          exit(1);
-        }
+        DB_STRESS_ASSERT_OK_MSG(s, "%sFailed to cleanup unverified state dir",
+                                db_label.c_str());
       }
     }
 
@@ -203,7 +197,7 @@ bool RunStressTestImpl(SharedState* shared) {
       }
       if (ShouldDisableAutoCompactionsBeforeVerifyDb()) {
         Status s = stress->EnableAutoCompaction();
-        assert(s.ok());
+        DB_STRESS_ASSERT_OK(s);
       }
       fprintf(stdout, "%s %sStarting database operations\n",
               clock->TimeToString(now / 1000000).c_str(), db_label.c_str());

--- a/db_stress_tool/db_stress_filters.cc
+++ b/db_stress_tool/db_stress_filters.cc
@@ -8,6 +8,8 @@
 #include <memory>
 #include <mutex>
 
+#include "db_stress_tool/db_stress_status.h"
+
 namespace ROCKSDB_NAMESPACE {
 
 #ifdef GFLAGS
@@ -82,7 +84,7 @@ SstQueryFilterConfigsManager& DbStressSqfcManager() {
   static std::shared_ptr<SstQueryFilterConfigsManager> mgr;
   std::call_once(flag, []() {
     Status s = SstQueryFilterConfigsManager::MakeShared(data, &mgr);
-    assert(s.ok());
+    DB_STRESS_ASSERT_OK(s);
     assert(mgr);
   });
   return *mgr;

--- a/db_stress_tool/db_stress_listener.cc
+++ b/db_stress_tool/db_stress_listener.cc
@@ -48,11 +48,7 @@ UniqueIdVerifier::UniqueIdVerifier(const std::string& dir)
   IOOptions opts;
 
   Status st = fs->CreateDirIfMissing(dir, opts, nullptr);
-  if (!st.ok()) {
-    fprintf(stderr, "Failed to create directory %s: %s\n", dir.c_str(),
-            st.ToString().c_str());
-    exit(1);
-  }
+  DB_STRESS_ASSERT_OK_MSG(st, "Failed to create directory %s", dir.c_str());
 
   // Avoid relying on ReopenWritableFile which is not supported by all
   // file systems. Create a new file and copy the old file contents to it.
@@ -99,7 +95,7 @@ UniqueIdVerifier::UniqueIdVerifier(const std::string& dir)
             id_set_.clear();
             reader.reset();
             s = fs->DeleteFile(tmp_path, opts, /*dbg*/ nullptr);
-            assert(s.ok());
+            DB_STRESS_ASSERT_OK(s);
             size = 0;
           }
           break;
@@ -113,9 +109,9 @@ UniqueIdVerifier::UniqueIdVerifier(const std::string& dir)
       // the failure. (Issue #9021)
       Status s2 = fs->FileExists(tmp_path, opts, /*dbg*/ nullptr);
       if (!s2.IsNotFound()) {
-        fprintf(stderr, "Error opening unique id file: %s\n",
-                s.ToString().c_str());
-        assert(false);
+        DB_STRESS_ASSERT_OK_MSG(
+            s, "Error opening unique id file; FileExists returned %s",
+            s2.ToString().c_str());
       }
       size = 0;
     }
@@ -152,7 +148,7 @@ UniqueIdVerifier::~UniqueIdVerifier() {
   ThreadStatusUtil::SetThreadOperation(ThreadStatus::OperationType::OP_UNKNOWN);
   IOStatus s;
   s = data_file_writer_->Close(IOOptions());
-  assert(s.ok());
+  DB_STRESS_ASSERT_OK(s);
   ThreadStatusUtil::SetThreadOperation(cur_op_type);
 }
 

--- a/db_stress_tool/db_stress_shared_state.cc
+++ b/db_stress_tool/db_stress_shared_state.cc
@@ -73,11 +73,7 @@ SharedState::SharedState(Env* /*env*/, StressTest* stress_test)
     }
     status = expected_state_manager_->Open();
   }
-  if (!status.ok()) {
-    fprintf(stderr, "Failed setting up expected state with error: %s\n",
-            status.ToString().c_str());
-    exit(1);  // NOLINT(concurrency-mt-unsafe)
-  }
+  DB_STRESS_ASSERT_OK_MSG(status, "Failed setting up expected state");
 
   if (FLAGS_test_batches_snapshots) {
     fprintf(stdout, "No lock creation because test_batches_snapshots set\n");

--- a/db_stress_tool/db_stress_status.h
+++ b/db_stress_tool/db_stress_status.h
@@ -1,0 +1,56 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+
+#include "rocksdb/status.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+template <typename... Args>
+inline void DbStressLogStatusFailure(const Status& status,
+                                     const char* expression,
+                                     const char* message_format, Args... args) {
+  assert(!status.ok());
+  if (message_format != nullptr) {
+    if constexpr (sizeof...(Args) == 0) {
+      std::fprintf(stderr, "%s", message_format);
+    } else {
+      std::fprintf(stderr, message_format, args...);
+    }
+    std::fprintf(stderr, ": ");
+  }
+  std::fprintf(stderr, "Status assertion failed for %s: %s\n", expression,
+               status.ToString().c_str());
+  std::fflush(stderr);
+}
+
+}  // namespace ROCKSDB_NAMESPACE
+
+#define DB_STRESS_ASSERT_OK(status)                                            \
+  do {                                                                         \
+    const auto& db_stress_status = (status);                                   \
+    if (!db_stress_status.ok()) {                                              \
+      ::ROCKSDB_NAMESPACE::DbStressLogStatusFailure(db_stress_status, #status, \
+                                                    nullptr);                  \
+      assert(db_stress_status.ok());                                           \
+      std::exit(1);                                                            \
+    }                                                                          \
+  } while (false)
+
+#define DB_STRESS_ASSERT_OK_MSG(status, ...)                                   \
+  do {                                                                         \
+    const auto& db_stress_status = (status);                                   \
+    if (!db_stress_status.ok()) {                                              \
+      ::ROCKSDB_NAMESPACE::DbStressLogStatusFailure(db_stress_status, #status, \
+                                                    __VA_ARGS__);              \
+      assert(db_stress_status.ok());                                           \
+      std::exit(1);                                                            \
+    }                                                                          \
+  } while (false)

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -278,11 +278,7 @@ std::string GetFaultInjectionLogPath(const std::string& db_label) {
   const std::string log_dir =
       GetFaultInjectionLogBaseDir() + "/fault_injection_logs";
   Status s = Env::Default()->CreateDirIfMissing(log_dir);
-  if (!s.ok()) {
-    fprintf(stderr, "Failed to create directory %s: %s\n", log_dir.c_str(),
-            s.ToString().c_str());
-    exit(1);
-  }
+  DB_STRESS_ASSERT_OK_MSG(s, "Failed to create directory %s", log_dir.c_str());
   return log_dir + "/fault_injection_" + std::to_string(port::GetProcessID()) +
          "_" + std::to_string(Env::Default()->NowMicros()) + "_" + db_label +
          ".bin";
@@ -449,19 +445,12 @@ StressTest::StressTest(int db_index, const std::string& db_path,
 
   if (FLAGS_destroy_db_initially) {
     const Status s = DbStressDestroyDb(GetDbPath());
-    if (!s.ok()) {
-      fprintf(stderr, "Cannot destroy original db: %s\n", s.ToString().c_str());
-      exit(1);
-    }
+    DB_STRESS_ASSERT_OK_MSG(s, "Cannot destroy original db");
   }
 
   Status s = DbStressSqfcManager().MakeSharedFactory(
       FLAGS_sqfc_name, FLAGS_sqfc_version, &sqfc_factory_);
-  if (!s.ok()) {
-    fprintf(stderr, "Error initializing SstQueryFilterConfig: %s\n",
-            s.ToString().c_str());
-    exit(1);
-  }
+  DB_STRESS_ASSERT_OK_MSG(s, "Error initializing SstQueryFilterConfig");
 
   CheckpointEngineOptions engine_options;
   engine_options.max_background_operations =
@@ -469,11 +458,7 @@ StressTest::StressTest(int db_index, const std::string& db_path,
   engine_options.use_link_file_when_available =
       FLAGS_checkpoint_engine_use_link_file_when_available;
   s = CheckpointEngine::Open(engine_options, &checkpoint_engine_);
-  if (!s.ok()) {
-    fprintf(stderr, "Error opening CheckpointEngine: %s\n",
-            s.ToString().c_str());
-    exit(1);
-  }
+  DB_STRESS_ASSERT_OK_MSG(s, "Error opening CheckpointEngine");
 }
 
 void StressTest::CleanUp() {
@@ -503,11 +488,9 @@ void StressTest::InitializeListenersForOpen(
     Status listener_status =
         ObjectRegistry::Default()->NewSharedObject<EventListener>(
             FLAGS_listener_uri, &listener);
-    if (!listener_status.ok()) {
-      fprintf(stderr, "Failed to create listener from URI '%s': %s\n",
-              FLAGS_listener_uri.c_str(), listener_status.ToString().c_str());
-      exit(1);
-    }
+    DB_STRESS_ASSERT_OK_MSG(listener_status,
+                            "Failed to create listener from URI '%s'",
+                            FLAGS_listener_uri.c_str());
     options_.listeners.emplace_back(std::move(listener));
   }
 }
@@ -1264,8 +1247,7 @@ void StressTest::PreloadDbAndReopenAsReadOnly(int64_t number_of_keys,
     // Reopen as read-only, can ignore all options related to updates
     Open(shared);
   } else {
-    fprintf(stderr, "Failed to preload db");
-    exit(1);
+    DB_STRESS_ASSERT_OK_MSG(s, "Failed to preload db");
   }
 }
 
@@ -1327,10 +1309,10 @@ void StressTest::ProcessRecoveredPreparedTxnsHelper(Transaction* txn,
   }
   if (rand.OneIn(2)) {
     Status s = txn->Commit();
-    assert(s.ok());
+    DB_STRESS_ASSERT_OK(s);
   } else {
     Status s = txn->Rollback();
-    assert(s.ok());
+    DB_STRESS_ASSERT_OK(s);
   }
 }
 
@@ -2696,7 +2678,7 @@ Status StressTest::TestIterateImpl(ThreadState* thread,
       if (!s.ok() && IsErrorInjectedAndRetryable(s)) {
         return s;
       }
-      assert(s.ok());
+      DB_STRESS_ASSERT_OK(s);
       op_logs += "Refresh ";
     }
 
@@ -4523,11 +4505,7 @@ void StressTest::Open(SharedState* shared, bool reopen) {
         true /* delete_existing_trash */, &status,
         0.25 /* max_trash_db_ratio */,
         FLAGS_sst_file_manager_bytes_per_truncate));
-    if (!status.ok()) {
-      fprintf(stderr, "SstFileManager creation failed: %s\n",
-              status.ToString().c_str());
-      exit(1);
-    }
+    DB_STRESS_ASSERT_OK_MSG(status, "SstFileManager creation failed");
   }
   DbStressCustomCompressionManager::Register();
 
@@ -4792,12 +4770,8 @@ void StressTest::Open(SharedState* shared, bool reopen) {
         s = OptimisticTransactionDB::Open(
             options_, optimistic_txn_db_options, GetDbPath(), cf_descriptors,
             &column_families_, &optimistic_txn_db_);
-        if (!s.ok()) {
-          fprintf(stderr, "Error in opening the OptimisticTransactionDB [%s]\n",
-                  s.ToString().c_str());
-          fflush(stderr);
-        }
-        assert(s.ok());
+        DB_STRESS_ASSERT_OK_MSG(s,
+                                "Error in opening the OptimisticTransactionDB");
         {
           db_owner_.reset(optimistic_txn_db_);
           db_ = optimistic_txn_db_;
@@ -4830,12 +4804,7 @@ void StressTest::Open(SharedState* shared, bool reopen) {
         PrepareTxnDbOptions(shared, txn_db_options);
         s = TransactionDB::Open(options_, txn_db_options, GetDbPath(),
                                 cf_descriptors, &column_families_, &txn_db_);
-        if (!s.ok()) {
-          fprintf(stderr, "Error in opening the TransactionDB [%s]\n",
-                  s.ToString().c_str());
-          fflush(stderr);
-        }
-        assert(s.ok());
+        DB_STRESS_ASSERT_OK_MSG(s, "Error in opening the TransactionDB");
 
         // Do not swap the order of the following.
         {
@@ -4845,11 +4814,7 @@ void StressTest::Open(SharedState* shared, bool reopen) {
         }
       }
     }
-    if (!s.ok()) {
-      fprintf(stderr, "Error in opening the DB [%s]\n", s.ToString().c_str());
-      fflush(stderr);
-    }
-    assert(s.ok());
+    DB_STRESS_ASSERT_OK_MSG(s, "Error in opening the DB");
     assert(column_families_.size() ==
            static_cast<size_t>(FLAGS_column_families));
     // Clear statistics reference from options_ to intentionally shorten the
@@ -4871,7 +4836,7 @@ void StressTest::Open(SharedState* shared, bool reopen) {
       const std::string& secondary_path = GetSecondariesBase();
       s = DB::OpenAsSecondary(tmp_opts, GetDbPath(), secondary_path,
                               cf_descriptors, &secondary_cfhs_, &secondary_db_);
-      assert(s.ok());
+      DB_STRESS_ASSERT_OK(s);
       assert(secondary_cfhs_.size() ==
              static_cast<size_t>(FLAGS_column_families));
     }
@@ -5258,22 +5223,13 @@ void StressTest::Reopen(ThreadState* thread) {
     } else {
       s = db_->SyncWAL();
     }
-    if (!s.ok()) {
-      fprintf(stderr,
-              "Error persisting WAL data which is needed before reopening the "
-              "DB: %s\n",
-              s.ToString().c_str());
-      exit(1);
-    }
+    DB_STRESS_ASSERT_OK_MSG(
+        s, "Error persisting WAL data which is needed before reopening the DB");
   }
 
   if (thread->rand.OneIn(2)) {
     Status s = db_->Close();
-    if (!s.ok()) {
-      fprintf(stderr, "Non-ok close status: %s\n", s.ToString().c_str());
-      fflush(stderr);
-    }
-    assert(s.ok());
+    DB_STRESS_ASSERT_OK_MSG(s, "Non-ok close status");
   }
   assert((txn_db_ == nullptr && optimistic_txn_db_ == nullptr) ||
          (db_ == txn_db_ || db_ == optimistic_txn_db_));
@@ -5299,11 +5255,7 @@ void StressTest::Reopen(ThreadState* thread) {
   if (thread->shared->GetStressTest()->MightHaveUnsyncedDataLoss() &&
       IsStateTracked()) {
     Status s = thread->shared->SaveAtAndAfter(db_);
-    if (!s.ok()) {
-      fprintf(stderr, "Error enabling history tracing: %s\n",
-              s.ToString().c_str());
-      exit(1);
-    }
+    DB_STRESS_ASSERT_OK_MSG(s, "Error enabling history tracing");
   }
 }
 
@@ -5431,11 +5383,8 @@ bool InitializeOptionsFromFile(Options& options) {
   if (!FLAGS_options_file.empty()) {
     Status s = LoadOptionsFromFile(config_options, FLAGS_options_file,
                                    &db_options, &cf_descriptors);
-    if (!s.ok()) {
-      fprintf(stderr, "Unable to load options file %s --- %s\n",
-              FLAGS_options_file.c_str(), s.ToString().c_str());
-      exit(1);
-    }
+    DB_STRESS_ASSERT_OK_MSG(s, "Unable to load options file %s",
+                            FLAGS_options_file.c_str());
     db_options.env = new CompositeEnvWrapper(raw_env);
     options = Options(db_options, cf_descriptors[0].options);
     return true;
@@ -5775,11 +5724,7 @@ void InitializeOptionsFromFlags(
             ";allow_trivial_copy_when_change_temperature=" +
             allowTrivialCopyBoolStr + "}",
         &options);
-    if (!s.ok()) {
-      fprintf(stderr, "While setting file_temperature_age_thresholds: %s\n",
-              s.ToString().c_str());
-      exit(1);
-    }
+    DB_STRESS_ASSERT_OK_MSG(s, "While setting file_temperature_age_thresholds");
   }
   // NOTE: allow -1 to mean starting disabled but dynamically changing
   options.preclude_last_level_data_seconds =
@@ -5948,11 +5893,7 @@ void InitializeOptionsGeneral(
         true /* delete_existing_trash */, &status,
         0.25 /* max_trash_db_ratio */,
         FLAGS_sst_file_manager_bytes_per_truncate));
-    if (!status.ok()) {
-      fprintf(stderr, "SstFileManager creation failed: %s\n",
-              status.ToString().c_str());
-      exit(1);
-    }
+    DB_STRESS_ASSERT_OK_MSG(status, "SstFileManager creation failed");
   }
 
   options.table_properties_collector_factories.clear();

--- a/db_stress_tool/db_stress_tool.cc
+++ b/db_stress_tool/db_stress_tool.cc
@@ -142,11 +142,8 @@ int db_stress_tool(int argc, char** argv) {
 
   Status s = Env::CreateFromUri(ConfigOptions(), FLAGS_env_uri, FLAGS_fs_uri,
                                 &raw_env, &env_guard);
-  if (!s.ok()) {
-    fprintf(stderr, "Error Creating Env URI: %s: %s\n", FLAGS_env_uri.c_str(),
-            s.ToString().c_str());
-    exit(1);  // NOLINT(concurrency-mt-unsafe)
-  }
+  DB_STRESS_ASSERT_OK_MSG(s, "Error creating Env URI %s",
+                          FLAGS_env_uri.c_str());
 
   // Handle --destroy_db_and_exit early
   if (FLAGS_destroy_db_and_exit) {
@@ -429,11 +426,8 @@ int db_stress_tool(int argc, char** argv) {
   const int num_dbs = FLAGS_num_dbs;
   if (num_dbs > 1) {
     s = raw_env->CreateDirIfMissing(FLAGS_db);
-    if (!s.ok()) {
-      fprintf(stderr, "Failed to create directory %s: %s\n", FLAGS_db.c_str(),
-              s.ToString().c_str());
-      exit(1);  // NOLINT(concurrency-mt-unsafe)
-    }
+    DB_STRESS_ASSERT_OK_MSG(s, "Failed to create directory %s",
+                            FLAGS_db.c_str());
   }
   std::vector<std::string> db_paths;
   std::vector<std::string> ev_paths;
@@ -443,11 +437,7 @@ int db_stress_tool(int argc, char** argv) {
     if (!FLAGS_expected_values_dir.empty()) {
       std::string ep = FLAGS_expected_values_dir + suffix;
       s = Env::Default()->CreateDirIfMissing(ep);
-      if (!s.ok()) {
-        fprintf(stderr, "Failed to create directory %s: %s\n", ep.c_str(),
-                s.ToString().c_str());
-        exit(1);  // NOLINT(concurrency-mt-unsafe)
-      }
+      DB_STRESS_ASSERT_OK_MSG(s, "Failed to create directory %s", ep.c_str());
       ev_paths.push_back(std::move(ep));
     }
   }
@@ -466,20 +456,14 @@ int db_stress_tool(int argc, char** argv) {
       sec_parent += "/dbstress_secondaries";
     }
     s = raw_env->CreateDirIfMissing(sec_parent);
-    if (!s.ok()) {
-      fprintf(stderr, "Failed to create directory %s: %s\n", sec_parent.c_str(),
-              s.ToString().c_str());
-      exit(1);  // NOLINT(concurrency-mt-unsafe)
-    }
+    DB_STRESS_ASSERT_OK_MSG(s, "Failed to create directory %s",
+                            sec_parent.c_str());
     for (int i = 0; i < num_dbs; i++) {
       std::string suffix = (num_dbs == 1) ? "" : "/db_" + std::to_string(i);
       std::string sec_path = sec_parent + suffix;
       s = raw_env->CreateDirIfMissing(sec_path);
-      if (!s.ok()) {
-        fprintf(stderr, "Failed to create directory %s: %s\n", sec_path.c_str(),
-                s.ToString().c_str());
-        exit(1);  // NOLINT(concurrency-mt-unsafe)
-      }
+      DB_STRESS_ASSERT_OK_MSG(s, "Failed to create directory %s",
+                              sec_path.c_str());
       sec_paths.push_back(std::move(sec_path));
     }
   }

--- a/db_stress_tool/multi_ops_txns_stress.cc
+++ b/db_stress_tool/multi_ops_txns_stress.cc
@@ -1479,10 +1479,10 @@ void MultiOpsTxnsStressTest::PersistKeySpacesDesc(
   std::unique_ptr<WritableFile> wfile;
   Status s1 =
       Env::Default()->NewWritableFile(key_spaces_path, &wfile, EnvOptions());
-  assert(s1.ok());
+  DB_STRESS_ASSERT_OK(s1);
   assert(wfile);
   s1 = wfile->Append(key_spaces_rep);
-  assert(s1.ok());
+  DB_STRESS_ASSERT_OK(s1);
 }
 
 MultiOpsTxnsStressTest::KeySpaces MultiOpsTxnsStressTest::ReadKeySpacesDesc(
@@ -1491,12 +1491,12 @@ MultiOpsTxnsStressTest::KeySpaces MultiOpsTxnsStressTest::ReadKeySpacesDesc(
   std::unique_ptr<SequentialFile> sfile;
   Status s1 =
       Env::Default()->NewSequentialFile(key_spaces_path, &sfile, EnvOptions());
-  assert(s1.ok());
+  DB_STRESS_ASSERT_OK(s1);
   assert(sfile);
   char buf[16];
   Slice result;
   s1 = sfile->Read(sizeof(buf), &result, buf);
-  assert(s1.ok());
+  DB_STRESS_ASSERT_OK(s1);
   if (!key_spaces.DecodeFrom(result)) {
     assert(false);
   }
@@ -1585,7 +1585,7 @@ void MultiOpsTxnsStressTest::PreloadDb(SharedState* shared, int threads,
     ProcessStatus(shared, "PreloadDB", s, /*ignore_injected_error=*/false);
 
     s = txn_db_->Write(wopts, &wb);
-    assert(s.ok());
+    DB_STRESS_ASSERT_OK(s);
     ProcessStatus(shared, "PreloadDB", s, /*ignore_injected_error=*/false);
 
     // TODO (yanqin): make the following check optional, especially when data
@@ -1691,12 +1691,9 @@ void MultiOpsTxnsStressTest::ScanExistingDb(SharedState* shared, int threads) {
     for (it->SeekToFirst(); it->Valid(); it->Next()) {
       Record record;
       Status s = record.DecodePrimaryIndexEntry(it->key(), it->value());
-      if (!s.ok()) {
-        fprintf(stderr, "Cannot decode primary index entry (%s => %s): %s\n",
-                it->key().ToString(true).c_str(),
-                it->value().ToString(true).c_str(), s.ToString().c_str());
-        assert(false);
-      }
+      DB_STRESS_ASSERT_OK_MSG(s, "Cannot decode primary index entry (%s => %s)",
+                              it->key().ToString(true).c_str(),
+                              it->value().ToString(true).c_str());
       uint32_t a = record.a_value();
       assert(a >= lb_a);
       assert(a < ub_a);

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -491,10 +491,7 @@ class NonBatchedOpsStressTest : public StressTest {
     assert(secondary_db_);
     assert(!secondary_cfhs_.empty());
     Status s = secondary_db_->TryCatchUpWithPrimary();
-    if (!s.ok()) {
-      assert(false);
-      exit(1);
-    }
+    DB_STRESS_ASSERT_OK_MSG(s, "TryCatchUpWithPrimary failed");
 
     const auto checksum_column_family = [](Iterator* iter,
                                            uint32_t* checksum) -> Status {
@@ -1427,7 +1424,7 @@ class NonBatchedOpsStressTest : public StressTest {
                 is_consistent = false;
               }
             } else {
-              assert(cmp_s.ok());
+              DB_STRESS_ASSERT_OK(cmp_s);
 
               if (s.IsNotFound()) {
                 fprintf(
@@ -1437,7 +1434,7 @@ class NonBatchedOpsStressTest : public StressTest {
                     StringToHex(keys[i]).c_str());
                 is_consistent = false;
               } else {
-                assert(s.ok());
+                DB_STRESS_ASSERT_OK(s);
 
                 const WideColumns& cmp_columns = cmp_result.columns();
 
@@ -3133,7 +3130,7 @@ class NonBatchedOpsStressTest : public StressTest {
       if (!rs.ok() && IsErrorInjectedAndRetryable(rs)) {
         return rs;
       }
-      assert(rs.ok());
+      DB_STRESS_ASSERT_OK(rs);
       op_logs += "Refresh ";
       for (int64_t i = 0; i < static_cast<int64_t>(expected_values_size); ++i) {
         post_read_expected_values.push_back(


### PR DESCRIPTION
Summary:

`db_stress` often terminates on raw `assert(status.ok())` checks, which discard the underlying error and make crash-test failures difficult to diagnose.

Log the expression and full status before terminating. A message variant preserves operation-specific context and variadic formatting. Exit with status 1 after logging so failures terminate consistently in debug and optimized builds.

Reviewed By: jaykorean

Differential Revision: D114756034


