### PR TITLE
Add num-running-remote-compactions DB property (#15074)

### DIFF
--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -152,7 +152,8 @@ CompactionJob::CompactionJob(
     const std::atomic<int>& compaction_aborted, const std::string& db_id,
     const std::string& db_session_id, std::string full_history_ts_low,
     std::string trim_ts, BlobFileCompletionCallback* blob_callback,
-    int* bg_compaction_scheduled, int* bg_bottom_compaction_scheduled)
+    int* bg_compaction_scheduled, int* bg_bottom_compaction_scheduled,
+    std::atomic<int>* num_running_remote_compactions)
     : compact_(new CompactionState(compaction)),
       internal_stats_(compaction->compaction_reason(), 1),
       db_options_(db_options),
@@ -198,7 +199,8 @@ CompactionJob::CompactionJob(
       blob_callback_(blob_callback),
       extra_num_subcompaction_threads_reserved_(0),
       bg_compaction_scheduled_(bg_compaction_scheduled),
-      bg_bottom_compaction_scheduled_(bg_bottom_compaction_scheduled) {
+      bg_bottom_compaction_scheduled_(bg_bottom_compaction_scheduled),
+      num_running_remote_compactions_(num_running_remote_compactions) {
   assert(job_stats_ != nullptr);
   assert(log_buffer_ != nullptr);
   assert(job_context);

--- a/db/compaction/compaction_job.h
+++ b/db/compaction/compaction_job.h
@@ -166,7 +166,8 @@ class CompactionJob {
                 std::string full_history_ts_low = "", std::string trim_ts = "",
                 BlobFileCompletionCallback* blob_callback = nullptr,
                 int* bg_compaction_scheduled = nullptr,
-                int* bg_bottom_compaction_scheduled = nullptr);
+                int* bg_bottom_compaction_scheduled = nullptr,
+                std::atomic<int>* num_running_remote_compactions = nullptr);
 
   virtual ~CompactionJob();
 
@@ -499,6 +500,12 @@ class CompactionJob {
   // or updating it.
   int* bg_compaction_scheduled_;
   int* bg_bottom_compaction_scheduled_;
+
+  // Stores the pointer to DBImpl::num_running_remote_compactions_, backing the
+  // public rocksdb.num-running-remote-compactions property. Null when the job
+  // has no owning DBImpl to report to (compaction service workers, unit tests).
+  // Updated without the DB mutex held.
+  std::atomic<int>* num_running_remote_compactions_;
 
   // Stores the sequence number to time mapping gathered from all input files
   // it also collects the smallest_seqno -> oldest_ancester_time from the SST.

--- a/db/compaction/compaction_service_job.cc
+++ b/db/compaction/compaction_service_job.cc
@@ -15,6 +15,7 @@
 #include "monitoring/thread_status_util.h"
 #include "options/options_helper.h"
 #include "rocksdb/utilities/options_type.h"
+#include "util/defer.h"
 
 namespace ROCKSDB_NAMESPACE {
 class SubcompactionState;
@@ -114,9 +115,6 @@ CompactionJob::ProcessKeyValueCompactionWithCompactionService(
       break;
   }
 
-  std::string debug_str_before_wait =
-      compaction->input_version()->DebugString(/*hex=*/true);
-
   // TODO: Update CompactionService API to support abort and resume
   // functionality. Currently, remote compaction jobs cannot be aborted via
   // AbortAllCompactions() because the CompactionService interface lacks methods
@@ -129,18 +127,29 @@ CompactionJob::ProcessKeyValueCompactionWithCompactionService(
                  "[%s] [JOB %d] Waiting for remote compaction...",
                  compaction->column_family_data()->GetName().c_str(), job_id_);
   std::string compaction_result_binary;
-  CompactionServiceJobStatus compaction_status =
-      db_options_.compaction_service->Wait(response.scheduled_job_id,
-                                           &compaction_result_binary);
+  CompactionServiceJobStatus compaction_status;
+  {
+    // Increment rocksdb.num-running-remote-compactions while this compaction
+    // service job is waiting in CompactionService::Wait().
+    std::atomic<int>* const num_running = num_running_remote_compactions_;
+    if (num_running != nullptr) {
+      num_running->fetch_add(1, std::memory_order_relaxed);
+    }
+    Defer decrement_num_running([num_running]() {
+      if (num_running != nullptr) {
+        num_running->fetch_sub(1, std::memory_order_relaxed);
+      }
+    });
+    compaction_status = db_options_.compaction_service->Wait(
+        response.scheduled_job_id, &compaction_result_binary);
+  }
 
   if (compaction_status != CompactionServiceJobStatus::kSuccess) {
     ROCKS_LOG_ERROR(
         db_options_.info_log,
         "[%s] [JOB %d] Wait() status is not kSuccess. "
-        "\nDebugString Before Wait():\n%s"
         "\nDebugString After Wait():\n%s",
         compaction->column_family_data()->GetName().c_str(), job_id_,
-        debug_str_before_wait.c_str(),
         compaction->input_version()->DebugString(/*hex=*/true).c_str());
   }
 

--- a/db/compaction/compaction_service_test.cc
+++ b/db/compaction/compaction_service_test.cc
@@ -1762,6 +1762,109 @@ TEST_F(CompactionServiceTest, SubCompaction) {
   ASSERT_GE(compaction_num, 2);
 }
 
+class PropertySamplingCompactionService : public MyTestCompactionService {
+ public:
+  using MyTestCompactionService::MyTestCompactionService;
+
+  void SetPrimaryDB(DB* db) { db_ = db; }
+
+  CompactionServiceJobStatus Wait(const std::string& scheduled_job_id,
+                                  std::string* result) override {
+    EXPECT_TRUE(
+        db_->GetIntProperty(DB::Properties::kNumRunningRemoteCompactions,
+                            &num_running_while_waiting_));
+    return MyTestCompactionService::Wait(scheduled_job_id, result);
+  }
+
+  uint64_t GetNumRunningWhileWaiting() const {
+    return num_running_while_waiting_;
+  }
+
+ private:
+  DB* db_ = nullptr;
+  uint64_t num_running_while_waiting_ = 0;
+};
+
+TEST_F(CompactionServiceTest, NumRunningRemoteCompactionsProperty) {
+  Options options = CurrentOptions();
+  options.disable_auto_compactions = true;
+  options.env = env_;
+  auto statistics = CreateDBStatistics();
+  auto compaction_service = std::make_shared<PropertySamplingCompactionService>(
+      dbname_, options, statistics,
+      std::vector<std::shared_ptr<EventListener>>{},
+      std::vector<std::shared_ptr<TablePropertiesCollectorFactory>>{});
+  options.compaction_service = compaction_service;
+  DestroyAndReopen(options);
+  compaction_service->SetPrimaryDB(db_.get());
+
+  // Overlapping key ranges across files so the compaction is not a trivial
+  // move, which would bypass the compaction service entirely.
+  for (int i = 0; i < 4; i++) {
+    for (int j = 0; j < 10; j++) {
+      ASSERT_OK(Put(Key(j), "value" + std::to_string(i * 10 + j)));
+    }
+    ASSERT_OK(Flush());
+  }
+
+  // No remote compaction is in flight yet.
+  uint64_t num_running = 0;
+  ASSERT_TRUE(db_->GetIntProperty(DB::Properties::kNumRunningRemoteCompactions,
+                                  &num_running));
+  ASSERT_EQ(num_running, 0U);
+
+  ASSERT_OK(db_->CompactRange(CompactRangeOptions(), nullptr, nullptr));
+  ASSERT_GE(compaction_service->GetCompactionNum(), 1);
+  ASSERT_GE(compaction_service->GetNumRunningWhileWaiting(), 1U);
+
+  // The counter is back to 0 once the remote jobs are installed.
+  ASSERT_TRUE(db_->GetIntProperty(DB::Properties::kNumRunningRemoteCompactions,
+                                  &num_running));
+  ASSERT_EQ(num_running, 0U);
+}
+
+TEST_F(CompactionServiceTest, NumRunningRemoteCompactionsPropertyLocalOnly) {
+  // Without a compaction_service configured, the property stays 0.
+  Options options = CurrentOptions();
+  options.disable_auto_compactions = true;
+  DestroyAndReopen(options);
+
+  // Overlapping key ranges across files so the compaction is not a trivial
+  // move, which would bypass the compaction service entirely.
+  for (int i = 0; i < 4; i++) {
+    for (int j = 0; j < 10; j++) {
+      ASSERT_OK(Put(Key(j), "value" + std::to_string(i * 10 + j)));
+    }
+    ASSERT_OK(Flush());
+  }
+
+  std::atomic<int> property_samples{0};
+  std::atomic_bool observed_non_zero{false};
+  SyncPoint::GetInstance()->SetCallBack(
+      "CompactionJob::ProcessKeyValueCompaction()::Processing",
+      [&](void* /*arg*/) {
+        uint64_t num_running = 0;
+        EXPECT_TRUE(db_->GetIntProperty(
+            DB::Properties::kNumRunningRemoteCompactions, &num_running));
+        property_samples.fetch_add(1);
+        if (num_running != 0) {
+          observed_non_zero.store(true);
+        }
+      });
+  SyncPoint::GetInstance()->EnableProcessing();
+  ASSERT_OK(db_->CompactRange(CompactRangeOptions(), nullptr, nullptr));
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+
+  ASSERT_GT(property_samples.load(), 0);
+  ASSERT_FALSE(observed_non_zero.load());
+
+  uint64_t num_running = 0;
+  ASSERT_TRUE(db_->GetIntProperty(DB::Properties::kNumRunningRemoteCompactions,
+                                  &num_running));
+  ASSERT_EQ(num_running, 0U);
+}
+
 class PartialDeleteCompactionFilter : public CompactionFilter {
  public:
   CompactionFilter::Decision FilterV2(

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -3563,6 +3563,10 @@ class DBImpl : public DB
   // stores the number of BOTTOM-priority compactions currently running
   int num_running_bottom_compactions_ = 0;
 
+  // Number of compaction service jobs currently waiting in
+  // CompactionService::Wait(), counted per executed subcompaction.
+  std::atomic<int> num_running_remote_compactions_ = 0;
+
   // number of background memtable flush jobs, submitted to the HIGH pool
   int bg_flush_scheduled_ = 0;
 

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -1915,7 +1915,7 @@ Status DBImpl::CompactFilesImpl(
       kManualCompactionCanceledFalse_, compaction_aborted_, db_id_,
       db_session_id_, c->column_family_data()->GetFullHistoryTsLow(),
       c->trim_ts(), &blob_callback_, &bg_compaction_scheduled_,
-      &bg_bottom_compaction_scheduled_);
+      &bg_bottom_compaction_scheduled_, &num_running_remote_compactions_);
 
   // Creating a compaction influences the compaction score because the score
   // takes running compactions into account (by skipping files that are already
@@ -5064,7 +5064,7 @@ Status DBImpl::BackgroundCompaction(bool* made_progress,
         compaction_aborted_, db_id_, db_session_id_,
         c->column_family_data()->GetFullHistoryTsLow(), c->trim_ts(),
         &blob_callback_, &bg_compaction_scheduled_,
-        &bg_bottom_compaction_scheduled_);
+        &bg_bottom_compaction_scheduled_, &num_running_remote_compactions_);
     compaction_job.Prepare(std::nullopt /*subcompact to be computed*/);
 
     std::unique_ptr<std::list<uint64_t>::iterator> min_options_file_number_elem;

--- a/db/internal_stats.cc
+++ b/db/internal_stats.cc
@@ -308,6 +308,8 @@ static const std::string aggregated_table_properties =
 static const std::string aggregated_table_properties_at_level =
     aggregated_table_properties + "-at-level";
 static const std::string num_running_compactions = "num-running-compactions";
+static const std::string num_running_remote_compactions =
+    "num-running-remote-compactions";
 static const std::string num_running_compaction_sorted_runs =
     "num-running-compaction-sorted-runs";
 static const std::string compaction_abort_count = "compaction-abort-count";
@@ -363,6 +365,8 @@ const std::string DB::Properties::kCompactionPending =
     rocksdb_prefix + compaction_pending;
 const std::string DB::Properties::kNumRunningCompactions =
     rocksdb_prefix + num_running_compactions;
+const std::string DB::Properties::kNumRunningRemoteCompactions =
+    rocksdb_prefix + num_running_remote_compactions;
 const std::string DB::Properties::kNumRunningCompactionSortedRuns =
     rocksdb_prefix + num_running_compaction_sorted_runs;
 const std::string DB::Properties::kCompactionAbortCount =
@@ -598,6 +602,9 @@ const UnorderedMap<std::string, DBPropertyInfo>
         {DB::Properties::kNumRunningCompactions,
          {false, nullptr, &InternalStats::HandleNumRunningCompactions, nullptr,
           nullptr}},
+        {DB::Properties::kNumRunningRemoteCompactions,
+         {false, nullptr, &InternalStats::HandleNumRunningRemoteCompactions,
+          nullptr, nullptr}},
         {DB::Properties::kNumRunningCompactionSortedRuns,
          {false, nullptr, &InternalStats::HandleNumRunningCompactionSortedRuns,
           nullptr, nullptr}},
@@ -1290,6 +1297,16 @@ bool InternalStats::HandleCompactionPending(uint64_t* value, DBImpl* /*db*/,
 bool InternalStats::HandleNumRunningCompactions(uint64_t* value, DBImpl* db,
                                                 Version* /*version*/) {
   *value = db->num_running_compactions_;
+  return true;
+}
+
+bool InternalStats::HandleNumRunningRemoteCompactions(uint64_t* value,
+                                                      DBImpl* db,
+                                                      Version* /*version*/) {
+  const int num_running =
+      db->num_running_remote_compactions_.load(std::memory_order_relaxed);
+  assert(num_running >= 0);
+  *value = static_cast<uint64_t>(num_running);
   return true;
 }
 

--- a/db/internal_stats.h
+++ b/db/internal_stats.h
@@ -850,6 +850,8 @@ class InternalStats {
   bool HandleCompactionPending(uint64_t* value, DBImpl* db, Version* version);
   bool HandleNumRunningCompactions(uint64_t* value, DBImpl* db,
                                    Version* version);
+  bool HandleNumRunningRemoteCompactions(uint64_t* value, DBImpl* db,
+                                         Version* version);
   bool HandleNumRunningCompactionSortedRuns(uint64_t* value, DBImpl* db,
                                             Version* version);
   bool HandleCompactionAbortCount(uint64_t* value, DBImpl* db,

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1426,6 +1426,13 @@ class DB {
     //      running compactions.
     static const std::string kNumRunningCompactions;
 
+    //  "rocksdb.num-running-remote-compactions" - returns the number of
+    //      compaction service jobs currently waiting in
+    //      `CompactionService::Wait()`. Remote work is scheduled per
+    //      subcompaction, so a single compaction may contribute more than one
+    //      to this count. Always 0 when no `compaction_service` is configured.
+    static const std::string kNumRunningRemoteCompactions;
+
     //  "rocksdb.num-running-compaction-sorted-runs" - returns the number of
     //  sorted runs being processed by currently running compactions.
     static const std::string kNumRunningCompactionSortedRuns;
@@ -1681,6 +1688,7 @@ class DB {
   //  "rocksdb.base-level"
   //  "rocksdb.estimate-pending-compaction-bytes"
   //  "rocksdb.num-running-compactions"
+  //  "rocksdb.num-running-remote-compactions"
   //  "rocksdb.num-running-flushes"
   //  "rocksdb.num-unscheduled-compactions"
   //  "rocksdb.actual-delayed-write-rate"

--- a/unreleased_history/new_features/num_running_remote_compactions_property.md
+++ b/unreleased_history/new_features/num_running_remote_compactions_property.md
@@ -1,0 +1,1 @@
+Added DB property `rocksdb.num-running-remote-compactions`, reporting the number of compaction service jobs currently waiting in `CompactionService::Wait()`.


### PR DESCRIPTION
Summary:

Why: We want to be able to monitor how many remote compaction jobs are running on a given server. Currently we know the total number of running compactions but not the local vs remote breakdown.

What: Add a new `rocksdb.num-running-remote-compaction-jobs` statistic. This measures in-progress remote compaction jobs.

Note that remote compaction work is scheduled per subcompaction, so one RocksDB compaction may contribute more than one running remote compaction job.

Reviewed By: jaykorean

Differential Revision: D115324149


