### PR TITLE
Expose number of unscheduled compactions as a statistic (#15060)

### DIFF
--- a/db/db_properties_test.cc
+++ b/db/db_properties_test.cc
@@ -1148,6 +1148,60 @@ TEST_F(DBPropertiesTest, EstimatePendingCompBytes) {
   ASSERT_EQ(int_num, 0U);
 }
 
+TEST_F(DBPropertiesTest, NumUnscheduledCompactions) {
+  if (env_ == nullptr) {
+    ADD_FAILURE() << "Missing test environment";
+    return;
+  }
+  auto& env = *env_;
+  env.SetBackgroundThreads(1, Env::HIGH);
+  env.SetBackgroundThreads(1, Env::LOW);
+
+  Options options = CurrentOptions();
+  WriteOptions writeOpt = WriteOptions();
+  writeOpt.disableWAL = true;
+  options.compaction_style = kCompactionStyleLevel;
+  options.level0_file_num_compaction_trigger = 2;
+  options.max_background_compactions = 1;
+  options.max_background_flushes = 1;
+  options.write_buffer_size = 1000000;
+  DestroyAndReopen(options);
+  CreateAndReopenWithCF({"one"}, options);
+
+  uint64_t int_num;
+
+  ASSERT_TRUE(dbfull()->GetIntProperty(
+      DB::Properties::kNumUnscheduledCompactions, &int_num));
+  ASSERT_EQ(int_num, 0U);
+
+  // Keep one scheduled compaction from completing.
+  test::SleepingBackgroundTask sleeping_task_low;
+  env.Schedule(&test::SleepingBackgroundTask::DoSleepTask, &sleeping_task_low,
+               Env::Priority::LOW);
+  sleeping_task_low.WaitUntilSleeping();
+
+  std::string big_value(1000000 * 2, 'x');
+  for (int cf = 0; cf < 2; cf++) {
+    for (int i = 0; i < 4; i++) {
+      ASSERT_OK(dbfull()->Put(writeOpt, handles_[cf], "k" + std::to_string(i),
+                              big_value));
+      ASSERT_OK(Flush(cf));
+    }
+  }
+
+  ASSERT_TRUE(dbfull()->GetIntProperty(
+      DB::Properties::kNumUnscheduledCompactions, &int_num));
+  ASSERT_GT(int_num, 0U);
+
+  sleeping_task_low.WakeUp();
+  sleeping_task_low.WaitUntilDone();
+  ASSERT_OK(dbfull()->TEST_WaitForCompact());
+
+  ASSERT_TRUE(dbfull()->GetIntProperty(
+      DB::Properties::kNumUnscheduledCompactions, &int_num));
+  ASSERT_EQ(int_num, 0U);
+}
+
 TEST_F(DBPropertiesTest, EstimateCompressionRatio) {
   if (!Snappy_Supported()) {
     return;

--- a/db/internal_stats.cc
+++ b/db/internal_stats.cc
@@ -311,6 +311,8 @@ static const std::string num_running_compactions = "num-running-compactions";
 static const std::string num_running_compaction_sorted_runs =
     "num-running-compaction-sorted-runs";
 static const std::string compaction_abort_count = "compaction-abort-count";
+static const std::string num_unscheduled_compactions =
+    "num-unscheduled-compactions";
 static const std::string num_running_flushes = "num-running-flushes";
 static const std::string actual_delayed_write_rate =
     "actual-delayed-write-rate";
@@ -365,6 +367,8 @@ const std::string DB::Properties::kNumRunningCompactionSortedRuns =
     rocksdb_prefix + num_running_compaction_sorted_runs;
 const std::string DB::Properties::kCompactionAbortCount =
     rocksdb_prefix + compaction_abort_count;
+const std::string DB::Properties::kNumUnscheduledCompactions =
+    rocksdb_prefix + num_unscheduled_compactions;
 const std::string DB::Properties::kNumRunningFlushes =
     rocksdb_prefix + num_running_flushes;
 const std::string DB::Properties::kBackgroundErrors =
@@ -600,6 +604,9 @@ const UnorderedMap<std::string, DBPropertyInfo>
         {DB::Properties::kCompactionAbortCount,
          {false, nullptr, &InternalStats::HandleCompactionAbortCount, nullptr,
           nullptr}},
+        {DB::Properties::kNumUnscheduledCompactions,
+         {false, nullptr, &InternalStats::HandleNumUnscheduledCompactions,
+          nullptr, nullptr}},
         {DB::Properties::kActualDelayedWriteRate,
          {false, nullptr, &InternalStats::HandleActualDelayedWriteRate, nullptr,
           nullptr}},
@@ -1302,6 +1309,14 @@ bool InternalStats::HandleCompactionAbortCount(uint64_t* value, DBImpl* db,
                                                Version* /*version*/) {
   *value = static_cast<uint64_t>(
       db->compaction_aborted_.load(std::memory_order_acquire));
+  return true;
+}
+
+bool InternalStats::HandleNumUnscheduledCompactions(uint64_t* value, DBImpl* db,
+                                                    Version* /*version*/) {
+  db->mutex()->AssertHeld();
+  assert(db->unscheduled_compactions_ >= 0);
+  *value = static_cast<uint64_t>(db->unscheduled_compactions_);
   return true;
 }
 

--- a/db/internal_stats.h
+++ b/db/internal_stats.h
@@ -854,6 +854,8 @@ class InternalStats {
                                             Version* version);
   bool HandleCompactionAbortCount(uint64_t* value, DBImpl* db,
                                   Version* version);
+  bool HandleNumUnscheduledCompactions(uint64_t* value, DBImpl* db,
+                                       Version* version);
   bool HandleBackgroundErrors(uint64_t* value, DBImpl* db, Version* version);
   bool HandleCurSizeActiveMemTable(uint64_t* value, DBImpl* db,
                                    Version* version);

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1376,6 +1376,12 @@ class DB {
     //      compaction abort counter.
     static const std::string kCompactionAbortCount;
 
+    //  "rocksdb.num-unscheduled-compactions" - returns the number of
+    //      compactions waiting in the DB's internal compaction queue but not
+    //      yet assigned to a background job. This is a DB-wide value, not
+    //      per-column family.
+    static const std::string kNumUnscheduledCompactions;
+
     //  "rocksdb.background-errors" - returns accumulated number of background
     //      errors.
     static const std::string kBackgroundErrors;
@@ -1618,6 +1624,7 @@ class DB {
   //  "rocksdb.estimate-pending-compaction-bytes"
   //  "rocksdb.num-running-compactions"
   //  "rocksdb.num-running-flushes"
+  //  "rocksdb.num-unscheduled-compactions"
   //  "rocksdb.actual-delayed-write-rate"
   //  "rocksdb.is-write-stopped"
   //  "rocksdb.estimate-oldest-key-time"

--- a/unreleased_history/new_features/num_unscheduled_compactions_property.md
+++ b/unreleased_history/new_features/num_unscheduled_compactions_property.md
@@ -1,0 +1,1 @@
+Added DB property `rocksdb.num-unscheduled-compactions`, reporting compactions waiting in the DB's internal compaction queue but not yet assigned to a background job.


### PR DESCRIPTION
Summary:

Expose the `rocksdb.num-unscheduled-compactions`  DB statistic to help troubleshoot high L0 counts.

The metric captures  the raw `unscheduled_compactions_` count. It measures compaction work waiting in the DB internal compaction queue, but not yet assigned to a background job.

This complements `rocksdb.compaction-pending`, which tells us "some compaction work is needed," and `rocksdb.num-running-compactions`, which tells us how many background compactions are executing.

Differential Revision: D114539448


