### PR TITLE
Add rocksdb_iter_is_key_pinned and rocksdb_iter_is_value_pinned to C API

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -3555,6 +3555,19 @@ void rocksdb_iter_refresh(const rocksdb_iterator_t* iter, char** errptr) {
   SaveError(errptr, iter->rep->Refresh());
 }
 
+unsigned char rocksdb_iter_is_key_pinned(const rocksdb_iterator_t* iter) {
+  std::string result;
+  Status s = iter->rep->GetProperty("rocksdb.iterator.is-key-pinned", &result);
+  return s.ok() && result == "1";
+}
+
+unsigned char rocksdb_iter_is_value_pinned(const rocksdb_iterator_t* iter) {
+  std::string result;
+  Status s =
+      iter->rep->GetProperty("rocksdb.iterator.is-value-pinned", &result);
+  return s.ok() && result == "1";
+}
+
 rocksdb_writebatch_t* rocksdb_writebatch_create() {
   return new rocksdb_writebatch_t;
 }

--- a/db/c_test.c
+++ b/db/c_test.c
@@ -2196,6 +2196,37 @@ int main(int argc, char** argv) {
     rocksdb_iter_destroy(iter);
   }
 
+  StartPhase("iter_pinned");
+  {
+    rocksdb_readoptions_t* pin_roptions = rocksdb_readoptions_create();
+    rocksdb_readoptions_set_pin_data(pin_roptions, 1);
+    rocksdb_iterator_t* iter = rocksdb_create_iterator(db, pin_roptions);
+    rocksdb_iter_seek_to_first(iter);
+    CheckCondition(rocksdb_iter_valid(iter));
+
+    // With pin_data=true, key and value should be pinned
+    CheckCondition(rocksdb_iter_is_key_pinned(iter));
+    CheckCondition(rocksdb_iter_is_value_pinned(iter));
+
+    rocksdb_iter_get_error(iter, &err);
+    CheckNoError(err);
+    rocksdb_iter_destroy(iter);
+    rocksdb_readoptions_destroy(pin_roptions);
+
+    // Without pin_data, test that the functions work (may return 0)
+    iter = rocksdb_create_iterator(db, roptions);
+    rocksdb_iter_seek_to_first(iter);
+    CheckCondition(rocksdb_iter_valid(iter));
+
+    // Just call them to ensure they don't crash; pinned status may vary
+    rocksdb_iter_is_key_pinned(iter);
+    rocksdb_iter_is_value_pinned(iter);
+
+    rocksdb_iter_get_error(iter, &err);
+    CheckNoError(err);
+    rocksdb_iter_destroy(iter);
+  }
+
   StartPhase("wbwi_iter");
   {
     rocksdb_iterator_t* base_iter = rocksdb_create_iterator(db, roptions);

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -970,6 +970,11 @@ rocksdb_iter_timestamp_slice(const rocksdb_iterator_t* iter);
 extern ROCKSDB_LIBRARY_API void rocksdb_iter_refresh(
     const rocksdb_iterator_t* iter, char** errptr);
 
+extern ROCKSDB_LIBRARY_API unsigned char rocksdb_iter_is_key_pinned(
+    const rocksdb_iterator_t*);
+extern ROCKSDB_LIBRARY_API unsigned char rocksdb_iter_is_value_pinned(
+    const rocksdb_iterator_t*);
+
 extern ROCKSDB_LIBRARY_API void rocksdb_wal_iter_next(
     rocksdb_wal_iterator_t* iter);
 extern ROCKSDB_LIBRARY_API unsigned char rocksdb_wal_iter_valid(


### PR DESCRIPTION
## Summary
- Adds two new C API functions to check whether an iterator's key or value is pinned:
  - `rocksdb_iter_is_key_pinned(const rocksdb_iterator_t*)`
  - `rocksdb_iter_is_value_pinned(const rocksdb_iterator_t*)`
- Uses the `Iterator::GetProperty` mechanism with `rocksdb.iterator.is-key-pinned` / `rocksdb.iterator.is-value-pinned`
- Includes test coverage in `db/c_test.c` exercising both with and without `pin_data`

## Test plan
- [ ] `c_test` passes with the new `iter_pinned` test phase
- [ ] Tests verify pinned status with `pin_data=true` and exercises the functions without `pin_data` to ensure no crashes
- [ ] Follows existing C API conventions (returns `unsigned char`, `const` iterator parameter)

Closes #14903