### PR TITLE
Avoid reusing MANIFEST after partial atomic group (#15103)

### DIFF
--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -11,6 +11,7 @@
 
 #include "db/db_test_util.h"
 #include "db/log_writer.h"
+#include "db/manifest_ops.h"
 #include "db/version_edit.h"
 #include "file/writable_file_writer.h"
 #include "options/options_helper.h"
@@ -143,6 +144,7 @@ struct RecoveryOptimizationCounters {
     sp->ClearAllCallBacks();
   }
 };
+
 }  // namespace
 
 // optimize_manifest_for_recovery=true: a clean reopen of a flushed DB must
@@ -980,27 +982,19 @@ TEST_F(DBBasicTest, WritableFileWriterInitialFileSizeAdoptsExistingSize) {
 TEST_F(DBBasicTest, ReuseManifestOnOpenSkipsOnTailCorruption) {
   Options options = CurrentOptions();
   options.create_if_missing = true;
+  options.optimize_manifest_for_recovery = true;
   options.reuse_manifest_on_open = true;
+  options.write_dbid_to_manifest = false;
   DestroyAndReopen(options);
   ASSERT_OK(Put("k", "v"));
   ASSERT_OK(Flush());
   Close();
 
-  // Find the MANIFEST file and append garbage to it.
   std::string manifest_path;
-  {
-    std::vector<std::string> files;
-    ASSERT_OK(env_->GetChildren(dbname_, &files));
-    for (const auto& f : files) {
-      uint64_t number;
-      FileType type;
-      if (ParseFileName(f, &number, &type) && type == kDescriptorFile) {
-        manifest_path = dbname_ + "/" + f;
-        break;
-      }
-    }
-  }
-  ASSERT_FALSE(manifest_path.empty());
+  uint64_t manifest_file_number = 0;
+  ASSERT_OK(GetCurrentManifestPath(dbname_, env_->GetFileSystem().get(),
+                                   /*is_retry=*/false, &manifest_path,
+                                   &manifest_file_number));
   {
     std::string contents;
     ASSERT_OK(ReadFileToString(env_, manifest_path, &contents));
@@ -1009,9 +1003,13 @@ TEST_F(DBBasicTest, ReuseManifestOnOpenSkipsOnTailCorruption) {
   }
 
   std::atomic<int> reopened{0};
+  std::atomic<int> new_manifest{0};
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
       "VersionSet::ReopenManifestForAppend:Reopened",
       [&](void* /*arg*/) { reopened.fetch_add(1); });
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
+      "VersionSet::ProcessManifestWrites:BeforeNewManifest",
+      [&](void* /*arg*/) { new_manifest.fetch_add(1); });
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
 
   Reopen(options);
@@ -1020,6 +1018,12 @@ TEST_F(DBBasicTest, ReuseManifestOnOpenSkipsOnTailCorruption) {
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->ClearAllCallBacks();
 
   ASSERT_EQ(0, reopened.load());
+  ASSERT_EQ(1, new_manifest.load());
+  std::string manifest_path_after;
+  ASSERT_OK(GetCurrentManifestPath(dbname_, env_->GetFileSystem().get(),
+                                   /*is_retry=*/false, &manifest_path_after,
+                                   &manifest_file_number));
+  ASSERT_NE(manifest_path, manifest_path_after);
   ASSERT_EQ("v", Get("k"));
 }
 
@@ -1032,27 +1036,19 @@ TEST_F(DBBasicTest, ReuseManifestOnOpenSkipsOnTailCorruption) {
 TEST_F(DBBasicTest, ReuseManifestOnOpenIncompleteAtomicGroupAtTail) {
   Options options = CurrentOptions();
   options.create_if_missing = true;
+  options.optimize_manifest_for_recovery = true;
   options.reuse_manifest_on_open = true;
+  options.write_dbid_to_manifest = false;
   DestroyAndReopen(options);
   ASSERT_OK(Put("k", "v"));
   ASSERT_OK(Flush());
   Close();
 
-  // Find the MANIFEST file.
   std::string manifest_path;
-  {
-    std::vector<std::string> files;
-    ASSERT_OK(env_->GetChildren(dbname_, &files));
-    for (const auto& f : files) {
-      uint64_t number;
-      FileType type;
-      if (ParseFileName(f, &number, &type) && type == kDescriptorFile) {
-        manifest_path = dbname_ + "/" + f;
-        break;
-      }
-    }
-  }
-  ASSERT_FALSE(manifest_path.empty());
+  uint64_t manifest_file_number = 0;
+  ASSERT_OK(GetCurrentManifestPath(dbname_, env_->GetFileSystem().get(),
+                                   /*is_retry=*/false, &manifest_path,
+                                   &manifest_file_number));
 
   // Append an incomplete atomic group (2 records of a 3-member group) to the
   // MANIFEST. These are valid log records with correct CRCs but the atomic
@@ -1090,11 +1086,29 @@ TEST_F(DBBasicTest, ReuseManifestOnOpenIncompleteAtomicGroupAtTail) {
     // Deliberately NOT writing the third record (remaining_entries=0)
   }
 
-  // Reopen: recovery should succeed (incomplete trailing group is ignored).
-  // With the fix, ReopenManifestForAppend will NOT reuse the MANIFEST because
-  // manifest_last_valid_record_end_ < physical_size (the incomplete group
-  // records are excluded from the valid end).
+  std::atomic<int> reopened{0};
+  std::atomic<int> new_manifest{0};
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
+      "VersionSet::ReopenManifestForAppend:Reopened",
+      [&](void* /*arg*/) { reopened.fetch_add(1); });
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
+      "VersionSet::ProcessManifestWrites:BeforeNewManifest",
+      [&](void* /*arg*/) { new_manifest.fetch_add(1); });
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
+
+  // Reopen: recovery should succeed, but ReopenManifestForAppend must not
+  // reuse a MANIFEST ending with an incomplete atomic group.
   Reopen(options);
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->ClearAllCallBacks();
+
+  ASSERT_EQ(0, reopened.load());
+  ASSERT_EQ(1, new_manifest.load());
+  std::string manifest_path_after;
+  ASSERT_OK(GetCurrentManifestPath(dbname_, env_->GetFileSystem().get(),
+                                   /*is_retry=*/false, &manifest_path_after,
+                                   &manifest_file_number));
+  ASSERT_NE(manifest_path, manifest_path_after);
   ASSERT_EQ("v", Get("k"));
 
   // Write new data to create new MANIFEST records.

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1629,6 +1629,15 @@ class DBImpl : public DB
       edit_lists_[i].emplace_back(new VersionEdit(edit));
     }
 
+    bool HasVersionEdits() const {
+      for (const auto& edit_list : edit_lists_) {
+        if (!edit_list.empty()) {
+          return true;
+        }
+      }
+      return false;
+    }
+
     std::unordered_map<uint32_t, uint32_t> map_;  // cf_id to index;
     autovector<ColumnFamilyData*> cfds_;
     autovector<autovector<VersionEdit*>> edit_lists_;
@@ -1998,7 +2007,7 @@ class DBImpl : public DB
   // LogAndApplyForRecovery should be called only once during recovery and it
   // should be called when RocksDB writes to a first new MANIFEST since this
   // recovery.
-  Status LogAndApplyForRecovery(const RecoveryContext& recovery_ctx);
+  Status LogAndApplyForRecovery(RecoveryContext& recovery_ctx);
 
   // Schedule background work to open and validate SST files asynchronously.
   // Called when open_files_async is enabled.

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -1034,7 +1034,7 @@ Status DBImpl::InitPersistStatsColumnFamily() {
   return s;
 }
 
-Status DBImpl::LogAndApplyForRecovery(const RecoveryContext& recovery_ctx) {
+Status DBImpl::LogAndApplyForRecovery(RecoveryContext& recovery_ctx) {
   mutex_.AssertHeld();
   // descriptor_log_ is normally null after Recover, but when
   // reuse_manifest_on_open is set VersionSet::Recover may have already
@@ -1044,9 +1044,21 @@ Status DBImpl::LogAndApplyForRecovery(const RecoveryContext& recovery_ctx) {
   const ReadOptions read_options(Env::IOActivity::kDBOpen);
   const WriteOptions write_options(Env::IOActivity::kDBOpen);
 
+  if (versions_->force_new_manifest_on_open_ &&
+      !recovery_ctx.HasVersionEdits()) {
+    VersionEdit edit;
+    ColumnFamilyData* default_cfd =
+        versions_->GetColumnFamilySet()->GetDefault();
+    assert(default_cfd);
+    recovery_ctx.UpdateVersionEdits(default_cfd, edit);
+  }
+
   Status s = versions_->LogAndApply(recovery_ctx.cfds_, read_options,
                                     write_options, recovery_ctx.edit_lists_,
                                     &mutex_, directories_.GetDbDir());
+  if (s.ok()) {
+    versions_->force_new_manifest_on_open_ = false;
+  }
   return s;
 }
 

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -5376,6 +5376,7 @@ VersionSet::VersionSet(
       current_version_number_(0),
       manifest_file_size_(0),
       manifest_last_valid_record_end_(0),
+      force_new_manifest_on_open_(false),
       last_compacted_manifest_file_size_(0),
       file_options_(storage_options),
       block_cache_tracer_(block_cache_tracer),
@@ -5586,6 +5587,7 @@ void VersionSet::Reset() {
   manifest_writers_.clear();
   manifest_file_size_ = 0;
   manifest_last_valid_record_end_ = 0;
+  force_new_manifest_on_open_ = false;
   last_compacted_manifest_file_size_ = 0;
   TuneMaxManifestFileSize();
   obsolete_files_.clear();
@@ -6502,6 +6504,10 @@ Status VersionSet::ReopenManifestForAppend(const std::string& manifest_path) {
     return Status::OK();
   }
 
+  auto force_new_manifest_on_open = [&]() {
+    force_new_manifest_on_open_ = true;
+  };
+
   FileOptions opt_file_opts = GetFileOptionsForManifestWrite();
 
   // Bail if the on-disk size diverges from what Recover's Reader
@@ -6514,8 +6520,9 @@ Status VersionSet::ReopenManifestForAppend(const std::string& manifest_path) {
     ROCKS_LOG_WARN(db_options_->info_log,
                    "reuse_manifest_on_open: physical size %" PRIu64
                    " != last valid record end %" PRIu64
-                   " (tail corruption?); falling back to fresh MANIFEST",
+                   " (tail corruption?); creating fresh MANIFEST during open",
                    physical_size, manifest_last_valid_record_end_);
+    force_new_manifest_on_open();
     return Status::OK();
   }
 
@@ -6525,7 +6532,8 @@ Status VersionSet::ReopenManifestForAppend(const std::string& manifest_path) {
   if (opt_file_opts.use_direct_writes) {
     ROCKS_LOG_WARN(db_options_->info_log,
                    "reuse_manifest_on_open: direct writes enabled; "
-                   "falling back to fresh MANIFEST");
+                   "creating fresh MANIFEST during open");
+    force_new_manifest_on_open();
     return Status::OK();
   }
 
@@ -6536,6 +6544,7 @@ Status VersionSet::ReopenManifestForAppend(const std::string& manifest_path) {
     ROCKS_LOG_WARN(db_options_->info_log,
                    "Failed to reopen MANIFEST for append: %s",
                    io_s.ToString().c_str());
+    force_new_manifest_on_open();
     return Status::OK();
   }
 
@@ -6545,8 +6554,9 @@ Status VersionSet::ReopenManifestForAppend(const std::string& manifest_path) {
     ROCKS_LOG_WARN(db_options_->info_log,
                    "reuse_manifest_on_open: reopened handle size %" PRIu64
                    " != last valid record end %" PRIu64
-                   "; falling back to fresh MANIFEST",
+                   "; creating fresh MANIFEST during open",
                    reopened_size, manifest_last_valid_record_end_);
+    force_new_manifest_on_open();
     return Status::OK();
   }
 
@@ -6727,6 +6737,7 @@ Status VersionSet::Recover(
   uint64_t current_manifest_file_size = 0;
   uint64_t log_number = 0;
   {
+    force_new_manifest_on_open_ = false;
     VersionSet::LogReporter reporter;
     Status log_read_status;
     reporter.status = &log_read_status;

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -1845,16 +1845,24 @@ class VersionSet {
   // Current size of manifest file
   uint64_t manifest_file_size_;
 
-  // File offset at the end of the last successfully completed logical
-  // record during MANIFEST recovery. Unlike manifest_file_size_ (the
-  // reader's I/O high-water mark, which includes any tolerated tail
-  // garbage), this value points to the byte after the last valid record.
-  // Used by ReopenManifestForAppend to detect intra-block tail
-  // corruption that doesn't extend the physical file size.
+  // File offset at the end of the last successfully completed logical unit
+  // during MANIFEST recovery. For atomic groups, this advances only after the
+  // whole group is buffered and applied. Unlike manifest_file_size_ (the
+  // reader's I/O high-water mark, which includes any tolerated tail garbage),
+  // this value points to the byte after the last valid record.
+  // Used by ReopenManifestForAppend to detect intra-block tail corruption that
+  // doesn't extend the physical file size, as well as partial atomic groups at
+  // EOF.
   // manifest_file_size_ is kept separate because it is used for
   // rotation decisions (ProcessManifestWrites), close-time verification
   // (Close), and backup metadata.
   uint64_t manifest_last_valid_record_end_;
+
+  // True when reuse_manifest_on_open was requested but the recovered MANIFEST
+  // could not be safely reopened for append. DB open must install a fresh
+  // MANIFEST before returning so other MANIFEST append paths never see the old
+  // tail.
+  bool force_new_manifest_on_open_;
 
   // Size of the populated manifest file last time it was re-written from
   // scratch.

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -5704,15 +5704,18 @@ void StressTest::RecordManifestStateBeforeReopen() {
     return;
   }
 
+  if (FLAGS_metadata_write_fault_one_in != 0 ||
+      FLAGS_open_metadata_write_fault_one_in != 0) {
+    manifest_verify_mode_ = MANIFEST_VERIFY_NONE;
+    return;
+  }
+
   if (reuse_manifest && optimize_manifest) {
     // Check if ALL conditions for complete avoidance are met.
     // If so, use STRICT mode where failures are fatal.
-    const bool no_fault_injection = FLAGS_metadata_write_fault_one_in == 0 &&
-                                    FLAGS_open_metadata_write_fault_one_in == 0;
     const bool no_manifest_writes_expected =
         FLAGS_avoid_flush_during_recovery &&  // No flush during recovery
-        !FLAGS_write_dbid_to_manifest &&      // No DB_ID write on open
-        no_fault_injection;
+        !FLAGS_write_dbid_to_manifest;        // No DB_ID write on open
     // Note: avoid_flush_during_shutdown is NOT required for STRICT mode.
     // If avoid_flush_during_shutdown=true leaves data in WAL, but
     // avoid_flush_during_recovery=true prevents flushing it, so MANIFEST

--- a/db_stress_tool/db_stress_test_base.h
+++ b/db_stress_tool/db_stress_test_base.h
@@ -407,7 +407,9 @@ class StressTest {
     kLastOpSeekToLast
   };
 
-  // Enum used to track MANIFEST verification mode during DB reopen
+  // Enum used to track MANIFEST verification mode during DB reopen.
+  // Verification is skipped when metadata write fault injection is enabled
+  // because recovery may have to abandon a partially written MANIFEST.
   enum ManifestVerifyMode {
     MANIFEST_VERIFY_NONE,
     // MANIFEST file should be reused (same file number), CURRENT should not

--- a/unreleased_history/bug_fixes/manifest_reuse_partial_atomic_group.md
+++ b/unreleased_history/bug_fixes/manifest_reuse_partial_atomic_group.md
@@ -1,0 +1,1 @@
+Fixed `reuse_manifest_on_open` to create a fresh MANIFEST instead of appending after recovery sees an incomplete atomic group at the MANIFEST tail.


### PR DESCRIPTION
Summary:

The crash artifact showed `MANIFEST-000005` was physically well-formed but contained an incomplete atomic group that had been tolerated at EOF. `reuse_manifest_on_open` then appended ordinary records after that tail, turning the tolerated crash tail into mid-file `corrupted atomic group` corruption seen by OpenAndCompact and backup restore.

Record whether MANIFEST recovery ended with a pending atomic group. When that marker is set, skip `ReopenManifestForAppend()` so the next manifest write creates a fresh MANIFEST instead of appending after the partial group. The existing physical-size guard remains as a separate torn-tail defense.

This replaces the earlier keep-size preallocation hypothesis with the artifact-backed root cause.

Differential Revision: D116062618


