### PR TITLE
Fix multi-DB checkpoints in legacy regression test

### DIFF
--- a/tools/regression_test.sh
+++ b/tools/regression_test.sh
@@ -346,12 +346,11 @@ function set_async_io_parameters {
 function build_checkpoint {
     echo "NUM_MULTI_DB=$NUM_MULTI_DB"
     if [ $NUM_MULTI_DB -gt 1 ]; then
+        run_remote "rm -rf $DB_PATH"
         run_remote "mkdir -p $DB_PATH"
-        run_remote "find $ORIGIN_PATH -type d -links 2"
-        dirs=$?
-        for dir in $dirs; do
-            db_index=$(basename $dir)
-            echo "Building checkpoints: $ORIGIN_PATH/$db_index -> $DB_PATH/$db_index ..."
+        for ((db_index = 0; db_index < NUM_MULTI_DB; db_index++)); do
+            run_remote "test -d $ORIGIN_PATH/$db_index"
+            echo "Building checkpoint: $ORIGIN_PATH/$db_index -> $DB_PATH/$db_index ..."
             run_remote "$DB_BENCH_DIR/ldb checkpoint --checkpoint_dir=$DB_PATH/$db_index --db=$ORIGIN_PATH/$db_index --try_load_options 2>&1"
             exit_on_error $?
         done


### PR DESCRIPTION
Summary:
The legacy regression test runner attempted to discover multi-DB origin directories by running find through run_remote, then assigned dirs=$?, which captured only find's exit code. For NUM_MULTI_DB > 1 this meant the checkpoint loop operated on the value 0 instead of the discovered sub-DB directories.

For NUM_MULTI_DB > 1, build checkpoints for the deterministic numeric sub-DB directories 0..NUM_MULTI_DB-1 and explicitly fail if any expected origin DB is missing. This avoids rediscovering DBs through find output, so checkpoint creation no longer depends on pipeline exit status or whitespace-sensitive word splitting.

Differential Revision: D115380183


