### PR TITLE
Add coroutine reads to stackable RocksDB utilities (#15080)

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -59,6 +59,7 @@ cpp_library_wrapper(name="rocksdb_lib", srcs=[
         "db/compaction/sst_partitioner.cc",
         "db/compaction/subcompaction_state.cc",
         "db/convenience.cc",
+        "db/coro_db.cc",
         "db/db_filesnapshot.cc",
         "db/db_impl/compacted_db_impl.cc",
         "db/db_impl/db_impl.cc",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -801,6 +801,7 @@ set(SOURCES
         db/compaction/sst_partitioner.cc
         db/compaction/subcompaction_state.cc
         db/convenience.cc
+        db/coro_db.cc
         db/db_filesnapshot.cc
         db/db_impl/compacted_db_impl.cc
         db/db_impl/db_impl.cc

--- a/db/coro_db.cc
+++ b/db/coro_db.cc
@@ -1,0 +1,160 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// This source code is licensed under both the GPLv2 (found in the
+// COPYING file in the root directory) and Apache 2.0 License
+// (found in the LICENSE.Apache file in the root directory).
+
+#include "rocksdb/rocksdb_namespace.h"
+
+#if USE_COROUTINES
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <vector>
+
+#include "folly/Executor.h"
+#include "folly/coro/Nothrow.h"
+#include "folly/executors/IOExecutor.h"
+#include "folly/io/async/EventBase.h"
+#include "rocksdb/coro_db.h"
+#include "rocksdb/file_system.h"
+#include "table/multiget_context.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+folly::coro::Task<Status> CoroDB::CoGet(DB* db, const ReadOptions& options,
+                                        ColumnFamilyHandle* column_family,
+                                        const Slice& key, PinnableSlice* value,
+                                        std::string* timestamp) {
+  assert(db != nullptr);
+  CoroDB* coro_db = db->GetCoroDB();
+  auto* file_system = db->GetFileSystem();
+  auto* read_executor =
+      file_system == nullptr ? nullptr : file_system->GetReadExecutor();
+  auto* read_event_base =
+      read_executor == nullptr ? nullptr : read_executor->getEventBase();
+
+  Status status;
+  if (coro_db == nullptr || read_event_base == nullptr) {
+    status = db->Get(options, column_family, key, value, timestamp);
+  } else {
+    status = co_await folly::coro::co_nothrow(folly::coro::co_withExecutor(
+        folly::Executor::getKeepAliveToken(read_event_base),
+        coro_db->GetCoroutine(options, column_family, key, value, timestamp)));
+  }
+  co_return status;
+}
+
+folly::coro::Task<Status> CoroDB::CoGet(DB* db, const ReadOptions& options,
+                                        ColumnFamilyHandle* column_family,
+                                        const Slice& key, std::string* value,
+                                        std::string* timestamp) {
+  assert(value != nullptr);
+  PinnableSlice pinnable_value(value);
+  assert(!pinnable_value.IsPinned());
+  Status status = co_await folly::coro::co_nothrow(
+      CoGet(db, options, column_family, key, &pinnable_value, timestamp));
+  if (status.ok() && pinnable_value.IsPinned()) {
+    value->assign(pinnable_value.data(), pinnable_value.size());
+  }
+  co_return status;
+}
+
+folly::coro::Task<Status> CoroDB::CoGet(DB* db, const ReadOptions& options,
+                                        const Slice& key, std::string* value) {
+  assert(db != nullptr);
+  return CoGet(db, options, db->DefaultColumnFamily(), key, value);
+}
+
+folly::coro::Task<Status> CoroDB::CoGet(DB* db, const ReadOptions& options,
+                                        const Slice& key, std::string* value,
+                                        std::string* timestamp) {
+  assert(db != nullptr);
+  return CoGet(db, options, db->DefaultColumnFamily(), key, value, timestamp);
+}
+
+folly::coro::Task<std::vector<Status>> CoroDB::CoMultiGet(
+    DB* db, const ReadOptions& options,
+    const std::vector<ColumnFamilyHandle*>& column_families,
+    const std::vector<Slice>& keys, std::vector<std::string>* values,
+    std::vector<std::string>* timestamps) {
+  const size_t num_keys = keys.size();
+  std::vector<Status> statuses(num_keys);
+  std::vector<PinnableSlice> pinnable_values(num_keys);
+
+  values->resize(num_keys);
+  if (timestamps != nullptr) {
+    timestamps->resize(num_keys);
+  }
+  co_await folly::coro::co_nothrow(CoMultiGet(
+      db, options, num_keys,
+      const_cast<ColumnFamilyHandle**>(column_families.data()), keys.data(),
+      pinnable_values.data(),
+      timestamps == nullptr ? nullptr : timestamps->data(), statuses.data(),
+      /*sorted_input=*/false));
+  for (size_t i = 0; i < num_keys; ++i) {
+    if (statuses[i].ok()) {
+      (*values)[i].assign(pinnable_values[i].data(), pinnable_values[i].size());
+    }
+  }
+  co_return statuses;
+}
+
+folly::coro::Task<std::vector<Status>> CoroDB::CoMultiGet(
+    DB* db, const ReadOptions& options, const std::vector<Slice>& keys,
+    std::vector<std::string>* values, std::vector<std::string>* timestamps) {
+  assert(db != nullptr);
+  std::vector<ColumnFamilyHandle*> column_families(keys.size(),
+                                                   db->DefaultColumnFamily());
+  co_return co_await folly::coro::co_nothrow(
+      CoMultiGet(db, options, column_families, keys, values, timestamps));
+}
+
+folly::coro::Task<void> CoroDB::CoMultiGet(
+    DB* db, const ReadOptions& options, size_t num_keys,
+    ColumnFamilyHandle** column_families, const Slice* keys,
+    PinnableSlice* values, std::string* timestamps, Status* statuses,
+    bool sorted_input) {
+  assert(db != nullptr);
+  CoroDB* coro_db = db->GetCoroDB();
+  auto* file_system = db->GetFileSystem();
+  auto* read_executor =
+      file_system == nullptr ? nullptr : file_system->GetReadExecutor();
+  auto* read_event_base =
+      read_executor == nullptr ? nullptr : read_executor->getEventBase();
+
+  if (coro_db == nullptr || read_event_base == nullptr) {
+    db->MultiGet(options, num_keys, column_families, keys, values, timestamps,
+                 statuses, sorted_input);
+  } else {
+    co_await folly::coro::co_nothrow(folly::coro::co_withExecutor(
+        folly::Executor::getKeepAliveToken(read_event_base),
+        coro_db->MultiGetCoroutine(options, num_keys, column_families, keys,
+                                   values, timestamps, statuses,
+                                   sorted_input)));
+  }
+}
+
+folly::coro::Task<void> CoroDB::CoMultiGet(
+    DB* db, const ReadOptions& options, ColumnFamilyHandle* column_family,
+    size_t num_keys, const Slice* keys, PinnableSlice* values,
+    std::string* timestamps, Status* statuses, bool sorted_input) {
+  if (num_keys > MultiGetContext::MAX_BATCH_SIZE) {
+    std::vector<ColumnFamilyHandle*> column_families(num_keys, column_family);
+    co_await folly::coro::co_nothrow(
+        CoMultiGet(db, options, num_keys, column_families.data(), keys, values,
+                   timestamps, statuses, sorted_input));
+  } else {
+    std::array<ColumnFamilyHandle*, MultiGetContext::MAX_BATCH_SIZE>
+        column_families;
+    std::fill(column_families.begin(), column_families.begin() + num_keys,
+              column_family);
+    co_await folly::coro::co_nothrow(
+        CoMultiGet(db, options, num_keys, column_families.data(), keys, values,
+                   timestamps, statuses, sorted_input));
+  }
+}
+
+}  // namespace ROCKSDB_NAMESPACE
+
+#endif  // USE_COROUTINES

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -4021,7 +4021,7 @@ TEST_P(DBMultiGetAsyncIOTest, GetFromL0) {
   }
 #else   // ROCKSDB_IOURING_PRESENT
   ASSERT_EQ(statistics()->getTickerCount(MULTIGET_COROUTINE_COUNT),
-            use_coroutine_ ? 3 : 0);
+            UseCoroutineRead() ? 3 : 0);
 #endif  // ROCKSDB_IOURING_PRESENT
 }
 
@@ -4049,7 +4049,7 @@ TEST_P(DBMultiGetAsyncIOTest, GetFromL1) {
             UseCoroutineRead() ? 6 : 3);
 #else   // ROCKSDB_IOURING_PRESENT
   ASSERT_EQ(statistics()->getTickerCount(MULTIGET_COROUTINE_COUNT),
-            use_coroutine_ ? 6 : 0);
+            UseCoroutineRead() ? 6 : 0);
 #endif  // ROCKSDB_IOURING_PRESENT
 }
 
@@ -4203,7 +4203,7 @@ TEST_P(DBMultiGetAsyncIOTest, GetFromL2WithRangeOverlapL0L1) {
             UseCoroutineRead() ? 3 : 2);
 #else   // ROCKSDB_IOURING_PRESENT
   ASSERT_EQ(statistics()->getTickerCount(MULTIGET_COROUTINE_COUNT),
-            use_coroutine_ ? 3 : 0);
+            UseCoroutineRead() ? 3 : 0);
 #endif  // ROCKSDB_IOURING_PRESENT
 }
 
@@ -4266,7 +4266,7 @@ TEST_P(DBMultiGetAsyncIOTest, GetNoIOUring) {
   ASSERT_EQ(async_read_bytes.count, 0);
   const uint64_t coroutine_count =
       statistics()->getTickerCount(MULTIGET_COROUTINE_COUNT);
-  if (use_coroutine_) {
+  if (UseCoroutineRead()) {
     ASSERT_GT(coroutine_count, 0);
   } else {
     ASSERT_EQ(coroutine_count, 0);

--- a/db/db_test_util.cc
+++ b/db/db_test_util.cc
@@ -24,14 +24,8 @@
 #include "util/random.h"
 
 #if USE_COROUTINES
-#include <utility>
-
-#include "folly/Executor.h"
 #include "folly/coro/BlockingWait.h"
-#include "folly/coro/Task.h"
-#include "folly/executors/IOExecutor.h"
-#include "folly/io/async/EventBase.h"
-#include "rocksdb/file_system.h"
+#include "rocksdb/coro_db.h"
 #endif  // USE_COROUTINES
 
 namespace ROCKSDB_NAMESPACE {
@@ -42,21 +36,6 @@ int64_t MaybeCurrentTime(Env* env) {
   env->GetCurrentTime(&time).PermitUncheckedError();
   return time;
 }
-
-#if USE_COROUTINES
-template <typename T>
-T BlockingWaitOnReadExecutor(DB* db, folly::coro::Task<T> task) {
-  auto* read_executor = db->GetFileSystem()->GetReadExecutor();
-  if (read_executor == nullptr) {
-    return folly::coro::blockingWait(std::move(task));
-  }
-
-  auto* read_event_base = read_executor->getEventBase();
-  assert(read_event_base != nullptr);
-  return folly::coro::blockingWait(folly::coro::co_withExecutor(
-      folly::Executor::getKeepAliveToken(read_event_base), std::move(task)));
-}
-#endif  // USE_COROUTINES
 
 }  // anonymous namespace
 
@@ -894,11 +873,9 @@ std::string DBTestBase::Get(const std::string& k, const Snapshot* snapshot,
 #if USE_COROUTINES
   if (use_coroutine) {
     PinnableSlice pinnable_value(&result);
-    s = BlockingWaitOnReadExecutor(
-        dbfull(),
-        dbfull()->GetCoroutine(options, dbfull()->DefaultColumnFamily(), k,
-                               &pinnable_value,
-                               /*timestamp=*/nullptr));
+    s = folly::coro::blockingWait(CoroDB::CoGet(
+        dbfull(), options, dbfull()->DefaultColumnFamily(), k, &pinnable_value,
+        /*timestamp=*/nullptr));
     if (s.ok() && pinnable_value.IsPinned()) {
       result.assign(pinnable_value.data(), pinnable_value.size());
     }
@@ -927,10 +904,9 @@ std::string DBTestBase::Get(int cf, const std::string& k,
 #if USE_COROUTINES
   if (use_coroutine) {
     PinnableSlice pinnable_value(&result);
-    s = BlockingWaitOnReadExecutor(
-        dbfull(),
-        dbfull()->GetCoroutine(options, handles_[cf], k, &pinnable_value,
-                               /*timestamp=*/nullptr));
+    s = folly::coro::blockingWait(CoroDB::CoGet(dbfull(), options, handles_[cf],
+                                                k, &pinnable_value,
+                                                /*timestamp=*/nullptr));
     if (s.ok() && pinnable_value.IsPinned()) {
       result.assign(pinnable_value.data(), pinnable_value.size());
     }
@@ -982,11 +958,10 @@ std::vector<std::string> DBTestBase::MultiGet(std::vector<int> cfs,
     s.resize(cfs.size());
 #if USE_COROUTINES
     if (use_coroutine) {
-      BlockingWaitOnReadExecutor(
-          dbfull(), dbfull()->MultiGetCoroutine(
-                        options, cfs.size(), handles.data(), keys.data(),
-                        pin_values.data(), /*timestamps=*/nullptr, s.data(),
-                        /*sorted_input=*/false));
+      folly::coro::blockingWait(CoroDB::CoMultiGet(
+          dbfull(), options, cfs.size(), handles.data(), keys.data(),
+          pin_values.data(), /*timestamps=*/nullptr, s.data(),
+          /*sorted_input=*/false));
     } else
 #else
     (void)use_coroutine;
@@ -1033,12 +1008,10 @@ std::vector<std::string> DBTestBase::MultiGet(const std::vector<std::string>& k,
   if (use_coroutine) {
     std::vector<ColumnFamilyHandle*> cfs(keys.size(),
                                          dbfull()->DefaultColumnFamily());
-    BlockingWaitOnReadExecutor(
-        dbfull(),
-        dbfull()->MultiGetCoroutine(options, keys.size(), cfs.data(),
-                                    keys.data(), pin_values.data(),
-                                    /*timestamps=*/nullptr, statuses.data(),
-                                    /*sorted_input=*/false));
+    folly::coro::blockingWait(CoroDB::CoMultiGet(
+        dbfull(), options, keys.size(), cfs.data(), keys.data(),
+        pin_values.data(), /*timestamps=*/nullptr, statuses.data(),
+        /*sorted_input=*/false));
   } else
 #else
   (void)use_coroutine;
@@ -1068,10 +1041,9 @@ Status DBTestBase::Get(const std::string& k, PinnableSlice* v,
   options.verify_checksums = true;
 #if USE_COROUTINES
   if (use_coroutine) {
-    return BlockingWaitOnReadExecutor(
-        dbfull(),
-        dbfull()->GetCoroutine(options, dbfull()->DefaultColumnFamily(), k, v,
-                               /*timestamp=*/nullptr));
+    return folly::coro::blockingWait(
+        CoroDB::CoGet(dbfull(), options, dbfull()->DefaultColumnFamily(), k, v,
+                      /*timestamp=*/nullptr));
   }
 #else
   (void)use_coroutine;

--- a/include/rocksdb/coro_db.h
+++ b/include/rocksdb/coro_db.h
@@ -8,11 +8,15 @@
 
 #include <cstddef>
 #include <string>
+#include <vector>
 
 #include "folly/coro/Task.h"
 #include "rocksdb/db.h"
 
 namespace ROCKSDB_NAMESPACE {
+
+template <typename Base>
+class CoroStackableDBBase;
 
 // EXPERIMENTAL native coroutine read interface.
 //
@@ -27,38 +31,109 @@ namespace ROCKSDB_NAMESPACE {
 // The returned tasks are lazy: no read begins until a task is awaited or
 // started.
 //
-// IMPORTANT: RocksDB assumes each request runs entirely on one thread. Schedule
-// coroutine reads on the read IOExecutor's EventBase and do not migrate them.
+// CoGet() and CoMultiGet() schedule native coroutine reads on the read
+// IOExecutor's EventBase. They use the synchronous DB API when native
+// coroutine reads or a read executor are unavailable.
 //
 // STATS:
-// Unlike the callback APIs, coroutine stats are returned through TLS. Each task
-// publishes its request-local PerfContext and IOStatsContext to TLS on its
-// execution thread before completing. Read them after the await resumes on the
-// same EventBase. The TLS values are defined only on the thread where the
-// RocksDB operation completes. Consume or copy them immediately after the
-// RocksDB await returns; no coroutine suspension may occur in between:
-//
-//   auto* coro_db = db->GetCoroDB();
-//   auto* read_executor = db->GetFileSystem()->GetReadExecutor();
-//   auto* read_event_base =
-//       read_executor == nullptr ? nullptr : read_executor->getEventBase();
-//   if (coro_db == nullptr || read_event_base == nullptr) {
-//     co_return db->Get(options, column_family, key, value, timestamp);
-//   }
-//
-//   auto read = [&]() -> folly::coro::Task<Status> {
-//     Status status = co_await coro_db->GetCoroutine(
-//         options, column_family, key, value, timestamp);
-//     const PerfContext* perf_context = get_perf_context();
-//     const IOStatsContext* iostats_context = get_iostats_context();
-//     // Consume or copy the stats here, before any further co_await.
-//     co_return status;
-//   };
-//   co_return co_await folly::coro::co_withExecutor(
-//       folly::Executor::getKeepAliveToken(read_event_base), read());
+// GetCoroutine() and MultiGetCoroutine() populate TLS with stats for only that
+// operation. CoGet() and CoMultiGet() can resume their callers on a different
+// thread, so reading TLS after awaiting them is not valid. To consume coroutine
+// stats, override the protected CoroStackableDB hook and copy the TLS values
+// immediately after awaiting the wrapped operation, before suspending again.
 class CoroDB {
  public:
   virtual ~CoroDB() = default;
+
+  static folly::coro::Task<Status> CoGet(DB* db, const ReadOptions& options,
+                                         ColumnFamilyHandle* column_family,
+                                         const Slice& key, PinnableSlice* value,
+                                         std::string* timestamp);
+
+  static folly::coro::Task<Status> CoGet(DB* db, const ReadOptions& options,
+                                         ColumnFamilyHandle* column_family,
+                                         const Slice& key, std::string* value,
+                                         std::string* timestamp);
+
+  static folly::coro::Task<Status> CoGet(DB* db, const ReadOptions& options,
+                                         ColumnFamilyHandle* column_family,
+                                         const Slice& key,
+                                         PinnableSlice* value) {
+    return CoGet(db, options, column_family, key, value,
+                 /*timestamp=*/nullptr);
+  }
+
+  static folly::coro::Task<Status> CoGet(DB* db, const ReadOptions& options,
+                                         ColumnFamilyHandle* column_family,
+                                         const Slice& key, std::string* value) {
+    return CoGet(db, options, column_family, key, value,
+                 /*timestamp=*/nullptr);
+  }
+
+  static folly::coro::Task<Status> CoGet(DB* db, const ReadOptions& options,
+                                         const Slice& key, std::string* value);
+
+  static folly::coro::Task<Status> CoGet(DB* db, const ReadOptions& options,
+                                         const Slice& key, std::string* value,
+                                         std::string* timestamp);
+
+  static folly::coro::Task<std::vector<Status>> CoMultiGet(
+      DB* db, const ReadOptions& options,
+      const std::vector<ColumnFamilyHandle*>& column_families,
+      const std::vector<Slice>& keys, std::vector<std::string>* values,
+      std::vector<std::string>* timestamps);
+
+  static folly::coro::Task<std::vector<Status>> CoMultiGet(
+      DB* db, const ReadOptions& options,
+      const std::vector<ColumnFamilyHandle*>& column_families,
+      const std::vector<Slice>& keys, std::vector<std::string>* values) {
+    return CoMultiGet(db, options, column_families, keys, values,
+                      /*timestamps=*/nullptr);
+  }
+
+  static folly::coro::Task<std::vector<Status>> CoMultiGet(
+      DB* db, const ReadOptions& options, const std::vector<Slice>& keys,
+      std::vector<std::string>* values) {
+    return CoMultiGet(db, options, keys, values, /*timestamps=*/nullptr);
+  }
+
+  static folly::coro::Task<std::vector<Status>> CoMultiGet(
+      DB* db, const ReadOptions& options, const std::vector<Slice>& keys,
+      std::vector<std::string>* values, std::vector<std::string>* timestamps);
+
+  static folly::coro::Task<void> CoMultiGet(
+      DB* db, const ReadOptions& options, size_t num_keys,
+      ColumnFamilyHandle** column_families, const Slice* keys,
+      PinnableSlice* values, std::string* timestamps, Status* statuses,
+      bool sorted_input = false);
+
+  static folly::coro::Task<void> CoMultiGet(
+      DB* db, const ReadOptions& options, ColumnFamilyHandle* column_family,
+      size_t num_keys, const Slice* keys, PinnableSlice* values,
+      std::string* timestamps, Status* statuses, bool sorted_input = false);
+
+  static folly::coro::Task<void> CoMultiGet(DB* db, const ReadOptions& options,
+                                            ColumnFamilyHandle* column_family,
+                                            size_t num_keys, const Slice* keys,
+                                            PinnableSlice* values,
+                                            Status* statuses,
+                                            bool sorted_input = false) {
+    return CoMultiGet(db, options, column_family, num_keys, keys, values,
+                      /*timestamps=*/nullptr, statuses, sorted_input);
+  }
+
+  static folly::coro::Task<void> CoMultiGet(
+      DB* db, const ReadOptions& options, size_t num_keys,
+      ColumnFamilyHandle** column_families, const Slice* keys,
+      PinnableSlice* values, Status* statuses, bool sorted_input = false) {
+    return CoMultiGet(db, options, num_keys, column_families, keys, values,
+                      /*timestamps=*/nullptr, statuses, sorted_input);
+  }
+
+ protected:
+  friend class DB;
+  template <typename Base>
+  friend class CoroStackableDBBase;
 
   // Reads key and completes after populating value and the optional timestamp.
   // The returned Status describes the operation and its outputs.

--- a/include/rocksdb/utilities/coro_stackable_db.h
+++ b/include/rocksdb/utilities/coro_stackable_db.h
@@ -1,0 +1,50 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// This source code is licensed under both the GPLv2 (found in the
+// COPYING file in the root directory) and Apache 2.0 License
+// (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+
+#include <cassert>
+
+#include "rocksdb/coro_db.h"
+#include "rocksdb/utilities/stackable_db.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+// Using this interface requires Folly to be available and RocksDB to be built
+// with USE_COROUTINES=1.
+template <typename Base>
+class CoroStackableDBBase : public Base, public CoroDB {
+ public:
+  using Base::Base;
+  CoroDB* GetCoroDB() override {
+    return this->db_->GetCoroDB() == nullptr ? nullptr : this;
+  }
+
+ protected:
+  folly::coro::Task<Status> GetCoroutine(const ReadOptions& options,
+                                         ColumnFamilyHandle* column_family,
+                                         const Slice& key, PinnableSlice* value,
+                                         std::string* timestamp) override {
+    CoroDB* coro_db = this->db_->GetCoroDB();
+    assert(coro_db != nullptr);
+    return coro_db->GetCoroutine(options, column_family, key, value, timestamp);
+  }
+
+  folly::coro::Task<void> MultiGetCoroutine(
+      const ReadOptions& options, size_t num_keys,
+      ColumnFamilyHandle** column_families, const Slice* keys,
+      PinnableSlice* values, std::string* timestamps, Status* statuses,
+      bool sorted_input) override {
+    CoroDB* coro_db = this->db_->GetCoroDB();
+    assert(coro_db != nullptr);
+    return coro_db->MultiGetCoroutine(options, num_keys, column_families, keys,
+                                      values, timestamps, statuses,
+                                      sorted_input);
+  }
+};
+
+using CoroStackableDB = CoroStackableDBBase<StackableDB>;
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -46,6 +46,10 @@ class StackableDB : public DB {
 
   DB* GetRootDB() override { return db_->GetRootDB(); }
 
+  // Wrappers must explicitly opt in so coroutine reads do not bypass their
+  // synchronous Get() and MultiGet() overrides.
+  CoroDB* GetCoroDB() override { return nullptr; }
+
   Status CreateColumnFamily(const ColumnFamilyOptions& options,
                             const std::string& column_family_name,
                             ColumnFamilyHandle** handle) override {

--- a/src.mk
+++ b/src.mk
@@ -49,6 +49,7 @@ LIB_SOURCES =                                                   \
   db/compaction/sst_partitioner.cc                              \
   db/compaction/subcompaction_state.cc                          \
   db/convenience.cc                                             \
+  db/coro_db.cc                                                 \
   db/db_filesnapshot.cc                                         \
   db/db_impl/compacted_db_impl.cc                               \
   db/db_impl/db_impl.cc                                         \

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -7685,15 +7685,14 @@ class Benchmark {
         cfh = db_with_cfh->db->DefaultColumnFamily();
       }
 
-      CoroDB* coro_db = db_with_cfh->db->GetCoroDB();
-      if (coro_db == nullptr) {
+      if (db_with_cfh->db->GetCoroDB() == nullptr) {
         fprintf(stderr,
                 "readrandomcoroutine requires a DB with native coroutine "
                 "reads\n");
         abort();
       }
-      Status s = co_await folly::coro::co_nothrow(
-          coro_db->GetCoroutine(options, cfh, key, &pinnable_val, ts_ptr));
+      Status s = co_await folly::coro::co_nothrow(CoroDB::CoGet(
+          db_with_cfh->db, options, cfh, key, &pinnable_val, ts_ptr));
       MergeCoroutineJobPerfContext(job_perf_context_ptr);
       ++job_ops;
       if (s.ok()) {
@@ -7719,7 +7718,7 @@ class Benchmark {
   // executor thread while its IO is in flight. Per-job buffers and RNG mean
   // jobs share no mutable state; results are folded into the shared counters.
   folly::coro::Task<void> MultiGetCoroutineJob(
-      CoroDB* coro_db, ColumnFamilyHandle* cfh, uint64_t seed, int64_t ops,
+      DB* db, ColumnFamilyHandle* cfh, uint64_t seed, int64_t ops,
       std::atomic<int64_t>* total_ops, std::atomic<int64_t>* total_found,
       std::atomic<int64_t>* total_bytes, int job_id,
       std::vector<std::string>* job_perf_contexts) {
@@ -7748,9 +7747,10 @@ class Benchmark {
         statuses[i] = Status::OK();
         values[i].Reset();
       }
-      co_await folly::coro::co_nothrow(coro_db->MultiGetCoroutine(
-          options, entries_per_batch_, cfs.data(), keys.data(), values.get(),
-          /*timestamps=*/nullptr, statuses.data(), /*sorted_input=*/false));
+      co_await folly::coro::co_nothrow(CoroDB::CoMultiGet(
+          db, options, entries_per_batch_, cfs.data(), keys.data(),
+          values.get(), /*timestamps=*/nullptr, statuses.data(),
+          /*sorted_input=*/false));
       MergeCoroutineJobPerfContext(job_perf_context_ptr);
       job_ops += entries_per_batch_;
       for (int64_t i = 0; i < entries_per_batch_; ++i) {
@@ -7904,7 +7904,7 @@ class Benchmark {
       futures.push_back(
           folly::coro::co_withExecutor(
               folly::Executor::getKeepAliveToken(read_executor->getEventBase()),
-              MultiGetCoroutineJob(coro_db, cfh, thread->rand.Next(), ops,
+              MultiGetCoroutineJob(db, cfh, thread->rand.Next(), ops,
                                    &total_ops, &total_found, &total_bytes, j,
                                    job_perf_contexts_ptr))
               .start());

--- a/unreleased_history/public_api_changes/stackable_coroutine_reads.md
+++ b/unreleased_history/public_api_changes/stackable_coroutine_reads.md
@@ -1,0 +1,1 @@
+Added `CoroStackableDB` for implementing wrappers over native coroutine reads and used it to add coroutine `Get` and `MultiGet` support to `DBWithTTL` and WritePrepared `TransactionDB`. A stackable wrapper advertises coroutine support only when its wrapped DB supports it; TTL value decoding and transaction visibility semantics are preserved.

--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -35,6 +35,11 @@
 #include "utilities/transactions/transaction_test.h"
 #include "utilities/transactions/write_prepared_txn_db.h"
 
+#if USE_COROUTINES
+#include "folly/coro/BlockingWait.h"
+#include "rocksdb/coro_db.h"
+#endif
+
 using std::string;
 
 namespace ROCKSDB_NAMESPACE {
@@ -724,6 +729,40 @@ INSTANTIATE_TEST_CASE_P(
         OneWriteQueue_SeqAdvanceConcurrentTest_Params)));
 
 #endif  // !defined(ROCKSDB_VALGRIND_RUN) || defined(ROCKSDB_FULL_VALGRIND_RUN)
+
+#if USE_COROUTINES
+TEST_P(WritePreparedTransactionTest, CoroutineReadsDoNotExposeUncommittedData) {
+  ASSERT_OK(db->Put(WriteOptions(), "key", "committed"));
+  std::unique_ptr<Transaction> transaction(
+      db->BeginTransaction(WriteOptions()));
+  ASSERT_NE(nullptr, transaction);
+  ASSERT_OK(transaction->SetName("txn"));
+  ASSERT_OK(transaction->Put("key", "uncommitted"));
+  ASSERT_OK(transaction->Prepare());
+
+  PinnableSlice value;
+  Status status = folly::coro::blockingWait(
+      CoroDB::CoGet(db, ReadOptions(), db->DefaultColumnFamily(), "key", &value,
+                    /*timestamp=*/nullptr));
+
+  ColumnFamilyHandle* column_families[] = {db->DefaultColumnFamily(),
+                                           db->DefaultColumnFamily()};
+  const Slice keys[] = {Slice("key"), Slice("key")};
+  PinnableSlice values[2];
+  Status statuses[2];
+  folly::coro::blockingWait(CoroDB::CoMultiGet(
+      db, ReadOptions(), 2, column_families, keys, values,
+      /*timestamps=*/nullptr, statuses, /*sorted_input=*/false));
+
+  ASSERT_OK(transaction->Rollback());
+  ASSERT_OK(status);
+  ASSERT_EQ("committed", value.ToString());
+  ASSERT_OK(statuses[0]);
+  ASSERT_OK(statuses[1]);
+  ASSERT_EQ("committed", values[0].ToString());
+  ASSERT_EQ("committed", values[1].ToString());
+}
+#endif  // USE_COROUTINES
 
 TEST_P(WritePreparedTransactionTest, CommitMap) {
   WritePreparedTxnDB* wp_db = dynamic_cast<WritePreparedTxnDB*>(db);

--- a/utilities/transactions/write_prepared_txn_db.cc
+++ b/utilities/transactions/write_prepared_txn_db.cc
@@ -246,53 +246,6 @@ Status WritePreparedTxnDB::WriteInternal(const WriteOptions& write_options_orig,
   return s;
 }
 
-Status WritePreparedTxnDB::Get(const ReadOptions& _read_options,
-                               ColumnFamilyHandle* column_family,
-                               const Slice& key, PinnableSlice* value,
-                               std::string* timestamp) {
-  if (_read_options.io_activity != Env::IOActivity::kUnknown &&
-      _read_options.io_activity != Env::IOActivity::kGet) {
-    return Status::InvalidArgument(
-        "Can only call Get with `ReadOptions::io_activity` is "
-        "`Env::IOActivity::kUnknown` or `Env::IOActivity::kGet`");
-  }
-  if (timestamp) {
-    return Status::NotSupported(
-        "Get() that returns timestamp is not implemented");
-  }
-  ReadOptions read_options(_read_options);
-  if (read_options.io_activity == Env::IOActivity::kUnknown) {
-    read_options.io_activity = Env::IOActivity::kGet;
-  }
-
-  return GetImpl(read_options, column_family, key, value);
-}
-
-Status WritePreparedTxnDB::GetImpl(const ReadOptions& options,
-                                   ColumnFamilyHandle* column_family,
-                                   const Slice& key, PinnableSlice* value) {
-  SequenceNumber min_uncommitted, snap_seq;
-  const SnapshotBackup backed_by_snapshot =
-      AssignMinMaxSeqs(options.snapshot, &min_uncommitted, &snap_seq);
-  WritePreparedTxnReadCallback callback(this, snap_seq, min_uncommitted,
-                                        backed_by_snapshot);
-  bool* dont_care = nullptr;
-  DBImpl::GetImplOptions get_impl_options;
-  get_impl_options.column_family = column_family;
-  get_impl_options.value = value;
-  get_impl_options.value_found = dont_care;
-  get_impl_options.callback = &callback;
-  auto res = db_impl_->GetImpl(options, key, get_impl_options);
-  if (LIKELY(callback.valid() && ValidateSnapshot(callback.max_visible_seq(),
-                                                  backed_by_snapshot))) {
-    return res;
-  } else {
-    res.PermitUncheckedError();
-    WPRecordTick(TXN_GET_TRY_AGAIN);
-    return Status::TryAgain();
-  }
-}
-
 void WritePreparedTxnDB::UpdateCFComparatorMap(
     const std::vector<ColumnFamilyHandle*>& handles) {
   auto cf_map = new std::map<uint32_t, const Comparator*>();
@@ -327,47 +280,6 @@ void WritePreparedTxnDB::UpdateCFComparatorMap(ColumnFamilyHandle* h) {
   (*handle_map)[id] = h;
   cf_map_.reset(cf_map);
   handle_map_.reset(handle_map);
-}
-
-void WritePreparedTxnDB::MultiGet(const ReadOptions& _read_options,
-                                  const size_t num_keys,
-                                  ColumnFamilyHandle** column_families,
-                                  const Slice* keys, PinnableSlice* values,
-                                  std::string* timestamps, Status* statuses,
-                                  const bool /*sorted_input*/) {
-  assert(values);
-
-  Status s;
-  if (_read_options.io_activity != Env::IOActivity::kUnknown &&
-      _read_options.io_activity != Env::IOActivity::kMultiGet) {
-    s = Status::InvalidArgument(
-        "Can only call MultiGet with `ReadOptions::io_activity` is "
-        "`Env::IOActivity::kUnknown` or `Env::IOActivity::kMultiGet`");
-  }
-
-  if (s.ok()) {
-    if (timestamps) {
-      s = Status::NotSupported(
-          "MultiGet() returning timestamps not implemented.");
-    }
-  }
-
-  if (!s.ok()) {
-    for (size_t i = 0; i < num_keys; ++i) {
-      statuses[i] = s;
-    }
-    return;
-  }
-
-  ReadOptions read_options(_read_options);
-  if (read_options.io_activity == Env::IOActivity::kUnknown) {
-    read_options.io_activity = Env::IOActivity::kMultiGet;
-  }
-
-  for (size_t i = 0; i < num_keys; ++i) {
-    statuses[i] =
-        this->GetImpl(read_options, column_families[i], keys[i], &values[i]);
-  }
 }
 
 // Struct to hold ownership of snapshot and read callback for iterator cleanup.
@@ -1097,3 +1009,12 @@ void SubBatchCounter::AddKey(const uint32_t cf, const Slice& key) {
 }
 
 }  // namespace ROCKSDB_NAMESPACE
+
+// clang-format off
+#define WITHOUT_COROUTINES
+#include "utilities/transactions/write_prepared_txn_db_sync_and_async.h"
+#undef WITHOUT_COROUTINES
+#define WITH_COROUTINES
+#include "utilities/transactions/write_prepared_txn_db_sync_and_async.h"
+#undef WITH_COROUTINES
+// clang-format on

--- a/utilities/transactions/write_prepared_txn_db.h
+++ b/utilities/transactions/write_prepared_txn_db.h
@@ -23,23 +23,34 @@
 #include "rocksdb/options.h"
 #include "rocksdb/utilities/transaction_db.h"
 #include "util/cast_util.h"
+#include "util/coro_utils.h"
 #include "util/set_comparator.h"
 #include "util/string_util.h"
 #include "utilities/transactions/pessimistic_transaction.h"
 #include "utilities/transactions/pessimistic_transaction_db.h"
 #include "utilities/transactions/write_prepared_txn.h"
 
+#if USE_COROUTINES
+#include "rocksdb/utilities/coro_stackable_db.h"
+#endif
+
 namespace ROCKSDB_NAMESPACE {
 enum SnapshotBackup : bool { kUnbackedByDBSnapshot, kBackedByDBSnapshot };
+
+#if USE_COROUTINES
+using WritePreparedTxnDBBase = CoroStackableDBBase<PessimisticTransactionDB>;
+#else
+using WritePreparedTxnDBBase = PessimisticTransactionDB;
+#endif
 
 // A PessimisticTransactionDB that writes data to DB after prepare phase of 2PC.
 // In this way some data in the DB might not be committed. The DB provides
 // mechanisms to tell such data apart from committed data.
-class WritePreparedTxnDB : public PessimisticTransactionDB {
+class WritePreparedTxnDB : public WritePreparedTxnDBBase {
  public:
   explicit WritePreparedTxnDB(DB* db,
                               const TransactionDBOptions& txn_db_options)
-      : PessimisticTransactionDB(db, txn_db_options),
+      : WritePreparedTxnDBBase(db, txn_db_options),
         SNAPSHOT_CACHE_BITS(txn_db_options.wp_snapshot_cache_bits),
         SNAPSHOT_CACHE_SIZE(static_cast<size_t>(1ull << SNAPSHOT_CACHE_BITS)),
         COMMIT_CACHE_BITS(txn_db_options.wp_commit_cache_bits),
@@ -50,7 +61,7 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
 
   explicit WritePreparedTxnDB(StackableDB* db,
                               const TransactionDBOptions& txn_db_options)
-      : PessimisticTransactionDB(db, txn_db_options),
+      : WritePreparedTxnDBBase(db, txn_db_options),
         SNAPSHOT_CACHE_BITS(txn_db_options.wp_snapshot_cache_bits),
         SNAPSHOT_CACHE_SIZE(static_cast<size_t>(1ull << SNAPSHOT_CACHE_BITS)),
         COMMIT_CACHE_BITS(txn_db_options.wp_commit_cache_bits),
@@ -83,15 +94,21 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
                        size_t batch_cnt, WritePreparedTxn* txn);
 
   using DB::Get;
-  Status Get(const ReadOptions& _read_options,
-             ColumnFamilyHandle* column_family, const Slice& key,
-             PinnableSlice* value, std::string* timestamp) override;
+  DECLARE_SYNC_AND_ASYNC_OVERRIDE(Status, Get, const ReadOptions& _read_options,
+                                  ColumnFamilyHandle* column_family,
+                                  const Slice& key, PinnableSlice* value,
+                                  std::string* timestamp);
+  using DB::GetAsync;
 
   using DB::MultiGet;
-  void MultiGet(const ReadOptions& _read_options, const size_t num_keys,
-                ColumnFamilyHandle** column_families, const Slice* keys,
-                PinnableSlice* values, std::string* timestamps,
-                Status* statuses, const bool sorted_input) override;
+  DECLARE_SYNC_AND_ASYNC_OVERRIDE(void, MultiGet,
+                                  const ReadOptions& _read_options,
+                                  const size_t num_keys,
+                                  ColumnFamilyHandle** column_families,
+                                  const Slice* keys, PinnableSlice* values,
+                                  std::string* timestamps, Status* statuses,
+                                  const bool sorted_input);
+  using DB::MultiGetAsync;
 
   using DB::NewIterator;
   Iterator* NewIterator(const ReadOptions& _read_options,
@@ -545,8 +562,9 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
     return s;
   }
 
-  Status GetImpl(const ReadOptions& options, ColumnFamilyHandle* column_family,
-                 const Slice& key, PinnableSlice* value);
+  DECLARE_SYNC_AND_ASYNC(Status, GetImpl, const ReadOptions& options,
+                         ColumnFamilyHandle* column_family, const Slice& key,
+                         PinnableSlice* value);
 
   // A heap with the amortized O(1) complexity for erase. It uses one extra heap
   // to keep track of erased entries that are not yet on top of the main heap.

--- a/utilities/transactions/write_prepared_txn_db_sync_and_async.h
+++ b/utilities/transactions/write_prepared_txn_db_sync_and_async.h
@@ -1,0 +1,109 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include "util/coro_utils.h"
+
+#if defined(USE_COROUTINES) && defined(WITH_COROUTINES)
+#include "util/coro_stats_util.h"
+#endif  // USE_COROUTINES && WITH_COROUTINES
+
+#if defined(WITHOUT_COROUTINES) || (USE_COROUTINES && defined(WITH_COROUTINES))
+
+namespace ROCKSDB_NAMESPACE {
+
+DEFINE_SYNC_AND_ASYNC(Status, WritePreparedTxnDB::Get)
+(const ReadOptions& _read_options, ColumnFamilyHandle* column_family,
+ const Slice& key, PinnableSlice* value, std::string* timestamp) {
+#ifdef WITH_COROUTINES
+  INSTALL_COROUTINE_STATS_CONTEXT_SCOPE(
+      db_impl_->GetFileSystem()->GetReadExecutor(), db_impl_->GetEnv());
+#endif
+  if (_read_options.io_activity != Env::IOActivity::kUnknown &&
+      _read_options.io_activity != Env::IOActivity::kGet) {
+    CO_RETURN Status::InvalidArgument(
+        "Can only call Get with `ReadOptions::io_activity` is "
+        "`Env::IOActivity::kUnknown` or `Env::IOActivity::kGet`");
+  }
+  if (timestamp) {
+    CO_RETURN Status::NotSupported(
+        "Get() that returns timestamp is not implemented");
+  }
+  ReadOptions read_options(_read_options);
+  if (read_options.io_activity == Env::IOActivity::kUnknown) {
+    read_options.io_activity = Env::IOActivity::kGet;
+  }
+
+  CO_RETURN CO_AWAIT(GetImpl, read_options, column_family, key, value);
+}
+
+DEFINE_SYNC_AND_ASYNC(Status, WritePreparedTxnDB::GetImpl)
+(const ReadOptions& options, ColumnFamilyHandle* column_family,
+ const Slice& key, PinnableSlice* value) {
+  SequenceNumber min_uncommitted, snap_seq;
+  const SnapshotBackup backed_by_snapshot =
+      AssignMinMaxSeqs(options.snapshot, &min_uncommitted, &snap_seq);
+  WritePreparedTxnReadCallback callback(this, snap_seq, min_uncommitted,
+                                        backed_by_snapshot);
+  bool* dont_care = nullptr;
+  DBImpl::GetImplOptions get_impl_options;
+  get_impl_options.column_family = column_family;
+  get_impl_options.value = value;
+  get_impl_options.value_found = dont_care;
+  get_impl_options.callback = &callback;
+  Status res = CO_AWAIT(db_impl_->GetImpl, options, key, get_impl_options);
+  if (LIKELY(callback.valid() && ValidateSnapshot(callback.max_visible_seq(),
+                                                  backed_by_snapshot))) {
+    CO_RETURN res;
+  }
+
+  res.PermitUncheckedError();
+  WPRecordTick(TXN_GET_TRY_AGAIN);
+  CO_RETURN Status::TryAgain();
+}
+
+DEFINE_SYNC_AND_ASYNC(void, WritePreparedTxnDB::MultiGet)
+(const ReadOptions& _read_options, const size_t num_keys,
+ ColumnFamilyHandle** column_families, const Slice* keys, PinnableSlice* values,
+ std::string* timestamps, Status* statuses, const bool /*sorted_input*/) {
+#ifdef WITH_COROUTINES
+  INSTALL_COROUTINE_STATS_CONTEXT_SCOPE(
+      db_impl_->GetFileSystem()->GetReadExecutor(), db_impl_->GetEnv());
+#endif
+  assert(values);
+
+  Status status;
+  if (_read_options.io_activity != Env::IOActivity::kUnknown &&
+      _read_options.io_activity != Env::IOActivity::kMultiGet) {
+    status = Status::InvalidArgument(
+        "Can only call MultiGet with `ReadOptions::io_activity` is "
+        "`Env::IOActivity::kUnknown` or `Env::IOActivity::kMultiGet`");
+  }
+
+  if (status.ok() && timestamps) {
+    status = Status::NotSupported(
+        "MultiGet() returning timestamps not implemented.");
+  }
+
+  if (!status.ok()) {
+    for (size_t i = 0; i < num_keys; ++i) {
+      statuses[i] = status;
+    }
+    CO_RETURN;
+  }
+
+  ReadOptions read_options(_read_options);
+  if (read_options.io_activity == Env::IOActivity::kUnknown) {
+    read_options.io_activity = Env::IOActivity::kMultiGet;
+  }
+
+  for (size_t i = 0; i < num_keys; ++i) {
+    statuses[i] = CO_AWAIT(GetImpl, read_options, column_families[i], keys[i],
+                           &values[i]);
+  }
+}
+
+}  // namespace ROCKSDB_NAMESPACE
+
+#endif  // WITHOUT_COROUTINES || (USE_COROUTINES && WITH_COROUTINES)

--- a/utilities/ttl/db_ttl_impl.cc
+++ b/utilities/ttl/db_ttl_impl.cc
@@ -5,6 +5,9 @@
 
 #include "utilities/ttl/db_ttl_impl.h"
 
+#include <memory>
+#include <utility>
+
 #include "db/write_batch_internal.h"
 #include "file/filename.h"
 #include "logging/logging.h"
@@ -18,6 +21,32 @@
 #include "util/coding.h"
 
 namespace ROCKSDB_NAMESPACE {
+
+namespace {
+
+Status CheckAndStripTimestamp(PinnableSlice* value) {
+  Status status = DBWithTTLImpl::SanityCheckTimestamp(*value);
+  if (status.ok()) {
+    status = DBWithTTLImpl::StripTS(value);
+  }
+  return status;
+}
+
+void ProcessMultiGetResults(size_t num_keys, PinnableSlice* values,
+                            Status* statuses) {
+  for (size_t i = 0; i < num_keys; ++i) {
+    if (!statuses[i].ok()) {
+      continue;
+    }
+    PinnableSlice tmp_val = std::move(values[i]);
+    values[i].PinSelf(tmp_val);
+    assert(!values[i].IsPinned());
+    statuses[i] = CheckAndStripTimestamp(&values[i]);
+  }
+}
+
+}  // namespace
+
 static std::unordered_map<std::string, OptionTypeInfo> ttl_merge_op_type_info =
     {{"user_operator", OptionTypeInfo::AsCustomSharedPtr<MergeOperator>(
                            0, OptionVerificationType::kByNameAllowNull,
@@ -306,7 +335,7 @@ int RegisterTtlObjects(ObjectLibrary& library, const std::string& /*arg*/) {
 }
 // Open the db inside DBWithTTLImpl because options needs pointer to its ttl
 DBWithTTLImpl::DBWithTTLImpl(std::unique_ptr<DB>&& db)
-    : DBWithTTL(std::move(db)), closed_(false) {}
+    : DBWithTTLImplBase(std::move(db)), closed_(false) {}
 
 DBWithTTLImpl::~DBWithTTLImpl() {
   if (!closed_) {
@@ -490,54 +519,6 @@ Status DBWithTTLImpl::Put(const WriteOptions& options,
   return st;
 }
 
-Status DBWithTTLImpl::Get(const ReadOptions& options,
-                          ColumnFamilyHandle* column_family, const Slice& key,
-                          PinnableSlice* value, std::string* timestamp) {
-  if (timestamp) {
-    return Status::NotSupported(
-        "Get() that returns timestamp is not supported");
-  }
-  Status st = db_->Get(options, column_family, key, value);
-  if (!st.ok()) {
-    return st;
-  }
-  st = SanityCheckTimestamp(*value);
-  if (!st.ok()) {
-    return st;
-  }
-  return StripTS(value);
-}
-
-void DBWithTTLImpl::MultiGet(const ReadOptions& options, const size_t num_keys,
-                             ColumnFamilyHandle** column_families,
-                             const Slice* keys, PinnableSlice* values,
-                             std::string* timestamps, Status* statuses,
-                             const bool /*sorted_input*/) {
-  if (timestamps) {
-    for (size_t i = 0; i < num_keys; ++i) {
-      statuses[i] = Status::NotSupported(
-          "MultiGet() returning timestamps not implemented.");
-    }
-    return;
-  }
-
-  db_->MultiGet(options, num_keys, column_families, keys, values, timestamps,
-                statuses);
-  for (size_t i = 0; i < num_keys; ++i) {
-    if (!statuses[i].ok()) {
-      continue;
-    }
-    PinnableSlice tmp_val = std::move(values[i]);
-    values[i].PinSelf(tmp_val);
-    assert(!values[i].IsPinned());
-    statuses[i] = SanityCheckTimestamp(values[i]);
-    if (!statuses[i].ok()) {
-      continue;
-    }
-    statuses[i] = StripTS(&values[i]);
-  }
-}
-
 bool DBWithTTLImpl::KeyMayExist(const ReadOptions& options,
                                 ColumnFamilyHandle* column_family,
                                 const Slice& key, std::string* value,
@@ -655,3 +636,12 @@ Status DBWithTTLImpl::GetTtl(ColumnFamilyHandle* h, int32_t* ttl) {
 }
 
 }  // namespace ROCKSDB_NAMESPACE
+
+// clang-format off
+#define WITHOUT_COROUTINES
+#include "utilities/ttl/db_ttl_impl_sync_and_async.h"
+#undef WITHOUT_COROUTINES
+#define WITH_COROUTINES
+#include "utilities/ttl/db_ttl_impl_sync_and_async.h"
+#undef WITH_COROUTINES
+// clang-format on

--- a/utilities/ttl/db_ttl_impl.h
+++ b/utilities/ttl/db_ttl_impl.h
@@ -17,6 +17,10 @@
 #include "rocksdb/utilities/db_ttl.h"
 #include "utilities/compaction_filters/layered_compaction_filter_base.h"
 
+#if USE_COROUTINES
+#include "rocksdb/utilities/coro_stackable_db.h"
+#endif
+
 #ifdef _WIN32
 // Windows API macro interference
 #undef GetCurrentTime
@@ -26,7 +30,12 @@ namespace ROCKSDB_NAMESPACE {
 struct ConfigOptions;
 class ObjectLibrary;
 class ObjectRegistry;
-class DBWithTTLImpl : public DBWithTTL {
+#if USE_COROUTINES
+using DBWithTTLImplBase = CoroStackableDBBase<DBWithTTL>;
+#else
+using DBWithTTLImplBase = DBWithTTL;
+#endif
+class DBWithTTLImpl : public DBWithTTLImplBase {
  public:
   static void SanitizeOptions(int32_t ttl, ColumnFamilyOptions* options,
                               SystemClock* clock);
@@ -52,15 +61,18 @@ class DBWithTTLImpl : public DBWithTTL {
              const Slice& key, const Slice& val) override;
 
   using StackableDB::Get;
-  Status Get(const ReadOptions& options, ColumnFamilyHandle* column_family,
-             const Slice& key, PinnableSlice* value,
-             std::string* timestamp) override;
+  DECLARE_SYNC_AND_ASYNC_OVERRIDE(Status, Get, const ReadOptions& options,
+                                  ColumnFamilyHandle* column_family,
+                                  const Slice& key, PinnableSlice* value,
+                                  std::string* timestamp);
 
   using StackableDB::MultiGet;
-  void MultiGet(const ReadOptions& options, const size_t num_keys,
-                ColumnFamilyHandle** column_families, const Slice* keys,
-                PinnableSlice* values, std::string* timestamps,
-                Status* statuses, const bool sorted_input) override;
+  DECLARE_SYNC_AND_ASYNC_OVERRIDE(void, MultiGet, const ReadOptions& options,
+                                  const size_t num_keys,
+                                  ColumnFamilyHandle** column_families,
+                                  const Slice* keys, PinnableSlice* values,
+                                  std::string* timestamps, Status* statuses,
+                                  const bool sorted_input);
 
   using StackableDB::KeyMayExist;
   bool KeyMayExist(const ReadOptions& options,

--- a/utilities/ttl/db_ttl_impl_sync_and_async.h
+++ b/utilities/ttl/db_ttl_impl_sync_and_async.h
@@ -1,0 +1,47 @@
+// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+
+#include "util/coro_utils.h"
+
+#if defined(WITHOUT_COROUTINES) || (USE_COROUTINES && defined(WITH_COROUTINES))
+
+namespace ROCKSDB_NAMESPACE {
+
+DEFINE_SYNC_AND_ASYNC(Status, DBWithTTLImpl::Get)
+(const ReadOptions& options, ColumnFamilyHandle* column_family,
+ const Slice& key, PinnableSlice* value, std::string* timestamp) {
+  if (timestamp) {
+    CO_RETURN Status::NotSupported(
+        "Get() that returns timestamp is not supported");
+  }
+
+  Status status = CO_AWAIT(DBWithTTLImplBase::Get, options, column_family, key,
+                           value, /*timestamp=*/nullptr);
+  if (!status.ok()) {
+    CO_RETURN status;
+  }
+  CO_RETURN CheckAndStripTimestamp(value);
+}
+
+DEFINE_SYNC_AND_ASYNC(void, DBWithTTLImpl::MultiGet)
+(const ReadOptions& options, const size_t num_keys,
+ ColumnFamilyHandle** column_families, const Slice* keys, PinnableSlice* values,
+ std::string* timestamps, Status* statuses, const bool sorted_input) {
+  if (timestamps) {
+    for (size_t i = 0; i < num_keys; ++i) {
+      statuses[i] = Status::NotSupported(
+          "MultiGet() returning timestamps not implemented.");
+    }
+    CO_RETURN;
+  }
+
+  CO_AWAIT(DBWithTTLImplBase::MultiGet, options, num_keys, column_families,
+           keys, values, /*timestamps=*/nullptr, statuses, sorted_input);
+  ProcessMultiGetResults(num_keys, values, statuses);
+}
+
+}  // namespace ROCKSDB_NAMESPACE
+
+#endif  // WITHOUT_COROUTINES || (USE_COROUTINES && WITH_COROUTINES)

--- a/utilities/ttl/ttl_test.cc
+++ b/utilities/ttl/ttl_test.cc
@@ -19,6 +19,11 @@
 #include <unistd.h>
 #endif
 
+#if USE_COROUTINES
+#include "folly/coro/BlockingWait.h"
+#include "rocksdb/coro_db.h"
+#endif
+
 namespace ROCKSDB_NAMESPACE {
 
 namespace {
@@ -411,6 +416,56 @@ class TtlTest : public testing::Test {
   const std::string kNewValue_ = "new_value";
   std::unique_ptr<CompactionFilter> test_comp_filter_;
 };  // class TtlTest
+
+#if USE_COROUTINES
+TEST_F(TtlTest, GetCoroutine) {
+  options_.env = Env::Default();
+  OpenTtl();
+  ASSERT_OK(db_ttl_->Put(WriteOptions(), "key", "value"));
+
+  PinnableSlice value;
+  CoroDB* coro_db = db_ttl_->GetCoroDB();
+  ASSERT_NE(nullptr, coro_db);
+  std::string timestamp;
+  ASSERT_TRUE(
+      folly::coro::blockingWait(CoroDB::CoGet(db_ttl_, ReadOptions(),
+                                              db_ttl_->DefaultColumnFamily(),
+                                              "key", &value, &timestamp))
+          .IsNotSupported());
+
+  Status status = folly::coro::blockingWait(CoroDB::CoGet(
+      db_ttl_, ReadOptions(), db_ttl_->DefaultColumnFamily(), "key", &value,
+      /*timestamp=*/nullptr));
+
+  ASSERT_OK(status);
+  ASSERT_EQ("value", value.ToString());
+}
+
+TEST_F(TtlTest, MultiGetCoroutine) {
+  options_.env = Env::Default();
+  OpenTtl();
+  ASSERT_OK(db_ttl_->Put(WriteOptions(), "key", "value"));
+
+  ColumnFamilyHandle* column_families[] = {db_ttl_->DefaultColumnFamily()};
+  const Slice keys[] = {Slice("key")};
+  PinnableSlice values[1];
+  Status statuses[1];
+  CoroDB* coro_db = db_ttl_->GetCoroDB();
+  ASSERT_NE(nullptr, coro_db);
+  std::string timestamps[1];
+  folly::coro::blockingWait(
+      CoroDB::CoMultiGet(db_ttl_, ReadOptions(), 1, column_families, keys,
+                         values, timestamps, statuses, /*sorted_input=*/false));
+  ASSERT_TRUE(statuses[0].IsNotSupported());
+
+  folly::coro::blockingWait(CoroDB::CoMultiGet(
+      db_ttl_, ReadOptions(), 1, column_families, keys, values,
+      /*timestamps=*/nullptr, statuses, /*sorted_input=*/false));
+
+  ASSERT_OK(statuses[0]);
+  ASSERT_EQ("value", values[0].ToString());
+}
+#endif  // USE_COROUTINES
 
 // If TTL is non positive or not provided, the behaviour is TTL = infinity
 // This test opens the db 3 times with such default behavior and inserts a


### PR DESCRIPTION
Summary:
## Summary


Introduce reusable `CoroStackableDBBase` forwarding and public `CoroDB::CoGet()` / `CoMultiGet()` entry points matching the `DB::Get()` / `MultiGet()` overloads. These helpers schedule native coroutine reads on the read executor and use the synchronous DB API when coroutine support or a read executor is unavailable.

Use the stackable coroutine hooks for TTL and WritePrepared transaction reads. TTL preserves expiration decoding and timestamp behavior, while WritePrepared preserves transaction visibility.

TTL keeps a single `DB` inheritance path while adding `CoroDB`:

```
DBWithTTLImpl
`-- CoroStackableDBBase<DBWithTTL>
    |-- DBWithTTL -> StackableDB -> DB
    `-- CoroDB
```

`CoroDB::CoGet()` dispatches through the stackable coroutine hook and schedules the operation on the read EventBase. `CoMultiGet()` follows the same path:

```
CoroDB::CoGet(db, ...)
|-- db->GetCoroDB() -> DBWithTTLImpl
|-- no CoroDB or read executor -> db->Get()
`-- schedule on read EventBase
    `-- virtual CoroDB::GetCoroutine()
        `-- DBWithTTLImpl::GetCoroutine()
            |-- CoroStackableDBBase<DBWithTTL>::GetCoroutine()
            |   `-- wrapped CoroDB::GetCoroutine()
            `-- strip TTL timestamp
```

Reviewed By: xingbowang

Differential Revision: D115232510


