### PR TITLE
Fix data race on `BackupInfo::env_for_open` in stress test with async coroutine reads

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -3932,6 +3932,10 @@ Status StressTest::TestBackupRestore(
       from = "BackupEngine::PurgeOldBackups";
     }
   }
+  // Prevent the backup env from being destroyed while IO executor coroutines
+  // that referenced it during async reads may still be completing.  Declared
+  // before `restored_db` so it outlives the DB (reverse destruction order).
+  std::shared_ptr<Env> restored_db_env_holder;
   std::unique_ptr<DB> restored_db;
   std::vector<ColumnFamilyHandle*> restored_cf_handles;
 
@@ -3955,7 +3959,8 @@ Status StressTest::TestBackupRestore(
     }
     if (inplace_not_restore) {
       BackupInfo& info = backup_info[thread->rand.Uniform(count)];
-      db_opt.env = info.env_for_open.get();
+      restored_db_env_holder = info.env_for_open;
+      db_opt.env = restored_db_env_holder.get();
       s = DB::OpenForReadOnly(DBOptions(db_opt), info.name_for_open,
                               cf_descriptors, &restored_cf_handles,
                               &restored_db);


### PR DESCRIPTION
Summary:
Fix a TSAN-detected data race in `TestBackupRestore` when `use_async_db_api=1`
and the new native coroutine read dispatch (D115232511) is active.

The race occurs because:
1. `TestBackupRestore` opens a restored backup DB using `info.env_for_open.get()`
   as the raw `Env*` pointer in `DBOptions`.
2. `DbStressGet` dispatches a coroutine on the IO thread pool via `GetAsync`.
3. After `OnComplete` fires (waking the calling thread), the IO thread still
   executes coroutine cleanup (`ViaCoroutinePromiseBase::executeContinuation`)
   which restores a `RequestContext` containing a `CoroutineStatsRequestData`
   that holds a raw `Env*` pointer to `env_for_open`.
4. Meanwhile, the calling thread proceeds to destroy `backup_info`, which drops
   the last `shared_ptr` reference to `env_for_open`, destroying the
   `CompositeEnvWrapper`.
5. The IO thread accesses the now-destroyed env via `env_->GetThreadID()`.

The fix keeps a local `shared_ptr<Env>` copy (`restored_db_env_holder`) that is
declared before `restored_db` so it is destroyed after the DB (reverse
declaration order in C++). This ensures the backup env remains valid until all
coroutine cleanup completes on the IO thread.

Differential Revision: D115515483


