### PR TITLE
Make ARM nightly crash test swap setup idempotent

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -140,7 +140,17 @@ jobs:
     - uses: "./.github/actions/pre-steps"
     - run: sudo apt-get update && sudo apt-get install -y build-essential libgflags-dev libsnappy-dev zlib1g-dev libbz2-dev liblz4-dev libzstd-dev
     - run: sudo mount -o remount,size=16G /dev/shm
-    - run: sudo dd bs=1048576 count=4096 if=/dev/zero of=/swapfile && sudo chmod 600 /swapfile && sudo mkswap /swapfile && sudo swapon /swapfile
+    - name: Ensure swap space
+      run: |-
+        if sudo swapon --show=NAME --noheadings --raw | grep -Fxq /swapfile; then
+          echo "/swapfile is already active"
+        else
+          sudo dd bs=1048576 count=4096 if=/dev/zero of=/swapfile
+          sudo chmod 600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
+        fi
+        sudo swapon --show
     - run: ulimit -S -n `ulimit -H -n` && make V=1 -j8 CRASH_TEST_EXT_ARGS='--duration=1800 --max_key=2500000' blackbox_crash_test_with_atomic_flush
     - run: rm -rf /dev/shm/rocksdb.*
     - run: ulimit -S -n `ulimit -H -n` && make V=1 -j8 CRASH_TEST_EXT_ARGS='--duration=1800 --max_key=2500000' blackbox_crash_test_with_multiops_wc_txn


### PR DESCRIPTION
## Summary

- make the ARM nightly crash-test swap setup skip `/swapfile` creation when it is already active
- keep the existing 4 GiB swap creation path for hosts without active `/swapfile`
- print the active swap devices after setup for easier workflow diagnostics

## Testing

- `git diff --check upstream/main...2026_08_06_arm_failure`
