### PR TITLE
Extend parallel checkpointing and db_stress coverage for column-family-subset checkpoints (#15059)

### DIFF
--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -232,6 +232,7 @@ DECLARE_int32(checkpoint_one_in);
 DECLARE_int32(checkpoint_engine_max_background_operations);
 DECLARE_bool(checkpoint_engine_use_link_file_when_available);
 DECLARE_int32(parallel_checkpoint_one_in);
+DECLARE_int32(subset_cf_checkpoint_one_in);
 DECLARE_int32(ingest_external_file_one_in);
 DECLARE_int32(ingest_external_file_width);
 DECLARE_int32(ingest_external_file_prepare_commit_one_in);

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -874,6 +874,12 @@ DEFINE_int32(parallel_checkpoint_one_in, 0,
              "probability 1/N, else the legacy serial API (0 = always serial, "
              "1 = always parallel).");
 
+DEFINE_int32(subset_cf_checkpoint_one_in, 0,
+             "Each checkpoint covers only a random proper subset of the column "
+             "families with probability 1/N (0 = always all column families, "
+             "1 = always a subset). Ignored when there is only the default "
+             "column family.");
+
 DEFINE_int32(ingest_external_file_one_in, 0,
              "If non-zero, then IngestExternalFile() will be called once for "
              "every N operations on average.  0 indicates IngestExternalFile() "

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -8,6 +8,7 @@
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 //
 
+#include <algorithm>
 #include <cstdlib>
 #include <iomanip>
 #include <ios>
@@ -372,6 +373,45 @@ void WriteDataCorruption(uint32_t thread_id, int cf, int64_t key,
             path.c_str());
     port::ImmediateExit(1);
   }
+}
+
+std::string JoinSorted(std::vector<std::string> names) {
+  std::sort(names.begin(), names.end());
+  std::string out;
+  for (const auto& name : names) {
+    if (!out.empty()) {
+      out += ", ";
+    }
+    out += name;
+  }
+  return out;
+}
+
+// Checks that a column-family-subset checkpoint holds exactly the requested
+// families: the excluded ones must have been recorded as dropped in the copied
+// MANIFEST, and the requested ones must have survived that rewrite.
+Status VerifyCheckpointColumnFamilies(
+    const std::string& checkpoint_dir, const DBOptions& db_options,
+    const std::vector<ColumnFamilyDescriptor>& expected_cf_descs) {
+  std::vector<std::string> actual_names;
+  Status s = DB::ListColumnFamilies(db_options, checkpoint_dir, &actual_names);
+  if (!s.ok()) {
+    return s;
+  }
+  std::vector<std::string> expected_names;
+  expected_names.reserve(expected_cf_descs.size());
+  for (const auto& desc : expected_cf_descs) {
+    expected_names.push_back(desc.name);
+  }
+  const std::string actual = JoinSorted(std::move(actual_names));
+  const std::string expected = JoinSorted(std::move(expected_names));
+  if (actual == expected) {
+    return Status::OK();
+  }
+  std::ostringstream oss;
+  oss << "Subset checkpoint " << checkpoint_dir << " has column families {"
+      << actual << "} but {" << expected << "} were requested";
+  return Status::Corruption(oss.str());
 }
 
 }  // namespace
@@ -4030,18 +4070,66 @@ Status StressTest::TestCheckpoint(ThreadState* thread,
   if (db_fault_injection_fs_) {
     db_fault_injection_fs_->EnableAllThreadLocalErrorInjection();
   }
+  const size_t num_cfs = column_families_.size();
+  const bool use_cf_subset =
+      num_cfs > 1 && thread->rand.OneInOpt(FLAGS_subset_cf_checkpoint_one_in);
   const bool use_parallel_engine =
       thread->rand.OneInOpt(FLAGS_parallel_checkpoint_one_in);
+
+  // `in_checkpoint[i]` is whether column family `i` is expected to exist in the
+  // checkpoint; all of them unless subset mode picked otherwise.
+  std::vector<bool> in_checkpoint(num_cfs, true);
+
+  // Picks a random non-empty proper subset of the column families, marking the
+  // excluded ones in `in_checkpoint` and returning the handles to pass to the
+  // Checkpoint API.
+  auto pick_cf_subset = [&]() {
+    // Index 0 is the default column family, which is in every checkpoint
+    // whether or not it is requested (it cannot be dropped), so only the
+    // non-default families at indices [1, num_cfs) can be excluded.
+    for (size_t i = 1; i < num_cfs; ++i) {
+      in_checkpoint[i] = thread->rand.OneIn(2);
+    }
+    // Force one exclusion so every subset checkpoint exercises the MANIFEST
+    // column-family-drop rewrite instead of degenerating into a whole-DB
+    // checkpoint.
+    in_checkpoint[1 + thread->rand.Uniform(static_cast<int>(num_cfs) - 1)] =
+        false;
+
+    std::vector<ColumnFamilyHandle*> cfhs;
+    cfhs.reserve(num_cfs);
+    for (size_t i = 1; i < num_cfs; ++i) {
+      if (in_checkpoint[i]) {
+        cfhs.push_back(column_families_[i]);
+      }
+    }
+    // Pass the default column family only half the time, to cover both sides
+    // of the "included whether or not you pass it" contract. An empty vector
+    // means "all column families" to the API, so it has to go in when nothing
+    // else did.
+    if (cfhs.empty() || thread->rand.OneIn(2)) {
+      cfhs.push_back(column_families_[0]);
+    }
+    return cfhs;
+  };
+
+  std::vector<ColumnFamilyHandle*> subset_cfhs;
+  if (use_cf_subset) {
+    subset_cfhs = pick_cf_subset();
+  }
+
   Checkpoint* checkpoint = nullptr;
   Status s;
   if (use_parallel_engine) {
-    const IOStatus io_s =
-        checkpoint_engine_->CreateCheckpoint(db_, checkpoint_dir);
+    CreateCheckpointOptions create_options;
+    create_options.column_families = subset_cfhs;
+    const IOStatus io_s = checkpoint_engine_->CreateCheckpoint(
+        db_, checkpoint_dir, /*sequence_number_ptr=*/nullptr, create_options);
     s = io_s;
   } else {
     s = Checkpoint::Create(db_, &checkpoint);
     if (s.ok()) {
-      s = checkpoint->CreateCheckpoint(checkpoint_dir);
+      s = checkpoint->CreateCheckpoint(checkpoint_dir, subset_cfhs);
     }
   }
   if (!s.ok() && !IsErrorInjectedAndRetryable(s)) {
@@ -4076,6 +4164,9 @@ Status StressTest::TestCheckpoint(ThreadState* thread,
   checkpoint = nullptr;
   std::vector<ColumnFamilyHandle*> cf_handles;
   std::unique_ptr<DB> checkpoint_db;
+  // Maps a column family index in `column_families_` to its index in
+  // `cf_handles`, or -1 when it was left out of a subset checkpoint.
+  std::vector<int> cf_handle_index(num_cfs, -1);
   if (s.ok()) {
     Options options(options_);
     options.best_efforts_recovery = false;
@@ -4089,11 +4180,22 @@ Status StressTest::TestCheckpoint(ThreadState* thread,
     // the same order as `column_family_names_`.
     assert(FLAGS_clear_column_family_one_in == 0);
     if (FLAGS_clear_column_family_one_in == 0) {
-      for (const auto& name : column_family_names_) {
-        cf_descs.emplace_back(name, ColumnFamilyOptions(options));
+      for (size_t i = 0; i < num_cfs; ++i) {
+        if (!in_checkpoint[i]) {
+          continue;
+        }
+        cf_handle_index[i] = static_cast<int>(cf_descs.size());
+        cf_descs.emplace_back(column_family_names_[i],
+                              ColumnFamilyOptions(options));
       }
-      s = DB::OpenForReadOnly(DBOptions(options), checkpoint_dir, cf_descs,
-                              &cf_handles, &checkpoint_db);
+      if (use_cf_subset) {
+        s = VerifyCheckpointColumnFamilies(checkpoint_dir, DBOptions(options),
+                                           cf_descs);
+      }
+      if (s.ok()) {
+        s = DB::OpenForReadOnly(DBOptions(options), checkpoint_dir, cf_descs,
+                                &cf_handles, &checkpoint_db);
+      }
     }
   }
   if (checkpoint_db != nullptr) {
@@ -4101,6 +4203,11 @@ Status StressTest::TestCheckpoint(ThreadState* thread,
     // dropped while the locks for `rand_keys` are held. So we should not have
     // to worry about accessing those column families throughout this function.
     for (size_t i = 0; s.ok() && i < rand_column_families.size(); ++i) {
+      const int handle_index = cf_handle_index[rand_column_families[i]];
+      if (handle_index < 0) {
+        // Left out of this subset checkpoint, so there is nothing to compare.
+        continue;
+      }
       std::string key_str = Key(rand_keys[0]);
       Slice key = key_str;
       std::string ts_str;
@@ -4112,9 +4219,8 @@ Status StressTest::TestCheckpoint(ThreadState* thread,
         read_opts.timestamp = &ts;
       }
       std::string value;
-      Status get_status =
-          DbStressGet(checkpoint_db.get(), read_opts,
-                      cf_handles[rand_column_families[i]], key, &value);
+      Status get_status = DbStressGet(checkpoint_db.get(), read_opts,
+                                      cf_handles[handle_index], key, &value);
       bool exists =
           thread->shared->Exists(rand_column_families[i], rand_keys[0]);
       if (get_status.ok()) {

--- a/db_stress_tool/db_stress_tool.cc
+++ b/db_stress_tool/db_stress_tool.cc
@@ -355,6 +355,16 @@ int db_stress_tool(int argc, char** argv) {
         "clear_column_family_one_in must be 0 when using backup");
   }
   if (FLAGS_clear_column_family_one_in > 0 &&
+      FLAGS_subset_cf_checkpoint_one_in > 0) {
+    // A subset checkpoint passes live handles from `column_families_` to the
+    // Checkpoint API and validates the checkpoint's column family list against
+    // `column_family_names_`; neither is stable while families are being
+    // dropped and recreated underneath.
+    return ReturnValidationError(
+        "clear_column_family_one_in must be 0 when using "
+        "subset_cf_checkpoint_one_in");
+  }
+  if (FLAGS_clear_column_family_one_in > 0 &&
       FLAGS_abort_and_resume_cf_compactions_one_in > 0) {
     fprintf(stderr,
             "Error: clear_column_family_one_in must be 0 when using "

--- a/include/rocksdb/utilities/checkpoint.h
+++ b/include/rocksdb/utilities/checkpoint.h
@@ -81,6 +81,19 @@ struct CreateCheckpointOptions : public CreateCheckpointOrBackupOptions {
   // recent writes when WAL writing is not always enabled. Always flushes for
   // 2PC.
   uint64_t log_size_for_flush = 0;
+
+  // Restricts the checkpoint to these column families. SST and blob files of
+  // the other column families are not hard-linked or copied, and the
+  // checkpoint's MANIFEST records those other column families as dropped, so
+  // the checkpoint still opens cleanly under the default paranoid_checks.
+  // - Handles must be non-null and belong to the source_db passed to
+  //   CreateCheckpoint(). Duplicate handles (by id) are coalesced.
+  // - The default column family is always included, whether or not it appears
+  //   here (it cannot be dropped).
+  // - The resulting checkpoint must be opened listing exactly these column
+  //   families (plus default); the excluded ones no longer exist in it.
+  // Default: empty, meaning all column families are included.
+  std::vector<ColumnFamilyHandle*> column_families;
 };
 
 // A reusable engine for creating checkpoints. Unlike the legacy Checkpoint API
@@ -102,6 +115,8 @@ class CheckpointEngineBase {
   // Builds an openable snapshot of source_db under destination_dir (must not
   // exist). Data files are hard-linked when possible, else copied, across the
   // pool. sequence_number_ptr, if set, receives a seqno in the checkpoint.
+  // Set options.column_families to checkpoint only a subset of the column
+  // families.
   virtual IOStatus CreateCheckpoint(
       DB* source_db, const std::string& destination_dir,
       uint64_t* sequence_number_ptr = nullptr,

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -158,6 +158,7 @@ default_params = {
     "checkpoint_engine_max_background_operations": lambda: random.choice([4, 8]),
     "checkpoint_engine_use_link_file_when_available": lambda: random.randint(0, 1),
     "parallel_checkpoint_one_in": lambda: random.choice([0, 1, 2]),
+    "subset_cf_checkpoint_one_in": lambda: random.choice([0, 1, 2]),
     "compression_type": lambda: random.choice(
         ["none", "snappy", "zlib", "lz4", "lz4hc", "xpress", "zstd"]
     ),

--- a/utilities/checkpoint/checkpoint_impl.cc
+++ b/utilities/checkpoint/checkpoint_impl.cc
@@ -82,11 +82,19 @@ class CheckpointEngineImpl : public CheckpointEngine {
           create_options.background_thread_cpu_priority);
     }
 
+    std::vector<uint32_t> include_cf_ids;
+    Status resolve_s = CheckpointImpl::ResolveIncludeColumnFamilyIds(
+        source_db, create_options.column_families, &include_cf_ids);
+    if (!resolve_s.ok()) {
+      return status_to_io_status(std::move(resolve_s));
+    }
+
     const bool use_link = options_.use_link_file_when_available;
     CheckpointImpl impl(source_db);
     return status_to_io_status(impl.CreateCheckpointImpl(
         destination_dir, create_options.log_size_for_flush, sequence_number_ptr,
-        copy_engine_.get(), use_link, options_.backup_rate_limiter.get()));
+        copy_engine_.get(), use_link, options_.backup_rate_limiter.get(),
+        include_cf_ids));
   }
 
   IOStatus ExportColumnFamily(
@@ -336,22 +344,20 @@ Status CheckpointImpl::CreateCheckpoint(const std::string& checkpoint_dir,
                               /*use_link=*/true, /*copy_rate_limiter=*/nullptr);
 }
 
-Status CheckpointImpl::CreateCheckpoint(
-    const std::string& checkpoint_dir,
-    const std::vector<ColumnFamilyHandle*>& column_families,
-    uint64_t log_size_for_flush, uint64_t* sequence_number_ptr) {
+Status CheckpointImpl::ResolveIncludeColumnFamilyIds(
+    DB* db, const std::vector<ColumnFamilyHandle*>& column_families,
+    std::vector<uint32_t>* include_cf_ids) {
+  assert(include_cf_ids != nullptr);
+  include_cf_ids->clear();
   // Empty list means "all column families" -- identical to the whole-DB API.
   if (column_families.empty()) {
-    return CreateCheckpointImpl(checkpoint_dir, log_size_for_flush,
-                                sequence_number_ptr, /*engine=*/nullptr,
-                                /*use_link=*/true,
-                                /*copy_rate_limiter=*/nullptr);
+    return Status::OK();
   }
 
   // Reject handles that do not belong to this DB. handle->GetID() alone would
   // silently coerce a foreign CF id into whatever CF in this DB happens to
   // share that id, producing a wrong-data subset checkpoint.
-  DBImpl* this_db_impl = static_cast_with_check<DBImpl>(db_->GetRootDB());
+  DBImpl* this_db_impl = static_cast_with_check<DBImpl>(db->GetRootDB());
   std::unordered_set<uint32_t> id_set;
   for (auto* handle : column_families) {
     if (handle == nullptr) {
@@ -370,9 +376,22 @@ Status CheckpointImpl::CreateCheckpoint(
   }
   // The default column family cannot be dropped and must exist in every
   // openable DB, so it is always included and never eligible for exclusion.
-  id_set.insert(db_->DefaultColumnFamily()->GetID());
+  id_set.insert(db->DefaultColumnFamily()->GetID());
 
-  std::vector<uint32_t> include_cf_ids(id_set.begin(), id_set.end());
+  include_cf_ids->assign(id_set.begin(), id_set.end());
+  return Status::OK();
+}
+
+Status CheckpointImpl::CreateCheckpoint(
+    const std::string& checkpoint_dir,
+    const std::vector<ColumnFamilyHandle*>& column_families,
+    uint64_t log_size_for_flush, uint64_t* sequence_number_ptr) {
+  std::vector<uint32_t> include_cf_ids;
+  Status s =
+      ResolveIncludeColumnFamilyIds(db_, column_families, &include_cf_ids);
+  if (!s.ok()) {
+    return s;
+  }
   return CreateCheckpointImpl(checkpoint_dir, log_size_for_flush,
                               sequence_number_ptr, /*engine=*/nullptr,
                               /*use_link=*/true, /*copy_rate_limiter=*/nullptr,

--- a/utilities/checkpoint/checkpoint_impl.h
+++ b/utilities/checkpoint/checkpoint_impl.h
@@ -32,6 +32,15 @@ class CheckpointImpl : public Checkpoint {
       const std::vector<ColumnFamilyHandle*>& column_families,
       uint64_t log_size_for_flush, uint64_t* sequence_number_ptr) override;
 
+  // Validates column_families against db and turns it into the coalesced,
+  // default-CF-inclusive id list that CreateCheckpointImpl expects. An empty
+  // column_families yields an empty *include_cf_ids, which means "all column
+  // families". Rejects null handles, handles from another DB, and handles for
+  // already-dropped column families.
+  static Status ResolveIncludeColumnFamilyIds(
+      DB* db, const std::vector<ColumnFamilyHandle*>& column_families,
+      std::vector<uint32_t>* include_cf_ids);
+
   // Shared by the legacy Checkpoint API and CheckpointEngine. engine == nullptr
   // links/copies serially; otherwise work runs on the pool, awaited before the
   // staging dir is committed. include_cf_ids, when non-empty, restricts the

--- a/utilities/checkpoint/checkpoint_test.cc
+++ b/utilities/checkpoint/checkpoint_test.cc
@@ -556,6 +556,41 @@ TEST_F(CheckpointTest, CheckpointCF) {
 }
 
 namespace {
+// The subset-checkpoint tests all share a {default, "one", "two", "three"}
+// layout, with handles in that order.
+constexpr size_t kNumSubsetCheckpointCfs = 4;
+
+// Writes one key per column family and flushes, so each family owns exactly one
+// SST file and the families excluded from a subset checkpoint are visible as
+// missing SSTs.
+void PopulateFourCfsForSubsetCheckpoint(
+    DB* db, const std::vector<ColumnFamilyHandle*>& handles) {
+  ASSERT_EQ(kNumSubsetCheckpointCfs, handles.size());
+  ASSERT_OK(db->Put(WriteOptions(), handles[0], "d_key", "d_val"));
+  ASSERT_OK(db->Put(WriteOptions(), handles[1], "one_key", "one_val"));
+  ASSERT_OK(db->Put(WriteOptions(), handles[2], "two_key", "two_val"));
+  ASSERT_OK(db->Put(WriteOptions(), handles[3], "three_key", "three_val"));
+  for (auto* handle : handles) {
+    ASSERT_OK(db->Flush(FlushOptions(), handle));
+  }
+}
+
+// Guards against a subset checkpoint dropping column families from the live DB
+// while post-processing the checkpoint's MANIFEST.
+void VerifyFourCfsIntact(DB* db,
+                         const std::vector<ColumnFamilyHandle*>& handles) {
+  ASSERT_EQ(kNumSubsetCheckpointCfs, handles.size());
+  std::string val;
+  ASSERT_OK(db->Get(ReadOptions(), handles[0], "d_key", &val));
+  ASSERT_EQ("d_val", val);
+  ASSERT_OK(db->Get(ReadOptions(), handles[1], "one_key", &val));
+  ASSERT_EQ("one_val", val);
+  ASSERT_OK(db->Get(ReadOptions(), handles[2], "two_key", &val));
+  ASSERT_EQ("two_val", val);
+  ASSERT_OK(db->Get(ReadOptions(), handles[3], "three_key", &val));
+  ASSERT_EQ("three_val", val);
+}
+
 int CountSstFiles(Env* env, const std::string& dir) {
   std::vector<std::string> children;
   EXPECT_OK(env->GetChildren(dir, &children));
@@ -569,52 +604,15 @@ int CountSstFiles(Env* env, const std::string& dir) {
   }
   return n;
 }
-}  // namespace
 
-TEST_F(CheckpointTest, CheckpointSubsetOfCF) {
-  Options options = CurrentOptions();
-  CreateAndReopenWithCF({"one", "two", "three"}, options);
-
-  ASSERT_OK(Put(0, "d_key", "d_val"));
-  ASSERT_OK(Put(1, "one_key", "one_val"));
-  ASSERT_OK(Put(2, "two_key", "two_val"));
-  ASSERT_OK(Put(3, "three_key", "three_val"));
-  // Flush so each column family owns at least one SST file.
-  for (int cf = 0; cf <= 3; ++cf) {
-    ASSERT_OK(Flush(cf));
-  }
-
-  // Checkpoint only {default, two}.
-  Checkpoint* checkpoint;
-  ASSERT_OK(Checkpoint::Create(db_.get(), &checkpoint));
-  std::unique_ptr<Checkpoint> uchk(checkpoint);
-  ASSERT_OK(uchk->CreateCheckpoint(snapshot_name_, {handles_[0], handles_[2]}));
-
-  // Only default's and two's SSTs are present: 4 CFs x 1 SST -> 2 kept.
-  ASSERT_EQ(2, CountSstFiles(env_, snapshot_name_));
-
-  auto verify_all_four_cfs_intact = [&]() {
-    std::string val;
-    ASSERT_OK(db_->Get(ReadOptions(), handles_[0], "d_key", &val));
-    ASSERT_EQ("d_val", val);
-    ASSERT_OK(db_->Get(ReadOptions(), handles_[1], "one_key", &val));
-    ASSERT_EQ("one_val", val);
-    ASSERT_OK(db_->Get(ReadOptions(), handles_[2], "two_key", &val));
-    ASSERT_EQ("two_val", val);
-    ASSERT_OK(db_->Get(ReadOptions(), handles_[3], "three_key", &val));
-    ASSERT_EQ("three_val", val);
-  };
-
-  // The source DB must be untouched: all four CFs and their data are still
-  // present. Guards against accidentally dropping CFs from the live DB when
-  // post-processing the checkpoint MANIFEST.
-  verify_all_four_cfs_intact();
-
-  // Close and reopen the source DB with the full CF list to prove the live
-  // MANIFEST was not mutated by the checkpoint post-processing.
-  ReopenWithColumnFamilies({kDefaultColumnFamilyName, "one", "two", "three"},
-                           options);
-  verify_all_four_cfs_intact();
+// Verifies a checkpoint taken from the {default, "one", "two", "three"} layout
+// built by the subset tests, when only {default, "two"} were requested: the
+// other families' SSTs were never captured, and the families themselves are
+// gone from the checkpoint's MANIFEST.
+void VerifyDefaultAndTwoSubsetCheckpoint(Env* env, const std::string& dir,
+                                         Options options) {
+  // 4 CFs x 1 SST each, of which only default's and two's are kept.
+  ASSERT_EQ(2, CountSstFiles(env, dir));
 
   options.create_if_missing = false;
 
@@ -625,7 +623,7 @@ TEST_F(CheckpointTest, CheckpointSubsetOfCF) {
     cfds.emplace_back("two", options);
     std::vector<ColumnFamilyHandle*> cph;
     std::unique_ptr<DB> snapshotDB;
-    ASSERT_OK(DB::Open(options, snapshot_name_, cfds, &cph, &snapshotDB));
+    ASSERT_OK(DB::Open(options, dir, cfds, &cph, &snapshotDB));
     std::string result;
     ASSERT_OK(snapshotDB->Get(ReadOptions(), cph[0], "d_key", &result));
     ASSERT_EQ("d_val", result);
@@ -647,12 +645,35 @@ TEST_F(CheckpointTest, CheckpointSubsetOfCF) {
     }
     std::vector<ColumnFamilyHandle*> cph;
     std::unique_ptr<DB> snapshotDB;
-    Status s = DB::Open(options, snapshot_name_, cfds, &cph, &snapshotDB);
+    Status s = DB::Open(options, dir, cfds, &cph, &snapshotDB);
     ASSERT_TRUE(s.IsInvalidArgument()) << s.ToString();
     for (auto h : cph) {
       delete h;
     }
   }
+}
+}  // namespace
+
+TEST_F(CheckpointTest, CheckpointSubsetOfCF) {
+  Options options = CurrentOptions();
+  CreateAndReopenWithCF({"one", "two", "three"}, options);
+  PopulateFourCfsForSubsetCheckpoint(db_.get(), handles_);
+
+  // Checkpoint only {default, two}.
+  Checkpoint* checkpoint;
+  ASSERT_OK(Checkpoint::Create(db_.get(), &checkpoint));
+  std::unique_ptr<Checkpoint> uchk(checkpoint);
+  ASSERT_OK(uchk->CreateCheckpoint(snapshot_name_, {handles_[0], handles_[2]}));
+
+  VerifyFourCfsIntact(db_.get(), handles_);
+
+  // Close and reopen the source DB with the full CF list to prove the live
+  // MANIFEST was not mutated by the checkpoint post-processing.
+  ReopenWithColumnFamilies({kDefaultColumnFamilyName, "one", "two", "three"},
+                           options);
+  VerifyFourCfsIntact(db_.get(), handles_);
+
+  VerifyDefaultAndTwoSubsetCheckpoint(env_, snapshot_name_, options);
 }
 
 TEST_F(CheckpointTest, CheckpointSubsetEmptyListEqualsAll) {
@@ -1878,6 +1899,150 @@ TEST_F(CheckpointTest, CheckpointEngineParallelCopyRecordsCheckpointBytes) {
   EXPECT_EQ(options.statistics->getTickerCount(BACKUP_WRITE_BYTES), 0U);
 
   Close();  // before tearing down the env the DB was opened with
+}
+
+TEST_F(CheckpointTest, CheckpointEngineSubsetOfCF) {
+  Options options = CurrentOptions();
+  CreateAndReopenWithCF({"one", "two", "three"}, options);
+  PopulateFourCfsForSubsetCheckpoint(db_.get(), handles_);
+
+  CheckpointEngineOptions engine_options;
+  engine_options.max_background_operations = 4;
+  std::unique_ptr<CheckpointEngine> engine;
+  ASSERT_OK(CheckpointEngine::Open(engine_options, &engine));
+  if (engine == nullptr) {
+    FAIL() << "CheckpointEngine::Open returned a null engine";
+  }
+
+  // Checkpoint only {default, two} through the parallel hard-link path.
+  CreateCheckpointOptions create_options;
+  create_options.column_families = {handles_[0], handles_[2]};
+  ASSERT_OK(engine->CreateCheckpoint(db_.get(), snapshot_name_,
+                                     /*sequence_number_ptr=*/nullptr,
+                                     create_options));
+
+  // The source DB must be untouched by the checkpoint MANIFEST rewrite.
+  ReopenWithColumnFamilies({kDefaultColumnFamilyName, "one", "two", "three"},
+                           options);
+  VerifyFourCfsIntact(db_.get(), handles_);
+
+  VerifyDefaultAndTwoSubsetCheckpoint(env_, snapshot_name_, options);
+}
+
+TEST_F(CheckpointTest, CheckpointEngineSubsetOfCFParallelCopy) {
+  // Links fail NotSupported, so the subset's files go through the parallel
+  // copy path while the MANIFEST drop records are appended afterwards.
+  auto no_link_fs = std::make_shared<NoLinkFileSystem>(FileSystem::Default());
+  std::unique_ptr<Env> no_link_env(NewCompositeEnv(no_link_fs));
+
+  Options options = CurrentOptions();
+  options.env = no_link_env.get();
+  CreateAndReopenWithCF({"one", "two", "three"}, options);
+  PopulateFourCfsForSubsetCheckpoint(db_.get(), handles_);
+
+  CheckpointEngineOptions engine_options;
+  engine_options.max_background_operations = 4;
+  std::unique_ptr<CheckpointEngine> engine;
+  ASSERT_OK(CheckpointEngine::Open(engine_options, &engine));
+  if (engine == nullptr) {
+    FAIL() << "CheckpointEngine::Open returned a null engine";
+  }
+
+  CreateCheckpointOptions create_options;
+  create_options.column_families = {handles_[2]};
+  ASSERT_OK(engine->CreateCheckpoint(db_.get(), snapshot_name_,
+                                     /*sequence_number_ptr=*/nullptr,
+                                     create_options));
+
+  Close();  // before tearing down the env the DB was opened with
+
+  options.env = env_;
+  VerifyDefaultAndTwoSubsetCheckpoint(env_, snapshot_name_, options);
+}
+
+TEST_F(CheckpointTest, CheckpointEngineSubsetEmptyListEqualsAll) {
+  Options options = CurrentOptions();
+  CreateAndReopenWithCF({"one", "two", "three"}, options);
+  PopulateFourCfsForSubsetCheckpoint(db_.get(), handles_);
+
+  CheckpointEngineOptions engine_options;
+  engine_options.max_background_operations = 4;
+  std::unique_ptr<CheckpointEngine> engine;
+  ASSERT_OK(CheckpointEngine::Open(engine_options, &engine));
+  if (engine == nullptr) {
+    FAIL() << "CheckpointEngine::Open returned a null engine";
+  }
+
+  // Default-constructed options leave column_families empty, which must remain
+  // equivalent to a whole-DB checkpoint.
+  ASSERT_OK(engine->CreateCheckpoint(db_.get(), snapshot_name_));
+
+  ASSERT_EQ(4, CountSstFiles(env_, snapshot_name_));
+
+  options.create_if_missing = false;
+  std::vector<ColumnFamilyDescriptor> cfds;
+  for (const std::string& cf : std::vector<std::string>{
+           kDefaultColumnFamilyName, "one", "two", "three"}) {
+    cfds.emplace_back(cf, options);
+  }
+  std::vector<ColumnFamilyHandle*> cph;
+  std::unique_ptr<DB> snapshotDB;
+  ASSERT_OK(DB::Open(options, snapshot_name_, cfds, &cph, &snapshotDB));
+  std::string result;
+  ASSERT_OK(snapshotDB->Get(ReadOptions(), cph[1], "one_key", &result));
+  ASSERT_EQ("one_val", result);
+  ASSERT_OK(snapshotDB->Get(ReadOptions(), cph[3], "three_key", &result));
+  ASSERT_EQ("three_val", result);
+  for (auto h : cph) {
+    delete h;
+  }
+}
+
+TEST_F(CheckpointTest, CheckpointEngineSubsetInvalidHandlesRejected) {
+  Options options = CurrentOptions();
+  CreateAndReopenWithCF({"one"}, options);
+  ASSERT_OK(Put(1, "a", "1"));
+
+  // Second, unrelated DB whose CF id collides with "one" from this DB (both
+  // are the first non-default CF -> id 1).
+  const std::string other_dbname = test::PerThreadDBPath("other_db_for_engine");
+  ASSERT_OK(DestroyDB(other_dbname, options));
+  Options open_opts = options;
+  open_opts.create_if_missing = true;
+  std::unique_ptr<DB> other_db;
+  ASSERT_OK(DB::Open(open_opts, other_dbname, &other_db));
+  ColumnFamilyHandle* other_cf = nullptr;
+  ASSERT_OK(
+      other_db->CreateColumnFamily(ColumnFamilyOptions(), "one", &other_cf));
+
+  CheckpointEngineOptions engine_options;
+  std::unique_ptr<CheckpointEngine> engine;
+  ASSERT_OK(CheckpointEngine::Open(engine_options, &engine));
+  if (engine == nullptr) {
+    FAIL() << "CheckpointEngine::Open returned a null engine";
+  }
+
+  // Validation must run before any staging directory is created, so a rejected
+  // request leaves nothing behind and can be retried at the same path.
+  auto expect_rejected = [&](const std::vector<ColumnFamilyHandle*>& cfs) {
+    CreateCheckpointOptions create_options;
+    create_options.column_families = cfs;
+    IOStatus io_s = engine->CreateCheckpoint(db_.get(), snapshot_name_,
+                                             /*sequence_number_ptr=*/nullptr,
+                                             create_options);
+    ASSERT_TRUE(io_s.IsInvalidArgument()) << io_s.ToString();
+    ASSERT_TRUE(env_->FileExists(snapshot_name_).IsNotFound());
+  };
+  expect_rejected({handles_[1], nullptr});
+  expect_rejected({other_cf});
+
+  ColumnFamilyHandle* dropped_handle = handles_[1];
+  ASSERT_OK(db_->DropColumnFamily(dropped_handle));
+  expect_rejected({dropped_handle});
+
+  ASSERT_OK(other_db->DestroyColumnFamilyHandle(other_cf));
+  other_db.reset();
+  ASSERT_OK(DestroyDB(other_dbname, options));
 }
 
 }  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
Summary:

**What**: 
 1. Extends the parallel `CheckpointEngine` so it can also checkpoint a subset of column families.
 2. Adds `db_stress` and `db_crashtest.py` coverage for subset checkpoints, over both the serial and the parallel API.

**How**:

 - **Engine API.** `CreateCheckpointOptions` gains a `std::vector<ColumnFamilyHandle*> column_families` field (empty, the default, still means all column families). This goes on the existing per-operation options
 truct rather than adding a second pure virtual to `CheckpointEngineBase`: it avoids overload-resolution hazards with the defaulted `sequence_number_ptr`, and it is the pattern the engine API already uses.
`CreateCheckpointOptions` has no users outside the engine API, so adding a field breaks nothing.
  - **Shared validation.** The handle checks that were inline in `CheckpointImpl::CreateCheckpoint` -- reject null handles, handles belonging to another DB, and handles for already-dropped families; coalesce ids;
always add the default CF -- move to `static CheckpointImpl::ResolveIncludeColumnFamilyIds()`, now called by both APIs. Rejecting a foreign handle matters because `handle->GetID()` alone would silently coerce a
foreign id onto whichever family in this DB happens to share it. Validation runs before any staging directory is created, so a rejected request leaves nothing behind.
  - **Almost no new plumbing.** `CheckpointImpl::CreateCheckpointImpl()` already accepted `include_cf_ids` and is shared by the serial and parallel movers, and the MANIFEST `kColumnFamilyDrop` rewrite runs after
`mover->Finish()`, so it was already mover-agnostic. The engine change is just resolving the ids and forwarding them.
  - **db_stress.** New `subset_cf_checkpoint_one_in` knob (mirrors `parallel_checkpoint_one_in`): each checkpoint operation covers a random proper subset with probability 1/N. It is a no-op when the DB has only the
default column family, and it is independent of `parallel_checkpoint_one_in`, so subset checkpoints get exercised through both the serial API and the engine. Subset selection includes each non-default family
with probability 1/2 and then force-excludes one, so every subset checkpoint exercises the MANIFEST rewrite instead of degenerating into a whole-DB checkpoint; the default handle is passed in only half the time,
covering the "default is always included whether or not you pass it" contract on both sides.
  - **db_stress validation.** `DB::ListColumnFamilies()` on the checkpoint must return exactly the requested set -- the direct check on the MANIFEST post-processing, catching both an excluded family that was not
recorded as dropped and a requested family that went missing. The checkpoint is then opened read-only with exactly those descriptors, proving the reduced MANIFEST and reduced file set are self-consistent under
the default `paranoid_checks`. The pre-existing per-key comparison against `SharedState::Exists()` still runs, restricted to the families actually present.
  - **Incompatibility.** `clear_column_family_one_in > 0` is rejected together with the new knob, the same way D113103899 did for `abort_and_resume_cf_compactions_one_in`: a subset checkpoint hands live handles
from `column_families_` to the API and validates against `column_family_names_`, and neither is stable while families are dropped and recreated underneath. `db_crashtest.py` already pins
`clear_column_family_one_in` to 0.
  - **Test cleanup.** The subset tests shared a lot of setup and verification, so `PopulateFourCfsForSubsetCheckpoint()`, `VerifyFourCfsIntact()` and `VerifyDefaultAndTwoSubsetCheckpoint()` were extracted into the
test file's anonymous namespace and are reused by the pre-existing `CheckpointSubsetOfCF` as well as the four new engine tests.

This extends `StressTest::TestCheckpoint` with a mode rather than adding a separate operation, which is how `parallel_checkpoint_one_in` was integrated.

Reviewed By: rban1

Differential Revision: D114832267


