### PR TITLE
Fix remote compaction filter test flake

### DIFF
--- a/db/compaction/compaction_service_test.cc
+++ b/db/compaction/compaction_service_test.cc
@@ -1779,6 +1779,7 @@ class PartialDeleteCompactionFilter : public CompactionFilter {
 
 TEST_F(CompactionServiceTest, CompactionFilter) {
   Options options = CurrentOptions();
+  options.disable_auto_compactions = true;
   std::unique_ptr<CompactionFilter> delete_comp_filter(
       new PartialDeleteCompactionFilter());
   options.compaction_filter = delete_comp_filter.get();


### PR DESCRIPTION
## Summary

- Disable automatic compactions in `CompactionServiceTest.CompactionFilter`.
- Keep the test focused on the explicit `CompactRange()` path that verifies remote compaction filter behavior.
- Avoid a flaky race where background remote compaction can obsolete an input SST before the manual compaction runs.

## Test Plan

- `make format-auto`
- `AUTO_CLEAN=1 COERCE_CONTEXT_SWITCH=1 make -j32 compaction_service_test`
- `tools/gtest_parallel_repro.py --binary ./compaction_service_test --gtest_filter=CompactionServiceTest.CompactionFilter --processes-per-iteration 32 --iteration-count 30 --cpu-count 4 --timeout 120 --stop-on-failure --out /tmp/ws28_compaction_service_flake_fixed_20260809_1`
- `git diff --check`
- `AUTO_CLEAN=1 make check-sources`
