### PR TITLE
Refresh recovery plan after error escalation (#15111)

### DIFF
--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1318,6 +1318,8 @@ class DBImpl : public DB
   // Get the background error status
   Status TEST_GetBGError();
 
+  void TEST_SetBGError(const IOStatus& error, BackgroundErrorReason reason);
+
   bool TEST_IsRecoveryInProgress();
 
   Status TEST_ResumeImpl(DBRecoverContext context);

--- a/db/db_impl/db_impl_debug.cc
+++ b/db/db_impl/db_impl_debug.cc
@@ -225,6 +225,12 @@ Status DBImpl::TEST_GetBGError() {
   return error_handler_.GetBGError();
 }
 
+void DBImpl::TEST_SetBGError(const IOStatus& error,
+                             BackgroundErrorReason reason) {
+  InstrumentedMutexLock l(&mutex_);
+  error_handler_.SetBGError(error, reason);
+}
+
 bool DBImpl::TEST_IsRecoveryInProgress() {
   InstrumentedMutexLock l(&mutex_);
   return error_handler_.IsRecoveryInProgress();

--- a/db/error_handler.cc
+++ b/db/error_handler.cc
@@ -433,13 +433,12 @@ void ErrorHandler::SetBGError(const Status& bg_status,
     // it can directly overwrite any existing bg_error_.
     bool auto_recovery = false;
     Status bg_err(new_bg_io_err, Status::Severity::kUnrecoverableError);
-    CheckAndSetRecoveryAndBGError(bg_err);
+    CheckAndSetRecoveryAndBGError(bg_err, context);
     ROCKS_LOG_INFO(
         db_options_.info_log,
         "ErrorHandler: Set background IO error as unrecoverable error\n");
     EventHelpers::NotifyOnBackgroundError(db_options_.listeners, reason,
                                           &bg_err, db_mutex_, &auto_recovery);
-    recover_context_ = context;
     return;
   }
   if (wal_related) {
@@ -457,13 +456,12 @@ void ErrorHandler::SetBGError(const Status& bg_status,
     //  from WAL write failures.
     bool auto_recovery = false;
     Status bg_err(new_bg_io_err, Status::Severity::kFatalError);
-    CheckAndSetRecoveryAndBGError(bg_err);
+    CheckAndSetRecoveryAndBGError(bg_err, context);
     ROCKS_LOG_WARN(db_options_.info_log,
                    "ErrorHandler: A potentially WAL error happened, set "
                    "background IO error as fatal error\n");
     EventHelpers::NotifyOnBackgroundError(db_options_.listeners, reason,
                                           &bg_err, db_mutex_, &auto_recovery);
-    recover_context_ = context;
     return;
   }
 
@@ -519,8 +517,7 @@ void ErrorHandler::SetBGError(const Status& bg_status,
       severity = Status::Severity::kHardError;
     }
     Status bg_err(new_bg_io_err, severity);
-    CheckAndSetRecoveryAndBGError(bg_err);
-    recover_context_ = context;
+    CheckAndSetRecoveryAndBGError(bg_err, context);
     bool auto_recovery = db_options_.max_bgerror_resume_count > 0;
     EventHelpers::NotifyOnBackgroundError(db_options_.listeners, reason,
                                           &new_bg_io_err, db_mutex_,
@@ -632,7 +629,7 @@ Status ErrorHandler::ClearBGError() {
 
 Status ErrorHandler::RecoverFromBGError(bool is_manual) {
   InstrumentedMutexLock l(db_mutex_);
-  bool no_bg_work_original_flag = soft_error_no_bg_work_;
+  const bool soft_error_no_bg_work_on_entry = soft_error_no_bg_work_;
   if (is_manual) {
     // If its a manual recovery and there's a background recovery in progress
     // return busy status
@@ -644,21 +641,15 @@ Status ErrorHandler::RecoverFromBGError(bool is_manual) {
     // In manual resume, we allow the bg work to run. If it is a auto resume,
     // the bg work should follow this tag.
     soft_error_no_bg_work_ = false;
-
-    // In manual resume, if the bg error is a soft error and also requires
-    // no bg work, the error must be recovered by call the flush with
-    // flush reason: kErrorRecoveryRetryFlush. In other case, the flush
-    // reason is set to kErrorRecovery.
-    if (no_bg_work_original_flag) {
-      recover_context_.flush_reason = FlushReason::kErrorRecoveryRetryFlush;
-    } else {
-      recover_context_.flush_reason = FlushReason::kErrorRecovery;
-    }
   }
 
+  // kErrorRecovery can be the default context for a generic soft error that
+  // needs no flush. It can also remain from an earlier error after a later
+  // no-WAL soft error sets soft_error_no_bg_work_. Only the first case may be
+  // cleared directly.
   if (bg_error_.severity() == Status::Severity::kSoftError &&
-      recover_context_.flush_reason == FlushReason::kErrorRecovery) {
-    // Simply clear the background error and return
+      recover_context_.flush_reason == FlushReason::kErrorRecovery &&
+      !soft_error_no_bg_work_on_entry) {
     recovery_error_ = IOStatus::OK();
     return ClearBGError();
   }
@@ -672,7 +663,7 @@ Status ErrorHandler::RecoverFromBGError(bool is_manual) {
   if (s.ok()) {
     soft_error_no_bg_work_ = false;
   } else {
-    soft_error_no_bg_work_ = no_bg_work_original_flag;
+    soft_error_no_bg_work_ = soft_error_no_bg_work_on_entry;
   }
 
   // For manual recover, shutdown, and fatal error  cases, set
@@ -746,8 +737,6 @@ void ErrorHandler::RecoverFromRetryableBGIOError() {
     recovery_in_prog_ = false;
     return;
   }
-  DBRecoverContext context = recover_context_;
-  context.flush_after_recovery = true;
   int resume_count = db_options_.max_bgerror_resume_count;
   uint64_t wait_interval = db_options_.bgerror_resume_retry_interval;
   uint64_t retry_count = 0;
@@ -763,6 +752,9 @@ void ErrorHandler::RecoverFromRetryableBGIOError() {
     TEST_SYNC_POINT("RecoverFromRetryableBGIOError:BeforeResume0");
     TEST_SYNC_POINT("RecoverFromRetryableBGIOError:BeforeResume1");
     recovery_error_ = IOStatus::OK();
+    // An error during the previous attempt can require stronger recovery.
+    DBRecoverContext context = recover_context_;
+    context.flush_after_recovery = true;
     retry_count++;
     Status s = db_->ResumeImpl(context, Env::IOActivity::kFlush);
     RecordStats({ERROR_HANDLER_AUTORESUME_RETRY_TOTAL_COUNT},
@@ -822,12 +814,16 @@ void ErrorHandler::RecoverFromRetryableBGIOError() {
               {{ERROR_HANDLER_AUTORESUME_RETRY_COUNT, retry_count}});
 }
 
-void ErrorHandler::CheckAndSetRecoveryAndBGError(const Status& bg_err) {
+void ErrorHandler::CheckAndSetRecoveryAndBGError(
+    const Status& bg_err, const DBRecoverContext& context) {
+  assert(context.flush_reason != FlushReason::kErrorRecoveryRetryFlush ||
+         bg_err.severity() == Status::Severity::kSoftError);
   if (recovery_in_prog_ && recovery_error_.ok()) {
     recovery_error_ = status_to_io_status(Status(bg_err));
   }
   if (bg_err.severity() > bg_error_.severity()) {
     bg_error_ = bg_err;
+    recover_context_ = context;
   }
   if (bg_error_.severity() >= Status::Severity::kHardError) {
     is_db_stopped_.store(true, std::memory_order_release);

--- a/db/error_handler.h
+++ b/db/error_handler.h
@@ -156,10 +156,10 @@ class ErrorHandler {
   void RecoverFromNoSpace();
   void StartRecoverFromRetryableBGIOError(const IOStatus& io_error);
   void RecoverFromRetryableBGIOError();
-  // First, if it is in recovery and the recovery_error is ok. Set the
-  // recovery_error_ to bg_err. Second, if the severity is higher than the
-  // current bg_error_, overwrite it.
-  void CheckAndSetRecoveryAndBGError(const Status& bg_err);
+  // If recovery is in progress, record the first new error for the current
+  // attempt. If this error is more severe, retain it and its recovery context.
+  void CheckAndSetRecoveryAndBGError(const Status& bg_err,
+                                     const DBRecoverContext& context);
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/error_handler_fs_test.cc
+++ b/db/error_handler_fs_test.cc
@@ -7,6 +7,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
+#include <atomic>
+#include <chrono>
+#include <future>
 #include <memory>
 
 #include "db/db_test_util.h"
@@ -1996,6 +1999,139 @@ TEST_F(DBErrorHandlingFSTest, FlushWritNoWALRetryableErrorAutoRecover2) {
   // be successful.
   ASSERT_OK(s);
   ASSERT_EQ("val2", Get(Key(2)));
+  Destroy(options);
+}
+
+TEST_F(DBErrorHandlingFSTest, AutoRecoveryEscalationSwitchesWAL) {
+  Options options = GetDefaultOptions();
+  options.env = fault_env_.get();
+  options.create_if_missing = true;
+  options.disable_auto_compactions = true;
+  options.track_and_verify_wals_in_manifest = true;
+  options.max_bgerror_resume_count = 3;
+  options.bgerror_resume_retry_interval = 1000;
+  options.avoid_flush_during_shutdown = true;
+  DestroyAndReopen(options);
+
+  struct ErrorInjectionState {
+    std::atomic<bool> fail_flush{true};
+    std::atomic<bool> fail_manifest{false};
+    std::atomic<bool> manifest_error_injected{false};
+    std::atomic<bool> recovery_notified{false};
+    std::promise<void> recovery_finished;
+  };
+  auto state = std::make_shared<ErrorInjectionState>();
+  auto recovery_finished = state->recovery_finished.get_future();
+  // Keep the failed flush counted as background work while the first recovery
+  // attempt waits without the DB mutex. This lets the foreground write safely
+  // escalate the retained recovery context.
+  SyncPoint::GetInstance()->LoadDependency(
+      {{"AutoRecoveryEscalationSwitchesWAL:ReleaseFailedFlush",
+        "DBImpl::BackgroundCallFlush:FilesFound"},
+       {"RecoverFromRetryableBGIOError:BeforeResume0",
+        "AutoRecoveryEscalationSwitchesWAL:RecoveryStarted"}});
+  SyncPoint::GetInstance()->SetCallBack(
+      "FlushJob::Run:PostBuildTable", [state](void* arg) {
+        if (state->fail_flush.exchange(false)) {
+          IOStatus error = IOStatus::IOError("injected retryable flush error");
+          error.SetRetryable(true);
+          *static_cast<Status*>(arg) = error;
+        }
+      });
+  SyncPoint::GetInstance()->SetCallBack(
+      "VersionSet::ProcessManifestWrites:AfterSyncManifest",
+      [state](void* arg) {
+        if (state->fail_manifest.exchange(false)) {
+          IOStatus error =
+              IOStatus::IOError("injected retryable MANIFEST error");
+          error.SetRetryable(true);
+          *static_cast<IOStatus*>(arg) = error;
+          state->manifest_error_injected.store(true);
+        }
+      });
+  SyncPoint::GetInstance()->SetCallBack(
+      "RecoverFromRetryableBGIOError:RecoverSuccess", [state](void*) {
+        if (!state->recovery_notified.exchange(true)) {
+          state->recovery_finished.set_value();
+        }
+      });
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  ASSERT_OK(Put(Key(0), "value"));
+  const uint64_t initial_wal = dbfull()->TEST_GetCurrentLogNumber();
+  Status flush_status = Flush();
+  ASSERT_EQ(Status::Severity::kSoftError, flush_status.severity());
+  ASSERT_FALSE(state->fail_flush.load());
+  const uint64_t failed_write_wal = dbfull()->TEST_GetCurrentLogNumber();
+  ASSERT_GT(failed_write_wal, initial_wal);
+  TEST_SYNC_POINT("AutoRecoveryEscalationSwitchesWAL:RecoveryStarted");
+
+  const SequenceNumber sequence_before_delete = db_->GetLatestSequenceNumber();
+
+  state->fail_manifest.store(true);
+  WriteOptions write_options;
+  write_options.sync = true;
+  Status delete_status = db_->Delete(write_options, Key(0));
+  ASSERT_TRUE(delete_status.IsIOError()) << delete_status.ToString();
+  ASSERT_TRUE(state->manifest_error_injected.load());
+  ASSERT_EQ(sequence_before_delete, db_->GetLatestSequenceNumber());
+  ASSERT_EQ(Status::Severity::kHardError,
+            dbfull()->TEST_GetBGError().severity());
+  ASSERT_TRUE(dbfull()->TEST_IsRecoveryInProgress());
+
+  TEST_SYNC_POINT("AutoRecoveryEscalationSwitchesWAL:ReleaseFailedFlush");
+  ASSERT_EQ(std::future_status::ready,
+            recovery_finished.wait_for(std::chrono::seconds(10)))
+      << "automatic recovery did not finish";
+
+  const uint64_t wal_after_recovery = dbfull()->TEST_GetCurrentLogNumber();
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+
+  ASSERT_GT(wal_after_recovery, failed_write_wal)
+      << "hard MANIFEST recovery must switch away from the WAL containing the "
+         "failed synced write";
+
+  ASSERT_OK(db_->Delete(write_options, Key(0)));
+  ASSERT_EQ("NOT_FOUND", Get(Key(0)));
+  Reopen(options);
+  ASSERT_EQ("NOT_FOUND", Get(Key(0)));
+  Destroy(options);
+}
+
+TEST_F(DBErrorHandlingFSTest, ManualResumePreservesStrongerRecoveryContext) {
+  auto listener = std::make_shared<ErrorHandlerFSListener>();
+  Options options = GetDefaultOptions();
+  options.env = fault_env_.get();
+  options.create_if_missing = true;
+  options.listeners.emplace_back(listener);
+  options.max_bgerror_resume_count = 0;
+  options.avoid_flush_during_shutdown = true;
+  listener->EnableAutoRecovery(false);
+  DestroyAndReopen(options);
+
+  ASSERT_OK(Put(Key(0), "value"));
+  const uint64_t wal_before_recovery = dbfull()->TEST_GetCurrentLogNumber();
+
+  IOStatus soft_error = IOStatus::IOError("injected soft error");
+  dbfull()->TEST_SetBGError(soft_error, BackgroundErrorReason::kAsyncFileOpen);
+  ASSERT_EQ(Status::Severity::kSoftError,
+            dbfull()->TEST_GetBGError().severity());
+
+  IOStatus retryable_error = IOStatus::IOError("injected retryable error");
+  retryable_error.SetRetryable(true);
+  dbfull()->TEST_SetBGError(retryable_error,
+                            BackgroundErrorReason::kFlushNoWAL);
+  ASSERT_EQ(Status::Severity::kSoftError,
+            dbfull()->TEST_GetBGError().severity());
+
+  ASSERT_OK(dbfull()->Resume());
+  const uint64_t wal_after_recovery = dbfull()->TEST_GetCurrentLogNumber();
+  ASSERT_GT(wal_after_recovery, wal_before_recovery)
+      << "manual resume must execute the retained stronger recovery context";
+
+  Reopen(options);
+  ASSERT_EQ("value", Get(Key(0)));
   Destroy(options);
 }
 

--- a/unreleased_history/bug_fixes/error_recovery_stale_retry_flush_plan.md
+++ b/unreleased_history/bug_fixes/error_recovery_stale_retry_flush_plan.md
@@ -1,0 +1,1 @@
+Fixed a race in online error recovery where a concurrent higher-severity I/O error could leave a stale retry-flush plan active, prevent the required WAL switch, and create duplicate internal WAL history detected on DB reopen.


### PR DESCRIPTION
Summary:

T284514290 exposed an online-recovery race between the automatic recovery coordinator and a foreground synchronous write. A retryable no-WAL flush error selected lightweight retry-flush recovery. While that recovery attempt waited for the failed background flush, `Delete(sync=true)` appended and synced sequence N to the active WAL, then failed while persisting WAL-tracking metadata to the MANIFEST. Because memtable insertion and sequence publication happen after that MANIFEST step, the record was durable but logically unpublished.

OLD: the concurrent error triggered another attempt, but the attempt reused a stale recovery plan. That preserved both ingredients needed for a duplicate: the first `Delete(key, N)` remained in the active WAL, while the published sequence remained `N-1`.

```
Recovery coordinator                         Foreground sync-write thread
------------------------------------         --------------------------------
[db_mutex held]
plan = RetryFlush
(copied once before the retry loop)

attempt 1: ResumeImpl(plan)
  WaitForBackgroundWork()
  bg_cv_.Wait()
  [atomically releases db_mutex]  ---------> assign sequence N
                                             append + sync Delete(key, N)
                                             [db_mutex held]
                                             MANIFEST WAL edit fails
                                             no memtable insert
                                             no LastSequence publication
                                             write returns I/O error

                                             recovery_error_ = Hard
                                               (requests another attempt)
                                             bg_error_ = Hard
                                             recover_context_ eventually
                                               becomes FullRecovery
                                             [db_mutex released]
  [db_mutex reacquired]          <---------
  ClearBGError() sees recovery_error_
  attempt 1 cannot clear the error

attempt 2:
  recovery_error_ = OK
  ResumeImpl(plan)
             ^
             +-- still the cached RetryFlush plan

  RetryFlushesForErrorRecovery()
    retries the failed immutable flush only
    does not call SwitchMemtable()
    does not switch the active WAL
  ClearBGError() succeeds
                                             caller retries Delete(key)
                                             LastSequence is still N-1
                                             => assigns sequence N again
                                             appends Delete(key, N) to same WAL
                                             memtable insert succeeds
                                             publishes LastSequence = N

Reopen / WAL replay:
  first  (key, N, deletion) -> memtable insert succeeds
  second (key, N, deletion) -> TryAgain("key+seq exists")
  normal WAL recovery has seq_per_batch_ == false
  assert(seq_per_batch_) fails
```

The cached argument to `ResumeImpl()` is therefore the direct bridge to the assertion: lightweight retry-flush recovery can report success without retiring the WAL that contains the unpublished record. Since it also does not publish sequence N, the successful caller retry writes the identical internal key into that same WAL.

NEW: the same recovery coordinator consumes the concurrent error through a mutex-ordered handoff.

```
Recovery coordinator                         Foreground sync-write thread
------------------------------------         --------------------------------
[db_mutex held]
attempt 1:
  plan = recover_context_  // RetryFlush
  ResumeImpl(plan)
  WaitForBackgroundWork()
  bg_cv_.Wait()
  [atomically releases db_mutex]  ---------> append + sync Delete(key, seq=N)
                                             [db_mutex held]
                                             MANIFEST WAL edit fails
                                             CheckAndSet...(Hard, FullRecovery):
                                               recovery_error_ = Hard
                                               bg_error_ = Hard
                                               recover_context_ = FullRecovery
                                             [db_mutex released]
  [db_mutex reacquired]          <---------
  ClearBGError() sees recovery_error_
  current attempt cannot clear the error

next retry, with db_mutex held:
  recovery_error_ = OK
  plan = recover_context_  // FullRecovery
  ResumeImpl(plan)
    SwitchMemtable()
    switch to a new WAL
    clear the background error
```

The foreground unlock of `db_mutex_` happens before the recovery coordinator reacquires it and snapshots the next plan. Publishing `bg_error_` and `recover_context_` together under that mutex prevents the next attempt from observing a new severity with an old recovery requirement. `recovery_error_` is the per-attempt latch: a concurrent I/O error cannot be cleared as part of the in-flight attempt; it either stops recovery or forces another attempt to consume the updated context. If another error arrives while `ResumeImpl()` releases the mutex again, the same handoff repeats. No second recovery coordinator is needed.

Manual `Resume()` now uses the retained recovery context instead of reconstructing one from the background-work scheduling flag, and the soft-error clear-only shortcut is allowed only when that flag shows there is no pending recovery work. The write ordering and `assert(seq_per_batch_)` detector are unchanged.

Reviewed By: anand1976

Differential Revision: D116106177


