### PR TITLE
Start format_version=8 development toward new features

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,11 +8,13 @@ This document provides guidance for generating and reviewing code in the RocksDB
 
 ### Code Quality and Maintainability
 
-**Clarity and Readability:** Write clear, self-documenting code. Use meaningful variable names, add comments for complex logic, and structure code to minimize cognitive load. Avoid clever tricks that sacrifice readability for marginal performance gains unless absolutely necessary. Avoid static_cast, reinterpret_cast, and C-style casts; static_cast_with_check, up_cast, and lossless_cast from cast_util.h are preferred.
+**Clarity and Readability:** Write clear, self-documenting code. Use meaningful variable names, add comments for complex logic, and structure code to minimize cognitive load. Avoid clever tricks that sacrifice readability for marginal performance gains unless absolutely necessary.
 
 **Consistent Style:** Follow existing code style conventions. RocksDB uses `.clang-format` for formatting, specific naming conventions, and structural patterns. Deviations from these patterns are frequently flagged in reviews.
 
 **Error Handling:** Ensure robust error handling throughout the codebase. Use RocksDB's `Status` type consistently, propagate errors appropriately, and avoid silently ignoring failures. Reviewers pay close attention to edge cases and failure modes.
+
+**Refactoring traps:** At least in production code, avoid constructs that could allow existing code to unexpectedly, quietly change meaning, such as new defaulted parameters and declared type `auto` (`auto&`, `auto*` OK). Avoid static_cast, reinterpret_cast, and C-style casts; static_cast_with_check, up_cast, and lossless_cast from cast_util.h are preferred.
 
 ### Testing Philosophy
 
@@ -32,7 +34,7 @@ This document provides guidance for generating and reviewing code in the RocksDB
 
 **Memory Copy:** Avoid unnecessary memory copies. Use move semantics, `std::string_view`, `Slice`, and pass-by-reference where appropriate. Be aware of implicit copies in STL containers and function returns. Prefer in-place operations over copy-and-modify patterns.
 
-**CPU Cache Efficiency:** Design data structures and access patterns to be cache-friendly. Keep frequently accessed data together (data locality). Prefer sequential memory access over random access. Be mindful of cache line sizes (typically 64 bytes) and avoid false sharing in concurrent code. Consider struct packing and field ordering to improve cache utilization.
+**CPU Cache Efficiency:** Design data structures and access patterns to be cache-friendly. Keep frequently accessed data together (data locality). Prefer sequential memory access over random access. Be mindful of cache line sizes (CACHE_LINE_SIZE, typically 64 bytes) and avoid false sharing in concurrent code (see CacheAlignedWrapper). Especially when adding new data members, be mindful of ordering within structs and classes to reduce unnecessary padding (special care with bool members) and avoid larger-than-necessary types (e.g. prefer OptSlice to std::optional<Slice>).
 
 **Loop Optimization:** Look for opportunities to collapse nested loops, reduce loop overhead, and minimize branch mispredictions. Hoist invariant computations out of loops. Consider loop unrolling for tight inner loops. Batch operations when possible to amortize per-operation overhead.
 
@@ -47,7 +49,7 @@ This document provides guidance for generating and reviewing code in the RocksDB
 - **Cold path** (executed rarely, e.g., DB open, configuration parsing, error handling): Maintainability and clarity are more important. Prefer readable code over micro-optimizations. Complex optimizations here add maintenance burden with negligible performance benefit.
 - **Warm path** (moderate frequency): Balance both concerns. Use profiling data to guide optimization decisions.
 
-**Avoid Premature Optimization:** While performance is critical, focus on correctness first, then optimize based on profiling data. However, be performance-aware from the start—choosing the right algorithm and data structure upfront is not premature optimization. Use the hot path analysis above to decide how much optimization effort is warranted.
+**Avoid Premature Optimization:** Performance is known critical in places like inner loops of compaction, read path and write path. Elsewhere, try to find a "holy trinity" solution of *correct, simple, and reasonably efficient*. More complex solutions are only appropriate when profiling/benchmarking data shows a measurable payoff.
 
 ### API Design and Compatibility
 
@@ -73,7 +75,7 @@ The database core handles write-ahead logging (WAL), memtables, compaction, and 
 
 **Testing:** Database core changes require extensive testing, including unit tests, integration tests, and stress tests. Test with various configurations, compaction styles, and concurrent workloads.
 
-### Public Headers (`include`)
+### Public Headers / "Public API" (`include/rocksdb/`)
 
 Public headers define RocksDB's API surface. Changes here have the highest compatibility impact.
 

--- a/c_api_gen/c_generated_metadata_structs_auto.cc.inc
+++ b/c_api_gen/c_generated_metadata_structs_auto.cc.inc
@@ -230,6 +230,12 @@ const char* rocksdb_table_properties_db_host_id(
   return props->rep.db_host_id.data();
 }
 
+const char* rocksdb_table_properties_user_key_common_prefix(
+    const rocksdb_table_properties_t* props, size_t* size) {
+  *size = props->rep.user_key_common_prefix.size();
+  return props->rep.user_key_common_prefix.data();
+}
+
 const char* rocksdb_table_properties_column_family_name(
     const rocksdb_table_properties_t* props, size_t* size) {
   *size = props->rep.column_family_name.size();

--- a/c_api_gen/c_generated_metadata_structs_auto.h.inc
+++ b/c_api_gen/c_generated_metadata_structs_auto.h.inc
@@ -161,6 +161,10 @@ extern ROCKSDB_LIBRARY_API const char* rocksdb_table_properties_db_host_id(
     const rocksdb_table_properties_t* props, size_t* size);
 
 extern ROCKSDB_LIBRARY_API const char*
+rocksdb_table_properties_user_key_common_prefix(
+    const rocksdb_table_properties_t* props, size_t* size);
+
+extern ROCKSDB_LIBRARY_API const char*
 rocksdb_table_properties_column_family_name(
     const rocksdb_table_properties_t* props, size_t* size);
 

--- a/db/c.cc
+++ b/db/c.cc
@@ -5138,6 +5138,12 @@ const char* rocksdb_table_properties_db_host_id(
   return props->rep.db_host_id.data();
 }
 
+const char* rocksdb_table_properties_user_key_common_prefix(
+    const rocksdb_table_properties_t* props, size_t* size) {
+  *size = props->rep.user_key_common_prefix.size();
+  return props->rep.user_key_common_prefix.data();
+}
+
 const char* rocksdb_table_properties_column_family_name(
     const rocksdb_table_properties_t* props, size_t* size) {
   *size = props->rep.column_family_name.size();

--- a/db/compaction/sst_partitioner.cc
+++ b/db/compaction/sst_partitioner.cc
@@ -25,6 +25,18 @@ SstPartitionerFixedPrefixFactory::SstPartitionerFixedPrefixFactory(size_t len)
   RegisterOptions("Length", &len_, &sst_fixed_prefix_type_info);
 }
 
+OptSlice SstPartitionerFixedPrefix::ShouldPartitionByPrefix(
+    const Slice& user_key) {
+  if (user_key.size() >= len_) {
+    return {user_key.data(), len_};
+  } else {
+    // ShouldPartition() cuts a partition for EVERY UNIQUE KEY outside the
+    // prefix length domain, for better or worse. We can't directly represent
+    // that so we defer to ShouldPartition().
+    return {};
+  }
+}
+
 PartitionerResult SstPartitionerFixedPrefix::ShouldPartition(
     const PartitionerRequest& request) {
   Slice last_key_fixed(*request.prev_user_key);

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -23,7 +23,9 @@
 #include "rocksdb/utilities/debug.h"
 #include "table/block_based/block_based_table_reader.h"
 #include "table/block_based/block_builder.h"
+#include "table/format.h"
 #include "test_util/sync_point.h"
+#include "util/defer.h"
 #include "util/file_checksum_helper.h"
 #include "util/random.h"
 #include "utilities/counted_fs.h"
@@ -2227,6 +2229,9 @@ INSTANTIATE_TEST_CASE_P(FormatVersions, DBBlockChecksumTest,
 TEST_P(DBBlockChecksumTest, BlockChecksumTest) {
   BlockBasedTableOptions table_options;
   table_options.format_version = GetParam();
+  // kFooterFormatVersionsToTest includes the unpublished draft format_version
+  // 8; writing it requires this opt-in.
+  SaveAndRestore<bool> allow_draft(&TEST_AllowUnsupportedFormatVersion(), true);
   Options options = CurrentOptions();
   const int kNumPerFile = 2;
 

--- a/db/db_flush_test.cc
+++ b/db/db_flush_test.cc
@@ -20,9 +20,11 @@
 #include "port/stack_trace.h"
 #include "rocksdb/utilities/transaction_db.h"
 #include "table/block_based/block_based_table_builder.h"
+#include "table/format.h"
 #include "test_util/sync_point.h"
 #include "test_util/testutil.h"
 #include "util/cast_util.h"
+#include "util/defer.h"
 #include "util/mutexlock.h"
 #include "utilities/fault_injection_env.h"
 #include "utilities/fault_injection_fs.h"
@@ -4006,6 +4008,112 @@ INSTANTIATE_TEST_CASE_P(
                      // the case where required padded bytes is
                      // larger than the max allowed padding size
                      testing::Values(4, kLowSpaceOverheadRatio)));
+
+// super_block_alignment pads data blocks, giving the padded block's index entry
+// a non-contiguous handle. At format_version <= 7 the writer forces that index
+// entry to shared==0 (full key AND full value). format_version 8 instead uses
+// the index value-delta escape (see IndexValue::EncodeTo), keeping the key
+// delta-encoded and the restart cadence intact. This verifies that fv8 returns
+// byte-identical read results to fv7 for the same keys (also with
+// separate_key_value_in_data_block, the intersection that motivated the
+// escape), that padding -- and hence the escape -- is actually exercised, and
+// that fv8 index values are delta encoded.
+TEST_F(DBFlushTest, SuperBlockAlignmentValueDeltaEscape) {
+  // Writing the unpublished draft format_version 8 requires this opt-in.
+  SaveAndRestore<bool> allow_draft(&TEST_AllowUnsupportedFormatVersion(), true);
+
+  constexpr int kKeyCount = 5000;
+  auto format_key = [](int i) {
+    char buf[16];
+    snprintf(buf, sizeof(buf), "%010d", i);
+    return std::string(buf);
+  };
+
+  // Deterministic values so fv7 and fv8 see identical input.
+  Random rnd(test::RandomSeed());
+  std::vector<std::string> values;
+  values.reserve(kKeyCount);
+  for (int i = 0; i < kKeyCount; ++i) {
+    values.push_back(rnd.RandomString(static_cast<int>(rnd.Uniform(1000))));
+  }
+
+  auto build_and_read = [&](uint32_t format_version, bool separate_kv,
+                            std::vector<std::string>* got_get,
+                            std::vector<std::string>* got_iter, int* pad_count,
+                            bool* index_delta_encoded) {
+    Options options = CurrentOptions();
+    options.compression = kNoCompression;
+    BlockBasedTableOptions bbto;
+    bbto.format_version = format_version;
+    bbto.index_block_restart_interval = 3;  // > 1 so value delta encoding is on
+    bbto.super_block_alignment_size = 16 * 1024;
+    bbto.super_block_alignment_space_overhead_ratio = 8;
+    bbto.separate_key_value_in_data_block = separate_kv;
+    options.table_factory.reset(NewBlockBasedTableFactory(bbto));
+    DestroyAndReopen(options);
+
+    int local_pad = 0;
+    SyncPoint::GetInstance()->SetCallBack(
+        "BlockBasedTableBuilder::WriteMaybeCompressedBlock:SuperBlockAlignment",
+        [&local_pad](void*) { local_pad++; });
+    SyncPoint::GetInstance()->EnableProcessing();
+
+    for (int i = 0; i < kKeyCount; ++i) {
+      ASSERT_OK(Put(format_key(i), values[i]));
+    }
+    ASSERT_OK(Flush());
+
+    SyncPoint::GetInstance()->DisableProcessing();
+    SyncPoint::GetInstance()->ClearAllCallBacks();
+    *pad_count = local_pad;
+
+    got_get->clear();
+    for (int i = 0; i < kKeyCount; ++i) {
+      PinnableSlice v;
+      ASSERT_OK(Get(format_key(i), &v));
+      got_get->push_back(v.ToString());
+    }
+    got_iter->clear();
+    {
+      std::unique_ptr<Iterator> it(db_->NewIterator(ReadOptions()));
+      for (it->SeekToFirst(); it->Valid(); it->Next()) {
+        ASSERT_OK(it->status());
+        got_iter->push_back(it->value().ToString());
+      }
+      ASSERT_OK(it->status());
+    }
+
+    // Confirm the index value encoding of the produced SST(s).
+    TablePropertiesCollection props;
+    ASSERT_OK(db_->GetPropertiesOfAllTables(&props));
+    ASSERT_FALSE(props.empty());
+    *index_delta_encoded = true;
+    for (const auto& kv : props) {
+      if (kv.second->index_value_is_delta_encoded == 0) {
+        *index_delta_encoded = false;
+      }
+    }
+  };
+
+  for (bool separate_kv : {false, true}) {
+    SCOPED_TRACE("separate_kv=" + std::to_string(separate_kv));
+    std::vector<std::string> get7, iter7, get8, iter8;
+    int pad7 = 0, pad8 = 0;
+    bool delta7 = false, delta8 = false;
+    build_and_read(7, separate_kv, &get7, &iter7, &pad7, &delta7);
+    build_and_read(/*format_version=*/8, separate_kv, &get8, &iter8, &pad8,
+                   &delta8);
+
+    // Reads must be identical across versions.
+    ASSERT_EQ(get7, get8);
+    ASSERT_EQ(iter7, iter8);
+    ASSERT_EQ(static_cast<int>(iter8.size()), kKeyCount);
+    // Padding (the non-contiguity that drives the escape) actually happened.
+    EXPECT_GT(pad8, 0);
+    // fv8 index values are delta encoded, so the escape path was exercised.
+    EXPECT_TRUE(delta8);
+  }
+}
 
 // Test that when the table builder's io_status becomes bad during flush
 // (simulating write fault injection), BuildTable properly propagates the

--- a/db/external_sst_file_test.cc
+++ b/db/external_sst_file_test.cc
@@ -18,8 +18,10 @@
 #include "port/stack_trace.h"
 #include "rocksdb/sst_file_reader.h"
 #include "rocksdb/sst_file_writer.h"
+#include "table/format.h"
 #include "table/prepared_file_info.h"
 #include "test_util/testutil.h"
+#include "util/defer.h"
 #include "util/random.h"
 #include "util/thread_guard.h"
 #include "utilities/fault_injection_env.h"
@@ -3528,6 +3530,9 @@ INSTANTIATE_TEST_CASE_P(FormatVersions, ExternalSSTBlockChecksumTest,
 TEST_P(ExternalSSTBlockChecksumTest, DISABLED_HugeBlockChecksum) {
   BlockBasedTableOptions table_options;
   table_options.format_version = GetParam();
+  // kFooterFormatVersionsToTest includes the unpublished draft format_version
+  // 8; writing it requires this opt-in.
+  SaveAndRestore<bool> allow_draft(&TEST_AllowUnsupportedFormatVersion(), true);
   for (auto t : GetSupportedChecksums()) {
     table_options.checksum = t;
     Options options = CurrentOptions();

--- a/db_stress_tool/db_stress_compression_manager.cc
+++ b/db_stress_tool/db_stress_compression_manager.cc
@@ -13,7 +13,6 @@ void DbStressCustomCompressionManager::Register() {
   // the current invocation, we can still read the SST files requiring it.
   static std::once_flag loaded;
   std::call_once(loaded, [&]() {
-    TEST_AllowUnsupportedFormatVersion() = true;
     auto& library = *ObjectLibrary::Default();
     library.AddFactory<CompressionManager>(
         DbStressCustomCompressionManager().CompatibilityName(),

--- a/db_stress_tool/db_stress_tool.cc
+++ b/db_stress_tool/db_stress_tool.cc
@@ -29,6 +29,7 @@
 #include "db_stress_tool/db_stress_shared_state.h"
 #include "port/stack_trace.h"
 #include "rocksdb/convenience.h"
+#include "table/format.h"
 #include "utilities/fault_injection_fs.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -123,6 +124,15 @@ int db_stress_tool(int argc, char** argv) {
   SanitizeDoubleParam(&FLAGS_bloom_bits);
   SanitizeDoubleParam(&FLAGS_memtable_prefix_bloom_size_ratio);
   SanitizeDoubleParam(&FLAGS_max_bytes_for_level_multiplier);
+
+  // db_stress may read and write in-development draft format_versions that are
+  // not yet published to users. Enable the TEST-only opt-in once, centrally,
+  // for the whole run. It stays on regardless of this run's --format_version:
+  // the crash test re-randomizes format_version per invocation on the same DB,
+  // so a run picking an older version may still need to READ draft-version SSTs
+  // written by an earlier run. The opt-in is inert unless an unsupported
+  // format_version is actually requested.
+  TEST_AllowUnsupportedFormatVersion() = true;
 
 #ifndef NDEBUG
   if (FLAGS_mock_direct_io) {

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -1816,6 +1816,10 @@ extern ROCKSDB_LIBRARY_API const char* rocksdb_table_properties_db_host_id(
     const rocksdb_table_properties_t* props, size_t* size);
 
 extern ROCKSDB_LIBRARY_API const char*
+rocksdb_table_properties_user_key_common_prefix(
+    const rocksdb_table_properties_t* props, size_t* size);
+
+extern ROCKSDB_LIBRARY_API const char*
 rocksdb_table_properties_column_family_name(
     const rocksdb_table_properties_t* props, size_t* size);
 

--- a/include/rocksdb/slice.h
+++ b/include/rocksdb/slice.h
@@ -140,6 +140,7 @@ class OptSlice {
   /*implicit*/ OptSlice(const std::string& s) : slice_(s) {}
   /*implicit*/ OptSlice(const std::string_view& sv) : slice_(sv) {}
   /*implicit*/ OptSlice(const char* c_str) : slice_(c_str) {}
+  OptSlice(const char* d, size_t n) : slice_(d, n) {}
   // For easier migrating from APIs uing Slice* as an optional type.
   // CAUTION: OptSlice{nullptr} is "no value" while Slice{nullptr} is "empty"
   /*implicit*/ OptSlice(std::nullptr_t) : OptSlice() {}

--- a/include/rocksdb/sst_partitioner.h
+++ b/include/rocksdb/sst_partitioner.h
@@ -49,6 +49,23 @@ class SstPartitioner {
   // Return the name of this partitioner.
   virtual const char* Name() const = 0;
 
+  // Called for the start of an SST file or block. When return value is
+  // present, it must be a prefix of user_key. Partitioning is requested
+  // EXACTLY at the next future key that does not share that same prefix
+  // with user_key. Implications for returned prefix p on recursive next
+  // user key k:
+  // * if k.size() < p.size(), partition is requested before k
+  // * if k[0..p-1] != p, same
+  // * if p.size() == 0, no further partitions are requested (odd 0-len prefix)
+  // * if !p, ambiguous; must consult ShouldPartition on every key transition
+  // Expected to be consistent with ShouldPartition for predictable
+  // partitioning behavior.
+  // NOTE: not currently used; in place for future optimization
+  virtual OptSlice ShouldPartitionByPrefix(const Slice& /*user_key*/) {
+    // Default: must consult ShouldPartition()
+    return {};
+  }
+
   // It is called for all keys in compaction. When partitioner want to create
   // new SST file it needs to return true. It means compaction job will finish
   // current SST file where last key is "prev_user_key" parameter and start new
@@ -107,6 +124,8 @@ class SstPartitionerFixedPrefix : public SstPartitioner {
   ~SstPartitionerFixedPrefix() override {}
 
   const char* Name() const override { return "SstPartitionerFixedPrefix"; }
+
+  OptSlice ShouldPartitionByPrefix(const Slice& user_key) override;
 
   PartitionerResult ShouldPartition(const PartitionerRequest& request) override;
 

--- a/include/rocksdb/table_properties.h
+++ b/include/rocksdb/table_properties.h
@@ -85,6 +85,7 @@ struct TablePropertiesNames {
   static const std::string kDataBlockRestartInterval;
   static const std::string kIndexBlockRestartInterval;
   static const std::string kSeparateKeyValueInDataBlock;
+  static const std::string kUserKeyCommonPrefix;
 };
 
 // `TablePropertiesCollector` provides the mechanism for users to collect
@@ -368,6 +369,15 @@ struct TableProperties {
   // (hostname by default, but can also be any string of the user's choosing).
   // It can potentially change whenever the DB is opened
   std::string db_host_id;
+
+  // Reserved for format_version >= 8: when non-empty, all user keys in the file
+  // share this common prefix, which is stored once here instead of in every
+  // key, changing the interpretation of the entire file. No writer emits this
+  // yet; a reader that finds it non-empty does not know how to interpret the
+  // file and returns NotSupported.
+  // NOTE: kept within the contiguous std::string region of this struct (see
+  // TEST_SetRandomTableProperties in table_properties.cc).
+  std::string user_key_common_prefix;
 
   // Name of the column family with which this SST file is associated.
   // If column family is unknown, `column_family_name` will be an empty string.

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -232,6 +232,8 @@ TEST_F(OptionsSettableTest, TablePropertiesAllFieldsSettable) {
       {offsetof(struct TableProperties, db_id), sizeof(std::string)},
       {offsetof(struct TableProperties, db_session_id), sizeof(std::string)},
       {offsetof(struct TableProperties, db_host_id), sizeof(std::string)},
+      {offsetof(struct TableProperties, user_key_common_prefix),
+       sizeof(std::string)},
       {offsetof(struct TableProperties, column_family_name),
        sizeof(std::string)},
       {offsetof(struct TableProperties, filter_policy_name),
@@ -291,7 +293,8 @@ TEST_F(OptionsSettableTest, TablePropertiesAllFieldsSettable) {
       "size=0;filter_size=0;orig_file_number=3;num_deletions=0;num_range_"
       "deletions=0;format_version=0;comparator_name="
       "636F6D70617261746F725F6E616D65;num_filter_entries=0;db_id="
-      "64625F686F73745F6964;column_family_id=2147483647;fixed_key_len=0;fast_"
+      "64625F686F73745F6964;user_key_common_prefix=707265666978;"
+      "column_family_id=2147483647;fixed_key_len=0;fast_"
       "compression_estimated_data_size=0;filter_policy_name="
       "66696C7465725F706F6C6963795F6E616D65;oldest_key_time=0;newest_key_time="
       "0;column_family_"

--- a/table/block_based/binary_search_index_reader.cc
+++ b/table/block_based/binary_search_index_reader.cc
@@ -64,7 +64,8 @@ InternalIteratorBase<IndexValue>* BinarySearchIndexReader::NewIterator(
       rep->get_global_seqno(BlockType::kIndex), iter, kNullStats, true,
       index_has_first_key(), index_key_includes_seq(), index_value_is_full(),
       false /* block_contents_pinned */, user_defined_timestamps_persisted(),
-      nullptr /* prefix_index */, rep->table_options.index_block_search_type);
+      nullptr /* prefix_index */, rep->table_options.index_block_search_type,
+      index_value_delta_escape());
 
   assert(it != nullptr);
   index_block.TransferTo(it);

--- a/table/block_based/block.cc
+++ b/table/block_based/block.cc
@@ -677,7 +677,8 @@ void IndexBlockIter::DecodeCurrentValue(bool is_shared) {
   assert(!value_delta_encoded_ || value_.size() == 0);
   Status decode_s __attribute__((__unused__)) = decoded_value_.DecodeFrom(
       &v, have_first_key_,
-      (value_delta_encoded_ && is_shared) ? &decoded_value_.handle : nullptr);
+      (value_delta_encoded_ && is_shared) ? &decoded_value_.handle : nullptr,
+      value_delta_escape_);
   assert(decode_s.ok());
   value_ = Slice(value_.data(), v.data() - value_.data());
   if (!values_section_ && value_delta_encoded_) {
@@ -1420,7 +1421,8 @@ void Block::InitializeDataBlockProtectionInfo(uint8_t protection_bytes_per_key,
 void Block::InitializeIndexBlockProtectionInfo(uint8_t protection_bytes_per_key,
                                                const Comparator* raw_ucmp,
                                                bool value_is_full,
-                                               bool index_has_first_key) {
+                                               bool index_has_first_key,
+                                               bool value_delta_escape) {
   protection_bytes_per_key_ = 0;
   if (num_restarts_ > 0 && protection_bytes_per_key > 0) {
     // Note that `global_seqno` and `key_includes_seq` are hardcoded here.
@@ -1436,8 +1438,8 @@ void Block::InitializeIndexBlockProtectionInfo(uint8_t protection_bytes_per_key,
         nullptr /* Statistics */, true /* total_order_seek */,
         index_has_first_key /* have_first_key */, false /* key_includes_seq */,
         value_is_full, true /* block_contents_pinned */,
-        true /* user_defined_timestamps_persisted*/,
-        nullptr /* prefix_index */)};
+        true /* user_defined_timestamps_persisted*/, nullptr /* prefix_index */,
+        BlockBasedTableOptions::kBinary, value_delta_escape)};
     if (iter->status().ok()) {
       // Only calculate restart interval if not already set via table properties
       if (block_restart_interval_ == 0) {
@@ -1564,7 +1566,8 @@ IndexBlockIter* Block::NewIndexIterator(
     bool have_first_key, bool key_includes_seq, bool value_is_full,
     bool block_contents_pinned, bool user_defined_timestamps_persisted,
     BlockPrefixIndex* prefix_index,
-    BlockBasedTableOptions::BlockSearchType index_block_search_type) {
+    BlockBasedTableOptions::BlockSearchType index_block_search_type,
+    bool value_delta_escape) {
   IndexBlockIter* ret_iter;
   if (iter != nullptr) {
     ret_iter = iter;
@@ -1598,7 +1601,7 @@ IndexBlockIter* Block::NewIndexIterator(
         prefix_index_ptr, have_first_key, key_includes_seq, value_is_full,
         block_contents_pinned, user_defined_timestamps_persisted,
         protection_bytes_per_key_, kv_checksum_, block_restart_interval_,
-        values_section_, resolved_search_type);
+        values_section_, resolved_search_type, value_delta_escape);
   }
 
   return ret_iter;

--- a/table/block_based/block.h
+++ b/table/block_based/block.h
@@ -220,13 +220,23 @@ class Block {
   // closed).
   MetaBlockIter* NewMetaIterator(bool block_contents_pinned = false);
 
+  // Returns an IndexBlockIter for iterating over a block containing index
+  // entries (the index itself, an index partition, a top-level index of index
+  // partitions, or the index of filter partitions).
+  //
+  // No parameter here is defaulted on purpose: `value_delta_escape` in
+  // particular must match how the block was written (see
+  // BlockBasedTable::Rep::index_value_delta_escape), and a silent default
+  // would mis-decode fv8 index values rather than fail to compile.
+  //
   // raw_ucmp is a raw (i.e., not wrapped by `UserComparatorWrapper`) user key
   // comparator.
   //
-  // key_includes_seq, default true, means that the keys are in internal key
-  // format.
-  // value_is_full, default true, means that no delta encoding is
-  // applied to values.
+  // key_includes_seq means that the keys are in internal key format.
+  // value_is_full means that no delta encoding is applied to values.
+  // value_delta_escape selects the format_version >= 8 value-delta codec,
+  // which reserves an in-value escape codepoint (see IndexValue::DecodeFrom).
+  // It is only consulted when values are delta encoded.
   //
   // If `prefix_index` is not nullptr this block will do hash lookup for the key
   // prefix. If total_order_seek is true, prefix_index_ is ignored.
@@ -245,11 +255,10 @@ class Block {
       const Comparator* raw_ucmp, SequenceNumber global_seqno,
       IndexBlockIter* iter, Statistics* stats, bool total_order_seek,
       bool have_first_key, bool key_includes_seq, bool value_is_full,
-      bool block_contents_pinned = false,
-      bool user_defined_timestamps_persisted = true,
-      BlockPrefixIndex* prefix_index = nullptr,
-      BlockBasedTableOptions::BlockSearchType index_block_search_type =
-          BlockBasedTableOptions::kBinary);
+      bool block_contents_pinned, bool user_defined_timestamps_persisted,
+      BlockPrefixIndex* prefix_index,
+      BlockBasedTableOptions::BlockSearchType index_block_search_type,
+      bool value_delta_escape);
 
   // Report an approximation of how much memory has been used.
   size_t ApproximateMemoryUsage() const;
@@ -271,7 +280,8 @@ class Block {
   void InitializeIndexBlockProtectionInfo(uint8_t protection_bytes_per_key,
                                           const Comparator* raw_ucmp,
                                           bool value_is_full,
-                                          bool index_has_first_key);
+                                          bool index_has_first_key,
+                                          bool value_delta_escape);
 
   // Initializes per key-value checksum protection.
   // After this method is called, each MetaBlockIter returned
@@ -912,6 +922,9 @@ class IndexBlockIter final : public BlockIter<IndexValue> {
   // format.
   // value_is_full, default true, means that no delta encoding is
   // applied to values.
+  // value_delta_escape means the value-delta codec is the format_version >= 8
+  // variant that reserves an in-value escape codepoint (see
+  // IndexValue::DecodeFrom). Only relevant when values are delta encoded.
   void Initialize(
       const Comparator* raw_ucmp, const char* data, uint32_t restarts,
       uint32_t num_restarts, SequenceNumber global_seqno,
@@ -920,7 +933,8 @@ class IndexBlockIter final : public BlockIter<IndexValue> {
       bool user_defined_timestamps_persisted, uint8_t protection_bytes_per_key,
       const char* kv_checksum, uint32_t block_restart_interval,
       const char* values_section,
-      BlockBasedTableOptions::BlockSearchType index_block_search_type) {
+      BlockBasedTableOptions::BlockSearchType index_block_search_type,
+      bool value_delta_escape) {
     InitializeBase(raw_ucmp, data, restarts, num_restarts,
                    kDisableGlobalSequenceNumber, block_contents_pinned,
                    user_defined_timestamps_persisted, protection_bytes_per_key,
@@ -928,6 +942,7 @@ class IndexBlockIter final : public BlockIter<IndexValue> {
     raw_key_.SetIsUserKey(!key_includes_seq);
     prefix_index_ = prefix_index;
     value_delta_encoded_ = !value_is_full;
+    value_delta_escape_ = value_delta_escape;
     have_first_key_ = have_first_key;
     index_search_type_ = index_block_search_type;
     if (have_first_key_ && global_seqno != kDisableGlobalSequenceNumber) {
@@ -995,6 +1010,9 @@ class IndexBlockIter final : public BlockIter<IndexValue> {
 
  private:
   bool value_delta_encoded_;
+  // format_version >= 8 value-delta codec (reserves an in-value escape). Only
+  // consulted when value_delta_encoded_ and the entry is a non-restart entry.
+  bool value_delta_escape_ = false;
   bool have_first_key_;  // value includes first_internal_key
   BlockPrefixIndex* prefix_index_;
   // Whether the value is delta encoded. In that case the value is assumed to be

--- a/table/block_based/block.h
+++ b/table/block_based/block.h
@@ -1012,7 +1012,7 @@ class IndexBlockIter final : public BlockIter<IndexValue> {
   bool value_delta_encoded_;
   // format_version >= 8 value-delta codec (reserves an in-value escape). Only
   // consulted when value_delta_encoded_ and the entry is a non-restart entry.
-  bool value_delta_escape_ = false;
+  bool value_delta_escape_;
   bool have_first_key_;  // value includes first_internal_key
   BlockPrefixIndex* prefix_index_;
   // Whether the value is delta encoded. In that case the value is assumed to be

--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -175,8 +175,9 @@ FilterBlockBuilder* CreateFilterBlockBuilder(
       return new PartitionedFilterBlockBuilder(
           mopt.prefix_extractor.get(), table_opt.whole_key_filtering,
           filter_bits_builder, table_opt.index_block_restart_interval,
-          use_delta_encoding_for_index_values, p_index_builder, partition_size,
-          ts_sz, persist_user_defined_timestamps,
+          use_delta_encoding_for_index_values, table_opt.format_version,
+          p_index_builder, partition_size, ts_sz,
+          persist_user_defined_timestamps,
           table_opt.decouple_partitioned_filters);
     } else {
       return new FullFilterBlockBuilder(mopt.prefix_extractor.get(),
@@ -1370,8 +1371,15 @@ struct BlockBasedTableBuilder::Rep {
             tbo.compression_opts.max_compressed_bytes_per_kb),
         use_delta_encoding_for_index_values(
             table_opt.format_version >= 4 && !table_opt.block_align &&
-            /* surely no embedded blobs */ tbo.embedded_blob_options ==
-                nullptr),
+            // Embedded blob records are interleaved between data blocks, which
+            // breaks the "next block starts where the last one ended"
+            // contiguity that plain index value-delta encoding assumes.
+            // format_version >= 8 handles non-contiguous index entries with the
+            // in-value escape (see IndexValue::EncodeTo), so value-delta
+            // encoding is safe with embedded blobs there; older versions must
+            // fall back to full handles.
+            (tbo.embedded_blob_options == nullptr ||
+             FormatVersionUsesValueDeltaEscape(table_opt.format_version))),
         reason(tbo.reason),
         target_file_size_is_upper_bound(
             tbo.moptions.target_file_size_is_upper_bound),
@@ -3119,6 +3127,12 @@ void BlockBasedTableBuilder::WritePropertiesBlock(
         rep_->num_data_blocks_compression_bypassed.LoadRelaxed();
 
     assert(IsEmpty() || rep_->props.key_largest_seqno != UINT64_MAX);
+    // TEST-only hook: allows injecting reserved properties (e.g. the
+    // format_version >= 8 "user_key_common_prefix") to exercise reader
+    // handling. Compiled out in release builds.
+    TEST_SYNC_POINT_CALLBACK(
+        "BlockBasedTableBuilder::WritePropertiesBlock:TableProps",
+        &rep_->props);
     // Add basic properties
     property_block_builder.AddTableProperty(rep_->props);
 
@@ -3194,6 +3208,30 @@ void BlockBasedTableBuilder::WriteFooter(BlockHandle& metaindex_block_handle,
                                          BlockHandle& index_block_handle) {
   assert(LIKELY(ok()));
   Rep* r = rep_.get();
+  IOOptions io_options;
+  IOStatus ios =
+      WritableFileWriter::PrepareIOOptions(r->write_options, io_options);
+  if (!ios.ok()) {
+    r->SetIOStatus(ios);
+    return;
+  }
+  // TEST-only hook: inject a gap of the requested number of bytes between the
+  // metaindex block and the footer, to exercise format_version >= 8 footer
+  // metaindex-gap decoding. The gap is reserved for future file checksum data;
+  // no production writer emits one yet. Compiled out in release builds.
+  size_t footer_gap = 0;
+  TEST_SYNC_POINT_CALLBACK("BlockBasedTableBuilder::WriteFooter:MetaindexGap",
+                           &footer_gap);
+  if (footer_gap > 0) {
+    std::string gap_bytes(footer_gap, '\0');
+    ios = r->file->Append(io_options, Slice(gap_bytes));
+    if (!ios.ok()) {
+      r->SetIOStatus(ios);
+      return;
+    }
+    r->pre_compression_size += footer_gap;
+    r->set_offset(r->get_offset() + footer_gap);
+  }
   FooterBuilder footer;
   Status s = footer.Build(kBlockBasedTableMagicNumber,
                           r->table_options.format_version, r->get_offset(),
@@ -3201,13 +3239,6 @@ void BlockBasedTableBuilder::WriteFooter(BlockHandle& metaindex_block_handle,
                           index_block_handle, r->base_context_checksum);
   if (!s.ok()) {
     r->SetStatus(s);
-    return;
-  }
-  IOOptions io_options;
-  IOStatus ios =
-      WritableFileWriter::PrepareIOOptions(r->write_options, io_options);
-  if (!ios.ok()) {
-    r->SetIOStatus(ios);
     return;
   }
   ios = r->file->Append(io_options, footer.GetSlice());

--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -1388,15 +1388,17 @@ struct BlockBasedTableBuilder::Rep {
                 table_options, data_block)),
         warm_cache_config(WarmCacheConfig::Compute(
             table_options.prepopulate_block_cache, reason)),
-        create_context(&table_options, &ioptions, ioptions.stats,
-                       /*decompressor=*/nullptr,
-                       tbo.moptions.block_protection_bytes_per_key,
-                       tbo.internal_comparator.user_comparator(),
-                       !use_delta_encoding_for_index_values,
-                       table_opt.index_type ==
-                           BlockBasedTableOptions::kBinarySearchWithFirstKey,
-                       table_options.block_restart_interval,
-                       table_options.index_block_restart_interval),
+        create_context(
+            &table_options, &ioptions, ioptions.stats,
+            /*decompressor=*/nullptr,
+            tbo.moptions.block_protection_bytes_per_key,
+            tbo.internal_comparator.user_comparator(),
+            !use_delta_encoding_for_index_values,
+            table_opt.index_type ==
+                BlockBasedTableOptions::kBinarySearchWithFirstKey,
+            FormatVersionUsesValueDeltaEscape(table_opt.format_version),
+            table_options.block_restart_interval,
+            table_options.index_block_restart_interval),
         tail_size(0),
         embedded_blob_options(
             tbo.embedded_blob_options

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -932,9 +932,9 @@ Status BlockBasedTable::Open(
       &rep->table_options, &rep->ioptions, rep->ioptions.stats,
       rep->decompressor.get(), block_protection_bytes_per_key,
       rep->internal_comparator.user_comparator(), rep->index_value_is_full,
-      rep->index_has_first_key, rep->data_block_restart_interval,
-      rep->index_block_restart_interval,
-      FormatVersionUsesValueDeltaEscape(rep->footer.format_version()));
+      rep->index_has_first_key,
+      FormatVersionUsesValueDeltaEscape(rep->footer.format_version()),
+      rep->data_block_restart_interval, rep->index_block_restart_interval);
 
   // Check expected unique id if provided
   if (expected_unique_id != kNullUniqueId64x2) {

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -933,7 +933,8 @@ Status BlockBasedTable::Open(
       rep->decompressor.get(), block_protection_bytes_per_key,
       rep->internal_comparator.user_comparator(), rep->index_value_is_full,
       rep->index_has_first_key, rep->data_block_restart_interval,
-      rep->index_block_restart_interval);
+      rep->index_block_restart_interval,
+      FormatVersionUsesValueDeltaEscape(rep->footer.format_version()));
 
   // Check expected unique id if provided
   if (expected_unique_id != kNullUniqueId64x2) {
@@ -1171,6 +1172,15 @@ Status BlockBasedTable::ReadPropertiesBlock(
 
   assert(table_properties != nullptr);
   rep_->table_properties = std::move(table_properties);
+
+  // Reserved for format_version >= 8 (see
+  // TableProperties::user_key_common_prefix). No reader knows how to interpret
+  // a file with a user-key common prefix yet, so refuse to open it rather than
+  // mis-reading the keys.
+  if (!rep_->table_properties->user_key_common_prefix.empty()) {
+    return Status::NotSupported(
+        "Unsupported user_key_common_prefix table property");
+  }
 
   rep_->data_block_restart_interval = static_cast<uint32_t>(
       rep_->table_properties->data_block_restart_interval);
@@ -2183,7 +2193,8 @@ IndexBlockIter* BlockBasedTable::InitBlockIterator<IndexBlockIter>(
       /* total_order_seek */ true, rep->index_has_first_key,
       rep->index_key_includes_seq, rep->index_value_is_full,
       block_contents_pinned, rep->user_defined_timestamps_persisted,
-      nullptr /* prefix_index */, rep->table_options.index_block_search_type);
+      nullptr /* prefix_index */, rep->table_options.index_block_search_type,
+      FormatVersionUsesValueDeltaEscape(rep->footer.format_version()));
 }
 
 // Right now only called for Data blocks.
@@ -2538,7 +2549,9 @@ BlockBasedTable::PartitionedIndexIteratorState::NewSecondaryIterator(
       rep->get_global_seqno(BlockType::kIndex), nullptr, kNullStats, true,
       rep->index_has_first_key, rep->index_key_includes_seq,
       rep->index_value_is_full, /*block_contents_pinned=*/false,
-      rep->user_defined_timestamps_persisted);
+      rep->user_defined_timestamps_persisted, nullptr /* prefix_index */,
+      BlockBasedTableOptions::kBinary,
+      FormatVersionUsesValueDeltaEscape(rep->footer.format_version()));
 }
 
 // This will be broken if the user specifies an unusual implementation

--- a/table/block_based/block_based_table_reader_test.cc
+++ b/table/block_based/block_based_table_reader_test.cc
@@ -27,6 +27,7 @@
 #include "table/format.h"
 #include "test_util/testharness.h"
 #include "test_util/testutil.h"
+#include "util/defer.h"
 #include "util/random.h"
 
 // Enable io_uring support for this test
@@ -128,7 +129,8 @@ class BlockBasedTableReaderBaseTest : public testing::Test {
                    const CompressionType& compression_type,
                    const std::vector<std::pair<std::string, std::string>>& kv,
                    uint32_t compression_parallel_threads = 1,
-                   uint32_t compression_dict_bytes = 0) {
+                   uint32_t compression_dict_bytes = 0,
+                   Status* out_status = nullptr) {
     std::unique_ptr<WritableFileWriter> writer;
     NewFileWriter(table_name, &writer);
 
@@ -160,7 +162,12 @@ class BlockBasedTableReaderBaseTest : public testing::Test {
       std::string v = it->second;
       table_builder->Add(it->first, v);
     }
-    ASSERT_OK(table_builder->Finish());
+    Status s = table_builder->Finish();
+    if (out_status != nullptr) {
+      *out_status = s;
+    } else {
+      ASSERT_OK(s);
+    }
   }
 
   void NewBlockBasedTableReader(const FileOptions& foptions,
@@ -245,6 +252,170 @@ class BlockBasedTableReaderBaseTest : public testing::Test {
                                              /*stats=*/stats));
   }
 };
+
+// Fixture for format_version 8 features tested at the builder+reader layer:
+// builds SSTs at format_version 8 through the real table builder and reads them
+// back.
+class BlockBasedTableReaderFormatVersion8Test
+    : public BlockBasedTableReaderBaseTest {
+ protected:
+  void ConfigureTableFactory() override {
+    BlockBasedTableOptions opts;
+    opts.format_version = 8;
+    options_.table_factory.reset(NewBlockBasedTableFactory(opts));
+  }
+};
+
+// format_version 8 records, in the footer, the gap (in bytes) between the end
+// of the metaindex block and the start of the footer, so the metaindex can be
+// located even when it is not adjacent to the footer (space reserved for future
+// file checksum data). No production writer emits a gap yet, so a sync point
+// injects one at build time. This verifies (1) the gap bytes are actually
+// written (the file grows by exactly the gap), (2) the table still reads back
+// correctly (i.e. the reader locates the metaindex via the recorded gap), and
+// (3) a gap too large to encode surfaces as an error from the table builder.
+TEST_F(BlockBasedTableReaderFormatVersion8Test, MetaindexGap) {
+  // Writing the unpublished draft format_version 8 requires this opt-in.
+  SaveAndRestore<bool> allow_draft(&TEST_AllowUnsupportedFormatVersion(), true);
+
+  Options options;
+  const ImmutableOptions ioptions(options);
+  const InternalKeyComparator comparator(options.comparator);
+  // Enough blocks that a mislocated metaindex (hence index) would clearly fail.
+  const std::vector<std::pair<std::string, std::string>> kv =
+      GenerateKVMap(/*num_block=*/8);
+
+  auto set_gap_injection = [](size_t gap, int* count) {
+    SyncPoint::GetInstance()->SetCallBack(
+        "BlockBasedTableBuilder::WriteFooter:MetaindexGap",
+        [gap, count](void* arg) {
+          *static_cast<size_t*>(arg) = gap;
+          ++*count;
+        });
+    SyncPoint::GetInstance()->EnableProcessing();
+  };
+  auto clear_gap_injection = []() {
+    SyncPoint::GetInstance()->DisableProcessing();
+    SyncPoint::GetInstance()->ClearAllCallBacks();
+  };
+
+  auto read_back_and_verify = [&](const std::string& name) {
+    std::unique_ptr<BlockBasedTable> table;
+    FileOptions foptions;
+    NewBlockBasedTableReader(foptions, ioptions, comparator, name, &table);
+    ReadOptions read_opts;
+    ASSERT_OK(table->VerifyChecksum(read_opts,
+                                    TableReaderCaller::kUserVerifyChecksum));
+    std::unique_ptr<InternalIterator> iter(table->NewIterator(
+        read_opts, options_.prefix_extractor.get(), /*arena=*/nullptr,
+        /*skip_filters=*/false, TableReaderCaller::kUncategorized));
+    iter->SeekToFirst();
+    ASSERT_OK(iter->status());
+    for (const auto& expected : kv) {
+      ASSERT_TRUE(iter->Valid());
+      EXPECT_EQ(iter->key().ToString(), expected.first);
+      EXPECT_EQ(iter->value().ToString(), expected.second);
+      iter->Next();
+      ASSERT_OK(iter->status());
+    }
+    EXPECT_FALSE(iter->Valid());
+  };
+
+  // Baseline: no gap. The build is deterministic (no wall-clock properties in
+  // this path), so its size is the reference for the gap-size assertions below.
+  const std::string baseline_name = "footer_gap_baseline";
+  CreateTable(baseline_name, ioptions, kNoCompression, kv);
+  uint64_t baseline_size = 0;
+  ASSERT_OK(env_->GetFileSize(Path(baseline_name), &baseline_size));
+  read_back_and_verify(baseline_name);
+
+  // A gap of the given size is physically inserted between the metaindex block
+  // and the footer (file grows by exactly `gap`), and the table still reads
+  // back correctly -- proving the reader located the metaindex via the recorded
+  // gap.
+  for (size_t gap : {size_t{1}, size_t{1234}, size_t{0xFFFF}}) {
+    SCOPED_TRACE("gap=" + std::to_string(gap));
+    const std::string name = "footer_gap_" + std::to_string(gap);
+    int injected = 0;
+    set_gap_injection(gap, &injected);
+    CreateTable(name, ioptions, kNoCompression, kv);
+    clear_gap_injection();
+    ASSERT_EQ(injected, 1);
+    uint64_t gapped_size = 0;
+    ASSERT_OK(env_->GetFileSize(Path(name), &gapped_size));
+    EXPECT_EQ(gapped_size, baseline_size + gap);
+    read_back_and_verify(name);
+  }
+
+  // A gap too large to encode in the footer's 16-bit field surfaces as an error
+  // from the full table builder (not just the low-level footer encoder).
+  {
+    const std::string name = "footer_gap_too_big";
+    int injected = 0;
+    set_gap_injection(/*gap=*/0x10000, &injected);
+    Status build_status;
+    CreateTable(name, ioptions, kNoCompression, kv,
+                /*compression_parallel_threads=*/1,
+                /*compression_dict_bytes=*/0, &build_status);
+    clear_gap_injection();
+    ASSERT_EQ(injected, 1);
+    EXPECT_TRUE(build_status.IsNotSupported()) << build_status.ToString();
+  }
+}
+
+// format_version 8 reserves the "user_key_common_prefix" table property for a
+// future feature that would change the interpretation of the entire file (all
+// user keys sharing a common prefix stored once). No writer emits it yet, so a
+// reader that finds it non-empty must refuse to open the file rather than
+// mis-read the keys. A sync point injects the property at build time; this
+// verifies the reader returns NotSupported, and that an ordinary file (without
+// the property) still opens.
+TEST_F(BlockBasedTableReaderFormatVersion8Test, ReservedUserKeyCommonPrefix) {
+  // Writing the unpublished draft format_version 8 requires this opt-in.
+  SaveAndRestore<bool> allow_draft(&TEST_AllowUnsupportedFormatVersion(), true);
+
+  Options options;
+  const ImmutableOptions ioptions(options);
+  const InternalKeyComparator comparator(options.comparator);
+  const std::vector<std::pair<std::string, std::string>> kv =
+      GenerateKVMap(/*num_block=*/4);
+
+  // Sanity: without the reserved property, the file opens fine.
+  const std::string ok_name = "user_key_common_prefix_absent";
+  CreateTable(ok_name, ioptions, kNoCompression, kv);
+  {
+    std::unique_ptr<BlockBasedTable> table;
+    FileOptions foptions;
+    Status status;
+    NewBlockBasedTableReader(foptions, ioptions, comparator, ok_name, &table,
+                             /*prefetch_index_and_filter_in_cache=*/true,
+                             &status);
+    ASSERT_OK(status);
+  }
+
+  // Inject a non-empty reserved property; the reader must reject the file.
+  const std::string prefix_name = "user_key_common_prefix_present";
+  int injected = 0;
+  SyncPoint::GetInstance()->SetCallBack(
+      "BlockBasedTableBuilder::WritePropertiesBlock:TableProps",
+      [&injected](void* arg) {
+        static_cast<TableProperties*>(arg)->user_key_common_prefix = "prefix";
+        ++injected;
+      });
+  SyncPoint::GetInstance()->EnableProcessing();
+  CreateTable(prefix_name, ioptions, kNoCompression, kv);
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+  ASSERT_EQ(injected, 1);
+
+  std::unique_ptr<BlockBasedTable> table;
+  FileOptions foptions;
+  Status status;
+  NewBlockBasedTableReader(foptions, ioptions, comparator, prefix_name, &table,
+                           /*prefetch_index_and_filter_in_cache=*/true,
+                           &status);
+  EXPECT_TRUE(status.IsNotSupported()) << status.ToString();
+}
 
 struct BlockBasedTableReaderTestParam {
   BlockBasedTableReaderTestParam(

--- a/table/block_based/block_builder.cc
+++ b/table/block_based/block_builder.cc
@@ -220,8 +220,7 @@ Slice BlockBuilder::Finish() {
 }
 
 void BlockBuilder::Add(const Slice& key, const Slice& value,
-                       const Slice* const delta_value,
-                       bool skip_delta_encoding) {
+                       const Slice& delta_value, bool skip_delta_encoding) {
   // Ensure no unsafe mixing of Add and AddWithLastKey
   assert(!add_with_last_key_called_);
 
@@ -237,7 +236,7 @@ void BlockBuilder::Add(const Slice& key, const Slice& value,
 
 void BlockBuilder::AddWithLastKey(const Slice& key, const Slice& value,
                                   const Slice& last_key_param,
-                                  const Slice* const delta_value,
+                                  const Slice& delta_value,
                                   bool skip_delta_encoding) {
   // Ensure no unsafe mixing of Add and AddWithLastKey
   assert(last_key_.empty());
@@ -261,19 +260,16 @@ void BlockBuilder::AddWithLastKey(const Slice& key, const Slice& value,
                      buffer_size);
 }
 
-inline void BlockBuilder::AddWithLastKeyImpl(const Slice& key,
-                                             const Slice& value,
-                                             const Slice& last_key,
-                                             const Slice* const delta_value,
-                                             bool skip_delta_encoding,
-                                             size_t buffer_size) {
+inline void BlockBuilder::AddWithLastKeyImpl(
+    const Slice& key, const Slice& value, const Slice& last_key,
+    const Slice& delta_value, bool skip_delta_encoding, size_t buffer_size) {
   assert(!finished_);
   assert(counter_ <= block_restart_interval_);
   // Verify < 4GB assumption (see API comments on Add())
   assert(key.size() < uint64_t{1} << 32);
   assert(value.size() < uint64_t{1} << 32);
   assert(last_key.size() < uint64_t{1} << 32);
-  assert(delta_value == nullptr || delta_value->size() < uint64_t{1} << 32);
+  assert(delta_value.size() < uint64_t{1} << 32);
   std::string key_buf;
   std::string last_key_buf;
   const Slice key_to_persist = MaybeStripTimestampFromKey(&key_buf, key);
@@ -342,9 +338,13 @@ inline void BlockBuilder::AddWithLastKeyImpl(const Slice& key,
   if (shared != 0 && use_value_delta_encoding_) {
     // Using only bottom 32 bits of size for consistent treatment in case of
     // corruption
-    assert(delta_value != nullptr);
-    values_buffer.append(delta_value->data(),
-                         static_cast<uint32_t>(delta_value->size()));
+    // NOTE: callers may pass an empty delta_value when they had no previous
+    // handle to delta against, relying on shared == 0 for a block's first
+    // entry. Catch that coupling breaking, which would otherwise silently
+    // write a zero-length value: a real delta encoding is never empty.
+    assert(!delta_value.empty());
+    values_buffer.append(delta_value.data(),
+                         static_cast<uint32_t>(delta_value.size()));
   } else {
     // Using only bottom 32 bits of size for consistent treatment in case of
     // corruption

--- a/table/block_based/block_builder.h
+++ b/table/block_based/block_builder.h
@@ -52,7 +52,7 @@ class BlockBuilder {
   // dedicated Slice32 type would likely incur data movement overheads for this
   // inner-loop code.)
   void Add(const Slice& key, const Slice& value,
-           const Slice* const delta_value = nullptr,
+           const Slice& delta_value = Slice(),
            bool skip_delta_encoding = false);
 
   // A faster version of Add() if the previous key is already known for all
@@ -67,8 +67,7 @@ class BlockBuilder {
   // For efficiency, the implementation assumes the sizes of the input slices
   // are each < 4GB, and only uses the bottom 32 bits of each size.
   void AddWithLastKey(const Slice& key, const Slice& value,
-                      const Slice& last_key,
-                      const Slice* const delta_value = nullptr,
+                      const Slice& last_key, const Slice& delta_value = Slice(),
                       bool skip_delta_encoding = false);
 
   // Finish building the block and return a slice that refers to the
@@ -99,7 +98,7 @@ class BlockBuilder {
  private:
   inline void AddWithLastKeyImpl(const Slice& key, const Slice& value,
                                  const Slice& last_key,
-                                 const Slice* const delta_value,
+                                 const Slice& delta_value,
                                  bool skip_delta_encoding, size_t buffer_size);
 
   bool ScanForUniformity() const;

--- a/table/block_based/block_cache.cc
+++ b/table/block_based/block_cache.cc
@@ -24,7 +24,7 @@ void BlockCreateContext::Create(std::unique_ptr<Block_kIndex>* parsed_out,
                                      index_block_restart_interval));
   parsed_out->get()->InitializeIndexBlockProtectionInfo(
       protection_bytes_per_key, raw_ucmp, index_value_is_full,
-      index_has_first_key);
+      index_has_first_key, index_value_delta_escape);
 }
 void BlockCreateContext::Create(
     std::unique_ptr<Block_kFilterPartitionIndex>* parsed_out,
@@ -34,7 +34,7 @@ void BlockCreateContext::Create(
       index_block_restart_interval));
   parsed_out->get()->InitializeIndexBlockProtectionInfo(
       protection_bytes_per_key, raw_ucmp, index_value_is_full,
-      index_has_first_key);
+      index_has_first_key, index_value_delta_escape);
 }
 void BlockCreateContext::Create(
     std::unique_ptr<Block_kRangeDeletion>* parsed_out, BlockContents&& block) {

--- a/table/block_based/block_cache.h
+++ b/table/block_based/block_cache.h
@@ -83,12 +83,10 @@ struct BlockCreateContext : public Cache::CreateContext {
                      const ImmutableOptions* _ioptions, Statistics* _statistics,
                      Decompressor* _decompressor,
                      uint8_t _protection_bytes_per_key,
-                     const Comparator* _raw_ucmp,
-                     bool _index_value_is_full = false,
-                     bool _index_has_first_key = false,
+                     const Comparator* _raw_ucmp, bool _index_value_is_full,
+                     bool _index_has_first_key, bool _index_value_delta_escape,
                      uint32_t _data_block_restart_interval = 0,
-                     uint32_t _index_block_restart_interval = 0,
-                     bool _index_value_delta_escape = false)
+                     uint32_t _index_block_restart_interval = 0)
       : table_options(_table_options),
         ioptions(_ioptions),
         statistics(_statistics),
@@ -97,9 +95,9 @@ struct BlockCreateContext : public Cache::CreateContext {
         protection_bytes_per_key(_protection_bytes_per_key),
         index_value_is_full(_index_value_is_full),
         index_has_first_key(_index_has_first_key),
+        index_value_delta_escape(_index_value_delta_escape),
         data_block_restart_interval(_data_block_restart_interval),
-        index_block_restart_interval(_index_block_restart_interval),
-        index_value_delta_escape(_index_value_delta_escape) {}
+        index_block_restart_interval(_index_block_restart_interval) {}
 
   const BlockBasedTableOptions* table_options = nullptr;
   const ImmutableOptions* ioptions = nullptr;
@@ -110,11 +108,11 @@ struct BlockCreateContext : public Cache::CreateContext {
   uint8_t protection_bytes_per_key = 0;
   bool index_value_is_full;
   bool index_has_first_key;
+  // format_version >= 8 index value-delta escape codec (see IndexValue).
+  bool index_value_delta_escape = false;
   // Restart intervals from table properties (0 if not available)
   uint32_t data_block_restart_interval = 0;
   uint32_t index_block_restart_interval = 0;
-  // format_version >= 8 index value-delta escape codec (see IndexValue).
-  bool index_value_delta_escape = false;
 
   // For TypedCacheInterface
   template <typename TBlocklike>

--- a/table/block_based/block_cache.h
+++ b/table/block_based/block_cache.h
@@ -87,7 +87,8 @@ struct BlockCreateContext : public Cache::CreateContext {
                      bool _index_value_is_full = false,
                      bool _index_has_first_key = false,
                      uint32_t _data_block_restart_interval = 0,
-                     uint32_t _index_block_restart_interval = 0)
+                     uint32_t _index_block_restart_interval = 0,
+                     bool _index_value_delta_escape = false)
       : table_options(_table_options),
         ioptions(_ioptions),
         statistics(_statistics),
@@ -97,7 +98,8 @@ struct BlockCreateContext : public Cache::CreateContext {
         index_value_is_full(_index_value_is_full),
         index_has_first_key(_index_has_first_key),
         data_block_restart_interval(_data_block_restart_interval),
-        index_block_restart_interval(_index_block_restart_interval) {}
+        index_block_restart_interval(_index_block_restart_interval),
+        index_value_delta_escape(_index_value_delta_escape) {}
 
   const BlockBasedTableOptions* table_options = nullptr;
   const ImmutableOptions* ioptions = nullptr;
@@ -111,6 +113,8 @@ struct BlockCreateContext : public Cache::CreateContext {
   // Restart intervals from table properties (0 if not available)
   uint32_t data_block_restart_interval = 0;
   uint32_t index_block_restart_interval = 0;
+  // format_version >= 8 index value-delta escape codec (see IndexValue).
+  bool index_value_delta_escape = false;
 
   // For TypedCacheInterface
   template <typename TBlocklike>

--- a/table/block_based/block_test.cc
+++ b/table/block_based/block_test.cc
@@ -608,7 +608,96 @@ void AddIndexBlockEntry(BlockBuilder& builder, const Slice& key,
     entry.EncodeTo(&delta_encoded_entry, include_first_key, prev);
   }
   const Slice delta_slice(delta_encoded_entry);
-  builder.Add(key, encoded_entry, &delta_slice);
+  builder.Add(key, encoded_entry, delta_slice);
+}
+
+// Directly exercises the format_version >= 8 index value-delta escape codec
+// (IndexValue::EncodeTo/DecodeFrom), independent of block/table machinery.
+// See table/format.h FormatVersionUsesValueDeltaEscape.
+TEST(IndexValueDeltaEscapeTest, EncodeDecodeRoundTrip) {
+  constexpr uint64_t kTrailer = BlockBasedTable::kBlockTrailerSize;
+  // Previous block handle. Size is large enough that prev.size() + delta stays
+  // positive for all deltas below.
+  const BlockHandle prev(1000, 4 * 1024 * 1024);
+  const uint64_t contiguous_offset = prev.offset() + prev.size() + kTrailer;
+
+  // Size deltas relative to prev.size(), including 0 (whose legacy encoding is
+  // a bare 0x00 -- the byte fv8 reuses as the escape), negatives, and large
+  // ones.
+  const int64_t deltas[] = {0,    1,     -1,     5,       -5,        255,
+                            -255, 12345, -12345, 1 << 20, -(1 << 20)};
+  for (int64_t d : deltas) {
+    SCOPED_TRACE("delta=" + std::to_string(d));
+    const uint64_t new_size =
+        static_cast<uint64_t>(static_cast<int64_t>(prev.size()) + d);
+    const BlockHandle contig(contiguous_offset, new_size);
+    const IndexValue iv(contig, Slice());
+
+    // format_version <= 7 (escape disabled): bytes must be byte-identical to
+    // the legacy PutVarsignedint64(size delta), and must round-trip.
+    std::string fv7;
+    iv.EncodeTo(&fv7, /*have_first_key=*/false, &prev,
+                /*use_value_delta_escape=*/false);
+    std::string expected_fv7;
+    PutVarsignedint64(&expected_fv7, d);
+    EXPECT_EQ(expected_fv7, fv7);
+    {
+      Slice in(fv7);
+      IndexValue dec;
+      ASSERT_OK(dec.DecodeFrom(&in, false, &prev, false));
+      EXPECT_EQ(contig.offset(), dec.handle.offset());
+      EXPECT_EQ(contig.size(), dec.handle.size());
+      EXPECT_EQ(0u, in.size());
+    }
+
+    // format_version >= 8 (escape enabled): a genuine (contiguous) delta is
+    // remapped so it never collides with the single-byte 0x00 escape, and it
+    // round-trips.
+    std::string fv8;
+    iv.EncodeTo(&fv8, false, &prev, /*use_value_delta_escape=*/true);
+    EXPECT_FALSE(fv8.size() == 1 && fv8[0] == '\0')
+        << "a real delta must not encode to the reserved escape byte";
+    {
+      Slice in(fv8);
+      IndexValue dec;
+      ASSERT_OK(dec.DecodeFrom(&in, false, &prev, true));
+      EXPECT_EQ(contig.offset(), dec.handle.offset());
+      EXPECT_EQ(contig.size(), dec.handle.size());
+      EXPECT_EQ(0u, in.size());
+    }
+  }
+
+  // format_version >= 8 escape: a NON-contiguous handle is encoded as the 0x00
+  // escape followed by a full BlockHandle, and decodes back to the exact
+  // (offset, size) -- ignoring prev's implied contiguous offset.
+  {
+    const BlockHandle noncontig(contiguous_offset + 777 /* gap */, 4096);
+    const IndexValue iv(noncontig, Slice());
+    std::string fv8;
+    iv.EncodeTo(&fv8, false, &prev, /*use_value_delta_escape=*/true);
+    ASSERT_GE(fv8.size(), 1u);
+    EXPECT_EQ('\0', fv8[0]);  // escape sentinel
+    Slice in(fv8);
+    IndexValue dec;
+    ASSERT_OK(dec.DecodeFrom(&in, false, &prev, true));
+    EXPECT_EQ(noncontig.offset(), dec.handle.offset());
+    EXPECT_EQ(noncontig.size(), dec.handle.size());
+    EXPECT_EQ(0u, in.size());
+  }
+
+  // A genuine legacy (fv7) 0x00 (delta 0) still decodes as delta 0 under fv7.
+  {
+    std::string bytes;
+    PutVarsignedint64(&bytes, 0);
+    ASSERT_EQ(1u, bytes.size());
+    ASSERT_EQ('\0', bytes[0]);
+    Slice in(bytes);
+    IndexValue dec;
+    ASSERT_OK(dec.DecodeFrom(&in, false, &prev,
+                             /*use_value_delta_escape=*/false));
+    EXPECT_EQ(contiguous_offset, dec.handle.offset());
+    EXPECT_EQ(prev.size(), dec.handle.size());  // delta 0 -> unchanged size
+  }
 }
 
 enum class KeyDistribution { kUniform, kNonUniform };
@@ -773,7 +862,8 @@ TEST_P(IndexBlockTest, IndexValueEncodingTest) {
       options.comparator, kDisableGlobalSequenceNumber, kNullIter, kNullStats,
       kTotalOrderSeek, includeFirstKey(), keyIncludesSeq(),
       !useValueDeltaEncoding(), false /* block_contents_pinned */,
-      shouldPersistUDT(), nullptr /* prefix_index */, indexSearchType());
+      shouldPersistUDT(), nullptr /* prefix_index */, indexSearchType(),
+      false /* value_delta_escape */);
   iter->SeekToFirst();
   for (int index = 0; index < num_records; ++index) {
     ASSERT_TRUE(iter->Valid());
@@ -812,7 +902,8 @@ TEST_P(IndexBlockTest, IndexValueEncodingTest) {
       options.comparator, kDisableGlobalSequenceNumber, kNullIter, kNullStats,
       kTotalOrderSeek, includeFirstKey(), keyIncludesSeq(),
       !useValueDeltaEncoding(), false /* block_contents_pinned */,
-      shouldPersistUDT(), nullptr /* prefix_index */, indexSearchType());
+      shouldPersistUDT(), nullptr /* prefix_index */, indexSearchType(),
+      false /* value_delta_escape */);
   for (int i = 0; i < num_records * 2; i++) {
     // find a random key in the lookaside array
     int index = rnd.Uniform(num_records);
@@ -920,7 +1011,8 @@ TEST(IndexBlockTest, InterpolationSearchPrefixBoundary) {
           false /* block_contents_pinned */,
           true /* user_defined_timestamps_persisted */,
           nullptr /* prefix_index */,
-          BlockBasedTableOptions::BlockSearchType::kInterpolation));
+          BlockBasedTableOptions::BlockSearchType::kInterpolation,
+          false /* value_delta_escape */));
 
   // Case 1: target prefix < shared prefix
   iter->Seek(make_target("AAAAAA"));
@@ -1004,7 +1096,8 @@ TEST(IndexBlockTest, InterpolationSearchPrefixBoundary2) {
           false /* block_contents_pinned */,
           true /* user_defined_timestamps_persisted */,
           nullptr /* prefix_index */,
-          BlockBasedTableOptions::BlockSearchType::kInterpolation));
+          BlockBasedTableOptions::BlockSearchType::kInterpolation,
+          false /* value_delta_escape */));
 
   // Seek to each existing sequence number
   for (int i = 0; i < kNumKeys; i++) {
@@ -1204,7 +1297,9 @@ TEST_F(BlockPerKVChecksumTest, InitializeProtectionInfo) {
     create_context.Create(&index_block, std::move(contents));
     std::unique_ptr<IndexBlockIter> iter{index_block->NewIndexIterator(
         options.comparator, kDisableGlobalSequenceNumber, nullptr, nullptr,
-        true, false, true, true)};
+        true, false, true, true, /*block_contents_pinned=*/false,
+        /*user_defined_timestamps_persisted=*/true, /*prefix_index=*/nullptr,
+        BlockBasedTableOptions::kBinary, /*value_delta_escape=*/false)};
     ASSERT_TRUE(iter->status().IsCorruption());
   }
   {
@@ -1269,6 +1364,36 @@ TEST_F(BlockPerKVChecksumTest, CorruptHashIndexNumBucketsNoOverRead) {
     return;
   }
   ASSERT_TRUE(iter->status().IsCorruption());
+}
+
+// A data block footer with the reserved "extended metadata" bit (bit 30) set
+// must be rejected as corruption. No writer sets it yet; format_version 8
+// reserves it so a future extension can be added in the one shared decoder.
+TEST(DataBlockFooterTest, ExtendedMetadataBitRejected) {
+  DataBlockFooter footer;
+  footer.num_restarts = 3;
+  footer.index_type = BlockBasedTableOptions::kDataBlockBinarySearch;
+  std::string encoded;
+  footer.EncodeTo(&encoded);
+  ASSERT_EQ(sizeof(uint32_t), encoded.size());
+
+  // Sanity: the unmodified footer decodes fine.
+  {
+    Slice in(encoded);
+    DataBlockFooter decoded;
+    ASSERT_OK(decoded.DecodeFrom(&in));
+    EXPECT_EQ(3u, decoded.num_restarts);
+  }
+
+  // Set bit 30 in the packed footer word and confirm it is rejected.
+  uint32_t packed = DecodeFixed32(encoded.data());
+  packed |= (uint32_t{1} << 30);
+  std::string corrupt;
+  PutFixed32(&corrupt, packed);
+  Slice in(corrupt);
+  DataBlockFooter decoded;
+  Status s = decoded.DecodeFrom(&in);
+  ASSERT_TRUE(s.IsCorruption()) << s.ToString();
 }
 
 TEST_F(BlockPerKVChecksumTest, ApproximateMemory) {
@@ -1349,7 +1474,7 @@ TEST_F(BlockPerKVChecksumTest, ApproximateMemory) {
         entry.EncodeTo(&encoded_entry, false, nullptr);
         last_encoded_handle = entry.handle;
         const Slice delta_encoded_entry_slice(delta_encoded_entry);
-        builder->Add(separators[i], encoded_entry, &delta_encoded_entry_slice);
+        builder->Add(separators[i], encoded_entry, delta_encoded_entry_slice);
       }
       Slice raw_block = builder->Finish();
       BlockContents contents;
@@ -1545,7 +1670,7 @@ class IndexBlockKVChecksumTest
 
       last_encoded_handle = entry.handle;
       const Slice delta_encoded_entry_slice(delta_encoded_entry);
-      builder_->Add(separators[i], encoded_entry, &delta_encoded_entry_slice);
+      builder_->Add(separators[i], encoded_entry, delta_encoded_entry_slice);
     }
     // read serialized contents of the block
     Slice raw_block = builder_->Finish();
@@ -1610,7 +1735,8 @@ TEST_P(IndexBlockKVChecksumTest, ChecksumConstructionAndVerification) {
           !UseValueDeltaEncoding() /* value_is_full */,
           true /* block_contents_pinned*/,
           true /* user_defined_timestamps_persisted */,
-          nullptr /* prefix_index */)};
+          nullptr /* prefix_index */, BlockBasedTableOptions::kBinary,
+          false /* value_delta_escape */)};
       biter->SeekToFirst();
       const char* checksum_ptr = index_block->TEST_GetKVChecksum();
       // Check checksum of correct length is generated
@@ -1851,7 +1977,8 @@ class IndexBlockKVChecksumCorruptionTest : public IndexBlockKVChecksumTest {
         !UseValueDeltaEncoding() /* value_is_full */,
         true /* block_contents_pinned */,
         true /* user_defined_timestamps_persisted */,
-        nullptr /* prefix_index */)};
+        nullptr /* prefix_index */, BlockBasedTableOptions::kBinary,
+        false /* value_delta_escape */)};
     SyncPoint::GetInstance()->EnableProcessing();
     return biter;
   }

--- a/table/block_based/block_test.cc
+++ b/table/block_based/block_test.cc
@@ -1236,10 +1236,15 @@ TEST_F(BlockPerKVChecksumTest, EmptyBlock) {
   std::unique_ptr<Block_kData> data_block;
   Options options = Options();
   uint8_t protection_bytes_per_key = 8;
-  BlockCreateContext create_context{
-      kTableOptions(),          nullptr,
-      nullptr /* statistics */, kDecompressor(),
-      protection_bytes_per_key, options.comparator};
+  BlockCreateContext create_context{kTableOptions(),
+                                    nullptr,
+                                    nullptr /* statistics */,
+                                    kDecompressor(),
+                                    protection_bytes_per_key,
+                                    options.comparator,
+                                    /*index_value_is_full=*/false,
+                                    /*index_has_first_key=*/false,
+                                    /*index_value_delta_escape=*/false};
   create_context.Create(&data_block, std::move(contents));
   std::unique_ptr<DataBlockIter> biter{data_block->NewDataIterator(
       options.comparator, kDisableGlobalSequenceNumber)};
@@ -1273,9 +1278,15 @@ TEST_F(BlockPerKVChecksumTest, InitializeProtectionInfo) {
   // when the block is itself already corrupted.
   Options options = Options();
   uint8_t protection_bytes_per_key = 8;
-  BlockCreateContext create_context{
-      kTableOptions(), nullptr /* ioptions */,   nullptr /* statistics */,
-      kDecompressor(), protection_bytes_per_key, options.comparator};
+  BlockCreateContext create_context{kTableOptions(),
+                                    nullptr /* ioptions */,
+                                    nullptr /* statistics */,
+                                    kDecompressor(),
+                                    protection_bytes_per_key,
+                                    options.comparator,
+                                    /*index_value_is_full=*/false,
+                                    /*index_has_first_key=*/false,
+                                    /*index_value_delta_escape=*/false};
 
   {
     std::string invalid_content = "1";
@@ -1329,7 +1340,10 @@ TEST_F(BlockPerKVChecksumTest, CorruptHashIndexNumBucketsNoOverRead) {
                                     nullptr /* statistics */,
                                     kDecompressor(),
                                     0 /* protection_bytes_per_key */,
-                                    options.comparator};
+                                    options.comparator,
+                                    /*index_value_is_full=*/false,
+                                    /*index_has_first_key=*/false,
+                                    /*index_value_delta_escape=*/false};
 
   // Body bytes followed by a 2-byte NUM_BUCKETS field, then the encoded footer
   // (values_section_offset + packed). Layout mirrors what DecodeFrom expects.
@@ -1425,14 +1439,18 @@ TEST_F(BlockPerKVChecksumTest, ApproximateMemory) {
       kDecompressor(),
       protection_bytes_per_key,
       options.comparator,
-      true /* index_value_is_full */};
+      true /* index_value_is_full */,
+      /*index_has_first_key=*/false,
+      /*index_value_delta_escape=*/false};
   BlockCreateContext create_context{kTableOptions(),
                                     nullptr /* ioptions */,
                                     nullptr /* statistics */,
                                     kDecompressor(),
                                     0,
                                     options.comparator,
-                                    true /* index_value_is_full */};
+                                    true /* index_value_is_full */,
+                                    /*index_has_first_key=*/false,
+                                    /*index_value_delta_escape=*/false};
 
   {
     std::unique_ptr<Block_kData> data_block;
@@ -1520,9 +1538,15 @@ class DataBlockKVChecksumTest
   std::unique_ptr<Block_kData> GenerateDataBlock(
       std::vector<std::string>& keys, std::vector<std::string>& values,
       int num_record) {
-    BlockCreateContext create_context{
-        kTableOptions(), nullptr /* statistics */, nullptr /* ioptions */,
-        kDecompressor(), GetChecksumLen(),         Options().comparator};
+    BlockCreateContext create_context{kTableOptions(),
+                                      nullptr /* statistics */,
+                                      nullptr /* ioptions */,
+                                      kDecompressor(),
+                                      GetChecksumLen(),
+                                      Options().comparator,
+                                      /*index_value_is_full=*/false,
+                                      /*index_has_first_key=*/false,
+                                      /*index_value_delta_escape=*/false};
     builder_ = std::make_unique<BlockBuilder>(
         static_cast<int>(GetRestartInterval()),
         GetUseDeltaEncoding() /* use_delta_encoding */,
@@ -1652,7 +1676,8 @@ class IndexBlockKVChecksumTest
         protection_bytes_per_key,
         options.comparator,
         !UseValueDeltaEncoding() /* value_is_full */,
-        IncludeFirstKey()};
+        IncludeFirstKey(),
+        /*index_value_delta_escape=*/false};
     builder_ = std::make_unique<BlockBuilder>(
         static_cast<int>(GetRestartInterval()), true /* use_delta_encoding */,
         UseValueDeltaEncoding() /* use_value_delta_encoding */,
@@ -1786,9 +1811,15 @@ class MetaIndexBlockKVChecksumTest
       int num_record) {
     Options options = Options();
     uint8_t protection_bytes_per_key = GetChecksumLen();
-    BlockCreateContext create_context{
-        kTableOptions(), nullptr /* ioptions */,   nullptr /* statistics */,
-        kDecompressor(), protection_bytes_per_key, options.comparator};
+    BlockCreateContext create_context{kTableOptions(),
+                                      nullptr /* ioptions */,
+                                      nullptr /* statistics */,
+                                      kDecompressor(),
+                                      protection_bytes_per_key,
+                                      options.comparator,
+                                      /*index_value_is_full=*/false,
+                                      /*index_has_first_key=*/false,
+                                      /*index_value_delta_escape=*/false};
     builder_ =
         std::make_unique<BlockBuilder>(static_cast<int>(GetRestartInterval()));
     // add a bunch of records to a block
@@ -1817,9 +1848,15 @@ INSTANTIATE_TEST_CASE_P(P, MetaIndexBlockKVChecksumTest,
 TEST_P(MetaIndexBlockKVChecksumTest, ChecksumConstructionAndVerification) {
   Options options = Options();
   uint8_t protection_bytes_per_key = GetChecksumLen();
-  BlockCreateContext create_context{
-      kTableOptions(), nullptr /* ioptions */,   nullptr /* statistics */,
-      kDecompressor(), protection_bytes_per_key, options.comparator};
+  BlockCreateContext create_context{kTableOptions(),
+                                    nullptr /* ioptions */,
+                                    nullptr /* statistics */,
+                                    kDecompressor(),
+                                    protection_bytes_per_key,
+                                    options.comparator,
+                                    /*index_value_is_full=*/false,
+                                    /*index_has_first_key=*/false,
+                                    /*index_value_delta_escape=*/false};
   std::vector<int> num_restart_intervals = {1, 16};
   for (const auto num_restart_interval : num_restart_intervals) {
     const int kNumRecords = num_restart_interval * GetRestartInterval();

--- a/table/block_based/data_block_footer.cc
+++ b/table/block_based/data_block_footer.cc
@@ -15,6 +15,14 @@ namespace ROCKSDB_NAMESPACE {
 
 // Hash index bit (bit 31)
 constexpr uint32_t kHashIndexBit = 1u << 31;
+// Extended metadata bit (bit 30): reserved "open up more metadata" escape.
+// When set, an additional (currently unspecified) metadata section is present.
+// No feature defines it yet, so it must be 0; a set bit is treated as an
+// unsupported/corrupt block. Reserving it in format_version 8 lets a future
+// extension add block metadata by setting this bit and writing its section,
+// handled in this one shared decoder -- without another format_version bump or
+// re-plumbing format_version into every block parser.
+constexpr uint32_t kExtendedMetadataBit = 1u << 30;
 // Uniform keys bit (bit 29) - indicates keys are uniformly distributed
 constexpr uint32_t kUniformKeysBit = 1u << 29;
 // Separated KV storage bit (bit 28)
@@ -72,6 +80,13 @@ Status DataBlockFooter::DecodeFrom(Slice* input) {
     packed &= ~kUniformKeysBit;
   } else {
     is_uniform = false;
+  }
+
+  // Reserved "extended metadata" escape (bit 30): no feature defines it yet, so
+  // a set bit means the block was written by a newer format we don't support.
+  if (packed & kExtendedMetadataBit) {
+    return Status::Corruption(
+        "Unsupported extended block metadata (reserved bit set)");
   }
 
   // Check for reserved/unrecognized feature bits (anything beyond

--- a/table/block_based/data_block_footer.h
+++ b/table/block_based/data_block_footer.h
@@ -26,16 +26,23 @@ namespace ROCKSDB_NAMESPACE {
 //   - The low 28 bits store the number of restart points (num_restarts)
 //   - The high 4 bits are reserved for metadata/features:
 //     - Bit 31: Hash index present (kDataBlockBinaryAndHash)
-//     - Bit 30: IMPORTANT: Cannot be used without format version bump.
+//     - Bit 30: RESERVED "extended metadata present" escape (format_version >=
+//       8). No feature defines it yet, so it must be 0; a set bit is rejected
+//       as unsupported/corrupt. It lets a future extension add block metadata
+//       by setting this bit and writing an additional section -- handled in the
+//       one shared DataBlockFooter decoder -- without another format_version
+//       bump or plumbing format_version into every kind of block parser.
 //     - Bit 29: Uniform keys flag (for kAuto index block search)
 //     - Bit 28: Separated KV storage (keys and values stored in separate
 //       sections within the block)
 //
 // Note on forward compatibility: Bits 28-29 can be read by older versions of
-// RocksDB and interpreted as an extremely large, which will be caught as a
-// corruption. Bit 30 is special because num_restarts is multipled by 4, causing
-// overflow and the corruption check to be silently ignored
+// RocksDB and interpreted as an extremely large num_restarts, which will be
+// caught as a corruption. Bit 30 is special because num_restarts is multipled
+// by 4, causing overflow and the corruption check to be silently ignored
 // (https://github.com/facebook/rocksdb/blob/10.11.fb/table/block_based/block.cc#L1070-L1103)
+// Now format_version >= 8 officially unlocks use of that bit because we know
+// the reader isn't going to ignore it.
 //
 // When separated KV is enabled, an additional uint32_t is prepended before the
 // packed footer, storing the offset to the values section within the block.

--- a/table/block_based/hash_index_reader.cc
+++ b/table/block_based/hash_index_reader.cc
@@ -136,7 +136,8 @@ InternalIteratorBase<IndexValue>* HashIndexReader::NewIterator(
       rep->get_global_seqno(BlockType::kIndex), iter, kNullStats,
       total_order_seek, index_has_first_key(), index_key_includes_seq(),
       index_value_is_full(), false /* block_contents_pinned */,
-      user_defined_timestamps_persisted(), prefix_index_.get());
+      user_defined_timestamps_persisted(), prefix_index_.get(),
+      BlockBasedTableOptions::kBinary, index_value_delta_escape());
 
   assert(it != nullptr);
   index_block.TransferTo(it);

--- a/table/block_based/index_builder.cc
+++ b/table/block_based/index_builder.cc
@@ -332,8 +332,9 @@ Status PartitionedIndexBuilder::Finish(
     std::string handle_delta_encoding;
     // NOTE: must go through IndexValue::EncodeTo, whose encoding depends on
     // format_version; readers decode this block with IndexValue::DecodeFrom.
-    // Nothing to delta against for the first entry, whose value BlockBuilder
-    // writes in full anyway.
+    // Nothing to delta against for the first entry; it is a restart point
+    // (shared == 0), so BlockBuilder writes its value in full and never
+    // consults this (empty) delta.
     if (use_value_delta_encoding_ && !last_encoded_handle_.IsNull()) {
       IndexValue(last_partition_block_handle, Slice())
           .EncodeTo(&handle_delta_encoding, /*have_first_key=*/false,

--- a/table/block_based/index_builder.cc
+++ b/table/block_based/index_builder.cc
@@ -172,6 +172,8 @@ PartitionedIndexBuilder::PartitionedIndexBuilder(
       // wil be enforced on all sub_index_builders on ::Finish.
       must_use_separator_with_seq_(false),
       use_value_delta_encoding_(use_value_delta_encoding),
+      value_delta_escape_(
+          FormatVersionUsesValueDeltaEscape(table_opt.format_version)),
       statistics_(statistics) {
   MakeNewSubIndexBuilder();
 }
@@ -328,18 +330,24 @@ Status PartitionedIndexBuilder::Finish(
     Entry& last_entry = entries_.front();
     EncodedBlockHandle handle_encoding(last_partition_block_handle);
     std::string handle_delta_encoding;
-    PutVarsignedint64(
-        &handle_delta_encoding,
-        last_partition_block_handle.size() - last_encoded_handle_.size());
+    // NOTE: must go through IndexValue::EncodeTo, whose encoding depends on
+    // format_version; readers decode this block with IndexValue::DecodeFrom.
+    // Nothing to delta against for the first entry, whose value BlockBuilder
+    // writes in full anyway.
+    if (use_value_delta_encoding_ && !last_encoded_handle_.IsNull()) {
+      IndexValue(last_partition_block_handle, Slice())
+          .EncodeTo(&handle_delta_encoding, /*have_first_key=*/false,
+                    &last_encoded_handle_, value_delta_escape_);
+    }
     last_encoded_handle_ = last_partition_block_handle;
     const Slice handle_delta_encoding_slice(handle_delta_encoding);
     // NOTE: WriteBatch guarantees keys < 4GB; handle values are also small
     index_block_builder_.Add(last_entry.key, handle_encoding.AsSlice(),
-                             &handle_delta_encoding_slice);
+                             handle_delta_encoding_slice);
     if (!must_use_separator_with_seq_.LoadRelaxed()) {
       index_block_builder_without_seq_.Add(ExtractUserKey(last_entry.key),
                                            handle_encoding.AsSlice(),
-                                           &handle_delta_encoding_slice);
+                                           handle_delta_encoding_slice);
     }
     entries_.pop_front();
   }

--- a/table/block_based/index_builder.h
+++ b/table/block_based/index_builder.h
@@ -251,6 +251,7 @@ class ShortenedIndexBuilder : public IndexBuilder {
             false /* use_separated_kv_storage */, statistics,
             uniform_cv_threshold),
         use_value_delta_encoding_(use_value_delta_encoding),
+        value_delta_escape_(FormatVersionUsesValueDeltaEscape(format_version)),
         include_first_key_(include_first_key),
         shortening_mode_(shortening_mode) {
     // Making the default true will disable the feature for old versions
@@ -324,10 +325,16 @@ class ShortenedIndexBuilder : public IndexBuilder {
     std::string encoded_entry;
     std::string delta_encoded_entry;
     entry.EncodeTo(&encoded_entry, include_first_key_, nullptr);
+    // Under format_version >= 8, a non-contiguous handle (skip_delta_encoding)
+    // is expressed with the in-value escape (see IndexValue::EncodeTo), so we
+    // still delta-encode the value AND keep the key delta-encoded (do not force
+    // the entry to a restart). Under format_version <= 7, keep legacy behavior:
+    // skip_delta_encoding forces both a full value and a full (shared==0) key.
+    const bool force_full_key = skip_delta_encoding && !value_delta_escape_;
     if (use_value_delta_encoding_ && !last_encoded_handle_.IsNull() &&
-        !skip_delta_encoding) {
+        (value_delta_escape_ || !skip_delta_encoding)) {
       entry.EncodeTo(&delta_encoded_entry, include_first_key_,
-                     &last_encoded_handle_);
+                     &last_encoded_handle_, value_delta_escape_);
     } else {
       // If it's the first block, or delta encoding is disabled,
       // BlockBuilder::Add() below won't use delta-encoded slice.
@@ -346,11 +353,11 @@ class ShortenedIndexBuilder : public IndexBuilder {
     // optimization is provided.
     // NOTE: WriteBatch guarantees keys < 4GB; handle values are also small
     index_block_builder_.Add(separator_with_seq, encoded_entry,
-                             &delta_encoded_entry_slice, skip_delta_encoding);
+                             delta_encoded_entry_slice, force_full_key);
     if (!must_use_separator_with_seq) {
       index_block_builder_without_seq_.Add(
           ExtractUserKey(separator_with_seq), encoded_entry,
-          &delta_encoded_entry_slice, skip_delta_encoding);
+          delta_encoded_entry_slice, force_full_key);
     }
 
     ++num_index_entries_;
@@ -486,6 +493,9 @@ class ShortenedIndexBuilder : public IndexBuilder {
   // before).
   BlockBuilder index_block_builder_without_seq_;
   const bool use_value_delta_encoding_;
+  // format_version >= 8: emit the in-value escape for non-contiguous handles
+  // instead of forcing the index entry to a restart (see IndexValue::EncodeTo).
+  const bool value_delta_escape_;
   RelaxedAtomic<bool> must_use_separator_with_seq_;
   const bool include_first_key_;
   BlockBasedTableOptions::IndexShorteningMode shortening_mode_;
@@ -769,12 +779,16 @@ class PartitionedIndexBuilder : public IndexBuilder {
   const BlockBasedTableOptions& table_opt_;
   RelaxedAtomic<bool> must_use_separator_with_seq_;
   bool use_value_delta_encoding_;
+  // format_version >= 8 value-delta codec for the top-level index (see
+  // IndexValue::EncodeTo). Must match what the reader of this block uses.
+  const bool value_delta_escape_;
   // true if an external entity (such as filter partition builder) request
   // cutting the next partition
   bool partition_cut_requested_ = true;
   // true if it should cut the next filter partition block
   bool cut_filter_block = false;
-  BlockHandle last_encoded_handle_;
+  // Start in a usable "no previous handle" state
+  BlockHandle last_encoded_handle_ = BlockHandle::NullBlockHandle();
   Statistics* statistics_;
   // Cached estimate of current index size, updated when data blocks are added
   RelaxedAtomic<uint64_t> estimated_index_size_{0};

--- a/table/block_based/index_reader_common.h
+++ b/table/block_based/index_reader_common.h
@@ -62,6 +62,13 @@ class BlockBasedTable::IndexReaderCommon : public BlockBasedTable::IndexReader {
     return table_->get_rep()->index_value_is_full;
   }
 
+  bool index_value_delta_escape() const {
+    assert(table_ != nullptr);
+    assert(table_->get_rep() != nullptr);
+    return FormatVersionUsesValueDeltaEscape(
+        table_->get_rep()->footer.format_version());
+  }
+
   bool cache_index_blocks() const {
     assert(table_ != nullptr);
     assert(table_->get_rep() != nullptr);

--- a/table/block_based/partitioned_filter_block.cc
+++ b/table/block_based/partitioned_filter_block.cc
@@ -17,14 +17,13 @@
 #include "rocksdb/filter_policy.h"
 #include "table/block_based/block.h"
 #include "table/block_based/block_based_table_reader.h"
-#include "util/coding.h"
 
 namespace ROCKSDB_NAMESPACE {
 
 PartitionedFilterBlockBuilder::PartitionedFilterBlockBuilder(
     const SliceTransform* _prefix_extractor, bool whole_key_filtering,
     FilterBitsBuilder* filter_bits_builder, int index_block_restart_interval,
-    const bool use_value_delta_encoding,
+    const bool use_value_delta_encoding, uint32_t format_version,
     PartitionedIndexBuilder* const p_index_builder,
     const uint32_t partition_size, size_t ts_sz,
     const bool persist_user_defined_timestamps,
@@ -47,7 +46,9 @@ PartitionedFilterBlockBuilder::PartitionedFilterBlockBuilder(
           BlockBasedTableOptions::kDataBlockBinarySearch /* index_type */,
           0.75 /* data_block_hash_table_util_ratio */, ts_sz,
           persist_user_defined_timestamps, true /* is_user_key */,
-          /*use_separated_kv_storage=*/false) {
+          /*use_separated_kv_storage=*/false),
+      use_value_delta_encoding_(use_value_delta_encoding),
+      value_delta_escape_(FormatVersionUsesValueDeltaEscape(format_version)) {
   // Compute keys_per_partition_
   keys_per_partition_ = static_cast<uint32_t>(
       filter_bits_builder_->ApproximateNumEntries(partition_size));
@@ -285,19 +286,24 @@ Status PartitionedFilterBlockBuilder::Finish(
     std::string handle_encoding;
     last_partition_block_handle.EncodeTo(&handle_encoding);
     std::string handle_delta_encoding;
-    PutVarsignedint64(
-        &handle_delta_encoding,
-        last_partition_block_handle.size() - last_encoded_handle_.size());
+    // NOTE: must go through IndexValue::EncodeTo, whose encoding depends on
+    // format_version; readers decode this block with IndexValue::DecodeFrom.
+    // Nothing to delta against for the first entry, whose value BlockBuilder
+    // writes in full anyway.
+    if (use_value_delta_encoding_ && !last_encoded_handle_.IsNull()) {
+      IndexValue(last_partition_block_handle, Slice())
+          .EncodeTo(&handle_delta_encoding, /*have_first_key=*/false,
+                    &last_encoded_handle_, value_delta_escape_);
+    }
     last_encoded_handle_ = last_partition_block_handle;
     const Slice handle_delta_encoding_slice(handle_delta_encoding);
 
     // NOTE: WriteBatch guarantees keys < 4GB; handle values are also small
     index_on_filter_block_builder_.Add(e.ikey, handle_encoding,
-                                       &handle_delta_encoding_slice);
+                                       handle_delta_encoding_slice);
     if (!p_index_builder_->separator_is_key_plus_seq()) {
       index_on_filter_block_builder_without_seq_.Add(
-          ExtractUserKey(e.ikey), handle_encoding,
-          &handle_delta_encoding_slice);
+          ExtractUserKey(e.ikey), handle_encoding, handle_delta_encoding_slice);
     }
 
     filters_.pop_front();
@@ -431,7 +437,8 @@ BlockHandle PartitionedFilterBlockReader::GetFilterPartitionHandle(
       &iter, kNullStats, true /* total_order_seek */,
       false /* have_first_key */, index_key_includes_seq(),
       index_value_is_full(), false /* block_contents_pinned */,
-      user_defined_timestamps_persisted());
+      user_defined_timestamps_persisted(), nullptr /* prefix_index */,
+      BlockBasedTableOptions::kBinary, index_value_delta_escape());
   iter.Seek(entry);
   if (UNLIKELY(!iter.Valid())) {
     // entry is larger than all the keys. However its prefix might still be
@@ -624,7 +631,9 @@ Status PartitionedFilterBlockReader::CacheDependencies(
       rep->get_global_seqno(BlockType::kFilterPartitionIndex), &biter,
       kNullStats, true /* total_order_seek */, false /* have_first_key */,
       index_key_includes_seq(), index_value_is_full(),
-      false /* block_contents_pinned */, user_defined_timestamps_persisted());
+      false /* block_contents_pinned */, user_defined_timestamps_persisted(),
+      nullptr /* prefix_index */, BlockBasedTableOptions::kBinary,
+      index_value_delta_escape());
   // Index partitions are assumed to be consecuitive. Prefetch them all.
   // Read the first block offset
   biter.SeekToFirst();
@@ -713,7 +722,8 @@ void PartitionedFilterBlockReader::EraseFromCacheBeforeDestruction(
           &biter, kNullStats, true /* total_order_seek */,
           false /* have_first_key */, index_key_includes_seq(),
           index_value_is_full(), false /* block_contents_pinned */,
-          user_defined_timestamps_persisted());
+          user_defined_timestamps_persisted(), nullptr /* prefix_index */,
+          BlockBasedTableOptions::kBinary, index_value_delta_escape());
 
       UncacheAggressivenessAdvisor advisor(uncache_aggressiveness);
       for (biter.SeekToFirst(); biter.Valid() && advisor.ShouldContinue();
@@ -750,6 +760,14 @@ bool PartitionedFilterBlockReader::index_value_is_full() const {
   assert(table()->get_rep());
 
   return table()->get_rep()->index_value_is_full;
+}
+
+bool PartitionedFilterBlockReader::index_value_delta_escape() const {
+  assert(table());
+  assert(table()->get_rep());
+
+  return FormatVersionUsesValueDeltaEscape(
+      table()->get_rep()->footer.format_version());
 }
 
 bool PartitionedFilterBlockReader::user_defined_timestamps_persisted() const {

--- a/table/block_based/partitioned_filter_block.h
+++ b/table/block_based/partitioned_filter_block.h
@@ -30,7 +30,7 @@ class PartitionedFilterBlockBuilder : public FullFilterBlockBuilder {
   explicit PartitionedFilterBlockBuilder(
       const SliceTransform* prefix_extractor, bool whole_key_filtering,
       FilterBitsBuilder* filter_bits_builder, int index_block_restart_interval,
-      const bool use_value_delta_encoding,
+      const bool use_value_delta_encoding, uint32_t format_version,
       PartitionedIndexBuilder* const p_index_builder,
       const uint32_t partition_size, size_t ts_sz,
       const bool persist_user_defined_timestamps,
@@ -140,7 +140,11 @@ class PartitionedFilterBlockBuilder : public FullFilterBlockBuilder {
   // same for user keys
   BlockBuilder index_on_filter_block_builder_without_seq_;
   // For delta-encoding handles
-  BlockHandle last_encoded_handle_;
+  BlockHandle last_encoded_handle_ = BlockHandle::NullBlockHandle();
+  const bool use_value_delta_encoding_;
+  // format_version >= 8 value-delta codec for the index on filter partitions
+  // (see IndexValue::EncodeTo). Must match what the reader of this block uses.
+  const bool value_delta_escape_;
   // True if we are between two calls to Finish(), because we have returned
   // the filter at the front of filters_ but haven't yet added it to the
   // partition index.
@@ -218,6 +222,7 @@ class PartitionedFilterBlockReader
   const InternalKeyComparator* internal_comparator() const;
   bool index_key_includes_seq() const;
   bool index_value_is_full() const;
+  bool index_value_delta_escape() const;
   bool user_defined_timestamps_persisted() const;
 
  protected:

--- a/table/block_based/partitioned_filter_block_test.cc
+++ b/table/block_based/partitioned_filter_block_test.cc
@@ -30,7 +30,10 @@ class MockedBlockBasedTable : public BlockBasedTable {
     rep->index_key_includes_seq = pib->separator_is_key_plus_seq();
     rep->index_value_is_full = !pib->get_use_value_delta_encoding();
     // Open decodes the footer from the file; there is no file here, and an
-    // un-decoded Footer reports kInvalidFormatVersion.
+    // un-decoded Footer reports kInvalidFormatVersion. Match the format_version
+    // the test's builders encode the index and filter-partition-index blocks
+    // with, so reader-side codec selection (e.g. index_value_delta_escape())
+    // stays consistent with how they were written, at any format_version.
     rep->footer.TEST_SetFormatVersion(rep->table_options.format_version);
   }
 };

--- a/table/block_based/partitioned_filter_block_test.cc
+++ b/table/block_based/partitioned_filter_block_test.cc
@@ -29,6 +29,9 @@ class MockedBlockBasedTable : public BlockBasedTable {
     // Initialize what Open normally does as much as necessary for the test
     rep->index_key_includes_seq = pib->separator_is_key_plus_seq();
     rep->index_value_is_full = !pib->get_use_value_delta_encoding();
+    // Open decodes the footer from the file; there is no file here, and an
+    // un-decoded Footer reports kInvalidFormatVersion.
+    rep->footer.TEST_SetFormatVersion(rep->table_options.format_version);
   }
 };
 
@@ -162,7 +165,7 @@ class PartitionedFilterBlockTest
         BloomFilterPolicy::GetBuilderFromContext(
             FilterBuildingContext(table_options_)),
         table_options_.index_block_restart_interval, !kValueDeltaEncoded,
-        p_index_builder, partition_size, ts_sz_,
+        table_options_.format_version, p_index_builder, partition_size, ts_sz_,
         user_defined_timestamps_persisted_, decouple_partitioned_filters);
   }
 

--- a/table/block_based/partitioned_index_reader.cc
+++ b/table/block_based/partitioned_index_reader.cc
@@ -75,7 +75,8 @@ InternalIteratorBase<IndexValue>* PartitionIndexReader::NewIterator(
             rep->get_global_seqno(BlockType::kIndex), nullptr, kNullStats, true,
             index_has_first_key(), index_key_includes_seq(),
             index_value_is_full(), false /* block_contents_pinned */,
-            user_defined_timestamps_persisted()));
+            user_defined_timestamps_persisted(), nullptr /* prefix_index */,
+            BlockBasedTableOptions::kBinary, index_value_delta_escape()));
   } else {
     ReadOptions ro{read_options};
     // FIXME? Possible regression seen in prefetch_test if this field is
@@ -90,7 +91,8 @@ InternalIteratorBase<IndexValue>* PartitionIndexReader::NewIterator(
             rep->get_global_seqno(BlockType::kIndex), nullptr, kNullStats, true,
             index_has_first_key(), index_key_includes_seq(),
             index_value_is_full(), false /* block_contents_pinned */,
-            user_defined_timestamps_persisted()));
+            user_defined_timestamps_persisted(), nullptr /* prefix_index */,
+            BlockBasedTableOptions::kBinary, index_value_delta_escape()));
 
     it = new PartitionedIndexIterator(
         table(), ro, *internal_comparator(), std::move(index_iter),
@@ -137,7 +139,9 @@ Status PartitionIndexReader::CacheDependencies(
       internal_comparator()->user_comparator(),
       rep->get_global_seqno(BlockType::kIndex), &biter, kNullStats, true,
       index_has_first_key(), index_key_includes_seq(), index_value_is_full(),
-      false /* block_contents_pinned */, user_defined_timestamps_persisted());
+      false /* block_contents_pinned */, user_defined_timestamps_persisted(),
+      nullptr /* prefix_index */, BlockBasedTableOptions::kBinary,
+      index_value_delta_escape());
   // Index partitions are assumed to be consecuitive. Prefetch them all.
   // Read the first block offset
   biter.SeekToFirst();
@@ -245,7 +249,8 @@ void PartitionIndexReader::EraseFromCacheBeforeDestruction(
           kNullStats, true /* total_order_seek */, index_has_first_key(),
           index_key_includes_seq(), index_value_is_full(),
           false /* block_contents_pinned */,
-          user_defined_timestamps_persisted());
+          user_defined_timestamps_persisted(), nullptr /* prefix_index */,
+          BlockBasedTableOptions::kBinary, index_value_delta_escape());
 
       UncacheAggressivenessAdvisor advisor(uncache_aggressiveness);
       for (biter.SeekToFirst(); biter.Valid() && advisor.ShouldContinue();

--- a/table/format.cc
+++ b/table/format.cc
@@ -28,6 +28,7 @@
 #include "table/block_based/block.h"
 #include "table/block_based/block_based_table_reader.h"
 #include "table/persistent_cache_helper.h"
+#include "test_util/sync_point.h"
 #include "unique_id_impl.h"
 #include "util/cast_util.h"
 #include "util/coding.h"
@@ -100,13 +101,35 @@ std::string BlockHandle::ToString(bool hex) const {
 const BlockHandle BlockHandle::kNullBlockHandle(0, 0);
 
 void IndexValue::EncodeTo(std::string* dst, bool have_first_key,
-                          const BlockHandle* previous_handle) const {
+                          const BlockHandle* previous_handle,
+                          bool use_value_delta_escape) const {
   if (previous_handle) {
     // WART: this is specific to Block-based table
-    assert(handle.offset() == previous_handle->offset() +
-                                  previous_handle->size() +
-                                  BlockBasedTable::kBlockTrailerSize);
-    PutVarsignedint64(dst, handle.size() - previous_handle->size());
+    const uint64_t contiguous_offset = previous_handle->offset() +
+                                       previous_handle->size() +
+                                       BlockBasedTable::kBlockTrailerSize;
+    if (use_value_delta_escape) {
+      // format_version >= 8: reserve varint 0 as an escape so a non-contiguous
+      // handle can still be a (key-delta-encoded) non-restart entry. Genuine
+      // size deltas are remapped to zigzag(delta)+1 (always >= 1) to keep 0
+      // free.
+      if (handle.offset() == contiguous_offset) {
+        int64_t size_delta = static_cast<int64_t>(handle.size()) -
+                             static_cast<int64_t>(previous_handle->size());
+        // +1 could only overflow for |size_delta| ~ 2^63, which is impossible
+        // for block-size deltas (block size is 32-bit).
+        assert(i64ToZigzag(size_delta) != ~uint64_t{0});
+        PutVarint64(dst, i64ToZigzag(size_delta) + 1);
+      } else {
+        // Escape: a full BlockHandle (offset + size) follows.
+        TEST_SYNC_POINT("IndexValue::EncodeTo:ValueDeltaEscape");
+        PutVarint64(dst, 0);
+        handle.EncodeTo(dst);
+      }
+    } else {
+      assert(handle.offset() == contiguous_offset);
+      PutVarsignedint64(dst, handle.size() - previous_handle->size());
+    }
   } else {
     handle.EncodeTo(dst);
   }
@@ -118,16 +141,36 @@ void IndexValue::EncodeTo(std::string* dst, bool have_first_key,
 }
 
 Status IndexValue::DecodeFrom(Slice* input, bool have_first_key,
-                              const BlockHandle* previous_handle) {
+                              const BlockHandle* previous_handle,
+                              bool use_value_delta_escape) {
   if (previous_handle) {
-    int64_t delta;
-    if (!GetVarsignedint64(input, &delta)) {
-      return Status::Corruption("bad delta-encoded index value");
-    }
     // WART: this is specific to Block-based table
-    handle = BlockHandle(previous_handle->offset() + previous_handle->size() +
-                             BlockBasedTable::kBlockTrailerSize,
-                         previous_handle->size() + delta);
+    const uint64_t contiguous_offset = previous_handle->offset() +
+                                       previous_handle->size() +
+                                       BlockBasedTable::kBlockTrailerSize;
+    if (use_value_delta_escape) {
+      uint64_t u;
+      if (!GetVarint64(input, &u)) {
+        return Status::Corruption("bad delta-encoded index value");
+      }
+      if (u == 0) {
+        // Escape: a full BlockHandle (offset + size) follows.
+        Status s = handle.DecodeFrom(input);
+        if (!s.ok()) {
+          return s;
+        }
+      } else {
+        int64_t delta = zigzagToI64(u - 1);
+        handle =
+            BlockHandle(contiguous_offset, previous_handle->size() + delta);
+      }
+    } else {
+      int64_t delta;
+      if (!GetVarsignedint64(input, &delta)) {
+        return Status::Corruption("bad delta-encoded index value");
+      }
+      handle = BlockHandle(contiguous_offset, previous_handle->size() + delta);
+    }
   } else {
     Status s = handle.DecodeFrom(input);
     if (!s.ok()) {
@@ -208,8 +251,12 @@ inline uint8_t BlockTrailerSizeForMagicNumber(uint64_t magic_number) {
 //        - Checksum of above checksum type of whole footer, with this field
 //          set to all zeros.
 //      base_context_checksum (uint32LE, 4 bytes)
-//      metaindex block size (uint32LE, 4 bytes)
-//        - Assumed to be immediately before footer, < 4GB
+//      metaindex block size (& offset from footer) (uint32LE, 4 bytes)
+//        -> format_version < 8
+//           - Assumed to be immediately before footer, < 4GB
+//        -> format_version >= 8
+//           - Top 16 bits are number of bytes gap between start of footer and
+//             end of metaindex block (space for future file checksum data)
 //      <zero padding> (24 bytes, reserved for future use)
 //        - Brings part2 size also to 40 bytes
 //        - Checked that last eight bytes == 0, so reserved for a future
@@ -289,16 +336,37 @@ Status FooterBuilder::Build(uint64_t magic_number, uint32_t format_version,
     // Save base context checksum
     EncodeFixed32(cur, base_context_checksum);
     cur += 4;
-    // Compute and save metaindex size
-    uint32_t metaindex_size = static_cast<uint32_t>(metaindex_handle.size());
-    if (metaindex_size != metaindex_handle.size()) {
-      return Status::NotSupported("Metaindex block size > 4GB");
+    // Compute and save the metaindex block size, and (format_version >= 8) the
+    // gap between the end of the metaindex block and the start of the footer.
+    const uint64_t metaindex_block_end =
+        metaindex_handle.offset() + metaindex_handle.size() +
+        BlockTrailerSizeForMagicNumber(magic_number);
+    if (FormatVersionUsesMetaindexGap(format_version)) {
+      // Low 16 bits: metaindex block size. High 16 bits: gap in bytes.
+      if (metaindex_handle.size() > 0xFFFF) {
+        return Status::NotSupported(
+            "Metaindex block size > 64KB with format_version >= 8");
+      }
+      uint32_t metaindex_size = static_cast<uint32_t>(metaindex_handle.size());
+      uint64_t gap = 0;
+      if (metaindex_size != 0) {
+        assert(metaindex_block_end <= footer_offset);
+        gap = footer_offset - metaindex_block_end;
+      }
+      if (gap > 0xFFFF) {
+        return Status::NotSupported(
+            "Gap between metaindex block and footer > 64KB");
+      }
+      EncodeFixed32(cur, (static_cast<uint32_t>(gap) << 16) | metaindex_size);
+    } else {
+      uint32_t metaindex_size = static_cast<uint32_t>(metaindex_handle.size());
+      if (metaindex_size != metaindex_handle.size()) {
+        return Status::NotSupported("Metaindex block size > 4GB");
+      }
+      // Metaindex must be adjacent to footer
+      assert(metaindex_size == 0 || metaindex_block_end == footer_offset);
+      EncodeFixed32(cur, metaindex_size);
     }
-    // Metaindex must be adjacent to footer
-    assert(metaindex_size == 0 ||
-           metaindex_handle.offset() + metaindex_handle.size() ==
-               footer_offset - BlockTrailerSizeForMagicNumber(magic_number));
-    EncodeFixed32(cur, metaindex_size);
     cur += 4;
 
     // Zero pad remainder (for future use)
@@ -437,7 +505,18 @@ Status Footer::DecodeFrom(Slice input, uint64_t input_offset,
     success = GetFixed32(&input, &metaindex_size);
     assert(success);
     (void)success;
-    uint64_t metaindex_end = footer_offset - GetBlockTrailerSize();
+    // For format_version >= 8, the high 16 bits are the gap (in bytes) between
+    // the end of the metaindex block and the start of the footer (reserved for
+    // future file checksum data), and the low 16 bits are the metaindex block
+    // size. For older versions the whole field is the metaindex block size and
+    // the metaindex is adjacent to the footer.
+    uint64_t metaindex_gap = 0;
+    if (FormatVersionUsesMetaindexGap(format_version_)) {
+      metaindex_gap = metaindex_size >> 16;
+      metaindex_size &= 0xFFFF;
+    }
+    uint64_t metaindex_end =
+        footer_offset - GetBlockTrailerSize() - metaindex_gap;
     metaindex_handle_ =
         BlockHandle(metaindex_end - metaindex_size, metaindex_size);
 

--- a/table/format.h
+++ b/table/format.h
@@ -124,13 +124,24 @@ struct IndexValue {
 
   // have_first_key indicates whether the `first_internal_key` is used.
   // If previous_handle is not null, delta encoding is used;
-  // in this case, the two handles must point to consecutive blocks:
+  // in this case, the two handles normally point to consecutive blocks:
   // handle.offset() ==
   //     previous_handle->offset() + previous_handle->size() + kBlockTrailerSize
+  //
+  // use_value_delta_escape enables the format_version >= 8 value-delta codec:
+  // genuine size deltas are remapped (zigzag(delta)+1, always >= 1) so that the
+  // varint 0 is free to act as an escape meaning "a full BlockHandle follows."
+  // The escape is emitted (only) for a non-contiguous handle, so such an entry
+  // does not have to be forced to a restart. When use_value_delta_escape is
+  // false (format_version <= 7), the encoding is byte-identical to the legacy
+  // PutVarsignedint64(size delta). Only meaningful when previous_handle !=
+  // null.
   void EncodeTo(std::string* dst, bool have_first_key,
-                const BlockHandle* previous_handle) const;
+                const BlockHandle* previous_handle,
+                bool use_value_delta_escape = false) const;
   Status DecodeFrom(Slice* input, bool have_first_key,
-                    const BlockHandle* previous_handle);
+                    const BlockHandle* previous_handle,
+                    bool use_value_delta_escape = false);
 
   std::string ToString(bool hex, bool have_first_key) const;
 };
@@ -169,7 +180,19 @@ inline uint32_t ChecksumModifierForContext(uint32_t base_context_checksum,
   return modifier & all_or_nothing;
 }
 
+// Latest format_version supported for both reading and writing new SST files in
+// block-based format. Newer "draft" format_versions that are still in
+// development (e.g. the format_version 8 index value-delta escape) are not
+// published: they are exercised only in tests, gated behind the TEST-only
+// TEST_AllowUnsupportedFormatVersion() hook, and are neither readable nor
+// writable in production until finalized by bumping this constant.
 constexpr uint32_t kLatestBbtFormatVersion = 7;
+
+// Sentinel for "no format_version known yet," e.g. a Footer that has not been
+// populated by DecodeFrom. Deliberately larger than any real version so that
+// accidentally treating it as one is caught by the FormatVersionUses*
+// predicates below rather than silently reading as "newest of everything."
+constexpr uint32_t kInvalidFormatVersion = 0xffffffffU;
 
 // Minimum format version supported for reading SST files in block-based format.
 //
@@ -214,17 +237,56 @@ inline bool IsSupportedFormatVersionForWrite(uint64_t magic, uint32_t version) {
   }
 }
 
+// The FormatVersionUses* predicates below answer "does this (known) format
+// version use feature X". Every one of them is a `version >= N` test, so
+// kInvalidFormatVersion would satisfy all of them and quietly report "uses the
+// newest of everything." Callers must therefore pass a real version -- from
+// BlockBasedTableOptions, or from a Footer that has actually been decoded.
+inline void AssertKnownFormatVersion(uint32_t version) {
+  assert(version != kInvalidFormatVersion);
+  (void)version;
+}
+
 // Same as having a unique id in footer.
 inline bool FormatVersionUsesContextChecksum(uint32_t version) {
+  AssertKnownFormatVersion(version);
   return version >= 6;
 }
 
 inline bool FormatVersionUsesIndexHandleInFooter(uint32_t version) {
+  AssertKnownFormatVersion(version);
   return version < 6;
 }
 
 inline bool FormatVersionUsesCompressionManagerName(uint32_t version) {
+  AssertKnownFormatVersion(version);
   return version >= 7;
+}
+
+// format_version >= 8 decouples the index block's value-delta encoding from the
+// key "shared" sentinel by reserving an in-value escape codepoint that means "a
+// full BlockHandle follows" (see IndexValue::EncodeTo/DecodeFrom). This lets a
+// non-contiguous index entry (whose block handle does NOT start where the
+// previous one ended, e.g. because of super_block_alignment padding or
+// interleaved embedded blob records) remain a normal key-delta-encoded,
+// on-cadence index entry instead of being forced to a restart (shared==0).
+inline bool FormatVersionUsesValueDeltaEscape(uint32_t version) {
+  AssertKnownFormatVersion(version);
+  return version >= 8;
+}
+
+// format_version >= 8 repurposes the top 16 bits of the footer's 4-byte
+// "metaindex block size" field to record the number of bytes of gap between the
+// end of the metaindex block (including its trailer) and the start of the
+// footer (space reserved for future file checksum data). The low 16 bits hold
+// the metaindex block size. For format_version < 8 the whole field is the
+// metaindex block size and the metaindex is assumed adjacent to the footer.
+// See Footer format documentation in format.cc. (Note: fv < 6 allowed an
+// arbitrary gap due to inefficient metaindex handle encoding, but that's
+// obsolete.)
+inline bool FormatVersionUsesMetaindexGap(uint32_t version) {
+  AssertKnownFormatVersion(version);
+  return version >= 8;
 }
 
 // Footer encapsulates the fixed information stored at the tail end of every
@@ -264,6 +326,13 @@ class Footer {
   // unnecessary complexity to separate footer versions and
   // BBTO::format_version.)
   uint32_t format_version() const { return format_version_; }
+
+  // Test-only: set just the format_version, for unit tests that construct a
+  // BlockBasedTable::Rep without a real file to decode a footer from.
+  // Production code must populate the whole footer via DecodeFrom.
+  void TEST_SetFormatVersion(uint32_t format_version) {
+    format_version_ = format_version;
+  }
 
   // See ChecksumModifierForContext()
   uint32_t base_context_checksum() const { return base_context_checksum_; }
@@ -306,8 +375,6 @@ class Footer {
   static constexpr uint32_t kMaxEncodedLength = kNewVersionsEncodedLength;
 
   static constexpr uint64_t kNullTableMagicNumber = 0;
-
-  static constexpr uint32_t kInvalidFormatVersion = 0xffffffffU;
 
  private:
   static constexpr int kInvalidChecksumType =

--- a/table/meta_blocks.cc
+++ b/table/meta_blocks.cc
@@ -193,6 +193,10 @@ void PropertyBlockBuilder::AddTableProperty(const TableProperties& props) {
     Add(TablePropertiesNames::kSeparateKeyValueInDataBlock,
         props.separate_key_value_in_data_block);
   }
+  if (!props.user_key_common_prefix.empty()) {
+    Add(TablePropertiesNames::kUserKeyCommonPrefix,
+        props.user_key_common_prefix);
+  }
 }
 
 Slice PropertyBlockBuilder::Finish() {
@@ -405,6 +409,8 @@ Status ParsePropertiesBlock(
       *(pos->second) = val;
     } else if (key == TablePropertiesNames::kDbId) {
       new_table_properties->db_id = raw_val.ToString();
+    } else if (key == TablePropertiesNames::kUserKeyCommonPrefix) {
+      new_table_properties->user_key_common_prefix = raw_val.ToString();
     } else if (key == TablePropertiesNames::kDbSessionId) {
       new_table_properties->db_session_id = raw_val.ToString();
     } else if (key == TablePropertiesNames::kDbHostId) {

--- a/table/sst_file_reader_test.cc
+++ b/table/sst_file_reader_test.cc
@@ -31,6 +31,7 @@
 #include "test_util/testharness.h"
 #include "test_util/testutil.h"
 #include "util/compression.h"
+#include "util/defer.h"
 #include "utilities/merge_operators.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -604,6 +605,107 @@ TEST_F(SstFileReaderTest, EmbeddedBlobInterleavedLayout) {
   }
   ASSERT_OK(iter->status());
   EXPECT_EQ(idx, expected.size());
+}
+
+// format_version >= 8 lets embedded-blob SSTs use index value-delta encoding:
+// the interleaved blob records make some data blocks non-contiguous, and those
+// index entries use the in-value escape (see IndexValue::EncodeTo) while the
+// rest are delta encoded. This verifies correct round-trip at fv8 and that fv8
+// (unlike fv7) marks the index as delta encoded, all with a > 1 index restart
+// interval so deltas (and the escape) are actually produced.
+TEST_F(SstFileReaderTest, EmbeddedBlobValueDeltaEscapeFv8) {
+  // Writing the unpublished draft format_version 8 requires this opt-in.
+  SaveAndRestore<bool> allow_draft(&TEST_AllowUnsupportedFormatVersion(), true);
+
+  SstFileWriterEmbeddedBlobOptions embedded_blob_options;
+  embedded_blob_options.min_blob_size = 64;
+
+  // Interleave small (inline) and large (embedded-blob) values so that some
+  // data blocks follow a blob record (non-contiguous -> escape) and some do
+  // not (contiguous -> delta).
+  std::vector<std::pair<std::string, std::string>> expected;
+  for (int i = 0; i < 200; ++i) {
+    char keybuf[16];
+    snprintf(keybuf, sizeof(keybuf), "%06d", i);
+    std::string key(keybuf);
+    std::string value =
+        (i % 2 == 0) ? std::string(4096, static_cast<char>('a' + (i % 26)))
+                     : ("tiny" + std::to_string(i));
+    expected.emplace_back(std::move(key), std::move(value));
+  }
+
+  auto build_and_read = [&](uint32_t format_version, bool* index_delta_encoded,
+                            int* escape_count, std::vector<std::string>* got) {
+    BlockBasedTableOptions bbto;
+    bbto.format_version = format_version;
+    bbto.block_size = 1;                    // one entry per data block
+    bbto.index_block_restart_interval = 4;  // > 1 so value delta encoding is on
+    options_.table_factory.reset(NewBlockBasedTableFactory(bbto));
+
+    // Count index entries actually written with the in-value escape, rather
+    // than inferring it from the layout.
+    *escape_count = 0;
+    SyncPoint::GetInstance()->SetCallBack(
+        "IndexValue::EncodeTo:ValueDeltaEscape",
+        [escape_count](void*) { ++*escape_count; });
+    SyncPoint::GetInstance()->EnableProcessing();
+
+    SstFileWriter writer(soptions_, options_);
+    ASSERT_OK(writer.OpenWithEmbeddedBlobs(sst_name_, embedded_blob_options));
+    for (const auto& kv : expected) {
+      ASSERT_OK(writer.Put(kv.first, kv.second));
+    }
+    ASSERT_OK(writer.Finish());
+
+    SyncPoint::GetInstance()->DisableProcessing();
+    SyncPoint::GetInstance()->ClearAllCallBacks();
+
+    SstFileReader reader(options_);
+    ASSERT_OK(reader.Open(sst_name_));
+    ASSERT_OK(reader.VerifyChecksum());
+
+    std::shared_ptr<const TableProperties> props = reader.GetTableProperties();
+    ASSERT_NE(props, nullptr);
+    *index_delta_encoded = props->index_value_is_delta_encoded != 0;
+
+    got->clear();
+    std::unique_ptr<Iterator> iter(reader.NewIterator(ReadOptions()));
+    for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
+      ASSERT_OK(iter->status());
+      got->push_back(iter->value().ToString());
+    }
+    ASSERT_OK(iter->status());
+
+    // Point lookups too (exercise index Seek + escape decode).
+    std::string value;
+    for (const auto& kv : expected) {
+      ASSERT_OK(reader.Get(ReadOptions(), kv.first, &value));
+      ASSERT_EQ(value, kv.second);
+    }
+  };
+
+  std::vector<std::string> got7, got8;
+  bool delta7 = false, delta8 = false;
+  int escapes7 = 0, escapes8 = 0;
+  build_and_read(7, &delta7, &escapes7, &got7);
+  build_and_read(/*format_version=*/8, &delta8, &escapes8, &got8);
+
+  // Reads identical across versions.
+  ASSERT_EQ(static_cast<int>(got8.size()), static_cast<int>(expected.size()));
+  ASSERT_EQ(got7, got8);
+  std::vector<std::string> expected_values;
+  for (const auto& kv : expected) {
+    expected_values.push_back(kv.second);
+  }
+  ASSERT_EQ(got8, expected_values);
+
+  // Escape entries were actually produced at fv8 (interleaved blob records
+  // make some data blocks non-contiguous), and never at fv7.
+  EXPECT_GT(escapes8, 0);
+  EXPECT_EQ(escapes7, 0);
+  // fv7 embedded blobs disable index value delta encoding; fv8 enables it.
+  EXPECT_FALSE(delta7);
+  EXPECT_TRUE(delta8);
 }
 
 TEST_F(SstFileReaderTest, EmbeddedBlobRecordCorruptionDetected) {

--- a/table/table_properties.cc
+++ b/table/table_properties.cc
@@ -294,10 +294,11 @@ std::size_t TableProperties::ApproximateMemoryUsage() const {
 
   std::size_t string_props_mem_usage =
       db_id.size() + db_session_id.size() + db_host_id.size() +
-      column_family_name.size() + filter_policy_name.size() +
-      comparator_name.size() + merge_operator_name.size() +
-      prefix_extractor_name.size() + property_collectors_names.size() +
-      compression_name.size() + compression_options.size();
+      user_key_common_prefix.size() + column_family_name.size() +
+      filter_policy_name.size() + comparator_name.size() +
+      merge_operator_name.size() + prefix_extractor_name.size() +
+      property_collectors_names.size() + compression_name.size() +
+      compression_options.size();
   usage += string_props_mem_usage;
 
   for (auto iter = user_collected_properties.begin();
@@ -393,6 +394,8 @@ const std::string TablePropertiesNames::kIndexBlockRestartInterval =
     "rocksdb.index.block.restart.interval";
 const std::string TablePropertiesNames::kSeparateKeyValueInDataBlock =
     "rocksdb.separate.key.value.in.data.block";
+const std::string TablePropertiesNames::kUserKeyCommonPrefix =
+    "rocksdb.user.key.common.prefix";
 
 static std::unordered_map<std::string, OptionTypeInfo>
     table_properties_type_info = {
@@ -547,6 +550,9 @@ static std::unordered_map<std::string, OptionTypeInfo>
           OptionTypeFlags::kNone}},
         {"db_id",
          {offsetof(struct TableProperties, db_id), OptionType::kEncodedString}},
+        {"user_key_common_prefix",
+         {offsetof(struct TableProperties, user_key_common_prefix),
+          OptionType::kEncodedString}},
         {"db_session_id",
          {offsetof(struct TableProperties, db_session_id),
           OptionType::kEncodedString}},

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -753,8 +753,11 @@ static std::vector<TestArgs> GenerateArgList() {
       for (auto restart_interval : restart_intervals) {
         for (auto compression_type : GetSupportedCompressions()) {
           for (auto num_threads : compression_parallel_threads) {
-            // format_version = 7 changes some compression handling
-            for (uint32_t fv : {kMinSupportedBbtFormatVersionForRead, 7U}) {
+            // format_version = 7 changes some compression handling; 8 is the
+            // unpublished draft that exercises the fv8 index value-delta escape
+            // read/write path (table_test opts in via
+            // TEST_AllowUnsupportedFormatVersion in main()).
+            for (uint32_t fv : {kMinSupportedBbtFormatVersionForRead, 7U, 8U}) {
               TestArgs one_arg;
               one_arg.type = test_type;
               one_arg.reverse_compare = reverse_compare;
@@ -2341,7 +2344,10 @@ TEST_P(BlockBasedTableTest, BadChecksumType) {
 }
 
 TEST_P(BlockBasedTableTest, ReservedBitInDataBlockFooter) {
-  // Test that reserved metadata bits in data block footer are detected.
+  // Bit 30 of the data block footer is the reserved "extended metadata present"
+  // escape (format_version >= 8). No feature defines it yet, so setting it must
+  // be detected as corruption rather than silently misread.
+  //
   // We construct a block directly rather than going through the full table
   // iterator path to avoid issues with iterator error handling.
 
@@ -2352,14 +2358,16 @@ TEST_P(BlockBasedTableTest, ReservedBitInDataBlockFooter) {
   Slice block_contents = builder.Finish();
   std::string block_data = block_contents.ToString();
 
-  // The footer is the last 4 bytes - corrupt it by setting reserved bit 30
+  // The footer is the last 4 bytes - set the reserved extended-metadata bit
+  // (bit 30).
   ASSERT_GE(block_data.size(), sizeof(uint32_t));
   size_t footer_offset = block_data.size() - sizeof(uint32_t);
   uint32_t footer = DecodeFixed32(block_data.data() + footer_offset);
-  footer |= (1u << 30);  // Set a reserved bit
+  footer |= (1u << 30);  // Set the reserved extended-metadata bit
   EncodeFixed32(&block_data[footer_offset], footer);
 
-  // Try to construct a Block from the corrupted data
+  // Try to construct a Block from the data with the reserved bit set. The
+  // footer decode must reject it.
   BlockContents contents(std::move(block_data));
   Block block(std::move(contents), 0 /* read_amp_bytes_per_bit */);
 
@@ -2372,9 +2380,6 @@ TEST_P(BlockBasedTableTest, ReservedBitInDataBlockFooter) {
                         /*stats=*/nullptr, /*block_contents_pinned=*/false);
   ASSERT_FALSE(iter.Valid());
   ASSERT_EQ(iter.status().code(), Status::kCorruption)
-      << iter.status().ToString();
-  ASSERT_NE(iter.status().ToString().find("reserved bits set"),
-            std::string::npos)
       << iter.status().ToString();
 }
 
@@ -2780,6 +2785,98 @@ TEST_P(BlockBasedTableTest, PartitionIndexTest) {
     table_options.metadata_block_size = i;
     IndexTest(table_options);
   }
+}
+
+// The index of index partitions and the index of filter partitions are written
+// by builders separate from the per-partition index builder, and their values
+// are only delta encoded when index_block_restart_interval > 1 (with the
+// default of 1 every entry is a restart and carries a full handle, so the
+// value-delta codec is never exercised). Cover that path here -- including at
+// the unpublished draft format_version 8, where the value-delta codec reserves
+// an in-value escape codepoint -- so that a codec mismatch between either
+// top-level index writer and its reader is caught.
+TEST_P(BlockBasedTableTest, PartitionedIndexAndFilterValueDelta) {
+  // BlockBasedTableTest is parameterized over kFooterFormatVersionsToTest,
+  // which includes the unpublished draft format_version 8. (table_test opts in
+  // globally via TEST_AllowUnsupportedFormatVersion in main().)
+  BlockBasedTableOptions table_options = GetBlockBasedTableOptions();
+  table_options.index_type = BlockBasedTableOptions::kTwoLevelIndexSearch;
+  table_options.partition_filters = true;
+  table_options.filter_policy.reset(NewBloomFilterPolicy(10));
+  // Small blocks and partitions so there are many index and filter partitions,
+  // hence many top-level index entries.
+  table_options.block_size = 512;
+  table_options.metadata_block_size = 128;
+  // > 1 so top-level index values are actually delta encoded.
+  table_options.index_block_restart_interval = 3;
+  table_options.block_cache = NewLRUCache(1 << 20);
+  table_options.cache_index_and_filter_blocks = true;
+
+  TableConstructor c(BytewiseComparator());
+  // Vary value sizes so that consecutive partition handles have both zero and
+  // non-zero size deltas. Zero is the interesting one: it is the delta whose
+  // legacy encoding collides with the format_version 8 escape codepoint.
+  Random rnd(302);
+  std::vector<std::string> user_keys;
+  for (int i = 0; i < 1000; i++) {
+    char buf[32];
+    snprintf(buf, sizeof(buf), "key%06d", i);
+    std::string user_key(buf);
+    InternalKey ikey(user_key, 0, kTypeValue);
+    c.Add(ikey.Encode().ToString(),
+          rnd.RandomString(i % 3 == 0 ? 40 : 8) /* value */);
+    user_keys.push_back(std::move(user_key));
+  }
+
+  std::vector<std::string> keys;
+  stl_wrappers::KVMap kvmap;
+  Options options;
+  options.table_factory.reset(NewBlockBasedTableFactory(table_options));
+  const ImmutableOptions ioptions(options);
+  const MutableCFOptions moptions(options);
+  const InternalKeyComparator ikc(options.comparator);
+  c.Finish(options, ioptions, moptions, table_options, ikc, &keys, &kvmap);
+
+  auto* reader = static_cast<BlockBasedTable*>(c.GetTableReader());
+  auto props = reader->GetTableProperties();
+  // Both top-level indexes must have enough entries that non-restart (i.e.
+  // delta encoded) entries exist, otherwise this test proves nothing.
+  ASSERT_GT(props->index_partitions,
+            static_cast<uint64_t>(table_options.index_block_restart_interval));
+  ASSERT_EQ(props->index_value_is_delta_encoded, 1);
+
+  // Full scan: drives the top-level index of index partitions.
+  ReadOptions read_options;
+  {
+    std::unique_ptr<InternalIterator> iter(reader->NewIterator(
+        read_options, moptions.prefix_extractor.get(), /*arena=*/nullptr,
+        /*skip_filters=*/false, TableReaderCaller::kUncategorized));
+    size_t i = 0;
+    for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
+      ASSERT_OK(iter->status());
+      ASSERT_LT(i, keys.size());
+      ASSERT_EQ(keys[i], iter->key().ToString());
+      ASSERT_EQ(kvmap[keys[i]], iter->value().ToString());
+      i++;
+    }
+    ASSERT_OK(iter->status());
+    ASSERT_EQ(i, keys.size());
+  }
+
+  // Point lookups: drive the index of filter partitions as well.
+  for (size_t i = 0; i < user_keys.size(); i += 7) {
+    SCOPED_TRACE("user_key=" + user_keys[i]);
+    InternalKey ikey(user_keys[i], 0, kTypeValue);
+    PinnableSlice value;
+    GetContext get_context(options.comparator, nullptr, nullptr, nullptr,
+                           GetContext::kNotFound, user_keys[i], &value, nullptr,
+                           nullptr, nullptr, true, nullptr, nullptr);
+    ASSERT_OK(reader->Get(read_options, ikey.Encode(), &get_context,
+                          moptions.prefix_extractor.get()));
+    ASSERT_EQ(kvmap[ikey.Encode().ToString()], value.ToString());
+  }
+
+  c.ResetTableReader();
 }
 
 TEST_P(BlockBasedTableTest, IndexSeekOptimizationIncomplete) {

--- a/test_util/testutil.cc
+++ b/test_util/testutil.cc
@@ -46,6 +46,10 @@ const std::set<uint32_t> kFooterFormatVersionsToTest{
     // In case any interesting future changes
     kDefaultFormatVersion,
     kLatestBbtFormatVersion,
+    // Unpublished draft format_version 8 (index value-delta escape). Writing it
+    // requires the TEST_AllowUnsupportedFormatVersion() opt-in, enabled by the
+    // test files that instantiate parameterized suites over this set.
+    8U,
 };
 const ReadOptionsNoIo kReadOptionsNoIo;
 

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -321,7 +321,7 @@ default_params = {
     "verify_checksum": 1,
     "write_buffer_size": lambda: random.choice([1024 * 1024, 4 * 1024 * 1024]),
     "writepercent": 35,
-    "format_version": lambda: random.choice([2, 3, 4, 5, 6, 7, 7]),
+    "format_version": lambda: random.choice([2, 3, 4, 5, 6, 7, 8, 8]),
     "separate_key_value_in_data_block": lambda: random.choice([0, 1, 1]),
     "index_block_restart_interval": lambda: random.choice(range(1, 16)),
     "use_multiget": lambda: random.randint(0, 1),

--- a/util/slice_test.cc
+++ b/util/slice_test.cc
@@ -18,6 +18,7 @@
 #include "port/port.h"
 #include "port/stack_trace.h"
 #include "rocksdb/data_structure.h"
+#include "rocksdb/sst_partitioner.h"
 #include "rocksdb/types.h"
 #include "test_util/testharness.h"
 #include "test_util/testutil.h"
@@ -704,6 +705,133 @@ TEST(BitFieldsTest, BitFields) {
     acqrel.Store(MyState{}.With<Field4>(0U));
     ASSERT_TESTABLE_FAILURE(
         acqrel.Apply(Field4::MinusTransformPromiseNoUnderflow(1U)));
+  }
+}
+
+namespace {
+// Whether the fixed-prefix partitioner cuts a new file between `prev` and
+// `cur`.
+bool FixedPrefixShouldPartition(SstPartitionerFixedPrefix& partitioner,
+                                const Slice& prev, const Slice& cur) {
+  return partitioner.ShouldPartition(PartitionerRequest(
+             prev, cur, /*current_output_file_size=*/0)) == kRequired;
+}
+
+// Given the prefix returned by ShouldPartitionByPrefix for some start key,
+// decide whether the transition to `next` requests a partition, per the
+// documented prefix contract (only meaningful when the prefix has a value).
+bool PrefixImpliesPartition(const Slice& prefix, const Slice& next) {
+  if (next.size() < prefix.size()) {
+    return true;
+  }
+  return Slice(next.data(), prefix.size()).compare(prefix) != 0;
+}
+}  // namespace
+
+TEST(SstPartitionerFixedPrefixTest, ShouldPartition) {
+  struct Case {
+    size_t len;
+    std::string prev;
+    std::string cur;
+    bool partition;
+  };
+  const Case kCases[] = {
+      // len 0 never partitions
+      {0, "", "", false},
+      {0, "abc", "xyz", false},
+      // equal prefixes -> no partition (differences beyond the prefix ignored)
+      {4, "abcd", "abcd", false},
+      {4, "abcd1", "abcd2", false},
+      {3, "abcX", "abcY", false},
+      // differences within the prefix -> partition
+      {4, "abcd", "abce", true},
+      {4, "abc1zzz", "abc2zzz", true},
+      // short keys (shorter than len are used as-is)
+      {4, "ab", "ab", false},  // identical short keys
+      {4, "ab", "abc", true},  // short vs longer sharing leading bytes
+      {4, "abc", "ab", true},  // longer vs short
+      {4, "ab", "ac", true},   // short, differing
+      {4, "", "a", true},      // empty vs non-empty
+      {4, "", "", false},      // empty vs empty
+  };
+  for (const auto& c : kCases) {
+    SCOPED_TRACE("len=" + std::to_string(c.len) + " prev=" + c.prev +
+                 " cur=" + c.cur);
+    SstPartitionerFixedPrefix partitioner(c.len);
+    EXPECT_EQ(FixedPrefixShouldPartition(partitioner, c.prev, c.cur),
+              c.partition);
+    // The decision is symmetric in prev/cur for this partitioner.
+    EXPECT_EQ(FixedPrefixShouldPartition(partitioner, c.cur, c.prev),
+              c.partition);
+  }
+}
+
+TEST(SstPartitionerFixedPrefixTest, ShouldPartitionByPrefix) {
+  // len 0: present but empty prefix, meaning "no further partitions".
+  {
+    SstPartitionerFixedPrefix partitioner(0);
+    std::string key = "anything";
+    OptSlice r = partitioner.ShouldPartitionByPrefix(key);
+    ASSERT_TRUE(r.has_value());
+    EXPECT_EQ(r->size(), 0u);
+  }
+  // key longer than len: the len-byte prefix, as a view into the key.
+  {
+    SstPartitionerFixedPrefix partitioner(3);
+    std::string key = "abcdef";
+    OptSlice r = partitioner.ShouldPartitionByPrefix(key);
+    ASSERT_TRUE(r.has_value());
+    EXPECT_EQ(*r, Slice("abc"));
+    EXPECT_EQ(r->data(), key.data());  // does not copy
+  }
+  // key exactly len: the whole key.
+  {
+    SstPartitionerFixedPrefix partitioner(3);
+    std::string key = "abc";
+    OptSlice r = partitioner.ShouldPartitionByPrefix(key);
+    ASSERT_TRUE(r.has_value());
+    EXPECT_EQ(*r, Slice("abc"));
+  }
+  // key shorter than len: no value (cannot be represented as a prefix).
+  {
+    SstPartitionerFixedPrefix partitioner(4);
+    EXPECT_FALSE(partitioner.ShouldPartitionByPrefix("ab").has_value());
+    EXPECT_FALSE(partitioner.ShouldPartitionByPrefix("").has_value());
+  }
+}
+
+// Whenever ShouldPartitionByPrefix returns a prefix, using that prefix to
+// decide partitioning must match calling ShouldPartition on every transition.
+TEST(SstPartitionerFixedPrefixTest, PrefixConsistentWithShouldPartition) {
+  const std::string kKeys[] = {"",     "a",      "ab",  "abc", "abcd", "abce",
+                               "abcz", "abcdef", "abd", "b",   "xyz",  "abcde"};
+  for (size_t len : {size_t{0}, size_t{1}, size_t{3}, size_t{4}, size_t{8}}) {
+    SstPartitionerFixedPrefix partitioner(len);
+    for (const std::string& start : kKeys) {
+      OptSlice prefix = partitioner.ShouldPartitionByPrefix(start);
+      if (!prefix.has_value()) {
+        // Contract allows deferring to ShouldPartition; nothing to cross-check.
+        continue;
+      }
+      for (const std::string& next : kKeys) {
+        SCOPED_TRACE("len=" + std::to_string(len) + " start=" + start +
+                     " next=" + next);
+        EXPECT_EQ(PrefixImpliesPartition(*prefix, next),
+                  FixedPrefixShouldPartition(partitioner, start, next));
+      }
+    }
+  }
+}
+
+TEST(SstPartitionerFixedPrefixTest, CanDoTrivialMove) {
+  {
+    SstPartitionerFixedPrefix partitioner(3);
+    EXPECT_TRUE(partitioner.CanDoTrivialMove("abc1", "abc2"));  // same prefix
+    EXPECT_FALSE(partitioner.CanDoTrivialMove("abc", "abd"));   // differ
+  }
+  {
+    SstPartitionerFixedPrefix partitioner(0);
+    EXPECT_TRUE(partitioner.CanDoTrivialMove("abc", "xyz"));  // len 0
   }
 }
 

--- a/utilities/trie_index/trie_index_test.cc
+++ b/utilities/trie_index/trie_index_test.cc
@@ -4760,7 +4760,10 @@ TEST_F(TrieSeekBenchmark, TrieVsRealIndexBlockIter) {
         BytewiseComparator(), kDisableGlobalSequenceNumber,
         /*iter=*/nullptr, /*stats=*/nullptr,
         /*total_order_seek=*/true, /*have_first_key=*/false,
-        /*key_includes_seq=*/true, /*value_is_full=*/true));
+        /*key_includes_seq=*/true, /*value_is_full=*/true,
+        /*block_contents_pinned=*/false,
+        /*user_defined_timestamps_persisted=*/true, /*prefix_index=*/nullptr,
+        BlockBasedTableOptions::kBinary, /*value_delta_escape=*/false));
 
     volatile uint64_t ibi_checksum = 0;
     auto t2 = std::chrono::high_resolution_clock::now();


### PR DESCRIPTION
Summary:
format_version background: SST files are shared across RocksDB versions. format_version is a critical tool in ensuring prior (and later) versioned readers do not misinterpret a file created by some version. Opt-in features can sometimes rely on previously-rejected corners of the schema space, but not always.

This change: lands much of the format_version=8 (fv8) format surface as an internal-only draft -- readable and testable but not user-writable -- so upcoming features can build on a stable base. fv8 is NOT published: kLatestBbtFormatVersion stays 7, and reading or writing fv8 is gated behind the existing TEST-only TEST_AllowUnsupportedFormatVersion() hook. Publishing fv8 (raising the ceiling) is deferred to a later change.

The pieces of fv8 added here, and what each unlocks:

- Index value-delta escape. Existing behavior: index blocks (format_version >= 4) store each block handle as a delta against the previous entry's handle, and signal "this value is a full handle instead" by reusing the key sentinel `shared == 0`. Because the two are coupled, an index entry whose handle is not contiguous with the previous one must be forced to a restart, costing a full key as well as a full value. fv8 decouples them with an in-value escape codepoint: varint 0 means "a full BlockHandle follows," and genuine size deltas are remapped to zigzag(delta)+1 so that 0 stays free. A non-contiguous entry can then remain an ordinary key-delta-encoded, on-cadence entry. The escape applies to every index-shaped block, which includes the top-level index of index partitions and the index of filter partitions, not just the index over data blocks. Unlocks: the upcoming optimize_key_common_prefix index feature (removes its need to special-case super_block_alignment) and value-delta encoding for embedded-blob SSTs (previously disabled outright because interleaved blob records break handle contiguity). Guarded strictly on fv8; format_version <= 7 encoding and decoding are byte-for-byte unchanged. Note that restart points must not delta-encode, so they still have full values without a sentinel.

- Data block footer bit 30 is reserved as an "extended metadata present" escape. Decode rejects a set bit as unsupported/corrupt at all versions. Unlocks: adding block-level metadata in the future through the one shared footer decoder, without another format_version bump or plumbing format_version into every block parser. (Older reader versions relied on this bit being zero for some integrity/consistency checking; format_version bump now makes it safe to use.)

- Footer metaindex gap. For fv8, the top 16 bits of the footer's 4-byte metaindex-size field record the gap (in bytes) between the end of the metaindex block and the start of the footer; the low 16 bits hold the metaindex block size. Unlocks: a space very near the end of the file to save full file checksum state, for a "files carry their own checksums" feature that doesn't require SST parsing to extract the checksum states (to run them to completion on the trivial file tail).

- Reserved "user_key_common_prefix" table property. The reader returns NotSupported when it is present and non-empty. Unlocks: a future whole-file optimization that stores the common prefix of all user keys once instead of in every restart key; until implemented, fv8 readers refuse such a file rather than mis-read it.
  - Because of the problem of inferring such a prefix at the start of constructing an SST file, we expect it will rely on SstPartitioner. Here we've added SstPartitioner::ShouldPartitionByPrefix() (not yet used) that will enable this optimization, and avoid the overhead of a virtual callback to SstPartitioner on every key written to an SST file.

Supporting cleanups: the Footer's "unset" format_version sentinel is named (kInvalidFormatVersion) and the FormatVersionUses*() predicates assert against it, as each is a `version >= N` test that an unpopulated Footer would silently satisfy. Index block reader entry points (Block::NewIndexIterator() and friends) drop their defaulted trailing arguments so each caller states which codec it expects, and BlockBuilder::Add() takes delta_value by const reference rather than a pointer whose null case no caller used.

Test Plan:
New unit tests, all exercising fv8 through TEST_AllowUnsupportedFormatVersion():

- block_test: value-delta escape codec round-trip (delta 0, negative, large, and the escape; asserts format_version <= 7 bytes match the legacy encoding and a legacy 0x00 still decodes as delta 0), and rejection of footer bit 30 at all versions.

- db_flush_test: fv7-vs-fv8 read equivalence for super_block_alignment, including the separate_key_value_in_data_block intersection, confirming padding events (hence escape entries) occur and fv8 index values are delta encoded.

- sst_file_reader_test: fv7-vs-fv8 read equivalence for embedded-blob SSTs, confirming fv8 (unlike fv7) delta-encodes their index values and actually emits escape entries (counted through a sync point).

- block_based_table_reader_test: a builder+reader test that injects a footer metaindex gap via a sync point (verifies the gap bytes are written and the reader locates the metaindex via the recorded gap, and that too large a gap surfaces as a builder error), and that a non-empty reserved user_key_common_prefix property makes the reader return NotSupported.

- table_test: two-level index with partitioned filters and index_block_restart_interval > 1, the configuration in which both top-level indexes delta-encode their values; verifies scan and point lookup round trips at each tested format_version including fv8.

- (Not strictly fv8) Basic SstPartitionerFixedPrefix tests in slice_test (ShouldPartition, ShouldPartitionByPrefix, their mutual consistency, and CanDoTrivialMove), which had no non-DB coverage before.

fv8 is also added to the table_test harness (GenerateArgList) and the shared footer version set (test::kFooterFormatVersionsToTest), so the existing table-level and DB-level property/checksum suites now also run at fv8. And added to crash test (minor revisions to db_stress).

## Performance details
Release db_bench (PORTABLE=0, -march=native) A/B/C on the read/write fast path,
comparing (a) parent, (b) this commit @ fv7, (c) this commit @ fv8. All DBs on
tmpfs, 20M keys, block_size=2048, compression=none. Note index_block_restart_
interval=16 (not the default 1) is required to actually exercise the fv7<->fv8
index value-delta codec -- with restart interval 1 every index entry is a full-
handle restart and the changed path never runs (confirmed delta-value=1 via
sst_dump). Reads single-thread + core-pinned, warm cache, interleaved/rotated
rounds, paired deltas.

Reads (readrandom + seekrandom, non-partitioned single ~1.9MB index block and
partitioned index+filters): fv7->fv8 in the *same* binary is within noise on all
four workloads (largest -1.0%, CIs cross zero). before->after (fv7 path) is also
within noise; perf shows a deterministic +0.4-0.6% instructions/op from the added
branches (the format_version>=8 value_delta_escape guard + refactored data-block
footer decode), which is below the throughput noise floor.

Writes (fillseq + compact total CPU): fv7->fv8 null. compact (which rewrites all
index blocks) is null before->after. fillseq showed +3.5% CPU before->after, but
perf attributes it entirely to cycles/IPC with *identical* instructions/op
(+0.01-0.04%) -- a code-layout effect on the untouched memtable-insert loop, not
this change.

Sanity: any single throughput/CPU delta <~1% is within the build-to-build noise
floor, measured directly by comparing two byte-identical binaries (swings up to
~0.9% reads; the pre-native/PORTABLE=1 build showed a spurious -1.85% that
vanished under -march=native).

Net: no measurable regression from fv8 draft; fv7 encoding/decoding byte-for-byte
unchanged, only the noted sub-1% instruction bump on the shared read path.
