### PR TITLE
Fix redundant direct I/O tail rewrite in WritableFileWriter

### DIFF
--- a/file/writable_file_writer.cc
+++ b/file/writable_file_writer.cc
@@ -75,6 +75,7 @@ IOStatus WritableFileWriter::Append(const IOOptions& opts, const Slice& data,
   size_t left = data.size();
   IOStatus s;
   pending_sync_ = true;
+  direct_io_buf_is_clean_tail_ = false;
 
   TEST_KILL_RANDOM_WITH_WEIGHT("WritableFileWriter::Append:0", REDUCE_ODDS2);
 
@@ -367,7 +368,7 @@ IOStatus WritableFileWriter::Flush(const IOOptions& opts) {
 
   if (buf_.CurrentSize() > 0) {
     if (use_direct_io()) {
-      if (pending_sync_) {
+      if (pending_sync_ && !direct_io_buf_is_clean_tail_) {
         if (perform_data_verification_ && buffered_data_with_checksum_) {
           s = WriteDirectWithChecksum(io_options);
         } else {
@@ -870,6 +871,10 @@ IOStatus WritableFileWriter::WriteDirect(const IOOptions& opts) {
     // This never happens during normal Append but rather during
     // explicit call to Flush()/Sync() or Close()
     buf_.RefitTail(file_advance, leftover_tail);
+    // buf_ now holds only bytes already durably issued above; a future
+    // Flush()/Sync()/Close() with no intervening Append() must not
+    // re-write them (see #12168).
+    direct_io_buf_is_clean_tail_ = (leftover_tail > 0);
     // This is where we start writing next time which may or not be
     // the actual file size on disk. They match if the buffer size
     // is a multiple of whole pages otherwise filesize_ is leftover_tail
@@ -978,6 +983,10 @@ IOStatus WritableFileWriter::WriteDirectWithChecksum(const IOOptions& opts) {
     // Adjust the checksum value to align with the data in the buffer
     buffered_data_crc32c_checksum_ =
         crc32c::Value(buf_.BufferStart(), buf_.CurrentSize());
+    // buf_ now holds only bytes already durably issued above; a future
+    // Flush()/Sync()/Close() with no intervening Append() must not
+    // re-write them (see #12168).
+    direct_io_buf_is_clean_tail_ = (leftover_tail > 0);
     // This is where we start writing next time which may or not be
     // the actual file size on disk. They match if the buffer size
     // is a multiple of whole pages otherwise filesize_ is leftover_tail

--- a/file/writable_file_writer.h
+++ b/file/writable_file_writer.h
@@ -151,6 +151,14 @@ class WritableFileWriter {
   // so we need to go back and write that page again
   uint64_t next_write_offset_;
   bool pending_sync_;
+  // True only when buf_'s entire current content is a "clean" leftover tail:
+  // bytes already durably issued to the file by a previous WriteDirect()/
+  // WriteDirectWithChecksum() call (as part of a zero-padded aligned write),
+  // parked here so a future Append() can glue more data onto them. False
+  // whenever buf_ contains any byte that has not yet been written to the
+  // file. Lets Flush() avoid re-issuing a write for a buffer that holds
+  // nothing but already-written tail bytes (see #12168).
+  bool direct_io_buf_is_clean_tail_;
   std::atomic<bool> seen_error_;
 #ifndef NDEBUG
   std::atomic<bool> seen_injected_error_;
@@ -191,6 +199,7 @@ class WritableFileWriter {
         flushed_size_(initial_file_size),
         next_write_offset_(initial_file_size),
         pending_sync_(false),
+        direct_io_buf_is_clean_tail_(false),
         seen_error_(false),
 #ifndef NDEBUG
         seen_injected_error_(false),

--- a/unreleased_history/bug_fixes/direct_io_writer_redundant_tail_write.md
+++ b/unreleased_history/bug_fixes/direct_io_writer_redundant_tail_write.md
@@ -1,0 +1,1 @@
+Fixed a bug in `WritableFileWriter`'s direct I/O (`O_DIRECT`) write path where `Flush()`, `Sync()`, and `Close()` could each re-issue a `PositionedAppend()` for the same already-written tail bytes left over from a previous unaligned write, whenever called with no intervening `Append()`, causing unnecessary redundant disk writes.

--- a/util/file_reader_writer_test.cc
+++ b/util/file_reader_writer_test.cc
@@ -334,6 +334,148 @@ TEST_F(WritableFileWriterTest, BufferWithZeroCapacityDirectIO) {
   }
 }
 
+// Regression test for https://github.com/facebook/rocksdb/issues/12168.
+//
+// WriteDirect() pads an unaligned tail with zeros, writes it once, and parks
+// the tail bytes at the front of buf_ via RefitTail() so a future Append()
+// can glue more data onto them before the next write. A second
+// Flush()/Sync() with no intervening Append() must not re-issue a
+// PositionedAppend() for those same already-written tail bytes.
+TEST_F(WritableFileWriterTest, DirectIOSkipsRedundantTailRewrite) {
+  // FakeWF writes into caller-owned storage (not members of FakeWF itself)
+  // because WritableFileWriter::Close() destroys the underlying FSWritableFile
+  // (via writable_file_.reset()); the test needs to inspect the recorded
+  // calls and file content after Close() runs, so that state must outlive
+  // the FakeWF object. Mirrors the existing IncrementalBuffer test's
+  // FakeWF(std::string* _file_data, ...) pattern above.
+  class FakeWF : public FSWritableFile {
+   public:
+    FakeWF(std::string* file_data, int* positioned_append_call_count,
+          size_t* positioned_append_total_bytes)
+        : file_data_(file_data),
+          positioned_append_call_count_(positioned_append_call_count),
+          positioned_append_total_bytes_(positioned_append_total_bytes) {}
+    ~FakeWF() override = default;
+
+    using FSWritableFile::Append;
+    IOStatus Append(const Slice& /*data*/, const IOOptions& /*options*/,
+                    IODebugContext* /*dbg*/) override {
+      // Direct I/O always routes through PositionedAppend(); this writer
+      // should never take the plain Append() path.
+      ADD_FAILURE() << "Unexpected FSWritableFile::Append() call under "
+                       "direct I/O";
+      return IOStatus::IOError("unexpected Append() call");
+    }
+    using FSWritableFile::PositionedAppend;
+    IOStatus PositionedAppend(const Slice& data, uint64_t offset,
+                              const IOOptions& /*options*/,
+                              IODebugContext* /*dbg*/) override {
+      (*positioned_append_call_count_)++;
+      *positioned_append_total_bytes_ += data.size();
+      if (offset + data.size() > file_data_->size()) {
+        file_data_->resize(offset + data.size());
+      }
+      memcpy(&(*file_data_)[offset], data.data(), data.size());
+      return IOStatus::OK();
+    }
+    IOStatus Truncate(uint64_t size, const IOOptions& /*options*/,
+                      IODebugContext* /*dbg*/) override {
+      file_data_->resize(size);
+      return IOStatus::OK();
+    }
+    IOStatus Close(const IOOptions& /*options*/,
+                   IODebugContext* /*dbg*/) override {
+      return IOStatus::OK();
+    }
+    IOStatus Flush(const IOOptions& /*options*/,
+                   IODebugContext* /*dbg*/) override {
+      return IOStatus::OK();
+    }
+    IOStatus Sync(const IOOptions& /*options*/,
+                  IODebugContext* /*dbg*/) override {
+      return IOStatus::OK();
+    }
+    IOStatus Fsync(const IOOptions& /*options*/,
+                   IODebugContext* /*dbg*/) override {
+      return IOStatus::OK();
+    }
+    void SetIOPriority(Env::IOPriority /*pri*/) override {}
+    uint64_t GetFileSize(const IOOptions& /*options*/,
+                         IODebugContext* /*dbg*/) override {
+      return file_data_->size();
+    }
+    void GetPreallocationStatus(size_t* /*block_size*/,
+                                size_t* /*last_allocated_block*/) override {}
+    size_t GetUniqueId(char* /*id*/, size_t /*max_size*/) const override {
+      return 0;
+    }
+    IOStatus InvalidateCache(size_t /*offset*/, size_t /*length*/) override {
+      return IOStatus::OK();
+    }
+    bool use_direct_io() const override { return true; }
+    size_t GetRequiredBufferAlignment() const override { return 512; }
+
+    std::string* file_data_;
+    int* positioned_append_call_count_;
+    size_t* positioned_append_total_bytes_;
+  };
+
+  std::string file_data;
+  int positioned_append_call_count = 0;
+  size_t positioned_append_total_bytes = 0;
+  std::unique_ptr<FakeWF> wf(new FakeWF(&file_data, &positioned_append_call_count,
+                                        &positioned_append_total_bytes));
+  std::unique_ptr<WritableFileWriter> writer(
+      new WritableFileWriter(std::move(wf), "" /* don't care */, EnvOptions()));
+
+  // Matches the issue's own repro numbers: an unaligned 1030-byte write with
+  // 512-byte alignment pads up to 1536 bytes (1024-byte aligned portion plus
+  // a 6-byte tail padded out to a full 512-byte sector).
+  const size_t kDataSize = 1030;
+  ASSERT_OK(writer->Append(IOOptions(), std::string(kDataSize, 'x')));
+
+  // First Flush() must write the data: exactly one PositionedAppend call,
+  // sized to the alignment-rounded amount.
+  ASSERT_OK(writer->Flush(IOOptions()));
+  ASSERT_EQ(1, positioned_append_call_count);
+  ASSERT_EQ(1536u, positioned_append_total_bytes);
+
+  // A second Flush() with no intervening Append() must NOT re-issue a write
+  // for the already-written tail. Before the fix, this issues one more
+  // PositionedAppend() of 512 bytes (Roundup(6, 512)) at offset 1024 --
+  // bytes that are already present in the file from the first call.
+  ASSERT_OK(writer->Flush(IOOptions()));
+  EXPECT_EQ(1, positioned_append_call_count)
+      << "Flush() issued a redundant PositionedAppend for an already-written "
+         "tail (see #12168)";
+  EXPECT_EQ(1536u, positioned_append_total_bytes);
+
+  // Sync() also routes through Flush() internally and must not redundantly
+  // rewrite the tail either.
+  ASSERT_OK(writer->Sync(IOOptions(), /*use_fsync=*/false));
+  EXPECT_EQ(1, positioned_append_call_count)
+      << "Sync() issued a redundant PositionedAppend for an already-written "
+         "tail (see #12168)";
+
+  // Appending more data must still correctly glue onto the parked tail --
+  // this is the actual purpose of RefitTail() and must keep working.
+  ASSERT_OK(writer->Append(IOOptions(), std::string(600, 'y')));
+  ASSERT_OK(writer->Flush(IOOptions()));
+  EXPECT_EQ(2, positioned_append_call_count);
+
+  // Close() must not issue a further redundant write for the new tail.
+  ASSERT_OK(writer->Close(IOOptions()));
+  EXPECT_EQ(2, positioned_append_call_count)
+      << "Close() issued a redundant PositionedAppend for an already-written "
+         "tail (see #12168)";
+
+  // Final on-disk content must be exactly correct: 1030 'x' bytes followed by
+  // 600 'y' bytes, with all padding truncated away.
+  ASSERT_EQ(kDataSize + 600, file_data.size());
+  ASSERT_EQ(std::string(kDataSize, 'x'), file_data.substr(0, kDataSize));
+  ASSERT_EQ(std::string(600, 'y'), file_data.substr(kDataSize, 600));
+}
+
 class DBWritableFileWriterTest : public DBTestBase {
  public:
   DBWritableFileWriterTest()


### PR DESCRIPTION
## Summary

Under O_DIRECT, `WriteDirect()`/`WriteDirectWithChecksum()` pad an unaligned tail with zeros, write it, and park the tail bytes at the front of `buf_` via `RefitTail()` so a future `Append()` can glue more data onto them before the next write. Neither function marked that parked tail as already written, so a later `Flush()`, `Sync()`, or `Close()` call with no intervening `Append()` would re-issue a `PositionedAppend()` for the same already-written bytes -- not a correctness issue, since the same bytes just get rewritten at the same offset, but wasted I/O.

This adds a `direct_io_buf_is_clean_tail_` flag: set after `RefitTail()` when the buffer holds only an already-written tail, cleared the moment `Append()` adds new data. `Flush()`'s direct-I/O path now also checks this flag and skips the redundant write.

Fixes #12168, following the fix direction @ajkr suggested on the issue: track whether the buffer is dirty or clean and skip the write when it's clean.

## Test Plan

Added `WritableFileWriterTest.DirectIOSkipsRedundantTailRewrite` (`util/file_reader_writer_test.cc`), which counts `PositionedAppend()` calls across `Flush()`/`Sync()`/`Close()` sequences with no intervening `Append()` and asserts no redundant write occurs, plus that appending more data still glues onto the tail correctly and final file content is byte-correct. Fails on unfixed code, passes with the fix. Full `file_reader_writer_test` suite (114 tests) and `make check` pass; `make check-sources` clean.