### PR TITLE
Fix outdated default value for level_compaction_dynamic_level_bytes in JavaDoc

### DIFF
--- a/java/src/main/java/org/rocksdb/AdvancedColumnFamilyOptionsInterface.java
+++ b/java/src/main/java/org/rocksdb/AdvancedColumnFamilyOptionsInterface.java
@@ -247,7 +247,7 @@ public interface AdvancedColumnFamilyOptionsInterface<
    *
    * <p><strong>Caution</strong>: this option is experimental</p>
    *
-   * <p>Default: false</p>
+   * <p>Default: true</p>
    *
    * @param enableLevelCompactionDynamicLevelBytes boolean value indicating
    *     if {@code LevelCompactionDynamicLevelBytes} shall be enabled.


### PR DESCRIPTION
## Summary
- The C++ header (`advanced_options.h:666`) declares `level_compaction_dynamic_level_bytes = true`
- The JavaDoc in `AdvancedColumnFamilyOptionsInterface.java` still documented the default as `false`
- Updated the JavaDoc to say `Default: true` to match the actual C++ default

## Test plan
- [ ] Documentation-only change, no code logic modified
- [ ] Verified against `include/rocksdb/advanced_options.h` line 666

Closes #14916