### PR TITLE
Make max_open_files configurable via options_map in OpenAndCompact (#15077)

### DIFF
--- a/db/compaction/compaction_service_test.cc
+++ b/db/compaction/compaction_service_test.cc
@@ -360,6 +360,7 @@ class CompactionServiceTest : public DBTestBase {
 
 TEST_F(CompactionServiceTest, BasicCompactions) {
   Options options = CurrentOptions();
+  options.max_open_files = -1;
   ReopenWithCompactionService(&options);
 
   Statistics* primary_statistics = GetPrimaryStatistics();

--- a/db/db_impl/db_impl_secondary.cc
+++ b/db/db_impl/db_impl_secondary.cc
@@ -1362,9 +1362,6 @@ Status DB::OpenAndCompact(
   db_options.statistics = override_options.statistics;
   db_options.listeners = override_options.listeners;
   db_options.compaction_service = nullptr;
-  // We will close the DB after the compaction anyway.
-  // Open as many files as needed for the compaction.
-  db_options.max_open_files = -1;
   db_options.info_log = override_options.info_log;
 
   // 4. Filter CFs that are needed for OpenAndCompact()

--- a/db/db_secondary_test.cc
+++ b/db/db_secondary_test.cc
@@ -749,8 +749,7 @@ TEST_F(DBSecondaryTest, OptionsOverrideTest) {
                   "blob_compaction_readahead_size=4194304;"
                   "some_invalid_option=ignore_me;"
                   "env=this_should_not_fail;"
-                  "max_open_files=100;",  // this should be always overriden as
-                                          // -1 in remote compaction
+                  "max_open_files=100;",
                   &override_options.options_map));
 
   bool verified = false;
@@ -761,7 +760,7 @@ TEST_F(DBSecondaryTest, OptionsOverrideTest) {
         auto secondary_db_options = secondary_db->GetOptions();
         // DBOption
         ASSERT_EQ(secondary_db_options.compaction_readahead_size, 8388608);
-        ASSERT_EQ(secondary_db_options.max_open_files, -1);
+        ASSERT_EQ(secondary_db_options.max_open_files, 100);
         // CFOption
         ASSERT_EQ(secondary_db_options.blob_compaction_readahead_size, 4194304);
         verified = true;


### PR DESCRIPTION
Summary:

__Why__: Allow offload compaction workers to configure  `max_open_files` via `options_map`.

__Problem__: `OpenAndCompact` hard-codes `max_open_files` to -1. This overwrites any value set via the `options_map` and prevents configuration in the remote compaction workers.

__Fix__: Remove the hard-coding assignment.

The value now comes from:
1. OPTIONS file via `LoadOptionsFromFile`
2. `override_options.options_map` via `GetDBOptionsFromMap`

The default value of `max_open_files` was already -1, so existing behavior is preserved.

Differential Revision: D115373592


