### PR TITLE
Fix native ReadOptions leak in RocksDB.close() (Java)

### DIFF
--- a/java/src/main/java/org/rocksdb/RocksDB.java
+++ b/java/src/main/java/org/rocksdb/RocksDB.java
@@ -44,6 +44,13 @@ public class RocksDB extends RocksObject {
   final List<ColumnFamilyHandle> ownedColumnFamilyHandles = new ArrayList<>();
 
   /**
+   * Package-private accessor for {@link #defaultReadOptions_}, for testing only.
+   */
+  ReadOptions getDefaultReadOptions() {
+    return defaultReadOptions_;
+  }
+
+  /**
    * Loads the necessary library files.
    * Calling this method twice will have no effect.
    * By default the method extracts the shared library for loading at
@@ -696,6 +703,7 @@ public class RocksDB extends RocksObject {
       } catch (final RocksDBException e) {
         // silently ignore the error report
       } finally {
+        defaultReadOptions_.close();
         disposeInternal();
       }
     }

--- a/java/src/test/java/org/rocksdb/RocksDBTest.java
+++ b/java/src/test/java/org/rocksdb/RocksDBTest.java
@@ -179,6 +179,17 @@ public class RocksDBTest {
   }
 
   @Test
+  public void closeReleasesDefaultReadOptions() throws RocksDBException {
+    try (final Options options = new Options().setCreateIfMissing(true)) {
+      final RocksDB db = RocksDB.open(options, dbFolder.getRoot().getAbsolutePath());
+      final ReadOptions defaultReadOptions = db.getDefaultReadOptions();
+      assertThat(defaultReadOptions.isOwningHandle()).isTrue();
+      db.close();
+      assertThat(defaultReadOptions.isOwningHandle()).isFalse();
+    }
+  }
+
+  @Test
   public void put() throws RocksDBException {
     try (final RocksDB db = RocksDB.open(dbFolder.getRoot().getAbsolutePath());
          final WriteOptions opt = new WriteOptions(); final ReadOptions optr = new ReadOptions()) {

--- a/unreleased_history/bug_fixes/java_close_readoptions_leak.md
+++ b/unreleased_history/bug_fixes/java_close_readoptions_leak.md
@@ -1,0 +1,1 @@
+Fixed a native memory leak in the Java API where `RocksDB.close()` did not release the default `ReadOptions`, leaking one native object per opened DB instance.


### PR DESCRIPTION
## Summary
`RocksDB.close()` disposes owned column family handles and its own native handle, but never releases `defaultReadOptions_`,  the `ReadOptions` object eagerly created in the field declaration and used internally by `newIterator()`. This leaks one native `ReadOptions` object per opened `RocksDB` instance for the lifetime of the JVM, since there is no finalizer or `Cleaner` fallback anywhere in the `RocksObject` hierarchy, an explicit `close()` call is the only path to native cleanup, and this one was never wired up.

## Fix
Added `defaultReadOptions_.close()` inside `close()`'s existing cleanup block, alongside `disposeInternal()`.

## Testing
Added `closeReleasesDefaultReadOptions` to `RocksDBTest.java`, asserting `defaultReadOptions_.isOwningHandle()` transitions from `true` to `false` across a `close()` call. Full Java suite passes (1241 tests, 0 failures).

Fixes #15036