### PR TITLE
Fix MSVC C4702 warnings in trie index factory

### DIFF
--- a/utilities/trie_index/trie_index_factory.h
+++ b/utilities/trie_index/trie_index_factory.h
@@ -298,12 +298,10 @@ class TrieIndexFactory : public UserDefinedIndexFactory {
   // builds) to surface programming errors immediately.
   UserDefinedIndexBuilder* NewBuilder() const override {
     abort();
-    return nullptr;
   }
   std::unique_ptr<UserDefinedIndexReader> NewReader(
       Slice& /*index_block*/) const override {
     abort();
-    return nullptr;
   }
 
   // New API with comparator.


### PR DESCRIPTION
## Summary

Remove the two `return nullptr` statements that follow unconditional `abort()` calls in the deprecated `TrieIndexFactory` overloads.

## Why

These overloads are intentionally non-returning, as documented by their existing comments. MSVC diagnoses each trailing return as unreachable code (C4702), which breaks Windows builds when warnings are treated as errors. Since `abort()` is non-returning, deleting the unreachable statements preserves the intended behavior and keeps warning-as-error coverage intact.

This was found while packaging RocksDB 11.8.1 for conda-forge. I searched the current RocksDB issues and pull requests for C4702, unreachable-code, and trie-index fixes and found no existing report or patch; current `main` still contains both returns.

## Validation

- the complete conda-forge RocksDB 11.8.1 matrix passed with this patch, including the native [Windows build](https://github.com/conda-forge/rocksdb-feedstock/actions/runs/31420671001/job/93560346459)
- `git diff --check`
