### PR TITLE
Fix MSVC C4702 in trie index factory

### DIFF
--- a/utilities/trie_index/trie_index_factory.h
+++ b/utilities/trie_index/trie_index_factory.h
@@ -298,12 +298,10 @@ class TrieIndexFactory : public UserDefinedIndexFactory {
   // builds) to surface programming errors immediately.
   UserDefinedIndexBuilder* NewBuilder() const override {
     abort();
-    return nullptr;
   }
   std::unique_ptr<UserDefinedIndexReader> NewReader(
       Slice& /*index_block*/) const override {
     abort();
-    return nullptr;
   }
 
   // New API with comparator.


### PR DESCRIPTION
## Summary

- Remove unreachable returns after unconditional `abort()` calls in the deprecated `TrieIndexFactory` overloads.
- Keep warnings-as-errors builds working with MSVC.

## Motivation

MSVC 19.44 diagnoses the returns as C4702 (unreachable code). With `/WX`, this prevents RocksDB 11.8.1 from building on Windows. The failing build is visible at https://github.com/conda-forge/rocksdb-feedstock/actions/runs/31295649691/job/93200203871.

`abort()` is non-returning, so deleting the returns does not change runtime behavior.

## Related work

PR #14963 removes these deprecated overloads as part of the broader `IndexFactory` migration. That PR is still open and currently conflicts with `main`; this PR is the minimal standalone fix for current `main` and the 11.8.x source, and can land independently of the larger refactor.

## Test plan

- `make check-sources`
- `AUTO_CLEAN=1 make -j16 utilities/trie_index/trie_index_factory.o`
- Windows package build with `/WX` (passes): https://github.com/conda-forge/rocksdb-feedstock/actions/runs/31420671001/job/93560346459