### PR TITLE
Add blob file writer buffer size option (#15061)

### DIFF
--- a/c_api_gen/c_generated_option_structs_auto.cc.inc
+++ b/c_api_gen/c_generated_option_structs_auto.cc.inc
@@ -1305,6 +1305,16 @@ uint64_t rocksdb_options_get_blob_file_size(rocksdb_options_t* opt) {
   return opt->rep.blob_file_size;
 }
 
+void rocksdb_options_set_blob_file_writable_file_max_buffer_size(
+    rocksdb_options_t* opt, uint64_t v) {
+  opt->rep.blob_file_writable_file_max_buffer_size = v;
+}
+
+uint64_t rocksdb_options_get_blob_file_writable_file_max_buffer_size(
+    rocksdb_options_t* opt) {
+  return opt->rep.blob_file_writable_file_max_buffer_size;
+}
+
 void rocksdb_options_set_blob_compression_type(rocksdb_options_t* opt, int v) {
   opt->rep.blob_compression_type =
       static_cast<decltype(opt->rep.blob_compression_type)>(v);

--- a/c_api_gen/c_generated_option_structs_auto.h.inc
+++ b/c_api_gen/c_generated_option_structs_auto.h.inc
@@ -387,6 +387,14 @@ rocksdb_options_set_preserve_internal_time_seconds(rocksdb_options_t* opt,
 extern ROCKSDB_LIBRARY_API uint64_t
 rocksdb_options_get_preserve_internal_time_seconds(rocksdb_options_t* opt);
 
+extern ROCKSDB_LIBRARY_API void
+rocksdb_options_set_blob_file_writable_file_max_buffer_size(
+    rocksdb_options_t* opt, uint64_t v);
+
+extern ROCKSDB_LIBRARY_API uint64_t
+rocksdb_options_get_blob_file_writable_file_max_buffer_size(
+    rocksdb_options_t* opt);
+
 extern ROCKSDB_LIBRARY_API void rocksdb_options_set_enable_blob_direct_write(
     rocksdb_options_t* opt, unsigned char v);
 

--- a/c_api_gen/c_generated_roundtrip_tests.c.inc
+++ b/c_api_gen/c_generated_roundtrip_tests.c.inc
@@ -647,6 +647,12 @@ static void rocksdb_roundtrip_test_rocksdb_options(void) {
   CheckCondition(rocksdb_options_get_blob_direct_write_partitions(obj) == 1);
   rocksdb_options_set_blob_direct_write_partitions(obj, 0);
   CheckCondition(rocksdb_options_get_blob_direct_write_partitions(obj) == 0);
+  rocksdb_options_set_blob_file_writable_file_max_buffer_size(obj, 1);
+  CheckCondition(
+      rocksdb_options_get_blob_file_writable_file_max_buffer_size(obj) == 1);
+  rocksdb_options_set_blob_file_writable_file_max_buffer_size(obj, 0);
+  CheckCondition(
+      rocksdb_options_get_blob_file_writable_file_max_buffer_size(obj) == 0);
   rocksdb_options_set_block_protection_bytes_per_key(obj, 1);
   CheckCondition(rocksdb_options_get_block_protection_bytes_per_key(obj) == 1);
   rocksdb_options_set_block_protection_bytes_per_key(obj, 0);

--- a/db/blob/blob_file_builder.cc
+++ b/db/blob/blob_file_builder.cc
@@ -67,6 +67,8 @@ BlobFileBuilder::BlobFileBuilder(
       immutable_options_(immutable_options),
       min_blob_size_(mutable_cf_options->min_blob_size),
       blob_file_size_(mutable_cf_options->blob_file_size),
+      blob_file_writable_file_max_buffer_size_(
+          mutable_cf_options->blob_file_writable_file_max_buffer_size),
       blob_compression_type_(mutable_cf_options->blob_compression_type),
       // TODO with schema change: support custom compression manager and options
       // such as max_compressed_bytes_per_kb
@@ -208,6 +210,10 @@ Status BlobFileBuilder::OpenBlobFileIfNeeded() {
     fo_copy.open_contract = FileOpenContract::kNoReopenForWrite |
                             FileOpenContract::kNoReadersWhileOpenForWrite;
     fo_copy.write_hint = write_hint_;
+    if (blob_file_writable_file_max_buffer_size_ > 0) {
+      fo_copy.writable_file_max_buffer_size =
+          blob_file_writable_file_max_buffer_size_;
+    }
     Status s = NewWritableFile(fs_, blob_file_path, &file, fo_copy);
 
     TEST_SYNC_POINT_CALLBACK(
@@ -232,7 +238,7 @@ Status BlobFileBuilder::OpenBlobFileIfNeeded() {
   FileTypeSet tmp_set = immutable_options_->checksum_handoff_file_types;
   Statistics* const statistics = immutable_options_->stats;
   std::unique_ptr<WritableFileWriter> file_writer(new WritableFileWriter(
-      std::move(file), output_file_paths_->back(), *file_options_,
+      std::move(file), output_file_paths_->back(), fo_copy,
       immutable_options_->clock, io_tracer_, statistics,
       Histograms::BLOB_DB_BLOB_FILE_WRITE_MICROS, immutable_options_->listeners,
       immutable_options_->file_checksum_gen_factory.get(),

--- a/db/blob/blob_file_builder.h
+++ b/db/blob/blob_file_builder.h
@@ -94,6 +94,7 @@ class BlobFileBuilder {
   const ImmutableOptions* immutable_options_;
   uint64_t min_blob_size_;
   uint64_t blob_file_size_;
+  uint64_t blob_file_writable_file_max_buffer_size_;
   CompressionType blob_compression_type_;
   std::unique_ptr<Compressor> blob_compressor_;
   mutable Compressor::ManagedWorkingArea blob_compressor_wa_;

--- a/db/blob/blob_file_partition_manager.cc
+++ b/db/blob/blob_file_partition_manager.cc
@@ -100,7 +100,8 @@ BlobFilePartitionManager::BlobFilePartitionManager(
     FileNumberAllocator file_number_allocator, FileSystem* fs,
     SystemClock* clock, Statistics* statistics, const FileOptions& file_options,
     std::string db_path, std::string column_family_name,
-    uint64_t blob_file_size, bool use_fsync, BlobFileCache* blob_file_cache,
+    uint64_t blob_file_size, bool use_fsync,
+    uint64_t blob_writer_max_buffer_size, BlobFileCache* blob_file_cache,
     BlobFileCompletionCallback* blob_callback,
     const std::vector<std::shared_ptr<EventListener>>& listeners,
     FileChecksumGenFactory* file_checksum_gen_factory,
@@ -120,6 +121,7 @@ BlobFilePartitionManager::BlobFilePartitionManager(
       column_family_name_(std::move(column_family_name)),
       blob_file_size_(blob_file_size),
       use_fsync_(use_fsync),
+      blob_writer_max_buffer_size_(blob_writer_max_buffer_size),
       blob_file_cache_(blob_file_cache),
       blob_callback_(blob_callback),
       listeners_(listeners),
@@ -202,6 +204,11 @@ Status BlobFilePartitionManager::OpenNewBlobFile(Partition* partition,
   std::unique_ptr<FSWritableFile> file;
   FileOptions writer_file_options = file_options_;
   writer_file_options.open_contract = FileOpenContract::kNoReopenForWrite;
+  const uint64_t max_buffer_size =
+      blob_writer_max_buffer_size_.load(std::memory_order_relaxed);
+  if (max_buffer_size > 0) {
+    writer_file_options.writable_file_max_buffer_size = max_buffer_size;
+  }
   Status s = NewWritableFile(fs_, blob_file_path, &file, writer_file_options);
   if (!s.ok()) {
     RemoveFilePartitionMapping(blob_file_number);

--- a/db/blob/blob_file_partition_manager.h
+++ b/db/blob/blob_file_partition_manager.h
@@ -4,6 +4,7 @@
 //  (found in the LICENSE.Apache file in the root directory).
 #pragma once
 
+#include <atomic>
 #include <cstdint>
 #include <deque>
 #include <functional>
@@ -61,7 +62,8 @@ class BlobFilePartitionManager {
       SystemClock* clock, Statistics* statistics,
       const FileOptions& file_options, std::string db_path,
       std::string column_family_name, uint64_t blob_file_size, bool use_fsync,
-      BlobFileCache* blob_file_cache, BlobFileCompletionCallback* blob_callback,
+      uint64_t blob_writer_max_buffer_size, BlobFileCache* blob_file_cache,
+      BlobFileCompletionCallback* blob_callback,
       const std::vector<std::shared_ptr<EventListener>>& listeners,
       FileChecksumGenFactory* file_checksum_gen_factory,
       const FileTypeSet& checksum_handoff_file_types,
@@ -128,6 +130,11 @@ class BlobFilePartitionManager {
   // Returns true when the blob file is still owned by the write path or
   // protected by a live memtable / old SuperVersion.
   bool IsTrackedBlobFileNumber(uint64_t file_number) const;
+
+  void SetBlobWriterMaxBufferSize(uint64_t blob_writer_max_buffer_size) {
+    blob_writer_max_buffer_size_.store(blob_writer_max_buffer_size,
+                                       std::memory_order_relaxed);
+  }
 
   // Increments / decrements memtable-held protection on sealed blob files.
   void ProtectSealedBlobFileNumbers(const std::vector<uint64_t>& file_numbers);
@@ -260,6 +267,7 @@ class BlobFilePartitionManager {
   // File creation policy and shared blob-file infrastructure.
   uint64_t blob_file_size_;
   bool use_fsync_;
+  std::atomic<uint64_t> blob_writer_max_buffer_size_;
   BlobFileCache* blob_file_cache_;
   BlobFileCompletionCallback* blob_callback_;
   std::vector<std::shared_ptr<EventListener>> listeners_;

--- a/db/blob/db_blob_basic_test.cc
+++ b/db/blob/db_blob_basic_test.cc
@@ -5,6 +5,8 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
+#include <cstdint>
 #include <set>
 #include <sstream>
 #include <string>
@@ -61,6 +63,75 @@ TEST_F(DBBlobBasicTest, GetBlob) {
   PinnableSlice result;
   ASSERT_TRUE(db_->Get(read_options, db_->DefaultColumnFamily(), key, &result)
                   .IsIncomplete());
+}
+
+TEST_F(DBBlobBasicTest, BlobFileWritableFileMaxBufferSize) {
+  constexpr uint64_t kBlobWriterBufferSize = 128 * 1024;
+
+  Options options = GetDefaultOptions();
+  options.enable_blob_files = true;
+  options.min_blob_size = 0;
+  options.writable_file_max_buffer_size = 1024 * 1024;
+  options.blob_file_writable_file_max_buffer_size = kBlobWriterBufferSize;
+
+  Reopen(options);
+
+  std::atomic<int> matching_blob_writer_count{0};
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+  SyncPoint::GetInstance()->SetCallBack(
+      "WritableFileWriter::WritableFileWriter:0", [&](void* arg) {
+        const uint64_t max_buffer_size =
+            static_cast<uint64_t>(reinterpret_cast<uintptr_t>(arg));
+        if (max_buffer_size == kBlobWriterBufferSize) {
+          ++matching_blob_writer_count;
+        }
+      });
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  ASSERT_OK(Put("key", std::string(1024, 'v')));
+  ASSERT_OK(Flush());
+
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+
+  ASSERT_GE(matching_blob_writer_count.load(), 1);
+}
+
+TEST_F(DBBlobBasicTest,
+       DirectWriteBlobFileWritableFileMaxBufferSizeSetOptions) {
+  constexpr uint64_t kBlobWriterBufferSize = 64 * 1024;
+
+  Options options = GetDefaultOptions();
+  options.enable_blob_files = true;
+  options.enable_blob_direct_write = true;
+  options.allow_concurrent_memtable_write = false;
+  options.min_blob_size = 0;
+  options.blob_file_size = 200;
+  options.writable_file_max_buffer_size = 1024 * 1024;
+
+  Reopen(options);
+
+  std::atomic<int> matching_blob_writer_count{0};
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+  SyncPoint::GetInstance()->SetCallBack(
+      "WritableFileWriter::WritableFileWriter:0", [&](void* arg) {
+        const uint64_t max_buffer_size =
+            static_cast<uint64_t>(reinterpret_cast<uintptr_t>(arg));
+        if (max_buffer_size == kBlobWriterBufferSize) {
+          ++matching_blob_writer_count;
+        }
+      });
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  ASSERT_OK(Put("first", std::string(300, 'a')));
+  ASSERT_OK(db_->SetOptions({{"blob_file_writable_file_max_buffer_size",
+                              std::to_string(kBlobWriterBufferSize)}}));
+  ASSERT_OK(Put("second", std::string(300, 'b')));
+
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+
+  ASSERT_GE(matching_blob_writer_count.load(), 1);
 }
 
 TEST_F(DBBlobBasicTest, EmptyValueNotStoredAsBlob) {

--- a/db/c.cc
+++ b/db/c.cc
@@ -10372,6 +10372,16 @@ uint64_t rocksdb_options_get_blob_file_size(rocksdb_options_t* opt) {
   return opt->rep.blob_file_size;
 }
 
+void rocksdb_options_set_blob_file_writable_file_max_buffer_size(
+    rocksdb_options_t* opt, uint64_t v) {
+  opt->rep.blob_file_writable_file_max_buffer_size = v;
+}
+
+uint64_t rocksdb_options_get_blob_file_writable_file_max_buffer_size(
+    rocksdb_options_t* opt) {
+  return opt->rep.blob_file_writable_file_max_buffer_size;
+}
+
 void rocksdb_options_set_blob_compression_type(rocksdb_options_t* opt, int v) {
   opt->rep.blob_compression_type =
       static_cast<decltype(opt->rep.blob_compression_type)>(v);

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -674,8 +674,9 @@ void DBImpl::MaybeInitBlobDirectWriteColumnFamily(
       [vs = versions_.get()]() { return vs->NewFileNumber(); }, fs_.get(),
       immutable_db_options_.clock, stats_, file_options_, dbname_,
       column_family_name, cf_options.blob_file_size,
-      immutable_db_options_.use_fsync, cfd->blob_file_cache(), &blob_callback_,
-      immutable_db_options_.listeners,
+      immutable_db_options_.use_fsync,
+      cf_options.blob_file_writable_file_max_buffer_size,
+      cfd->blob_file_cache(), &blob_callback_, immutable_db_options_.listeners,
       immutable_db_options_.file_checksum_gen_factory.get(),
       immutable_db_options_.checksum_handoff_file_types, io_tracer_, db_id_,
       db_session_id_, immutable_db_options_.info_log.get());
@@ -1691,7 +1692,13 @@ Status DBImpl::SetOptions(
       // options to file, otherwise there will be a deadlock with writer
       // thread.
       for (const auto& cfd_opts : column_family_datas) {
-        InstallSuperVersionForConfigChange(cfd_opts.first, &sv_context);
+        auto* cfd = cfd_opts.first;
+        InstallSuperVersionForConfigChange(cfd, &sv_context);
+        if (auto* blob_partition_manager = cfd->blob_partition_manager()) {
+          blob_partition_manager->SetBlobWriterMaxBufferSize(
+              cfd->GetLatestMutableCFOptions()
+                  .blob_file_writable_file_max_buffer_size);
+        }
       }
 
       persist_options_status =

--- a/db/db_options_test.cc
+++ b/db/db_options_test.cc
@@ -566,6 +566,25 @@ TEST_F(DBOptionsTest, SetOptionsAndReopen) {
   ASSERT_OK(TryReopen(options));
 }
 
+TEST_F(DBOptionsTest, SetBlobFileWritableFileMaxBufferSize) {
+  constexpr uint64_t kBlobWriterBufferSize = 128 * 1024;
+
+  Options options;
+  options.env = env_;
+  options.create_if_missing = true;
+  options.enable_blob_files = true;
+  options.min_blob_size = 0;
+  Reopen(options);
+
+  ASSERT_EQ(db_->GetOptions().blob_file_writable_file_max_buffer_size, 0U);
+
+  ASSERT_OK(db_->SetOptions({{"blob_file_writable_file_max_buffer_size",
+                              std::to_string(kBlobWriterBufferSize)}}));
+
+  ASSERT_EQ(db_->GetOptions().blob_file_writable_file_max_buffer_size,
+            kBlobWriterBufferSize);
+}
+
 TEST_F(DBOptionsTest, EnableAutoCompactionAndTriggerStall) {
   const std::string kValue(1024, 'v');
   for (int method_type = 0; method_type < 2; method_type++) {

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -349,6 +349,7 @@ DECLARE_bool(enable_blob_direct_write);
 DECLARE_uint64(blob_direct_write_partitions);
 DECLARE_uint64(min_blob_size);
 DECLARE_uint64(blob_file_size);
+DECLARE_uint64(blob_file_writable_file_max_buffer_size);
 DECLARE_string(blob_compression_type);
 DECLARE_bool(enable_blob_garbage_collection);
 DECLARE_double(blob_garbage_collection_age_cutoff);

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -527,6 +527,13 @@ DEFINE_uint64(blob_file_size,
               ROCKSDB_NAMESPACE::AdvancedColumnFamilyOptions().blob_file_size,
               "[Integrated BlobDB] The size limit for blob files.");
 
+DEFINE_uint64(
+    blob_file_writable_file_max_buffer_size,
+    ROCKSDB_NAMESPACE::AdvancedColumnFamilyOptions()
+        .blob_file_writable_file_max_buffer_size,
+    "[Integrated BlobDB] Max WritableFileWriter buffer size for blob files. "
+    "0 means inherit writable_file_max_buffer_size.");
+
 DEFINE_string(blob_compression_type, "none",
               "[Integrated BlobDB] The compression algorithm to use for large "
               "values stored in blob files.");

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -5172,12 +5172,14 @@ void StressTest::Open(SharedState* shared, bool reopen) {
           "Integrated BlobDB: blob files enabled %d, min blob size %" PRIu64
           ", direct write enabled %d, direct write partitions %" PRIu32
           ", blob file size %" PRIu64
+          ", blob file writable file max buffer size %" PRIu64
           ", blob compression type %s, blob GC enabled %d, cutoff %f, force "
           "threshold %f, blob compaction readahead size %" PRIu64
           ", blob file starting level %d\n",
           options_.enable_blob_files, options_.min_blob_size,
           options_.enable_blob_direct_write,
           options_.blob_direct_write_partitions, options_.blob_file_size,
+          options_.blob_file_writable_file_max_buffer_size,
           CompressionTypeToString(options_.blob_compression_type).c_str(),
           options_.enable_blob_garbage_collection,
           options_.blob_garbage_collection_age_cutoff,
@@ -6258,6 +6260,8 @@ void InitializeOptionsFromFlags(
       static_cast<uint32_t>(FLAGS_blob_direct_write_partitions);
   options.min_blob_size = FLAGS_min_blob_size;
   options.blob_file_size = FLAGS_blob_file_size;
+  options.blob_file_writable_file_max_buffer_size =
+      FLAGS_blob_file_writable_file_max_buffer_size;
   options.blob_compression_type =
       StringToCompressionType(FLAGS_blob_compression_type.c_str());
   options.enable_blob_garbage_collection = FLAGS_enable_blob_garbage_collection;

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -1102,6 +1102,15 @@ struct AdvancedColumnFamilyOptions {
   // Dynamically changeable through the SetOptions() API
   uint64_t blob_file_size = 1ULL << 28;
 
+  // Max size of the in-memory write buffer for blob files only, overriding
+  // DBOptions::writable_file_max_buffer_size for blob writers.
+  // 0 => inherit DBOptions::writable_file_max_buffer_size.
+  //
+  // Default: 0
+  //
+  // Dynamically changeable through the SetOptions() API
+  uint64_t blob_file_writable_file_max_buffer_size = 0;
+
   // The compression algorithm to use for large values stored in blob files.
   // Note that enable_blob_files has to be set in order for this option to have
   // any effect.

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -5372,6 +5372,14 @@ rocksdb_options_set_preserve_internal_time_seconds(rocksdb_options_t* opt,
 extern ROCKSDB_LIBRARY_API uint64_t
 rocksdb_options_get_preserve_internal_time_seconds(rocksdb_options_t* opt);
 
+extern ROCKSDB_LIBRARY_API void
+rocksdb_options_set_blob_file_writable_file_max_buffer_size(
+    rocksdb_options_t* opt, uint64_t v);
+
+extern ROCKSDB_LIBRARY_API uint64_t
+rocksdb_options_get_blob_file_writable_file_max_buffer_size(
+    rocksdb_options_t* opt);
+
 extern ROCKSDB_LIBRARY_API void rocksdb_options_set_enable_blob_direct_write(
     rocksdb_options_t* opt, unsigned char v);
 

--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -625,6 +625,11 @@ static std::unordered_map<std::string, OptionTypeInfo>
          {offsetof(struct MutableCFOptions, blob_file_size),
           OptionType::kUInt64T, OptionVerificationType::kNormal,
           OptionTypeFlags::kMutable}},
+        {"blob_file_writable_file_max_buffer_size",
+         {offsetof(struct MutableCFOptions,
+                   blob_file_writable_file_max_buffer_size),
+          OptionType::kUInt64T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kMutable}},
         {"blob_compression_type",
          {offsetof(struct MutableCFOptions, blob_compression_type),
           OptionType::kCompressionType, OptionVerificationType::kNormal,
@@ -1349,6 +1354,8 @@ void MutableCFOptions::Dump(Logger* log) const {
                  min_blob_size);
   ROCKS_LOG_INFO(log, "                           blob_file_size: %" PRIu64,
                  blob_file_size);
+  ROCKS_LOG_INFO(log, "  blob_file_writable_file_max_buffer_size: %" PRIu64,
+                 blob_file_writable_file_max_buffer_size);
   ROCKS_LOG_INFO(log, "                    blob_compression_type: %s",
                  CompressionTypeToString(blob_compression_type).c_str());
   ROCKS_LOG_INFO(log, "             blob_compression_opts.level: %d",

--- a/options/cf_options.h
+++ b/options/cf_options.h
@@ -166,6 +166,8 @@ struct MutableCFOptions {
         enable_blob_files(options.enable_blob_files),
         min_blob_size(options.min_blob_size),
         blob_file_size(options.blob_file_size),
+        blob_file_writable_file_max_buffer_size(
+            options.blob_file_writable_file_max_buffer_size),
         blob_compression_type(options.blob_compression_type),
         blob_compression_opts(options.blob_compression_opts),
         enable_blob_garbage_collection(options.enable_blob_garbage_collection),
@@ -242,6 +244,7 @@ struct MutableCFOptions {
         enable_blob_files(false),
         min_blob_size(0),
         blob_file_size(0),
+        blob_file_writable_file_max_buffer_size(0),
         blob_compression_type(kNoCompression),
         blob_compression_opts(),
         enable_blob_garbage_collection(false),
@@ -349,6 +352,7 @@ struct MutableCFOptions {
   bool enable_blob_files;
   uint64_t min_blob_size;
   uint64_t blob_file_size;
+  uint64_t blob_file_writable_file_max_buffer_size;
   CompressionType blob_compression_type;
   CompressionOptions blob_compression_opts;
   bool enable_blob_garbage_collection;

--- a/options/options.cc
+++ b/options/options.cc
@@ -102,6 +102,8 @@ AdvancedColumnFamilyOptions::AdvancedColumnFamilyOptions(const Options& options)
       enable_blob_files(options.enable_blob_files),
       min_blob_size(options.min_blob_size),
       blob_file_size(options.blob_file_size),
+      blob_file_writable_file_max_buffer_size(
+          options.blob_file_writable_file_max_buffer_size),
       blob_compression_type(options.blob_compression_type),
       blob_compression_opts(options.blob_compression_opts),
       enable_blob_garbage_collection(options.enable_blob_garbage_collection),
@@ -446,6 +448,9 @@ void ColumnFamilyOptions::Dump(Logger* log) const {
   ROCKS_LOG_HEADER(log,
                    "                         Options.blob_file_size: %" PRIu64,
                    blob_file_size);
+  ROCKS_LOG_HEADER(log,
+                   "Options.blob_file_writable_file_max_buffer_size: %" PRIu64,
+                   blob_file_writable_file_max_buffer_size);
   ROCKS_LOG_HEADER(log, "                  Options.blob_compression_type: %s",
                    CompressionTypeToString(blob_compression_type).c_str());
   ROCKS_LOG_HEADER(log, "            Options.blob_compression_opts.level: %d",

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -296,6 +296,8 @@ void UpdateColumnFamilyOptions(const MutableCFOptions& moptions,
   cf_opts->enable_blob_files = moptions.enable_blob_files;
   cf_opts->min_blob_size = moptions.min_blob_size;
   cf_opts->blob_file_size = moptions.blob_file_size;
+  cf_opts->blob_file_writable_file_max_buffer_size =
+      moptions.blob_file_writable_file_max_buffer_size;
   cf_opts->blob_compression_type = moptions.blob_compression_type;
   cf_opts->blob_compression_opts = moptions.blob_compression_opts;
   cf_opts->enable_blob_garbage_collection =

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -688,6 +688,7 @@ TEST_F(OptionsSettableTest, ColumnFamilyOptionsAllFieldsSettable) {
       "enable_blob_direct_write=true;"
       "min_blob_size=256;"
       "blob_file_size=1000000;"
+      "blob_file_writable_file_max_buffer_size=131072;"
       "blob_compression_type=kBZip2Compression;"
       "blob_compression_opts={window_bits=-14;level=1;strategy=0;max_dict_"
       "bytes=0;"
@@ -739,6 +740,7 @@ TEST_F(OptionsSettableTest, ColumnFamilyOptionsAllFieldsSettable) {
   // kColumnFamilyOptionsExcluded
   ASSERT_TRUE(new_options->enable_blob_direct_write);
   ASSERT_EQ(new_options->blob_direct_write_partitions, 3U);
+  ASSERT_EQ(new_options->blob_file_writable_file_max_buffer_size, 131072U);
   ASSERT_EQ(new_options->compaction_options_fifo.max_table_files_size, 3);
   ASSERT_EQ(new_options->compaction_options_fifo.allow_compaction, true);
   ASSERT_EQ(new_options->compaction_options_fifo.file_temperature_age_thresholds

--- a/options/options_test.cc
+++ b/options/options_test.cc
@@ -131,6 +131,7 @@ TEST_F(OptionsTest, GetOptionsFromMapTest) {
       {"enable_blob_files", "true"},
       {"min_blob_size", "1K"},
       {"blob_file_size", "1G"},
+      {"blob_file_writable_file_max_buffer_size", "128K"},
       {"blob_compression_type", "kZSTD"},
       {"blob_compression_opts", "-14:1:0:0:0:true"},
       {"enable_blob_garbage_collection", "true"},
@@ -291,6 +292,7 @@ TEST_F(OptionsTest, GetOptionsFromMapTest) {
   ASSERT_EQ(new_cf_opt.enable_blob_files, true);
   ASSERT_EQ(new_cf_opt.min_blob_size, 1ULL << 10);
   ASSERT_EQ(new_cf_opt.blob_file_size, 1ULL << 30);
+  ASSERT_EQ(new_cf_opt.blob_file_writable_file_max_buffer_size, 128ULL << 10);
   ASSERT_EQ(new_cf_opt.blob_compression_type, kZSTD);
   ASSERT_EQ(new_cf_opt.blob_compression_opts.level, 1);
   ASSERT_EQ(new_cf_opt.enable_blob_garbage_collection, true);
@@ -2667,6 +2669,7 @@ TEST_F(OptionsOldApiTest, GetOptionsFromMapTest) {
       {"enable_blob_files", "true"},
       {"min_blob_size", "1K"},
       {"blob_file_size", "1G"},
+      {"blob_file_writable_file_max_buffer_size", "128K"},
       {"blob_compression_type", "kZSTD"},
       {"blob_compression_opts", "-14:1:0:0:0:true"},
       {"enable_blob_garbage_collection", "true"},
@@ -2825,6 +2828,7 @@ TEST_F(OptionsOldApiTest, GetOptionsFromMapTest) {
   ASSERT_EQ(new_cf_opt.enable_blob_files, true);
   ASSERT_EQ(new_cf_opt.min_blob_size, 1ULL << 10);
   ASSERT_EQ(new_cf_opt.blob_file_size, 1ULL << 30);
+  ASSERT_EQ(new_cf_opt.blob_file_writable_file_max_buffer_size, 128ULL << 10);
   ASSERT_EQ(new_cf_opt.blob_compression_type, kZSTD);
   ASSERT_EQ(new_cf_opt.blob_compression_opts.level, 1);
   ASSERT_EQ(new_cf_opt.enable_blob_garbage_collection, true);

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -1194,6 +1194,13 @@ DEFINE_uint64(blob_file_size,
               ROCKSDB_NAMESPACE::AdvancedColumnFamilyOptions().blob_file_size,
               "[Integrated BlobDB] The size limit for blob files.");
 
+DEFINE_uint64(
+    blob_file_writable_file_max_buffer_size,
+    ROCKSDB_NAMESPACE::AdvancedColumnFamilyOptions()
+        .blob_file_writable_file_max_buffer_size,
+    "[Integrated BlobDB] Max WritableFileWriter buffer size for blob files. "
+    "0 means inherit writable_file_max_buffer_size.");
+
 DEFINE_string(blob_compression_type, "none",
               "[Integrated BlobDB] The compression algorithm to use for large "
               "values stored in blob files.");
@@ -5820,6 +5827,8 @@ class Benchmark {
         static_cast<uint32_t>(FLAGS_blob_direct_write_partitions);
     options.min_blob_size = FLAGS_min_blob_size;
     options.blob_file_size = FLAGS_blob_file_size;
+    options.blob_file_writable_file_max_buffer_size =
+        FLAGS_blob_file_writable_file_max_buffer_size;
     options.blob_compression_type =
         StringToCompressionType(FLAGS_blob_compression_type.c_str());
     options.enable_blob_garbage_collection =

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -770,6 +770,9 @@ blob_params = {
     ),
     "blob_garbage_collection_force_threshold": lambda: random.choice([0.5, 0.75, 1.0]),
     "blob_compaction_readahead_size": lambda: random.choice([0, 1048576, 4194304]),
+    "blob_file_writable_file_max_buffer_size": lambda: random.choice(
+        [0, 65536, 131072, 1048576]
+    ),
     "blob_file_starting_level": lambda: random.choice(
         [0] * 4 + [1] * 3 + [2] * 2 + [3]
     ),
@@ -791,6 +794,9 @@ blob_direct_write_params = {
     "inplace_update_support": 0,
     "min_blob_size": lambda: random.choice([8, 16, 64]),
     "blob_file_size": lambda: random.choice([1048576, 16777216, 268435456]),
+    "blob_file_writable_file_max_buffer_size": lambda: random.choice(
+        [0, 65536, 131072, 1048576]
+    ),
     "blob_compression_type": lambda: random.choice(["none", "snappy", "lz4", "zstd"]),
     "enable_blob_garbage_collection": 0,
     "blob_garbage_collection_age_cutoff": 0.0,

--- a/unreleased_history/new_features/blob_file_writable_file_max_buffer_size.md
+++ b/unreleased_history/new_features/blob_file_writable_file_max_buffer_size.md
@@ -1,0 +1,1 @@
+Added the `blob_file_writable_file_max_buffer_size` mutable column family option. When set to a non-zero value, blob-file writers use it as their `WritableFileWriter` max buffer size instead of inheriting `DBOptions::writable_file_max_buffer_size`.


### PR DESCRIPTION
Summary:

Adds mutable ColumnFamilyOptions field `blob_file_writable_file_max_buffer_size` to cap blob-file WritableFileWriter buffers independently from DBOptions::writable_file_max_buffer_size.

The default value is 0, which preserves existing behavior by inheriting the DB-wide writer buffer cap. Non-zero values apply to both flush/compaction blob writers and direct-write blob writers. Direct-write updates are propagated through DBImpl::SetOptions to newly opened blob files without requiring a DB restart.

Also wires option parsing, dumping, db_bench, db_stress, crashtest, and release-note coverage.

Reviewed By: xingbowang

Differential Revision: D114979265


