### PR TITLE
CI: pin claude-code-base-action to a full commit SHA

### DIFF
--- a/.github/workflows/ai-review-analysis.yml
+++ b/.github/workflows/ai-review-analysis.yml
@@ -495,7 +495,7 @@ jobs:
           steps.check_existing.outputs.skip != 'true' &&
           inputs.provider == 'claude'
         id: classify_claude
-        uses: anthropics/claude-code-base-action@beta
+        uses: anthropics/claude-code-base-action@e8132bc5e637a42c27763fc757faa37e1ee43b34 # beta
         with:
           prompt_file: /tmp/complexity_prompt.txt
           model: ${{ inputs.classifier_model }}
@@ -616,7 +616,7 @@ jobs:
         env:
           MAX_THINKING_TOKENS: ${{ steps.budget_claude.outputs.tokens }}
           CLAUDE_COMPLEXITY: ${{ steps.budget_claude.outputs.label }}
-        uses: anthropics/claude-code-base-action@beta
+        uses: anthropics/claude-code-base-action@e8132bc5e637a42c27763fc757faa37e1ee43b34 # beta
         with:
           prompt_file: /tmp/prompt.txt
           model: ${{ inputs.default_model }}
@@ -656,7 +656,7 @@ jobs:
           inputs.provider == 'claude' &&
           steps.recover_claude.outputs.needs_recovery == 'true'
         id: format_recovery_claude
-        uses: anthropics/claude-code-base-action@beta
+        uses: anthropics/claude-code-base-action@e8132bc5e637a42c27763fc757faa37e1ee43b34 # beta
         with:
           prompt_file: claude_md/ci_recovery_prompt.md
           model: ${{ inputs.recovery_model }}
@@ -1086,7 +1086,7 @@ jobs:
           steps.request.outputs.type == 'review' &&
           inputs.provider == 'claude'
         id: manual_classify_claude
-        uses: anthropics/claude-code-base-action@beta
+        uses: anthropics/claude-code-base-action@e8132bc5e637a42c27763fc757faa37e1ee43b34 # beta
         with:
           prompt_file: /tmp/complexity_prompt.txt
           model: ${{ inputs.classifier_model }}
@@ -1242,7 +1242,7 @@ jobs:
         env:
           MAX_THINKING_TOKENS: ${{ steps.manual_budget_claude.outputs.tokens }}
           CLAUDE_COMPLEXITY: ${{ steps.manual_budget_claude.outputs.label }}
-        uses: anthropics/claude-code-base-action@beta
+        uses: anthropics/claude-code-base-action@e8132bc5e637a42c27763fc757faa37e1ee43b34 # beta
         with:
           prompt_file: /tmp/prompt.txt
           model: ${{ inputs.selected_model != '' && inputs.selected_model || inputs.default_model }}
@@ -1283,7 +1283,7 @@ jobs:
           inputs.provider == 'claude' &&
           steps.manual_recover_claude.outputs.needs_recovery == 'true'
         id: manual_format_recovery_claude
-        uses: anthropics/claude-code-base-action@beta
+        uses: anthropics/claude-code-base-action@e8132bc5e637a42c27763fc757faa37e1ee43b34 # beta
         with:
           prompt_file: claude_md/ci_recovery_prompt.md
           model: ${{ inputs.recovery_model }}


### PR DESCRIPTION
Fixes #14936.

`ai-review-analysis.yml` uses `anthropics/claude-code-base-action@beta` in six steps. `beta` is a lightweight tag, so it can be re-pointed at any commit without anything changing here:

```
$ gh api repos/anthropics/claude-code-base-action/git/refs/tags/beta --jq .object.type
commit
```

That matters more than usual for this workflow because `claude-review.yml` calls it on `pull_request_target` and `issue_comment` with `secrets: inherit`, so whatever the tag resolves to runs with `ANTHROPIC_API_KEY` and the rest of the provider keys in scope. GitHub's hardening guidance for third-party actions is a full commit SHA, and Dependabot will still bump a pinned SHA.

Pinned all six to `e8132bc`, which is what `beta` points at right now, with the tag kept as a trailing comment so it stays readable and Dependabot-friendly.

Only the six third-party `uses:` lines changed. The `actions/*` ones are first-party and left alone, matching what the issue asked for.
