### PR TITLE
Fix CompactedDBImpl blob values unreadable via read-only Get/MultiGet

### DIFF
--- a/db/blob/db_blob_basic_test.cc
+++ b/db/blob/db_blob_basic_test.cc
@@ -63,6 +63,42 @@ TEST_F(DBBlobBasicTest, GetBlob) {
                   .IsIncomplete());
 }
 
+// Regression test for a bug where a read-only DB opened against a fully
+// compacted blob DB (i.e. one that qualifies for the CompactedDBImpl fast
+// path: max_open_files == -1 and at most a single file per level) could not
+// retrieve blob values at all. CompactedDBImpl::Get/MultiGet passed a null
+// is_blob_index pointer into GetContext, so any key resolving to a blob
+// index immediately hit GetContext::kUnexpectedBlobIndex and was reported
+// as NotFound, even though the key/blob file were both present.
+TEST_F(DBBlobBasicTest, GetBlobReadOnlyFullyCompacted) {
+  Options options = GetDefaultOptions();
+  options.enable_blob_files = true;
+  options.min_blob_size = 0;
+  // CompactedDBImpl::Open requires max_open_files == -1; the DBTestBase
+  // default (5000) would skip the fast path this test targets.
+  options.max_open_files = -1;
+
+  Reopen(options);
+
+  constexpr char key1[] = "key1";
+  constexpr char blob_value1[] = "blob_value1";
+  constexpr char key2[] = "key2";
+  constexpr char blob_value2[] = "blob_value2";
+
+  ASSERT_OK(Put(key1, blob_value1));
+  ASSERT_OK(Put(key2, blob_value2));
+  ASSERT_OK(Flush());
+
+  ASSERT_OK(ReadOnlyReopen(options));
+
+  ASSERT_EQ(Get(key1), blob_value1);
+
+  auto values = MultiGet({key1, key2});
+  ASSERT_EQ(values.size(), 2);
+  ASSERT_EQ(values[0], blob_value1);
+  ASSERT_EQ(values[1], blob_value2);
+}
+
 TEST_F(DBBlobBasicTest, EmptyValueNotStoredAsBlob) {
   // Regression test for crash when empty blob value is evicted to
   // CompressedSecondaryCache (T261142690). Empty values should always be

--- a/db/db_impl/compacted_db_impl_sync_and_async.h
+++ b/db/db_impl/compacted_db_impl_sync_and_async.h
@@ -57,12 +57,12 @@ DEFINE_SYNC_AND_ASYNC(Status, CompactedDBImpl::Get)
   std::string* ts =
       user_comparator_->timestamp_size() > 0 ? timestamp : nullptr;
   LookupKey lkey(key, kMaxSequenceNumber, read_options.timestamp);
+  bool is_blob_index = false;
   GetContext get_context(user_comparator_, nullptr, nullptr, nullptr,
                          GetContext::kNotFound, lkey.user_key(), value,
                          /*columns=*/nullptr, ts, nullptr, nullptr, true,
                          nullptr, nullptr, nullptr, nullptr, &read_cb,
-                         nullptr /* is_blob_index */, 0 /* tracing_get_id */,
-                         &blob_fetcher);
+                         &is_blob_index, 0 /* tracing_get_id */, &blob_fetcher);
 
   const FdWithKeyRange& f = files_.files[FindFile(lkey.user_key())];
   if (user_comparator_->CompareWithoutTimestamp(
@@ -92,6 +92,19 @@ DEFINE_SYNC_AND_ASYNC(Status, CompactedDBImpl::Get)
     CO_RETURN s;
   }
   if (get_context.State() == GetContext::kFound) {
+    if (is_blob_index) {
+      // The TableReader above only decoded the blob reference into *value;
+      // resolve it to the actual blob content, mirroring Version::Get.
+      constexpr FilePrefetchBuffer* prefetch_buffer = nullptr;
+      constexpr uint64_t* bytes_read = nullptr;
+      PinnableSlice blob_value;
+      s = blob_fetcher.FetchBlob(get_context.ukey_to_get_blob_value(), *value,
+                                 prefetch_buffer, &blob_value, bytes_read);
+      if (!s.ok()) {
+        CO_RETURN s;
+      }
+      *value = std::move(blob_value);
+    }
     CO_RETURN Status::OK();
   }
   CO_RETURN Status::NotFound();
@@ -162,12 +175,13 @@ DEFINE_SYNC_AND_ASYNC(void, CompactedDBImpl::MultiGet)
 
     PinnableSlice& pinnable_val = values[i];
     std::string* timestamp = timestamps ? &timestamps[i] : nullptr;
+    bool is_blob_index = false;
     GetContext get_context(
         user_comparator_, nullptr, nullptr, nullptr, GetContext::kNotFound,
         lkey.user_key(), &pinnable_val, /*columns=*/nullptr,
         user_comparator_->timestamp_size() > 0 ? timestamp : nullptr, nullptr,
         nullptr, true, nullptr, nullptr, nullptr, nullptr, &read_cb,
-        nullptr /* is_blob_index */, 0 /* tracing_get_id */, &blob_fetcher);
+        &is_blob_index, 0 /* tracing_get_id */, &blob_fetcher);
     TableReader* t = nullptr;
     TableCache::TypedHandle* handle = nullptr;
     Status status = cfd_->table_cache()->FindTable(
@@ -187,7 +201,22 @@ DEFINE_SYNC_AND_ASYNC(void, CompactedDBImpl::MultiGet)
     if (!status.ok() && !status.IsNotFound()) {
       statuses[i] = status;
     } else if (get_context.State() == GetContext::kFound) {
-      statuses[i] = Status::OK();
+      if (is_blob_index) {
+        // The TableReader above only decoded the blob reference into
+        // pinnable_val; resolve it to the actual blob content, mirroring
+        // Version::Get.
+        constexpr FilePrefetchBuffer* prefetch_buffer = nullptr;
+        constexpr uint64_t* bytes_read = nullptr;
+        PinnableSlice blob_value;
+        statuses[i] =
+            blob_fetcher.FetchBlob(lkey.user_key(), pinnable_val,
+                                   prefetch_buffer, &blob_value, bytes_read);
+        if (statuses[i].ok()) {
+          pinnable_val = std::move(blob_value);
+        }
+      } else {
+        statuses[i] = Status::OK();
+      }
     } else {
       statuses[i] = Status::NotFound();
     }

--- a/unreleased_history/bug_fixes/compacted_db_readonly_blob.md
+++ b/unreleased_history/bug_fixes/compacted_db_readonly_blob.md
@@ -1,0 +1,1 @@
+Fixed a bug where a read-only DB opened against a fully compacted blob DB (qualifying for the `CompactedDBImpl` fast path, i.e. `max_open_files == -1`) could not retrieve blob values at all: `Get()`/`MultiGet()` reported `NotFound` for any key resolving to a blob index, even though the key and blob file were both present.


### PR DESCRIPTION
## Summary

Fixes #12503.

`CompactedDBImpl::Get` and `CompactedDBImpl::MultiGet` (the fast path `DB::OpenForReadOnly` takes when `max_open_files == -1` and the DB has at most one file per level) pass a null `is_blob_index` pointer into `GetContext`. Any key resolving to a blob index therefore hits `GetContext::kUnexpectedBlobIndex` immediately, even though a `VersionBlobFetcher` is already constructed and passed in -- the fetcher is unreachable because `GetContext::SaveValue` bails out for `kTypeBlobIndex` before ever reaching the branch that would use it, unless `is_blob_index_` is non-null. The key is reported as `Status::NotFound()`, even though it and its blob file are both present.

```cpp
Path db_dir = ...;
Options options;
options.enable_blob_files = true;
options.min_blob_size = 0;
// options.max_open_files defaults to -1

{
  DB* db;
  DB::Open(options, db_dir, &db);
  db->Put(WriteOptions(), "key", std::string(1000, 'a'));
  db->Flush(FlushOptions());  // single L0 file -> qualifies for CompactedDBImpl
  delete db;
}

DB* db;
DB::OpenForReadOnly(options, db_dir, &db);  // silently opens as CompactedDBImpl
std::string value;
db->Get(ReadOptions(), "key", &value);  // Status::NotFound() -- data loss on read
```

### Fix

Pass a real `is_blob_index` flag through in both `Get` and `MultiGet`, and when it comes back true, resolve the raw blob reference via the `VersionBlobFetcher` both methods already construct -- mirroring what `Version::Get` does after its own `TableReader` lookup succeeds.

### Why the existing test suite never caught this

The original issue's investigation (thank you @rhubner for the deep dive) suspected `Options::fs` / filesystem-implementation differences, based on `CurrentOptions()` (the `DBTestBase` test-framework helper) not reproducing the bug while a bare default-constructed `Options()` did.

The actual variable was `max_open_files`: `DBTestBase::GetDefaultOptions()` hardcodes `5000` (`db/db_test_util.cc`), while a real default-constructed `Options()` has RocksDB's actual default of `-1` -- exactly the value `CompactedDBImpl::Open` requires to engage at all. With `max_open_files != -1`, `DB::OpenForReadOnly` always falls through to the ordinary `DBImplReadOnly` path, where this bug does not exist. Since none of the blob tests use RocksDB's parameterized `kInfiniteMaxOpenFiles` config sweep (the one existing config that does set `-1`), the `CompactedDBImpl` fast path was never exercised against blob data by any existing test.

I verified this directly: temporarily forcing `GetDefaultOptions()` to `-1` and running the full `db_blob_basic_test` suite (46 tests) all still pass with this fix applied, confirming this was an isolated gap rather than a symptom of something broader in `CompactedDBImpl`. Without the fix, the new regression test below reproducibly fails with the reported `NotFound`.

## Test plan

- [x] Added `DBBlobBasicTest.GetBlob_ReadOnlyFullyCompacted` to `db/blob/db_blob_basic_test.cc`, covering both `Get` and `MultiGet` through `CompactedDBImpl`, with `max_open_files = -1` explicitly set (the `DBTestBase` default of `5000` would skip the fast path this test targets).
- [x] Confirmed the new test fails with `Status::NotFound()` when the fix is reverted, and passes with it applied.
- [x] Full `db_blob_basic_test` suite (46 tests) passes with the fix.
- [x] `make check-sources` and `make format-auto` clean.