### PR TITLE
Track newer snapshot versions in RocksDB metadata reads (#15086)

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -2623,6 +2623,59 @@ char* rocksdb_get(rocksdb_t* db, const rocksdb_readoptions_t* options,
   return result;
 }
 
+static char* rocksdb_get_with_metadata_impl(
+    rocksdb_t* db, const rocksdb_readoptions_t* options,
+    ColumnFamilyHandle* column_family, const char* key, size_t keylen,
+    size_t* vallen, char** timestamp, size_t* timestamp_len,
+    unsigned char* newer_version_present, char** errptr) {
+  ROCKSDB_NAMESPACE::OutputMetadata output_metadata;
+  if (timestamp != nullptr && timestamp_len != nullptr) {
+    output_metadata.WantTimestamp();
+  }
+  if (newer_version_present != nullptr) {
+    output_metadata.WantNewerVersionPresent();
+  }
+
+  PinnableSlice pinnable_val;
+  const Status s =
+      db->rep->GetWithMetadata(options->rep, column_family, Slice(key, keylen),
+                               &pinnable_val, &output_metadata);
+  if (newer_version_present != nullptr) {
+    *newer_version_present = *output_metadata.newer_version_present ? 1 : 0;
+  }
+
+  char* result = nullptr;
+  if (s.ok()) {
+    *vallen = pinnable_val.size();
+    result = CopyString(pinnable_val);
+    if (output_metadata.timestamp.has_value()) {
+      *timestamp_len = output_metadata.timestamp->size();
+      *timestamp = CopyString(*output_metadata.timestamp);
+    }
+  } else {
+    *vallen = 0;
+    if (output_metadata.timestamp.has_value()) {
+      *timestamp = nullptr;
+      *timestamp_len = 0;
+    }
+    if (!s.IsNotFound()) {
+      SaveError(errptr, s);
+    }
+  }
+  return result;
+}
+
+char* rocksdb_get_with_metadata(rocksdb_t* db,
+                                const rocksdb_readoptions_t* options,
+                                const char* key, size_t keylen, size_t* vallen,
+                                char** timestamp, size_t* timestamp_len,
+                                unsigned char* newer_version_present,
+                                char** errptr) {
+  return rocksdb_get_with_metadata_impl(
+      db, options, db->rep->DefaultColumnFamily(), key, keylen, vallen,
+      timestamp, timestamp_len, newer_version_present, errptr);
+}
+
 char* rocksdb_get_cf(rocksdb_t* db, const rocksdb_readoptions_t* options,
                      rocksdb_column_family_handle_t* column_family,
                      const char* key, size_t keylen, size_t* vallen,
@@ -2643,6 +2696,16 @@ char* rocksdb_get_cf(rocksdb_t* db, const rocksdb_readoptions_t* options,
     }
   }
   return result;
+}
+
+char* rocksdb_get_cf_with_metadata(
+    rocksdb_t* db, const rocksdb_readoptions_t* options,
+    rocksdb_column_family_handle_t* column_family, const char* key,
+    size_t keylen, size_t* vallen, char** timestamp, size_t* timestamp_len,
+    unsigned char* newer_version_present, char** errptr) {
+  return rocksdb_get_with_metadata_impl(
+      db, options, column_family->rep, key, keylen, vallen, timestamp,
+      timestamp_len, newer_version_present, errptr);
 }
 
 char* rocksdb_get_with_ts(rocksdb_t* db, const rocksdb_readoptions_t* options,
@@ -2736,6 +2799,72 @@ void rocksdb_multi_get(rocksdb_t* db, const rocksdb_readoptions_t* options,
   }
 }
 
+static void rocksdb_multi_get_with_metadata_impl(
+    rocksdb_t* db, const rocksdb_readoptions_t* options,
+    ColumnFamilyHandle* const* column_families, size_t num_keys,
+    const char* const* keys_list, const size_t* keys_list_sizes,
+    char** values_list, size_t* values_list_sizes, char** timestamp_list,
+    size_t* timestamp_list_sizes, unsigned char* newer_version_present,
+    char** errs) {
+  std::unique_ptr<Slice[]> keys(new Slice[num_keys]);
+  std::vector<PinnableSlice> values(num_keys);
+  std::vector<Status> statuses(num_keys);
+  for (size_t i = 0; i < num_keys; ++i) {
+    keys[i] = Slice(keys_list[i], keys_list_sizes[i]);
+  }
+
+  ROCKSDB_NAMESPACE::MultiGetOutputMetadata output_metadata;
+  if (timestamp_list != nullptr && timestamp_list_sizes != nullptr) {
+    output_metadata.WantTimestamps();
+  }
+  if (newer_version_present != nullptr) {
+    output_metadata.WantNewerVersionPresent();
+  }
+  db->rep->MultiGetWithMetadata(options->rep, num_keys, column_families,
+                                keys.get(), values.data(), statuses.data(),
+                                &output_metadata);
+
+  for (size_t i = 0; i < num_keys; ++i) {
+    if (newer_version_present != nullptr) {
+      newer_version_present[i] =
+          (*output_metadata.newer_version_present)[i] ? 1 : 0;
+    }
+    if (statuses[i].ok()) {
+      values_list[i] = CopyString(values[i]);
+      values_list_sizes[i] = values[i].size();
+      if (output_metadata.timestamps.has_value()) {
+        timestamp_list[i] = CopyString((*output_metadata.timestamps)[i]);
+        timestamp_list_sizes[i] = (*output_metadata.timestamps)[i].size();
+      }
+      errs[i] = nullptr;
+    } else {
+      values_list[i] = nullptr;
+      values_list_sizes[i] = 0;
+      if (output_metadata.timestamps.has_value()) {
+        timestamp_list[i] = nullptr;
+        timestamp_list_sizes[i] = 0;
+      }
+      errs[i] = statuses[i].IsNotFound()
+                    ? nullptr
+                    : strdup(statuses[i].ToString().c_str());
+    }
+  }
+}
+
+void rocksdb_multi_get_with_metadata(
+    rocksdb_t* db, const rocksdb_readoptions_t* options, size_t num_keys,
+    const char* const* keys_list, const size_t* keys_list_sizes,
+    char** values_list, size_t* values_list_sizes, char** timestamp_list,
+    size_t* timestamp_list_sizes, unsigned char* newer_version_present,
+    char** errs) {
+  std::vector<ColumnFamilyHandle*> column_families(
+      num_keys, db->rep->DefaultColumnFamily());
+  rocksdb_multi_get_with_metadata_impl(
+      db, options, column_families.data(), num_keys, keys_list, keys_list_sizes,
+      values_list, values_list_sizes, timestamp_list, timestamp_list_sizes,
+      newer_version_present, errs);
+}
+
 void rocksdb_multi_get_with_ts(rocksdb_t* db,
                                const rocksdb_readoptions_t* options,
                                size_t num_keys, const char* const* keys_list,
@@ -2809,6 +2938,24 @@ void rocksdb_multi_get_cf(
       }
     }
   }
+}
+
+void rocksdb_multi_get_cf_with_metadata(
+    rocksdb_t* db, const rocksdb_readoptions_t* options,
+    const rocksdb_column_family_handle_t* const* column_families,
+    size_t num_keys, const char* const* keys_list,
+    const size_t* keys_list_sizes, char** values_list,
+    size_t* values_list_sizes, char** timestamp_list,
+    size_t* timestamp_list_sizes, unsigned char* newer_version_present,
+    char** errs) {
+  std::vector<ColumnFamilyHandle*> cfs(num_keys);
+  for (size_t i = 0; i < num_keys; ++i) {
+    cfs[i] = column_families[i]->rep;
+  }
+  rocksdb_multi_get_with_metadata_impl(
+      db, options, cfs.data(), num_keys, keys_list, keys_list_sizes,
+      values_list, values_list_sizes, timestamp_list, timestamp_list_sizes,
+      newer_version_present, errs);
 }
 
 void rocksdb_multi_get_cf_with_ts(

--- a/db/c_test.c
+++ b/db/c_test.c
@@ -2474,6 +2474,35 @@ int main(int argc, char** argv) {
     CheckNoError(err);
     rocksdb_readoptions_set_snapshot(roptions, snap);
     CheckGet(db, roptions, "foo", "hello");
+
+    size_t metadata_value_len = 0;
+    unsigned char newer_version_present = 0;
+    char* metadata_value =
+        rocksdb_get_with_metadata(db, roptions, "foo", 3, &metadata_value_len,
+                                  NULL, NULL, &newer_version_present, &err);
+    // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
+    CheckNoError(err);
+    CheckEqual("hello", metadata_value, metadata_value_len);
+    // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
+    CheckCondition(newer_version_present == 1);
+    Free(&metadata_value);
+
+    const char* metadata_keys[] = {"foo"};
+    const size_t metadata_key_sizes[] = {3};
+    char* metadata_values[1];
+    size_t metadata_value_sizes[1];
+    unsigned char newer_versions[1];
+    char* metadata_errors[1];
+    rocksdb_multi_get_with_metadata(
+        db, roptions, 1, metadata_keys, metadata_key_sizes, metadata_values,
+        metadata_value_sizes, NULL, NULL, newer_versions, metadata_errors);
+    // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
+    CheckCondition(metadata_errors[0] == NULL);
+    CheckEqual("hello", metadata_values[0], metadata_value_sizes[0]);
+    // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
+    CheckCondition(newer_versions[0] == 1);
+    Free(&metadata_values[0]);
+
     rocksdb_readoptions_set_snapshot(roptions, NULL);
     CheckGet(db, roptions, "foo", NULL);
     rocksdb_release_snapshot(db, snap);

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -24,6 +24,7 @@
 #include "table/block_based/block_based_table_reader.h"
 #include "table/block_based/block_builder.h"
 #include "test_util/sync_point.h"
+#include "util/defer.h"
 #include "util/file_checksum_helper.h"
 #include "util/random.h"
 #include "utilities/counted_fs.h"
@@ -34,6 +35,19 @@
 
 namespace ROCKSDB_NAMESPACE {
 namespace {
+
+OutputMetadata NewerVersionOutputMetadata() {
+  OutputMetadata output_metadata;
+  output_metadata.WantNewerVersionPresent();
+  return output_metadata;
+}
+
+MultiGetOutputMetadata NewerVersionMultiGetOutputMetadata() {
+  MultiGetOutputMetadata output_metadata;
+  output_metadata.WantNewerVersionPresent();
+  return output_metadata;
+}
+
 class MyFlushBlockPolicy : public FlushBlockPolicy {
  public:
   explicit MyFlushBlockPolicy(const int num_keys_in_block,
@@ -1228,6 +1242,24 @@ TEST_F(DBBasicTest, ReadOnlyDB) {
   ASSERT_OK(EnforcedReadOnlyReopen(options));
   ASSERT_EQ("v3", Get("foo"));
   ASSERT_EQ("v2", Get("bar"));
+  std::string metadata_value;
+  ReadOptions metadata_read_options;
+  OutputMetadata output_metadata = NewerVersionOutputMetadata();
+  ASSERT_OK(db_->GetWithMetadata(metadata_read_options, "foo", &metadata_value,
+                                 &output_metadata));
+  ASSERT_EQ("v3", metadata_value);
+  ASSERT_FALSE(*output_metadata.newer_version_present);
+  std::vector<Slice> metadata_keys{Slice("foo")};
+  std::vector<std::string> metadata_values;
+  MultiGetOutputMetadata multiget_output_metadata =
+      NewerVersionMultiGetOutputMetadata();
+  std::vector<Status> metadata_statuses =
+      db_->MultiGetWithMetadata(metadata_read_options, metadata_keys,
+                                &metadata_values, &multiget_output_metadata);
+  ASSERT_EQ(1, metadata_statuses.size());
+  ASSERT_OK(metadata_statuses[0]);
+  ASSERT_EQ("v3", metadata_values[0]);
+  ASSERT_FALSE((*multiget_output_metadata.newer_version_present)[0]);
   verify_all_iters();
   ASSERT_EQ(db_->SyncWAL().code(), Status::Code::kNotSupported);
 
@@ -1408,6 +1440,35 @@ TEST_F(DBBasicTest, CompactedDB) {
   ASSERT_EQ(DummyString(kFileSize / 2, 'i'), Get("iii"));
   ASSERT_EQ(DummyString(kFileSize / 2, 'j'), Get("jjj"));
   ASSERT_EQ("NOT_FOUND", Get("kkk"));
+
+  std::string metadata_value;
+  ReadOptions metadata_read_options;
+  const Snapshot* metadata_snapshot = db_->GetSnapshot();
+  metadata_read_options.snapshot = metadata_snapshot;
+  OutputMetadata output_metadata = NewerVersionOutputMetadata();
+  ASSERT_OK(db_->GetWithMetadata(metadata_read_options, "aaa", &metadata_value,
+                                 &output_metadata));
+  ASSERT_EQ(DummyString(kFileSize / 2, 'a'), metadata_value);
+  ASSERT_FALSE(*output_metadata.newer_version_present);
+  std::vector<Slice> metadata_keys{Slice("aaa"), Slice("ccc")};
+  std::vector<std::string> metadata_values;
+  MultiGetOutputMetadata multiget_output_metadata =
+      NewerVersionMultiGetOutputMetadata();
+  std::vector<Status> metadata_statuses =
+      db_->MultiGetWithMetadata(metadata_read_options, metadata_keys,
+                                &metadata_values, &multiget_output_metadata);
+  ASSERT_EQ(metadata_keys.size(), metadata_statuses.size());
+  ASSERT_OK(metadata_statuses[0]);
+  ASSERT_EQ(DummyString(kFileSize / 2, 'a'), metadata_values[0]);
+  ASSERT_FALSE((*multiget_output_metadata.newer_version_present)[0]);
+  ASSERT_TRUE(metadata_statuses[1].IsNotFound());
+  ASSERT_FALSE((*multiget_output_metadata.newer_version_present)[1]);
+  db_->ReleaseSnapshot(metadata_snapshot);
+
+  ASSERT_TRUE(db_->GetWithMetadata(ReadOptions(), db_->DefaultColumnFamily(),
+                                   "aaa", static_cast<PinnableSlice*>(nullptr),
+                                   &output_metadata)
+                  .IsInvalidArgument());
 
   // TODO: validate that other write ops return NotImplemented
   // (CompactedDB is missing some overrides)
@@ -1594,6 +1655,397 @@ TEST_P(DBBasicGetWithParam, GetSnapshot) {
       db_->ReleaseSnapshot(s1);
     }
   } while (ChangeOptions());
+}
+
+TEST_F(DBBasicTest, GetNewerVersionPresent) {
+  // Snapshot reads report later point and range-delete writes without changing
+  // the snapshot-visible value.
+  Options options = CurrentOptions();
+  options.merge_operator = MergeOperators::CreateStringAppendOperator();
+  CreateAndReopenWithCF({"pikachu"}, options);
+
+  ASSERT_OK(Put(1, "key", "v1"));
+  ASSERT_OK(Put(1, "merge_key", "base"));
+  ASSERT_OK(Put(1, "stable", "s1"));
+  ASSERT_OK(Put(1, "range_key", "r1"));
+  const Snapshot* snapshot = db_->GetSnapshot();
+
+  ReadOptions snapshot_read;
+  snapshot_read.snapshot = snapshot;
+
+  std::string value;
+  OutputMetadata output_metadata = NewerVersionOutputMetadata();
+  ASSERT_OK(db_->GetWithMetadata(snapshot_read, handles_[1], "key", &value,
+                                 &output_metadata));
+  ASSERT_EQ("v1", value);
+  ASSERT_FALSE(*output_metadata.newer_version_present);
+
+  ASSERT_OK(Put(1, "other", "v2"));
+  ASSERT_OK(Put(1, "created_after_put", "new"));
+  ASSERT_OK(Merge(1, "created_after_merge", "new"));
+  ASSERT_OK(
+      db_->DeleteRange(WriteOptions(), handles_[1], "range_key", "range_key~"));
+  ASSERT_OK(Merge(1, "merge_key", "new"));
+  value.clear();
+  *output_metadata.newer_version_present = true;
+  ASSERT_OK(db_->GetWithMetadata(snapshot_read, handles_[1], "stable", &value,
+                                 &output_metadata));
+  ASSERT_EQ("s1", value);
+  ASSERT_FALSE(*output_metadata.newer_version_present);
+
+  value.clear();
+  *output_metadata.newer_version_present = true;
+  ASSERT_TRUE(db_->GetWithMetadata(snapshot_read, handles_[1],
+                                   "created_after_put", &value,
+                                   &output_metadata)
+                  .IsNotFound());
+  ASSERT_TRUE(*output_metadata.newer_version_present);
+
+  value.clear();
+  *output_metadata.newer_version_present = false;
+  ASSERT_TRUE(db_->GetWithMetadata(snapshot_read, handles_[1],
+                                   "created_after_merge", &value,
+                                   &output_metadata)
+                  .IsNotFound());
+  ASSERT_TRUE(*output_metadata.newer_version_present);
+
+  value.clear();
+  *output_metadata.newer_version_present = false;
+  ASSERT_OK(db_->GetWithMetadata(snapshot_read, handles_[1], "range_key",
+                                 &value, &output_metadata));
+  ASSERT_EQ("r1", value);
+  ASSERT_TRUE(*output_metadata.newer_version_present);
+
+  value.clear();
+  *output_metadata.newer_version_present = false;
+  ASSERT_OK(db_->GetWithMetadata(snapshot_read, handles_[1], "merge_key",
+                                 &value, &output_metadata));
+  ASSERT_EQ("base", value);
+  ASSERT_TRUE(*output_metadata.newer_version_present);
+
+  ASSERT_OK(Put(1, "key", "v2"));
+  value.clear();
+  ASSERT_OK(db_->GetWithMetadata(snapshot_read, handles_[1], "key", &value,
+                                 &output_metadata));
+  ASSERT_EQ("v1", value);
+  ASSERT_TRUE(*output_metadata.newer_version_present);
+
+  ASSERT_OK(Flush(1));
+  value.clear();
+  *output_metadata.newer_version_present = false;
+  ASSERT_OK(db_->GetWithMetadata(snapshot_read, handles_[1], "key", &value,
+                                 &output_metadata));
+  ASSERT_EQ("v1", value);
+  ASSERT_TRUE(*output_metadata.newer_version_present);
+
+  value.clear();
+  *output_metadata.newer_version_present = false;
+  ASSERT_OK(db_->GetWithMetadata(snapshot_read, handles_[1], "range_key",
+                                 &value, &output_metadata));
+  ASSERT_EQ("r1", value);
+  ASSERT_TRUE(*output_metadata.newer_version_present);
+
+  ReadOptions latest_read;
+  value.clear();
+  *output_metadata.newer_version_present = true;
+  ASSERT_OK(db_->GetWithMetadata(latest_read, handles_[1], "key", &value,
+                                 &output_metadata));
+  ASSERT_EQ("v2", value);
+  ASSERT_FALSE(*output_metadata.newer_version_present);
+
+  db_->ReleaseSnapshot(snapshot);
+}
+
+TEST_F(DBBasicTest, NewerVersionPresentRequestedByOutputMetadata) {
+  // Newer-version tracking is opt-in through OutputMetadata and
+  // MultiGetOutputMetadata.
+  Options options = CurrentOptions();
+  CreateAndReopenWithCF({"pikachu"}, options);
+
+  ASSERT_OK(Put(1, "key", "old"));
+  const Snapshot* snapshot = db_->GetSnapshot();
+  ASSERT_OK(Put(1, "key", "new"));
+
+  ReadOptions read_options;
+  read_options.snapshot = snapshot;
+
+  std::string value;
+  OutputMetadata output_metadata = NewerVersionOutputMetadata();
+  ASSERT_OK(db_->GetWithMetadata(read_options, handles_[1], "key", &value,
+                                 &output_metadata));
+  ASSERT_EQ("old", value);
+  ASSERT_TRUE(*output_metadata.newer_version_present);
+
+  std::vector<Slice> keys{"key"};
+  std::vector<ColumnFamilyHandle*> cfs(keys.size(), handles_[1]);
+  std::vector<std::string> values;
+  MultiGetOutputMetadata multiget_output_metadata =
+      NewerVersionMultiGetOutputMetadata();
+  std::vector<Status> statuses = db_->MultiGetWithMetadata(
+      read_options, cfs, keys, &values, &multiget_output_metadata);
+  ASSERT_EQ(1, statuses.size());
+  ASSERT_OK(statuses[0]);
+  ASSERT_EQ("old", values[0]);
+  ASSERT_EQ(1, multiget_output_metadata.newer_version_present->size());
+  ASSERT_TRUE((*multiget_output_metadata.newer_version_present)[0]);
+
+  db_->ReleaseSnapshot(snapshot);
+}
+
+TEST_F(DBBasicTest, NewerVersionPresentIgnoreRangeDeletions) {
+  // ignore_range_deletions affects the returned value, not newer-version
+  // metadata about covering range tombstones.
+  Options options = CurrentOptions();
+  CreateAndReopenWithCF({"pikachu"}, options);
+
+  ASSERT_OK(Put(1, "range_key", "old"));
+  const Snapshot* snapshot = db_->GetSnapshot();
+  ASSERT_OK(
+      db_->DeleteRange(WriteOptions(), handles_[1], "range_key", "range_key~"));
+
+  ReadOptions read_options;
+  read_options.snapshot = snapshot;
+  read_options.ignore_range_deletions = true;
+
+  std::string value;
+  OutputMetadata output_metadata = NewerVersionOutputMetadata();
+  ASSERT_OK(db_->GetWithMetadata(read_options, handles_[1], "range_key", &value,
+                                 &output_metadata));
+  ASSERT_EQ("old", value);
+  ASSERT_TRUE(*output_metadata.newer_version_present);
+
+  std::vector<Slice> keys{"range_key"};
+  std::vector<ColumnFamilyHandle*> cfs(keys.size(), handles_[1]);
+  std::vector<std::string> values;
+  MultiGetOutputMetadata multiget_output_metadata =
+      NewerVersionMultiGetOutputMetadata();
+  std::vector<Status> statuses = db_->MultiGetWithMetadata(
+      read_options, cfs, keys, &values, &multiget_output_metadata);
+  ASSERT_EQ(1, statuses.size());
+  ASSERT_OK(statuses[0]);
+  ASSERT_EQ("old", values[0]);
+  ASSERT_TRUE((*multiget_output_metadata.newer_version_present)[0]);
+
+  ASSERT_OK(Flush(1));
+  value.clear();
+  *output_metadata.newer_version_present = false;
+  ASSERT_OK(db_->GetWithMetadata(read_options, handles_[1], "range_key", &value,
+                                 &output_metadata));
+  ASSERT_EQ("old", value);
+  ASSERT_TRUE(*output_metadata.newer_version_present);
+
+  values.clear();
+  multiget_output_metadata.newer_version_present->clear();
+  statuses = db_->MultiGetWithMetadata(read_options, cfs, keys, &values,
+                                       &multiget_output_metadata);
+  ASSERT_EQ(1, statuses.size());
+  ASSERT_OK(statuses[0]);
+  ASSERT_EQ("old", values[0]);
+  ASSERT_TRUE((*multiget_output_metadata.newer_version_present)[0]);
+
+  db_->ReleaseSnapshot(snapshot);
+}
+
+TEST_F(DBBasicTest, NewerVersionPresentFromImmutableMemTable) {
+  Options options = CurrentOptions();
+  CreateAndReopenWithCF({"pikachu"}, options);
+
+  ASSERT_OK(Put(1, "point_key", "old_point"));
+  ASSERT_OK(Put(1, "range_key", "old_range"));
+  ManagedSnapshot snapshot(db_.get());
+
+  ASSERT_OK(Put(1, "point_key", "new_point"));
+  ASSERT_OK(
+      db_->DeleteRange(WriteOptions(), handles_[1], "range_key", "range_key~"));
+
+  auto* cfd =
+      static_cast_with_check<ColumnFamilyHandleImpl>(handles_[1])->cfd();
+  Status resume_status;
+  {
+    ASSERT_OK(db_->PauseBackgroundWork());
+    Defer resume_background(
+        [&] { resume_status = db_->ContinueBackgroundWork(); });
+    ASSERT_OK(dbfull()->TEST_SwitchMemtable(cfd));
+
+    ReadOptions read_options;
+    read_options.snapshot = snapshot.snapshot();
+
+    std::string value;
+    OutputMetadata output_metadata = NewerVersionOutputMetadata();
+    ASSERT_OK(db_->GetWithMetadata(read_options, handles_[1], "point_key",
+                                   &value, &output_metadata));
+    ASSERT_EQ("old_point", value);
+    ASSERT_TRUE(*output_metadata.newer_version_present);
+
+    value.clear();
+    *output_metadata.newer_version_present = false;
+    ASSERT_OK(db_->GetWithMetadata(read_options, handles_[1], "range_key",
+                                   &value, &output_metadata));
+    ASSERT_EQ("old_range", value);
+    ASSERT_TRUE(*output_metadata.newer_version_present);
+
+    std::vector<Slice> keys{"point_key", "range_key"};
+    std::vector<ColumnFamilyHandle*> cfs(keys.size(), handles_[1]);
+    std::vector<std::string> values;
+    MultiGetOutputMetadata multiget_output_metadata =
+        NewerVersionMultiGetOutputMetadata();
+    const std::vector<Status> statuses = db_->MultiGetWithMetadata(
+        read_options, cfs, keys, &values, &multiget_output_metadata);
+    ASSERT_EQ(2, statuses.size());
+    ASSERT_OK(statuses[0]);
+    ASSERT_OK(statuses[1]);
+    ASSERT_EQ(std::vector<std::string>({"old_point", "old_range"}), values);
+    ASSERT_TRUE((*multiget_output_metadata.newer_version_present)[0]);
+    ASSERT_TRUE((*multiget_output_metadata.newer_version_present)[1]);
+  }
+  ASSERT_OK(resume_status);
+  ASSERT_OK(Flush(1));
+}
+
+TEST_F(DBBasicTest, NewerVersionPresentBypassesRowCacheWhileTracking) {
+  // Prime row-cache entries for the snapshot values, then verify metadata
+  // reads still inspect SST sequence numbers instead of replaying those
+  // entries.
+  option_config_ = kRowCache;
+  Options options = CurrentOptions();
+  options.statistics = ROCKSDB_NAMESPACE::CreateDBStatistics();
+  CreateAndReopenWithCF({"pikachu"}, options);
+
+  ASSERT_OK(Put(1, "get_key", "old_get"));
+  ASSERT_OK(Put(1, "multiget_key", "old_multiget"));
+  ASSERT_OK(Flush(1));
+  ManagedSnapshot snapshot(db_.get());
+  ASSERT_OK(Put(1, "get_key", "new_get"));
+  ASSERT_OK(Put(1, "multiget_key", "new_multiget"));
+  ASSERT_OK(Flush(1));
+
+  ReadOptions read_options;
+  read_options.snapshot = snapshot.snapshot();
+
+  std::string primed_value;
+  ASSERT_OK(db_->Get(read_options, handles_[1], "get_key", &primed_value));
+  ASSERT_EQ("old_get", primed_value);
+  std::vector<Slice> primed_keys{"multiget_key"};
+  std::vector<ColumnFamilyHandle*> primed_cfs(primed_keys.size(), handles_[1]);
+  std::vector<std::string> primed_values;
+  const std::vector<Status> primed_statuses =
+      db_->MultiGet(read_options, primed_cfs, primed_keys, &primed_values);
+  ASSERT_OK(primed_statuses[0]);
+  ASSERT_EQ("old_multiget", primed_values[0]);
+
+  for (int i = 0; i < 2; ++i) {
+    SCOPED_TRACE(i);
+    std::string value;
+    OutputMetadata output_metadata = NewerVersionOutputMetadata();
+    ASSERT_OK(db_->GetWithMetadata(read_options, handles_[1], "get_key", &value,
+                                   &output_metadata));
+    ASSERT_EQ("old_get", value);
+    ASSERT_TRUE(*output_metadata.newer_version_present);
+  }
+
+  std::vector<Slice> keys{"multiget_key"};
+  std::vector<ColumnFamilyHandle*> cfs(keys.size(), handles_[1]);
+  for (int i = 0; i < 2; ++i) {
+    SCOPED_TRACE(i);
+    std::vector<std::string> values;
+    MultiGetOutputMetadata multiget_output_metadata =
+        NewerVersionMultiGetOutputMetadata();
+    std::vector<Status> statuses = db_->MultiGetWithMetadata(
+        read_options, cfs, keys, &values, &multiget_output_metadata);
+    ASSERT_EQ(1, statuses.size());
+    ASSERT_OK(statuses[0]);
+    ASSERT_EQ("old_multiget", values[0]);
+    ASSERT_TRUE((*multiget_output_metadata.newer_version_present)[0]);
+  }
+}
+
+TEST_F(DBBasicTest, NewerVersionPresentPersistedTierNotSupported) {
+  // kPersistedTier is incompatible with snapshot newer-version tracking but not
+  // with untracked latest-version reads.
+  Options options = CurrentOptions();
+  CreateAndReopenWithCF({"pikachu"}, options);
+
+  ASSERT_OK(Put(1, "key", "old"));
+  const Snapshot* snapshot = db_->GetSnapshot();
+  ASSERT_OK(Put(1, "key", "new"));
+
+  ReadOptions read_options;
+  read_options.snapshot = snapshot;
+  read_options.read_tier = kPersistedTier;
+
+  std::string value;
+  OutputMetadata output_metadata = NewerVersionOutputMetadata();
+  ASSERT_TRUE(db_->GetWithMetadata(read_options, handles_[1], "key", &value,
+                                   &output_metadata)
+                  .IsNotSupported());
+
+  std::vector<Slice> keys{"key"};
+  std::vector<ColumnFamilyHandle*> cfs(keys.size(), handles_[1]);
+  std::vector<std::string> values;
+  MultiGetOutputMetadata multiget_output_metadata =
+      NewerVersionMultiGetOutputMetadata();
+  std::vector<Status> statuses = db_->MultiGetWithMetadata(
+      read_options, cfs, keys, &values, &multiget_output_metadata);
+  ASSERT_EQ(1, statuses.size());
+  ASSERT_TRUE(statuses[0].IsNotSupported());
+  ASSERT_FALSE((*multiget_output_metadata.newer_version_present)[0]);
+
+  read_options.snapshot = nullptr;
+  value.clear();
+  *output_metadata.newer_version_present = true;
+  ASSERT_OK(db_->GetWithMetadata(read_options, handles_[1], "key", &value,
+                                 &output_metadata));
+  ASSERT_EQ("new", value);
+  ASSERT_FALSE(*output_metadata.newer_version_present);
+
+  values.clear();
+  multiget_output_metadata.newer_version_present->clear();
+  statuses = db_->MultiGetWithMetadata(read_options, cfs, keys, &values,
+                                       &multiget_output_metadata);
+  ASSERT_EQ(1, statuses.size());
+  ASSERT_OK(statuses[0]);
+  ASSERT_EQ("new", values[0]);
+  ASSERT_FALSE((*multiget_output_metadata.newer_version_present)[0]);
+
+  db_->ReleaseSnapshot(snapshot);
+}
+
+TEST_F(DBBasicTest, ReadOnlyNewerVersionPresentReturnsFalse) {
+  // Read-only DBs do not widen snapshot reads, so requested metadata remains
+  // false.
+  Options options = CurrentOptions();
+  CreateAndReopenWithCF({"pikachu"}, options);
+
+  ASSERT_OK(Put(1, "key", "value"));
+  ASSERT_OK(Flush(1));
+  ASSERT_OK(
+      TryReopenReadOnlyWithColumnFamilies({"default", "pikachu"}, options));
+
+  const Snapshot* snapshot = db_->GetSnapshot();
+  ReadOptions read_options;
+  read_options.snapshot = snapshot;
+
+  std::string value;
+  OutputMetadata output_metadata = NewerVersionOutputMetadata();
+  ASSERT_OK(db_->GetWithMetadata(read_options, handles_[1], "key", &value,
+                                 &output_metadata));
+  ASSERT_EQ("value", value);
+  ASSERT_FALSE(*output_metadata.newer_version_present);
+
+  std::vector<Slice> keys{"key"};
+  std::vector<ColumnFamilyHandle*> cfs(keys.size(), handles_[1]);
+  std::vector<std::string> values;
+  MultiGetOutputMetadata multiget_output_metadata =
+      NewerVersionMultiGetOutputMetadata();
+  std::vector<Status> statuses = db_->MultiGetWithMetadata(
+      read_options, cfs, keys, &values, &multiget_output_metadata);
+  ASSERT_EQ(1, statuses.size());
+  ASSERT_OK(statuses[0]);
+  ASSERT_EQ("value", values[0]);
+  ASSERT_EQ(1, multiget_output_metadata.newer_version_present->size());
+  ASSERT_FALSE((*multiget_output_metadata.newer_version_present)[0]);
+
+  db_->ReleaseSnapshot(snapshot);
 }
 
 TEST_F(DBBasicTest, CheckLock) {
@@ -2186,6 +2638,151 @@ TEST_F(DBBasicTest, MultiGetSimple) {
     ASSERT_TRUE(s[5].IsNotFound());
     SetPerfLevel(kDisable);
   } while (ChangeCompactOptions());
+}
+
+TEST_F(DBBasicTest, MultiGetNewerVersionPresent) {
+  // A mixed MultiGet batch reports newer writes independently for each key in
+  // input order.
+  Options options = CurrentOptions();
+  options.merge_operator = MergeOperators::CreateStringAppendOperator();
+  CreateAndReopenWithCF({"pikachu"}, options);
+
+  ASSERT_OK(Put(1, "updated", "old"));
+  ASSERT_OK(Put(1, "unchanged", "same"));
+  ASSERT_OK(Put(1, "deleted", "old"));
+  ASSERT_OK(Put(1, "merged", "old"));
+  ASSERT_OK(Put(1, "range_deleted", "old"));
+  const Snapshot* snapshot = db_->GetSnapshot();
+
+  ASSERT_OK(Put(1, "updated", "new"));
+  ASSERT_OK(Put(1, "created_after_put", "new"));
+  ASSERT_OK(Merge(1, "created_after_merge", "new"));
+  ASSERT_OK(Delete(1, "deleted"));
+  ASSERT_OK(Merge(1, "merged", "new"));
+  ASSERT_OK(db_->DeleteRange(WriteOptions(), handles_[1], "range_deleted",
+                             "range_deleted~"));
+
+  ReadOptions read_options;
+  read_options.snapshot = snapshot;
+  std::vector<Slice> keys({"updated", "unchanged", "deleted", "merged",
+                           "range_deleted", "created_after_put",
+                           "created_after_merge", "missing"});
+  std::vector<ColumnFamilyHandle*> cfs(keys.size(), handles_[1]);
+  std::vector<std::string> values;
+  MultiGetOutputMetadata output_metadata = NewerVersionMultiGetOutputMetadata();
+
+  std::vector<Status> statuses = db_->MultiGetWithMetadata(
+      read_options, cfs, keys, &values, &output_metadata);
+
+  ASSERT_EQ(keys.size(), statuses.size());
+  ASSERT_OK(statuses[0]);
+  ASSERT_EQ("old", values[0]);
+  ASSERT_TRUE((*output_metadata.newer_version_present)[0]);
+
+  ASSERT_OK(statuses[1]);
+  ASSERT_EQ("same", values[1]);
+  ASSERT_FALSE((*output_metadata.newer_version_present)[1]);
+
+  ASSERT_OK(statuses[2]);
+  ASSERT_EQ("old", values[2]);
+  ASSERT_TRUE((*output_metadata.newer_version_present)[2]);
+
+  ASSERT_OK(statuses[3]);
+  ASSERT_EQ("old", values[3]);
+  ASSERT_TRUE((*output_metadata.newer_version_present)[3]);
+
+  ASSERT_OK(statuses[4]);
+  ASSERT_EQ("old", values[4]);
+  ASSERT_TRUE((*output_metadata.newer_version_present)[4]);
+
+  ASSERT_TRUE(statuses[5].IsNotFound());
+  ASSERT_TRUE((*output_metadata.newer_version_present)[5]);
+
+  ASSERT_TRUE(statuses[6].IsNotFound());
+  ASSERT_TRUE((*output_metadata.newer_version_present)[6]);
+
+  ASSERT_TRUE(statuses[7].IsNotFound());
+  ASSERT_FALSE((*output_metadata.newer_version_present)[7]);
+
+  db_->ReleaseSnapshot(snapshot);
+}
+
+TEST_F(DBBasicTest, MultiGetNewerVersionPresentAcrossColumnFamilies) {
+  // Unsorted mixed-CF reads keep metadata aligned with input order after each
+  // CF is processed independently.
+  Options options = CurrentOptions();
+  CreateAndReopenWithCF({"one", "two"}, options);
+
+  ASSERT_OK(Put(1, "updated_one", "old_one"));
+  ASSERT_OK(Put(2, "updated_two", "old_two"));
+  ASSERT_OK(Put(2, "stable_two", "stable"));
+  const Snapshot* snapshot = db_->GetSnapshot();
+  ASSERT_OK(Put(1, "updated_one", "new_one"));
+  ASSERT_OK(Put(2, "updated_two", "new_two"));
+  ASSERT_OK(Flush(1));
+  ASSERT_OK(Flush(2));
+
+  ReadOptions read_options;
+  read_options.snapshot = snapshot;
+  std::vector<Slice> keys{"updated_two", "updated_one", "stable_two"};
+  std::vector<ColumnFamilyHandle*> column_families{handles_[2], handles_[1],
+                                                   handles_[2]};
+  std::vector<std::string> values;
+  MultiGetOutputMetadata output_metadata = NewerVersionMultiGetOutputMetadata();
+  const std::vector<Status> statuses = db_->MultiGetWithMetadata(
+      read_options, column_families, keys, &values, &output_metadata);
+
+  for (const Status& status : statuses) {
+    ASSERT_OK(status);
+  }
+  ASSERT_EQ(std::vector<std::string>({"old_two", "old_one", "stable"}), values);
+  ASSERT_TRUE((*output_metadata.newer_version_present)[0]);
+  ASSERT_TRUE((*output_metadata.newer_version_present)[1]);
+  ASSERT_FALSE((*output_metadata.newer_version_present)[2]);
+
+  db_->ReleaseSnapshot(snapshot);
+}
+
+TEST_F(DBBasicTest, MultiGetWithMetadataColumnFamiliesKeysSizeMismatch) {
+  CreateAndReopenWithCF({"pikachu"}, CurrentOptions());
+
+  std::vector<Slice> keys({"k1", "k2"});
+  std::vector<ColumnFamilyHandle*> cfs({handles_[1]});
+  std::vector<std::string> values({"stale"});
+  MultiGetOutputMetadata output_metadata;
+  output_metadata.timestamps.emplace();
+  output_metadata.newer_version_present = std::vector<bool>({true});
+
+  std::vector<Status> statuses = db_->MultiGetWithMetadata(
+      ReadOptions(), cfs, keys, &values, &output_metadata);
+
+  ASSERT_EQ(keys.size(), statuses.size());
+  ASSERT_EQ(keys.size(), values.size());
+  for (const Status& status : statuses) {
+    ASSERT_TRUE(status.IsInvalidArgument());
+  }
+  ASSERT_EQ(keys.size(), output_metadata.timestamps->size());
+  ASSERT_EQ(keys.size(), output_metadata.newer_version_present->size());
+  ASSERT_FALSE((*output_metadata.newer_version_present)[0]);
+  ASSERT_FALSE((*output_metadata.newer_version_present)[1]);
+}
+
+TEST_F(DBBasicTest, GetWithMetadataNullValueInvalidArgument) {
+  CreateAndReopenWithCF({"pikachu"}, CurrentOptions());
+
+  OutputMetadata output_metadata = NewerVersionOutputMetadata();
+  ASSERT_TRUE(db_->GetWithMetadata(ReadOptions(), handles_[1], "key",
+                                   static_cast<PinnableSlice*>(nullptr),
+                                   &output_metadata)
+                  .IsInvalidArgument());
+  ASSERT_FALSE(*output_metadata.newer_version_present);
+
+  *output_metadata.newer_version_present = true;
+  ASSERT_TRUE(db_->GetWithMetadata(ReadOptions(), "key",
+                                   static_cast<std::string*>(nullptr),
+                                   &output_metadata)
+                  .IsInvalidArgument());
+  ASSERT_FALSE(*output_metadata.newer_version_present);
 }
 
 TEST_F(DBBasicTest, MultiGetEmpty) {

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -38,6 +38,19 @@
 
 namespace ROCKSDB_NAMESPACE {
 namespace {
+
+OutputMetadata NewerVersionOutputMetadata() {
+  OutputMetadata output_metadata;
+  output_metadata.WantNewerVersionPresent();
+  return output_metadata;
+}
+
+MultiGetOutputMetadata NewerVersionMultiGetOutputMetadata() {
+  MultiGetOutputMetadata output_metadata;
+  output_metadata.WantNewerVersionPresent();
+  return output_metadata;
+}
+
 class MyFlushBlockPolicy : public FlushBlockPolicy {
  public:
   explicit MyFlushBlockPolicy(const int num_keys_in_block,
@@ -1321,6 +1334,24 @@ TEST_F(DBBasicTest, ReadOnlyDB) {
   ASSERT_OK(EnforcedReadOnlyReopen(options));
   ASSERT_EQ("v3", Get("foo"));
   ASSERT_EQ("v2", Get("bar"));
+  std::string metadata_value;
+  ReadOptions metadata_read_options;
+  OutputMetadata output_metadata = NewerVersionOutputMetadata();
+  ASSERT_OK(db_->GetWithMetadata(metadata_read_options, "foo", &metadata_value,
+                                 &output_metadata));
+  ASSERT_EQ("v3", metadata_value);
+  ASSERT_FALSE(*output_metadata.newer_version_present);
+  std::vector<Slice> metadata_keys{Slice("foo")};
+  std::vector<std::string> metadata_values;
+  MultiGetOutputMetadata multiget_output_metadata =
+      NewerVersionMultiGetOutputMetadata();
+  std::vector<Status> metadata_statuses =
+      db_->MultiGetWithMetadata(metadata_read_options, metadata_keys,
+                                &metadata_values, &multiget_output_metadata);
+  ASSERT_EQ(1, metadata_statuses.size());
+  ASSERT_OK(metadata_statuses[0]);
+  ASSERT_EQ("v3", metadata_values[0]);
+  ASSERT_FALSE((*multiget_output_metadata.newer_version_present)[0]);
   verify_all_iters();
   ASSERT_EQ(db_->SyncWAL().code(), Status::Code::kNotSupported);
 
@@ -1501,6 +1532,35 @@ TEST_F(DBBasicTest, CompactedDB) {
   ASSERT_EQ(DummyString(kFileSize / 2, 'i'), Get("iii"));
   ASSERT_EQ(DummyString(kFileSize / 2, 'j'), Get("jjj"));
   ASSERT_EQ("NOT_FOUND", Get("kkk"));
+
+  std::string metadata_value;
+  ReadOptions metadata_read_options;
+  const Snapshot* metadata_snapshot = db_->GetSnapshot();
+  metadata_read_options.snapshot = metadata_snapshot;
+  OutputMetadata output_metadata = NewerVersionOutputMetadata();
+  ASSERT_OK(db_->GetWithMetadata(metadata_read_options, "aaa", &metadata_value,
+                                 &output_metadata));
+  ASSERT_EQ(DummyString(kFileSize / 2, 'a'), metadata_value);
+  ASSERT_FALSE(*output_metadata.newer_version_present);
+  std::vector<Slice> metadata_keys{Slice("aaa"), Slice("ccc")};
+  std::vector<std::string> metadata_values;
+  MultiGetOutputMetadata multiget_output_metadata =
+      NewerVersionMultiGetOutputMetadata();
+  std::vector<Status> metadata_statuses =
+      db_->MultiGetWithMetadata(metadata_read_options, metadata_keys,
+                                &metadata_values, &multiget_output_metadata);
+  ASSERT_EQ(metadata_keys.size(), metadata_statuses.size());
+  ASSERT_OK(metadata_statuses[0]);
+  ASSERT_EQ(DummyString(kFileSize / 2, 'a'), metadata_values[0]);
+  ASSERT_FALSE((*multiget_output_metadata.newer_version_present)[0]);
+  ASSERT_TRUE(metadata_statuses[1].IsNotFound());
+  ASSERT_FALSE((*multiget_output_metadata.newer_version_present)[1]);
+  db_->ReleaseSnapshot(metadata_snapshot);
+
+  ASSERT_TRUE(db_->GetWithMetadata(ReadOptions(), db_->DefaultColumnFamily(),
+                                   "aaa", static_cast<PinnableSlice*>(nullptr),
+                                   &output_metadata)
+                  .IsInvalidArgument());
 
   // TODO: validate that other write ops return NotImplemented
   // (CompactedDB is missing some overrides)
@@ -1687,6 +1747,430 @@ TEST_P(DBBasicGetWithParam, GetSnapshot) {
       db_->ReleaseSnapshot(s1);
     }
   } while (ChangeOptions());
+}
+
+TEST_F(DBBasicTest, GetNewerVersionPresent) {
+  // Snapshot reads report later point and range-delete writes without changing
+  // the snapshot-visible value.
+  Options options = CurrentOptions();
+  options.merge_operator = MergeOperators::CreateStringAppendOperator();
+  CreateAndReopenWithCF({"pikachu"}, options);
+
+  ASSERT_OK(Put(1, "key", "v1"));
+  ASSERT_OK(Put(1, "merge_key", "base"));
+  ASSERT_OK(Put(1, "stable", "s1"));
+  ASSERT_OK(Put(1, "range_key", "r1"));
+  const Snapshot* snapshot = db_->GetSnapshot();
+
+  ReadOptions snapshot_read;
+  snapshot_read.snapshot = snapshot;
+
+  std::string value;
+  OutputMetadata output_metadata = NewerVersionOutputMetadata();
+  ASSERT_OK(db_->GetWithMetadata(snapshot_read, handles_[1], "key", &value,
+                                 &output_metadata));
+  ASSERT_EQ("v1", value);
+  ASSERT_FALSE(*output_metadata.newer_version_present);
+
+  ASSERT_OK(Put(1, "other", "v2"));
+  ASSERT_OK(Put(1, "created_after_put", "new"));
+  ASSERT_OK(Merge(1, "created_after_merge", "new"));
+  ASSERT_OK(
+      db_->DeleteRange(WriteOptions(), handles_[1], "range_key", "range_key~"));
+  ASSERT_OK(Merge(1, "merge_key", "new"));
+  value.clear();
+  *output_metadata.newer_version_present = true;
+  ASSERT_OK(db_->GetWithMetadata(snapshot_read, handles_[1], "stable", &value,
+                                 &output_metadata));
+  ASSERT_EQ("s1", value);
+  ASSERT_FALSE(*output_metadata.newer_version_present);
+
+  value.clear();
+  *output_metadata.newer_version_present = true;
+  ASSERT_TRUE(db_->GetWithMetadata(snapshot_read, handles_[1],
+                                   "created_after_put", &value,
+                                   &output_metadata)
+                  .IsNotFound());
+  ASSERT_TRUE(*output_metadata.newer_version_present);
+
+  value.clear();
+  *output_metadata.newer_version_present = false;
+  ASSERT_TRUE(db_->GetWithMetadata(snapshot_read, handles_[1],
+                                   "created_after_merge", &value,
+                                   &output_metadata)
+                  .IsNotFound());
+  ASSERT_TRUE(*output_metadata.newer_version_present);
+
+  value.clear();
+  *output_metadata.newer_version_present = false;
+  ASSERT_OK(db_->GetWithMetadata(snapshot_read, handles_[1], "range_key",
+                                 &value, &output_metadata));
+  ASSERT_EQ("r1", value);
+  ASSERT_TRUE(*output_metadata.newer_version_present);
+
+  value.clear();
+  *output_metadata.newer_version_present = false;
+  ASSERT_OK(db_->GetWithMetadata(snapshot_read, handles_[1], "merge_key",
+                                 &value, &output_metadata));
+  ASSERT_EQ("base", value);
+  ASSERT_TRUE(*output_metadata.newer_version_present);
+
+  ASSERT_OK(Put(1, "key", "v2"));
+  value.clear();
+  ASSERT_OK(db_->GetWithMetadata(snapshot_read, handles_[1], "key", &value,
+                                 &output_metadata));
+  ASSERT_EQ("v1", value);
+  ASSERT_TRUE(*output_metadata.newer_version_present);
+
+  ASSERT_OK(Flush(1));
+  value.clear();
+  *output_metadata.newer_version_present = false;
+  ASSERT_OK(db_->GetWithMetadata(snapshot_read, handles_[1], "key", &value,
+                                 &output_metadata));
+  ASSERT_EQ("v1", value);
+  ASSERT_TRUE(*output_metadata.newer_version_present);
+
+  value.clear();
+  *output_metadata.newer_version_present = false;
+  ASSERT_OK(db_->GetWithMetadata(snapshot_read, handles_[1], "range_key",
+                                 &value, &output_metadata));
+  ASSERT_EQ("r1", value);
+  ASSERT_TRUE(*output_metadata.newer_version_present);
+
+  ReadOptions latest_read;
+  value.clear();
+  *output_metadata.newer_version_present = true;
+  ASSERT_OK(db_->GetWithMetadata(latest_read, handles_[1], "key", &value,
+                                 &output_metadata));
+  ASSERT_EQ("v2", value);
+  ASSERT_FALSE(*output_metadata.newer_version_present);
+
+  db_->ReleaseSnapshot(snapshot);
+}
+
+TEST_F(DBBasicTest, NewerVersionPresentRequestedByOutputMetadata) {
+  // Newer-version tracking is opt-in through OutputMetadata and
+  // MultiGetOutputMetadata.
+  Options options = CurrentOptions();
+  CreateAndReopenWithCF({"pikachu"}, options);
+
+  ASSERT_OK(Put(1, "key", "old"));
+  const Snapshot* snapshot = db_->GetSnapshot();
+  ASSERT_OK(Put(1, "key", "new"));
+
+  ReadOptions read_options;
+  read_options.snapshot = snapshot;
+
+  std::string value;
+  OutputMetadata output_metadata = NewerVersionOutputMetadata();
+  ASSERT_OK(db_->GetWithMetadata(read_options, handles_[1], "key", &value,
+                                 &output_metadata));
+  ASSERT_EQ("old", value);
+  ASSERT_TRUE(*output_metadata.newer_version_present);
+
+  std::vector<Slice> keys{"key"};
+  std::vector<ColumnFamilyHandle*> cfs(keys.size(), handles_[1]);
+  std::vector<std::string> values;
+  MultiGetOutputMetadata multiget_output_metadata =
+      NewerVersionMultiGetOutputMetadata();
+  std::vector<Status> statuses = db_->MultiGetWithMetadata(
+      read_options, cfs, keys, &values, &multiget_output_metadata);
+  ASSERT_EQ(1, statuses.size());
+  ASSERT_OK(statuses[0]);
+  ASSERT_EQ("old", values[0]);
+  ASSERT_EQ(1, multiget_output_metadata.newer_version_present->size());
+  ASSERT_TRUE((*multiget_output_metadata.newer_version_present)[0]);
+
+  db_->ReleaseSnapshot(snapshot);
+}
+
+TEST_F(DBBasicTest, NewerVersionPresentIgnoreRangeDeletions) {
+  // ignore_range_deletions affects the returned value, not newer-version
+  // metadata about covering range tombstones.
+  Options options = CurrentOptions();
+  CreateAndReopenWithCF({"pikachu"}, options);
+
+  ASSERT_OK(Put(1, "range_key", "old"));
+  const Snapshot* snapshot = db_->GetSnapshot();
+  ASSERT_OK(
+      db_->DeleteRange(WriteOptions(), handles_[1], "range_key", "range_key~"));
+
+  ReadOptions read_options;
+  read_options.snapshot = snapshot;
+  read_options.ignore_range_deletions = true;
+
+  std::string value;
+  OutputMetadata output_metadata = NewerVersionOutputMetadata();
+  ASSERT_OK(db_->GetWithMetadata(read_options, handles_[1], "range_key", &value,
+                                 &output_metadata));
+  ASSERT_EQ("old", value);
+  ASSERT_TRUE(*output_metadata.newer_version_present);
+
+  std::vector<Slice> keys{"range_key"};
+  std::vector<ColumnFamilyHandle*> cfs(keys.size(), handles_[1]);
+  std::vector<std::string> values;
+  MultiGetOutputMetadata multiget_output_metadata =
+      NewerVersionMultiGetOutputMetadata();
+  std::vector<Status> statuses = db_->MultiGetWithMetadata(
+      read_options, cfs, keys, &values, &multiget_output_metadata);
+  ASSERT_EQ(1, statuses.size());
+  ASSERT_OK(statuses[0]);
+  ASSERT_EQ("old", values[0]);
+  ASSERT_TRUE((*multiget_output_metadata.newer_version_present)[0]);
+
+  ASSERT_OK(Flush(1));
+  value.clear();
+  *output_metadata.newer_version_present = false;
+  ASSERT_OK(db_->GetWithMetadata(read_options, handles_[1], "range_key", &value,
+                                 &output_metadata));
+  ASSERT_EQ("old", value);
+  ASSERT_TRUE(*output_metadata.newer_version_present);
+
+  values.clear();
+  multiget_output_metadata.newer_version_present->clear();
+  statuses = db_->MultiGetWithMetadata(read_options, cfs, keys, &values,
+                                       &multiget_output_metadata);
+  ASSERT_EQ(1, statuses.size());
+  ASSERT_OK(statuses[0]);
+  ASSERT_EQ("old", values[0]);
+  ASSERT_TRUE((*multiget_output_metadata.newer_version_present)[0]);
+
+  db_->ReleaseSnapshot(snapshot);
+}
+
+TEST_F(DBBasicTest, NewerVersionPresentFromImmutableMemTable) {
+  Options options = CurrentOptions();
+  CreateAndReopenWithCF({"pikachu"}, options);
+
+  ASSERT_OK(Put(1, "point_key", "old_point"));
+  ASSERT_OK(Put(1, "range_key", "old_range"));
+  ManagedSnapshot snapshot(db_.get());
+
+  ASSERT_OK(Put(1, "point_key", "new_point"));
+  ASSERT_OK(
+      db_->DeleteRange(WriteOptions(), handles_[1], "range_key", "range_key~"));
+
+  auto* cfd =
+      static_cast_with_check<ColumnFamilyHandleImpl>(handles_[1])->cfd();
+  Status resume_status;
+  {
+    ASSERT_OK(db_->PauseBackgroundWork());
+    Defer resume_background(
+        [&] { resume_status = db_->ContinueBackgroundWork(); });
+    ASSERT_OK(dbfull()->TEST_SwitchMemtable(cfd));
+
+    ReadOptions read_options;
+    read_options.snapshot = snapshot.snapshot();
+
+    std::string value;
+    OutputMetadata output_metadata = NewerVersionOutputMetadata();
+    ASSERT_OK(db_->GetWithMetadata(read_options, handles_[1], "point_key",
+                                   &value, &output_metadata));
+    ASSERT_EQ("old_point", value);
+    ASSERT_TRUE(*output_metadata.newer_version_present);
+
+    value.clear();
+    *output_metadata.newer_version_present = false;
+    ASSERT_OK(db_->GetWithMetadata(read_options, handles_[1], "range_key",
+                                   &value, &output_metadata));
+    ASSERT_EQ("old_range", value);
+    ASSERT_TRUE(*output_metadata.newer_version_present);
+
+    std::vector<Slice> keys{"point_key", "range_key"};
+    std::vector<ColumnFamilyHandle*> cfs(keys.size(), handles_[1]);
+    std::vector<std::string> values;
+    MultiGetOutputMetadata multiget_output_metadata =
+        NewerVersionMultiGetOutputMetadata();
+    const std::vector<Status> statuses = db_->MultiGetWithMetadata(
+        read_options, cfs, keys, &values, &multiget_output_metadata);
+    ASSERT_EQ(2, statuses.size());
+    ASSERT_OK(statuses[0]);
+    ASSERT_OK(statuses[1]);
+    ASSERT_EQ(std::vector<std::string>({"old_point", "old_range"}), values);
+    ASSERT_TRUE((*multiget_output_metadata.newer_version_present)[0]);
+    ASSERT_TRUE((*multiget_output_metadata.newer_version_present)[1]);
+  }
+  ASSERT_OK(resume_status);
+  ASSERT_OK(Flush(1));
+}
+
+TEST_F(DBBasicTest, NewerVersionPresentBypassesRowCacheWhileTracking) {
+  // Prime row-cache entries for the snapshot values, then verify metadata
+  // reads still inspect SST sequence numbers instead of replaying those
+  // entries.
+  option_config_ = kRowCache;
+  Options options = CurrentOptions();
+  options.statistics = ROCKSDB_NAMESPACE::CreateDBStatistics();
+  CreateAndReopenWithCF({"pikachu"}, options);
+
+  ASSERT_OK(Put(1, "get_key", "old_get"));
+  ASSERT_OK(Put(1, "multiget_key", "old_multiget"));
+  ASSERT_OK(Flush(1));
+  ManagedSnapshot snapshot(db_.get());
+  ASSERT_OK(Put(1, "get_key", "new_get"));
+  ASSERT_OK(Put(1, "multiget_key", "new_multiget"));
+  ASSERT_OK(Flush(1));
+
+  ReadOptions read_options;
+  read_options.snapshot = snapshot.snapshot();
+
+  std::string primed_value;
+  ASSERT_OK(db_->Get(read_options, handles_[1], "get_key", &primed_value));
+  ASSERT_EQ("old_get", primed_value);
+  std::vector<Slice> primed_keys{"multiget_key"};
+  std::vector<ColumnFamilyHandle*> primed_cfs(primed_keys.size(), handles_[1]);
+  std::vector<std::string> primed_values;
+  const std::vector<Status> primed_statuses =
+      db_->MultiGet(read_options, primed_cfs, primed_keys, &primed_values);
+  ASSERT_OK(primed_statuses[0]);
+  ASSERT_EQ("old_multiget", primed_values[0]);
+
+  for (int i = 0; i < 2; ++i) {
+    SCOPED_TRACE(i);
+    std::string value;
+    OutputMetadata output_metadata = NewerVersionOutputMetadata();
+    ASSERT_OK(db_->GetWithMetadata(read_options, handles_[1], "get_key", &value,
+                                   &output_metadata));
+    ASSERT_EQ("old_get", value);
+    ASSERT_TRUE(*output_metadata.newer_version_present);
+  }
+
+  std::vector<Slice> keys{"multiget_key"};
+  std::vector<ColumnFamilyHandle*> cfs(keys.size(), handles_[1]);
+  for (int i = 0; i < 2; ++i) {
+    SCOPED_TRACE(i);
+    std::vector<std::string> values;
+    MultiGetOutputMetadata multiget_output_metadata =
+        NewerVersionMultiGetOutputMetadata();
+    std::vector<Status> statuses = db_->MultiGetWithMetadata(
+        read_options, cfs, keys, &values, &multiget_output_metadata);
+    ASSERT_EQ(1, statuses.size());
+    ASSERT_OK(statuses[0]);
+    ASSERT_EQ("old_multiget", values[0]);
+    ASSERT_TRUE((*multiget_output_metadata.newer_version_present)[0]);
+  }
+}
+
+TEST_F(DBBasicTest, NewerVersionPresentUsesRowCacheAfterObservation) {
+  option_config_ = kRowCache;
+  Options options = CurrentOptions();
+  options.statistics = ROCKSDB_NAMESPACE::CreateDBStatistics();
+  CreateAndReopenWithCF({"pikachu"}, options);
+
+  ASSERT_OK(Put(1, "key", "old"));
+  ASSERT_OK(Flush(1));
+  ManagedSnapshot snapshot(db_.get());
+
+  ReadOptions read_options;
+  read_options.snapshot = snapshot.snapshot();
+  std::vector<Slice> keys{"key"};
+  std::vector<ColumnFamilyHandle*> cfs(keys.size(), handles_[1]);
+  std::vector<std::string> values;
+  std::vector<Status> statuses =
+      db_->MultiGet(read_options, cfs, keys, &values);
+  ASSERT_OK(statuses[0]);
+  ASSERT_EQ("old", values[0]);
+
+  ASSERT_OK(Put(1, "key", "new"));
+  const uint64_t row_cache_hits = TestGetTickerCount(options, ROW_CACHE_HIT);
+
+  values.clear();
+  MultiGetOutputMetadata output_metadata = NewerVersionMultiGetOutputMetadata();
+  statuses = db_->MultiGetWithMetadata(read_options, cfs, keys, &values,
+                                       &output_metadata);
+  ASSERT_OK(statuses[0]);
+  ASSERT_EQ("old", values[0]);
+  ASSERT_TRUE((*output_metadata.newer_version_present)[0]);
+  ASSERT_EQ(row_cache_hits + 1, TestGetTickerCount(options, ROW_CACHE_HIT));
+}
+
+TEST_F(DBBasicTest, NewerVersionPresentPersistedTierNotSupported) {
+  // kPersistedTier is incompatible with snapshot newer-version tracking but not
+  // with untracked latest-version reads.
+  Options options = CurrentOptions();
+  CreateAndReopenWithCF({"pikachu"}, options);
+
+  ASSERT_OK(Put(1, "key", "old"));
+  const Snapshot* snapshot = db_->GetSnapshot();
+  ASSERT_OK(Put(1, "key", "new"));
+
+  ReadOptions read_options;
+  read_options.snapshot = snapshot;
+  read_options.read_tier = kPersistedTier;
+
+  std::string value;
+  OutputMetadata output_metadata = NewerVersionOutputMetadata();
+  ASSERT_TRUE(db_->GetWithMetadata(read_options, handles_[1], "key", &value,
+                                   &output_metadata)
+                  .IsNotSupported());
+
+  std::vector<Slice> keys{"key"};
+  std::vector<ColumnFamilyHandle*> cfs(keys.size(), handles_[1]);
+  std::vector<std::string> values;
+  MultiGetOutputMetadata multiget_output_metadata =
+      NewerVersionMultiGetOutputMetadata();
+  std::vector<Status> statuses = db_->MultiGetWithMetadata(
+      read_options, cfs, keys, &values, &multiget_output_metadata);
+  ASSERT_EQ(1, statuses.size());
+  ASSERT_TRUE(statuses[0].IsNotSupported());
+  ASSERT_FALSE((*multiget_output_metadata.newer_version_present)[0]);
+
+  read_options.snapshot = nullptr;
+  value.clear();
+  *output_metadata.newer_version_present = true;
+  ASSERT_OK(db_->GetWithMetadata(read_options, handles_[1], "key", &value,
+                                 &output_metadata));
+  ASSERT_EQ("new", value);
+  ASSERT_FALSE(*output_metadata.newer_version_present);
+
+  values.clear();
+  multiget_output_metadata.newer_version_present->clear();
+  statuses = db_->MultiGetWithMetadata(read_options, cfs, keys, &values,
+                                       &multiget_output_metadata);
+  ASSERT_EQ(1, statuses.size());
+  ASSERT_OK(statuses[0]);
+  ASSERT_EQ("new", values[0]);
+  ASSERT_FALSE((*multiget_output_metadata.newer_version_present)[0]);
+
+  db_->ReleaseSnapshot(snapshot);
+}
+
+TEST_F(DBBasicTest, ReadOnlyNewerVersionPresentReturnsFalse) {
+  // Read-only DBs do not widen snapshot reads, so requested metadata remains
+  // false.
+  Options options = CurrentOptions();
+  CreateAndReopenWithCF({"pikachu"}, options);
+
+  ASSERT_OK(Put(1, "key", "value"));
+  ASSERT_OK(Flush(1));
+  ASSERT_OK(
+      TryReopenReadOnlyWithColumnFamilies({"default", "pikachu"}, options));
+
+  const Snapshot* snapshot = db_->GetSnapshot();
+  ReadOptions read_options;
+  read_options.snapshot = snapshot;
+
+  std::string value;
+  OutputMetadata output_metadata = NewerVersionOutputMetadata();
+  ASSERT_OK(db_->GetWithMetadata(read_options, handles_[1], "key", &value,
+                                 &output_metadata));
+  ASSERT_EQ("value", value);
+  ASSERT_FALSE(*output_metadata.newer_version_present);
+
+  std::vector<Slice> keys{"key"};
+  std::vector<ColumnFamilyHandle*> cfs(keys.size(), handles_[1]);
+  std::vector<std::string> values;
+  MultiGetOutputMetadata multiget_output_metadata =
+      NewerVersionMultiGetOutputMetadata();
+  std::vector<Status> statuses = db_->MultiGetWithMetadata(
+      read_options, cfs, keys, &values, &multiget_output_metadata);
+  ASSERT_EQ(1, statuses.size());
+  ASSERT_OK(statuses[0]);
+  ASSERT_EQ("value", values[0]);
+  ASSERT_EQ(1, multiget_output_metadata.newer_version_present->size());
+  ASSERT_FALSE((*multiget_output_metadata.newer_version_present)[0]);
+
+  db_->ReleaseSnapshot(snapshot);
 }
 
 TEST_F(DBBasicTest, CheckLock) {
@@ -2279,6 +2763,151 @@ TEST_F(DBBasicTest, MultiGetSimple) {
     ASSERT_TRUE(s[5].IsNotFound());
     SetPerfLevel(kDisable);
   } while (ChangeCompactOptions());
+}
+
+TEST_F(DBBasicTest, MultiGetNewerVersionPresent) {
+  // A mixed MultiGet batch reports newer writes independently for each key in
+  // input order.
+  Options options = CurrentOptions();
+  options.merge_operator = MergeOperators::CreateStringAppendOperator();
+  CreateAndReopenWithCF({"pikachu"}, options);
+
+  ASSERT_OK(Put(1, "updated", "old"));
+  ASSERT_OK(Put(1, "unchanged", "same"));
+  ASSERT_OK(Put(1, "deleted", "old"));
+  ASSERT_OK(Put(1, "merged", "old"));
+  ASSERT_OK(Put(1, "range_deleted", "old"));
+  const Snapshot* snapshot = db_->GetSnapshot();
+
+  ASSERT_OK(Put(1, "updated", "new"));
+  ASSERT_OK(Put(1, "created_after_put", "new"));
+  ASSERT_OK(Merge(1, "created_after_merge", "new"));
+  ASSERT_OK(Delete(1, "deleted"));
+  ASSERT_OK(Merge(1, "merged", "new"));
+  ASSERT_OK(db_->DeleteRange(WriteOptions(), handles_[1], "range_deleted",
+                             "range_deleted~"));
+
+  ReadOptions read_options;
+  read_options.snapshot = snapshot;
+  std::vector<Slice> keys({"updated", "unchanged", "deleted", "merged",
+                           "range_deleted", "created_after_put",
+                           "created_after_merge", "missing"});
+  std::vector<ColumnFamilyHandle*> cfs(keys.size(), handles_[1]);
+  std::vector<std::string> values;
+  MultiGetOutputMetadata output_metadata = NewerVersionMultiGetOutputMetadata();
+
+  std::vector<Status> statuses = db_->MultiGetWithMetadata(
+      read_options, cfs, keys, &values, &output_metadata);
+
+  ASSERT_EQ(keys.size(), statuses.size());
+  ASSERT_OK(statuses[0]);
+  ASSERT_EQ("old", values[0]);
+  ASSERT_TRUE((*output_metadata.newer_version_present)[0]);
+
+  ASSERT_OK(statuses[1]);
+  ASSERT_EQ("same", values[1]);
+  ASSERT_FALSE((*output_metadata.newer_version_present)[1]);
+
+  ASSERT_OK(statuses[2]);
+  ASSERT_EQ("old", values[2]);
+  ASSERT_TRUE((*output_metadata.newer_version_present)[2]);
+
+  ASSERT_OK(statuses[3]);
+  ASSERT_EQ("old", values[3]);
+  ASSERT_TRUE((*output_metadata.newer_version_present)[3]);
+
+  ASSERT_OK(statuses[4]);
+  ASSERT_EQ("old", values[4]);
+  ASSERT_TRUE((*output_metadata.newer_version_present)[4]);
+
+  ASSERT_TRUE(statuses[5].IsNotFound());
+  ASSERT_TRUE((*output_metadata.newer_version_present)[5]);
+
+  ASSERT_TRUE(statuses[6].IsNotFound());
+  ASSERT_TRUE((*output_metadata.newer_version_present)[6]);
+
+  ASSERT_TRUE(statuses[7].IsNotFound());
+  ASSERT_FALSE((*output_metadata.newer_version_present)[7]);
+
+  db_->ReleaseSnapshot(snapshot);
+}
+
+TEST_F(DBBasicTest, MultiGetNewerVersionPresentAcrossColumnFamilies) {
+  // Unsorted mixed-CF reads keep metadata aligned with input order after each
+  // CF is processed independently.
+  Options options = CurrentOptions();
+  CreateAndReopenWithCF({"one", "two"}, options);
+
+  ASSERT_OK(Put(1, "updated_one", "old_one"));
+  ASSERT_OK(Put(2, "updated_two", "old_two"));
+  ASSERT_OK(Put(2, "stable_two", "stable"));
+  const Snapshot* snapshot = db_->GetSnapshot();
+  ASSERT_OK(Put(1, "updated_one", "new_one"));
+  ASSERT_OK(Put(2, "updated_two", "new_two"));
+  ASSERT_OK(Flush(1));
+  ASSERT_OK(Flush(2));
+
+  ReadOptions read_options;
+  read_options.snapshot = snapshot;
+  std::vector<Slice> keys{"updated_two", "updated_one", "stable_two"};
+  std::vector<ColumnFamilyHandle*> column_families{handles_[2], handles_[1],
+                                                   handles_[2]};
+  std::vector<std::string> values;
+  MultiGetOutputMetadata output_metadata = NewerVersionMultiGetOutputMetadata();
+  const std::vector<Status> statuses = db_->MultiGetWithMetadata(
+      read_options, column_families, keys, &values, &output_metadata);
+
+  for (const Status& status : statuses) {
+    ASSERT_OK(status);
+  }
+  ASSERT_EQ(std::vector<std::string>({"old_two", "old_one", "stable"}), values);
+  ASSERT_TRUE((*output_metadata.newer_version_present)[0]);
+  ASSERT_TRUE((*output_metadata.newer_version_present)[1]);
+  ASSERT_FALSE((*output_metadata.newer_version_present)[2]);
+
+  db_->ReleaseSnapshot(snapshot);
+}
+
+TEST_F(DBBasicTest, MultiGetWithMetadataColumnFamiliesKeysSizeMismatch) {
+  CreateAndReopenWithCF({"pikachu"}, CurrentOptions());
+
+  std::vector<Slice> keys({"k1", "k2"});
+  std::vector<ColumnFamilyHandle*> cfs({handles_[1]});
+  std::vector<std::string> values({"stale"});
+  MultiGetOutputMetadata output_metadata;
+  output_metadata.timestamps.emplace();
+  output_metadata.newer_version_present = std::vector<uint8_t>({1});
+
+  std::vector<Status> statuses = db_->MultiGetWithMetadata(
+      ReadOptions(), cfs, keys, &values, &output_metadata);
+
+  ASSERT_EQ(keys.size(), statuses.size());
+  ASSERT_EQ(keys.size(), values.size());
+  for (const Status& status : statuses) {
+    ASSERT_TRUE(status.IsInvalidArgument());
+  }
+  ASSERT_EQ(keys.size(), output_metadata.timestamps->size());
+  ASSERT_EQ(keys.size(), output_metadata.newer_version_present->size());
+  ASSERT_FALSE((*output_metadata.newer_version_present)[0]);
+  ASSERT_FALSE((*output_metadata.newer_version_present)[1]);
+}
+
+TEST_F(DBBasicTest, GetWithMetadataNullValueInvalidArgument) {
+  CreateAndReopenWithCF({"pikachu"}, CurrentOptions());
+
+  OutputMetadata output_metadata = NewerVersionOutputMetadata();
+  ASSERT_TRUE(db_->GetWithMetadata(ReadOptions(), handles_[1], "key",
+                                   static_cast<PinnableSlice*>(nullptr),
+                                   &output_metadata)
+                  .IsInvalidArgument());
+  ASSERT_FALSE(*output_metadata.newer_version_present);
+
+  *output_metadata.newer_version_present = true;
+  ASSERT_TRUE(db_->GetWithMetadata(ReadOptions(), "key",
+                                   static_cast<std::string*>(nullptr),
+                                   &output_metadata)
+                  .IsInvalidArgument());
+  ASSERT_FALSE(*output_metadata.newer_version_present);
 }
 
 TEST_F(DBBasicTest, MultiGetEmpty) {

--- a/db/db_impl/compacted_db_impl.cc
+++ b/db/db_impl/compacted_db_impl.cc
@@ -34,6 +34,69 @@ size_t CompactedDBImpl::FindFile(const Slice& key) {
       files_.files);
 }
 
+Status CompactedDBImpl::GetWithMetadata(const ReadOptions& options,
+                                        ColumnFamilyHandle* column_family,
+                                        const Slice& key, PinnableSlice* value,
+                                        OutputMetadata* output_metadata) {
+  std::string* timestamp =
+      output_metadata != nullptr && output_metadata->timestamp.has_value()
+          ? &*output_metadata->timestamp
+          : nullptr;
+  bool* newer_version_present =
+      output_metadata != nullptr &&
+              output_metadata->newer_version_present.has_value()
+          ? &*output_metadata->newer_version_present
+          : nullptr;
+  if (newer_version_present != nullptr) {
+    *newer_version_present = false;
+  }
+  if (value == nullptr) {
+    return Status::InvalidArgument(
+        "Cannot call GetWithMetadata with a null value");
+  }
+  return Get(options, column_family, key, value, timestamp);
+}
+
+void CompactedDBImpl::MultiGetWithMetadata(
+    const ReadOptions& options, size_t num_keys,
+    ColumnFamilyHandle* const* column_families, const Slice* keys,
+    PinnableSlice* values, Status* statuses,
+    MultiGetOutputMetadata* output_metadata, const bool sorted_input) {
+  std::vector<std::string>* timestamps =
+      output_metadata != nullptr && output_metadata->timestamps.has_value()
+          ? &*output_metadata->timestamps
+          : nullptr;
+  if (timestamps != nullptr) {
+    timestamps->resize(num_keys);
+  }
+  std::vector<bool>* newer_version_present =
+      output_metadata != nullptr &&
+              output_metadata->newer_version_present.has_value()
+          ? &*output_metadata->newer_version_present
+          : nullptr;
+  if (newer_version_present != nullptr) {
+    newer_version_present->assign(num_keys, false);
+  }
+  autovector<ColumnFamilyHandle*, MultiGetContext::MAX_BATCH_SIZE>
+      stack_column_families;
+  std::vector<ColumnFamilyHandle*> heap_column_families;
+  ColumnFamilyHandle** mutable_column_families = nullptr;
+  if (num_keys <= MultiGetContext::MAX_BATCH_SIZE) {
+    stack_column_families.resize(num_keys);
+    mutable_column_families =
+        num_keys == 0 ? nullptr : &stack_column_families[0];
+  } else {
+    heap_column_families.resize(num_keys);
+    mutable_column_families = heap_column_families.data();
+  }
+  for (size_t i = 0; i < num_keys; ++i) {
+    mutable_column_families[i] = column_families[i];
+  }
+  MultiGet(options, num_keys, mutable_column_families, keys, values,
+           timestamps != nullptr ? timestamps->data() : nullptr, statuses,
+           sorted_input);
+}
+
 Status CompactedDBImpl::Init(const Options& options) {
   SuperVersionContext sv_context(/* create_superversion */ true);
   mutex_.Lock();

--- a/db/db_impl/compacted_db_impl.cc
+++ b/db/db_impl/compacted_db_impl.cc
@@ -7,6 +7,7 @@
 
 #include "db/blob/blob_fetcher.h"
 #include "db/db_impl/db_impl.h"
+#include "db/db_impl/db_impl_metadata.h"
 #include "db/version_set.h"
 #include "logging/logging.h"
 #include "table/get_context.h"
@@ -32,6 +33,46 @@ size_t CompactedDBImpl::FindFile(const Slice& key) {
   return static_cast<size_t>(
       std::lower_bound(files_.files, files_.files + right, key, cmp) -
       files_.files);
+}
+
+Status CompactedDBImpl::GetWithMetadata(const ReadOptions& options,
+                                        ColumnFamilyHandle* column_family,
+                                        const Slice& key, PinnableSlice* value,
+                                        OutputMetadata* output_metadata) {
+  std::string* timestamp = GetOutputTimestamp(output_metadata);
+  bool* newer_version_present = GetOutputNewerVersionPresent(output_metadata);
+  if (newer_version_present != nullptr) {
+    *newer_version_present = false;
+  }
+  if (value == nullptr) {
+    return Status::InvalidArgument(
+        "Cannot call GetWithMetadata with a null value");
+  }
+  return Get(options, column_family, key, value, timestamp);
+}
+
+void CompactedDBImpl::MultiGetWithMetadata(
+    const ReadOptions& options, size_t num_keys,
+    ColumnFamilyHandle* const* column_families, const Slice* keys,
+    PinnableSlice* values, Status* statuses,
+    MultiGetOutputMetadata* output_metadata, const bool sorted_input) {
+  std::vector<std::string>* timestamps = GetOutputTimestamps(output_metadata);
+  if (timestamps != nullptr) {
+    timestamps->resize(num_keys);
+  }
+  std::vector<uint8_t>* newer_version_present =
+      GetOutputNewerVersionPresent(output_metadata);
+  if (newer_version_present != nullptr) {
+    newer_version_present->assign(num_keys, false);
+  }
+  autovector<ColumnFamilyHandle*, MultiGetContext::MAX_BATCH_SIZE>
+      stack_column_families;
+  std::vector<ColumnFamilyHandle*> heap_column_families;
+  ColumnFamilyHandle** mutable_column_families = MakeMutableCfHandles(
+      column_families, num_keys, &stack_column_families, &heap_column_families);
+  MultiGet(options, num_keys, mutable_column_families, keys, values,
+           timestamps != nullptr ? timestamps->data() : nullptr, statuses,
+           sorted_input);
 }
 
 Status CompactedDBImpl::Init(const Options& options) {

--- a/db/db_impl/compacted_db_impl.h
+++ b/db/db_impl/compacted_db_impl.h
@@ -31,6 +31,12 @@ class CompactedDBImpl : public DBImpl {
                                   const Slice& key, PinnableSlice* value,
                                   std::string* timestamp);
 
+  using DB::GetWithMetadata;
+  Status GetWithMetadata(const ReadOptions& options,
+                         ColumnFamilyHandle* column_family, const Slice& key,
+                         PinnableSlice* value,
+                         OutputMetadata* output_metadata) override;
+
   using DB::MultiGet;
   // Note that CompactedDBImpl::MultiGet is not the optimized version of
   // MultiGet to use.
@@ -41,6 +47,14 @@ class CompactedDBImpl : public DBImpl {
                                   const Slice* keys, PinnableSlice* values,
                                   std::string* timestamps, Status* statuses,
                                   const bool sorted_input);
+
+  using DB::MultiGetWithMetadata;
+  void MultiGetWithMetadata(const ReadOptions& options, size_t num_keys,
+                            ColumnFamilyHandle* const* column_families,
+                            const Slice* keys, PinnableSlice* values,
+                            Status* statuses,
+                            MultiGetOutputMetadata* output_metadata,
+                            const bool sorted_input) override;
 
   using DBImpl::Put;
   Status Put(const WriteOptions& /*options*/,

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -2706,6 +2706,131 @@ ColumnFamilyHandle* DBImpl::PersistentStatsColumnFamily() const {
   return persist_stats_cf_handle_;
 }
 
+namespace {
+
+std::string* GetOutputTimestamp(OutputMetadata* output_metadata) {
+  return output_metadata != nullptr && output_metadata->timestamp.has_value()
+             ? &*output_metadata->timestamp
+             : nullptr;
+}
+
+std::vector<std::string>* GetOutputTimestamps(
+    MultiGetOutputMetadata* output_metadata) {
+  return output_metadata != nullptr && output_metadata->timestamps.has_value()
+             ? &*output_metadata->timestamps
+             : nullptr;
+}
+
+bool* GetOutputNewerVersionPresent(OutputMetadata* output_metadata) {
+  return output_metadata != nullptr &&
+                 output_metadata->newer_version_present.has_value()
+             ? &*output_metadata->newer_version_present
+             : nullptr;
+}
+
+std::vector<bool>* GetOutputNewerVersionPresent(
+    MultiGetOutputMetadata* output_metadata) {
+  return output_metadata != nullptr &&
+                 output_metadata->newer_version_present.has_value()
+             ? &*output_metadata->newer_version_present
+             : nullptr;
+}
+
+void CopyNewerVersionPresent(
+    const autovector<KeyContext, MultiGetContext::MAX_BATCH_SIZE>& key_context,
+    std::vector<bool>* output) {
+  if (output == nullptr) {
+    return;
+  }
+  for (size_t i = 0; i < key_context.size(); ++i) {
+    (*output)[i] = key_context[i].newer_version_present;
+  }
+}
+
+void CopyNewerVersionPresent(
+    const autovector<KeyContext, MultiGetContext::MAX_BATCH_SIZE>& key_context,
+    bool* output) {
+  if (output == nullptr) {
+    return;
+  }
+  for (size_t i = 0; i < key_context.size(); ++i) {
+    output[i] = key_context[i].newer_version_present;
+  }
+}
+
+}  // namespace
+
+Status DB::GetWithMetadata(const ReadOptions& options,
+                           ColumnFamilyHandle* column_family, const Slice& key,
+                           PinnableSlice* value,
+                           OutputMetadata* output_metadata) {
+  std::string* timestamp = GetOutputTimestamp(output_metadata);
+  bool* newer_version_present = GetOutputNewerVersionPresent(output_metadata);
+  if (newer_version_present != nullptr) {
+    *newer_version_present = false;
+  }
+  if (value == nullptr) {
+    return Status::InvalidArgument(
+        "Cannot call GetWithMetadata with a null value");
+  }
+  if (newer_version_present == nullptr || options.snapshot == nullptr) {
+    return Get(options, column_family, key, value, timestamp);
+  }
+  return Status::NotSupported(
+      "GetWithMetadata is not implemented by this DB subclass");
+}
+
+Status DBImpl::GetWithMetadata(const ReadOptions& _read_options,
+                               ColumnFamilyHandle* column_family,
+                               const Slice& key, PinnableSlice* value,
+                               OutputMetadata* output_metadata) {
+  std::string* timestamp = GetOutputTimestamp(output_metadata);
+  bool* newer_version_present = GetOutputNewerVersionPresent(output_metadata);
+  if (newer_version_present != nullptr) {
+    *newer_version_present = false;
+  }
+  if (value == nullptr) {
+    return Status::InvalidArgument(
+        "Cannot call GetWithMetadata with a null value");
+  }
+  value->Reset();
+
+  if (_read_options.io_activity != Env::IOActivity::kUnknown &&
+      _read_options.io_activity != Env::IOActivity::kGet) {
+    return Status::InvalidArgument(
+        "Can only call Get with `ReadOptions::io_activity` is "
+        "`Env::IOActivity::kUnknown` or `Env::IOActivity::kGet`");
+  }
+
+  ReadOptions read_options(_read_options);
+  if (read_options.io_activity == Env::IOActivity::kUnknown) {
+    read_options.io_activity = Env::IOActivity::kGet;
+  }
+  if (newer_version_present != nullptr && read_options.snapshot != nullptr &&
+      read_options.read_tier == kPersistedTier) {
+    return Status::NotSupported(
+        "Newer-version metadata is not supported with kPersistedTier");
+  }
+
+  return GetImpl(
+      read_options, column_family, key, value, timestamp,
+      read_options.snapshot != nullptr ? newer_version_present : nullptr);
+}
+
+Status DBImpl::GetImpl(const ReadOptions& read_options,
+                       ColumnFamilyHandle* column_family, const Slice& key,
+                       PinnableSlice* value, std::string* timestamp,
+                       bool* newer_version_present) {
+  GetImplOptions get_impl_options;
+  get_impl_options.column_family = column_family;
+  get_impl_options.value = value;
+  get_impl_options.timestamp = timestamp;
+  get_impl_options.newer_version_present = newer_version_present;
+
+  Status s = GetImpl(read_options, key, get_impl_options);
+  return s;
+}
+
 Status DBImpl::GetEntity(const ReadOptions& _read_options,
                          ColumnFamilyHandle* column_family, const Slice& key,
                          PinnableWideColumns* columns) {
@@ -2947,10 +3072,11 @@ Status DBImpl::GetEntity(const ReadOptions& _read_options, const Slice& key,
   }
   std::vector<PinnableWideColumns> columns(num_column_families);
   std::vector<Status> statuses(num_column_families);
-  MultiGetCommon(
-      read_options, num_column_families, column_families.data(), keys.data(),
-      /* values */ nullptr, columns.data(),
-      /* timestamps */ nullptr, statuses.data(), /* sorted_input */ false);
+  MultiGetCommon(read_options, num_column_families, column_families.data(),
+                 keys.data(),
+                 /* values */ nullptr, columns.data(),
+                 /* timestamps */ nullptr, statuses.data(),
+                 /* newer_version_present */ nullptr, /* sorted_input */ false);
   // Set results
   for (size_t i = 0; i < num_column_families; ++i) {
     (*result)[i].Reset();
@@ -3565,6 +3691,68 @@ Status DBImpl::MultiCFSnapshot(const ReadOptions& read_options,
   return s;
 }
 
+void DBImpl::MultiGetWithMetadata(const ReadOptions& _read_options,
+                                  const size_t num_keys,
+                                  ColumnFamilyHandle* const* column_families,
+                                  const Slice* keys, PinnableSlice* values,
+                                  Status* statuses,
+                                  MultiGetOutputMetadata* output_metadata,
+                                  const bool sorted_input) {
+  std::vector<std::string>* timestamps = GetOutputTimestamps(output_metadata);
+  if (timestamps != nullptr) {
+    timestamps->resize(num_keys);
+  }
+  std::vector<bool>* newer_version_present =
+      GetOutputNewerVersionPresent(output_metadata);
+  if (newer_version_present != nullptr) {
+    newer_version_present->assign(num_keys, false);
+  }
+  std::string* timestamp_data =
+      timestamps != nullptr ? timestamps->data() : nullptr;
+  if (_read_options.io_activity != Env::IOActivity::kUnknown &&
+      _read_options.io_activity != Env::IOActivity::kMultiGet) {
+    Status s = Status::InvalidArgument(
+        "Can only call MultiGet with `ReadOptions::io_activity` is "
+        "`Env::IOActivity::kUnknown` or `Env::IOActivity::kMultiGet`");
+    for (size_t i = 0; i < num_keys; ++i) {
+      if (statuses[i].ok()) {
+        statuses[i] = s;
+      }
+    }
+    return;
+  }
+
+  ReadOptions read_options(_read_options);
+  if (read_options.io_activity == Env::IOActivity::kUnknown) {
+    read_options.io_activity = Env::IOActivity::kMultiGet;
+  }
+  const bool newer_version_present_requested =
+      newer_version_present != nullptr && read_options.snapshot != nullptr;
+  if (newer_version_present_requested &&
+      read_options.read_tier == kPersistedTier) {
+    Status s = Status::NotSupported(
+        "Newer-version metadata is not supported with kPersistedTier");
+    for (size_t i = 0; i < num_keys; ++i) {
+      if (statuses[i].ok()) {
+        statuses[i] = s;
+      }
+    }
+    return;
+  }
+  autovector<ColumnFamilyHandle*, MultiGetContext::MAX_BATCH_SIZE>
+      mutable_column_families;
+  mutable_column_families.resize(num_keys);
+  for (size_t i = 0; i < num_keys; ++i) {
+    mutable_column_families[i] = column_families[i];
+  }
+  MultiGetCommon(
+      read_options, num_keys,
+      num_keys == 0 ? nullptr : &mutable_column_families[0], keys, values,
+      /* columns */ nullptr, timestamp_data, statuses,
+      newer_version_present_requested ? newer_version_present : nullptr,
+      sorted_input);
+}
+
 namespace {
 // Order keys by CF ID, followed by key contents
 struct CompareKeyContext {
@@ -3609,12 +3797,71 @@ void DBImpl::PrepareMultiGetKeys(
             CompareKeyContext());
 }
 
+void DB::MultiGetWithMetadata(const ReadOptions& options, const size_t num_keys,
+                              ColumnFamilyHandle* const* column_families,
+                              const Slice* keys, PinnableSlice* values,
+                              Status* statuses,
+                              MultiGetOutputMetadata* output_metadata,
+                              const bool sorted_input) {
+  std::vector<std::string>* timestamps = GetOutputTimestamps(output_metadata);
+  if (timestamps != nullptr) {
+    timestamps->resize(num_keys);
+  }
+  std::vector<bool>* newer_version_present =
+      GetOutputNewerVersionPresent(output_metadata);
+  if (newer_version_present != nullptr) {
+    newer_version_present->assign(num_keys, false);
+  }
+  std::string* timestamp_data =
+      timestamps != nullptr ? timestamps->data() : nullptr;
+  if (newer_version_present == nullptr || options.snapshot == nullptr) {
+    autovector<ColumnFamilyHandle*, MultiGetContext::MAX_BATCH_SIZE>
+        mutable_column_families;
+    mutable_column_families.resize(num_keys);
+    for (size_t i = 0; i < num_keys; ++i) {
+      mutable_column_families[i] = column_families[i];
+    }
+    MultiGet(options, num_keys,
+             num_keys == 0 ? nullptr : &mutable_column_families[0], keys,
+             values, timestamp_data, statuses, sorted_input);
+    return;
+  }
+  const Status s = Status::NotSupported(
+      "MultiGetWithMetadata is not implemented by this DB subclass");
+  for (size_t i = 0; i < num_keys; ++i) {
+    if (statuses[i].ok()) {
+      statuses[i] = s;
+    }
+  }
+}
+
+void DB::MultiGetWithMetadata(const ReadOptions& options,
+                              ColumnFamilyHandle* column_family,
+                              const size_t num_keys, const Slice* keys,
+                              PinnableSlice* values, Status* statuses,
+                              MultiGetOutputMetadata* output_metadata,
+                              const bool sorted_input) {
+  // Use std::array, if possible, to avoid memory allocation overhead
+  if (num_keys > MultiGetContext::MAX_BATCH_SIZE) {
+    std::vector<ColumnFamilyHandle*> column_families(num_keys, column_family);
+    MultiGetWithMetadata(options, num_keys, column_families.data(), keys,
+                         values, statuses, output_metadata, sorted_input);
+  } else {
+    std::array<ColumnFamilyHandle*, MultiGetContext::MAX_BATCH_SIZE>
+        column_families{};
+    std::fill(column_families.begin(), column_families.begin() + num_keys,
+              column_family);
+    MultiGetWithMetadata(options, num_keys, column_families.data(), keys,
+                         values, statuses, output_metadata, sorted_input);
+  }
+}
+
 void DBImpl::MultiGetCommon(const ReadOptions& read_options,
                             ColumnFamilyHandle* column_family,
                             const size_t num_keys, const Slice* keys,
                             PinnableSlice* values, PinnableWideColumns* columns,
                             std::string* timestamps, Status* statuses,
-                            bool sorted_input) {
+                            bool* newer_version_present, bool sorted_input) {
   if (tracer_) {
     // TODO: This mutex should be removed later, to improve performance when
     // tracing is enabled.
@@ -3650,7 +3897,9 @@ void DBImpl::MultiGetCommon(const ReadOptions& read_options,
     sorted_keys[i] = &key_context[i];
   }
   PrepareMultiGetKeys(num_keys, sorted_input, &sorted_keys);
-  MultiGetWithCallbackImpl(read_options, column_family, nullptr, &sorted_keys);
+  MultiGetWithCallbackImpl(read_options, column_family, nullptr, &sorted_keys,
+                           newer_version_present != nullptr);
+  CopyNewerVersionPresent(key_context, newer_version_present);
 }
 
 void DBImpl::MultiGetWithCallback(
@@ -3673,7 +3922,8 @@ void DBImpl::MultiGetWithCallback(
 void DBImpl::MultiGetWithCallbackImpl(
     const ReadOptions& read_options, ColumnFamilyHandle* column_family,
     ReadCallback* callback,
-    autovector<KeyContext*, MultiGetContext::MAX_BATCH_SIZE>* sorted_keys) {
+    autovector<KeyContext*, MultiGetContext::MAX_BATCH_SIZE>* sorted_keys,
+    bool newer_version_present_requested) {
   assert(sorted_keys != nullptr);
   std::array<ColumnFamilySuperVersionPair, 1> cf_sv_pairs;
   cf_sv_pairs[0] = ColumnFamilySuperVersionPair(column_family, nullptr);
@@ -3719,17 +3969,40 @@ void DBImpl::MultiGetWithCallbackImpl(
     consistent_seqnum = callback->max_visible_seq();
   }
 
+  SequenceNumber lookup_seqnum = consistent_seqnum;
+  newer_version_present_requested =
+      newer_version_present_requested && read_options.snapshot != nullptr;
+  const SequenceNumber newer_version_upper_bound_seq =
+      newer_version_present_requested ? GetLastPublishedSequence()
+                                      : consistent_seqnum;
+  const bool track_newer_versions =
+      newer_version_present_requested &&
+      consistent_seqnum < newer_version_upper_bound_seq;
+  autovector<std::optional<MetadataReadCtx>, MultiGetContext::MAX_BATCH_SIZE>
+      metadata_ctxs;
+  if (track_newer_versions) {
+    lookup_seqnum = newer_version_upper_bound_seq;
+    metadata_ctxs.resize(sorted_keys->size());
+    size_t i = 0;
+    for (KeyContext* key_ctx : *sorted_keys) {
+      metadata_ctxs[i].emplace(consistent_seqnum, newer_version_upper_bound_seq,
+                               key_ctx->newer_version_present);
+      key_ctx->metadata_ctx = &*metadata_ctxs[i];
+      ++i;
+    }
+  }
+
   GetWithTimestampReadCallback timestamp_read_callback(0);
   ReadCallback* read_callback = callback;
-  if (read_options.timestamp && read_options.timestamp->size() > 0) {
+  if ((read_options.timestamp && read_options.timestamp->size() > 0) ||
+      (track_newer_versions && read_callback == nullptr)) {
     assert(!read_callback);  // timestamp with callback is not supported
     timestamp_read_callback.Refresh(consistent_seqnum);
     read_callback = &timestamp_read_callback;
   }
 
   s = MultiGetImpl(read_options, 0, num_keys, sorted_keys,
-                   cf_sv_pairs[0].super_version, consistent_seqnum,
-                   read_callback);
+                   cf_sv_pairs[0].super_version, lookup_seqnum, read_callback);
   assert(s.ok() || s.IsTimedOut() || s.IsAborted());
   ReturnAndCleanupSuperVersion(cf_sv_pairs[0].cfd,
                                cf_sv_pairs[0].super_version);
@@ -3790,7 +4063,7 @@ void DBImpl::MultiGetEntity(const ReadOptions& _read_options, size_t num_keys,
 
   MultiGetCommon(read_options, num_keys, column_families, keys,
                  /* values */ nullptr, results, /* timestamps */ nullptr,
-                 statuses, sorted_input);
+                 statuses, /* newer_version_present */ nullptr, sorted_input);
 }
 
 void DBImpl::MultiGetEntity(const ReadOptions& _read_options,
@@ -3847,7 +4120,7 @@ void DBImpl::MultiGetEntity(const ReadOptions& _read_options,
 
   MultiGetCommon(read_options, column_family, num_keys, keys,
                  /* values */ nullptr, results, /* timestamps */ nullptr,
-                 statuses, sorted_input);
+                 statuses, /* newer_version_present */ nullptr, sorted_input);
 }
 
 void DBImpl::MultiGetEntity(const ReadOptions& _read_options, size_t num_keys,
@@ -3905,6 +4178,7 @@ void DBImpl::MultiGetEntity(const ReadOptions& _read_options, size_t num_keys,
                  all_keys.data(),
                  /* values */ nullptr, columns.data(),
                  /* timestamps */ nullptr, statuses.data(),
+                 /* newer_version_present */ nullptr,
                  /* sorted_input */ false);
 
   // Set results

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -11,6 +11,8 @@
 #include <algorithm>
 #include <array>
 #include <cstdint>
+
+#include "db/db_impl/db_impl_metadata.h"
 #ifdef OS_SOLARIS
 #include <alloca.h>
 #endif
@@ -2786,6 +2788,92 @@ ColumnFamilyHandle* DBImpl::PersistentStatsColumnFamily() const {
   return persist_stats_cf_handle_;
 }
 
+namespace {
+
+void CopyNewerVersionPresent(
+    const autovector<KeyContext, MultiGetContext::MAX_BATCH_SIZE>& key_context,
+    std::vector<uint8_t>* output) {
+  if (output == nullptr) {
+    return;
+  }
+  for (size_t i = 0; i < key_context.size(); ++i) {
+    (*output)[i] = key_context[i].newer_version_present;
+  }
+}
+
+}  // namespace
+
+Status DB::GetWithMetadata(const ReadOptions& options,
+                           ColumnFamilyHandle* column_family, const Slice& key,
+                           PinnableSlice* value,
+                           OutputMetadata* output_metadata) {
+  std::string* timestamp = GetOutputTimestamp(output_metadata);
+  bool* newer_version_present = GetOutputNewerVersionPresent(output_metadata);
+  if (newer_version_present != nullptr) {
+    *newer_version_present = false;
+  }
+  if (value == nullptr) {
+    return Status::InvalidArgument(
+        "Cannot call GetWithMetadata with a null value");
+  }
+  if (newer_version_present == nullptr || options.snapshot == nullptr) {
+    return Get(options, column_family, key, value, timestamp);
+  }
+  return Status::NotSupported(
+      "GetWithMetadata is not implemented by this DB subclass");
+}
+
+Status DBImpl::GetWithMetadata(const ReadOptions& _read_options,
+                               ColumnFamilyHandle* column_family,
+                               const Slice& key, PinnableSlice* value,
+                               OutputMetadata* output_metadata) {
+  std::string* timestamp = GetOutputTimestamp(output_metadata);
+  bool* newer_version_present = GetOutputNewerVersionPresent(output_metadata);
+  if (newer_version_present != nullptr) {
+    *newer_version_present = false;
+  }
+  if (value == nullptr) {
+    return Status::InvalidArgument(
+        "Cannot call GetWithMetadata with a null value");
+  }
+  value->Reset();
+
+  if (_read_options.io_activity != Env::IOActivity::kUnknown &&
+      _read_options.io_activity != Env::IOActivity::kGet) {
+    return Status::InvalidArgument(
+        "Can only call Get with `ReadOptions::io_activity` is "
+        "`Env::IOActivity::kUnknown` or `Env::IOActivity::kGet`");
+  }
+
+  ReadOptions read_options(_read_options);
+  if (read_options.io_activity == Env::IOActivity::kUnknown) {
+    read_options.io_activity = Env::IOActivity::kGet;
+  }
+  if (newer_version_present != nullptr && read_options.snapshot != nullptr &&
+      read_options.read_tier == kPersistedTier) {
+    return Status::NotSupported(
+        "Newer-version metadata is not supported with kPersistedTier");
+  }
+
+  return GetImpl(
+      read_options, column_family, key, value, timestamp,
+      read_options.snapshot != nullptr ? newer_version_present : nullptr);
+}
+
+Status DBImpl::GetImpl(const ReadOptions& read_options,
+                       ColumnFamilyHandle* column_family, const Slice& key,
+                       PinnableSlice* value, std::string* timestamp,
+                       bool* newer_version_present) {
+  GetImplOptions get_impl_options;
+  get_impl_options.column_family = column_family;
+  get_impl_options.value = value;
+  get_impl_options.timestamp = timestamp;
+  get_impl_options.newer_version_present = newer_version_present;
+
+  Status s = GetImpl(read_options, key, get_impl_options);
+  return s;
+}
+
 Status DBImpl::GetEntityLazyImpl(const ReadOptions& read_options,
                                  ColumnFamilyHandle* column_family,
                                  const Slice& key, LazyWideColumns* result) {
@@ -3548,6 +3636,66 @@ Status DBImpl::MultiCFSnapshot(const ReadOptions& read_options,
   return s;
 }
 
+void DBImpl::MultiGetWithMetadata(const ReadOptions& _read_options,
+                                  const size_t num_keys,
+                                  ColumnFamilyHandle* const* column_families,
+                                  const Slice* keys, PinnableSlice* values,
+                                  Status* statuses,
+                                  MultiGetOutputMetadata* output_metadata,
+                                  const bool sorted_input) {
+  std::vector<std::string>* timestamps = GetOutputTimestamps(output_metadata);
+  if (timestamps != nullptr) {
+    timestamps->resize(num_keys);
+  }
+  std::vector<uint8_t>* newer_version_present =
+      GetOutputNewerVersionPresent(output_metadata);
+  if (newer_version_present != nullptr) {
+    newer_version_present->assign(num_keys, false);
+  }
+  std::string* timestamp_data =
+      timestamps != nullptr ? timestamps->data() : nullptr;
+  if (_read_options.io_activity != Env::IOActivity::kUnknown &&
+      _read_options.io_activity != Env::IOActivity::kMultiGet) {
+    Status s = Status::InvalidArgument(
+        "Can only call MultiGet with `ReadOptions::io_activity` is "
+        "`Env::IOActivity::kUnknown` or `Env::IOActivity::kMultiGet`");
+    for (size_t i = 0; i < num_keys; ++i) {
+      if (statuses[i].ok()) {
+        statuses[i] = s;
+      }
+    }
+    return;
+  }
+
+  ReadOptions read_options(_read_options);
+  if (read_options.io_activity == Env::IOActivity::kUnknown) {
+    read_options.io_activity = Env::IOActivity::kMultiGet;
+  }
+  const bool newer_version_present_requested =
+      newer_version_present != nullptr && read_options.snapshot != nullptr;
+  if (newer_version_present_requested &&
+      read_options.read_tier == kPersistedTier) {
+    Status s = Status::NotSupported(
+        "Newer-version metadata is not supported with kPersistedTier");
+    for (size_t i = 0; i < num_keys; ++i) {
+      if (statuses[i].ok()) {
+        statuses[i] = s;
+      }
+    }
+    return;
+  }
+  autovector<ColumnFamilyHandle*, MultiGetContext::MAX_BATCH_SIZE>
+      stack_column_families;
+  std::vector<ColumnFamilyHandle*> heap_column_families;
+  ColumnFamilyHandle** mutable_column_families = MakeMutableCfHandles(
+      column_families, num_keys, &stack_column_families, &heap_column_families);
+  MultiGetCommon(
+      read_options, num_keys, mutable_column_families, keys, values,
+      /* columns */ nullptr, timestamp_data, statuses,
+      newer_version_present_requested ? newer_version_present : nullptr,
+      sorted_input);
+}
+
 namespace {
 // Order keys by CF ID, followed by key contents
 struct CompareKeyContext {
@@ -3590,6 +3738,64 @@ void DBImpl::PrepareMultiGetKeys(
 
   std::sort(sorted_keys->begin(), sorted_keys->begin() + num_keys,
             CompareKeyContext());
+}
+
+void DB::MultiGetWithMetadata(const ReadOptions& options, const size_t num_keys,
+                              ColumnFamilyHandle* const* column_families,
+                              const Slice* keys, PinnableSlice* values,
+                              Status* statuses,
+                              MultiGetOutputMetadata* output_metadata,
+                              const bool sorted_input) {
+  std::vector<std::string>* timestamps = GetOutputTimestamps(output_metadata);
+  if (timestamps != nullptr) {
+    timestamps->resize(num_keys);
+  }
+  std::vector<uint8_t>* newer_version_present =
+      GetOutputNewerVersionPresent(output_metadata);
+  if (newer_version_present != nullptr) {
+    newer_version_present->assign(num_keys, false);
+  }
+  std::string* timestamp_data =
+      timestamps != nullptr ? timestamps->data() : nullptr;
+  if (newer_version_present == nullptr || options.snapshot == nullptr) {
+    autovector<ColumnFamilyHandle*, MultiGetContext::MAX_BATCH_SIZE>
+        stack_column_families;
+    std::vector<ColumnFamilyHandle*> heap_column_families;
+    ColumnFamilyHandle** mutable_column_families =
+        MakeMutableCfHandles(column_families, num_keys, &stack_column_families,
+                             &heap_column_families);
+    MultiGet(options, num_keys, mutable_column_families, keys, values,
+             timestamp_data, statuses, sorted_input);
+    return;
+  }
+  const Status s = Status::NotSupported(
+      "MultiGetWithMetadata is not implemented by this DB subclass");
+  for (size_t i = 0; i < num_keys; ++i) {
+    if (statuses[i].ok()) {
+      statuses[i] = s;
+    }
+  }
+}
+
+void DB::MultiGetWithMetadata(const ReadOptions& options,
+                              ColumnFamilyHandle* column_family,
+                              const size_t num_keys, const Slice* keys,
+                              PinnableSlice* values, Status* statuses,
+                              MultiGetOutputMetadata* output_metadata,
+                              const bool sorted_input) {
+  // Use std::array, if possible, to avoid memory allocation overhead
+  if (num_keys > MultiGetContext::MAX_BATCH_SIZE) {
+    std::vector<ColumnFamilyHandle*> column_families(num_keys, column_family);
+    MultiGetWithMetadata(options, num_keys, column_families.data(), keys,
+                         values, statuses, output_metadata, sorted_input);
+  } else {
+    std::array<ColumnFamilyHandle*, MultiGetContext::MAX_BATCH_SIZE>
+        column_families{};
+    std::fill(column_families.begin(), column_families.begin() + num_keys,
+              column_family);
+    MultiGetWithMetadata(options, num_keys, column_families.data(), keys,
+                         values, statuses, output_metadata, sorted_input);
+  }
 }
 
 void DBImpl::MultiGetCommon(const ReadOptions& read_options,
@@ -3773,7 +3979,7 @@ void DBImpl::MultiGetEntity(const ReadOptions& _read_options, size_t num_keys,
 
   MultiGetCommon(read_options, num_keys, column_families, keys,
                  /* values */ nullptr, results, /* timestamps */ nullptr,
-                 statuses, sorted_input);
+                 statuses, /* newer_version_present */ nullptr, sorted_input);
 }
 
 void DBImpl::MultiGetEntity(const ReadOptions& _read_options,
@@ -3888,6 +4094,7 @@ void DBImpl::MultiGetEntity(const ReadOptions& _read_options, size_t num_keys,
                  all_keys.data(),
                  /* values */ nullptr, columns.data(),
                  /* timestamps */ nullptr, statuses.data(),
+                 /* newer_version_present */ nullptr,
                  /* sorted_input */ false);
 
   // Set results

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -290,6 +290,12 @@ class DBImpl : public DB
                                   const Slice& key, PinnableSlice* value,
                                   std::string* timestamp);
 
+  using DB::GetWithMetadata;
+  Status GetWithMetadata(const ReadOptions& _read_options,
+                         ColumnFamilyHandle* column_family, const Slice& key,
+                         PinnableSlice* value,
+                         OutputMetadata* output_metadata) override;
+
   using DB::GetEntity;
   Status GetEntity(const ReadOptions& options,
                    ColumnFamilyHandle* column_family, const Slice& key,
@@ -331,6 +337,15 @@ class DBImpl : public DB
                                   const Slice* keys, PinnableSlice* values,
                                   std::string* timestamps, Status* statuses,
                                   const bool sorted_input = false);
+
+  using DB::MultiGetWithMetadata;
+  void MultiGetWithMetadata(const ReadOptions& _read_options,
+                            const size_t num_keys,
+                            ColumnFamilyHandle* const* column_families,
+                            const Slice* keys, PinnableSlice* values,
+                            Status* statuses,
+                            MultiGetOutputMetadata* output_metadata,
+                            const bool sorted_input = false) override;
 
   void MultiGetWithCallback(
       const ReadOptions& _read_options, ColumnFamilyHandle* column_family,
@@ -765,6 +780,7 @@ class DBImpl : public DB
     PinnableSlice* value = nullptr;
     PinnableWideColumns* columns = nullptr;
     std::string* timestamp = nullptr;
+    bool* newer_version_present = nullptr;
     bool* value_found = nullptr;
     ReadCallback* callback = nullptr;
     bool* is_blob_index = nullptr;
@@ -804,6 +820,11 @@ class DBImpl : public DB
   DECLARE_SYNC_AND_ASYNC(Status, GetImpl, const ReadOptions& read_options,
                          ColumnFamilyHandle* column_family, const Slice& key,
                          PinnableSlice* value, std::string* timestamp);
+
+  Status GetImpl(const ReadOptions& read_options,
+                 ColumnFamilyHandle* column_family, const Slice& key,
+                 PinnableSlice* value, std::string* timestamp,
+                 bool* newer_version_present);
 
   // Function that Get and KeyMayExist call with no_io true or false
   // Note: 'value_found' from KeyMayExist propagates here
@@ -3085,14 +3106,17 @@ class DBImpl : public DB
                       ColumnFamilyHandle* column_family, const size_t num_keys,
                       const Slice* keys, PinnableSlice* values,
                       PinnableWideColumns* columns, std::string* timestamps,
-                      Status* statuses, bool sorted_input);
+                      Status* statuses, bool* newer_version_present,
+                      bool sorted_input);
 
   DECLARE_SYNC_AND_ASYNC(void, MultiGetCommon, const ReadOptions& options,
                          const size_t num_keys,
                          ColumnFamilyHandle** column_families,
                          const Slice* keys, PinnableSlice* values,
                          PinnableWideColumns* columns, std::string* timestamps,
-                         Status* statuses, bool sorted_input);
+                         Status* statuses,
+                         std::vector<bool>* newer_version_present,
+                         bool sorted_input);
 
   // A structure to hold the information required to process MultiGet of keys
   // belonging to one column family. For a multi column family MultiGet, there
@@ -3176,7 +3200,8 @@ class DBImpl : public DB
   void MultiGetWithCallbackImpl(
       const ReadOptions& read_options, ColumnFamilyHandle* column_family,
       ReadCallback* callback,
-      autovector<KeyContext*, MultiGetContext::MAX_BATCH_SIZE>* sorted_keys);
+      autovector<KeyContext*, MultiGetContext::MAX_BATCH_SIZE>* sorted_keys,
+      bool newer_version_present_requested = false);
 
   Status DisableFileDeletionsWithLock();
 
@@ -3778,6 +3803,11 @@ class GetWithTimestampReadCallback : public ReadCallback {
       : ReadCallback(seq) {}
   bool IsVisibleFullCheck(SequenceNumber seq) override {
     return seq <= max_visible_seq_;
+  }
+  bool IsNewerVisibleForMetadataRead(SequenceNumber seq,
+                                     SequenceNumber snapshot,
+                                     SequenceNumber max_visible_seq) override {
+    return snapshot < seq && seq <= max_visible_seq;
   }
 };
 

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -290,6 +290,12 @@ class DBImpl : public DB
                                   const Slice& key, PinnableSlice* value,
                                   std::string* timestamp);
 
+  using DB::GetWithMetadata;
+  Status GetWithMetadata(const ReadOptions& _read_options,
+                         ColumnFamilyHandle* column_family, const Slice& key,
+                         PinnableSlice* value,
+                         OutputMetadata* output_metadata) override;
+
   using DB::GetEntity;
   DECLARE_SYNC_AND_ASYNC_OVERRIDE(Status, GetEntity,
                                   const ReadOptions& _read_options,
@@ -335,6 +341,15 @@ class DBImpl : public DB
                                   const Slice* keys, PinnableSlice* values,
                                   std::string* timestamps, Status* statuses,
                                   const bool sorted_input = false);
+
+  using DB::MultiGetWithMetadata;
+  void MultiGetWithMetadata(const ReadOptions& _read_options,
+                            const size_t num_keys,
+                            ColumnFamilyHandle* const* column_families,
+                            const Slice* keys, PinnableSlice* values,
+                            Status* statuses,
+                            MultiGetOutputMetadata* output_metadata,
+                            const bool sorted_input = false) override;
 
   void MultiGetWithCallback(
       const ReadOptions& _read_options, ColumnFamilyHandle* column_family,
@@ -769,6 +784,7 @@ class DBImpl : public DB
     PinnableSlice* value = nullptr;
     PinnableWideColumns* columns = nullptr;
     std::string* timestamp = nullptr;
+    bool* newer_version_present = nullptr;
     bool* value_found = nullptr;
     ReadCallback* callback = nullptr;
     bool* is_blob_index = nullptr;
@@ -808,6 +824,11 @@ class DBImpl : public DB
   DECLARE_SYNC_AND_ASYNC(Status, GetImpl, const ReadOptions& read_options,
                          ColumnFamilyHandle* column_family, const Slice& key,
                          PinnableSlice* value, std::string* timestamp);
+
+  Status GetImpl(const ReadOptions& read_options,
+                 ColumnFamilyHandle* column_family, const Slice& key,
+                 PinnableSlice* value, std::string* timestamp,
+                 bool* newer_version_present);
 
   // Function that Get and KeyMayExist call with no_io true or false
   // Note: 'value_found' from KeyMayExist propagates here
@@ -3137,7 +3158,9 @@ class DBImpl : public DB
                          ColumnFamilyHandle** column_families,
                          const Slice* keys, PinnableSlice* values,
                          PinnableWideColumns* columns, std::string* timestamps,
-                         Status* statuses, bool sorted_input);
+                         Status* statuses,
+                         std::vector<uint8_t>* newer_version_present,
+                         bool sorted_input);
 
   // A structure to hold the information required to process MultiGet of keys
   // belonging to one column family. For a multi column family MultiGet, there
@@ -3821,9 +3844,47 @@ class GetWithTimestampReadCallback : public ReadCallback {
  public:
   explicit GetWithTimestampReadCallback(SequenceNumber seq)
       : ReadCallback(seq) {}
+  // A null result is used by MultiGet, whose per-key results live in
+  // KeyContext/GetContext.
+  void EnableNewerVersionTracking(SequenceNumber read_snapshot_seq,
+                                  SequenceNumber upper_bound_seq,
+                                  bool* single_key_result) {
+    metadata_read_bounds_.emplace(
+        MetadataReadBounds{read_snapshot_seq, upper_bound_seq});
+    newer_version_present_ = single_key_result;
+  }
+  const MetadataReadBounds* GetMetadataReadBounds() const override {
+    return metadata_read_bounds_.has_value() ? &*metadata_read_bounds_
+                                             : nullptr;
+  }
+  bool NeedToTrackNewerVersions(
+      const bool* per_key_result = nullptr) const override {
+    const bool* result =
+        per_key_result != nullptr ? per_key_result : newer_version_present_;
+    return metadata_read_bounds_.has_value() && result != nullptr && !*result;
+  }
   bool IsVisibleFullCheck(SequenceNumber seq) override {
     return seq <= max_visible_seq_;
   }
+  bool IsNewerVisibleForMetadataRead(SequenceNumber seq) override {
+    const MetadataReadBounds* bounds = GetMetadataReadBounds();
+    return bounds != nullptr && bounds->read_snapshot_seq < seq &&
+           seq <= bounds->newer_version_upper_bound_seq;
+  }
+  void MaybeRecordNewerVersion(SequenceNumber seq, ValueType type,
+                               bool* per_key_result = nullptr) override {
+    bool* result =
+        per_key_result != nullptr ? per_key_result : newer_version_present_;
+    if (result != nullptr && !*result &&
+        (IsValueType(type) || type == kTypeRangeDeletion) &&
+        IsNewerVisibleForMetadataRead(seq)) {
+      *result = true;
+    }
+  }
+
+ private:
+  std::optional<MetadataReadBounds> metadata_read_bounds_;
+  bool* newer_version_present_ = nullptr;
 };
 
 Options SanitizeOptions(const std::string& db, const Options& src,

--- a/db/db_impl/db_impl_metadata.h
+++ b/db/db_impl/db_impl_metadata.h
@@ -1,0 +1,67 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "rocksdb/db.h"
+#include "table/multiget_context.h"
+#include "util/autovector.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+inline std::string* GetOutputTimestamp(OutputMetadata* output_metadata) {
+  return output_metadata != nullptr && output_metadata->timestamp.has_value()
+             ? &*output_metadata->timestamp
+             : nullptr;
+}
+
+inline std::vector<std::string>* GetOutputTimestamps(
+    MultiGetOutputMetadata* output_metadata) {
+  return output_metadata != nullptr && output_metadata->timestamps.has_value()
+             ? &*output_metadata->timestamps
+             : nullptr;
+}
+
+inline bool* GetOutputNewerVersionPresent(OutputMetadata* output_metadata) {
+  return output_metadata != nullptr &&
+                 output_metadata->newer_version_present.has_value()
+             ? &*output_metadata->newer_version_present
+             : nullptr;
+}
+
+inline std::vector<uint8_t>* GetOutputNewerVersionPresent(
+    MultiGetOutputMetadata* output_metadata) {
+  return output_metadata != nullptr &&
+                 output_metadata->newer_version_present.has_value()
+             ? &*output_metadata->newer_version_present
+             : nullptr;
+}
+
+inline ColumnFamilyHandle** MakeMutableCfHandles(
+    ColumnFamilyHandle* const* column_families, size_t num_keys,
+    autovector<ColumnFamilyHandle*, MultiGetContext::MAX_BATCH_SIZE>*
+        stack_column_families,
+    std::vector<ColumnFamilyHandle*>* heap_column_families) {
+  ColumnFamilyHandle** mutable_column_families;
+  if (num_keys <= MultiGetContext::MAX_BATCH_SIZE) {
+    stack_column_families->resize(num_keys);
+    mutable_column_families =
+        num_keys == 0 ? nullptr : &(*stack_column_families)[0];
+  } else {
+    heap_column_families->resize(num_keys);
+    mutable_column_families = heap_column_families->data();
+  }
+  for (size_t i = 0; i < num_keys; ++i) {
+    mutable_column_families[i] = column_families[i];
+  }
+  return mutable_column_families;
+}
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/db/db_impl/db_impl_readonly.cc
+++ b/db/db_impl/db_impl_readonly.cc
@@ -30,6 +30,46 @@ DBImplReadOnly::DBImplReadOnly(const DBOptions& db_options,
 
 DBImplReadOnly::~DBImplReadOnly() = default;
 
+void DBImplReadOnly::MultiGetWithMetadata(
+    const ReadOptions& options, const size_t num_keys,
+    ColumnFamilyHandle* const* column_families, const Slice* keys,
+    PinnableSlice* values, Status* statuses,
+    MultiGetOutputMetadata* output_metadata, const bool sorted_input) {
+  std::vector<std::string>* timestamps =
+      output_metadata != nullptr && output_metadata->timestamps.has_value()
+          ? &*output_metadata->timestamps
+          : nullptr;
+  if (timestamps != nullptr) {
+    timestamps->resize(num_keys);
+  }
+  std::vector<bool>* newer_version_present =
+      output_metadata != nullptr &&
+              output_metadata->newer_version_present.has_value()
+          ? &*output_metadata->newer_version_present
+          : nullptr;
+  if (newer_version_present != nullptr) {
+    newer_version_present->assign(num_keys, false);
+  }
+  autovector<ColumnFamilyHandle*, MultiGetContext::MAX_BATCH_SIZE>
+      stack_column_families;
+  std::vector<ColumnFamilyHandle*> heap_column_families;
+  ColumnFamilyHandle** mutable_column_families = nullptr;
+  if (num_keys <= MultiGetContext::MAX_BATCH_SIZE) {
+    stack_column_families.resize(num_keys);
+    mutable_column_families =
+        num_keys == 0 ? nullptr : &stack_column_families[0];
+  } else {
+    heap_column_families.resize(num_keys);
+    mutable_column_families = heap_column_families.data();
+  }
+  for (size_t i = 0; i < num_keys; ++i) {
+    mutable_column_families[i] = column_families[i];
+  }
+  DBImpl::MultiGet(options, num_keys, mutable_column_families, keys, values,
+                   timestamps != nullptr ? timestamps->data() : nullptr,
+                   statuses, sorted_input);
+}
+
 Iterator* DBImplReadOnly::NewIterator(const ReadOptions& _read_options,
                                       ColumnFamilyHandle* column_family) {
   if (_read_options.io_activity != Env::IOActivity::kUnknown &&

--- a/db/db_impl/db_impl_readonly.cc
+++ b/db/db_impl/db_impl_readonly.cc
@@ -11,6 +11,7 @@
 #include "db/blob/blob_fetcher.h"
 #include "db/db_impl/compacted_db_impl.h"
 #include "db/db_impl/db_impl.h"
+#include "db/db_impl/db_impl_metadata.h"
 #include "db/manifest_ops.h"
 #include "db/merge_context.h"
 #include "logging/logging.h"
@@ -29,6 +30,30 @@ DBImplReadOnly::DBImplReadOnly(const DBOptions& db_options,
 }
 
 DBImplReadOnly::~DBImplReadOnly() = default;
+
+void DBImplReadOnly::MultiGetWithMetadata(
+    const ReadOptions& options, const size_t num_keys,
+    ColumnFamilyHandle* const* column_families, const Slice* keys,
+    PinnableSlice* values, Status* statuses,
+    MultiGetOutputMetadata* output_metadata, const bool sorted_input) {
+  std::vector<std::string>* timestamps = GetOutputTimestamps(output_metadata);
+  if (timestamps != nullptr) {
+    timestamps->resize(num_keys);
+  }
+  std::vector<uint8_t>* newer_version_present =
+      GetOutputNewerVersionPresent(output_metadata);
+  if (newer_version_present != nullptr) {
+    newer_version_present->assign(num_keys, false);
+  }
+  autovector<ColumnFamilyHandle*, MultiGetContext::MAX_BATCH_SIZE>
+      stack_column_families;
+  std::vector<ColumnFamilyHandle*> heap_column_families;
+  ColumnFamilyHandle** mutable_column_families = MakeMutableCfHandles(
+      column_families, num_keys, &stack_column_families, &heap_column_families);
+  DBImpl::MultiGet(options, num_keys, mutable_column_families, keys, values,
+                   timestamps != nullptr ? timestamps->data() : nullptr,
+                   statuses, sorted_input);
+}
 
 Iterator* DBImplReadOnly::NewIterator(const ReadOptions& _read_options,
                                       ColumnFamilyHandle* column_family) {

--- a/db/db_impl/db_impl_readonly.h
+++ b/db/db_impl/db_impl_readonly.h
@@ -28,7 +28,13 @@ class DBImplReadOnly : public DBImpl {
                                   const Slice& key,
                                   GetImplOptions& get_impl_options);
 
-  // TODO: Implement ReadOnly MultiGet?
+  using DBImpl::MultiGetWithMetadata;
+  void MultiGetWithMetadata(const ReadOptions& options, const size_t num_keys,
+                            ColumnFamilyHandle* const* column_families,
+                            const Slice* keys, PinnableSlice* values,
+                            Status* statuses,
+                            MultiGetOutputMetadata* output_metadata,
+                            const bool sorted_input = false) override;
 
   using DBImpl::NewIterator;
   Iterator* NewIterator(const ReadOptions& _read_options,

--- a/db/db_impl/db_impl_readonly_sync_and_async.h
+++ b/db/db_impl/db_impl_readonly_sync_and_async.h
@@ -20,6 +20,10 @@ DEFINE_SYNC_AND_ASYNC(Status, DBImplReadOnly::GetImpl)
          get_impl_options.merge_operands != nullptr);
   assert(get_impl_options.column_family);
 
+  // This instance cannot observe writes after one of its snapshots, so the
+  // false result initialized by GetWithMetadata is definitive.
+  get_impl_options.newer_version_present = nullptr;
+
   Status s;
 
   if (read_options.timestamp) {

--- a/db/db_impl/db_impl_secondary.cc
+++ b/db/db_impl/db_impl_secondary.cc
@@ -336,6 +336,54 @@ Status DBImplSecondary::RecoverLogFiles(
   return status;
 }
 
+void DBImplSecondary::MultiGetWithMetadata(
+    const ReadOptions& options, const size_t num_keys,
+    ColumnFamilyHandle* const* column_families, const Slice* keys,
+    PinnableSlice* values, Status* statuses,
+    MultiGetOutputMetadata* output_metadata, const bool sorted_input) {
+  std::vector<std::string>* timestamps =
+      output_metadata != nullptr && output_metadata->timestamps.has_value()
+          ? &*output_metadata->timestamps
+          : nullptr;
+  if (timestamps != nullptr) {
+    timestamps->resize(num_keys);
+  }
+  std::vector<bool>* newer_version_present =
+      output_metadata != nullptr &&
+              output_metadata->newer_version_present.has_value()
+          ? &*output_metadata->newer_version_present
+          : nullptr;
+  if (newer_version_present != nullptr) {
+    newer_version_present->assign(num_keys, false);
+    if (options.snapshot != nullptr) {
+      const Status s = Status::NotSupported(
+          "MultiGetWithMetadata is not supported in secondary DB mode");
+      for (size_t i = 0; i < num_keys; ++i) {
+        statuses[i] = s;
+      }
+      return;
+    }
+  }
+  autovector<ColumnFamilyHandle*, MultiGetContext::MAX_BATCH_SIZE>
+      stack_column_families;
+  std::vector<ColumnFamilyHandle*> heap_column_families;
+  ColumnFamilyHandle** mutable_column_families = nullptr;
+  if (num_keys <= MultiGetContext::MAX_BATCH_SIZE) {
+    stack_column_families.resize(num_keys);
+    mutable_column_families =
+        num_keys == 0 ? nullptr : &stack_column_families[0];
+  } else {
+    heap_column_families.resize(num_keys);
+    mutable_column_families = heap_column_families.data();
+  }
+  for (size_t i = 0; i < num_keys; ++i) {
+    mutable_column_families[i] = column_families[i];
+  }
+  DBImpl::MultiGet(options, num_keys, mutable_column_families, keys, values,
+                   timestamps != nullptr ? timestamps->data() : nullptr,
+                   statuses, sorted_input);
+}
+
 Iterator* DBImplSecondary::NewIterator(const ReadOptions& _read_options,
                                        ColumnFamilyHandle* column_family) {
   if (_read_options.io_activity != Env::IOActivity::kUnknown &&

--- a/db/db_impl/db_impl_secondary.cc
+++ b/db/db_impl/db_impl_secondary.cc
@@ -11,6 +11,7 @@
 
 #include "db/arena_wrapped_db_iter.h"
 #include "db/blob/blob_fetcher.h"
+#include "db/db_impl/db_impl_metadata.h"
 #include "db/log_reader.h"
 #include "db/log_writer.h"
 #include "db/merge_context.h"
@@ -519,6 +520,42 @@ void DBImplSecondary::DeleteResolvedRecoveredTransactions() {
                     " recovered transaction(s) prepared before WAL %" PRIu64,
                     deleted, min_log_number_to_keep);
   }
+}
+
+void DBImplSecondary::MultiGetWithMetadata(
+    const ReadOptions& options, const size_t num_keys,
+    ColumnFamilyHandle* const* column_families, const Slice* keys,
+    PinnableSlice* values, Status* statuses,
+    MultiGetOutputMetadata* output_metadata, const bool sorted_input) {
+  // The only secondary-specific policy here is rejecting newer-version
+  // tracking for explicit snapshots: catch-up can advance a secondary's view.
+  // The remaining code initializes requested metadata and forwards to the
+  // existing MultiGet implementation.
+  std::vector<std::string>* timestamps = GetOutputTimestamps(output_metadata);
+  if (timestamps != nullptr) {
+    timestamps->resize(num_keys);
+  }
+  std::vector<uint8_t>* newer_version_present =
+      GetOutputNewerVersionPresent(output_metadata);
+  if (newer_version_present != nullptr) {
+    newer_version_present->assign(num_keys, false);
+    if (options.snapshot != nullptr) {
+      const Status s = Status::NotSupported(
+          "MultiGetWithMetadata is not supported in secondary DB mode");
+      for (size_t i = 0; i < num_keys; ++i) {
+        statuses[i] = s;
+      }
+      return;
+    }
+  }
+  autovector<ColumnFamilyHandle*, MultiGetContext::MAX_BATCH_SIZE>
+      stack_column_families;
+  std::vector<ColumnFamilyHandle*> heap_column_families;
+  ColumnFamilyHandle** mutable_column_families = MakeMutableCfHandles(
+      column_families, num_keys, &stack_column_families, &heap_column_families);
+  DBImpl::MultiGet(options, num_keys, mutable_column_families, keys, values,
+                   timestamps != nullptr ? timestamps->data() : nullptr,
+                   statuses, sorted_input);
 }
 
 Iterator* DBImplSecondary::NewIterator(const ReadOptions& _read_options,

--- a/db/db_impl/db_impl_secondary.h
+++ b/db/db_impl/db_impl_secondary.h
@@ -101,6 +101,14 @@ class DBImplSecondary : public DBImpl {
                                   const Slice& key,
                                   GetImplOptions& get_impl_options);
 
+  using DBImpl::MultiGetWithMetadata;
+  void MultiGetWithMetadata(const ReadOptions& options, const size_t num_keys,
+                            ColumnFamilyHandle* const* column_families,
+                            const Slice* keys, PinnableSlice* values,
+                            Status* statuses,
+                            MultiGetOutputMetadata* output_metadata,
+                            const bool sorted_input = false) override;
+
   using DBImpl::NewIterator;
   // Operations on the created iterators can return IOError due to files being
   // deleted by the primary. To avoid IOError in this case, application can

--- a/db/db_impl/db_impl_secondary.h
+++ b/db/db_impl/db_impl_secondary.h
@@ -104,6 +104,14 @@ class DBImplSecondary : public DBImpl {
                                   const Slice& key,
                                   GetImplOptions& get_impl_options);
 
+  using DBImpl::MultiGetWithMetadata;
+  void MultiGetWithMetadata(const ReadOptions& options, const size_t num_keys,
+                            ColumnFamilyHandle* const* column_families,
+                            const Slice* keys, PinnableSlice* values,
+                            Status* statuses,
+                            MultiGetOutputMetadata* output_metadata,
+                            const bool sorted_input = false) override;
+
   using DBImpl::NewIterator;
   // Operations on the created iterators can return IOError due to files being
   // deleted by the primary. To avoid IOError in this case, application can

--- a/db/db_impl/db_impl_secondary_sync_and_async.h
+++ b/db/db_impl/db_impl_secondary_sync_and_async.h
@@ -19,6 +19,14 @@ DEFINE_SYNC_AND_ASYNC(Status, DBImplSecondary::GetImpl)
          get_impl_options.merge_operands != nullptr);
   assert(get_impl_options.column_family);
 
+  if (get_impl_options.newer_version_present != nullptr) {
+    if (read_options.snapshot != nullptr) {
+      CO_RETURN Status::NotSupported(
+          "GetWithMetadata is not supported in secondary DB mode");
+    }
+    get_impl_options.newer_version_present = nullptr;
+  }
+
   Status s;
 
   if (read_options.timestamp) {

--- a/db/db_impl/db_impl_sync_and_async.h
+++ b/db/db_impl/db_impl_sync_and_async.h
@@ -69,6 +69,13 @@ DEFINE_SYNC_AND_ASYNC(Status, DBImpl::GetImpl)
 
   assert(get_impl_options.column_family);
 
+  if (get_impl_options.newer_version_present != nullptr &&
+      read_options.snapshot != nullptr &&
+      get_impl_options.callback != nullptr) {
+    CO_RETURN Status::NotSupported(
+        "Newer-version metadata is not supported with a read callback");
+  }
+
   if (read_options.timestamp) {
     const Status s = FailIfTsMismatchCf(get_impl_options.column_family,
                                         *(read_options.timestamp));
@@ -173,6 +180,22 @@ DEFINE_SYNC_AND_ASYNC(Status, DBImpl::GetImpl)
       snapshot = get_impl_options.callback->max_visible_seq();
     }
   }
+  SequenceNumber lookup_snapshot = snapshot;
+  const bool newer_version_present_requested =
+      get_impl_options.newer_version_present != nullptr &&
+      read_options.snapshot != nullptr;
+  const SequenceNumber newer_version_upper_bound_seq =
+      newer_version_present_requested ? GetLastPublishedSequence() : snapshot;
+  const bool track_newer_versions = newer_version_present_requested &&
+                                    snapshot < newer_version_upper_bound_seq;
+  std::optional<MetadataReadCtx> metadata_ctx_storage;
+  const MetadataReadCtx* metadata_ctx = nullptr;
+  if (track_newer_versions) {
+    lookup_snapshot = newer_version_upper_bound_seq;
+    metadata_ctx_storage.emplace(snapshot, newer_version_upper_bound_seq,
+                                 *get_impl_options.newer_version_present);
+    metadata_ctx = &*metadata_ctx_storage;
+  }
   // If timestamp is used, we use read callback to ensure <key,t,s> is returned
   // only if t <= read_opts.timestamp and s <= snapshot.
   // HACK: temporarily overwrite input struct field but restore
@@ -182,6 +205,9 @@ DEFINE_SYNC_AND_ASYNC(Status, DBImpl::GetImpl)
   if (ucmp->timestamp_size() > 0) {
     assert(!get_impl_options
                 .callback);  // timestamp with callback is not supported
+    read_cb.Refresh(snapshot);
+    get_impl_options.callback = &read_cb;
+  } else if (track_newer_versions && get_impl_options.callback == nullptr) {
     read_cb.Refresh(snapshot);
     get_impl_options.callback = &read_cb;
   }
@@ -198,7 +224,7 @@ DEFINE_SYNC_AND_ASYNC(Status, DBImpl::GetImpl)
   // First look in the memtable, then in the immutable memtable (if any).
   // s is both in/out. When in, s could either be OK or MergeInProgress.
   // merge_operands will contain the sequence of merges in the latter case.
-  LookupKey lkey(key, snapshot, read_options.timestamp);
+  LookupKey lkey(key, lookup_snapshot, read_options.timestamp);
   PERF_TIMER_STOP(get_snapshot_time);
 
   bool skip_memtable = (read_options.read_tier == kPersistedTier &&
@@ -230,15 +256,15 @@ DEFINE_SYNC_AND_ASYNC(Status, DBImpl::GetImpl)
   if (!skip_memtable) {
     // Get value associated with key
     if (get_impl_options.get_value) {
-      if (sv->mem->Get(lkey,
-                       get_impl_options.value
-                           ? get_impl_options.value->GetSelf()
-                           : nullptr,
-                       get_impl_options.columns, timestamp, &s, &merge_context,
-                       &max_covering_tombstone_seq, read_options,
-                       false /* immutable_memtable */,
-                       get_impl_options.callback, is_blob_ptr,
-                       /*do_merge=*/true, memtable_blob_fetcher_ptr)) {
+      if (sv->mem->Get(
+              lkey,
+              get_impl_options.value ? get_impl_options.value->GetSelf()
+                                     : nullptr,
+              get_impl_options.columns, timestamp, &s, &merge_context,
+              &max_covering_tombstone_seq, read_options,
+              false /* immutable_memtable */, get_impl_options.callback,
+              is_blob_ptr,
+              /*do_merge=*/true, memtable_blob_fetcher_ptr, metadata_ctx)) {
         done = true;
         PostprocessDirectWriteValueRead(
             read_options, key, timestamp, resolve_direct_write_value,
@@ -248,14 +274,14 @@ DEFINE_SYNC_AND_ASYNC(Status, DBImpl::GetImpl)
 
         RecordTick(stats_, MEMTABLE_HIT);
       } else if ((s.ok() || s.IsMergeInProgress()) &&
-                 sv->imm->Get(lkey,
-                              get_impl_options.value
-                                  ? get_impl_options.value->GetSelf()
-                                  : nullptr,
-                              get_impl_options.columns, timestamp, &s,
-                              &merge_context, &max_covering_tombstone_seq,
-                              read_options, get_impl_options.callback,
-                              is_blob_ptr, memtable_blob_fetcher_ptr)) {
+                 sv->imm->Get(
+                     lkey,
+                     get_impl_options.value ? get_impl_options.value->GetSelf()
+                                            : nullptr,
+                     get_impl_options.columns, timestamp, &s, &merge_context,
+                     &max_covering_tombstone_seq, read_options,
+                     get_impl_options.callback, is_blob_ptr,
+                     memtable_blob_fetcher_ptr, metadata_ctx)) {
         done = true;
         PostprocessDirectWriteValueRead(
             read_options, key, timestamp, resolve_direct_write_value,
@@ -302,7 +328,7 @@ DEFINE_SYNC_AND_ASYNC(Status, DBImpl::GetImpl)
         get_impl_options.get_value ? get_impl_options.callback : nullptr,
         get_impl_options.get_value ? is_blob_ptr : nullptr,
         get_impl_options.get_value,
-        get_impl_options.lazy_columns_same_file_reader);
+        get_impl_options.lazy_columns_same_file_reader, metadata_ctx);
     if (get_impl_options.get_value && resolve_direct_write_value) {
       assert(memtable_blob_fetcher_ptr != nullptr);
       std::string blob_lookup_key_storage;
@@ -635,7 +661,7 @@ DEFINE_SYNC_AND_ASYNC(void, DBImpl::MultiGetCommon)
 (const ReadOptions& read_options, const size_t num_keys,
  ColumnFamilyHandle** column_families, const Slice* keys, PinnableSlice* values,
  PinnableWideColumns* columns, std::string* timestamps, Status* statuses,
- const bool sorted_input) {
+ std::vector<bool>* newer_version_present, const bool sorted_input) {
   if (num_keys == 0) {
     CO_RETURN;
   }
@@ -754,7 +780,30 @@ DEFINE_SYNC_AND_ASYNC(void, DBImpl::MultiGetCommon)
 
   GetWithTimestampReadCallback timestamp_read_callback(0);
   ReadCallback* read_callback = nullptr;
-  if (read_options.timestamp && read_options.timestamp->size() > 0) {
+  SequenceNumber lookup_seqnum = consistent_seqnum;
+  const bool newer_version_present_requested =
+      newer_version_present != nullptr && read_options.snapshot != nullptr;
+  const SequenceNumber newer_version_upper_bound_seq =
+      newer_version_present_requested ? GetLastPublishedSequence()
+                                      : consistent_seqnum;
+  const bool track_newer_versions =
+      newer_version_present_requested &&
+      consistent_seqnum < newer_version_upper_bound_seq;
+  autovector<std::optional<MetadataReadCtx>, MultiGetContext::MAX_BATCH_SIZE>
+      metadata_ctxs;
+  if (track_newer_versions) {
+    lookup_seqnum = newer_version_upper_bound_seq;
+    metadata_ctxs.resize(key_context.size());
+    size_t i = 0;
+    for (auto& key_ctx : key_context) {
+      metadata_ctxs[i].emplace(consistent_seqnum, newer_version_upper_bound_seq,
+                               key_ctx.newer_version_present);
+      key_ctx.metadata_ctx = &*metadata_ctxs[i];
+      ++i;
+    }
+  }
+  if ((read_options.timestamp && read_options.timestamp->size() > 0) ||
+      track_newer_versions) {
     timestamp_read_callback.Refresh(consistent_seqnum);
     read_callback = &timestamp_read_callback;
   }
@@ -766,8 +815,7 @@ DEFINE_SYNC_AND_ASYNC(void, DBImpl::MultiGetCommon)
          cf_sv_pair_iter != cf_sv_pairs.end()) {
     s = CO_AWAIT(MultiGetImpl, read_options, key_range_per_cf_iter->start,
                  key_range_per_cf_iter->num_keys, &sorted_keys,
-                 cf_sv_pair_iter->super_version, consistent_seqnum,
-                 read_callback);
+                 cf_sv_pair_iter->super_version, lookup_seqnum, read_callback);
     if (!s.ok()) {
       break;
     }
@@ -795,6 +843,7 @@ DEFINE_SYNC_AND_ASYNC(void, DBImpl::MultiGetCommon)
       CleanupSuperVersion(cf_sv_pair.super_version);
     }
   }
+  CopyNewerVersionPresent(key_context, newer_version_present);
 }
 
 DEFINE_SYNC_AND_ASYNC(void, DBImpl::MultiGet)
@@ -823,7 +872,8 @@ DEFINE_SYNC_AND_ASYNC(void, DBImpl::MultiGet)
   }
   CO_AWAIT(MultiGetCommon, read_options, num_keys, column_families, keys,
            values,
-           /* columns */ nullptr, timestamps, statuses, sorted_input);
+           /* columns */ nullptr, timestamps, statuses,
+           /* newer_version_present */ nullptr, sorted_input);
   CO_RETURN;
 }
 

--- a/db/db_impl/db_impl_sync_and_async.h
+++ b/db/db_impl/db_impl_sync_and_async.h
@@ -129,6 +129,7 @@ DEFINE_SYNC_AND_ASYNC(Status, DBImpl::GetEntity)
            column_families.data(), keys.data(),
            /* values */ nullptr, columns.data(),
            /* timestamps */ nullptr, statuses.data(),
+           /* newer_version_present */ nullptr,
            /* sorted_input */ false);
   // Set results
   for (size_t i = 0; i < num_column_families; ++i) {
@@ -159,6 +160,13 @@ DEFINE_SYNC_AND_ASYNC(Status, DBImpl::GetImpl)
          get_impl_options.columns != nullptr);
 
   assert(get_impl_options.column_family);
+
+  if (get_impl_options.newer_version_present != nullptr &&
+      read_options.snapshot != nullptr &&
+      get_impl_options.callback != nullptr) {
+    CO_RETURN Status::NotSupported(
+        "Newer-version metadata is not supported with a read callback");
+  }
 
   if (read_options.timestamp) {
     const Status s = FailIfTsMismatchCf(get_impl_options.column_family,
@@ -264,6 +272,17 @@ DEFINE_SYNC_AND_ASYNC(Status, DBImpl::GetImpl)
       snapshot = get_impl_options.callback->max_visible_seq();
     }
   }
+  SequenceNumber lookup_snapshot = snapshot;
+  const bool newer_version_present_requested =
+      get_impl_options.newer_version_present != nullptr &&
+      read_options.snapshot != nullptr;
+  const SequenceNumber newer_version_upper_bound_seq =
+      newer_version_present_requested ? GetLastPublishedSequence() : snapshot;
+  const bool track_newer_versions = newer_version_present_requested &&
+                                    snapshot < newer_version_upper_bound_seq;
+  if (track_newer_versions) {
+    lookup_snapshot = newer_version_upper_bound_seq;
+  }
   // If timestamp is used, we use read callback to ensure <key,t,s> is returned
   // only if t <= read_opts.timestamp and s <= snapshot.
   // HACK: temporarily overwrite input struct field but restore
@@ -275,6 +294,13 @@ DEFINE_SYNC_AND_ASYNC(Status, DBImpl::GetImpl)
                 .callback);  // timestamp with callback is not supported
     read_cb.Refresh(snapshot);
     get_impl_options.callback = &read_cb;
+  } else if (track_newer_versions && get_impl_options.callback == nullptr) {
+    read_cb.Refresh(snapshot);
+    get_impl_options.callback = &read_cb;
+  }
+  if (track_newer_versions) {
+    read_cb.EnableNewerVersionTracking(snapshot, newer_version_upper_bound_seq,
+                                       get_impl_options.newer_version_present);
   }
   TEST_SYNC_POINT("DBImpl::GetImpl:3");
   TEST_SYNC_POINT("DBImpl::GetImpl:4");
@@ -289,7 +315,7 @@ DEFINE_SYNC_AND_ASYNC(Status, DBImpl::GetImpl)
   // First look in the memtable, then in the immutable memtable (if any).
   // s is both in/out. When in, s could either be OK or MergeInProgress.
   // merge_operands will contain the sequence of merges in the latter case.
-  LookupKey lkey(key, snapshot, read_options.timestamp);
+  LookupKey lkey(key, lookup_snapshot, read_options.timestamp);
   PERF_TIMER_STOP(get_snapshot_time);
 
   bool skip_memtable = (read_options.read_tier == kPersistedTier &&
@@ -726,7 +752,7 @@ DEFINE_SYNC_AND_ASYNC(void, DBImpl::MultiGetCommon)
 (const ReadOptions& read_options, const size_t num_keys,
  ColumnFamilyHandle** column_families, const Slice* keys, PinnableSlice* values,
  PinnableWideColumns* columns, std::string* timestamps, Status* statuses,
- const bool sorted_input) {
+ std::vector<uint8_t>* newer_version_present, const bool sorted_input) {
   if (num_keys == 0) {
     CO_RETURN;
   }
@@ -845,8 +871,26 @@ DEFINE_SYNC_AND_ASYNC(void, DBImpl::MultiGetCommon)
 
   GetWithTimestampReadCallback timestamp_read_callback(0);
   ReadCallback* read_callback = nullptr;
-  if (read_options.timestamp && read_options.timestamp->size() > 0) {
+  SequenceNumber lookup_seqnum = consistent_seqnum;
+  const bool newer_version_present_requested =
+      newer_version_present != nullptr && read_options.snapshot != nullptr;
+  const SequenceNumber newer_version_upper_bound_seq =
+      newer_version_present_requested ? GetLastPublishedSequence()
+                                      : consistent_seqnum;
+  const bool track_newer_versions =
+      newer_version_present_requested &&
+      consistent_seqnum < newer_version_upper_bound_seq;
+  if (track_newer_versions) {
+    lookup_seqnum = newer_version_upper_bound_seq;
+  }
+  if ((read_options.timestamp && read_options.timestamp->size() > 0) ||
+      track_newer_versions) {
     timestamp_read_callback.Refresh(consistent_seqnum);
+    if (track_newer_versions) {
+      timestamp_read_callback.EnableNewerVersionTracking(
+          consistent_seqnum, newer_version_upper_bound_seq,
+          /*single_key_result=*/nullptr);
+    }
     read_callback = &timestamp_read_callback;
   }
 
@@ -857,8 +901,7 @@ DEFINE_SYNC_AND_ASYNC(void, DBImpl::MultiGetCommon)
          cf_sv_pair_iter != cf_sv_pairs.end()) {
     s = CO_AWAIT(MultiGetImpl, read_options, key_range_per_cf_iter->start,
                  key_range_per_cf_iter->num_keys, &sorted_keys,
-                 cf_sv_pair_iter->super_version, consistent_seqnum,
-                 read_callback);
+                 cf_sv_pair_iter->super_version, lookup_seqnum, read_callback);
     if (!s.ok()) {
       break;
     }
@@ -886,6 +929,7 @@ DEFINE_SYNC_AND_ASYNC(void, DBImpl::MultiGetCommon)
       CleanupSuperVersion(cf_sv_pair.super_version);
     }
   }
+  CopyNewerVersionPresent(key_context, newer_version_present);
 }
 
 DEFINE_SYNC_AND_ASYNC(void, DBImpl::MultiGet)
@@ -910,7 +954,8 @@ DEFINE_SYNC_AND_ASYNC(void, DBImpl::MultiGet)
   }
   CO_AWAIT(MultiGetCommon, read_options, num_keys, column_families, keys,
            values,
-           /* columns */ nullptr, timestamps, statuses, sorted_input);
+           /* columns */ nullptr, timestamps, statuses,
+           /* newer_version_present */ nullptr, sorted_input);
   CO_RETURN;
 }
 

--- a/db/db_secondary_test.cc
+++ b/db/db_secondary_test.cc
@@ -178,6 +178,19 @@ TEST_F(DBSecondaryTest, ReopenAsSecondary) {
   ASSERT_OK(ReopenAsSecondary(options));
   ASSERT_EQ("foo_value", Get("foo"));
   ASSERT_EQ("bar_value", Get("bar"));
+
+  MultiGetOutputMetadata output_metadata;
+  output_metadata.WantNewerVersionPresent();
+  std::vector<Slice> metadata_keys{"foo", "missing"};
+  std::vector<std::string> metadata_values;
+  const std::vector<Status> metadata_statuses = db_->MultiGetWithMetadata(
+      ReadOptions(), metadata_keys, &metadata_values, &output_metadata);
+  ASSERT_OK(metadata_statuses[0]);
+  ASSERT_EQ("foo_value", metadata_values[0]);
+  ASSERT_FALSE((*output_metadata.newer_version_present)[0]);
+  ASSERT_TRUE(metadata_statuses[1].IsNotFound());
+  ASSERT_FALSE((*output_metadata.newer_version_present)[1]);
+
   PinnableWideColumns result;
   ASSERT_OK(db_->GetEntity(ReadOptions(), db_->DefaultColumnFamily(), "baz",
                            &result));

--- a/db/db_secondary_test.cc
+++ b/db/db_secondary_test.cc
@@ -324,6 +324,19 @@ TEST_F(DBSecondaryTest, ReopenAsSecondary) {
   ASSERT_OK(ReopenAsSecondary(options));
   ASSERT_EQ("foo_value", Get("foo"));
   ASSERT_EQ("bar_value", Get("bar"));
+
+  MultiGetOutputMetadata output_metadata;
+  output_metadata.WantNewerVersionPresent();
+  std::vector<Slice> metadata_keys{"foo", "missing"};
+  std::vector<std::string> metadata_values;
+  const std::vector<Status> metadata_statuses = db_->MultiGetWithMetadata(
+      ReadOptions(), metadata_keys, &metadata_values, &output_metadata);
+  ASSERT_OK(metadata_statuses[0]);
+  ASSERT_EQ("foo_value", metadata_values[0]);
+  ASSERT_FALSE((*output_metadata.newer_version_present)[0]);
+  ASSERT_TRUE(metadata_statuses[1].IsNotFound());
+  ASSERT_FALSE((*output_metadata.newer_version_present)[1]);
+
   PinnableWideColumns result;
   ASSERT_OK(db_->GetEntity(ReadOptions(), db_->DefaultColumnFamily(), "baz",
                            &result));

--- a/db/db_with_timestamp_basic_test.cc
+++ b/db/db_with_timestamp_basic_test.cc
@@ -32,6 +32,46 @@ class DBBasicTestWithTimestamp : public DBBasicTestWithTimestampBase {
       : DBBasicTestWithTimestampBase("db_basic_test_with_timestamp") {}
 };
 
+TEST_F(DBBasicTestWithTimestamp, GetWithMetadataTimestampAndNewerVersion) {
+  Options options = CurrentOptions();
+  options.comparator = test::BytewiseComparatorWithU64TsWrapper();
+  DestroyAndReopen(options);
+
+  const std::string old_timestamp = EncodeAsUint64(1);
+  const std::string new_timestamp = EncodeAsUint64(2);
+  ASSERT_OK(db_->Put(WriteOptions(), "key", old_timestamp, "old"));
+  const Snapshot* snapshot = db_->GetSnapshot();
+  ASSERT_OK(db_->Put(WriteOptions(), "key", new_timestamp, "new"));
+  ASSERT_OK(Flush());
+
+  Slice read_timestamp(new_timestamp);
+  ReadOptions read_options;
+  read_options.snapshot = snapshot;
+  read_options.timestamp = &read_timestamp;
+
+  OutputMetadata output_metadata;
+  output_metadata.WantTimestamp().WantNewerVersionPresent();
+  std::string value;
+  ASSERT_OK(
+      db_->GetWithMetadata(read_options, "key", &value, &output_metadata));
+  ASSERT_EQ("old", value);
+  ASSERT_EQ(old_timestamp, *output_metadata.timestamp);
+  ASSERT_TRUE(*output_metadata.newer_version_present);
+
+  MultiGetOutputMetadata multiget_output_metadata;
+  multiget_output_metadata.WantTimestamps().WantNewerVersionPresent();
+  std::vector<Slice> keys{"key"};
+  std::vector<std::string> values;
+  const std::vector<Status> statuses = db_->MultiGetWithMetadata(
+      read_options, keys, &values, &multiget_output_metadata);
+  ASSERT_OK(statuses[0]);
+  ASSERT_EQ("old", values[0]);
+  ASSERT_EQ(old_timestamp, (*multiget_output_metadata.timestamps)[0]);
+  ASSERT_TRUE((*multiget_output_metadata.newer_version_present)[0]);
+
+  db_->ReleaseSnapshot(snapshot);
+}
+
 TEST_F(DBBasicTestWithTimestamp, SanityChecks) {
   Options options = CurrentOptions();
   options.env = env_;

--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -1307,11 +1307,17 @@ struct Saver {
   bool* is_blob_index;
   bool allow_data_in_errors;
   uint32_t protection_bytes_per_key;
+  // nullptr when newer-version metadata tracking is not requested.
+  const MetadataReadCtx* metadata_ctx;
   bool CheckCallback(SequenceNumber _seq) {
     if (callback_) {
       return callback_->IsVisible(_seq);
     }
     return true;
+  }
+  bool CanRecordNewerVersion(SequenceNumber _seq) {
+    assert(metadata_ctx != nullptr);
+    return metadata_ctx->ShouldRecordNewerVersion(_seq, callback_);
   }
 };
 }  // anonymous namespace
@@ -1366,6 +1372,10 @@ static bool SaveValue(void* arg, const char* entry) {
     ValueType type;
     SequenceNumber seq;
     UnPackSequenceAndType(tag, &seq, &type);
+    if (UNLIKELY(s->metadata_ctx != nullptr) && IsValueType(type) &&
+        s->CanRecordNewerVersion(seq)) {
+      s->metadata_ctx->MarkNewerVersionPresent();
+    }
     // If the value is not in the snapshot, skip it
     if (!s->CheckCallback(seq)) {
       return true;  // to continue to the next seq
@@ -1572,7 +1582,8 @@ bool MemTable::Get(const LookupKey& key, std::string* value,
                    SequenceNumber* seq, const ReadOptions& read_opts,
                    bool immutable_memtable, ReadCallback* callback,
                    bool* is_blob_index, bool do_merge,
-                   const BlobFetcher* blob_fetcher) {
+                   const BlobFetcher* blob_fetcher,
+                   const MetadataReadCtx* metadata_ctx) {
   // The sequence number is updated synchronously in version_set.h
   if (IsEmpty()) {
     // Avoiding recording stats for speed.
@@ -1581,9 +1592,29 @@ bool MemTable::Get(const LookupKey& key, std::string* value,
 
   PERF_TIMER_GUARD(get_from_memtable_time);
 
+  // Metadata reads widen the lookup seq to detect newer range tombstones. The
+  // regular masking iterator must stay at the user's snapshot seq so such
+  // tombstones only set metadata and do not hide snapshot-visible values.
+  const SequenceNumber lookup_seq = GetInternalKeySeqno(key.internal_key());
+  const SequenceNumber range_del_read_seq =
+      metadata_ctx != nullptr ? metadata_ctx->read_snapshot_seq : lookup_seq;
+  assert(range_del_read_seq <= lookup_seq);
+  if (metadata_ctx != nullptr && !metadata_ctx->HasNewerVersion() &&
+      !is_range_del_table_empty_.LoadRelaxed()) {
+    std::unique_ptr<FragmentedRangeTombstoneIterator> latest_range_del_iter(
+        NewRangeTombstoneIteratorInternal(read_opts, lookup_seq,
+                                          immutable_memtable));
+    const SequenceNumber covering_seq =
+        latest_range_del_iter != nullptr
+            ? latest_range_del_iter->MaxCoveringTombstoneSeqnum(
+                  key.user_key(), *metadata_ctx, callback)
+            : 0;
+    if (covering_seq != 0) {
+      metadata_ctx->MarkNewerVersionPresent();
+    }
+  }
   std::unique_ptr<FragmentedRangeTombstoneIterator> range_del_iter(
-      NewRangeTombstoneIterator(read_opts,
-                                GetInternalKeySeqno(key.internal_key()),
+      NewRangeTombstoneIterator(read_opts, range_del_read_seq,
                                 immutable_memtable));
   if (range_del_iter != nullptr) {
     SequenceNumber covering_seq =
@@ -1630,7 +1661,8 @@ bool MemTable::Get(const LookupKey& key, std::string* value,
     }
     GetFromTable(key, *max_covering_tombstone_seq, do_merge, callback,
                  is_blob_index, value, columns, timestamp, s, merge_context,
-                 seq, &found_final_value, &merge_in_progress, blob_fetcher);
+                 seq, &found_final_value, &merge_in_progress, blob_fetcher,
+                 metadata_ctx);
   }
 
   // No change to value, since we have not yet found a Put/Delete
@@ -1646,15 +1678,13 @@ bool MemTable::Get(const LookupKey& key, std::string* value,
   return found_final_value;
 }
 
-void MemTable::GetFromTable(const LookupKey& key,
-                            SequenceNumber max_covering_tombstone_seq,
-                            bool do_merge, ReadCallback* callback,
-                            bool* is_blob_index, std::string* value,
-                            PinnableWideColumns* columns,
-                            std::string* timestamp, Status* s,
-                            MergeContext* merge_context, SequenceNumber* seq,
-                            bool* found_final_value, bool* merge_in_progress,
-                            const BlobFetcher* blob_fetcher) {
+void MemTable::GetFromTable(
+    const LookupKey& key, SequenceNumber max_covering_tombstone_seq,
+    bool do_merge, ReadCallback* callback, bool* is_blob_index,
+    std::string* value, PinnableWideColumns* columns, std::string* timestamp,
+    Status* s, MergeContext* merge_context, SequenceNumber* seq,
+    bool* found_final_value, bool* merge_in_progress,
+    const BlobFetcher* blob_fetcher, const MetadataReadCtx* metadata_ctx) {
   Saver saver;
   saver.status = s;
   saver.found_final_value = found_final_value;
@@ -1678,6 +1708,7 @@ void MemTable::GetFromTable(const LookupKey& key,
   saver.do_merge = do_merge;
   saver.allow_data_in_errors = moptions_.allow_data_in_errors;
   saver.protection_bytes_per_key = moptions_.protection_bytes_per_key;
+  saver.metadata_ctx = metadata_ctx;
 
   if (!moptions_.paranoid_memory_checks &&
       !moptions_.memtable_verify_per_key_checksum_on_seek) {
@@ -1711,13 +1742,25 @@ void MemTable::MultiGet(const ReadOptions& read_options, MultiGetRange* range,
   }
   PERF_TIMER_GUARD(get_from_memtable_time);
 
-  // For now, memtable Bloom filter is effectively disabled if there are any
-  // range tombstones. This is the simplest way to ensure range tombstones are
-  // handled. TODO: allow Bloom checks where max_covering_tombstone_seq==0
-  bool no_range_del = read_options.ignore_range_deletions ||
-                      is_range_del_table_empty_.LoadRelaxed();
   MultiGetRange temp_range(*range, range->begin(), range->end());
-  if (bloom_filter_ && no_range_del) {
+  const bool has_range_del = !is_range_del_table_empty_.LoadRelaxed();
+  const bool apply_range_del =
+      has_range_del && !read_options.ignore_range_deletions;
+  bool track_range_del_metadata = false;
+  if (has_range_del && range->context()->HasMetadataReadCtx()) {
+    for (auto iter = temp_range.begin(); iter != temp_range.end(); ++iter) {
+      if (iter->metadata_ctx != nullptr &&
+          !iter->metadata_ctx->HasNewerVersion()) {
+        track_range_del_metadata = true;
+        break;
+      }
+    }
+  }
+
+  // For now, memtable Bloom filter is effectively disabled if there are range
+  // tombstones that must affect either read results or metadata.
+  // TODO: allow Bloom checks where max_covering_tombstone_seq==0.
+  if (bloom_filter_ && !apply_range_del && !track_range_del_metadata) {
     bool whole_key =
         !prefix_extractor_ || moptions_.memtable_whole_key_filtering;
     std::array<Slice, MultiGetContext::MAX_BATCH_SIZE> bloom_keys;
@@ -1750,6 +1793,26 @@ void MemTable::MultiGet(const ReadOptions& read_options, MultiGetRange* range,
   bool validate = moptions_.paranoid_memory_checks ||
                   moptions_.memtable_verify_per_key_checksum_on_seek;
 
+  // For metadata-tracking reads, allocate one "latest" range tombstone
+  // iterator per memtable batch (highest seq across the keys that requested
+  // metadata that has not already observed newer data) instead of one per key.
+  std::unique_ptr<FragmentedRangeTombstoneIterator> latest_range_del_iter;
+  if (track_range_del_metadata) {
+    SequenceNumber latest_range_del_read_seq = 0;
+    for (auto iter = temp_range.begin(); iter != temp_range.end(); ++iter) {
+      if (iter->metadata_ctx != nullptr &&
+          !iter->metadata_ctx->HasNewerVersion()) {
+        latest_range_del_read_seq =
+            std::max(latest_range_del_read_seq,
+                     GetInternalKeySeqno(iter->lkey->internal_key()));
+      }
+    }
+    if (latest_range_del_read_seq > 0) {
+      latest_range_del_iter.reset(NewRangeTombstoneIteratorInternal(
+          read_options, latest_range_del_read_seq, immutable_memtable));
+    }
+  }
+
   if (use_batch_optimization) {
     // Phase 1: Handle range tombstones and set up Savers for batched lookup
     std::array<Saver, MultiGetContext::MAX_BATCH_SIZE> savers{};
@@ -1760,18 +1823,36 @@ void MemTable::MultiGet(const ReadOptions& read_options, MultiGetRange* range,
     size_t num_keys = 0;
 
     for (auto iter = temp_range.begin(); iter != temp_range.end(); ++iter) {
-      if (!no_range_del) {
-        std::unique_ptr<FragmentedRangeTombstoneIterator> range_del_iter(
-            NewRangeTombstoneIteratorInternal(
-                read_options, GetInternalKeySeqno(iter->lkey->internal_key()),
-                immutable_memtable));
-        SequenceNumber covering_seq =
-            range_del_iter->MaxCoveringTombstoneSeqnum(iter->lkey->user_key());
-        if (covering_seq > iter->max_covering_tombstone_seq) {
-          iter->max_covering_tombstone_seq = covering_seq;
-          if (iter->timestamp) {
-            iter->timestamp->assign(range_del_iter->timestamp().data(),
-                                    range_del_iter->timestamp().size());
+      if (apply_range_del || latest_range_del_iter != nullptr) {
+        if (latest_range_del_iter != nullptr && iter->metadata_ctx != nullptr &&
+            !iter->metadata_ctx->HasNewerVersion()) {
+          const SequenceNumber covering_seq =
+              latest_range_del_iter->MaxCoveringTombstoneSeqnum(
+                  iter->lkey->user_key(), *iter->metadata_ctx, callback);
+          if (covering_seq != 0) {
+            iter->metadata_ctx->MarkNewerVersionPresent();
+          }
+        }
+        if (apply_range_del) {
+          const SequenceNumber lookup_seq =
+              GetInternalKeySeqno(iter->lkey->internal_key());
+          const SequenceNumber range_del_read_seq =
+              iter->metadata_ctx != nullptr
+                  ? iter->metadata_ctx->read_snapshot_seq
+                  : lookup_seq;
+          assert(range_del_read_seq <= lookup_seq);
+          std::unique_ptr<FragmentedRangeTombstoneIterator> range_del_iter(
+              NewRangeTombstoneIteratorInternal(
+                  read_options, range_del_read_seq, immutable_memtable));
+          SequenceNumber covering_seq =
+              range_del_iter->MaxCoveringTombstoneSeqnum(
+                  iter->lkey->user_key());
+          if (covering_seq > iter->max_covering_tombstone_seq) {
+            iter->max_covering_tombstone_seq = covering_seq;
+            if (iter->timestamp) {
+              iter->timestamp->assign(range_del_iter->timestamp().data(),
+                                      range_del_iter->timestamp().size());
+            }
           }
         }
       }
@@ -1801,6 +1882,7 @@ void MemTable::MultiGet(const ReadOptions& read_options, MultiGetRange* range,
       saver.do_merge = true;
       saver.allow_data_in_errors = moptions_.allow_data_in_errors;
       saver.protection_bytes_per_key = moptions_.protection_bytes_per_key;
+      saver.metadata_ctx = iter->metadata_ctx;
 
       memtable_keys[num_keys] = iter->lkey->memtable_key().data();
       callback_args[num_keys] = &savers[num_keys];
@@ -1867,27 +1949,46 @@ void MemTable::MultiGet(const ReadOptions& read_options, MultiGetRange* range,
     for (auto iter = temp_range.begin(); iter != temp_range.end(); ++iter) {
       bool found_final_value{false};
       bool merge_in_progress = iter->s->IsMergeInProgress();
-      if (!no_range_del) {
-        std::unique_ptr<FragmentedRangeTombstoneIterator> range_del_iter(
-            NewRangeTombstoneIteratorInternal(
-                read_options, GetInternalKeySeqno(iter->lkey->internal_key()),
-                immutable_memtable));
-        SequenceNumber covering_seq =
-            range_del_iter->MaxCoveringTombstoneSeqnum(iter->lkey->user_key());
-        if (covering_seq > iter->max_covering_tombstone_seq) {
-          iter->max_covering_tombstone_seq = covering_seq;
-          if (iter->timestamp) {
-            iter->timestamp->assign(range_del_iter->timestamp().data(),
-                                    range_del_iter->timestamp().size());
+      if (apply_range_del || latest_range_del_iter != nullptr) {
+        if (latest_range_del_iter != nullptr && iter->metadata_ctx != nullptr &&
+            !iter->metadata_ctx->HasNewerVersion()) {
+          const SequenceNumber covering_seq =
+              latest_range_del_iter->MaxCoveringTombstoneSeqnum(
+                  iter->lkey->user_key(), *iter->metadata_ctx, callback);
+          if (covering_seq != 0) {
+            iter->metadata_ctx->MarkNewerVersionPresent();
+          }
+        }
+        if (apply_range_del) {
+          const SequenceNumber lookup_seq =
+              GetInternalKeySeqno(iter->lkey->internal_key());
+          const SequenceNumber range_del_read_seq =
+              iter->metadata_ctx != nullptr
+                  ? iter->metadata_ctx->read_snapshot_seq
+                  : lookup_seq;
+          assert(range_del_read_seq <= lookup_seq);
+          std::unique_ptr<FragmentedRangeTombstoneIterator> range_del_iter(
+              NewRangeTombstoneIteratorInternal(
+                  read_options, range_del_read_seq, immutable_memtable));
+          SequenceNumber covering_seq =
+              range_del_iter->MaxCoveringTombstoneSeqnum(
+                  iter->lkey->user_key());
+          if (covering_seq > iter->max_covering_tombstone_seq) {
+            iter->max_covering_tombstone_seq = covering_seq;
+            if (iter->timestamp) {
+              iter->timestamp->assign(range_del_iter->timestamp().data(),
+                                      range_del_iter->timestamp().size());
+            }
           }
         }
       }
       SequenceNumber dummy_seq;
-      GetFromTable(
-          *(iter->lkey), iter->max_covering_tombstone_seq, true, callback,
-          &iter->is_blob_index, iter->value ? iter->value->GetSelf() : nullptr,
-          iter->columns, iter->timestamp, iter->s, &(iter->merge_context),
-          &dummy_seq, &found_final_value, &merge_in_progress, blob_fetcher);
+      GetFromTable(*(iter->lkey), iter->max_covering_tombstone_seq, true,
+                   callback, &iter->is_blob_index,
+                   iter->value ? iter->value->GetSelf() : nullptr,
+                   iter->columns, iter->timestamp, iter->s,
+                   &(iter->merge_context), &dummy_seq, &found_final_value,
+                   &merge_in_progress, blob_fetcher, iter->metadata_ctx);
 
       if (!found_final_value && merge_in_progress) {
         if (iter->s->ok()) {

--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -1307,6 +1307,8 @@ struct Saver {
   bool* is_blob_index;
   bool allow_data_in_errors;
   uint32_t protection_bytes_per_key;
+  // MultiGet's per-key result. Single-key Get stores its result on callback_.
+  bool* newer_version_present;
   bool CheckCallback(SequenceNumber _seq) {
     if (callback_) {
       return callback_->IsVisible(_seq);
@@ -1366,6 +1368,12 @@ static bool SaveValue(void* arg, const char* entry) {
     ValueType type;
     SequenceNumber seq;
     UnPackSequenceAndType(tag, &seq, &type);
+    if (UNLIKELY(
+            s->callback_ != nullptr &&
+            s->callback_->NeedToTrackNewerVersions(s->newer_version_present))) {
+      s->callback_->MaybeRecordNewerVersion(seq, type,
+                                            s->newer_version_present);
+    }
     // If the value is not in the snapshot, skip it
     if (!s->CheckCallback(seq)) {
       return true;  // to continue to the next seq
@@ -1581,9 +1589,32 @@ bool MemTable::Get(const LookupKey& key, std::string* value,
 
   PERF_TIMER_GUARD(get_from_memtable_time);
 
+  // Metadata reads widen the lookup seq to detect newer range tombstones. The
+  // regular masking iterator must stay at the user's snapshot seq so such
+  // tombstones only set metadata and do not hide snapshot-visible values.
+  const SequenceNumber lookup_seq = GetInternalKeySeqno(key.internal_key());
+  const MetadataReadBounds* metadata_read_bounds =
+      callback != nullptr ? callback->GetMetadataReadBounds() : nullptr;
+  const SequenceNumber range_del_read_seq =
+      metadata_read_bounds != nullptr ? metadata_read_bounds->read_snapshot_seq
+                                      : lookup_seq;
+  assert(range_del_read_seq <= lookup_seq);
+  if (callback != nullptr && callback->NeedToTrackNewerVersions() &&
+      !is_range_del_table_empty_.LoadRelaxed()) {
+    std::unique_ptr<FragmentedRangeTombstoneIterator> latest_range_del_iter(
+        NewRangeTombstoneIteratorInternal(read_opts, lookup_seq,
+                                          immutable_memtable));
+    const SequenceNumber covering_seq =
+        latest_range_del_iter != nullptr
+            ? latest_range_del_iter->MaxCoveringTombstoneSeqnum(key.user_key(),
+                                                                callback)
+            : 0;
+    if (covering_seq != 0) {
+      callback->MaybeRecordNewerVersion(covering_seq, kTypeRangeDeletion);
+    }
+  }
   std::unique_ptr<FragmentedRangeTombstoneIterator> range_del_iter(
-      NewRangeTombstoneIterator(read_opts,
-                                GetInternalKeySeqno(key.internal_key()),
+      NewRangeTombstoneIterator(read_opts, range_del_read_seq,
                                 immutable_memtable));
   if (range_del_iter != nullptr) {
     SequenceNumber covering_seq =
@@ -1646,15 +1677,13 @@ bool MemTable::Get(const LookupKey& key, std::string* value,
   return found_final_value;
 }
 
-void MemTable::GetFromTable(const LookupKey& key,
-                            SequenceNumber max_covering_tombstone_seq,
-                            bool do_merge, ReadCallback* callback,
-                            bool* is_blob_index, std::string* value,
-                            PinnableWideColumns* columns,
-                            std::string* timestamp, Status* s,
-                            MergeContext* merge_context, SequenceNumber* seq,
-                            bool* found_final_value, bool* merge_in_progress,
-                            const BlobFetcher* blob_fetcher) {
+void MemTable::GetFromTable(
+    const LookupKey& key, SequenceNumber max_covering_tombstone_seq,
+    bool do_merge, ReadCallback* callback, bool* is_blob_index,
+    std::string* value, PinnableWideColumns* columns, std::string* timestamp,
+    Status* s, MergeContext* merge_context, SequenceNumber* seq,
+    bool* found_final_value, bool* merge_in_progress,
+    const BlobFetcher* blob_fetcher, bool* newer_version_present) {
   Saver saver;
   saver.status = s;
   saver.found_final_value = found_final_value;
@@ -1678,6 +1707,7 @@ void MemTable::GetFromTable(const LookupKey& key,
   saver.do_merge = do_merge;
   saver.allow_data_in_errors = moptions_.allow_data_in_errors;
   saver.protection_bytes_per_key = moptions_.protection_bytes_per_key;
+  saver.newer_version_present = newer_version_present;
 
   if (!moptions_.paranoid_memory_checks &&
       !moptions_.memtable_verify_per_key_checksum_on_seek) {
@@ -1711,13 +1741,25 @@ void MemTable::MultiGet(const ReadOptions& read_options, MultiGetRange* range,
   }
   PERF_TIMER_GUARD(get_from_memtable_time);
 
-  // For now, memtable Bloom filter is effectively disabled if there are any
-  // range tombstones. This is the simplest way to ensure range tombstones are
-  // handled. TODO: allow Bloom checks where max_covering_tombstone_seq==0
-  bool no_range_del = read_options.ignore_range_deletions ||
-                      is_range_del_table_empty_.LoadRelaxed();
   MultiGetRange temp_range(*range, range->begin(), range->end());
-  if (bloom_filter_ && no_range_del) {
+  const bool has_range_del = !is_range_del_table_empty_.LoadRelaxed();
+  const bool apply_range_del =
+      has_range_del && !read_options.ignore_range_deletions;
+  bool track_range_del_metadata = false;
+  if (has_range_del && callback != nullptr &&
+      callback->GetMetadataReadBounds() != nullptr) {
+    for (auto iter = temp_range.begin(); iter != temp_range.end(); ++iter) {
+      if (callback->NeedToTrackNewerVersions(&iter->newer_version_present)) {
+        track_range_del_metadata = true;
+        break;
+      }
+    }
+  }
+
+  // For now, memtable Bloom filter is effectively disabled if there are range
+  // tombstones that must affect either read results or metadata.
+  // TODO: allow Bloom checks where max_covering_tombstone_seq==0.
+  if (bloom_filter_ && !apply_range_del && !track_range_del_metadata) {
     bool whole_key =
         !prefix_extractor_ || moptions_.memtable_whole_key_filtering;
     std::array<Slice, MultiGetContext::MAX_BATCH_SIZE> bloom_keys;
@@ -1750,6 +1792,25 @@ void MemTable::MultiGet(const ReadOptions& read_options, MultiGetRange* range,
   bool validate = moptions_.paranoid_memory_checks ||
                   moptions_.memtable_verify_per_key_checksum_on_seek;
 
+  // For metadata-tracking reads, allocate one "latest" range tombstone
+  // iterator per memtable batch (highest seq across the keys that requested
+  // metadata that has not already observed newer data) instead of one per key.
+  std::unique_ptr<FragmentedRangeTombstoneIterator> latest_range_del_iter;
+  if (track_range_del_metadata) {
+    SequenceNumber latest_range_del_read_seq = 0;
+    for (auto iter = temp_range.begin(); iter != temp_range.end(); ++iter) {
+      if (callback->NeedToTrackNewerVersions(&iter->newer_version_present)) {
+        latest_range_del_read_seq =
+            std::max(latest_range_del_read_seq,
+                     GetInternalKeySeqno(iter->lkey->internal_key()));
+      }
+    }
+    if (latest_range_del_read_seq > 0) {
+      latest_range_del_iter.reset(NewRangeTombstoneIteratorInternal(
+          read_options, latest_range_del_read_seq, immutable_memtable));
+    }
+  }
+
   if (use_batch_optimization) {
     // Phase 1: Handle range tombstones and set up Savers for batched lookup
     std::array<Saver, MultiGetContext::MAX_BATCH_SIZE> savers{};
@@ -1760,18 +1821,39 @@ void MemTable::MultiGet(const ReadOptions& read_options, MultiGetRange* range,
     size_t num_keys = 0;
 
     for (auto iter = temp_range.begin(); iter != temp_range.end(); ++iter) {
-      if (!no_range_del) {
-        std::unique_ptr<FragmentedRangeTombstoneIterator> range_del_iter(
-            NewRangeTombstoneIteratorInternal(
-                read_options, GetInternalKeySeqno(iter->lkey->internal_key()),
-                immutable_memtable));
-        SequenceNumber covering_seq =
-            range_del_iter->MaxCoveringTombstoneSeqnum(iter->lkey->user_key());
-        if (covering_seq > iter->max_covering_tombstone_seq) {
-          iter->max_covering_tombstone_seq = covering_seq;
-          if (iter->timestamp) {
-            iter->timestamp->assign(range_del_iter->timestamp().data(),
-                                    range_del_iter->timestamp().size());
+      if (apply_range_del || latest_range_del_iter != nullptr) {
+        if (latest_range_del_iter != nullptr &&
+            callback->NeedToTrackNewerVersions(&iter->newer_version_present)) {
+          const SequenceNumber covering_seq =
+              latest_range_del_iter->MaxCoveringTombstoneSeqnum(
+                  iter->lkey->user_key(), callback);
+          if (covering_seq != 0) {
+            callback->MaybeRecordNewerVersion(covering_seq, kTypeRangeDeletion,
+                                              &iter->newer_version_present);
+          }
+        }
+        if (apply_range_del) {
+          const SequenceNumber lookup_seq =
+              GetInternalKeySeqno(iter->lkey->internal_key());
+          const MetadataReadBounds* metadata_read_bounds =
+              callback != nullptr ? callback->GetMetadataReadBounds() : nullptr;
+          const SequenceNumber range_del_read_seq =
+              metadata_read_bounds != nullptr
+                  ? metadata_read_bounds->read_snapshot_seq
+                  : lookup_seq;
+          assert(range_del_read_seq <= lookup_seq);
+          std::unique_ptr<FragmentedRangeTombstoneIterator> range_del_iter(
+              NewRangeTombstoneIteratorInternal(
+                  read_options, range_del_read_seq, immutable_memtable));
+          SequenceNumber covering_seq =
+              range_del_iter->MaxCoveringTombstoneSeqnum(
+                  iter->lkey->user_key());
+          if (covering_seq > iter->max_covering_tombstone_seq) {
+            iter->max_covering_tombstone_seq = covering_seq;
+            if (iter->timestamp) {
+              iter->timestamp->assign(range_del_iter->timestamp().data(),
+                                      range_del_iter->timestamp().size());
+            }
           }
         }
       }
@@ -1801,6 +1883,10 @@ void MemTable::MultiGet(const ReadOptions& read_options, MultiGetRange* range,
       saver.do_merge = true;
       saver.allow_data_in_errors = moptions_.allow_data_in_errors;
       saver.protection_bytes_per_key = moptions_.protection_bytes_per_key;
+      saver.newer_version_present =
+          callback != nullptr && callback->GetMetadataReadBounds() != nullptr
+              ? &iter->newer_version_present
+              : nullptr;
 
       memtable_keys[num_keys] = iter->lkey->memtable_key().data();
       callback_args[num_keys] = &savers[num_keys];
@@ -1867,18 +1953,39 @@ void MemTable::MultiGet(const ReadOptions& read_options, MultiGetRange* range,
     for (auto iter = temp_range.begin(); iter != temp_range.end(); ++iter) {
       bool found_final_value{false};
       bool merge_in_progress = iter->s->IsMergeInProgress();
-      if (!no_range_del) {
-        std::unique_ptr<FragmentedRangeTombstoneIterator> range_del_iter(
-            NewRangeTombstoneIteratorInternal(
-                read_options, GetInternalKeySeqno(iter->lkey->internal_key()),
-                immutable_memtable));
-        SequenceNumber covering_seq =
-            range_del_iter->MaxCoveringTombstoneSeqnum(iter->lkey->user_key());
-        if (covering_seq > iter->max_covering_tombstone_seq) {
-          iter->max_covering_tombstone_seq = covering_seq;
-          if (iter->timestamp) {
-            iter->timestamp->assign(range_del_iter->timestamp().data(),
-                                    range_del_iter->timestamp().size());
+      if (apply_range_del || latest_range_del_iter != nullptr) {
+        if (latest_range_del_iter != nullptr &&
+            callback->NeedToTrackNewerVersions(&iter->newer_version_present)) {
+          const SequenceNumber covering_seq =
+              latest_range_del_iter->MaxCoveringTombstoneSeqnum(
+                  iter->lkey->user_key(), callback);
+          if (covering_seq != 0) {
+            callback->MaybeRecordNewerVersion(covering_seq, kTypeRangeDeletion,
+                                              &iter->newer_version_present);
+          }
+        }
+        if (apply_range_del) {
+          const SequenceNumber lookup_seq =
+              GetInternalKeySeqno(iter->lkey->internal_key());
+          const MetadataReadBounds* metadata_read_bounds =
+              callback != nullptr ? callback->GetMetadataReadBounds() : nullptr;
+          const SequenceNumber range_del_read_seq =
+              metadata_read_bounds != nullptr
+                  ? metadata_read_bounds->read_snapshot_seq
+                  : lookup_seq;
+          assert(range_del_read_seq <= lookup_seq);
+          std::unique_ptr<FragmentedRangeTombstoneIterator> range_del_iter(
+              NewRangeTombstoneIteratorInternal(
+                  read_options, range_del_read_seq, immutable_memtable));
+          SequenceNumber covering_seq =
+              range_del_iter->MaxCoveringTombstoneSeqnum(
+                  iter->lkey->user_key());
+          if (covering_seq > iter->max_covering_tombstone_seq) {
+            iter->max_covering_tombstone_seq = covering_seq;
+            if (iter->timestamp) {
+              iter->timestamp->assign(range_del_iter->timestamp().data(),
+                                      range_del_iter->timestamp().size());
+            }
           }
         }
       }
@@ -1887,7 +1994,10 @@ void MemTable::MultiGet(const ReadOptions& read_options, MultiGetRange* range,
           *(iter->lkey), iter->max_covering_tombstone_seq, true, callback,
           &iter->is_blob_index, iter->value ? iter->value->GetSelf() : nullptr,
           iter->columns, iter->timestamp, iter->s, &(iter->merge_context),
-          &dummy_seq, &found_final_value, &merge_in_progress, blob_fetcher);
+          &dummy_seq, &found_final_value, &merge_in_progress, blob_fetcher,
+          callback != nullptr && callback->GetMetadataReadBounds() != nullptr
+              ? &iter->newer_version_present
+              : nullptr);
 
       if (!found_final_value && merge_in_progress) {
         if (iter->s->ok()) {

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -238,18 +238,20 @@ class ReadOnlyMemTable {
                    SequenceNumber* seq, const ReadOptions& read_opts,
                    bool immutable_memtable, ReadCallback* callback = nullptr,
                    bool* is_blob_index = nullptr, bool do_merge = true,
-                   const BlobFetcher* blob_fetcher = nullptr) = 0;
+                   const BlobFetcher* blob_fetcher = nullptr,
+                   const MetadataReadCtx* metadata_ctx = nullptr) = 0;
   bool Get(const LookupKey& key, std::string* value,
            PinnableWideColumns* columns, std::string* timestamp, Status* s,
            MergeContext* merge_context,
            SequenceNumber* max_covering_tombstone_seq,
            const ReadOptions& read_opts, bool immutable_memtable,
            ReadCallback* callback = nullptr, bool* is_blob_index = nullptr,
-           bool do_merge = true, const BlobFetcher* blob_fetcher = nullptr) {
+           bool do_merge = true, const BlobFetcher* blob_fetcher = nullptr,
+           const MetadataReadCtx* metadata_ctx = nullptr) {
     SequenceNumber seq;
     return Get(key, value, columns, timestamp, s, merge_context,
                max_covering_tombstone_seq, &seq, read_opts, immutable_memtable,
-               callback, is_blob_index, do_merge, blob_fetcher);
+               callback, is_blob_index, do_merge, blob_fetcher, metadata_ctx);
   }
 
   // @param immutable_memtable Whether this memtable is immutable. Used
@@ -691,8 +693,8 @@ class MemTable final : public ReadOnlyMemTable {
            SequenceNumber* max_covering_tombstone_seq, SequenceNumber* seq,
            const ReadOptions& read_opts, bool immutable_memtable,
            ReadCallback* callback = nullptr, bool* is_blob_index = nullptr,
-           bool do_merge = true,
-           const BlobFetcher* blob_fetcher = nullptr) override;
+           bool do_merge = true, const BlobFetcher* blob_fetcher = nullptr,
+           const MetadataReadCtx* metadata_ctx = nullptr) override;
 
   void MultiGet(const ReadOptions& read_options, MultiGetRange* range,
                 ReadCallback* callback, bool immutable_memtable,
@@ -1001,7 +1003,8 @@ class MemTable final : public ReadOnlyMemTable {
                     std::string* timestamp, Status* s,
                     MergeContext* merge_context, SequenceNumber* seq,
                     bool* found_final_value, bool* merge_in_progress,
-                    const BlobFetcher* blob_fetcher);
+                    const BlobFetcher* blob_fetcher,
+                    const MetadataReadCtx* metadata_ctx = nullptr);
 
   // Always returns non-null and assumes certain pre-checks (e.g.,
   // is_range_del_table_empty_) are done. This is only valid during the lifetime

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -1001,7 +1001,8 @@ class MemTable final : public ReadOnlyMemTable {
                     std::string* timestamp, Status* s,
                     MergeContext* merge_context, SequenceNumber* seq,
                     bool* found_final_value, bool* merge_in_progress,
-                    const BlobFetcher* blob_fetcher);
+                    const BlobFetcher* blob_fetcher,
+                    bool* newer_version_present = nullptr);
 
   // Always returns non-null and assumes certain pre-checks (e.g.,
   // is_range_del_table_empty_) are done. This is only valid during the lifetime

--- a/db/memtable_list.cc
+++ b/db/memtable_list.cc
@@ -175,17 +175,15 @@ int MemTableList::NumFlushed() const { return current_->NumFlushed(); }
 // Search all the memtables starting from the most recent one.
 // Return the most recent value found, if any.
 // Operands stores the list of merge operations to apply, so far.
-bool MemTableListVersion::Get(const LookupKey& key, std::string* value,
-                              PinnableWideColumns* columns,
-                              std::string* timestamp, Status* s,
-                              MergeContext* merge_context,
-                              SequenceNumber* max_covering_tombstone_seq,
-                              SequenceNumber* seq, const ReadOptions& read_opts,
-                              ReadCallback* callback, bool* is_blob_index,
-                              const BlobFetcher* blob_fetcher) {
+bool MemTableListVersion::Get(
+    const LookupKey& key, std::string* value, PinnableWideColumns* columns,
+    std::string* timestamp, Status* s, MergeContext* merge_context,
+    SequenceNumber* max_covering_tombstone_seq, SequenceNumber* seq,
+    const ReadOptions& read_opts, ReadCallback* callback, bool* is_blob_index,
+    const BlobFetcher* blob_fetcher, const MetadataReadCtx* metadata_ctx) {
   return GetFromList(&memlist_, key, value, columns, timestamp, s,
                      merge_context, max_covering_tombstone_seq, seq, read_opts,
-                     callback, is_blob_index, blob_fetcher);
+                     callback, is_blob_index, blob_fetcher, metadata_ctx);
 }
 
 void MemTableListVersion::MultiGet(const ReadOptions& read_options,
@@ -233,17 +231,18 @@ bool MemTableListVersion::GetFromList(
     Status* s, MergeContext* merge_context,
     SequenceNumber* max_covering_tombstone_seq, SequenceNumber* seq,
     const ReadOptions& read_opts, ReadCallback* callback, bool* is_blob_index,
-    const BlobFetcher* blob_fetcher) {
+    const BlobFetcher* blob_fetcher, const MetadataReadCtx* metadata_ctx) {
   *seq = kMaxSequenceNumber;
 
   for (auto& memtable : *list) {
     assert(memtable->IsFragmentedRangeTombstonesConstructed());
     SequenceNumber current_seq = kMaxSequenceNumber;
 
-    bool done = memtable->Get(key, value, columns, timestamp, s, merge_context,
-                              max_covering_tombstone_seq, &current_seq,
-                              read_opts, true /* immutable_memtable */,
-                              callback, is_blob_index, true, blob_fetcher);
+    bool done =
+        memtable->Get(key, value, columns, timestamp, s, merge_context,
+                      max_covering_tombstone_seq, &current_seq, read_opts,
+                      true /* immutable_memtable */, callback, is_blob_index,
+                      true /* do_merge */, blob_fetcher, metadata_ctx);
     if (*seq == kMaxSequenceNumber) {
       // Store the most recent sequence number of any operation on this key.
       // Since we only care about the most recent change, we only need to

--- a/db/memtable_list.cc
+++ b/db/memtable_list.cc
@@ -240,10 +240,11 @@ bool MemTableListVersion::GetFromList(
     assert(memtable->IsFragmentedRangeTombstonesConstructed());
     SequenceNumber current_seq = kMaxSequenceNumber;
 
-    bool done = memtable->Get(key, value, columns, timestamp, s, merge_context,
-                              max_covering_tombstone_seq, &current_seq,
-                              read_opts, true /* immutable_memtable */,
-                              callback, is_blob_index, true, blob_fetcher);
+    bool done =
+        memtable->Get(key, value, columns, timestamp, s, merge_context,
+                      max_covering_tombstone_seq, &current_seq, read_opts,
+                      true /* immutable_memtable */, callback, is_blob_index,
+                      true /* do_merge */, blob_fetcher);
     if (*seq == kMaxSequenceNumber) {
       // Store the most recent sequence number of any operation on this key.
       // Since we only care about the most recent change, we only need to

--- a/db/memtable_list.h
+++ b/db/memtable_list.h
@@ -77,7 +77,8 @@ class MemTableListVersion {
            SequenceNumber* max_covering_tombstone_seq, SequenceNumber* seq,
            const ReadOptions& read_opts, ReadCallback* callback = nullptr,
            bool* is_blob_index = nullptr,
-           const BlobFetcher* blob_fetcher = nullptr);
+           const BlobFetcher* blob_fetcher = nullptr,
+           const MetadataReadCtx* metadata_ctx = nullptr);
 
   bool Get(const LookupKey& key, std::string* value,
            PinnableWideColumns* columns, std::string* timestamp, Status* s,
@@ -85,11 +86,12 @@ class MemTableListVersion {
            SequenceNumber* max_covering_tombstone_seq,
            const ReadOptions& read_opts, ReadCallback* callback = nullptr,
            bool* is_blob_index = nullptr,
-           const BlobFetcher* blob_fetcher = nullptr) {
+           const BlobFetcher* blob_fetcher = nullptr,
+           const MetadataReadCtx* metadata_ctx = nullptr) {
     SequenceNumber seq;
     return Get(key, value, columns, timestamp, s, merge_context,
                max_covering_tombstone_seq, &seq, read_opts, callback,
-               is_blob_index, blob_fetcher);
+               is_blob_index, blob_fetcher, metadata_ctx);
   }
 
   void MultiGet(const ReadOptions& read_options, MultiGetRange* range,
@@ -216,7 +218,8 @@ class MemTableListVersion {
                    SequenceNumber* seq, const ReadOptions& read_opts,
                    ReadCallback* callback = nullptr,
                    bool* is_blob_index = nullptr,
-                   const BlobFetcher* blob_fetcher = nullptr);
+                   const BlobFetcher* blob_fetcher = nullptr,
+                   const MetadataReadCtx* metadata_ctx = nullptr);
 
   void AddMemTable(ReadOnlyMemTable* m);
 

--- a/db/range_tombstone_fragmenter.cc
+++ b/db/range_tombstone_fragmenter.cc
@@ -11,6 +11,7 @@
 #include <functional>
 #include <set>
 
+#include "db/read_callback.h"
 #include "util/autovector.h"
 #include "util/kv_map.h"
 #include "util/vector_iterator.h"
@@ -488,6 +489,26 @@ SequenceNumber FragmentedRangeTombstoneIterator::MaxCoveringTombstoneSeqnum(
                                                       target_user_key) <= 0
              ? seq()
              : 0;
+}
+
+SequenceNumber FragmentedRangeTombstoneIterator::MaxCoveringTombstoneSeqnum(
+    const Slice& target_user_key, const MetadataReadCtx& metadata_ctx,
+    ReadCallback* callback) {
+  SeekToCoveringTombstone(target_user_key);
+  if (!ValidPos() ||
+      ucmp_->CompareWithoutTimestamp(start_key(), target_user_key) > 0) {
+    return 0;
+  }
+
+  const auto seq_end = tombstones_->seq_iter(pos_->seq_end_idx);
+  while (seq_pos_ != seq_end && *seq_pos_ >= lower_bound_) {
+    const SequenceNumber candidate_seq = *seq_pos_;
+    if (metadata_ctx.ShouldRecordNewerVersion(candidate_seq, callback)) {
+      return candidate_seq;
+    }
+    ++seq_pos_;
+  }
+  return 0;
 }
 
 std::map<SequenceNumber, std::unique_ptr<FragmentedRangeTombstoneIterator>>

--- a/db/range_tombstone_fragmenter.cc
+++ b/db/range_tombstone_fragmenter.cc
@@ -11,6 +11,7 @@
 #include <functional>
 #include <set>
 
+#include "db/read_callback.h"
 #include "util/autovector.h"
 #include "util/kv_map.h"
 #include "util/vector_iterator.h"
@@ -488,6 +489,29 @@ SequenceNumber FragmentedRangeTombstoneIterator::MaxCoveringTombstoneSeqnum(
                                                       target_user_key) <= 0
              ? seq()
              : 0;
+}
+
+SequenceNumber FragmentedRangeTombstoneIterator::MaxCoveringTombstoneSeqnum(
+    const Slice& target_user_key, ReadCallback* callback) {
+  assert(callback != nullptr);
+  SeekToCoveringTombstone(target_user_key);
+  if (!ValidPos() ||
+      ucmp_->CompareWithoutTimestamp(start_key(), target_user_key) > 0) {
+    return 0;
+  }
+
+  const auto seq_end = tombstones_->seq_iter(pos_->seq_end_idx);
+  // Sequence numbers are ordered newest to oldest and seq_pos_ is already
+  // bounded by upper_bound_. Return the first tombstone the metadata callback
+  // considers newer than the read snapshot.
+  while (seq_pos_ != seq_end && *seq_pos_ >= lower_bound_) {
+    const SequenceNumber candidate_seq = *seq_pos_;
+    if (callback->IsNewerVisibleForMetadataRead(candidate_seq)) {
+      return candidate_seq;
+    }
+    ++seq_pos_;
+  }
+  return 0;
 }
 
 std::map<SequenceNumber, std::unique_ptr<FragmentedRangeTombstoneIterator>>

--- a/db/range_tombstone_fragmenter.h
+++ b/db/range_tombstone_fragmenter.h
@@ -17,6 +17,10 @@
 #include "table/internal_iterator.h"
 
 namespace ROCKSDB_NAMESPACE {
+
+class ReadCallback;
+struct MetadataReadCtx;
+
 struct FragmentedRangeTombstoneList {
  public:
   // A compact representation of a "stack" of range tombstone fragments, which
@@ -235,6 +239,13 @@ class FragmentedRangeTombstoneIterator : public InternalIterator {
   // the given user key.
   // If there is no covering tombstone, then 0 is returned.
   SequenceNumber MaxCoveringTombstoneSeqnum(const Slice& user_key);
+
+  // Return the max sequence number of a covering range tombstone that should
+  // be reported as newer-version metadata. If there is no such tombstone, then
+  // 0 is returned.
+  SequenceNumber MaxCoveringTombstoneSeqnum(const Slice& user_key,
+                                            const MetadataReadCtx& metadata_ctx,
+                                            ReadCallback* callback);
 
   // Splits the iterator into n+1 iterators (where n is the number of
   // snapshots), each providing a view over a "stripe" of sequence numbers. The

--- a/db/range_tombstone_fragmenter.h
+++ b/db/range_tombstone_fragmenter.h
@@ -17,6 +17,9 @@
 #include "table/internal_iterator.h"
 
 namespace ROCKSDB_NAMESPACE {
+
+class ReadCallback;
+
 struct FragmentedRangeTombstoneList {
  public:
   // A compact representation of a "stack" of range tombstone fragments, which
@@ -235,6 +238,12 @@ class FragmentedRangeTombstoneIterator : public InternalIterator {
   // the given user key.
   // If there is no covering tombstone, then 0 is returned.
   SequenceNumber MaxCoveringTombstoneSeqnum(const Slice& user_key);
+
+  // Return the max sequence number of a covering range tombstone that should
+  // be reported as newer-version metadata. If there is no such tombstone, then
+  // 0 is returned.
+  SequenceNumber MaxCoveringTombstoneSeqnum(const Slice& user_key,
+                                            ReadCallback* callback);
 
   // Splits the iterator into n+1 iterators (where n is the number of
   // snapshots), each providing a view over a "stripe" of sequence numbers. The

--- a/db/read_callback.h
+++ b/db/read_callback.h
@@ -10,6 +10,40 @@
 
 namespace ROCKSDB_NAMESPACE {
 
+class ReadCallback;
+
+struct MetadataReadBounds {
+  // The snapshot-visible sequence and the upper bound sampled for this read.
+  // Lookups scan through the upper bound but return data only through the
+  // snapshot sequence.
+  SequenceNumber read_snapshot_seq;
+  SequenceNumber newer_version_upper_bound_seq;
+
+  bool IsNewerVersion(SequenceNumber seq, ReadCallback* callback) const;
+};
+
+// Single-key metadata state. MultiGet keeps each result directly in KeyContext
+// and binds it to a per-key MetadataReadCtx while tracking is active.
+struct MetadataReadCtx : MetadataReadBounds {
+  MetadataReadCtx(SequenceNumber snapshot_seq, SequenceNumber upper_bound_seq,
+                  bool& result)
+      : MetadataReadBounds{snapshot_seq, upper_bound_seq},
+        newer_version_present_(result) {}
+
+  bool HasNewerVersion() const { return newer_version_present_; }
+
+  void MarkNewerVersionPresent() const { newer_version_present_ = true; }
+
+  // LIFETIME: referenced output storage must outlive this context.
+  bool ShouldRecordNewerVersion(SequenceNumber seq,
+                                ReadCallback* callback) const {
+    return !newer_version_present_ && IsNewerVersion(seq, callback);
+  }
+
+ private:
+  bool& newer_version_present_;
+};
+
 class ReadCallback {
  public:
   explicit ReadCallback(SequenceNumber last_visible_seq)
@@ -38,6 +72,14 @@ class ReadCallback {
     }
   }
 
+  virtual bool IsNewerVisibleForMetadataRead(
+      SequenceNumber /*seq*/, SequenceNumber /*read_snapshot_seq*/,
+      SequenceNumber /*newer_version_upper_bound_seq*/) {
+    // Metadata reads with custom visibility callbacks are unsupported. The
+    // timestamp callback overrides this method for regular DB reads.
+    return false;
+  }
+
   inline SequenceNumber max_visible_seq() { return max_visible_seq_; }
 
   inline SequenceNumber min_uncommitted() const { return min_uncommitted_; }
@@ -52,5 +94,17 @@ class ReadCallback {
   // Any seq less than min_uncommitted_ is committed.
   const SequenceNumber min_uncommitted_ = kMinUnCommittedSeq;
 };
+
+inline bool MetadataReadBounds::IsNewerVersion(SequenceNumber seq,
+                                               ReadCallback* callback) const {
+  if (seq == 0) {
+    return false;
+  }
+  if (callback != nullptr) {
+    return callback->IsNewerVisibleForMetadataRead(
+        seq, read_snapshot_seq, newer_version_upper_bound_seq);
+  }
+  return read_snapshot_seq < seq && seq <= newer_version_upper_bound_seq;
+}
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/read_callback.h
+++ b/db/read_callback.h
@@ -10,6 +10,14 @@
 
 namespace ROCKSDB_NAMESPACE {
 
+struct MetadataReadBounds {
+  // The snapshot-visible sequence and the upper bound sampled for this read.
+  // Lookups scan through the upper bound but return data only through the
+  // snapshot sequence.
+  SequenceNumber read_snapshot_seq;
+  SequenceNumber newer_version_upper_bound_seq;
+};
+
 class ReadCallback {
  public:
   explicit ReadCallback(SequenceNumber last_visible_seq)
@@ -37,6 +45,25 @@ class ReadCallback {
       return IsVisibleFullCheck(seq);
     }
   }
+
+  virtual const MetadataReadBounds* GetMetadataReadBounds() const {
+    return nullptr;
+  }
+
+  virtual bool NeedToTrackNewerVersions(
+      const bool* /*per_key_result*/ = nullptr) const {
+    return false;
+  }
+
+  virtual bool IsNewerVisibleForMetadataRead(SequenceNumber /*seq*/) {
+    // Metadata reads with custom visibility callbacks are unsupported. The
+    // timestamp callback overrides this method for regular DB reads.
+    return false;
+  }
+
+  virtual void MaybeRecordNewerVersion(SequenceNumber /*seq*/,
+                                       ValueType /*type*/,
+                                       bool* /*per_key_result*/ = nullptr) {}
 
   inline SequenceNumber max_visible_seq() { return max_visible_seq_; }
 

--- a/db/table_cache.cc
+++ b/db/table_cache.cc
@@ -9,6 +9,8 @@
 
 #include "db/table_cache.h"
 
+#include <algorithm>
+
 #include "db/dbformat.h"
 #include "db/range_tombstone_fragmenter.h"
 #include "db/snapshot_impl.h"
@@ -548,7 +550,10 @@ uint64_t TableCache::CreateRowCacheKeyPrefix(const ReadOptions& options,
     // We should consider to use options.snapshot->GetSequenceNumber()
     // instead of GetInternalKeySeqno(k), which will make the code
     // easier to understand.
-    cache_entry_seq_no = 1 + GetInternalKeySeqno(internal_key);
+    const MetadataReadCtx* metadata_ctx = get_context->metadata_read_ctx();
+    cache_entry_seq_no =
+        1 + (metadata_ctx != nullptr ? metadata_ctx->read_snapshot_seq
+                                     : GetInternalKeySeqno(internal_key));
   }
 
   // Compute row cache key.
@@ -597,10 +602,47 @@ bool TableCache::GetFromRowCache(const Slice& user_key, IterKey& row_cache_key,
 void TableCache::UpdateRangeTombstoneSeqnums(
     const ReadOptions& options, TableReader* t,
     MultiGetContext::Range& table_range) {
-  std::unique_ptr<FragmentedRangeTombstoneIterator> range_del_iter(
-      t->NewRangeTombstoneIterator(options));
-  if (range_del_iter != nullptr) {
+  std::unique_ptr<FragmentedRangeTombstoneIterator> latest_range_del_iter;
+  bool track_newer_versions = false;
+  if (table_range.context()->HasMetadataReadCtx()) {
     for (auto iter = table_range.begin(); iter != table_range.end(); ++iter) {
+      if (iter->get_context->NeedToTrackNewerVersions()) {
+        track_newer_versions = true;
+        break;
+      }
+    }
+  }
+  if (track_newer_versions) {
+    SequenceNumber latest_range_del_read_seq = 0;
+    for (auto iter = table_range.begin(); iter != table_range.end(); ++iter) {
+      if (iter->get_context->NeedToTrackNewerVersions()) {
+        latest_range_del_read_seq = std::max(latest_range_del_read_seq,
+                                             GetInternalKeySeqno(iter->ikey));
+      }
+    }
+    if (latest_range_del_read_seq > 0) {
+      latest_range_del_iter.reset(t->NewRangeTombstoneIterator(
+          latest_range_del_read_seq, options.timestamp));
+    }
+  }
+
+  std::unique_ptr<FragmentedRangeTombstoneIterator> range_del_iter;
+  if (!options.ignore_range_deletions) {
+    range_del_iter.reset(t->NewRangeTombstoneIterator(options));
+  }
+  if (range_del_iter != nullptr || latest_range_del_iter != nullptr) {
+    for (auto iter = table_range.begin(); iter != table_range.end(); ++iter) {
+      if (latest_range_del_iter != nullptr &&
+          iter->get_context->NeedToTrackNewerVersions()) {
+        if (latest_range_del_iter->MaxCoveringTombstoneSeqnum(
+                iter->ukey_with_ts, *iter->get_context->metadata_read_ctx(),
+                iter->get_context->read_callback()) != 0) {
+          iter->get_context->MarkNewerVersionPresent();
+        }
+      }
+      if (range_del_iter == nullptr) {
+        continue;
+      }
       SequenceNumber* max_covering_tombstone_seq =
           iter->get_context->max_covering_tombstone_seq();
       SequenceNumber seq =
@@ -630,7 +672,19 @@ Status TableCache::MultiGetFilter(
   // filtering here, since the filtering needs to happen after the row cache
   // lookup.
   KeyContext& first_key = *mget_range->begin();
-  if (ioptions_.row_cache && !first_key.get_context->NeedToReadSequence()) {
+  const bool has_metadata_read_ctx =
+      mget_range->context()->HasMetadataReadCtx();
+  bool track_newer_versions = false;
+  if (has_metadata_read_ctx) {
+    for (auto iter = mget_range->begin(); iter != mget_range->end(); ++iter) {
+      if (iter->get_context->NeedToTrackNewerVersions()) {
+        track_newer_versions = true;
+        break;
+      }
+    }
+  }
+  if (ioptions_.row_cache && !first_key.get_context->NeedToReadSequence() &&
+      !track_newer_versions) {
     return Status::NotSupported();
   }
   Status s;
@@ -649,7 +703,7 @@ Status TableCache::MultiGetFilter(
     s = t->MultiGetFilter(options, mutable_cf_options.prefix_extractor.get(),
                           mget_range);
   }
-  if (s.ok() && !options.ignore_range_deletions) {
+  if (s.ok() && (!options.ignore_range_deletions || track_newer_versions)) {
     // Update the range tombstone sequence numbers for the keys here
     // as TableCache::MultiGet may or may not be called, and even if it
     // is, it may be called with fewer keys in the rangedue to filtering.

--- a/db/table_cache.cc
+++ b/db/table_cache.cc
@@ -9,6 +9,8 @@
 
 #include "db/table_cache.h"
 
+#include <algorithm>
+
 #include "db/dbformat.h"
 #include "db/range_tombstone_fragmenter.h"
 #include "db/snapshot_impl.h"
@@ -548,7 +550,11 @@ uint64_t TableCache::CreateRowCacheKeyPrefix(const ReadOptions& options,
     // We should consider to use options.snapshot->GetSequenceNumber()
     // instead of GetInternalKeySeqno(k), which will make the code
     // easier to understand.
-    cache_entry_seq_no = 1 + GetInternalKeySeqno(internal_key);
+    const MetadataReadBounds* metadata_read_bounds =
+        get_context->metadata_read_bounds();
+    cache_entry_seq_no = 1 + (metadata_read_bounds != nullptr
+                                  ? metadata_read_bounds->read_snapshot_seq
+                                  : GetInternalKeySeqno(internal_key));
   }
 
   // Compute row cache key.
@@ -597,10 +603,52 @@ bool TableCache::GetFromRowCache(const Slice& user_key, IterKey& row_cache_key,
 void TableCache::UpdateRangeTombstoneSeqnums(
     const ReadOptions& options, TableReader* t,
     MultiGetContext::Range& table_range) {
-  std::unique_ptr<FragmentedRangeTombstoneIterator> range_del_iter(
-      t->NewRangeTombstoneIterator(options));
-  if (range_del_iter != nullptr) {
+  std::unique_ptr<FragmentedRangeTombstoneIterator> latest_range_del_iter;
+  bool track_newer_versions = false;
+  if (!table_range.empty()) {
+    ReadCallback* callback = table_range.begin()->get_context->read_callback();
+    if (callback != nullptr && callback->GetMetadataReadBounds() != nullptr) {
+      for (auto iter = table_range.begin(); iter != table_range.end(); ++iter) {
+        if (iter->get_context->NeedToTrackNewerVersions()) {
+          track_newer_versions = true;
+          break;
+        }
+      }
+    }
+  }
+  if (track_newer_versions) {
+    SequenceNumber latest_range_del_read_seq = 0;
     for (auto iter = table_range.begin(); iter != table_range.end(); ++iter) {
+      if (iter->get_context->NeedToTrackNewerVersions()) {
+        latest_range_del_read_seq = std::max(latest_range_del_read_seq,
+                                             GetInternalKeySeqno(iter->ikey));
+      }
+    }
+    if (latest_range_del_read_seq > 0) {
+      latest_range_del_iter.reset(t->NewRangeTombstoneIterator(
+          latest_range_del_read_seq, options.timestamp));
+    }
+  }
+
+  std::unique_ptr<FragmentedRangeTombstoneIterator> range_del_iter;
+  if (!options.ignore_range_deletions) {
+    range_del_iter.reset(t->NewRangeTombstoneIterator(options));
+  }
+  if (range_del_iter != nullptr || latest_range_del_iter != nullptr) {
+    for (auto iter = table_range.begin(); iter != table_range.end(); ++iter) {
+      if (latest_range_del_iter != nullptr &&
+          iter->get_context->NeedToTrackNewerVersions()) {
+        const SequenceNumber covering_seq =
+            latest_range_del_iter->MaxCoveringTombstoneSeqnum(
+                iter->ukey_with_ts, iter->get_context->read_callback());
+        if (covering_seq != 0) {
+          iter->get_context->RecordNewerVersionIfNeeded(covering_seq,
+                                                        kTypeRangeDeletion);
+        }
+      }
+      if (range_del_iter == nullptr) {
+        continue;
+      }
       SequenceNumber* max_covering_tombstone_seq =
           iter->get_context->max_covering_tombstone_seq();
       SequenceNumber seq =
@@ -630,7 +678,18 @@ Status TableCache::MultiGetFilter(
   // filtering here, since the filtering needs to happen after the row cache
   // lookup.
   KeyContext& first_key = *mget_range->begin();
-  if (ioptions_.row_cache && !first_key.get_context->NeedToReadSequence()) {
+  bool track_newer_versions = false;
+  ReadCallback* callback = first_key.get_context->read_callback();
+  if (callback != nullptr && callback->GetMetadataReadBounds() != nullptr) {
+    for (auto iter = mget_range->begin(); iter != mget_range->end(); ++iter) {
+      if (iter->get_context->NeedToTrackNewerVersions()) {
+        track_newer_versions = true;
+        break;
+      }
+    }
+  }
+  if (ioptions_.row_cache && !first_key.get_context->NeedToReadSequence() &&
+      !track_newer_versions) {
     return Status::NotSupported();
   }
   Status s;
@@ -649,7 +708,7 @@ Status TableCache::MultiGetFilter(
     s = t->MultiGetFilter(options, mutable_cf_options.prefix_extractor.get(),
                           mget_range);
   }
-  if (s.ok() && !options.ignore_range_deletions) {
+  if (s.ok() && (!options.ignore_range_deletions || track_newer_versions)) {
     // Update the range tombstone sequence numbers for the keys here
     // as TableCache::MultiGet may or may not be called, and even if it
     // is, it may be called with fewer keys in the rangedue to filtering.

--- a/db/table_cache_sync_and_async.h
+++ b/db/table_cache_sync_and_async.h
@@ -25,7 +25,8 @@ DEFINE_SYNC_AND_ASYNC(Status, TableCache::Get)
   // Check row cache if enabled.
   // Reuse row_cache_key sequence number when row cache hits.
   Status s;
-  if (ioptions_.row_cache && !get_context->NeedToReadSequence()) {
+  if (ioptions_.row_cache && !get_context->NeedToReadSequence() &&
+      !get_context->NeedToTrackNewerVersions()) {
     auto user_key = ExtractUserKey(k);
     uint64_t cache_entry_seq_no =
         CreateRowCacheKeyPrefix(options, fd, k, get_context, row_cache_key);
@@ -49,18 +50,34 @@ DEFINE_SYNC_AND_ASYNC(Status, TableCache::Get)
                   should_pin_table_handles_);
     SequenceNumber* max_covering_tombstone_seq =
         get_context->max_covering_tombstone_seq();
-    if (s.ok() && max_covering_tombstone_seq != nullptr &&
-        !options.ignore_range_deletions) {
-      std::unique_ptr<FragmentedRangeTombstoneIterator> range_del_iter(
-          t->NewRangeTombstoneIterator(options));
-      if (range_del_iter != nullptr) {
-        SequenceNumber seq =
-            range_del_iter->MaxCoveringTombstoneSeqnum(ExtractUserKey(k));
-        if (seq > *max_covering_tombstone_seq) {
-          *max_covering_tombstone_seq = seq;
-          if (get_context->NeedTimestamp()) {
-            get_context->SetTimestampFromRangeTombstone(
-                range_del_iter->timestamp());
+    const bool track_newer_versions = get_context->NeedToTrackNewerVersions();
+    if (s.ok() && ((max_covering_tombstone_seq != nullptr &&
+                    !options.ignore_range_deletions) ||
+                   track_newer_versions)) {
+      if (track_newer_versions) {
+        std::unique_ptr<FragmentedRangeTombstoneIterator> latest_range_del_iter(
+            t->NewRangeTombstoneIterator(GetInternalKeySeqno(k),
+                                         options.timestamp));
+        if (latest_range_del_iter != nullptr &&
+            latest_range_del_iter->MaxCoveringTombstoneSeqnum(
+                ExtractUserKey(k), *get_context->metadata_read_ctx(),
+                get_context->read_callback()) != 0) {
+          get_context->MarkNewerVersionPresent();
+        }
+      }
+      if (max_covering_tombstone_seq != nullptr &&
+          !options.ignore_range_deletions) {
+        std::unique_ptr<FragmentedRangeTombstoneIterator> range_del_iter(
+            t->NewRangeTombstoneIterator(options));
+        if (range_del_iter != nullptr) {
+          SequenceNumber seq =
+              range_del_iter->MaxCoveringTombstoneSeqnum(ExtractUserKey(k));
+          if (seq > *max_covering_tombstone_seq) {
+            *max_covering_tombstone_seq = seq;
+            if (get_context->NeedTimestamp()) {
+              get_context->SetTimestampFromRangeTombstone(
+                  range_del_iter->timestamp());
+            }
           }
         }
       }
@@ -115,16 +132,29 @@ DEFINE_SYNC_AND_ASYNC(Status, TableCache::MultiGet)
   autovector<std::string, MultiGetContext::MAX_BATCH_SIZE> row_cache_entries;
   IterKey row_cache_key;
   size_t row_cache_key_prefix_size = 0;
+  SequenceNumber row_cache_entry_seq_no = kMaxSequenceNumber;
   KeyContext& first_key = *table_range.begin();
-  bool lookup_row_cache =
-      ioptions_.row_cache && !first_key.get_context->NeedToReadSequence();
+  const bool has_metadata_read_ctx =
+      table_range.context()->HasMetadataReadCtx();
+  bool track_newer_versions = false;
+  if (has_metadata_read_ctx) {
+    for (auto iter = table_range.begin(); iter != table_range.end(); ++iter) {
+      if (iter->get_context->NeedToTrackNewerVersions()) {
+        track_newer_versions = true;
+        break;
+      }
+    }
+  }
+  bool lookup_row_cache = ioptions_.row_cache &&
+                          !first_key.get_context->NeedToReadSequence() &&
+                          !track_newer_versions;
 
   // Check row cache if enabled. Since row cache does not currently store
   // sequence numbers, we cannot use it if we need to fetch the sequence.
   if (lookup_row_cache) {
     GetContext* first_context = first_key.get_context;
-    CreateRowCacheKeyPrefix(options, fd, first_key.ikey, first_context,
-                            row_cache_key);
+    row_cache_entry_seq_no = CreateRowCacheKeyPrefix(
+        options, fd, first_key.ikey, first_context, row_cache_key);
     row_cache_key_prefix_size = row_cache_key.Size();
 
     for (auto miter = table_range.begin(); miter != table_range.end();
@@ -136,7 +166,7 @@ DEFINE_SYNC_AND_ASYNC(Status, TableCache::MultiGet)
       Status read_status;
       bool ret =
           GetFromRowCache(user_key, row_cache_key, row_cache_key_prefix_size,
-                          get_context, &read_status);
+                          get_context, &read_status, row_cache_entry_seq_no);
       if (!read_status.ok()) {
         CO_RETURN read_status;
       }
@@ -164,7 +194,8 @@ DEFINE_SYNC_AND_ASYNC(Status, TableCache::MultiGet)
       TEST_SYNC_POINT_CALLBACK("TableCache::MultiGet:FindTable", &s);
       assert(!s.ok() || t);
     }
-    if (s.ok() && !options.ignore_range_deletions && !skip_range_deletions) {
+    if (s.ok() && !skip_range_deletions &&
+        (!options.ignore_range_deletions || track_newer_versions)) {
       UpdateRangeTombstoneSeqnums(options, t, table_range);
     }
     if (s.ok()) {

--- a/db/table_cache_sync_and_async.h
+++ b/db/table_cache_sync_and_async.h
@@ -25,7 +25,8 @@ DEFINE_SYNC_AND_ASYNC(Status, TableCache::Get)
   // Check row cache if enabled.
   // Reuse row_cache_key sequence number when row cache hits.
   Status s;
-  if (ioptions_.row_cache && !get_context->NeedToReadSequence()) {
+  if (ioptions_.row_cache && !get_context->NeedToReadSequence() &&
+      !get_context->NeedToTrackNewerVersions()) {
     auto user_key = ExtractUserKey(k);
     uint64_t cache_entry_seq_no =
         CreateRowCacheKeyPrefix(options, fd, k, get_context, row_cache_key);
@@ -49,18 +50,37 @@ DEFINE_SYNC_AND_ASYNC(Status, TableCache::Get)
                   should_pin_table_handles_);
     SequenceNumber* max_covering_tombstone_seq =
         get_context->max_covering_tombstone_seq();
-    if (s.ok() && max_covering_tombstone_seq != nullptr &&
-        !options.ignore_range_deletions) {
-      std::unique_ptr<FragmentedRangeTombstoneIterator> range_del_iter(
-          t->NewRangeTombstoneIterator(options));
-      if (range_del_iter != nullptr) {
-        SequenceNumber seq =
-            range_del_iter->MaxCoveringTombstoneSeqnum(ExtractUserKey(k));
-        if (seq > *max_covering_tombstone_seq) {
-          *max_covering_tombstone_seq = seq;
-          if (get_context->NeedTimestamp()) {
-            get_context->SetTimestampFromRangeTombstone(
-                range_del_iter->timestamp());
+    const bool track_newer_versions = get_context->NeedToTrackNewerVersions();
+    if (s.ok() && ((max_covering_tombstone_seq != nullptr &&
+                    !options.ignore_range_deletions) ||
+                   track_newer_versions)) {
+      if (track_newer_versions) {
+        std::unique_ptr<FragmentedRangeTombstoneIterator> latest_range_del_iter(
+            t->NewRangeTombstoneIterator(GetInternalKeySeqno(k),
+                                         options.timestamp));
+        const SequenceNumber covering_seq =
+            latest_range_del_iter != nullptr
+                ? latest_range_del_iter->MaxCoveringTombstoneSeqnum(
+                      ExtractUserKey(k), get_context->read_callback())
+                : 0;
+        if (covering_seq != 0) {
+          get_context->RecordNewerVersionIfNeeded(covering_seq,
+                                                  kTypeRangeDeletion);
+        }
+      }
+      if (max_covering_tombstone_seq != nullptr &&
+          !options.ignore_range_deletions) {
+        std::unique_ptr<FragmentedRangeTombstoneIterator> range_del_iter(
+            t->NewRangeTombstoneIterator(options));
+        if (range_del_iter != nullptr) {
+          SequenceNumber seq =
+              range_del_iter->MaxCoveringTombstoneSeqnum(ExtractUserKey(k));
+          if (seq > *max_covering_tombstone_seq) {
+            *max_covering_tombstone_seq = seq;
+            if (get_context->NeedTimestamp()) {
+              get_context->SetTimestampFromRangeTombstone(
+                  range_del_iter->timestamp());
+            }
           }
         }
       }
@@ -116,15 +136,30 @@ DEFINE_SYNC_AND_ASYNC(Status, TableCache::MultiGet)
   IterKey row_cache_key;
   size_t row_cache_key_prefix_size = 0;
   KeyContext& first_key = *table_range.begin();
-  bool lookup_row_cache =
-      ioptions_.row_cache && !first_key.get_context->NeedToReadSequence();
+  bool track_newer_versions = false;
+  ReadCallback* callback = first_key.get_context->read_callback();
+  const bool is_metadata_read =
+      callback != nullptr && callback->GetMetadataReadBounds() != nullptr;
+  if (is_metadata_read) {
+    for (auto iter = table_range.begin(); iter != table_range.end(); ++iter) {
+      if (iter->get_context->NeedToTrackNewerVersions()) {
+        track_newer_versions = true;
+        break;
+      }
+    }
+  }
+  bool lookup_row_cache = ioptions_.row_cache &&
+                          !first_key.get_context->NeedToReadSequence() &&
+                          !track_newer_versions;
 
   // Check row cache if enabled. Since row cache does not currently store
   // sequence numbers, we cannot use it if we need to fetch the sequence.
   if (lookup_row_cache) {
     GetContext* first_context = first_key.get_context;
-    CreateRowCacheKeyPrefix(options, fd, first_key.ikey, first_context,
-                            row_cache_key);
+    const SequenceNumber row_cache_entry_seq_no = CreateRowCacheKeyPrefix(
+        options, fd, first_key.ikey, first_context, row_cache_key);
+    const SequenceNumber replay_seq_no =
+        is_metadata_read ? row_cache_entry_seq_no : kMaxSequenceNumber;
     row_cache_key_prefix_size = row_cache_key.Size();
 
     for (auto miter = table_range.begin(); miter != table_range.end();
@@ -136,7 +171,7 @@ DEFINE_SYNC_AND_ASYNC(Status, TableCache::MultiGet)
       Status read_status;
       bool ret =
           GetFromRowCache(user_key, row_cache_key, row_cache_key_prefix_size,
-                          get_context, &read_status);
+                          get_context, &read_status, replay_seq_no);
       if (!read_status.ok()) {
         CO_RETURN read_status;
       }
@@ -164,7 +199,8 @@ DEFINE_SYNC_AND_ASYNC(Status, TableCache::MultiGet)
       TEST_SYNC_POINT_CALLBACK("TableCache::MultiGet:FindTable", &s);
       assert(!s.ok() || t);
     }
-    if (s.ok() && !options.ignore_range_deletions && !skip_range_deletions) {
+    if (s.ok() && !skip_range_deletions &&
+        (!options.ignore_range_deletions || track_newer_versions)) {
       UpdateRangeTombstoneSeqnums(options, t, table_range);
     }
     if (s.ok()) {

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -971,7 +971,8 @@ class Version {
       bool* key_exists = nullptr, SequenceNumber* seq = nullptr,
       ReadCallback* callback = nullptr, bool* is_blob = nullptr,
       bool do_merge = true,
-      const SameFileBlobReader** lazy_columns_same_file_reader = nullptr);
+      const SameFileBlobReader** lazy_columns_same_file_reader = nullptr,
+      const MetadataReadCtx* metadata_ctx = nullptr);
 
   DECLARE_SYNC_AND_ASYNC(void, MultiGet, const ReadOptions&,
                          MultiGetRange* range,

--- a/db/version_set_sync_and_async.h
+++ b/db/version_set_sync_and_async.h
@@ -17,7 +17,8 @@ DEFINE_SYNC_AND_ASYNC(void, Version::Get)
  MergeContext* merge_context, SequenceNumber* max_covering_tombstone_seq,
  PinnedIteratorsManager* pinned_iters_mgr, bool* value_found, bool* key_exists,
  SequenceNumber* seq, ReadCallback* callback, bool* is_blob, bool do_merge,
- const SameFileBlobReader** lazy_columns_same_file_reader) {
+ const SameFileBlobReader** lazy_columns_same_file_reader,
+ const MetadataReadCtx* metadata_ctx) {
   Slice ikey = k.internal_key();
   Slice user_key = k.user_key();
 
@@ -50,6 +51,7 @@ DEFINE_SYNC_AND_ASYNC(void, Version::Get)
       max_covering_tombstone_seq, clock_, seq,
       merge_operator_ ? pinned_iters_mgr : nullptr, callback, is_blob_to_use,
       tracing_get_id, &blob_fetcher, lazy_columns_same_file_reader);
+  get_context.SetMetadataReadCtx(metadata_ctx);
 
   // Pin blocks that we read to hold merge operands
   if (merge_operator_) {
@@ -415,6 +417,7 @@ DEFINE_SYNC_AND_ASYNC(void, Version::MultiGet)
         &iter->max_covering_tombstone_seq, clock_, nullptr,
         merge_operator_ ? &pinned_iters_mgr : nullptr, callback,
         &iter->is_blob_index, tracing_mget_id, &blob_fetcher);
+    get_ctx.back().SetMetadataReadCtx(iter->metadata_ctx);
     // MergeInProgress status, if set, has been transferred to the get_context
     // state, so we set status to ok here. From now on, the iter status will
     // be used for IO errors, and get_context state will be used for any

--- a/db/version_set_sync_and_async.h
+++ b/db/version_set_sync_and_async.h
@@ -415,6 +415,9 @@ DEFINE_SYNC_AND_ASYNC(void, Version::MultiGet)
         &iter->max_covering_tombstone_seq, clock_, nullptr,
         merge_operator_ ? &pinned_iters_mgr : nullptr, callback,
         &iter->is_blob_index, tracing_mget_id, &blob_fetcher);
+    if (callback != nullptr && callback->GetMetadataReadBounds() != nullptr) {
+      get_ctx.back().SetNewerVersionResult(&iter->newer_version_present);
+    }
     // MergeInProgress status, if set, has been transferred to the get_context
     // state, so we set status to ok here. From now on, the iter status will
     // be used for IO errors, and get_context state will be used for any

--- a/db_stress_tool/batched_ops_stress.cc
+++ b/db_stress_tool/batched_ops_stress.cc
@@ -163,7 +163,14 @@ class BatchedOpsStressTest : public StressTest {
     for (int i = 0; i < 10; i++) {
       keys[i] += key.ToString();
       key_slices[i] = keys[i];
-      s = DbStressGet(db_, readoptionscopy, cfh, key_slices[i], &from_db);
+      if (i == 0) {
+        OutputMetadata output_metadata;
+        output_metadata.WantNewerVersionPresent();
+        s = db_->GetWithMetadata(readoptionscopy, cfh, key_slices[i], &from_db,
+                                 &output_metadata);
+      } else {
+        s = DbStressGet(db_, readoptionscopy, cfh, key_slices[i], &from_db);
+      }
       if (!s.ok() && !s.IsNotFound()) {
         fprintf(stderr, "get error: %s\n", s.ToString().c_str());
         values[i] = "";
@@ -235,8 +242,25 @@ class BatchedOpsStressTest : public StressTest {
         key_str.emplace_back(keys[key] + Key(rand_keys[rand_key]));
         key_slices.emplace_back(key_str.back());
       }
-      DbStressMultiGet(db_, readoptionscopy, cfh, num_prefixes,
-                       key_slices.data(), values.data(), statuses.data());
+      MultiGetOutputMetadata output_metadata;
+      output_metadata.WantNewerVersionPresent();
+      db_->MultiGetWithMetadata(readoptionscopy, cfh, num_prefixes,
+                                key_slices.data(), values.data(),
+                                statuses.data(), &output_metadata);
+      const std::vector<bool>& newer_versions =
+          *output_metadata.newer_version_present;
+      if (newer_versions.size() != num_prefixes ||
+          !std::all_of(newer_versions.begin(), newer_versions.end(),
+                       [&](bool present) {
+                         return present == newer_versions.front();
+                       })) {
+        fprintf(stderr,
+                "multiget error: inconsistent newer-version metadata for "
+                "atomic batch\n");
+        thread->stats.AddErrors(1);
+        ret_status[rand_key] = Status::Corruption(
+            "Inconsistent newer-version metadata for atomic batch");
+      }
       for (size_t i = 0; i < num_prefixes; i++) {
         Status s = statuses[i];
         if (!s.ok() && !s.IsNotFound()) {

--- a/db_stress_tool/batched_ops_stress.cc
+++ b/db_stress_tool/batched_ops_stress.cc
@@ -163,7 +163,20 @@ class BatchedOpsStressTest : public StressTest {
     for (int i = 0; i < 10; i++) {
       keys[i] += key.ToString();
       key_slices[i] = keys[i];
-      s = DbStressGet(db_, readoptionscopy, cfh, key_slices[i], &from_db);
+      if (i == 0) {
+        OutputMetadata output_metadata;
+        output_metadata.WantNewerVersionPresent();
+        s = db_->GetWithMetadata(readoptionscopy, cfh, key_slices[i], &from_db,
+                                 &output_metadata);
+        if (s.IsNotSupported()) {
+          // Transaction DBs that require custom visibility callbacks cannot
+          // provide newer-version metadata. Preserve the ordinary batched
+          // stress coverage for those configurations.
+          s = DbStressGet(db_, readoptionscopy, cfh, key_slices[i], &from_db);
+        }
+      } else {
+        s = DbStressGet(db_, readoptionscopy, cfh, key_slices[i], &from_db);
+      }
       if (!s.ok() && !s.IsNotFound()) {
         fprintf(stderr, "get error: %s\n", s.ToString().c_str());
         values[i] = "";
@@ -235,8 +248,20 @@ class BatchedOpsStressTest : public StressTest {
         key_str.emplace_back(keys[key] + Key(rand_keys[rand_key]));
         key_slices.emplace_back(key_str.back());
       }
-      DbStressMultiGet(db_, readoptionscopy, cfh, num_prefixes,
-                       key_slices.data(), values.data(), statuses.data());
+      MultiGetOutputMetadata output_metadata;
+      output_metadata.WantNewerVersionPresent();
+      db_->MultiGetWithMetadata(readoptionscopy, cfh, num_prefixes,
+                                key_slices.data(), values.data(),
+                                statuses.data(), &output_metadata);
+      const bool metadata_not_supported = std::all_of(
+          statuses.begin(), statuses.end(),
+          [](const Status& status) { return status.IsNotSupported(); });
+      if (metadata_not_supported) {
+        // Preserve compatibility with transaction DBs whose custom visibility
+        // callbacks make newer-version tracking unsupported.
+        DbStressMultiGet(db_, readoptionscopy, cfh, num_prefixes,
+                         key_slices.data(), values.data(), statuses.data());
+      }
       for (size_t i = 0; i < num_prefixes; i++) {
         Status s = statuses[i];
         if (!s.ok() && !s.IsNotFound()) {

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -626,6 +626,11 @@ extern ROCKSDB_LIBRARY_API char* rocksdb_get(
     rocksdb_t* db, const rocksdb_readoptions_t* options, const char* key,
     size_t keylen, size_t* vallen, char** errptr);
 
+extern ROCKSDB_LIBRARY_API char* rocksdb_get_with_metadata(
+    rocksdb_t* db, const rocksdb_readoptions_t* options, const char* key,
+    size_t keylen, size_t* vallen, char** timestamp, size_t* timestamp_len,
+    unsigned char* newer_version_present, char** errptr);
+
 extern ROCKSDB_LIBRARY_API char* rocksdb_get_with_ts(
     rocksdb_t* db, const rocksdb_readoptions_t* options, const char* key,
     size_t keylen, size_t* vallen, char** ts, size_t* tslen, char** errptr);
@@ -634,6 +639,12 @@ extern ROCKSDB_LIBRARY_API char* rocksdb_get_cf(
     rocksdb_t* db, const rocksdb_readoptions_t* options,
     rocksdb_column_family_handle_t* column_family, const char* key,
     size_t keylen, size_t* vallen, char** errptr);
+
+extern ROCKSDB_LIBRARY_API char* rocksdb_get_cf_with_metadata(
+    rocksdb_t* db, const rocksdb_readoptions_t* options,
+    rocksdb_column_family_handle_t* column_family, const char* key,
+    size_t keylen, size_t* vallen, char** timestamp, size_t* timestamp_len,
+    unsigned char* newer_version_present, char** errptr);
 
 extern ROCKSDB_LIBRARY_API char* rocksdb_get_cf_with_ts(
     rocksdb_t* db, const rocksdb_readoptions_t* options,
@@ -663,6 +674,13 @@ extern ROCKSDB_LIBRARY_API void rocksdb_multi_get(
     const char* const* keys_list, const size_t* keys_list_sizes,
     char** values_list, size_t* values_list_sizes, char** errs);
 
+extern ROCKSDB_LIBRARY_API void rocksdb_multi_get_with_metadata(
+    rocksdb_t* db, const rocksdb_readoptions_t* options, size_t num_keys,
+    const char* const* keys_list, const size_t* keys_list_sizes,
+    char** values_list, size_t* values_list_sizes, char** timestamp_list,
+    size_t* timestamp_list_sizes, unsigned char* newer_version_present,
+    char** errs);
+
 extern ROCKSDB_LIBRARY_API void rocksdb_multi_get_with_ts(
     rocksdb_t* db, const rocksdb_readoptions_t* options, size_t num_keys,
     const char* const* keys_list, const size_t* keys_list_sizes,
@@ -675,6 +693,15 @@ extern ROCKSDB_LIBRARY_API void rocksdb_multi_get_cf(
     size_t num_keys, const char* const* keys_list,
     const size_t* keys_list_sizes, char** values_list,
     size_t* values_list_sizes, char** errs);
+
+extern ROCKSDB_LIBRARY_API void rocksdb_multi_get_cf_with_metadata(
+    rocksdb_t* db, const rocksdb_readoptions_t* options,
+    const rocksdb_column_family_handle_t* const* column_families,
+    size_t num_keys, const char* const* keys_list,
+    const size_t* keys_list_sizes, char** values_list,
+    size_t* values_list_sizes, char** timestamp_list,
+    size_t* timestamp_list_sizes, unsigned char* newer_version_present,
+    char** errs);
 
 extern ROCKSDB_LIBRARY_API void rocksdb_multi_get_cf_with_ts(
     rocksdb_t* db, const rocksdb_readoptions_t* options,

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -13,6 +13,7 @@
 
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -74,6 +75,85 @@ struct ColumnFamilyDescriptor {
   ColumnFamilyDescriptor(const std::string& _name,
                          const ColumnFamilyOptions& _options)
       : name(_name), options(_options) {}
+};
+
+struct OutputMetadata {
+  // For each field, std::nullopt means the metadata was not requested.
+
+  // If engaged, receives the key timestamp.
+  std::optional<std::string> timestamp;
+
+  OutputMetadata& WantTimestamp(bool want = true) {
+    if (want) {
+      timestamp.emplace();
+    } else {
+      timestamp.reset();
+    }
+    return *this;
+  }
+
+  // If engaged, set to true when an explicit-snapshot read observed a later
+  // write for the same key than the snapshot can return. May be true when the
+  // read returns NotFound because the key was created after the snapshot.
+  //
+  // A "later write" is any committed (visible) point operation of type Put,
+  // Delete, Merge, SingleDelete, BlobIndex, DeletionWithTimestamp,
+  // WideColumnEntity, or ValuePreferredSeqno, as well as a covering range
+  // tombstone (DeleteRange) with sequence number greater than the snapshot.
+  // Transaction reads that require a custom visibility callback are not
+  // supported.
+  //
+  // Caveats:
+  //   * Best-effort: false negatives are possible because the latest visible
+  //     sequence is sampled after the SuperVersion is pinned for this read.
+  //     Writes published in the narrow window between SuperVersion pin and
+  //     sequence sampling may be missed.
+  //   * When `Options::row_cache` is configured, tracking bypasses cached rows
+  //     until a newer version is observed because cached rows do not expose
+  //     sequence numbers. Remaining snapshot-visible lookups can use the cache.
+  //   * `ReadOptions::ignore_range_deletions` does not affect metadata
+  //     tracking: newer covering range tombstones are still reported.
+  //   * Has no effect when `read_options.snapshot` is null; the field is
+  //     always left as false in that case.
+  std::optional<bool> newer_version_present;
+
+  OutputMetadata& WantNewerVersionPresent(bool want = true) {
+    if (want) {
+      newer_version_present.emplace(false);
+    } else {
+      newer_version_present.reset();
+    }
+    return *this;
+  }
+};
+
+struct MultiGetOutputMetadata {
+  // For each field, std::nullopt means the metadata was not requested.
+
+  // If engaged, resized to num_keys and filled with key timestamps.
+  std::optional<std::vector<std::string>> timestamps;
+
+  MultiGetOutputMetadata& WantTimestamps(bool want = true) {
+    if (want) {
+      timestamps.emplace();
+    } else {
+      timestamps.reset();
+    }
+    return *this;
+  }
+
+  // If engaged, resized to num_keys and filled with newer-version metadata.
+  // See OutputMetadata::newer_version_present.
+  std::optional<std::vector<bool>> newer_version_present;
+
+  MultiGetOutputMetadata& WantNewerVersionPresent(bool want = true) {
+    if (want) {
+      newer_version_present.emplace();
+    } else {
+      newer_version_present.reset();
+    }
+    return *this;
+  }
 };
 
 class ColumnFamilyHandle {
@@ -657,6 +737,28 @@ class DB {
     return s;
   }
 
+  inline Status GetWithMetadata(const ReadOptions& options,
+                                ColumnFamilyHandle* column_family,
+                                const Slice& key, std::string* value,
+                                OutputMetadata* output_metadata) {
+    if (output_metadata != nullptr &&
+        output_metadata->newer_version_present.has_value()) {
+      *output_metadata->newer_version_present = false;
+    }
+    if (value == nullptr) {
+      return Status::InvalidArgument(
+          "Cannot call GetWithMetadata with a null value");
+    }
+    PinnableSlice pinnable_val(value);
+    assert(!pinnable_val.IsPinned());
+    auto s = GetWithMetadata(options, column_family, key, &pinnable_val,
+                             output_metadata);
+    if (s.ok() && pinnable_val.IsPinned()) {
+      value->assign(pinnable_val.data(), pinnable_val.size());
+    }  // else value is already assigned
+    return s;
+  }
+
   // No timestamp, and value is returned in a PinnableSlice
   // NOTE: virtual final => disallow override (was previously allowed)
   virtual Status Get(const ReadOptions& options,
@@ -694,6 +796,12 @@ class DB {
   virtual Status Get(const ReadOptions& options, const Slice& key,
                      std::string* value, std::string* timestamp) final {
     return Get(options, DefaultColumnFamily(), key, value, timestamp);
+  }
+
+  Status GetWithMetadata(const ReadOptions& options, const Slice& key,
+                         std::string* value, OutputMetadata* output_metadata) {
+    return GetWithMetadata(options, DefaultColumnFamily(), key, value,
+                           output_metadata);
   }
 
   // If the column family specified by "column_family" contains an entry for
@@ -834,6 +942,42 @@ class DB {
     return statuses;
   }
 
+  std::vector<Status> MultiGetWithMetadata(
+      const ReadOptions& options,
+      const std::vector<ColumnFamilyHandle*>& column_families,
+      const std::vector<Slice>& keys, std::vector<std::string>* values,
+      MultiGetOutputMetadata* output_metadata) {
+    size_t num_keys = keys.size();
+    values->resize(num_keys);
+    if (column_families.size() != num_keys) {
+      if (output_metadata != nullptr) {
+        if (output_metadata->timestamps.has_value()) {
+          output_metadata->timestamps->resize(num_keys);
+        }
+        if (output_metadata->newer_version_present.has_value()) {
+          output_metadata->newer_version_present->assign(num_keys, false);
+        }
+      }
+      return std::vector<Status>(
+          num_keys,
+          Status::InvalidArgument("Number of column families does not match "
+                                  "number of keys"));
+    }
+
+    std::vector<Status> statuses(num_keys);
+    std::vector<PinnableSlice> pin_values(num_keys);
+
+    MultiGetWithMetadata(options, num_keys, column_families.data(), keys.data(),
+                         pin_values.data(), statuses.data(), output_metadata,
+                         /*sorted_input=*/false);
+    for (size_t i = 0; i < num_keys; ++i) {
+      if (statuses[i].ok()) {
+        (*values)[i].assign(pin_values[i].data(), pin_values[i].size());
+      }
+    }
+    return statuses;
+  }
+
   // No timestamps are returned
   // NOTE: virtual final => disallow override (was previously allowed)
   virtual std::vector<Status> MultiGet(
@@ -854,6 +998,17 @@ class DB {
         options,
         std::vector<ColumnFamilyHandle*>(keys.size(), DefaultColumnFamily()),
         keys, values);
+  }
+
+  std::vector<Status> MultiGetWithMetadata(
+      const ReadOptions& options, const std::vector<Slice>& keys,
+      std::vector<std::string>* values,
+      MultiGetOutputMetadata* output_metadata) {
+    values->resize(keys.size());
+    return MultiGetWithMetadata(
+        options,
+        std::vector<ColumnFamilyHandle*>(keys.size(), DefaultColumnFamily()),
+        keys, values, output_metadata);
   }
 
   // MultiGet for default column family
@@ -910,6 +1065,15 @@ class DB {
                         PinnableSlice* values, std::string* timestamps,
                         Status* statuses,
                         const bool sorted_input = false) final;
+
+  // MultiGet for single column family with optional output metadata vectors.
+  // Non-null vectors in output_metadata are resized to num_keys entries.
+  void MultiGetWithMetadata(const ReadOptions& options,
+                            ColumnFamilyHandle* column_family,
+                            const size_t num_keys, const Slice* keys,
+                            PinnableSlice* values, Status* statuses,
+                            MultiGetOutputMetadata* output_metadata,
+                            const bool sorted_input = false);
 
   // MultiGet for single column family, no timestamps returned
   // NOTE: virtual final => disallow override (was previously allowed)
@@ -2619,6 +2783,27 @@ class DB {
   // Returns the non-owning native coroutine interface, or nullptr when this DB
   // does not support it. The returned pointer must not outlive this DB.
   virtual CoroDB* GetCoroDB() { return nullptr; }
+
+  // EXPERIMENTAL, subject to change.
+  // Returns the same value as Get() and populates requested output metadata.
+  // Newer-version tracking is supported for explicit-snapshot reads on the
+  // primary DB implementation. It is not supported with kPersistedTier or by
+  // transaction reads that require a custom visibility callback.
+  virtual Status GetWithMetadata(const ReadOptions& options,
+                                 ColumnFamilyHandle* column_family,
+                                 const Slice& key, PinnableSlice* value,
+                                 OutputMetadata* output_metadata);
+
+  // EXPERIMENTAL, subject to change.
+  // MultiGet equivalent of GetWithMetadata(). Requested output vectors are
+  // resized to num_keys entries.
+  virtual void MultiGetWithMetadata(const ReadOptions& options,
+                                    const size_t num_keys,
+                                    ColumnFamilyHandle* const* column_families,
+                                    const Slice* keys, PinnableSlice* values,
+                                    Status* statuses,
+                                    MultiGetOutputMetadata* output_metadata,
+                                    const bool sorted_input = false);
 };
 
 struct WriteStallStatsMapKeys {

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -13,6 +13,7 @@
 
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -74,6 +75,84 @@ struct ColumnFamilyDescriptor {
   ColumnFamilyDescriptor(const std::string& _name,
                          const ColumnFamilyOptions& _options)
       : name(_name), options(_options) {}
+};
+
+struct OutputMetadata {
+  // For each field, std::nullopt means the metadata was not requested.
+
+  // If engaged, receives the key timestamp.
+  std::optional<std::string> timestamp;
+
+  OutputMetadata& WantTimestamp(bool want = true) {
+    if (want) {
+      timestamp.emplace();
+    } else {
+      timestamp.reset();
+    }
+    return *this;
+  }
+
+  // If engaged, set to true when an explicit-snapshot read observes a later
+  // write for the same key than the snapshot can return. May be true when the
+  // read returns NotFound because the key was created after the snapshot.
+  //
+  // A "later write" is any committed (visible) point operation of type Put,
+  // Delete, Merge, SingleDelete, BlobIndex, DeletionWithTimestamp,
+  // WideColumnEntity, or ValuePreferredSeqno, as well as a covering range
+  // tombstone (DeleteRange) with sequence number greater than the snapshot.
+  // For ordinary DB reads, a committed write that completes before this read
+  // begins is guaranteed to be reported. A write that races with this read may
+  // or may not be reported. A true result always identifies a committed write
+  // in the sequence-number interval after the snapshot and through the read's
+  // sampled upper bound.
+  //
+  // Caveats:
+  //   * Transaction reads that require a custom visibility callback are not
+  //     supported.
+  //   * `ReadOptions::ignore_range_deletions` does not affect metadata
+  //     tracking: newer covering range tombstones are still reported.
+  //   * Has no effect when `read_options.snapshot` is null; the field is
+  //     always left as false in that case.
+  std::optional<bool> newer_version_present;
+
+  OutputMetadata& WantNewerVersionPresent(bool want = true) {
+    if (want) {
+      newer_version_present.emplace(false);
+    } else {
+      newer_version_present.reset();
+    }
+    return *this;
+  }
+};
+
+struct MultiGetOutputMetadata {
+  // For each field, std::nullopt means the metadata was not requested.
+
+  // If engaged, resized to num_keys and filled with key timestamps.
+  std::optional<std::vector<std::string>> timestamps;
+
+  MultiGetOutputMetadata& WantTimestamps(bool want = true) {
+    if (want) {
+      timestamps.emplace();
+    } else {
+      timestamps.reset();
+    }
+    return *this;
+  }
+
+  // If engaged, resized to num_keys and filled with newer-version metadata.
+  // See OutputMetadata::newer_version_present.
+  // Each entry is 0 for false and 1 for true.
+  std::optional<std::vector<uint8_t>> newer_version_present;
+
+  MultiGetOutputMetadata& WantNewerVersionPresent(bool want = true) {
+    if (want) {
+      newer_version_present.emplace();
+    } else {
+      newer_version_present.reset();
+    }
+    return *this;
+  }
 };
 
 class ColumnFamilyHandle {
@@ -665,6 +744,28 @@ class DB {
     return s;
   }
 
+  inline Status GetWithMetadata(const ReadOptions& options,
+                                ColumnFamilyHandle* column_family,
+                                const Slice& key, std::string* value,
+                                OutputMetadata* output_metadata) {
+    if (output_metadata != nullptr &&
+        output_metadata->newer_version_present.has_value()) {
+      *output_metadata->newer_version_present = false;
+    }
+    if (value == nullptr) {
+      return Status::InvalidArgument(
+          "Cannot call GetWithMetadata with a null value");
+    }
+    PinnableSlice pinnable_val(value);
+    assert(!pinnable_val.IsPinned());
+    auto s = GetWithMetadata(options, column_family, key, &pinnable_val,
+                             output_metadata);
+    if (s.ok() && pinnable_val.IsPinned()) {
+      value->assign(pinnable_val.data(), pinnable_val.size());
+    }  // else value is already assigned
+    return s;
+  }
+
   // No timestamp, and value is returned in a PinnableSlice
   // NOTE: virtual final => disallow override (was previously allowed)
   virtual Status Get(const ReadOptions& options,
@@ -702,6 +803,12 @@ class DB {
   virtual Status Get(const ReadOptions& options, const Slice& key,
                      std::string* value, std::string* timestamp) final {
     return Get(options, DefaultColumnFamily(), key, value, timestamp);
+  }
+
+  Status GetWithMetadata(const ReadOptions& options, const Slice& key,
+                         std::string* value, OutputMetadata* output_metadata) {
+    return GetWithMetadata(options, DefaultColumnFamily(), key, value,
+                           output_metadata);
   }
 
   // If the column family specified by "column_family" contains an entry for
@@ -842,6 +949,42 @@ class DB {
     return statuses;
   }
 
+  std::vector<Status> MultiGetWithMetadata(
+      const ReadOptions& options,
+      const std::vector<ColumnFamilyHandle*>& column_families,
+      const std::vector<Slice>& keys, std::vector<std::string>* values,
+      MultiGetOutputMetadata* output_metadata) {
+    size_t num_keys = keys.size();
+    values->resize(num_keys);
+    if (column_families.size() != num_keys) {
+      if (output_metadata != nullptr) {
+        if (output_metadata->timestamps.has_value()) {
+          output_metadata->timestamps->resize(num_keys);
+        }
+        if (output_metadata->newer_version_present.has_value()) {
+          output_metadata->newer_version_present->assign(num_keys, false);
+        }
+      }
+      return std::vector<Status>(
+          num_keys,
+          Status::InvalidArgument("Number of column families does not match "
+                                  "number of keys"));
+    }
+
+    std::vector<Status> statuses(num_keys);
+    std::vector<PinnableSlice> pin_values(num_keys);
+
+    MultiGetWithMetadata(options, num_keys, column_families.data(), keys.data(),
+                         pin_values.data(), statuses.data(), output_metadata,
+                         /*sorted_input=*/false);
+    for (size_t i = 0; i < num_keys; ++i) {
+      if (statuses[i].ok()) {
+        (*values)[i].assign(pin_values[i].data(), pin_values[i].size());
+      }
+    }
+    return statuses;
+  }
+
   // No timestamps are returned
   // NOTE: virtual final => disallow override (was previously allowed)
   virtual std::vector<Status> MultiGet(
@@ -862,6 +1005,17 @@ class DB {
         options,
         std::vector<ColumnFamilyHandle*>(keys.size(), DefaultColumnFamily()),
         keys, values);
+  }
+
+  std::vector<Status> MultiGetWithMetadata(
+      const ReadOptions& options, const std::vector<Slice>& keys,
+      std::vector<std::string>* values,
+      MultiGetOutputMetadata* output_metadata) {
+    values->resize(keys.size());
+    return MultiGetWithMetadata(
+        options,
+        std::vector<ColumnFamilyHandle*>(keys.size(), DefaultColumnFamily()),
+        keys, values, output_metadata);
   }
 
   // MultiGet for default column family
@@ -918,6 +1072,15 @@ class DB {
                         PinnableSlice* values, std::string* timestamps,
                         Status* statuses,
                         const bool sorted_input = false) final;
+
+  // MultiGet for single column family with optional output metadata vectors.
+  // Non-null vectors in output_metadata are resized to num_keys entries.
+  void MultiGetWithMetadata(const ReadOptions& options,
+                            ColumnFamilyHandle* column_family,
+                            const size_t num_keys, const Slice* keys,
+                            PinnableSlice* values, Status* statuses,
+                            MultiGetOutputMetadata* output_metadata,
+                            const bool sorted_input = false);
 
   // MultiGet for single column family, no timestamps returned
   // NOTE: virtual final => disallow override (was previously allowed)
@@ -2637,6 +2800,30 @@ class DB {
   // Returns the non-owning native coroutine interface, or nullptr when this DB
   // does not support it. The returned pointer must not outlive this DB.
   virtual CoroDB* GetCoroDB() { return nullptr; }
+
+  // EXPERIMENTAL, subject to change.
+  // Returns the same value as Get() and populates requested output metadata.
+  // Newer-version tracking is supported for explicit-snapshot reads on the
+  // primary DB implementation. Newer-version tracking is not supported with
+  // kPersistedTier or by transaction reads that require a custom visibility
+  // callback. Read-only and compacted DBs return false because their in-process
+  // views are static. Secondary DBs and subclasses that do not implement
+  // tracking return NotSupported for explicit-snapshot tracking requests.
+  virtual Status GetWithMetadata(const ReadOptions& options,
+                                 ColumnFamilyHandle* column_family,
+                                 const Slice& key, PinnableSlice* value,
+                                 OutputMetadata* output_metadata);
+
+  // EXPERIMENTAL, subject to change.
+  // MultiGet equivalent of GetWithMetadata(). For each requested metadata
+  // field, the corresponding output vector is resized to num_keys entries.
+  virtual void MultiGetWithMetadata(const ReadOptions& options,
+                                    const size_t num_keys,
+                                    ColumnFamilyHandle* const* column_families,
+                                    const Slice* keys, PinnableSlice* values,
+                                    Status* statuses,
+                                    MultiGetOutputMetadata* output_metadata,
+                                    const bool sorted_input = false);
 };
 
 struct WriteStallStatsMapKeys {

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -111,6 +111,14 @@ class StackableDB : public DB {
   }
 
   using DB::GetAsync;
+  using DB::GetWithMetadata;
+  Status GetWithMetadata(const ReadOptions& options,
+                         ColumnFamilyHandle* column_family, const Slice& key,
+                         PinnableSlice* value,
+                         OutputMetadata* output_metadata) override {
+    return db_->GetWithMetadata(options, column_family, key, value,
+                                output_metadata);
+  }
 
   using DB::GetEntity;
 
@@ -153,6 +161,16 @@ class StackableDB : public DB {
   }
 
   using DB::MultiGetAsync;
+  using DB::MultiGetWithMetadata;
+  void MultiGetWithMetadata(const ReadOptions& options, const size_t num_keys,
+                            ColumnFamilyHandle* const* column_families,
+                            const Slice* keys, PinnableSlice* values,
+                            Status* statuses,
+                            MultiGetOutputMetadata* output_metadata,
+                            const bool sorted_input = false) override {
+    db_->MultiGetWithMetadata(options, num_keys, column_families, keys, values,
+                              statuses, output_metadata, sorted_input);
+  }
 
   using DB::MultiGetEntity;
 

--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -174,6 +174,7 @@ set(JAVA_MAIN_CLASSES
   src/main/java/org/rocksdb/FlushOptions.java
   src/main/java/org/rocksdb/FlushReason.java
   src/main/java/org/rocksdb/GetStatus.java
+  src/main/java/org/rocksdb/GetWithMetadataResult.java
   src/main/java/org/rocksdb/HashLinkedListMemTableConfig.java
   src/main/java/org/rocksdb/HashSkipListMemTableConfig.java
   src/main/java/org/rocksdb/HistogramData.java

--- a/java/rocksjni/rocksjni.cc
+++ b/java/rocksjni/rocksjni.cc
@@ -1568,6 +1568,79 @@ jbyteArray Java_org_rocksdb_RocksDB_get__JJ_3BIIJ(
   }
 }
 
+jobject Java_org_rocksdb_RocksDB_getWithMetadata(
+    JNIEnv* env, jclass, jlong jdb_handle, jlong jropt_handle, jbyteArray jkey,
+    jint jkey_off, jint jkey_len, jlong jcf_handle) {
+  auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
+  ROCKSDB_NAMESPACE::ColumnFamilyHandle* cf_handle =
+      jcf_handle == 0
+          ? db->DefaultColumnFamily()
+          : ROCKSDB_NAMESPACE::ColumnFamilyJNIHelpers::handleFromJLong(
+                env, jcf_handle);
+  if (cf_handle == nullptr) {
+    return nullptr;
+  }
+
+  try {
+    ROCKSDB_NAMESPACE::JByteArraySlice key(env, jkey, jkey_off, jkey_len);
+    ROCKSDB_NAMESPACE::JByteArrayPinnableSlice value(env);
+    ROCKSDB_NAMESPACE::OutputMetadata output_metadata;
+    output_metadata.WantTimestamp().WantNewerVersionPresent();
+    const ROCKSDB_NAMESPACE::Status s = db->GetWithMetadata(
+        *reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jropt_handle),
+        cf_handle, key.slice(), &value.pinnable_slice(), &output_metadata);
+    if (!s.ok() && !s.IsNotFound()) {
+      ROCKSDB_NAMESPACE::KVException::ThrowOnError(env, s);
+    }
+
+    jclass result_class = env->FindClass("org/rocksdb/GetWithMetadataResult");
+    if (result_class == nullptr) {
+      return nullptr;
+    }
+    jmethodID constructor =
+        env->GetMethodID(result_class, "<init>", "([B[BZ)V");
+    if (constructor == nullptr) {
+      env->DeleteLocalRef(result_class);
+      return nullptr;
+    }
+    jbyteArray jvalue_array = s.ok() ? value.NewByteArray() : nullptr;
+    if (s.ok() && jvalue_array == nullptr) {
+      env->DeleteLocalRef(result_class);
+      return nullptr;
+    }
+    jbyteArray jtimestamp =
+        ROCKSDB_NAMESPACE::JniUtil::createJavaByteArrayWithSizeCheck(
+            env, output_metadata.timestamp->data(),
+            static_cast<jint>(output_metadata.timestamp->size()));
+    if (jtimestamp == nullptr) {
+      if (jvalue_array != nullptr) {
+        env->DeleteLocalRef(jvalue_array);
+      }
+      env->DeleteLocalRef(result_class);
+      return nullptr;
+    }
+    jobject result = env->NewObject(
+        result_class, constructor, jvalue_array, jtimestamp,
+        static_cast<jboolean>(*output_metadata.newer_version_present));
+    if (result == nullptr) {
+      if (jvalue_array != nullptr) {
+        env->DeleteLocalRef(jvalue_array);
+      }
+      env->DeleteLocalRef(jtimestamp);
+      env->DeleteLocalRef(result_class);
+      return nullptr;
+    }
+    if (jvalue_array != nullptr) {
+      env->DeleteLocalRef(jvalue_array);
+    }
+    env->DeleteLocalRef(jtimestamp);
+    env->DeleteLocalRef(result_class);
+    return result;
+  } catch (ROCKSDB_NAMESPACE::KVException&) {
+    return nullptr;
+  }
+}
+
 /*
  * Class:     org_rocksdb_RocksDB
  * Method:    get
@@ -1805,6 +1878,105 @@ jobjectArray Java_org_rocksdb_RocksDB_multiGet__JJ_3_3B_3I_3I_3J(
 
   return ROCKSDB_NAMESPACE::MultiGetJNIValues::byteArrays(env, values,
                                                           statuses);
+}
+
+jobjectArray Java_org_rocksdb_RocksDB_multiGetWithMetadata(
+    JNIEnv* env, jclass, jlong jdb_handle, jlong jropt_handle,
+    jobjectArray jkeys, jintArray jkey_offs, jintArray jkey_lens,
+    jlongArray jcolumn_family_handles) {
+  ROCKSDB_NAMESPACE::MultiGetJNIKeys keys;
+  if (!keys.fromByteArrays(env, jkeys, jkey_offs, jkey_lens)) {
+    return nullptr;
+  }
+  auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
+  std::vector<ROCKSDB_NAMESPACE::ColumnFamilyHandle*> cf_handles;
+  if (jcolumn_family_handles == nullptr) {
+    cf_handles.assign(keys.size(), db->DefaultColumnFamily());
+  } else {
+    auto handles =
+        ROCKSDB_NAMESPACE::ColumnFamilyJNIHelpers::handlesFromJLongArray(
+            env, jcolumn_family_handles);
+    if (!handles) {
+      return nullptr;
+    }
+    cf_handles = std::move(*handles);
+  }
+
+  std::vector<ROCKSDB_NAMESPACE::PinnableSlice> values(keys.size());
+  std::vector<ROCKSDB_NAMESPACE::Status> statuses(keys.size());
+  ROCKSDB_NAMESPACE::MultiGetOutputMetadata output_metadata;
+  output_metadata.WantTimestamps().WantNewerVersionPresent();
+  db->MultiGetWithMetadata(
+      *reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jropt_handle),
+      keys.size(), cf_handles.data(), keys.data(), values.data(),
+      statuses.data(), &output_metadata);
+
+  jclass result_class = env->FindClass("org/rocksdb/GetWithMetadataResult");
+  if (result_class == nullptr) {
+    return nullptr;
+  }
+  jmethodID constructor = env->GetMethodID(result_class, "<init>", "([B[BZ)V");
+  if (constructor == nullptr) {
+    env->DeleteLocalRef(result_class);
+    return nullptr;
+  }
+  jobjectArray results = env->NewObjectArray(static_cast<jsize>(keys.size()),
+                                             result_class, nullptr);
+  if (results == nullptr) {
+    env->DeleteLocalRef(result_class);
+    return nullptr;
+  }
+
+  for (size_t i = 0; i < keys.size(); ++i) {
+    if (!statuses[i].ok() && !statuses[i].IsNotFound()) {
+      ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env, statuses[i]);
+      env->DeleteLocalRef(result_class);
+      return nullptr;
+    }
+    jbyteArray jvalue_array =
+        statuses[i].ok()
+            ? ROCKSDB_NAMESPACE::JniUtil::createJavaByteArrayWithSizeCheck(
+                  env, values[i].data(), static_cast<jint>(values[i].size()))
+            : nullptr;
+    if (statuses[i].ok() && jvalue_array == nullptr) {
+      env->DeleteLocalRef(result_class);
+      return nullptr;
+    }
+    const std::string& timestamp = (*output_metadata.timestamps)[i];
+    jbyteArray jtimestamp =
+        ROCKSDB_NAMESPACE::JniUtil::createJavaByteArrayWithSizeCheck(
+            env, timestamp.data(), static_cast<jint>(timestamp.size()));
+    if (jtimestamp == nullptr) {
+      if (jvalue_array != nullptr) {
+        env->DeleteLocalRef(jvalue_array);
+      }
+      env->DeleteLocalRef(result_class);
+      return nullptr;
+    }
+    jobject result = env->NewObject(
+        result_class, constructor, jvalue_array, jtimestamp,
+        static_cast<jboolean>((*output_metadata.newer_version_present)[i]));
+    if (result == nullptr) {
+      if (jvalue_array != nullptr) {
+        env->DeleteLocalRef(jvalue_array);
+      }
+      env->DeleteLocalRef(jtimestamp);
+      env->DeleteLocalRef(result_class);
+      return nullptr;
+    }
+    env->SetObjectArrayElement(results, static_cast<jsize>(i), result);
+    if (jvalue_array != nullptr) {
+      env->DeleteLocalRef(jvalue_array);
+    }
+    env->DeleteLocalRef(jtimestamp);
+    env->DeleteLocalRef(result);
+    if (env->ExceptionCheck()) {
+      env->DeleteLocalRef(result_class);
+      return nullptr;
+    }
+  }
+  env->DeleteLocalRef(result_class);
+  return results;
 }
 
 /*

--- a/java/rocksjni/rocksjni.cc
+++ b/java/rocksjni/rocksjni.cc
@@ -1568,6 +1568,85 @@ jbyteArray Java_org_rocksdb_RocksDB_get__JJ_3BIIJ(
   }
 }
 
+jobject Java_org_rocksdb_RocksDB_getWithMetadata(
+    JNIEnv* env, jclass, jlong jdb_handle, jlong jropt_handle, jbyteArray jkey,
+    jint jkey_off, jint jkey_len, jlong jcf_handle) {
+  auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
+  ROCKSDB_NAMESPACE::ColumnFamilyHandle* cf_handle =
+      jcf_handle == 0
+          ? db->DefaultColumnFamily()
+          : ROCKSDB_NAMESPACE::ColumnFamilyJNIHelpers::handleFromJLong(
+                env, jcf_handle);
+  if (cf_handle == nullptr) {
+    return nullptr;
+  }
+
+  try {
+    ROCKSDB_NAMESPACE::JByteArraySlice key(env, jkey, jkey_off, jkey_len);
+    ROCKSDB_NAMESPACE::JByteArrayPinnableSlice value(env);
+    ROCKSDB_NAMESPACE::OutputMetadata output_metadata;
+    output_metadata.WantNewerVersionPresent();
+    if (cf_handle->GetComparator()->timestamp_size() > 0) {
+      output_metadata.WantTimestamp();
+    }
+    const ROCKSDB_NAMESPACE::Status s = db->GetWithMetadata(
+        *reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jropt_handle),
+        cf_handle, key.slice(), &value.pinnable_slice(), &output_metadata);
+    if (!s.ok() && !s.IsNotFound()) {
+      ROCKSDB_NAMESPACE::KVException::ThrowOnError(env, s);
+    }
+
+    jclass result_class = env->FindClass("org/rocksdb/GetWithMetadataResult");
+    if (result_class == nullptr) {
+      return nullptr;
+    }
+    jmethodID constructor =
+        env->GetMethodID(result_class, "<init>", "([B[BZ)V");
+    if (constructor == nullptr) {
+      env->DeleteLocalRef(result_class);
+      return nullptr;
+    }
+    jbyteArray jvalue_array = s.ok() ? value.NewByteArray() : nullptr;
+    if (s.ok() && jvalue_array == nullptr) {
+      env->DeleteLocalRef(result_class);
+      return nullptr;
+    }
+    const std::string empty_timestamp;
+    const std::string& timestamp = output_metadata.timestamp.has_value()
+                                       ? *output_metadata.timestamp
+                                       : empty_timestamp;
+    jbyteArray jtimestamp =
+        ROCKSDB_NAMESPACE::JniUtil::createJavaByteArrayWithSizeCheck(
+            env, timestamp.data(), static_cast<jint>(timestamp.size()));
+    if (jtimestamp == nullptr) {
+      if (jvalue_array != nullptr) {
+        env->DeleteLocalRef(jvalue_array);
+      }
+      env->DeleteLocalRef(result_class);
+      return nullptr;
+    }
+    jobject result = env->NewObject(
+        result_class, constructor, jvalue_array, jtimestamp,
+        static_cast<jboolean>(*output_metadata.newer_version_present));
+    if (result == nullptr) {
+      if (jvalue_array != nullptr) {
+        env->DeleteLocalRef(jvalue_array);
+      }
+      env->DeleteLocalRef(jtimestamp);
+      env->DeleteLocalRef(result_class);
+      return nullptr;
+    }
+    if (jvalue_array != nullptr) {
+      env->DeleteLocalRef(jvalue_array);
+    }
+    env->DeleteLocalRef(jtimestamp);
+    env->DeleteLocalRef(result_class);
+    return result;
+  } catch (ROCKSDB_NAMESPACE::KVException&) {
+    return nullptr;
+  }
+}
+
 /*
  * Class:     org_rocksdb_RocksDB
  * Method:    get
@@ -1805,6 +1884,114 @@ jobjectArray Java_org_rocksdb_RocksDB_multiGet__JJ_3_3B_3I_3I_3J(
 
   return ROCKSDB_NAMESPACE::MultiGetJNIValues::byteArrays(env, values,
                                                           statuses);
+}
+
+jobjectArray Java_org_rocksdb_RocksDB_multiGetWithMetadata(
+    JNIEnv* env, jclass, jlong jdb_handle, jlong jropt_handle,
+    jobjectArray jkeys, jintArray jkey_offs, jintArray jkey_lens,
+    jlongArray jcolumn_family_handles) {
+  ROCKSDB_NAMESPACE::MultiGetJNIKeys keys;
+  if (!keys.fromByteArrays(env, jkeys, jkey_offs, jkey_lens)) {
+    return nullptr;
+  }
+  auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
+  std::vector<ROCKSDB_NAMESPACE::ColumnFamilyHandle*> cf_handles;
+  if (jcolumn_family_handles == nullptr) {
+    cf_handles.assign(keys.size(), db->DefaultColumnFamily());
+  } else {
+    auto handles =
+        ROCKSDB_NAMESPACE::ColumnFamilyJNIHelpers::handlesFromJLongArray(
+            env, jcolumn_family_handles);
+    if (!handles) {
+      return nullptr;
+    }
+    cf_handles = std::move(*handles);
+  }
+
+  std::vector<ROCKSDB_NAMESPACE::PinnableSlice> values(keys.size());
+  std::vector<ROCKSDB_NAMESPACE::Status> statuses(keys.size());
+  ROCKSDB_NAMESPACE::MultiGetOutputMetadata output_metadata;
+  output_metadata.WantNewerVersionPresent();
+  for (ROCKSDB_NAMESPACE::ColumnFamilyHandle* cf_handle : cf_handles) {
+    if (cf_handle->GetComparator()->timestamp_size() > 0) {
+      output_metadata.WantTimestamps();
+      break;
+    }
+  }
+  db->MultiGetWithMetadata(
+      *reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jropt_handle),
+      keys.size(), cf_handles.data(), keys.data(), values.data(),
+      statuses.data(), &output_metadata);
+
+  jclass result_class = env->FindClass("org/rocksdb/GetWithMetadataResult");
+  if (result_class == nullptr) {
+    return nullptr;
+  }
+  jmethodID constructor = env->GetMethodID(result_class, "<init>", "([B[BZ)V");
+  if (constructor == nullptr) {
+    env->DeleteLocalRef(result_class);
+    return nullptr;
+  }
+  jobjectArray results = env->NewObjectArray(static_cast<jsize>(keys.size()),
+                                             result_class, nullptr);
+  if (results == nullptr) {
+    env->DeleteLocalRef(result_class);
+    return nullptr;
+  }
+
+  const std::string empty_timestamp;
+  for (size_t i = 0; i < keys.size(); ++i) {
+    if (!statuses[i].ok() && !statuses[i].IsNotFound()) {
+      ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env, statuses[i]);
+      env->DeleteLocalRef(result_class);
+      return nullptr;
+    }
+    jbyteArray jvalue_array =
+        statuses[i].ok()
+            ? ROCKSDB_NAMESPACE::JniUtil::createJavaByteArrayWithSizeCheck(
+                  env, values[i].data(), static_cast<jint>(values[i].size()))
+            : nullptr;
+    if (statuses[i].ok() && jvalue_array == nullptr) {
+      env->DeleteLocalRef(result_class);
+      return nullptr;
+    }
+    const std::string& timestamp = output_metadata.timestamps.has_value()
+                                       ? (*output_metadata.timestamps)[i]
+                                       : empty_timestamp;
+    jbyteArray jtimestamp =
+        ROCKSDB_NAMESPACE::JniUtil::createJavaByteArrayWithSizeCheck(
+            env, timestamp.data(), static_cast<jint>(timestamp.size()));
+    if (jtimestamp == nullptr) {
+      if (jvalue_array != nullptr) {
+        env->DeleteLocalRef(jvalue_array);
+      }
+      env->DeleteLocalRef(result_class);
+      return nullptr;
+    }
+    jobject result = env->NewObject(
+        result_class, constructor, jvalue_array, jtimestamp,
+        static_cast<jboolean>((*output_metadata.newer_version_present)[i]));
+    if (result == nullptr) {
+      if (jvalue_array != nullptr) {
+        env->DeleteLocalRef(jvalue_array);
+      }
+      env->DeleteLocalRef(jtimestamp);
+      env->DeleteLocalRef(result_class);
+      return nullptr;
+    }
+    env->SetObjectArrayElement(results, static_cast<jsize>(i), result);
+    if (jvalue_array != nullptr) {
+      env->DeleteLocalRef(jvalue_array);
+    }
+    env->DeleteLocalRef(jtimestamp);
+    env->DeleteLocalRef(result);
+    if (env->ExceptionCheck()) {
+      env->DeleteLocalRef(result_class);
+      return nullptr;
+    }
+  }
+  env->DeleteLocalRef(result_class);
+  return results;
 }
 
 /*

--- a/java/src/main/java/org/rocksdb/AbstractEventListener.java
+++ b/java/src/main/java/org/rocksdb/AbstractEventListener.java
@@ -5,8 +5,6 @@
 
 package org.rocksdb;
 
-import static org.rocksdb.AbstractEventListener.EnabledEventCallback.*;
-
 /**
  * Base class for Event Listeners.
  */
@@ -79,13 +77,20 @@ public abstract class AbstractEventListener extends RocksCallbackObject implemen
    * {@link #AbstractEventListener(EnabledEventCallback...)} instead.
    */
   protected AbstractEventListener() {
-    this(ON_FLUSH_COMPLETED, ON_FLUSH_BEGIN, ON_TABLE_FILE_DELETED, ON_COMPACTION_BEGIN,
-        ON_COMPACTION_COMPLETED, ON_TABLE_FILE_CREATED, ON_TABLE_FILE_CREATION_STARTED,
-        ON_MEMTABLE_SEALED, ON_COLUMN_FAMILY_HANDLE_DELETION_STARTED, ON_EXTERNAL_FILE_INGESTED,
-        ON_BACKGROUND_ERROR, ON_STALL_CONDITIONS_CHANGED, ON_FILE_READ_FINISH, ON_FILE_WRITE_FINISH,
-        ON_FILE_FLUSH_FINISH, ON_FILE_SYNC_FINISH, ON_FILE_RANGE_SYNC_FINISH,
-        ON_FILE_TRUNCATE_FINISH, ON_FILE_CLOSE_FINISH, SHOULD_BE_NOTIFIED_ON_FILE_IO,
-        ON_ERROR_RECOVERY_BEGIN, ON_ERROR_RECOVERY_COMPLETED);
+    this(EnabledEventCallback.ON_FLUSH_COMPLETED, EnabledEventCallback.ON_FLUSH_BEGIN,
+        EnabledEventCallback.ON_TABLE_FILE_DELETED, EnabledEventCallback.ON_COMPACTION_BEGIN,
+        EnabledEventCallback.ON_COMPACTION_COMPLETED, EnabledEventCallback.ON_TABLE_FILE_CREATED,
+        EnabledEventCallback.ON_TABLE_FILE_CREATION_STARTED,
+        EnabledEventCallback.ON_MEMTABLE_SEALED,
+        EnabledEventCallback.ON_COLUMN_FAMILY_HANDLE_DELETION_STARTED,
+        EnabledEventCallback.ON_EXTERNAL_FILE_INGESTED, EnabledEventCallback.ON_BACKGROUND_ERROR,
+        EnabledEventCallback.ON_STALL_CONDITIONS_CHANGED, EnabledEventCallback.ON_FILE_READ_FINISH,
+        EnabledEventCallback.ON_FILE_WRITE_FINISH, EnabledEventCallback.ON_FILE_FLUSH_FINISH,
+        EnabledEventCallback.ON_FILE_SYNC_FINISH, EnabledEventCallback.ON_FILE_RANGE_SYNC_FINISH,
+        EnabledEventCallback.ON_FILE_TRUNCATE_FINISH, EnabledEventCallback.ON_FILE_CLOSE_FINISH,
+        EnabledEventCallback.SHOULD_BE_NOTIFIED_ON_FILE_IO,
+        EnabledEventCallback.ON_ERROR_RECOVERY_BEGIN,
+        EnabledEventCallback.ON_ERROR_RECOVERY_COMPLETED);
   }
 
   /**

--- a/java/src/main/java/org/rocksdb/GetWithMetadataResult.java
+++ b/java/src/main/java/org/rocksdb/GetWithMetadataResult.java
@@ -1,0 +1,22 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+package org.rocksdb;
+
+/** Result from an experimental metadata read. */
+public final class GetWithMetadataResult {
+  public final byte[] value;
+  public final byte[] timestamp;
+  public final boolean newerVersionPresent;
+
+  @SuppressWarnings("PMD.ArrayIsStoredDirectly")
+  GetWithMetadataResult(
+      final byte[] value, final byte[] timestamp, final boolean newerVersionPresent) {
+    this.value = value;
+    this.timestamp = timestamp;
+    this.newerVersionPresent = newerVersionPresent;
+  }
+}

--- a/java/src/main/java/org/rocksdb/RocksDB.java
+++ b/java/src/main/java/org/rocksdb/RocksDB.java
@@ -2276,6 +2276,35 @@ public class RocksDB extends RocksObject {
   }
 
   /**
+   * Returns the snapshot-visible value together with timestamp and
+   * newer-version metadata.
+   *
+   * @param opt read options
+   * @param key key to read
+   * @return metadata result; its value is null when the key is not found
+   * @throws RocksDBException if the native read fails
+   */
+  public GetWithMetadataResult getWithMetadata(final ReadOptions opt, final byte[] key)
+      throws RocksDBException {
+    return getWithMetadata(nativeHandle_, opt.nativeHandle_, key, 0, key.length, 0);
+  }
+
+  /**
+   * Returns metadata for a key in the specified column family.
+   *
+   * @param columnFamilyHandle column family containing the key
+   * @param opt read options
+   * @param key key to read
+   * @return metadata result; its value is null when the key is not found
+   * @throws RocksDBException if the native read fails
+   */
+  public GetWithMetadataResult getWithMetadata(final ColumnFamilyHandle columnFamilyHandle,
+      final ReadOptions opt, final byte[] key) throws RocksDBException {
+    return getWithMetadata(
+        nativeHandle_, opt.nativeHandle_, key, 0, key.length, columnFamilyHandle.nativeHandle_);
+  }
+
+  /**
    * Takes a list of keys, and returns a list of values for the given list of
    * keys. List will contain null for keys which could not be found.
    *
@@ -2372,6 +2401,56 @@ public class RocksDB extends RocksObject {
 
     return Arrays.asList(multiGet(nativeHandle_, opt.nativeHandle_,
         keysArray, keyOffsets, keyLengths));
+  }
+
+  /**
+   * Returns values and metadata for the supplied keys.
+   *
+   * @param opt read options
+   * @param keys keys to read
+   * @return results in input order
+   * @throws RocksDBException if a native read fails
+   */
+  public List<GetWithMetadataResult> multiGetWithMetadata(
+      final ReadOptions opt, final List<byte[]> keys) throws RocksDBException {
+    assert (!keys.isEmpty());
+    final byte[][] keysArray = keys.toArray(new byte[keys.size()][]);
+    final int[] keyOffsets = new int[keysArray.length];
+    final int[] keyLengths = new int[keysArray.length];
+    for (int i = 0; i < keyLengths.length; i++) {
+      keyLengths[i] = keysArray[i].length;
+    }
+    return Arrays.asList(multiGetWithMetadata(
+        nativeHandle_, opt.nativeHandle_, keysArray, keyOffsets, keyLengths, null));
+  }
+
+  /**
+   * Returns values and metadata for keys in the supplied column families.
+   *
+   * @param opt read options
+   * @param columnFamilyHandles one column family for each key
+   * @param keys keys to read
+   * @return results in input order
+   * @throws RocksDBException if a native read fails
+   */
+  public List<GetWithMetadataResult> multiGetWithMetadata(final ReadOptions opt,
+      final List<ColumnFamilyHandle> columnFamilyHandles, final List<byte[]> keys)
+      throws RocksDBException {
+    if (keys.size() != columnFamilyHandles.size()) {
+      throw new IllegalArgumentException("For each key there must be a ColumnFamilyHandle.");
+    }
+    final long[] cfHandles = new long[columnFamilyHandles.size()];
+    for (int i = 0; i < columnFamilyHandles.size(); i++) {
+      cfHandles[i] = columnFamilyHandles.get(i).nativeHandle_;
+    }
+    final byte[][] keysArray = keys.toArray(new byte[keys.size()][]);
+    final int[] keyOffsets = new int[keysArray.length];
+    final int[] keyLengths = new int[keysArray.length];
+    for (int i = 0; i < keyLengths.length; i++) {
+      keyLengths[i] = keysArray[i].length;
+    }
+    return Arrays.asList(multiGetWithMetadata(
+        nativeHandle_, opt.nativeHandle_, keysArray, keyOffsets, keyLengths, cfHandles));
   }
 
   /**
@@ -4985,6 +5064,9 @@ public class RocksDB extends RocksObject {
       final int keyOffset, final int keyLength) throws RocksDBException;
   private static native byte[] get(final long handle, final long readOptHandle, final byte[] key,
       final int keyOffset, final int keyLength, final long cfHandle) throws RocksDBException;
+  private static native GetWithMetadataResult getWithMetadata(final long handle,
+      final long readOptHandle, final byte[] key, final int keyOffset, final int keyLength,
+      final long cfHandle) throws RocksDBException;
   private static native byte[][] multiGet(
       final long dbHandle, final byte[][] keys, final int[] keyOffsets, final int[] keyLengths);
   private static native byte[][] multiGet(final long dbHandle, final byte[][] keys,
@@ -4993,6 +5075,9 @@ public class RocksDB extends RocksObject {
       final byte[][] keys, final int[] keyOffsets, final int[] keyLengths);
   private static native byte[][] multiGet(final long dbHandle, final long rOptHandle,
       final byte[][] keys, final int[] keyOffsets, final int[] keyLengths,
+      final long[] columnFamilyHandles);
+  private static native GetWithMetadataResult[] multiGetWithMetadata(final long dbHandle,
+      final long rOptHandle, final byte[][] keys, final int[] keyOffsets, final int[] keyLengths,
       final long[] columnFamilyHandles);
 
   private static native void multiGet(final long dbHandle, final long rOptHandle,

--- a/java/src/main/java/org/rocksdb/util/BytewiseComparator.java
+++ b/java/src/main/java/org/rocksdb/util/BytewiseComparator.java
@@ -5,15 +5,15 @@
 
 package org.rocksdb.util;
 
-import org.rocksdb.*;
+import static org.rocksdb.util.ByteUtil.memcmp;
 
 import java.nio.ByteBuffer;
-
-import static org.rocksdb.util.ByteUtil.memcmp;
+import org.rocksdb.AbstractComparator;
+import org.rocksdb.ComparatorOptions;
 
 /**
  * This is a Java Native implementation of the C++
- * equivalent BytewiseComparatorImpl using {@link Slice}
+ * equivalent BytewiseComparatorImpl using {@link org.rocksdb.Slice}
  *
  * The performance of Comparators implemented in Java is always
  * less than their C++ counterparts due to the bridging overhead,

--- a/java/src/test/java/org/rocksdb/SnapshotTest.java
+++ b/java/src/test/java/org/rocksdb/SnapshotTest.java
@@ -4,12 +4,14 @@
 //  (found in the LICENSE.Apache file in the root directory).
 package org.rocksdb;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class SnapshotTest {
 
@@ -43,6 +45,18 @@ public class SnapshotTest {
               "key".getBytes()))).isEqualTo("value");
           // add new key/value pair
           db.put("newkey".getBytes(), "newvalue".getBytes());
+          final GetWithMetadataResult createdAfterSnapshot =
+              db.getWithMetadata(readOptions, "newkey".getBytes());
+          assertThat(createdAfterSnapshot.value).isNull();
+          assertThat(createdAfterSnapshot.newerVersionPresent).isTrue();
+
+          final List<GetWithMetadataResult> metadataResults = db.multiGetWithMetadata(
+              readOptions, Arrays.asList("key".getBytes(), "newkey".getBytes()));
+          assertThat(new String(metadataResults.get(0).value)).isEqualTo("value");
+          assertThat(metadataResults.get(0).newerVersionPresent).isFalse();
+          assertThat(metadataResults.get(1).value).isNull();
+          assertThat(metadataResults.get(1).newerVersionPresent).isTrue();
+
           // using no snapshot the latest db entries
           // will be taken into account
           assertThat(new String(db.get("newkey".getBytes()))).

--- a/java/src/test/java/org/rocksdb/TtlDBTest.java
+++ b/java/src/test/java/org/rocksdb/TtlDBTest.java
@@ -52,6 +52,33 @@ public class TtlDBTest {
   }
 
   @Test
+  public void metadataReadsWithSnapshot() throws RocksDBException {
+    final byte[] key = "key".getBytes(StandardCharsets.UTF_8);
+    final byte[] oldValue = "old".getBytes(StandardCharsets.UTF_8);
+    final byte[] newValue = "new".getBytes(StandardCharsets.UTF_8);
+    try (final Options options = new Options().setCreateIfMissing(true);
+        final TtlDB ttlDB = TtlDB.open(options, dbFolder.getRoot().getAbsolutePath())) {
+      ttlDB.put(key, oldValue);
+      try (final Snapshot snapshot = ttlDB.getSnapshot();
+          final ReadOptions readOptions = new ReadOptions().setSnapshot(snapshot)) {
+        ttlDB.put(key, newValue);
+
+        final GetWithMetadataResult result = ttlDB.getWithMetadata(readOptions, key);
+        assertThat(result.value).isEqualTo(oldValue);
+        assertThat(result.timestamp).isEmpty();
+        assertThat(result.newerVersionPresent).isTrue();
+
+        final List<GetWithMetadataResult> results =
+            ttlDB.multiGetWithMetadata(readOptions, Arrays.asList(key));
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).value).isEqualTo(oldValue);
+        assertThat(results.get(0).timestamp).isEmpty();
+        assertThat(results.get(0).newerVersionPresent).isTrue();
+      }
+    }
+  }
+
+  @Test
   public void ttlDBSimpleIterator() throws RocksDBException {
     try (final Options options = new Options().setCreateIfMissing(true).setMaxCompactionBytes(0);
          final TtlDB ttlDB = TtlDB.open(options, dbFolder.getRoot().getAbsolutePath())) {

--- a/memtable/wbwi_memtable.cc
+++ b/memtable/wbwi_memtable.cc
@@ -49,7 +49,8 @@ bool WBWIMemTable::Get(const LookupKey& key, std::string* value,
                        SequenceNumber* out_seq, const ReadOptions&,
                        bool immutable_memtable, ReadCallback* callback,
                        bool* is_blob_index, bool do_merge,
-                       const BlobFetcher* blob_fetcher) {
+                       const BlobFetcher* blob_fetcher,
+                       const MetadataReadCtx* metadata_ctx) {
   assert(s->ok() || s->IsMergeInProgress());
   (void)immutable_memtable;
   (void)timestamp;
@@ -89,6 +90,10 @@ bool WBWIMemTable::Get(const LookupKey& key, std::string* value,
     assert(type != kTypeWideColumnEntity);
     assert(type != kTypeValuePreferredSeqno);
     assert(type != kTypeDeletionWithTimestamp);
+    if (UNLIKELY(metadata_ctx != nullptr) && IsValueType(type) &&
+        metadata_ctx->ShouldRecordNewerVersion(seq, callback)) {
+      metadata_ctx->MarkNewerVersionPresent();
+    }
     if (!callback || callback->IsVisible(seq)) {
       if (*out_seq == kMaxSequenceNumber) {
         *out_seq = std::max(seq, *max_covering_tombstone_seq);
@@ -171,11 +176,11 @@ void WBWIMemTable::MultiGet(const ReadOptions& read_options,
   // TODO: reuse the InternalIterator created in Get().
   for (auto iter = range->begin(); iter != range->end(); ++iter) {
     SequenceNumber dummy_seq = 0;
-    bool found_final_value =
-        Get(*iter->lkey, iter->value ? iter->value->GetSelf() : nullptr,
-            iter->columns, iter->timestamp, iter->s, &(iter->merge_context),
-            &(iter->max_covering_tombstone_seq), &dummy_seq, read_options, true,
-            callback, nullptr, true);
+    bool found_final_value = Get(
+        *iter->lkey, iter->value ? iter->value->GetSelf() : nullptr,
+        iter->columns, iter->timestamp, iter->s, &(iter->merge_context),
+        &(iter->max_covering_tombstone_seq), &dummy_seq, read_options, true,
+        callback, nullptr, true, /*blob_fetcher=*/nullptr, iter->metadata_ctx);
     if (found_final_value) {
       if (iter->s->ok() || iter->s->IsNotFound()) {
         if (iter->value) {

--- a/memtable/wbwi_memtable.cc
+++ b/memtable/wbwi_memtable.cc
@@ -46,10 +46,25 @@ bool WBWIMemTable::Get(const LookupKey& key, std::string* value,
                        PinnableWideColumns* columns, std::string* timestamp,
                        Status* s, MergeContext* merge_context,
                        SequenceNumber* max_covering_tombstone_seq,
-                       SequenceNumber* out_seq, const ReadOptions&,
+                       SequenceNumber* out_seq, const ReadOptions& read_opts,
                        bool immutable_memtable, ReadCallback* callback,
                        bool* is_blob_index, bool do_merge,
                        const BlobFetcher* blob_fetcher) {
+  return GetImpl(key, value, columns, timestamp, s, merge_context,
+                 max_covering_tombstone_seq, out_seq, read_opts,
+                 immutable_memtable, callback, is_blob_index, do_merge,
+                 blob_fetcher, /*newer_version_present=*/nullptr);
+}
+
+bool WBWIMemTable::GetImpl(const LookupKey& key, std::string* value,
+                           PinnableWideColumns* columns, std::string* timestamp,
+                           Status* s, MergeContext* merge_context,
+                           SequenceNumber* max_covering_tombstone_seq,
+                           SequenceNumber* out_seq, const ReadOptions&,
+                           bool immutable_memtable, ReadCallback* callback,
+                           bool* is_blob_index, bool do_merge,
+                           const BlobFetcher* blob_fetcher,
+                           bool* newer_version_present) {
   assert(s->ok() || s->IsMergeInProgress());
   (void)immutable_memtable;
   (void)timestamp;
@@ -89,6 +104,10 @@ bool WBWIMemTable::Get(const LookupKey& key, std::string* value,
     assert(type != kTypeWideColumnEntity);
     assert(type != kTypeValuePreferredSeqno);
     assert(type != kTypeDeletionWithTimestamp);
+    if (UNLIKELY(callback != nullptr &&
+                 callback->NeedToTrackNewerVersions(newer_version_present))) {
+      callback->MaybeRecordNewerVersion(seq, type, newer_version_present);
+    }
     if (!callback || callback->IsVisible(seq)) {
       if (*out_seq == kMaxSequenceNumber) {
         *out_seq = std::max(seq, *max_covering_tombstone_seq);
@@ -171,11 +190,14 @@ void WBWIMemTable::MultiGet(const ReadOptions& read_options,
   // TODO: reuse the InternalIterator created in Get().
   for (auto iter = range->begin(); iter != range->end(); ++iter) {
     SequenceNumber dummy_seq = 0;
-    bool found_final_value =
-        Get(*iter->lkey, iter->value ? iter->value->GetSelf() : nullptr,
-            iter->columns, iter->timestamp, iter->s, &(iter->merge_context),
-            &(iter->max_covering_tombstone_seq), &dummy_seq, read_options, true,
-            callback, nullptr, true);
+    bool found_final_value = GetImpl(
+        *iter->lkey, iter->value ? iter->value->GetSelf() : nullptr,
+        iter->columns, iter->timestamp, iter->s, &(iter->merge_context),
+        &(iter->max_covering_tombstone_seq), &dummy_seq, read_options, true,
+        callback, nullptr, true, /*blob_fetcher=*/nullptr,
+        callback != nullptr && callback->GetMetadataReadBounds() != nullptr
+            ? &iter->newer_version_present
+            : nullptr);
     if (found_final_value) {
       if (iter->s->ok() || iter->s->IsNotFound()) {
         if (iter->value) {

--- a/memtable/wbwi_memtable.h
+++ b/memtable/wbwi_memtable.h
@@ -134,8 +134,8 @@ class WBWIMemTable final : public ReadOnlyMemTable {
            SequenceNumber* max_covering_tombstone_seq, SequenceNumber* seq,
            const ReadOptions& read_opts, bool immutable_memtable,
            ReadCallback* callback = nullptr, bool* is_blob_index = nullptr,
-           bool do_merge = true,
-           const BlobFetcher* blob_fetcher = nullptr) override;
+           bool do_merge = true, const BlobFetcher* blob_fetcher = nullptr,
+           const MetadataReadCtx* metadata_ctx = nullptr) override;
 
   void MultiGet(const ReadOptions& read_options, MultiGetRange* range,
                 ReadCallback* callback, bool immutable_memtable,

--- a/memtable/wbwi_memtable.h
+++ b/memtable/wbwi_memtable.h
@@ -226,6 +226,14 @@ class WBWIMemTable final : public ReadOnlyMemTable {
  private:
   inline InternalIterator* NewIterator() const;
 
+  bool GetImpl(const LookupKey& key, std::string* value,
+               PinnableWideColumns* columns, std::string* timestamp, Status* s,
+               MergeContext* merge_context,
+               SequenceNumber* max_covering_tombstone_seq, SequenceNumber* seq,
+               const ReadOptions& read_opts, bool immutable_memtable,
+               ReadCallback* callback, bool* is_blob_index, bool do_merge,
+               const BlobFetcher* blob_fetcher, bool* newer_version_present);
+
   std::shared_ptr<WriteBatchWithIndex> wbwi_;
   const Comparator* comparator_;
   InternalKeyComparator ikey_comparator_;

--- a/table/get_context.cc
+++ b/table/get_context.cc
@@ -113,6 +113,15 @@ void GetContext::MarkKeyMayExist() {
   }
 }
 
+void GetContext::RecordNewerVersionIfNeeded(SequenceNumber seq) {
+  // Caller already filtered out the no-tracking case via
+  // NeedToTrackNewerVersions().
+  assert(metadata_ctx_ != nullptr);
+  if (metadata_ctx_->ShouldRecordNewerVersion(seq, callback_)) {
+    metadata_ctx_->MarkNewerVersionPresent();
+  }
+}
+
 Status GetContext::SaveWideColumnEntityToPinnable(
     const Slice& user_key, const Slice& entity, Cleanable* value_pinner,
     const SameFileBlobReader* same_file_reader) {
@@ -361,6 +370,9 @@ bool GetContext::SaveValue(const ParsedInternalKey& parsed_key,
          merge_context_ != nullptr);
   if (ucmp_->EqualWithoutTimestamp(parsed_key.user_key, user_key_)) {
     *matched = true;
+    if (UNLIKELY(NeedToTrackNewerVersions()) && IsValueType(parsed_key.type)) {
+      RecordNewerVersionIfNeeded(parsed_key.sequence);
+    }
     // If the value is not in the snapshot, skip it
     if (!CheckCallback(parsed_key.sequence)) {
       return true;  // to continue to the next seq

--- a/table/get_context.cc
+++ b/table/get_context.cc
@@ -113,6 +113,15 @@ void GetContext::MarkKeyMayExist() {
   }
 }
 
+void GetContext::RecordNewerVersionIfNeeded(SequenceNumber seq,
+                                            ValueType type) {
+  // Caller already filtered out the no-tracking case via
+  // NeedToTrackNewerVersions().
+  assert(callback_ != nullptr);
+  callback_->MaybeRecordNewerVersion(
+      seq, type, has_newer_version_result_ ? newer_version_present_ : nullptr);
+}
+
 Status GetContext::SaveWideColumnEntityToPinnable(
     const Slice& user_key, const Slice& entity, Cleanable* value_pinner,
     const SameFileBlobReader* same_file_reader) {
@@ -155,7 +164,7 @@ Status GetContext::SaveWideColumnEntityToColumns(
     return status;
   }
 
-  if (lazy_columns_same_file_reader_ != nullptr) {
+  if (!has_newer_version_result_ && lazy_columns_same_file_reader_ != nullptr) {
     // Lazy mode (GetEntityLazy): leave blob references unresolved so the caller
     // can resolve them on demand (by column / byte range). Capture the
     // SameFileBlobReader (the SST that held this entity, if it has embedded
@@ -361,9 +370,14 @@ bool GetContext::SaveValue(const ParsedInternalKey& parsed_key,
          merge_context_ != nullptr);
   if (ucmp_->EqualWithoutTimestamp(parsed_key.user_key, user_key_)) {
     *matched = true;
-    // If the value is not in the snapshot, skip it
-    if (!CheckCallback(parsed_key.sequence)) {
-      return true;  // to continue to the next seq
+    if (callback_ != nullptr) {
+      if (UNLIKELY(NeedToTrackNewerVersions())) {
+        RecordNewerVersionIfNeeded(parsed_key.sequence, parsed_key.type);
+      }
+      // If the value is not in the snapshot, skip it.
+      if (!callback_->IsVisible(parsed_key.sequence)) {
+        return true;  // to continue to the next seq
+      }
     }
 
     if (seq_ != nullptr) {

--- a/table/get_context.h
+++ b/table/get_context.h
@@ -202,6 +202,27 @@ class GetContext {
   // Do we need to fetch the SequenceNumber for this key?
   bool NeedToReadSequence() const { return (seq_ != nullptr); }
 
+  // Do we need to track point versions skipped by the read visibility
+  // callback?
+  bool NeedToTrackNewerVersions() const {
+    return metadata_ctx_ != nullptr && !metadata_ctx_->HasNewerVersion();
+  }
+
+  void SetMetadataReadCtx(const MetadataReadCtx* metadata_ctx) {
+    metadata_ctx_ = metadata_ctx;
+  }
+
+  const MetadataReadCtx* metadata_read_ctx() const { return metadata_ctx_; }
+
+  ReadCallback* read_callback() const { return callback_; }
+
+  void RecordNewerVersionIfNeeded(SequenceNumber seq);
+
+  void MarkNewerVersionPresent() {
+    assert(metadata_ctx_ != nullptr);
+    metadata_ctx_->MarkNewerVersionPresent();
+  }
+
   bool sample() const { return sample_; }
 
   bool CheckCallback(SequenceNumber seq) {
@@ -297,6 +318,8 @@ class GetContext {
   // caller can resolve same-file/embedded references on demand later. Only the
   // SST read path (Version::Get) sets this; memtable hits are unaffected.
   const SameFileBlobReader** lazy_columns_same_file_reader_;
+  // nullptr when newer-version metadata tracking is not requested.
+  const MetadataReadCtx* metadata_ctx_ = nullptr;
 };
 
 // Call this to replay a log and bring the get_context up to date. The replay

--- a/table/get_context.h
+++ b/table/get_context.h
@@ -202,6 +202,30 @@ class GetContext {
   // Do we need to fetch the SequenceNumber for this key?
   bool NeedToReadSequence() const { return (seq_ != nullptr); }
 
+  // Do we need to track point versions skipped by the read visibility
+  // callback?
+  bool NeedToTrackNewerVersions() const {
+    const bool* per_key_result =
+        has_newer_version_result_ ? newer_version_present_ : nullptr;
+    return callback_ != nullptr &&
+           callback_->NeedToTrackNewerVersions(per_key_result);
+  }
+
+  void SetNewerVersionResult(bool* newer_version_present) {
+    assert(!has_newer_version_result_);
+    assert(lazy_columns_same_file_reader_ == nullptr);
+    newer_version_present_ = newer_version_present;
+    has_newer_version_result_ = true;
+  }
+
+  const MetadataReadBounds* metadata_read_bounds() const {
+    return callback_ != nullptr ? callback_->GetMetadataReadBounds() : nullptr;
+  }
+
+  ReadCallback* read_callback() const { return callback_; }
+
+  void RecordNewerVersionIfNeeded(SequenceNumber seq, ValueType type);
+
   bool sample() const { return sample_; }
 
   bool CheckCallback(SequenceNumber seq) {
@@ -286,6 +310,7 @@ class GetContext {
   // called as part of DB GetMergeOperands API. When it's false merge operators
   // are never merged.
   bool do_merge_;
+  bool has_newer_version_result_ = false;
   bool* is_blob_index_;
   // Used for block cache tracing only. A tracing get id uniquely identifies a
   // Get or a MultiGet.
@@ -296,7 +321,12 @@ class GetContext {
   // SameFileBlobReader for the SST that held it (if any) is stored here so the
   // caller can resolve same-file/embedded references on demand later. Only the
   // SST read path (Version::Get) sets this; memtable hits are unaffected.
-  const SameFileBlobReader** lazy_columns_same_file_reader_;
+  // Lazy-column and metadata reads are mutually exclusive. Reuse the pointer
+  // slot so ordinary reads do not pay an object-size cost for metadata output.
+  union {
+    const SameFileBlobReader** lazy_columns_same_file_reader_;
+    bool* newer_version_present_;
+  };
 };
 
 // Call this to replay a log and bring the get_context up to date. The replay

--- a/table/multiget_context.h
+++ b/table/multiget_context.h
@@ -11,6 +11,7 @@
 #include "db/dbformat.h"
 #include "db/lookup_key.h"
 #include "db/merge_context.h"
+#include "db/read_callback.h"
 #include "rocksdb/env.h"
 #include "rocksdb/options.h"
 #include "rocksdb/statistics.h"
@@ -36,10 +37,14 @@ struct KeyContext {
   SequenceNumber max_covering_tombstone_seq;
   bool key_exists;
   bool is_blob_index;
+  bool newer_version_present;
   void* cb_arg;
   PinnableSlice* value;
   PinnableWideColumns* columns;
   std::string* timestamp;
+  // Read-path metadata bundle; nullptr when not tracking newer versions.
+  // Storage owned by the caller (e.g., a per-batch array in MultiGetCommon).
+  const MetadataReadCtx* metadata_ctx;
   GetContext* get_context;
 
   KeyContext(ColumnFamilyHandle* col_family, const Slice& user_key,
@@ -52,10 +57,12 @@ struct KeyContext {
         max_covering_tombstone_seq(0),
         key_exists(false),
         is_blob_index(false),
+        newer_version_present(false),
         cb_arg(nullptr),
         value(val),
         columns(cols),
         timestamp(ts),
+        metadata_ctx(nullptr),
         get_context(nullptr) {}
 };
 
@@ -145,6 +152,9 @@ class MultiGetContext {
       sorted_keys_[iter]->timestamp = (*sorted_keys)[begin + iter]->timestamp;
       sorted_keys_[iter]->get_context =
           (*sorted_keys)[begin + iter]->get_context;
+      if (sorted_keys_[iter]->metadata_ctx != nullptr) {
+        has_metadata_read_ctx_ = true;
+      }
     }
   }
 
@@ -169,6 +179,7 @@ class MultiGetContext {
                                                     MAX_LOOKUP_KEYS_ON_STACK];
   std::array<KeyContext*, MAX_BATCH_SIZE> sorted_keys_;
   size_t num_keys_;
+  bool has_metadata_read_ctx_ = false;
   Mask value_mask_;
   uint64_t value_size_;
   std::unique_ptr<char[]> lookup_key_heap_buf;
@@ -180,6 +191,8 @@ class MultiGetContext {
 #endif  // USE_COROUTINES
 
  public:
+  bool HasMetadataReadCtx() const { return has_metadata_read_ctx_; }
+
   // MultiGetContext::Range - Specifies a range of keys, by start and end index,
   // from the parent MultiGetContext. Each range contains a bit vector that
   // indicates whether the corresponding keys need to be processed or skipped.

--- a/table/multiget_context.h
+++ b/table/multiget_context.h
@@ -11,6 +11,7 @@
 #include "db/dbformat.h"
 #include "db/lookup_key.h"
 #include "db/merge_context.h"
+#include "db/read_callback.h"
 #include "rocksdb/env.h"
 #include "rocksdb/options.h"
 #include "rocksdb/statistics.h"
@@ -36,6 +37,7 @@ struct KeyContext {
   SequenceNumber max_covering_tombstone_seq;
   bool key_exists;
   bool is_blob_index;
+  bool newer_version_present;
   void* cb_arg;
   PinnableSlice* value;
   PinnableWideColumns* columns;
@@ -52,6 +54,7 @@ struct KeyContext {
         max_covering_tombstone_seq(0),
         key_exists(false),
         is_blob_index(false),
+        newer_version_present(false),
         cb_arg(nullptr),
         value(val),
         columns(cols),

--- a/tools/c_api_gen/c_base.cc
+++ b/tools/c_api_gen/c_base.cc
@@ -2429,6 +2429,59 @@ char* rocksdb_get(rocksdb_t* db, const rocksdb_readoptions_t* options,
   return result;
 }
 
+static char* rocksdb_get_with_metadata_impl(
+    rocksdb_t* db, const rocksdb_readoptions_t* options,
+    ColumnFamilyHandle* column_family, const char* key, size_t keylen,
+    size_t* vallen, char** timestamp, size_t* timestamp_len,
+    unsigned char* newer_version_present, char** errptr) {
+  ROCKSDB_NAMESPACE::OutputMetadata output_metadata;
+  if (timestamp != nullptr && timestamp_len != nullptr) {
+    output_metadata.WantTimestamp();
+  }
+  if (newer_version_present != nullptr) {
+    output_metadata.WantNewerVersionPresent();
+  }
+
+  PinnableSlice pinnable_val;
+  const Status s =
+      db->rep->GetWithMetadata(options->rep, column_family, Slice(key, keylen),
+                               &pinnable_val, &output_metadata);
+  if (newer_version_present != nullptr) {
+    *newer_version_present = *output_metadata.newer_version_present ? 1 : 0;
+  }
+
+  char* result = nullptr;
+  if (s.ok()) {
+    *vallen = pinnable_val.size();
+    result = CopyString(pinnable_val);
+    if (output_metadata.timestamp.has_value()) {
+      *timestamp_len = output_metadata.timestamp->size();
+      *timestamp = CopyString(*output_metadata.timestamp);
+    }
+  } else {
+    *vallen = 0;
+    if (output_metadata.timestamp.has_value()) {
+      *timestamp = nullptr;
+      *timestamp_len = 0;
+    }
+    if (!s.IsNotFound()) {
+      SaveError(errptr, s);
+    }
+  }
+  return result;
+}
+
+char* rocksdb_get_with_metadata(rocksdb_t* db,
+                                const rocksdb_readoptions_t* options,
+                                const char* key, size_t keylen, size_t* vallen,
+                                char** timestamp, size_t* timestamp_len,
+                                unsigned char* newer_version_present,
+                                char** errptr) {
+  return rocksdb_get_with_metadata_impl(
+      db, options, db->rep->DefaultColumnFamily(), key, keylen, vallen,
+      timestamp, timestamp_len, newer_version_present, errptr);
+}
+
 char* rocksdb_get_cf(rocksdb_t* db, const rocksdb_readoptions_t* options,
                      rocksdb_column_family_handle_t* column_family,
                      const char* key, size_t keylen, size_t* vallen,
@@ -2449,6 +2502,16 @@ char* rocksdb_get_cf(rocksdb_t* db, const rocksdb_readoptions_t* options,
     }
   }
   return result;
+}
+
+char* rocksdb_get_cf_with_metadata(
+    rocksdb_t* db, const rocksdb_readoptions_t* options,
+    rocksdb_column_family_handle_t* column_family, const char* key,
+    size_t keylen, size_t* vallen, char** timestamp, size_t* timestamp_len,
+    unsigned char* newer_version_present, char** errptr) {
+  return rocksdb_get_with_metadata_impl(
+      db, options, column_family->rep, key, keylen, vallen, timestamp,
+      timestamp_len, newer_version_present, errptr);
 }
 
 char* rocksdb_get_with_ts(rocksdb_t* db, const rocksdb_readoptions_t* options,
@@ -2542,6 +2605,72 @@ void rocksdb_multi_get(rocksdb_t* db, const rocksdb_readoptions_t* options,
   }
 }
 
+static void rocksdb_multi_get_with_metadata_impl(
+    rocksdb_t* db, const rocksdb_readoptions_t* options,
+    ColumnFamilyHandle* const* column_families, size_t num_keys,
+    const char* const* keys_list, const size_t* keys_list_sizes,
+    char** values_list, size_t* values_list_sizes, char** timestamp_list,
+    size_t* timestamp_list_sizes, unsigned char* newer_version_present,
+    char** errs) {
+  std::unique_ptr<Slice[]> keys(new Slice[num_keys]);
+  std::vector<PinnableSlice> values(num_keys);
+  std::vector<Status> statuses(num_keys);
+  for (size_t i = 0; i < num_keys; ++i) {
+    keys[i] = Slice(keys_list[i], keys_list_sizes[i]);
+  }
+
+  ROCKSDB_NAMESPACE::MultiGetOutputMetadata output_metadata;
+  if (timestamp_list != nullptr && timestamp_list_sizes != nullptr) {
+    output_metadata.WantTimestamps();
+  }
+  if (newer_version_present != nullptr) {
+    output_metadata.WantNewerVersionPresent();
+  }
+  db->rep->MultiGetWithMetadata(options->rep, num_keys, column_families,
+                                keys.get(), values.data(), statuses.data(),
+                                &output_metadata);
+
+  for (size_t i = 0; i < num_keys; ++i) {
+    if (newer_version_present != nullptr) {
+      newer_version_present[i] =
+          (*output_metadata.newer_version_present)[i] ? 1 : 0;
+    }
+    if (statuses[i].ok()) {
+      values_list[i] = CopyString(values[i]);
+      values_list_sizes[i] = values[i].size();
+      if (output_metadata.timestamps.has_value()) {
+        timestamp_list[i] = CopyString((*output_metadata.timestamps)[i]);
+        timestamp_list_sizes[i] = (*output_metadata.timestamps)[i].size();
+      }
+      errs[i] = nullptr;
+    } else {
+      values_list[i] = nullptr;
+      values_list_sizes[i] = 0;
+      if (output_metadata.timestamps.has_value()) {
+        timestamp_list[i] = nullptr;
+        timestamp_list_sizes[i] = 0;
+      }
+      errs[i] = statuses[i].IsNotFound()
+                    ? nullptr
+                    : strdup(statuses[i].ToString().c_str());
+    }
+  }
+}
+
+void rocksdb_multi_get_with_metadata(
+    rocksdb_t* db, const rocksdb_readoptions_t* options, size_t num_keys,
+    const char* const* keys_list, const size_t* keys_list_sizes,
+    char** values_list, size_t* values_list_sizes, char** timestamp_list,
+    size_t* timestamp_list_sizes, unsigned char* newer_version_present,
+    char** errs) {
+  std::vector<ColumnFamilyHandle*> column_families(
+      num_keys, db->rep->DefaultColumnFamily());
+  rocksdb_multi_get_with_metadata_impl(
+      db, options, column_families.data(), num_keys, keys_list, keys_list_sizes,
+      values_list, values_list_sizes, timestamp_list, timestamp_list_sizes,
+      newer_version_present, errs);
+}
+
 void rocksdb_multi_get_with_ts(rocksdb_t* db,
                                const rocksdb_readoptions_t* options,
                                size_t num_keys, const char* const* keys_list,
@@ -2615,6 +2744,24 @@ void rocksdb_multi_get_cf(
       }
     }
   }
+}
+
+void rocksdb_multi_get_cf_with_metadata(
+    rocksdb_t* db, const rocksdb_readoptions_t* options,
+    const rocksdb_column_family_handle_t* const* column_families,
+    size_t num_keys, const char* const* keys_list,
+    const size_t* keys_list_sizes, char** values_list,
+    size_t* values_list_sizes, char** timestamp_list,
+    size_t* timestamp_list_sizes, unsigned char* newer_version_present,
+    char** errs) {
+  std::vector<ColumnFamilyHandle*> cfs(num_keys);
+  for (size_t i = 0; i < num_keys; ++i) {
+    cfs[i] = column_families[i]->rep;
+  }
+  rocksdb_multi_get_with_metadata_impl(
+      db, options, cfs.data(), num_keys, keys_list, keys_list_sizes,
+      values_list, values_list_sizes, timestamp_list, timestamp_list_sizes,
+      newer_version_present, errs);
 }
 
 void rocksdb_multi_get_cf_with_ts(

--- a/tools/c_api_gen/c_base.h
+++ b/tools/c_api_gen/c_base.h
@@ -497,6 +497,11 @@ extern ROCKSDB_LIBRARY_API char* rocksdb_get(
     rocksdb_t* db, const rocksdb_readoptions_t* options, const char* key,
     size_t keylen, size_t* vallen, char** errptr);
 
+extern ROCKSDB_LIBRARY_API char* rocksdb_get_with_metadata(
+    rocksdb_t* db, const rocksdb_readoptions_t* options, const char* key,
+    size_t keylen, size_t* vallen, char** timestamp, size_t* timestamp_len,
+    unsigned char* newer_version_present, char** errptr);
+
 extern ROCKSDB_LIBRARY_API char* rocksdb_get_with_ts(
     rocksdb_t* db, const rocksdb_readoptions_t* options, const char* key,
     size_t keylen, size_t* vallen, char** ts, size_t* tslen, char** errptr);
@@ -505,6 +510,12 @@ extern ROCKSDB_LIBRARY_API char* rocksdb_get_cf(
     rocksdb_t* db, const rocksdb_readoptions_t* options,
     rocksdb_column_family_handle_t* column_family, const char* key,
     size_t keylen, size_t* vallen, char** errptr);
+
+extern ROCKSDB_LIBRARY_API char* rocksdb_get_cf_with_metadata(
+    rocksdb_t* db, const rocksdb_readoptions_t* options,
+    rocksdb_column_family_handle_t* column_family, const char* key,
+    size_t keylen, size_t* vallen, char** timestamp, size_t* timestamp_len,
+    unsigned char* newer_version_present, char** errptr);
 
 extern ROCKSDB_LIBRARY_API char* rocksdb_get_cf_with_ts(
     rocksdb_t* db, const rocksdb_readoptions_t* options,
@@ -534,6 +545,13 @@ extern ROCKSDB_LIBRARY_API void rocksdb_multi_get(
     const char* const* keys_list, const size_t* keys_list_sizes,
     char** values_list, size_t* values_list_sizes, char** errs);
 
+extern ROCKSDB_LIBRARY_API void rocksdb_multi_get_with_metadata(
+    rocksdb_t* db, const rocksdb_readoptions_t* options, size_t num_keys,
+    const char* const* keys_list, const size_t* keys_list_sizes,
+    char** values_list, size_t* values_list_sizes, char** timestamp_list,
+    size_t* timestamp_list_sizes, unsigned char* newer_version_present,
+    char** errs);
+
 extern ROCKSDB_LIBRARY_API void rocksdb_multi_get_with_ts(
     rocksdb_t* db, const rocksdb_readoptions_t* options, size_t num_keys,
     const char* const* keys_list, const size_t* keys_list_sizes,
@@ -546,6 +564,15 @@ extern ROCKSDB_LIBRARY_API void rocksdb_multi_get_cf(
     size_t num_keys, const char* const* keys_list,
     const size_t* keys_list_sizes, char** values_list,
     size_t* values_list_sizes, char** errs);
+
+extern ROCKSDB_LIBRARY_API void rocksdb_multi_get_cf_with_metadata(
+    rocksdb_t* db, const rocksdb_readoptions_t* options,
+    const rocksdb_column_family_handle_t* const* column_families,
+    size_t num_keys, const char* const* keys_list,
+    const size_t* keys_list_sizes, char** values_list,
+    size_t* values_list_sizes, char** timestamp_list,
+    size_t* timestamp_list_sizes, unsigned char* newer_version_present,
+    char** errs);
 
 extern ROCKSDB_LIBRARY_API void rocksdb_multi_get_cf_with_ts(
     rocksdb_t* db, const rocksdb_readoptions_t* options,

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -1473,6 +1473,10 @@ DEFINE_bool(explicit_snapshot, false,
             "When set to true iterators will be initialized with explicit "
             "snapshot");
 
+DEFINE_bool(read_with_metadata, false,
+            "Use GetWithMetadata/MultiGetWithMetadata with an explicit "
+            "snapshot in readrandom and multireadrandom");
+
 DEFINE_uint32(memtable_op_scan_flush_trigger,
               ROCKSDB_NAMESPACE::AdvancedColumnFamilyOptions()
                   .memtable_op_scan_flush_trigger,
@@ -7463,6 +7467,8 @@ class Benchmark {
     }
     std::unique_ptr<char[]> ts_guard;
     Slice ts;
+    std::unordered_map<DB*, std::unique_ptr<ManagedSnapshot>>
+        metadata_snapshots;
     if (user_timestamp_size_ > 0) {
       ts_guard.reset(new char[user_timestamp_size_]);
     }
@@ -7508,6 +7514,13 @@ class Benchmark {
       } else {
         cfh = db_with_cfh->db->DefaultColumnFamily();
       }
+      if (FLAGS_read_with_metadata) {
+        auto& snapshot = metadata_snapshots[db_with_cfh->db];
+        if (snapshot == nullptr) {
+          snapshot = std::make_unique<ManagedSnapshot>(db_with_cfh->db);
+        }
+        options.snapshot = snapshot->snapshot();
+      }
       if (read_operands_) {
         GetMergeOperandsOptions get_merge_operands_options;
         get_merge_operands_options.expected_max_number_of_operands =
@@ -7531,7 +7544,17 @@ class Benchmark {
       } else if (read_entity_) {
         s = db_with_cfh->db->GetEntity(options, cfh, key, &pinnable_columns);
       } else {
-        s = db_with_cfh->db->Get(options, cfh, key, &pinnable_val, ts_ptr);
+        if (FLAGS_read_with_metadata) {
+          OutputMetadata output_metadata;
+          output_metadata.WantNewerVersionPresent();
+          if (ts_ptr != nullptr) {
+            output_metadata.WantTimestamp();
+          }
+          s = db_with_cfh->db->GetWithMetadata(options, cfh, key, &pinnable_val,
+                                               &output_metadata);
+        } else {
+          s = db_with_cfh->db->Get(options, cfh, key, &pinnable_val, ts_ptr);
+        }
       }
 
       if (s.ok()) {
@@ -7600,6 +7623,8 @@ class Benchmark {
     }
 
     std::unique_ptr<char[]> ts_guard;
+    std::unordered_map<DB*, std::unique_ptr<ManagedSnapshot>>
+        metadata_snapshots;
     if (user_timestamp_size_ > 0) {
       ts_guard.reset(new char[user_timestamp_size_]);
     }
@@ -7627,6 +7652,13 @@ class Benchmark {
         ts = mock_app_clock_->GetTimestampForRead(thread->rand, ts_guard.get());
         options.timestamp = &ts;
       }
+      if (FLAGS_read_with_metadata) {
+        auto& snapshot = metadata_snapshots[db];
+        if (snapshot == nullptr) {
+          snapshot = std::make_unique<ManagedSnapshot>(db);
+        }
+        options.snapshot = snapshot->snapshot();
+      }
       if (multiread_entity_) {
         db->MultiGetEntity(options, db->DefaultColumnFamily(), keys.size(),
                            keys.data(), pin_columns, stat_list.data());
@@ -7649,7 +7681,18 @@ class Benchmark {
           pin_columns[i].Reset();
         }
       } else if (!FLAGS_multiread_batched) {
-        std::vector<Status> statuses = db->MultiGet(options, keys, &values);
+        std::vector<Status> statuses;
+        if (FLAGS_read_with_metadata) {
+          MultiGetOutputMetadata output_metadata;
+          output_metadata.WantNewerVersionPresent();
+          if (user_timestamp_size_ > 0) {
+            output_metadata.WantTimestamps();
+          }
+          statuses = db->MultiGetWithMetadata(options, keys, &values,
+                                              &output_metadata);
+        } else {
+          statuses = db->MultiGet(options, keys, &values);
+        }
         assert(static_cast<int64_t>(statuses.size()) == entries_per_batch_);
 
         read += entries_per_batch_;
@@ -7664,8 +7707,19 @@ class Benchmark {
           }
         }
       } else {
-        db->MultiGet(options, db->DefaultColumnFamily(), keys.size(),
-                     keys.data(), pin_values, stat_list.data());
+        if (FLAGS_read_with_metadata) {
+          MultiGetOutputMetadata output_metadata;
+          output_metadata.WantNewerVersionPresent();
+          if (user_timestamp_size_ > 0) {
+            output_metadata.WantTimestamps();
+          }
+          db->MultiGetWithMetadata(options, db->DefaultColumnFamily(),
+                                   keys.size(), keys.data(), pin_values,
+                                   stat_list.data(), &output_metadata);
+        } else {
+          db->MultiGet(options, db->DefaultColumnFamily(), keys.size(),
+                       keys.data(), pin_values, stat_list.data());
+        }
 
         read += entries_per_batch_;
         num_multireads++;

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -1519,6 +1519,10 @@ DEFINE_bool(explicit_snapshot, false,
             "When set to true iterators will be initialized with explicit "
             "snapshot");
 
+DEFINE_bool(read_with_metadata, false,
+            "Use GetWithMetadata/MultiGetWithMetadata with an explicit "
+            "snapshot in readrandom and multireadrandom");
+
 DEFINE_uint32(memtable_op_scan_flush_trigger,
               ROCKSDB_NAMESPACE::AdvancedColumnFamilyOptions()
                   .memtable_op_scan_flush_trigger,
@@ -7975,6 +7979,8 @@ class Benchmark {
             : static_cast<size_t>(FLAGS_lazy_entity_read_length);
     std::unique_ptr<char[]> ts_guard;
     Slice ts;
+    std::unordered_map<DB*, std::unique_ptr<ManagedSnapshot>>
+        metadata_snapshots;
     if (user_timestamp_size_ > 0) {
       ts_guard.reset(new char[user_timestamp_size_]);
     }
@@ -8023,6 +8029,13 @@ class Benchmark {
       } else {
         cfh = db_with_cfh->db->DefaultColumnFamily();
       }
+      if (FLAGS_read_with_metadata) {
+        auto& snapshot = metadata_snapshots[db_with_cfh->db];
+        if (snapshot == nullptr) {
+          snapshot = std::make_unique<ManagedSnapshot>(db_with_cfh->db);
+        }
+        options.snapshot = snapshot->snapshot();
+      }
       if (read_operands_) {
         GetMergeOperandsOptions get_merge_operands_options;
         get_merge_operands_options.expected_max_number_of_operands =
@@ -8048,7 +8061,17 @@ class Benchmark {
       } else if (read_entity_lazy_) {
         s = db_with_cfh->db->GetEntityLazy(options, cfh, key, &lazy_columns);
       } else {
-        s = db_with_cfh->db->Get(options, cfh, key, &pinnable_val, ts_ptr);
+        if (FLAGS_read_with_metadata) {
+          OutputMetadata output_metadata;
+          output_metadata.WantNewerVersionPresent();
+          if (ts_ptr != nullptr) {
+            output_metadata.WantTimestamp();
+          }
+          s = db_with_cfh->db->GetWithMetadata(options, cfh, key, &pinnable_val,
+                                               &output_metadata);
+        } else {
+          s = db_with_cfh->db->Get(options, cfh, key, &pinnable_val, ts_ptr);
+        }
       }
 
       if (s.ok()) {
@@ -8148,6 +8171,8 @@ class Benchmark {
     }
 
     std::unique_ptr<char[]> ts_guard;
+    std::unordered_map<DB*, std::unique_ptr<ManagedSnapshot>>
+        metadata_snapshots;
     if (user_timestamp_size_ > 0) {
       ts_guard.reset(new char[user_timestamp_size_]);
     }
@@ -8175,6 +8200,13 @@ class Benchmark {
         ts = mock_app_clock_->GetTimestampForRead(thread->rand, ts_guard.get());
         options.timestamp = &ts;
       }
+      if (FLAGS_read_with_metadata) {
+        auto& snapshot = metadata_snapshots[db];
+        if (snapshot == nullptr) {
+          snapshot = std::make_unique<ManagedSnapshot>(db);
+        }
+        options.snapshot = snapshot->snapshot();
+      }
       if (multiread_entity_) {
         db->MultiGetEntity(options, db->DefaultColumnFamily(), keys.size(),
                            keys.data(), pin_columns, stat_list.data());
@@ -8197,7 +8229,18 @@ class Benchmark {
           pin_columns[i].Reset();
         }
       } else if (!FLAGS_multiread_batched) {
-        std::vector<Status> statuses = db->MultiGet(options, keys, &values);
+        std::vector<Status> statuses;
+        if (FLAGS_read_with_metadata) {
+          MultiGetOutputMetadata output_metadata;
+          output_metadata.WantNewerVersionPresent();
+          if (user_timestamp_size_ > 0) {
+            output_metadata.WantTimestamps();
+          }
+          statuses = db->MultiGetWithMetadata(options, keys, &values,
+                                              &output_metadata);
+        } else {
+          statuses = db->MultiGet(options, keys, &values);
+        }
         assert(static_cast<int64_t>(statuses.size()) == entries_per_batch_);
 
         read += entries_per_batch_;
@@ -8212,8 +8255,19 @@ class Benchmark {
           }
         }
       } else {
-        db->MultiGet(options, db->DefaultColumnFamily(), keys.size(),
-                     keys.data(), pin_values, stat_list.data());
+        if (FLAGS_read_with_metadata) {
+          MultiGetOutputMetadata output_metadata;
+          output_metadata.WantNewerVersionPresent();
+          if (user_timestamp_size_ > 0) {
+            output_metadata.WantTimestamps();
+          }
+          db->MultiGetWithMetadata(options, db->DefaultColumnFamily(),
+                                   keys.size(), keys.data(), pin_values,
+                                   stat_list.data(), &output_metadata);
+        } else {
+          db->MultiGet(options, db->DefaultColumnFamily(), keys.size(),
+                       keys.data(), pin_values, stat_list.data());
+        }
 
         read += entries_per_batch_;
         num_multireads++;

--- a/unreleased_history/public_api_changes/get_with_metadata_newer_version.md
+++ b/unreleased_history/public_api_changes/get_with_metadata_newer_version.md
@@ -1,0 +1,1 @@
+Added experimental `DB::GetWithMetadata()` and `DB::MultiGetWithMetadata()` APIs with opt-in output metadata for key timestamps and explicit-snapshot newer-version detection.

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -1261,6 +1261,43 @@ void BlobDBImpl::MultiGet(const ReadOptions& _read_options, size_t num_keys,
                           const Slice* keys, PinnableSlice* values,
                           std::string* timestamps, Status* statuses,
                           const bool /*sorted_input*/) {
+  MultiGetImpl(_read_options, num_keys, column_families, keys, values,
+               timestamps, statuses);
+}
+
+void BlobDBImpl::MultiGetWithMetadata(
+    const ReadOptions& _read_options, size_t num_keys,
+    ColumnFamilyHandle* const* column_families, const Slice* keys,
+    PinnableSlice* values, Status* statuses,
+    MultiGetOutputMetadata* output_metadata, const bool /*sorted_input*/) {
+  std::vector<std::string>* timestamps =
+      output_metadata != nullptr && output_metadata->timestamps.has_value()
+          ? &*output_metadata->timestamps
+          : nullptr;
+  if (timestamps != nullptr) {
+    timestamps->resize(num_keys);
+  }
+  std::vector<bool>* newer_version_present =
+      output_metadata != nullptr &&
+              output_metadata->newer_version_present.has_value()
+          ? &*output_metadata->newer_version_present
+          : nullptr;
+  const bool newer_version_present_requested =
+      newer_version_present != nullptr && _read_options.snapshot != nullptr;
+  if (newer_version_present != nullptr) {
+    newer_version_present->assign(num_keys, false);
+  }
+  MultiGetImpl(
+      _read_options, num_keys, column_families, keys, values,
+      timestamps != nullptr ? timestamps->data() : nullptr, statuses,
+      newer_version_present_requested ? newer_version_present : nullptr);
+}
+
+void BlobDBImpl::MultiGetImpl(const ReadOptions& _read_options, size_t num_keys,
+                              ColumnFamilyHandle* const* column_families,
+                              const Slice* keys, PinnableSlice* values,
+                              std::string* timestamps, Status* statuses,
+                              std::vector<bool>* newer_version_present) {
   StopWatch multiget_sw(clock_, statistics_, BLOB_DB_MULTIGET_MICROS);
   RecordTick(statistics_, BLOB_DB_NUM_MULTIGET);
   // Get a snapshot to avoid blob file get deleted between we
@@ -1299,11 +1336,29 @@ void BlobDBImpl::MultiGet(const ReadOptions& _read_options, size_t num_keys,
   if (read_options.io_activity == Env::IOActivity::kUnknown) {
     read_options.io_activity = Env::IOActivity::kMultiGet;
   }
+  if (newer_version_present != nullptr && _read_options.snapshot != nullptr &&
+      read_options.read_tier == kPersistedTier) {
+    const Status not_supported = Status::NotSupported(
+        "MultiGetWithMetadata is not supported with kPersistedTier");
+    for (size_t i = 0; i < num_keys; ++i) {
+      statuses[i] = not_supported;
+    }
+    return;
+  }
   bool snapshot_created = SetSnapshotIfNeeded(&read_options);
 
   for (size_t i = 0; i < num_keys; i++) {
     PinnableSlice& value = values[i];
-    statuses[i] = GetImpl(read_options, DefaultColumnFamily(), keys[i], &value);
+    bool key_newer_version_present = false;
+    statuses[i] = GetImpl(
+        read_options, DefaultColumnFamily(), keys[i], &value,
+        /*expiration=*/nullptr,
+        _read_options.snapshot != nullptr && newer_version_present != nullptr
+            ? &key_newer_version_present
+            : nullptr);
+    if (newer_version_present != nullptr) {
+      (*newer_version_present)[i] = key_newer_version_present;
+    }
   }
   if (snapshot_created) {
     db_->ReleaseSnapshot(read_options.snapshot);
@@ -1476,7 +1531,54 @@ Status BlobDBImpl::Get(const ReadOptions& _read_options,
   if (read_options.io_activity == Env::IOActivity::kUnknown) {
     read_options.io_activity = Env::IOActivity::kGet;
   }
-  return GetImpl(read_options, column_family, key, value);
+  return GetImpl(read_options, column_family, key, value,
+                 /*expiration=*/nullptr, /*newer_version_present=*/nullptr);
+}
+
+Status BlobDBImpl::GetWithMetadata(const ReadOptions& _read_options,
+                                   ColumnFamilyHandle* column_family,
+                                   const Slice& key, PinnableSlice* value,
+                                   OutputMetadata* output_metadata) {
+  std::string* timestamp =
+      output_metadata != nullptr && output_metadata->timestamp.has_value()
+          ? &*output_metadata->timestamp
+          : nullptr;
+  bool* newer_version_present =
+      output_metadata != nullptr &&
+              output_metadata->newer_version_present.has_value()
+          ? &*output_metadata->newer_version_present
+          : nullptr;
+  if (newer_version_present != nullptr) {
+    *newer_version_present = false;
+  }
+  if (value == nullptr) {
+    return Status::InvalidArgument(
+        "Cannot call GetWithMetadata with a null value");
+  }
+  if (_read_options.io_activity != Env::IOActivity::kUnknown &&
+      _read_options.io_activity != Env::IOActivity::kGet) {
+    return Status::InvalidArgument(
+        "Can only call Get with `ReadOptions::io_activity` is "
+        "`Env::IOActivity::kUnknown` or `Env::IOActivity::kGet`");
+  }
+  if (timestamp) {
+    return Status::NotSupported(
+        "Get() that returns timestamp is not implemented.");
+  }
+
+  ReadOptions read_options(_read_options);
+  if (read_options.io_activity == Env::IOActivity::kUnknown) {
+    read_options.io_activity = Env::IOActivity::kGet;
+  }
+  if (newer_version_present != nullptr && read_options.snapshot != nullptr &&
+      read_options.read_tier == kPersistedTier) {
+    return Status::NotSupported(
+        "GetWithMetadata is not supported with kPersistedTier");
+  }
+  return GetImpl(
+      read_options, column_family, key, value,
+      /*expiration=*/nullptr,
+      read_options.snapshot != nullptr ? newer_version_present : nullptr);
 }
 
 Status BlobDBImpl::Get(const ReadOptions& _read_options,
@@ -1500,7 +1602,8 @@ Status BlobDBImpl::Get(const ReadOptions& _read_options,
 
 Status BlobDBImpl::GetImpl(const ReadOptions& read_options,
                            ColumnFamilyHandle* column_family, const Slice& key,
-                           PinnableSlice* value, uint64_t* expiration) {
+                           PinnableSlice* value, uint64_t* expiration,
+                           bool* newer_version_present) {
   if (column_family->GetID() != DefaultColumnFamily()->GetID()) {
     return Status::NotSupported(
         "Blob DB doesn't support non-default column family.");
@@ -1518,6 +1621,9 @@ Status BlobDBImpl::GetImpl(const ReadOptions& read_options,
   get_impl_options.column_family = column_family;
   get_impl_options.value = &index_entry;
   get_impl_options.is_blob_index = &is_blob_index;
+  if (newer_version_present != nullptr && read_options.snapshot != nullptr) {
+    get_impl_options.newer_version_present = newer_version_present;
+  }
   s = db_impl_->GetImpl(ro, key, get_impl_options);
   if (expiration != nullptr) {
     *expiration = kNoExpiration;

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -14,6 +14,7 @@
 
 #include "db/blob/blob_index.h"
 #include "db/db_impl/db_impl.h"
+#include "db/db_impl/db_impl_metadata.h"
 #include "db/write_batch_internal.h"
 #include "file/file_util.h"
 #include "file/filename.h"
@@ -1261,6 +1262,37 @@ void BlobDBImpl::MultiGet(const ReadOptions& _read_options, size_t num_keys,
                           const Slice* keys, PinnableSlice* values,
                           std::string* timestamps, Status* statuses,
                           const bool /*sorted_input*/) {
+  MultiGetImpl(_read_options, num_keys, column_families, keys, values,
+               timestamps, statuses);
+}
+
+void BlobDBImpl::MultiGetWithMetadata(
+    const ReadOptions& _read_options, size_t num_keys,
+    ColumnFamilyHandle* const* column_families, const Slice* keys,
+    PinnableSlice* values, Status* statuses,
+    MultiGetOutputMetadata* output_metadata, const bool /*sorted_input*/) {
+  std::vector<std::string>* timestamps = GetOutputTimestamps(output_metadata);
+  if (timestamps != nullptr) {
+    timestamps->resize(num_keys);
+  }
+  std::vector<uint8_t>* newer_version_present =
+      GetOutputNewerVersionPresent(output_metadata);
+  const bool newer_version_present_requested =
+      newer_version_present != nullptr && _read_options.snapshot != nullptr;
+  if (newer_version_present != nullptr) {
+    newer_version_present->assign(num_keys, false);
+  }
+  MultiGetImpl(
+      _read_options, num_keys, column_families, keys, values,
+      timestamps != nullptr ? timestamps->data() : nullptr, statuses,
+      newer_version_present_requested ? newer_version_present : nullptr);
+}
+
+void BlobDBImpl::MultiGetImpl(const ReadOptions& _read_options, size_t num_keys,
+                              ColumnFamilyHandle* const* column_families,
+                              const Slice* keys, PinnableSlice* values,
+                              std::string* timestamps, Status* statuses,
+                              std::vector<uint8_t>* newer_version_present) {
   StopWatch multiget_sw(clock_, statistics_, BLOB_DB_MULTIGET_MICROS);
   RecordTick(statistics_, BLOB_DB_NUM_MULTIGET);
   // Get a snapshot to avoid blob file get deleted between we
@@ -1299,11 +1331,29 @@ void BlobDBImpl::MultiGet(const ReadOptions& _read_options, size_t num_keys,
   if (read_options.io_activity == Env::IOActivity::kUnknown) {
     read_options.io_activity = Env::IOActivity::kMultiGet;
   }
+  if (newer_version_present != nullptr && _read_options.snapshot != nullptr &&
+      read_options.read_tier == kPersistedTier) {
+    const Status not_supported = Status::NotSupported(
+        "MultiGetWithMetadata is not supported with kPersistedTier");
+    for (size_t i = 0; i < num_keys; ++i) {
+      statuses[i] = not_supported;
+    }
+    return;
+  }
   bool snapshot_created = SetSnapshotIfNeeded(&read_options);
 
   for (size_t i = 0; i < num_keys; i++) {
     PinnableSlice& value = values[i];
-    statuses[i] = GetImpl(read_options, DefaultColumnFamily(), keys[i], &value);
+    bool key_newer_version_present = false;
+    statuses[i] = GetImpl(
+        read_options, DefaultColumnFamily(), keys[i], &value,
+        /*expiration=*/nullptr,
+        _read_options.snapshot != nullptr && newer_version_present != nullptr
+            ? &key_newer_version_present
+            : nullptr);
+    if (newer_version_present != nullptr) {
+      (*newer_version_present)[i] = key_newer_version_present;
+    }
   }
   if (snapshot_created) {
     db_->ReleaseSnapshot(read_options.snapshot);
@@ -1476,7 +1526,47 @@ Status BlobDBImpl::Get(const ReadOptions& _read_options,
   if (read_options.io_activity == Env::IOActivity::kUnknown) {
     read_options.io_activity = Env::IOActivity::kGet;
   }
-  return GetImpl(read_options, column_family, key, value);
+  return GetImpl(read_options, column_family, key, value,
+                 /*expiration=*/nullptr, /*newer_version_present=*/nullptr);
+}
+
+Status BlobDBImpl::GetWithMetadata(const ReadOptions& _read_options,
+                                   ColumnFamilyHandle* column_family,
+                                   const Slice& key, PinnableSlice* value,
+                                   OutputMetadata* output_metadata) {
+  std::string* timestamp = GetOutputTimestamp(output_metadata);
+  bool* newer_version_present = GetOutputNewerVersionPresent(output_metadata);
+  if (newer_version_present != nullptr) {
+    *newer_version_present = false;
+  }
+  if (value == nullptr) {
+    return Status::InvalidArgument(
+        "Cannot call GetWithMetadata with a null value");
+  }
+  if (_read_options.io_activity != Env::IOActivity::kUnknown &&
+      _read_options.io_activity != Env::IOActivity::kGet) {
+    return Status::InvalidArgument(
+        "Can only call Get with `ReadOptions::io_activity` is "
+        "`Env::IOActivity::kUnknown` or `Env::IOActivity::kGet`");
+  }
+  if (timestamp) {
+    return Status::NotSupported(
+        "Get() that returns timestamp is not implemented.");
+  }
+
+  ReadOptions read_options(_read_options);
+  if (read_options.io_activity == Env::IOActivity::kUnknown) {
+    read_options.io_activity = Env::IOActivity::kGet;
+  }
+  if (newer_version_present != nullptr && read_options.snapshot != nullptr &&
+      read_options.read_tier == kPersistedTier) {
+    return Status::NotSupported(
+        "GetWithMetadata is not supported with kPersistedTier");
+  }
+  return GetImpl(
+      read_options, column_family, key, value,
+      /*expiration=*/nullptr,
+      read_options.snapshot != nullptr ? newer_version_present : nullptr);
 }
 
 Status BlobDBImpl::Get(const ReadOptions& _read_options,
@@ -1500,7 +1590,8 @@ Status BlobDBImpl::Get(const ReadOptions& _read_options,
 
 Status BlobDBImpl::GetImpl(const ReadOptions& read_options,
                            ColumnFamilyHandle* column_family, const Slice& key,
-                           PinnableSlice* value, uint64_t* expiration) {
+                           PinnableSlice* value, uint64_t* expiration,
+                           bool* newer_version_present) {
   if (column_family->GetID() != DefaultColumnFamily()->GetID()) {
     return Status::NotSupported(
         "Blob DB doesn't support non-default column family.");
@@ -1518,6 +1609,9 @@ Status BlobDBImpl::GetImpl(const ReadOptions& read_options,
   get_impl_options.column_family = column_family;
   get_impl_options.value = &index_entry;
   get_impl_options.is_blob_index = &is_blob_index;
+  if (newer_version_present != nullptr && read_options.snapshot != nullptr) {
+    get_impl_options.newer_version_present = newer_version_present;
+  }
   s = db_impl_->GetImpl(ro, key, get_impl_options);
   if (expiration != nullptr) {
     *expiration = kNoExpiration;

--- a/utilities/blob_db/blob_db_impl.h
+++ b/utilities/blob_db/blob_db_impl.h
@@ -98,6 +98,12 @@ class BlobDBImpl : public BlobDB {
              ColumnFamilyHandle* column_family, const Slice& key,
              PinnableSlice* value, std::string* timestamp) override;
 
+  using BlobDB::GetWithMetadata;
+  Status GetWithMetadata(const ReadOptions& _read_options,
+                         ColumnFamilyHandle* column_family, const Slice& key,
+                         PinnableSlice* value,
+                         OutputMetadata* output_metadata) override;
+
   Status Get(const ReadOptions& _read_options,
              ColumnFamilyHandle* column_family, const Slice& key,
              PinnableSlice* value, uint64_t* expiration) override;
@@ -118,6 +124,14 @@ class BlobDBImpl : public BlobDB {
                 ColumnFamilyHandle** column_families, const Slice* keys,
                 PinnableSlice* values, std::string* timestamps,
                 Status* statuses, const bool sorted_input) override;
+
+  using BlobDB::MultiGetWithMetadata;
+  void MultiGetWithMetadata(const ReadOptions& _read_options, size_t num_keys,
+                            ColumnFamilyHandle* const* column_families,
+                            const Slice* keys, PinnableSlice* values,
+                            Status* statuses,
+                            MultiGetOutputMetadata* output_metadata,
+                            const bool sorted_input) override;
 
   using BlobDB::Write;
   Status Write(const WriteOptions& opts, WriteBatch* updates) override;
@@ -210,7 +224,14 @@ class BlobDBImpl : public BlobDB {
 
   Status GetImpl(const ReadOptions& read_options,
                  ColumnFamilyHandle* column_family, const Slice& key,
-                 PinnableSlice* value, uint64_t* expiration = nullptr);
+                 PinnableSlice* value, uint64_t* expiration = nullptr,
+                 bool* newer_version_present = nullptr);
+
+  void MultiGetImpl(const ReadOptions& read_options, size_t num_keys,
+                    ColumnFamilyHandle* const* column_families,
+                    const Slice* keys, PinnableSlice* values,
+                    std::string* timestamps, Status* statuses,
+                    std::vector<bool>* newer_version_present = nullptr);
 
   Status GetBlobValue(const Slice& key, const Slice& index_entry,
                       PinnableSlice* value, uint64_t* expiration = nullptr);

--- a/utilities/blob_db/blob_db_impl.h
+++ b/utilities/blob_db/blob_db_impl.h
@@ -98,6 +98,12 @@ class BlobDBImpl : public BlobDB {
              ColumnFamilyHandle* column_family, const Slice& key,
              PinnableSlice* value, std::string* timestamp) override;
 
+  using BlobDB::GetWithMetadata;
+  Status GetWithMetadata(const ReadOptions& _read_options,
+                         ColumnFamilyHandle* column_family, const Slice& key,
+                         PinnableSlice* value,
+                         OutputMetadata* output_metadata) override;
+
   Status Get(const ReadOptions& _read_options,
              ColumnFamilyHandle* column_family, const Slice& key,
              PinnableSlice* value, uint64_t* expiration) override;
@@ -118,6 +124,14 @@ class BlobDBImpl : public BlobDB {
                 ColumnFamilyHandle** column_families, const Slice* keys,
                 PinnableSlice* values, std::string* timestamps,
                 Status* statuses, const bool sorted_input) override;
+
+  using BlobDB::MultiGetWithMetadata;
+  void MultiGetWithMetadata(const ReadOptions& _read_options, size_t num_keys,
+                            ColumnFamilyHandle* const* column_families,
+                            const Slice* keys, PinnableSlice* values,
+                            Status* statuses,
+                            MultiGetOutputMetadata* output_metadata,
+                            const bool sorted_input) override;
 
   using BlobDB::Write;
   Status Write(const WriteOptions& opts, WriteBatch* updates) override;
@@ -210,7 +224,14 @@ class BlobDBImpl : public BlobDB {
 
   Status GetImpl(const ReadOptions& read_options,
                  ColumnFamilyHandle* column_family, const Slice& key,
-                 PinnableSlice* value, uint64_t* expiration = nullptr);
+                 PinnableSlice* value, uint64_t* expiration = nullptr,
+                 bool* newer_version_present = nullptr);
+
+  void MultiGetImpl(const ReadOptions& read_options, size_t num_keys,
+                    ColumnFamilyHandle* const* column_families,
+                    const Slice* keys, PinnableSlice* values,
+                    std::string* timestamps, Status* statuses,
+                    std::vector<uint8_t>* newer_version_present = nullptr);
 
   Status GetBlobValue(const Slice& key, const Slice& index_entry,
                       PinnableSlice* value, uint64_t* expiration = nullptr);

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -32,6 +32,18 @@
 
 namespace ROCKSDB_NAMESPACE::blob_db {
 
+OutputMetadata NewerVersionOutputMetadata() {
+  OutputMetadata output_metadata;
+  output_metadata.WantNewerVersionPresent();
+  return output_metadata;
+}
+
+MultiGetOutputMetadata NewerVersionMultiGetOutputMetadata() {
+  MultiGetOutputMetadata output_metadata;
+  output_metadata.WantNewerVersionPresent();
+  return output_metadata;
+}
+
 class BlobDBTest : public testing::Test {
  public:
   const int kMaxBlobSize = 1 << 14;
@@ -354,6 +366,59 @@ TEST_F(BlobDBTest, StackableDBGet) {
     ASSERT_EQ(string_value, pinnable_value.ToString());
     ASSERT_EQ(string_value, data[key]);
   }
+}
+
+TEST_F(BlobDBTest, GetWithMetadataResolvesBlobValue) {
+  // BlobDB reports newer blob values while returning the snapshot-visible blob.
+  BlobDBOptions bdb_options;
+  bdb_options.disable_background_tasks = true;
+  Open(bdb_options);
+  assert(blob_db_ != nullptr);
+
+  ASSERT_OK(Put("key", "old_blob_value"));
+  const Snapshot* snapshot = blob_db_->GetSnapshot();
+  ASSERT_OK(Put("key", "new_blob_value"));
+
+  ReadOptions read_options;
+  read_options.snapshot = snapshot;
+  std::string value;
+  OutputMetadata output_metadata = NewerVersionOutputMetadata();
+  ASSERT_OK(
+      blob_db_->GetWithMetadata(read_options, "key", &value, &output_metadata));
+  ASSERT_EQ("old_blob_value", value);
+  ASSERT_TRUE(*output_metadata.newer_version_present);
+
+  blob_db_->ReleaseSnapshot(snapshot);
+}
+
+TEST_F(BlobDBTest, MultiGetWithMetadataResolvesBlobValues) {
+  // BlobDB MultiGet preserves per-key newer-version metadata while resolving
+  // blob indexes to values.
+  BlobDBOptions bdb_options;
+  bdb_options.disable_background_tasks = true;
+  Open(bdb_options);
+  assert(blob_db_ != nullptr);
+
+  ASSERT_OK(Put("key", "old_blob_value"));
+  const Snapshot* snapshot = blob_db_->GetSnapshot();
+  ASSERT_OK(Put("key", "new_blob_value"));
+
+  ReadOptions read_options;
+  read_options.snapshot = snapshot;
+  std::vector<Slice> keys{"key", "missing"};
+  std::vector<std::string> values;
+  MultiGetOutputMetadata output_metadata = NewerVersionMultiGetOutputMetadata();
+  std::vector<Status> statuses = blob_db_->MultiGetWithMetadata(
+      read_options, keys, &values, &output_metadata);
+
+  ASSERT_EQ(keys.size(), statuses.size());
+  ASSERT_OK(statuses[0]);
+  ASSERT_EQ("old_blob_value", values[0]);
+  ASSERT_TRUE((*output_metadata.newer_version_present)[0]);
+  ASSERT_TRUE(statuses[1].IsNotFound());
+  ASSERT_FALSE((*output_metadata.newer_version_present)[1]);
+
+  blob_db_->ReleaseSnapshot(snapshot);
 }
 
 TEST_F(BlobDBTest, GetExpiration) {

--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -545,6 +545,33 @@ class WritePreparedTransactionTest
             std::get<4>(GetParam()), std::get<5>(GetParam())) {}
 };
 
+TEST_P(WritePreparedTransactionTest, SnapshotNewerVersionMetadataNotSupported) {
+  // Write-prepared DB-level snapshot reads require a custom visibility
+  // callback, so they must reject metadata tracking instead of forwarding past
+  // the transaction visibility layer.
+  assert(db);
+  ASSERT_OK(db->Put(WriteOptions(), "key", "value"));
+  const Snapshot* snapshot = db->GetSnapshot();
+  ReadOptions read_options;
+  read_options.snapshot = snapshot;
+
+  OutputMetadata output_metadata;
+  output_metadata.WantNewerVersionPresent();
+  std::string value;
+  ASSERT_TRUE(db->GetWithMetadata(read_options, "key", &value, &output_metadata)
+                  .IsNotSupported());
+
+  MultiGetOutputMetadata multiget_output_metadata;
+  multiget_output_metadata.WantNewerVersionPresent();
+  std::vector<Slice> keys{"key"};
+  std::vector<std::string> values;
+  const std::vector<Status> statuses = db->MultiGetWithMetadata(
+      read_options, keys, &values, &multiget_output_metadata);
+  ASSERT_TRUE(statuses[0].IsNotSupported());
+
+  db->ReleaseSnapshot(snapshot);
+}
+
 #if !defined(ROCKSDB_VALGRIND_RUN) || defined(ROCKSDB_FULL_VALGRIND_RUN)
 class SnapshotConcurrentAccessTest
     : public WritePreparedTransactionTestBase,

--- a/utilities/transactions/write_prepared_txn_db.cc
+++ b/utilities/transactions/write_prepared_txn_db.cc
@@ -246,6 +246,15 @@ Status WritePreparedTxnDB::WriteInternal(const WriteOptions& write_options_orig,
   return s;
 }
 
+Status WritePreparedTxnDB::GetWithMetadata(const ReadOptions& options,
+                                           ColumnFamilyHandle* column_family,
+                                           const Slice& key,
+                                           PinnableSlice* value,
+                                           OutputMetadata* output_metadata) {
+  return DB::GetWithMetadata(options, column_family, key, value,
+                             output_metadata);
+}
+
 void WritePreparedTxnDB::UpdateCFComparatorMap(
     const std::vector<ColumnFamilyHandle*>& handles) {
   auto cf_map = new std::map<uint32_t, const Comparator*>();
@@ -280,6 +289,15 @@ void WritePreparedTxnDB::UpdateCFComparatorMap(ColumnFamilyHandle* h) {
   (*handle_map)[id] = h;
   cf_map_.reset(cf_map);
   handle_map_.reset(handle_map);
+}
+
+void WritePreparedTxnDB::MultiGetWithMetadata(
+    const ReadOptions& options, const size_t num_keys,
+    ColumnFamilyHandle* const* column_families, const Slice* keys,
+    PinnableSlice* values, Status* statuses,
+    MultiGetOutputMetadata* output_metadata, const bool sorted_input) {
+  DB::MultiGetWithMetadata(options, num_keys, column_families, keys, values,
+                           statuses, output_metadata, sorted_input);
 }
 
 // Struct to hold ownership of snapshot and read callback for iterator cleanup.

--- a/utilities/transactions/write_prepared_txn_db.h
+++ b/utilities/transactions/write_prepared_txn_db.h
@@ -100,6 +100,12 @@ class WritePreparedTxnDB : public WritePreparedTxnDBBase {
                                   std::string* timestamp);
   using DB::GetAsync;
 
+  using DB::GetWithMetadata;
+  Status GetWithMetadata(const ReadOptions& options,
+                         ColumnFamilyHandle* column_family, const Slice& key,
+                         PinnableSlice* value,
+                         OutputMetadata* output_metadata) override;
+
   using DB::MultiGet;
   DECLARE_SYNC_AND_ASYNC_OVERRIDE(void, MultiGet,
                                   const ReadOptions& _read_options,
@@ -109,6 +115,14 @@ class WritePreparedTxnDB : public WritePreparedTxnDBBase {
                                   std::string* timestamps, Status* statuses,
                                   const bool sorted_input);
   using DB::MultiGetAsync;
+
+  using DB::MultiGetWithMetadata;
+  void MultiGetWithMetadata(const ReadOptions& options, const size_t num_keys,
+                            ColumnFamilyHandle* const* column_families,
+                            const Slice* keys, PinnableSlice* values,
+                            Status* statuses,
+                            MultiGetOutputMetadata* output_metadata,
+                            const bool sorted_input) override;
 
   using DB::NewIterator;
   Iterator* NewIterator(const ReadOptions& _read_options,

--- a/utilities/transactions/write_prepared_txn_db.h
+++ b/utilities/transactions/write_prepared_txn_db.h
@@ -109,6 +109,12 @@ class WritePreparedTxnDB : public WritePreparedTxnDBBase {
                                   const Slice& key,
                                   PinnableAttributeGroups* result);
 
+  using DB::GetWithMetadata;
+  Status GetWithMetadata(const ReadOptions& options,
+                         ColumnFamilyHandle* column_family, const Slice& key,
+                         PinnableSlice* value,
+                         OutputMetadata* output_metadata) override;
+
   using DB::MultiGet;
   DECLARE_SYNC_AND_ASYNC_OVERRIDE(void, MultiGet,
                                   const ReadOptions& _read_options,
@@ -118,6 +124,14 @@ class WritePreparedTxnDB : public WritePreparedTxnDBBase {
                                   std::string* timestamps, Status* statuses,
                                   const bool sorted_input);
   using DB::MultiGetAsync;
+
+  using DB::MultiGetWithMetadata;
+  void MultiGetWithMetadata(const ReadOptions& options, const size_t num_keys,
+                            ColumnFamilyHandle* const* column_families,
+                            const Slice* keys, PinnableSlice* values,
+                            Status* statuses,
+                            MultiGetOutputMetadata* output_metadata,
+                            const bool sorted_input) override;
 
   using DB::NewIterator;
   Iterator* NewIterator(const ReadOptions& _read_options,

--- a/utilities/ttl/db_ttl_impl.cc
+++ b/utilities/ttl/db_ttl_impl.cc
@@ -5,6 +5,7 @@
 
 #include "utilities/ttl/db_ttl_impl.h"
 
+#include <array>
 #include <memory>
 #include <utility>
 
@@ -18,6 +19,7 @@
 #include "rocksdb/utilities/db_ttl.h"
 #include "rocksdb/utilities/object_registry.h"
 #include "rocksdb/utilities/options_type.h"
+#include "table/multiget_context.h"
 #include "util/coding.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -517,6 +519,106 @@ Status DBWithTTLImpl::Put(const WriteOptions& options,
     st = Write(options, &batch);
   }
   return st;
+}
+
+Status DBWithTTLImpl::GetWithMetadata(const ReadOptions& options,
+                                      ColumnFamilyHandle* column_family,
+                                      const Slice& key, PinnableSlice* value,
+                                      OutputMetadata* output_metadata) {
+  std::string* timestamp =
+      output_metadata != nullptr && output_metadata->timestamp.has_value()
+          ? &*output_metadata->timestamp
+          : nullptr;
+  bool* newer_version_present =
+      output_metadata != nullptr &&
+              output_metadata->newer_version_present.has_value()
+          ? &*output_metadata->newer_version_present
+          : nullptr;
+  if (newer_version_present != nullptr) {
+    *newer_version_present = false;
+  }
+  if (value == nullptr) {
+    return Status::InvalidArgument(
+        "Cannot call GetWithMetadata with a null value");
+  }
+  if (timestamp) {
+    return Status::NotSupported(
+        "Get() that returns timestamp is not supported");
+  }
+  Status st = newer_version_present != nullptr && options.snapshot != nullptr
+                  ? DBWithTTLImplBase::GetWithMetadata(
+                        options, column_family, key, value, output_metadata)
+                  : DBWithTTLImplBase::Get(options, column_family, key, value,
+                                           /*timestamp=*/nullptr);
+  if (!st.ok()) {
+    return st;
+  }
+  return CheckAndStripTimestamp(value);
+}
+
+void DBWithTTLImpl::MultiGetWithMetadata(
+    const ReadOptions& options, const size_t num_keys,
+    ColumnFamilyHandle* const* column_families, const Slice* keys,
+    PinnableSlice* values, Status* statuses,
+    MultiGetOutputMetadata* output_metadata, const bool sorted_input) {
+  std::vector<std::string>* timestamps =
+      output_metadata != nullptr && output_metadata->timestamps.has_value()
+          ? &*output_metadata->timestamps
+          : nullptr;
+  if (timestamps != nullptr) {
+    timestamps->resize(num_keys);
+  }
+  std::vector<bool>* newer_version_present =
+      output_metadata != nullptr &&
+              output_metadata->newer_version_present.has_value()
+          ? &*output_metadata->newer_version_present
+          : nullptr;
+  if (newer_version_present != nullptr) {
+    newer_version_present->assign(num_keys, false);
+  }
+  MultiGetInternal(options, num_keys, column_families, keys, values,
+                   timestamps != nullptr ? timestamps->data() : nullptr,
+                   statuses, output_metadata, newer_version_present,
+                   sorted_input);
+}
+
+void DBWithTTLImpl::MultiGetInternal(const ReadOptions& options,
+                                     const size_t num_keys,
+                                     ColumnFamilyHandle* const* column_families,
+                                     const Slice* keys, PinnableSlice* values,
+                                     std::string* timestamps, Status* statuses,
+                                     MultiGetOutputMetadata* output_metadata,
+                                     std::vector<bool>* newer_version_present,
+                                     const bool sorted_input) {
+  if (timestamps) {
+    for (size_t i = 0; i < num_keys; ++i) {
+      statuses[i] = Status::NotSupported(
+          "MultiGet() returning timestamps not implemented.");
+    }
+    return;
+  }
+
+  if (newer_version_present != nullptr && options.snapshot != nullptr) {
+    DBWithTTLImplBase::MultiGetWithMetadata(options, num_keys, column_families,
+                                            keys, values, statuses,
+                                            output_metadata, sorted_input);
+  } else {
+    std::array<ColumnFamilyHandle*, MultiGetContext::MAX_BATCH_SIZE>
+        stack_column_families{};
+    std::unique_ptr<ColumnFamilyHandle*[]> heap_column_families;
+    ColumnFamilyHandle** mutable_column_families = stack_column_families.data();
+    if (num_keys > stack_column_families.size()) {
+      heap_column_families.reset(new ColumnFamilyHandle*[num_keys]);
+      mutable_column_families = heap_column_families.get();
+    }
+    for (size_t i = 0; i < num_keys; ++i) {
+      mutable_column_families[i] = column_families[i];
+    }
+    DBWithTTLImplBase::MultiGet(
+        options, num_keys, num_keys == 0 ? nullptr : mutable_column_families,
+        keys, values, /*timestamps=*/nullptr, statuses, sorted_input);
+  }
+  ProcessMultiGetResults(num_keys, values, statuses);
 }
 
 bool DBWithTTLImpl::KeyMayExist(const ReadOptions& options,

--- a/utilities/ttl/db_ttl_impl.cc
+++ b/utilities/ttl/db_ttl_impl.cc
@@ -5,9 +5,11 @@
 
 #include "utilities/ttl/db_ttl_impl.h"
 
+#include <array>
 #include <memory>
 #include <utility>
 
+#include "db/db_impl/db_impl_metadata.h"
 #include "db/write_batch_internal.h"
 #include "file/filename.h"
 #include "logging/logging.h"
@@ -18,6 +20,7 @@
 #include "rocksdb/utilities/db_ttl.h"
 #include "rocksdb/utilities/object_registry.h"
 #include "rocksdb/utilities/options_type.h"
+#include "table/multiget_context.h"
 #include "util/coding.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -517,6 +520,91 @@ Status DBWithTTLImpl::Put(const WriteOptions& options,
     st = Write(options, &batch);
   }
   return st;
+}
+
+Status DBWithTTLImpl::GetWithMetadata(const ReadOptions& options,
+                                      ColumnFamilyHandle* column_family,
+                                      const Slice& key, PinnableSlice* value,
+                                      OutputMetadata* output_metadata) {
+  std::string* timestamp = GetOutputTimestamp(output_metadata);
+  bool* newer_version_present = GetOutputNewerVersionPresent(output_metadata);
+  if (newer_version_present != nullptr) {
+    *newer_version_present = false;
+  }
+  if (value == nullptr) {
+    return Status::InvalidArgument(
+        "Cannot call GetWithMetadata with a null value");
+  }
+  if (timestamp) {
+    return Status::NotSupported(
+        "Get() that returns timestamp is not supported");
+  }
+  Status st = newer_version_present != nullptr && options.snapshot != nullptr
+                  ? DBWithTTLImplBase::GetWithMetadata(
+                        options, column_family, key, value, output_metadata)
+                  : DBWithTTLImplBase::Get(options, column_family, key, value,
+                                           /*timestamp=*/nullptr);
+  if (!st.ok()) {
+    return st;
+  }
+  return CheckAndStripTimestamp(value);
+}
+
+void DBWithTTLImpl::MultiGetWithMetadata(
+    const ReadOptions& options, const size_t num_keys,
+    ColumnFamilyHandle* const* column_families, const Slice* keys,
+    PinnableSlice* values, Status* statuses,
+    MultiGetOutputMetadata* output_metadata, const bool sorted_input) {
+  std::vector<std::string>* timestamps = GetOutputTimestamps(output_metadata);
+  if (timestamps != nullptr) {
+    timestamps->resize(num_keys);
+  }
+  std::vector<uint8_t>* newer_version_present =
+      GetOutputNewerVersionPresent(output_metadata);
+  if (newer_version_present != nullptr) {
+    newer_version_present->assign(num_keys, false);
+  }
+  MultiGetInternal(options, num_keys, column_families, keys, values,
+                   timestamps != nullptr ? timestamps->data() : nullptr,
+                   statuses, output_metadata, newer_version_present,
+                   sorted_input);
+}
+
+void DBWithTTLImpl::MultiGetInternal(
+    const ReadOptions& options, const size_t num_keys,
+    ColumnFamilyHandle* const* column_families, const Slice* keys,
+    PinnableSlice* values, std::string* timestamps, Status* statuses,
+    MultiGetOutputMetadata* output_metadata,
+    std::vector<uint8_t>* newer_version_present, const bool sorted_input) {
+  if (timestamps) {
+    for (size_t i = 0; i < num_keys; ++i) {
+      statuses[i] = Status::NotSupported(
+          "MultiGet() returning timestamps not implemented.");
+    }
+    return;
+  }
+
+  if (newer_version_present != nullptr && options.snapshot != nullptr) {
+    DBWithTTLImplBase::MultiGetWithMetadata(options, num_keys, column_families,
+                                            keys, values, statuses,
+                                            output_metadata, sorted_input);
+  } else {
+    std::array<ColumnFamilyHandle*, MultiGetContext::MAX_BATCH_SIZE>
+        stack_column_families{};
+    std::unique_ptr<ColumnFamilyHandle*[]> heap_column_families;
+    ColumnFamilyHandle** mutable_column_families = stack_column_families.data();
+    if (num_keys > stack_column_families.size()) {
+      heap_column_families.reset(new ColumnFamilyHandle*[num_keys]);
+      mutable_column_families = heap_column_families.get();
+    }
+    for (size_t i = 0; i < num_keys; ++i) {
+      mutable_column_families[i] = column_families[i];
+    }
+    DBWithTTLImplBase::MultiGet(
+        options, num_keys, num_keys == 0 ? nullptr : mutable_column_families,
+        keys, values, /*timestamps=*/nullptr, statuses, sorted_input);
+  }
+  ProcessMultiGetResults(num_keys, values, statuses);
 }
 
 bool DBWithTTLImpl::KeyMayExist(const ReadOptions& options,

--- a/utilities/ttl/db_ttl_impl.h
+++ b/utilities/ttl/db_ttl_impl.h
@@ -66,6 +66,12 @@ class DBWithTTLImpl : public DBWithTTLImplBase {
                                   const Slice& key, PinnableSlice* value,
                                   std::string* timestamp);
 
+  using StackableDB::GetWithMetadata;
+  Status GetWithMetadata(const ReadOptions& options,
+                         ColumnFamilyHandle* column_family, const Slice& key,
+                         PinnableSlice* value,
+                         OutputMetadata* output_metadata) override;
+
   using StackableDB::MultiGet;
   DECLARE_SYNC_AND_ASYNC_OVERRIDE(void, MultiGet, const ReadOptions& options,
                                   const size_t num_keys,
@@ -73,6 +79,14 @@ class DBWithTTLImpl : public DBWithTTLImplBase {
                                   const Slice* keys, PinnableSlice* values,
                                   std::string* timestamps, Status* statuses,
                                   const bool sorted_input);
+
+  using StackableDB::MultiGetWithMetadata;
+  void MultiGetWithMetadata(const ReadOptions& options, const size_t num_keys,
+                            ColumnFamilyHandle* const* column_families,
+                            const Slice* keys, PinnableSlice* values,
+                            Status* statuses,
+                            MultiGetOutputMetadata* output_metadata,
+                            const bool sorted_input) override;
 
   using StackableDB::KeyMayExist;
   bool KeyMayExist(const ReadOptions& options,
@@ -115,6 +129,14 @@ class DBWithTTLImpl : public DBWithTTLImplBase {
   Status GetTtl(ColumnFamilyHandle* h, int32_t* ttl) override;
 
  private:
+  void MultiGetInternal(const ReadOptions& options, const size_t num_keys,
+                        ColumnFamilyHandle* const* column_families,
+                        const Slice* keys, PinnableSlice* values,
+                        std::string* timestamps, Status* statuses,
+                        MultiGetOutputMetadata* output_metadata,
+                        std::vector<bool>* newer_version_present,
+                        const bool sorted_input);
+
   // remember whether the Close completes or not
   bool closed_;
 };

--- a/utilities/ttl/db_ttl_impl.h
+++ b/utilities/ttl/db_ttl_impl.h
@@ -66,6 +66,12 @@ class DBWithTTLImpl : public DBWithTTLImplBase {
                                   const Slice& key, PinnableSlice* value,
                                   std::string* timestamp);
 
+  using StackableDB::GetWithMetadata;
+  Status GetWithMetadata(const ReadOptions& options,
+                         ColumnFamilyHandle* column_family, const Slice& key,
+                         PinnableSlice* value,
+                         OutputMetadata* output_metadata) override;
+
   using StackableDB::MultiGet;
   DECLARE_SYNC_AND_ASYNC_OVERRIDE(void, MultiGet, const ReadOptions& options,
                                   const size_t num_keys,
@@ -73,6 +79,14 @@ class DBWithTTLImpl : public DBWithTTLImplBase {
                                   const Slice* keys, PinnableSlice* values,
                                   std::string* timestamps, Status* statuses,
                                   const bool sorted_input);
+
+  using StackableDB::MultiGetWithMetadata;
+  void MultiGetWithMetadata(const ReadOptions& options, const size_t num_keys,
+                            ColumnFamilyHandle* const* column_families,
+                            const Slice* keys, PinnableSlice* values,
+                            Status* statuses,
+                            MultiGetOutputMetadata* output_metadata,
+                            const bool sorted_input) override;
 
   using StackableDB::KeyMayExist;
   bool KeyMayExist(const ReadOptions& options,
@@ -115,6 +129,14 @@ class DBWithTTLImpl : public DBWithTTLImplBase {
   Status GetTtl(ColumnFamilyHandle* h, int32_t* ttl) override;
 
  private:
+  void MultiGetInternal(const ReadOptions& options, const size_t num_keys,
+                        ColumnFamilyHandle* const* column_families,
+                        const Slice* keys, PinnableSlice* values,
+                        std::string* timestamps, Status* statuses,
+                        MultiGetOutputMetadata* output_metadata,
+                        std::vector<uint8_t>* newer_version_present,
+                        const bool sorted_input);
+
   // remember whether the Close completes or not
   bool closed_;
 };

--- a/utilities/ttl/ttl_test.cc
+++ b/utilities/ttl/ttl_test.cc
@@ -467,6 +467,36 @@ TEST_F(TtlTest, MultiGetCoroutine) {
 }
 #endif  // USE_COROUTINES
 
+TEST_F(TtlTest, SnapshotNewerVersionMetadata) {
+  OpenTtl();
+  assert(db_ttl_);
+  ASSERT_OK(db_ttl_->Put(WriteOptions(), "key", "old"));
+  const Snapshot* snapshot = db_ttl_->GetSnapshot();
+  ASSERT_OK(db_ttl_->Put(WriteOptions(), "key", "new"));
+
+  ReadOptions read_options;
+  read_options.snapshot = snapshot;
+  OutputMetadata output_metadata;
+  output_metadata.WantNewerVersionPresent();
+  std::string value;
+  ASSERT_OK(
+      db_ttl_->GetWithMetadata(read_options, "key", &value, &output_metadata));
+  ASSERT_EQ("old", value);
+  ASSERT_TRUE(*output_metadata.newer_version_present);
+
+  MultiGetOutputMetadata multiget_output_metadata;
+  multiget_output_metadata.WantNewerVersionPresent();
+  std::vector<Slice> keys{"key"};
+  std::vector<std::string> values;
+  const std::vector<Status> statuses = db_ttl_->MultiGetWithMetadata(
+      read_options, keys, &values, &multiget_output_metadata);
+  ASSERT_OK(statuses[0]);
+  ASSERT_EQ("old", values[0]);
+  ASSERT_TRUE((*multiget_output_metadata.newer_version_present)[0]);
+
+  db_ttl_->ReleaseSnapshot(snapshot);
+}
+
 // If TTL is non positive or not provided, the behaviour is TTL = infinity
 // This test opens the db 3 times with such default behavior and inserts a
 // bunch of kvs each time. All kvs should accumulate in the db till the end


### PR DESCRIPTION
Summary:

Why: An application built on top of RocksDB could use cache population reads through explicit snapshots and needs to know when the returned value has already been superseded, without a second point read. 

Previous behavior: Get and MultiGet returned the snapshot-visible value and optional timestamp but could not report a newer point update or covering range deletion. 

New behavior: experimental C++, C, and Java metadata-read APIs report newer committed puts, deletes, merges, and covering range tombstones; ordinary primary-DB writes completed before the read are guaranteed to be reported, racing writes remain best-effort, and true has no false positives. 

Implementation: metadata reads widen lookup behind read-callback hooks while keeping metadata-only state off passive common object layouts; per-key state stays in KeyContext/GetContext, ordinary MultiGet row-cache replay semantics are preserved, BlobDB/TTL use shared output helpers, dead single-CF plumbing and an invalid cross-key stress assertion are removed, and the range-tombstone ordering invariant is documented without changing behavior. 

Safety and unsupported cases: tracking is opt-in and requires an explicit snapshot; persisted-tier reads, custom transactional visibility callbacks, secondary DBs, and unsupported subclasses return NotSupported, while read-only/compacted DBs return false because their in-process views are static. 

Tests and limitations: 1,265 Buck tests plus focused metadata, 100x coerced-context-switch row-cache, write-committed/write-prepared crash tests, builds, and lint passed. Current-parent release db_bench found no material passive regression: readrandom +0.65%, MultiGet batch 4 -1.40%, and batch 32 +0.48%.

Reviewed By: pdillinger

Differential Revision: D104182397
