### PR TITLE
Do not test GetEntityLazy on read-only primary handle

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -5496,7 +5496,7 @@ void StressTest::MaybeOpenReadOnlyOnPrimary(ThreadState* thread) {
 
   // A read-only instance opened concurrently with the primary can trip over
   // injected faults or files the primary mutates underneath it, so disable
-  // error injection while we open, read, and close the reader. The primary's
+  // error injection while we open and close the reader. The primary's
   // own subsequent operations run with injection re-enabled, so a genuinely
   // deleted live file still surfaces on the normal verification path.
   if (db_fault_injection_fs_) {
@@ -5518,16 +5518,6 @@ void StressTest::MaybeOpenReadOnlyOnPrimary(ThreadState* thread) {
   // Opening read-only while the primary mutates the same directory is
   // best-effort; a transient failure here is expected and not a bug.
   if (s.ok()) {
-    // Exercise the lazy wide-column read path on the read-only instance: the
-    // differential self-checks lazy vs eager on this same reader. No-op unless
-    // the lazy API is enabled (open_files == -1, no UDT/txn) and sampled.
-    {
-      const size_t cf = thread->rand.Next() % ro_cfhs.size();
-      const std::string key_str = Key(thread->rand.Next() % FLAGS_max_key);
-      MaybeTestGetEntityLazy(thread, ReadOptions(), ro_cfhs[cf], key_str,
-                             /*eager_reference=*/nullptr, ro_db.get());
-    }
-
     // Create new SST files in the primary that are absent from the reader's
     // frozen live-file snapshot, so that a read-only close wrongly running
     // obsolete-file cleanup would delete these live files. Flush all column


### PR DESCRIPTION
Summary:
MaybeOpenReadOnlyOnPrimary is intended to exercise opening and closing a read-only DB on the primary live directory, then verify that read-only close does not delete files still live in the primary.

D115278311 diagnosed T283967366 as a race between GetEntityLazy on that read-only handle and the primary deleting SST files. After checking the call path, the ENOENT is from GetEntityLazy's initial point lookup opening an SST through TableCache, not from deferred lazy column resolution. Other read APIs are not exercised on this read-only-on-primary handle, so adding GetEntityLazy there made this old open/close harness test also perform a live-directory point read.

Remove the read-only-handle GetEntityLazy exercise and keep GetEntityLazy coverage in the normal stress read paths, consistent with the other read operations.

Differential Revision: D115569968


