### PR TITLE
Add SST build context: is_remote_compaction, db_name, kSstFileWriter

### DIFF
--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -2618,7 +2618,8 @@ Status CompactionJob::OpenCompactionOutputFile(SubcompactionState* sub_compact,
       bottommost_level_, TableFileCreationReason::kCompaction,
       0 /* oldest_key_time */, current_time, db_id_, db_session_id_,
       sub_compact->compaction->max_output_file_size(), file_number,
-      proximal_after_seqno_ /*last_level_inclusive_max_seqno_threshold*/);
+      proximal_after_seqno_ /*last_level_inclusive_max_seqno_threshold*/,
+      dbname_ /*db_name*/, IsRemoteCompaction() /*is_remote_compaction*/);
 
   outputs.NewBuilder(tboptions);
 

--- a/db/compaction/compaction_job.h
+++ b/db/compaction/compaction_job.h
@@ -523,6 +523,10 @@ class CompactionJob {
   // Get table file name in where it's outputting to, which should also be in
   // `output_directory_`.
   virtual std::string GetTableFileName(uint64_t file_number);
+
+  // True if this job builds output files as a remote (offloaded)
+  // CompactionService worker. Overridden by CompactionServiceCompactionJob.
+  virtual bool IsRemoteCompaction() const { return false; }
   // The rate limiter priority (io_priority) is determined dynamically here.
   // The Compaction Read and Write priorities are the same for different
   // scenarios, such as write stalled.
@@ -730,6 +734,7 @@ class CompactionServiceCompactionJob : private CompactionJob {
  private:
   // Get table file name in output_path
   std::string GetTableFileName(uint64_t file_number) override;
+  bool IsRemoteCompaction() const override { return true; }
   // Specific the compaction output path, otherwise it uses default DB path
   const std::string output_path_;
 

--- a/db/compaction/compaction_service_test.cc
+++ b/db/compaction/compaction_service_test.cc
@@ -3,11 +3,15 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
+#include <atomic>
 #include <memory>
 
 #include "db/db_test_util.h"
 #include "file/file_util.h"
 #include "port/stack_trace.h"
+#include "rocksdb/advanced_compression.h"
+#include "rocksdb/filter_policy.h"
+#include "rocksdb/utilities/object_registry.h"
 #include "rocksdb/utilities/options_util.h"
 #include "table/unique_id_impl.h"
 #include "utilities/merge_operators/string_append/stringappend.h"
@@ -479,6 +483,113 @@ TEST_F(CompactionServiceTest, BasicCompactions) {
 
   Close();
   SyncPoint::GetInstance()->DisableProcessing();
+}
+
+namespace {
+
+// A CompressionManager that records, per GetCompressorForSST() call, whether
+// the FilterBuildingContext reports the SST as being built by a remote
+// (offloaded) compaction worker. Observations go into process-global counters
+// because the remote worker reconstructs its own manager instance from the
+// persisted OPTIONS file (same process in this test).
+struct RemoteAwareObservations {
+  std::atomic<int> num_remote{0};
+  std::atomic<int> num_non_remote{0};
+  void Reset() {
+    num_remote.store(0);
+    num_non_remote.store(0);
+  }
+};
+
+RemoteAwareObservations& GetRemoteAwareObservations() {
+  static RemoteAwareObservations obs;
+  return obs;
+}
+
+class RemoteAwareCompressionManager : public CompressionManagerWrapper {
+ public:
+  RemoteAwareCompressionManager()
+      : CompressionManagerWrapper(GetBuiltinV2CompressionManager()) {}
+
+  static const char* kClassName() { return "RemoteAwareCompressionManager"; }
+  const char* Name() const override { return kClassName(); }
+
+  std::unique_ptr<Compressor> GetCompressorForSST(
+      const FilterBuildingContext& context, const CompressionOptions& opts,
+      CompressionType preferred) override {
+    if (context.is_remote_compaction) {
+      GetRemoteAwareObservations().num_remote.fetch_add(1);
+    } else {
+      GetRemoteAwareObservations().num_non_remote.fetch_add(1);
+    }
+    return CompressionManagerWrapper::GetCompressorForSST(context, opts,
+                                                          preferred);
+  }
+};
+
+}  // namespace
+
+TEST_F(CompactionServiceTest, IsRemoteCompactionInCompressorContext) {
+  // Register so the remote worker's DB::OpenAndCompact can reconstruct the
+  // custom CompressionManager from the persisted OPTIONS file
+  // (CompactionServiceOptionsOverride does not carry a compression_manager).
+  ObjectLibrary::Default()->AddFactory<CompressionManager>(
+      RemoteAwareCompressionManager::kClassName(),
+      [](const std::string& /*uri*/, std::unique_ptr<CompressionManager>* guard,
+         std::string* /*errmsg*/) {
+        *guard = std::make_unique<RemoteAwareCompressionManager>();
+        return guard->get();
+      });
+
+  auto& obs = GetRemoteAwareObservations();
+  obs.Reset();
+
+  Options options = CurrentOptions();
+  options.compression_manager =
+      std::make_shared<RemoteAwareCompressionManager>();
+  ReopenWithCompactionService(&options);
+
+  GenerateTestData();
+  ASSERT_OK(dbfull()->TEST_WaitForCompact());
+  VerifyTestData();
+
+  auto my_cs = GetCompactionService();
+  ASSERT_GE(my_cs->GetCompactionNum(), 1);
+
+  // The offloaded worker built the compaction output SSTs and therefore must
+  // have observed is_remote_compaction == true in GetCompressorForSST().
+  ASSERT_GT(obs.num_remote.load(), 0);
+  // The primary's own flushes, seen by the same manager, must report false
+  ASSERT_GT(obs.num_non_remote.load(), 0);
+
+  Close();
+}
+
+TEST_F(CompactionServiceTest, IsRemoteCompactionFalseForLocalCompaction) {
+  // Same custom manager, but no compaction_service: everything runs locally,
+  // so GetCompressorForSST() must never see is_remote_compaction == true.
+  auto& obs = GetRemoteAwareObservations();
+  obs.Reset();
+
+  Options options = CurrentOptions();
+  options.compression_manager =
+      std::make_shared<RemoteAwareCompressionManager>();
+  DestroyAndReopen(options);
+
+  Random rnd(301);
+  for (int i = 0; i < 4; i++) {
+    for (int j = 0; j < 100; j++) {
+      ASSERT_OK(Put(Key(i * 100 + j), rnd.RandomString(64)));
+    }
+    ASSERT_OK(Flush());
+  }
+  ASSERT_OK(db_->CompactRange(CompactRangeOptions(), nullptr, nullptr));
+
+  // Local flushes and compactions must all report not-remote.
+  ASSERT_GT(obs.num_non_remote.load(), 0);
+  ASSERT_EQ(obs.num_remote.load(), 0);
+
+  Close();
 }
 
 TEST_F(CompactionServiceTest, SkipWALRecoveryInOpenAndCompact) {

--- a/db/db_bloom_filter_test.cc
+++ b/db/db_bloom_filter_test.cc
@@ -1800,6 +1800,7 @@ static std::map<TableFileCreationReason, std::string>
         {TableFileCreationReason::kFlush, "kFlush"},
         {TableFileCreationReason::kMisc, "kMisc"},
         {TableFileCreationReason::kRecovery, "kRecovery"},
+        {TableFileCreationReason::kSstFileWriter, "kSstFileWriter"},
     };
 
 class TestingContextCustomFilterPolicy
@@ -1814,6 +1815,15 @@ class TestingContextCustomFilterPolicy
       const FilterBuildingContext& context) const override {
     test_report_ += "cf=";
     test_report_ += context.column_family_name;
+    // Token rather than path, so expectations don't depend on test directory
+    test_report_ += ",db=";
+    if (context.db_name.empty()) {
+      test_report_ += "none";
+    } else if (context.db_name == Slice(expected_db_name_)) {
+      test_report_ += "expected";
+    } else {
+      test_report_ += "UNEXPECTED:" + context.db_name.ToString();
+    }
     test_report_ += ",s=";
     test_report_ +=
         OptionsHelper::compaction_style_to_string[context.compaction_style];
@@ -1836,8 +1846,13 @@ class TestingContextCustomFilterPolicy
     return rv;
   }
 
+  void SetExpectedDbName(std::string db_name) {
+    expected_db_name_ = std::move(db_name);
+  }
+
  private:
   mutable std::string test_report_;
+  std::string expected_db_name_;
 };
 }  // anonymous namespace
 
@@ -1859,6 +1874,13 @@ TEST_F(DBBloomFilterTest, ContextCustomFilterPolicy) {
 
     ASSERT_OK(TryReopen(options));
     CreateAndReopenWithCF({fifo ? "abe" : "bob"}, options);
+    policy->SetExpectedDbName(dbname_);
+
+    const char* expected_flush_report =
+        fifo
+            ? "cf=abe,db=expected,s=kCompactionStyleFIFO,n=7,l=0,b=0,r=kFlush\n"
+            : "cf=bob,db=expected,s=kCompactionStyleLevel,n=7,l=0,b=0,r="
+              "kFlush\n";
 
     const int maxKey = 10000;
     for (int i = 0; i < maxKey / 2; i++) {
@@ -1867,17 +1889,13 @@ TEST_F(DBBloomFilterTest, ContextCustomFilterPolicy) {
     // Add a large key to make the file contain wide range
     ASSERT_OK(Put(1, Key(maxKey + 55555), Key(maxKey + 55555)));
     ASSERT_OK(Flush(1));
-    EXPECT_EQ(policy->DumpTestReport(),
-              fifo ? "cf=abe,s=kCompactionStyleFIFO,n=7,l=0,b=0,r=kFlush\n"
-                   : "cf=bob,s=kCompactionStyleLevel,n=7,l=0,b=0,r=kFlush\n");
+    EXPECT_EQ(policy->DumpTestReport(), expected_flush_report);
 
     for (int i = maxKey / 2; i < maxKey; i++) {
       ASSERT_OK(Put(1, Key(i), Key(i)));
     }
     ASSERT_OK(Flush(1));
-    EXPECT_EQ(policy->DumpTestReport(),
-              fifo ? "cf=abe,s=kCompactionStyleFIFO,n=7,l=0,b=0,r=kFlush\n"
-                   : "cf=bob,s=kCompactionStyleLevel,n=7,l=0,b=0,r=kFlush\n");
+    EXPECT_EQ(policy->DumpTestReport(), expected_flush_report);
 
     // Check that they can be found
     for (int i = 0; i < maxKey; i++) {
@@ -1904,7 +1922,8 @@ TEST_F(DBBloomFilterTest, ContextCustomFilterPolicy) {
       ASSERT_OK(db_->CompactRange(CompactRangeOptions(), handles_[1], nullptr,
                                   nullptr));
       EXPECT_EQ(policy->DumpTestReport(),
-                "cf=bob,s=kCompactionStyleLevel,n=7,l=1,b=1,r=kCompaction\n");
+                "cf=bob,db=expected,s=kCompactionStyleLevel,n=7,l=1,b=1,r="
+                "kCompaction\n");
 
       // Check that we now have one filter, about 9.2% FP rate (5 bits per key)
       for (int i = 0; i < maxKey; i++) {
@@ -1926,7 +1945,8 @@ TEST_F(DBBloomFilterTest, ContextCustomFilterPolicy) {
       }
       // Note: kCompactionStyleLevel is default, ignored if num_levels == -1
       EXPECT_EQ(policy->DumpTestReport(),
-                "cf=abe,s=kCompactionStyleLevel,n=-1,l=-1,b=0,r=kMisc\n");
+                "cf=abe,db=none,s=kCompactionStyleLevel,n=-1,l=-1,b=0,r="
+                "kSstFileWriter\n");
     }
 
     // Destroy

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -2176,7 +2176,7 @@ Status DBImpl::WriteLevel0TableForRecovery(int job_id, ColumnFamilyData* cfd,
           false /* is_bottommost */, TableFileCreationReason::kRecovery,
           0 /* oldest_key_time */, 0 /* file_creation_time */, db_id_,
           db_session_id_, 0 /* target_file_size */, meta.fd.GetNumber(),
-          kMaxSequenceNumber);
+          kMaxSequenceNumber, dbname_ /* db_name */);
       Version* version = cfd->current();
       version->Ref();
       TableProperties temp_table_proerties;

--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -1042,7 +1042,8 @@ Status FlushJob::WriteLevel0Table() {
           meta_.fd.GetNumber(),
           preclude_last_level_min_seqno_ == kMaxSequenceNumber
               ? preclude_last_level_min_seqno_
-              : std::min(earliest_snapshot_, preclude_last_level_min_seqno_));
+              : std::min(earliest_snapshot_, preclude_last_level_min_seqno_),
+          dbname_ /*db_name*/);
       s = BuildTable(
           dbname_, versions_, db_options_, tboptions, file_options_,
           cfd_->table_cache(), iter.get(), std::move(range_del_iters), &meta_,

--- a/db/repair.cc
+++ b/db/repair.cc
@@ -482,7 +482,9 @@ class Repairer {
           current_time /* newest_key_time */, false /* is_bottommost */,
           TableFileCreationReason::kRecovery, 0 /* oldest_key_time */,
           0 /* file_creation_time */, "DB Repairer" /* db_id */, db_session_id_,
-          0 /*target_file_size*/, meta.fd.GetNumber());
+          0 /*target_file_size*/, meta.fd.GetNumber(),
+          kMaxSequenceNumber /*last_level_inclusive_max_seqno_threshold*/,
+          dbname_ /*db_name*/);
 
       SeqnoToTimeMapping empty_seqno_to_time_mapping;
       status = BuildTable(

--- a/include/rocksdb/external_table.h
+++ b/include/rocksdb/external_table.h
@@ -236,6 +236,8 @@ struct ExternalTableBuilderOptions {
   const std::string db_session_id;
   const TableFileCreationReason reason;
   const std::shared_ptr<FileSystem>& fs;
+  // NOTE: a number of internal TableBuilderOptions could also be plumbed
+  // through to here
 
   ExternalTableBuilderOptions(
       const ReadOptions& _read_options, const WriteOptions& _write_options,

--- a/include/rocksdb/filter_policy.h
+++ b/include/rocksdb/filter_policy.h
@@ -29,12 +29,12 @@
 
 #include "rocksdb/advanced_options.h"
 #include "rocksdb/customizable.h"
+#include "rocksdb/slice.h"
 #include "rocksdb/status.h"
 #include "rocksdb/types.h"
 
 namespace ROCKSDB_NAMESPACE {
 
-class Slice;
 struct BlockBasedTableOptions;
 struct ConfigOptions;
 
@@ -67,6 +67,12 @@ struct FilterBuildingContext {
   // TODO: consider changing to Slice
   std::string column_family_name;
 
+  // Name (path) of the DB the table is being built for, or empty if there is
+  // no such DB, as with SstFileWriter. Under remote compaction this is the DB
+  // name as opened by the worker, which can differ from the primary's.
+  // Non-owning; do not retain beyond the call receiving this context.
+  Slice db_name;
+
   // The table level at time of constructing the SST file, or -1 if unknown
   // or N/A as in SstFileWriter. (The table file could later be used at a
   // different level.)
@@ -79,6 +85,11 @@ struct FilterBuildingContext {
 
   // Reason for creating the file with the filter
   TableFileCreationReason reason = TableFileCreationReason::kMisc;
+
+  // True if the file is being built by a remote (offloaded) compaction worker
+  // via CompactionService. False otherwise (including local/fallback
+  // compactions, flushes, and SstFileWriter).
+  bool is_remote_compaction = false;
 };
 
 // Determines what kind of filter (if any) to generate in SST files, and under

--- a/include/rocksdb/types.h
+++ b/include/rocksdb/types.h
@@ -27,11 +27,12 @@ using TablePropertiesCollection =
 
 const SequenceNumber kMinUnCommittedSeq = 1;  // 0 is always committed
 
-enum class TableFileCreationReason {
+enum class TableFileCreationReason : uint8_t {
   kFlush,
   kCompaction,
   kRecovery,
   kMisc,
+  kSstFileWriter,
 };
 
 enum class BlobFileCreationReason {

--- a/java/src/main/java/org/rocksdb/TableFileCreationReason.java
+++ b/java/src/main/java/org/rocksdb/TableFileCreationReason.java
@@ -9,7 +9,8 @@ public enum TableFileCreationReason {
   FLUSH((byte) 0x00),
   COMPACTION((byte) 0x01),
   RECOVERY((byte) 0x02),
-  MISC((byte) 0x03);
+  MISC((byte) 0x03),
+  SST_FILE_WRITER((byte) 0x04);
 
   private final byte value;
 

--- a/java/src/test/java/org/rocksdb/EventListenerTest.java
+++ b/java/src/test/java/org/rocksdb/EventListenerTest.java
@@ -286,12 +286,12 @@ public class EventListenerTest {
     final Status statusTestData = new Status(Status.Code.Incomplete, Status.SubCode.NoSpace, null);
     final TableFileDeletionInfo tableFileDeletionInfoTestData =
         new TableFileDeletionInfo("dbName", "/file/path", Integer.MAX_VALUE, statusTestData);
-    final TableFileCreationInfo tableFileCreationInfoTestData =
-        new TableFileCreationInfo(TEST_LONG_VAL, tablePropertiesTestData, statusTestData, "dbName",
-            "columnFamilyName", "/file/path", Integer.MAX_VALUE, (byte) 0x03);
+    final TableFileCreationInfo tableFileCreationInfoTestData = new TableFileCreationInfo(
+        TEST_LONG_VAL, tablePropertiesTestData, statusTestData, "dbName", "columnFamilyName",
+        "/file/path", Integer.MAX_VALUE, TableFileCreationReason.MISC.getValue());
     final TableFileCreationBriefInfo tableFileCreationBriefInfoTestData =
-        new TableFileCreationBriefInfo(
-            "dbName", "columnFamilyName", "/file/path", Integer.MAX_VALUE, (byte) 0x03);
+        new TableFileCreationBriefInfo("dbName", "columnFamilyName", "/file/path",
+            Integer.MAX_VALUE, TableFileCreationReason.MISC.getValue());
     final MemTableInfo memTableInfoTestData = new MemTableInfo(
         "columnFamilyName", TEST_LONG_VAL, TEST_LONG_VAL, TEST_LONG_VAL, TEST_LONG_VAL);
     final FileOperationInfo fileOperationInfoTestData = new FileOperationInfo("/file/path",

--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -1147,16 +1147,25 @@ struct BlockBasedTableBuilder::Rep {
 
     filter_context.info_log = ioptions.logger;
     filter_context.column_family_name = tbo.column_family_name;
+    filter_context.db_name = tbo.db_name;
     filter_context.reason = reason;
 
     // Only populate other fields if known to be in LSM rather than
     // generating external SST file
-    if (reason != TableFileCreationReason::kMisc) {
-      filter_context.compaction_style = ioptions.compaction_style;
-      filter_context.num_levels = ioptions.num_levels;
-      filter_context.level_at_creation = tbo.level_at_creation;
-      filter_context.is_bottommost = tbo.is_bottommost;
-      assert(filter_context.level_at_creation < filter_context.num_levels);
+    switch (reason) {
+      case TableFileCreationReason::kFlush:
+      case TableFileCreationReason::kCompaction:
+      case TableFileCreationReason::kRecovery:
+        filter_context.compaction_style = ioptions.compaction_style;
+        filter_context.num_levels = ioptions.num_levels;
+        filter_context.level_at_creation = tbo.level_at_creation;
+        filter_context.is_bottommost = tbo.is_bottommost;
+        filter_context.is_remote_compaction = tbo.is_remote_compaction;
+        assert(filter_context.level_at_creation < filter_context.num_levels);
+        break;
+      case TableFileCreationReason::kSstFileWriter:
+      case TableFileCreationReason::kMisc:
+        break;
     }
 
     props.compression_options =

--- a/table/sst_file_writer.cc
+++ b/table/sst_file_writer.cc
@@ -417,9 +417,10 @@ Status SstFileWriter::Open(const std::string& file_path, Temperature temp) {
       r->internal_comparator, &internal_tbl_prop_coll_factories,
       compression_type, compression_opts, cf_id, r->column_family_name,
       unknown_level, kUnknownNewestKeyTime, false /* is_bottommost */,
-      TableFileCreationReason::kMisc, 0 /* oldest_key_time */,
+      TableFileCreationReason::kSstFileWriter, 0 /* oldest_key_time */,
       0 /* file_creation_time */, "SST Writer" /* db_id */, r->db_session_id,
       0 /* target_file_size */, r->next_file_number, kMaxSequenceNumber,
+      Slice() /* db_name */, false /* is_remote_compaction */,
       r->embedded_blob_options.get());
   // External SST files used to each get a unique session id. Now for
   // slightly better uniqueness probability in constructing cache keys, we

--- a/table/table_builder.h
+++ b/table/table_builder.h
@@ -21,6 +21,7 @@
 #include "file/writable_file_writer.h"
 #include "options/cf_options.h"
 #include "rocksdb/options.h"
+#include "rocksdb/slice.h"
 #include "rocksdb/table_properties.h"
 #include "table/embedded_blob_sst.h"
 #include "table/unique_id_impl.h"
@@ -138,6 +139,7 @@ struct TableBuilderOptions : public TablePropertiesCollectorFactory::Context {
       const uint64_t _target_file_size = 0, const uint64_t _cur_file_num = 0,
       const SequenceNumber _last_level_inclusive_max_seqno_threshold =
           kMaxSequenceNumber,
+      const Slice _db_name = Slice(), const bool _is_remote_compaction = false,
       const EmbeddedBlobSstBuilderOptions* _embedded_blob_options = nullptr)
       : TablePropertiesCollectorFactory::Context(
             _column_family_id, _level, _ioptions.num_levels,
@@ -159,6 +161,8 @@ struct TableBuilderOptions : public TablePropertiesCollectorFactory::Context {
         db_session_id(_db_session_id),
         is_bottommost(_is_bottommost),
         reason(_reason),
+        db_name(_db_name),
+        is_remote_compaction(_is_remote_compaction),
         cur_file_num(_cur_file_num),
         embedded_blob_options(_embedded_blob_options) {}
 
@@ -180,6 +184,8 @@ struct TableBuilderOptions : public TablePropertiesCollectorFactory::Context {
   // BEGIN for FilterBuildingContext
   const bool is_bottommost;
   const TableFileCreationReason reason;
+  const Slice db_name;
+  const bool is_remote_compaction;
   // END for FilterBuildingContext
 
   const uint64_t cur_file_num;

--- a/unreleased_history/public_api_changes/table_file_creation_reason_sst_file_writer.md
+++ b/unreleased_history/public_api_changes/table_file_creation_reason_sst_file_writer.md
@@ -1,0 +1,1 @@
+Added a `kSstFileWriter` value to `TableFileCreationReason`, which `SstFileWriter` now reports instead of the catch-all `kMisc`. This, along with new `db_name` and `is_remote_compaction` fields in `FilterBuildingContext`, improves the contextual information available to custom filter and compression strategies.

--- a/util/bloom_test.cc
+++ b/util/bloom_test.cc
@@ -1173,7 +1173,7 @@ TEST(RibbonTest, RibbonTestLevelThreshold) {
 
         // Like SST file writer
         ctx.level_at_creation = -1;
-        ctx.reason = TableFileCreationReason::kMisc;
+        ctx.reason = TableFileCreationReason::kSstFileWriter;
 
         builder.reset(policy->GetBuilderWithContext(ctx));
 


### PR DESCRIPTION
Summary:
Custom filter and compression strategies decide what to build per SST from a FilterBuildingContext (shared by FilterPolicy::GetBuilderWithContext and CompressionManager::GetCompressorForSST). This adds more context so those strategies can adapt to where and how a file is being produced.

FilterBuildingContext gains two fields:
* is_remote_compaction: true only when the file is produced by an offloaded CompactionService worker. Detected with a new virtual CompactionJob::IsRemoteCompaction() (default false) overridden by CompactionServiceCompactionJob, mirroring the existing GetTableFileName hook. Local/fallback compactions and flushes are false.
* db_name: a non-owning Slice naming the DB, populated for flush, compaction, recovery, and repair, and empty only where there is no DB, as with SstFileWriter. Under remote compaction it is the DB as opened by the worker, which can differ from the primary's.

Both are threaded through TableBuilderOptions and populated in BlockBasedTableBuilder::Rep, whose "is this file in the LSM" test becomes a switch with no default case, so that a future TableFileCreationReason has to be classified there.

Separately, TableFileCreationReason is now backed by uint8_t and gains a kSstFileWriter value, which SstFileWriter reports instead of the catch-all kMisc. It is appended after kMisc so existing enumerator values are unchanged; those values are public API, surfaced to EventListener and mirrored by the Java binding (updated here). Note that SstFileWriter neither notifies listeners nor consults CompactionFilterFactory, so for now the new value is only observable through FilterBuildingContext.

Test Plan:
* New CompactionServiceTest.IsRemoteCompactionInCompressorContext installs a custom CompressionManager and asserts GetCompressorForSST sees is_remote_compaction == true for the offloaded worker's output files and false for the primary's flushes in the same run, so the flag is shown to be per-file rather than global. IsRemoteCompactionFalseForLocalCompaction covers the same manager with no compaction_service configured.
* DBBloomFilterTest.ContextCustomFilterPolicy now reports db_name as a token (expected / none / UNEXPECTED:<value>), so the value rather than just its presence is checked for flush and compaction, and expects kSstFileWriter instead of kMisc for the external SstFileWriter file.
* bloom_test's "Like SST file writer" case uses kSstFileWriter so that it keeps modelling SstFileWriter.
* Java EventListenerTest references TableFileCreationReason.MISC.getValue() instead of a hardcoded enum byte, so it stays correct across enum changes.