### PR TITLE
Fix TestPrefixScan assertion failure with injected IO errors

### DIFF
--- a/db_stress_tool/batched_ops_stress.cc
+++ b/db_stress_tool/batched_ops_stress.cc
@@ -646,6 +646,7 @@ class BatchedOpsStressTest : public StressTest {
     }
 
     uint64_t count = 0;
+    bool error_injected = false;
 
     while (iters[0]->Valid() && iters[0]->key().starts_with(prefix_slices[0])) {
       ++count;
@@ -655,8 +656,24 @@ class BatchedOpsStressTest : public StressTest {
       // get list of all values for this iteration
       for (size_t i = 0; i < num_prefixes; ++i) {
         // no iterator should finish before the first one
-        assert(iters[i]->Valid() &&
-               iters[i]->key().starts_with(prefix_slices[i]));
+        if (!iters[i]->Valid() ||
+            !iters[i]->key().starts_with(prefix_slices[i])) {
+          // An injected IO error can cause an iterator to become invalid
+          // before others (e.g. secondary_cache_fault_one_in). Confirm the
+          // failure carries the injected-error marker (rather than swallowing
+          // any non-OK status, which would mask a genuine consistency bug) and
+          // stop the scan instead of asserting a false consistency failure.
+          const Status& iter_status = iters[i]->status();
+          if (!iter_status.ok() && IsErrorInjectedAndRetryable(iter_status)) {
+            error_injected = true;
+            break;
+          }
+          fprintf(stderr,
+                  "prefix scan error: iterator %" ROCKSDB_PRIszt
+                  " finished before iterator 0, prefix %s\n",
+                  i, prefix_slices[i].ToString(/* hex */ true).c_str());
+          assert(false);
+        }
 
         if (ro_copies[i].allow_unprepared_value) {
           // Save key in case PrepareValue fails and invalidates the iterator
@@ -713,14 +730,33 @@ class BatchedOpsStressTest : public StressTest {
 
         iters[i]->Next();
       }
+
+      if (error_injected) {
+        break;
+      }
     }
 
     // cleanup iterators and snapshot
+    if (!error_injected) {
+      // An injected IO error on any iterator's last Next() only surfaces on the
+      // following outer iteration, which never runs once iterator 0 finishes.
+      // Check every iterator's status (not just iterator 0) so we skip the
+      // cleanup assertions when any iterator hit a fault-injected error.
+      for (size_t i = 0; i < num_prefixes; ++i) {
+        const Status& iter_status = iters[i]->status();
+        if (!iter_status.ok() && IsErrorInjectedAndRetryable(iter_status)) {
+          error_injected = true;
+          break;
+        }
+      }
+    }
     for (size_t i = 0; i < num_prefixes; ++i) {
-      // if the first iterator finished, they should have all finished
-      assert(!iters[i]->Valid() ||
-             !iters[i]->key().starts_with(prefix_slices[i]));
-      DB_STRESS_ASSERT_OK(iters[i]->status());
+      if (!error_injected) {
+        // if the first iterator finished, they should have all finished
+        assert(!iters[i]->Valid() ||
+               !iters[i]->key().starts_with(prefix_slices[i]));
+        DB_STRESS_ASSERT_OK(iters[i]->status());
+      }
     }
 
     db_->ReleaseSnapshot(snapshot);

--- a/utilities/fault_injection_secondary_cache.cc
+++ b/utilities/fault_injection_secondary_cache.cc
@@ -8,6 +8,8 @@
 
 #include "utilities/fault_injection_secondary_cache.h"
 
+#include "utilities/fault_injection_fs.h"
+
 namespace ROCKSDB_NAMESPACE {
 
 void FaultInjectionSecondaryCache::ResultHandle::UpdateHandleValue(
@@ -81,7 +83,11 @@ Status FaultInjectionSecondaryCache::Insert(
     const Cache::CacheItemHelper* helper, bool force_insert) {
   ErrorContext* ctx = GetErrorContext();
   if (ctx->rand.OneIn(prob_)) {
-    return Status::IOError();
+    // Tag the status with the standard injected-error marker so callers can
+    // distinguish a fault-injected failure from a genuine one via
+    // FaultInjectionTestFS::IsInjectedError / StressTest::IsErrorInjectedAndRetryable.
+    return Status::IOError(FaultInjectionTestFS::kInjected +
+                           " secondary cache insert error");
   }
 
   return base_->Insert(key, value, helper, force_insert);


### PR DESCRIPTION
Summary:
`BatchedOpsStressTest::TestPrefixScan` opens 10 iterators with different prefixes and asserts they all progress in lockstep. However, when `secondary_cache_fault_one_in` is set (or other IO error injection is active), individual iterators can become invalid with a non-OK status due to injected read errors. The assertion at line 658 did not account for this, causing spurious crash test failures.

The fix checks iterator status before asserting validity. When an injected IO error causes an iterator to become invalid, the scan terminates gracefully instead of asserting a false consistency failure. The cleanup assertions are also skipped when an injected error was detected.

Key non-default option triggering this: `--secondary_cache_fault_one_in=32` in the failing crash test iteration, which randomly injects IO errors during secondary cache reads.

[Session trajectory link](https://www.internalfb.com/intern/devai/devmate/inspector/?id=7bdab4cd-818f-4661-94f4-1db4e02409f2)

Differential Revision: D115737242


