### PR TITLE
Add stat for number of bottom-pri compactions. (#15071)

### DIFF
--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -813,6 +813,23 @@ TEST_F(DBCompactionTest, CompactRangeBottomPri) {
   int low_pri_count = 0;
   int bottom_pri_count = 0;
   bool bottom_running_seen = false;
+  std::atomic<bool> bottom_property_seen = false;
+  SyncPoint::GetInstance()->SetCallBack(
+      "CompactionJob::Run():Start", [&](void*) {
+        uint64_t total = 0;
+        uint64_t bottom = 0;
+        ASSERT_TRUE(db_->GetIntProperty(DB::Properties::kNumRunningCompactions,
+                                        &total));
+        ASSERT_TRUE(db_->GetIntProperty(
+            DB::Properties::kNumRunningBottomCompactions, &bottom));
+        ASSERT_GE(total, bottom);
+        ASSERT_GE(total, 1);
+        ASSERT_LE(total, 2);
+        ASSERT_LE(bottom, 1);
+        if (bottom > 0) {
+          bottom_property_seen = true;
+        }
+      });
   SyncPoint::GetInstance()->SetCallBack(
       "BackgroundCallCompaction:1", [&](void*) {
         if (dbfull()->TEST_NumRunningBottomCompactions() > 0) {
@@ -838,6 +855,7 @@ TEST_F(DBCompactionTest, CompactRangeBottomPri) {
   ASSERT_EQ(1, low_pri_count);
   ASSERT_EQ(1, bottom_pri_count);
   ASSERT_TRUE(bottom_running_seen);
+  ASSERT_TRUE(bottom_property_seen);
   ASSERT_EQ("0,0,2", FilesPerLevel(0));
 
   // Recompact bottom most level uses bottom pool
@@ -6156,6 +6174,7 @@ TEST_F(DBCompactionTest, CompactRangeFlushOverlappingMemtable) {
 TEST_F(DBCompactionTest, CompactionStatsTest) {
   Options options = CurrentOptions();
   options.level0_file_num_compaction_trigger = 2;
+  options.max_background_compactions = 1;
   CompactionStatsCollector* collector = new CompactionStatsCollector();
   options.listeners.emplace_back(collector);
   DestroyAndReopen(options);
@@ -6163,9 +6182,13 @@ TEST_F(DBCompactionTest, CompactionStatsTest) {
   // Verify that the internal statistics for num_running_compactions and
   // num_running_compaction_sorted_runs start and end at valid states
   uint64_t num_running_compactions = 0;
+  uint64_t num_running_bottom_compactions = 0;
   ASSERT_TRUE(db_->GetIntProperty(DB::Properties::kNumRunningCompactions,
                                   &num_running_compactions));
-  ASSERT_EQ(num_running_compactions, 0);
+  ASSERT_TRUE(db_->GetIntProperty(DB::Properties::kNumRunningBottomCompactions,
+                                  &num_running_bottom_compactions));
+  ASSERT_EQ(0, num_running_compactions);
+  ASSERT_EQ(0, num_running_bottom_compactions);
   uint64_t num_running_compaction_sorted_runs = 0;
   ASSERT_TRUE(
       db_->GetIntProperty(DB::Properties::kNumRunningCompactionSortedRuns,
@@ -6174,6 +6197,18 @@ TEST_F(DBCompactionTest, CompactionStatsTest) {
   // Check that the stat actually gets changed some time between the start and
   // end of compaction
   std::atomic<bool> sorted_runs_count_incremented = false;
+  std::atomic<bool> running_compaction_seen = false;
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
+      "CompactionJob::Run():Start", [&](void*) {
+        ASSERT_TRUE(db_->GetIntProperty(DB::Properties::kNumRunningCompactions,
+                                        &num_running_compactions));
+        ASSERT_TRUE(
+            db_->GetIntProperty(DB::Properties::kNumRunningBottomCompactions,
+                                &num_running_bottom_compactions));
+        ASSERT_EQ(1, num_running_compactions);
+        ASSERT_EQ(0, num_running_bottom_compactions);
+        running_compaction_seen = true;
+      });
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
       "CompactionMergingIterator::UpdateInternalStats",
       [&](void*) { sorted_runs_count_incremented = true; });
@@ -6197,11 +6232,15 @@ TEST_F(DBCompactionTest, CompactionStatsTest) {
   // to process
   ASSERT_TRUE(db_->GetIntProperty(DB::Properties::kNumRunningCompactions,
                                   &num_running_compactions));
-  ASSERT_EQ(num_running_compactions, 0);
+  ASSERT_TRUE(db_->GetIntProperty(DB::Properties::kNumRunningBottomCompactions,
+                                  &num_running_bottom_compactions));
+  ASSERT_EQ(0, num_running_compactions);
+  ASSERT_EQ(0, num_running_bottom_compactions);
   ASSERT_TRUE(
       db_->GetIntProperty(DB::Properties::kNumRunningCompactionSortedRuns,
                           &num_running_compaction_sorted_runs));
   ASSERT_EQ(num_running_compaction_sorted_runs, 0);
+  ASSERT_TRUE(running_compaction_seen);
   ASSERT_TRUE(sorted_runs_count_incremented);
 
   SyncPoint::GetInstance()->DisableProcessing();

--- a/db/internal_stats.cc
+++ b/db/internal_stats.cc
@@ -310,6 +310,8 @@ static const std::string aggregated_table_properties_at_level =
 static const std::string num_running_compactions = "num-running-compactions";
 static const std::string num_running_remote_compactions =
     "num-running-remote-compactions";
+static const std::string num_running_bottom_compactions =
+    "num-running-bottom-compactions";
 static const std::string num_running_compaction_sorted_runs =
     "num-running-compaction-sorted-runs";
 static const std::string compaction_abort_count = "compaction-abort-count";
@@ -367,6 +369,8 @@ const std::string DB::Properties::kNumRunningCompactions =
     rocksdb_prefix + num_running_compactions;
 const std::string DB::Properties::kNumRunningRemoteCompactions =
     rocksdb_prefix + num_running_remote_compactions;
+const std::string DB::Properties::kNumRunningBottomCompactions =
+    rocksdb_prefix + num_running_bottom_compactions;
 const std::string DB::Properties::kNumRunningCompactionSortedRuns =
     rocksdb_prefix + num_running_compaction_sorted_runs;
 const std::string DB::Properties::kCompactionAbortCount =
@@ -604,6 +608,9 @@ const UnorderedMap<std::string, DBPropertyInfo>
           nullptr}},
         {DB::Properties::kNumRunningRemoteCompactions,
          {false, nullptr, &InternalStats::HandleNumRunningRemoteCompactions,
+          nullptr, nullptr}},
+        {DB::Properties::kNumRunningBottomCompactions,
+         {false, nullptr, &InternalStats::HandleNumRunningBottomCompactions,
           nullptr, nullptr}},
         {DB::Properties::kNumRunningCompactionSortedRuns,
          {false, nullptr, &InternalStats::HandleNumRunningCompactionSortedRuns,
@@ -1307,6 +1314,13 @@ bool InternalStats::HandleNumRunningRemoteCompactions(uint64_t* value,
       db->num_running_remote_compactions_.load(std::memory_order_relaxed);
   assert(num_running >= 0);
   *value = static_cast<uint64_t>(num_running);
+  return true;
+}
+
+bool InternalStats::HandleNumRunningBottomCompactions(uint64_t* value,
+                                                      DBImpl* db,
+                                                      Version* /*version*/) {
+  *value = static_cast<uint64_t>(db->num_running_bottom_compactions_);
   return true;
 }
 

--- a/db/internal_stats.h
+++ b/db/internal_stats.h
@@ -852,6 +852,8 @@ class InternalStats {
                                    Version* version);
   bool HandleNumRunningRemoteCompactions(uint64_t* value, DBImpl* db,
                                          Version* version);
+  bool HandleNumRunningBottomCompactions(uint64_t* value, DBImpl* db,
+                                         Version* version);
   bool HandleNumRunningCompactionSortedRuns(uint64_t* value, DBImpl* db,
                                             Version* version);
   bool HandleCompactionAbortCount(uint64_t* value, DBImpl* db,

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1433,6 +1433,10 @@ class DB {
     //      to this count. Always 0 when no `compaction_service` is configured.
     static const std::string kNumRunningRemoteCompactions;
 
+    //  "rocksdb.num-running-bottom-compactions" - returns the number of
+    //      currently running bottom-priority compactions.
+    static const std::string kNumRunningBottomCompactions;
+
     //  "rocksdb.num-running-compaction-sorted-runs" - returns the number of
     //  sorted runs being processed by currently running compactions.
     static const std::string kNumRunningCompactionSortedRuns;
@@ -1689,6 +1693,7 @@ class DB {
   //  "rocksdb.estimate-pending-compaction-bytes"
   //  "rocksdb.num-running-compactions"
   //  "rocksdb.num-running-remote-compactions"
+  //  "rocksdb.num-running-bottom-compactions"
   //  "rocksdb.num-running-flushes"
   //  "rocksdb.num-unscheduled-compactions"
   //  "rocksdb.actual-delayed-write-rate"


### PR DESCRIPTION
Summary:

__Why__: Give operators visibility into currently running bottom-priority compactions. Low-priority running compactions can be derived from `rocksdb.num-running-compactions - rocksdb.num-running-bottom-compactions`.

__What__: Expose `rocksdb.num-running-bottom-compactions` as a new statistics property.

__How__: We already record `num_running_bottom_compactions_`, so this feeds that value through the DB property path.

Reviewed By: xingbowang

Differential Revision: D114989532


