### PR TITLE
Fix wal_write_mutex_ self-deadlock when unordered_write and manual_wal_flush are enabled

### DIFF
--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -2278,7 +2278,8 @@ IOStatus DBImpl::WriteToWAL(const WriteBatch& merged_batch,
   // from the two queues anyway and wal_write_mutex_ is already held. Otherwise
   // if manual_wal_flush_ is enabled we need to protect log_writer->AddRecord
   // from possible concurrent calls via the FlushWAL by the application.
-  const bool needs_locking = manual_wal_flush_ && !two_write_queues_;
+  const bool needs_locking = manual_wal_flush_ && !two_write_queues_ &&
+                             !immutable_db_options_.unordered_write;
   // Due to performance cocerns of missed branch prediction penalize the new
   // manual_wal_flush_ feature (by UNLIKELY) instead of the more common case
   // when we do not need any locking.
@@ -2363,7 +2364,8 @@ IOStatus DBImpl::WriteGroupToWAL(const WriteThread::WriteGroup& write_group,
     //   if without locked wal_write_mutex_, the log file may get data
     //   corruption
 
-    const bool needs_locking = manual_wal_flush_ && !two_write_queues_;
+    const bool needs_locking = manual_wal_flush_ && !two_write_queues_ &&
+                               !immutable_db_options_.unordered_write;
     if (UNLIKELY(needs_locking)) {
       wal_write_mutex_.Lock();
     }

--- a/db/db_write_test.cc
+++ b/db/db_write_test.cc
@@ -4,8 +4,10 @@
 //  (found in the LICENSE.Apache file in the root directory).
 
 #include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <fstream>
+#include <future>
 #include <memory>
 #include <thread>
 #include <vector>
@@ -1074,6 +1076,26 @@ INSTANTIATE_TEST_CASE_P(DBWriteTestInstance, DBWriteTest,
                         testing::Values(DBTestBase::kDefault,
                                         DBTestBase::kConcurrentWALWrites,
                                         DBTestBase::kPipelinedWrite));
+
+TEST_F(DBWriteTestUnparameterized,
+       UnorderedWriteManualWalFlushDoesNotDeadlock) {
+  Options options = CurrentOptions();
+  options.unordered_write = true;
+  options.manual_wal_flush = true;
+  DestroyAndReopen(options);
+
+  std::promise<Status> p;
+  auto f = p.get_future();
+  std::thread writer([&] { p.set_value(db_->Put(WriteOptions(), "k", "v")); });
+
+  if (f.wait_for(std::chrono::seconds(10)) == std::future_status::timeout) {
+    writer.detach();
+    FAIL() << "Put deadlocked (unordered_write + manual_wal_flush + "
+              "!two_write_queues)";
+  }
+  writer.join();
+  ASSERT_OK(f.get());
+}
 
 }  // namespace ROCKSDB_NAMESPACE
 


### PR DESCRIPTION
Fixes #15097

Summary: When unordered_write=true and manual_wal_flush=true are configured (and two_write_queues is false), DBImpl::ConcurrentWriteGroupToWAL acquires wal_write_mutex_ before calling WriteToWAL. Inside WriteToWAL, the thread attempts to re-acquire the same non-recursive wal_write_mutex_, resulting in a self-deadlock.

This PR fixes the issue by updating the needs_locking boolean inside WriteToWAL (and WriteGroupToWAL) to explicitly skip acquiring the lock if unordered_write is enabled, since it is already held by the caller.

Test Plan: Added UnorderedWriteManualWalFlushDoesNotDeadlock to db_write_test.cc to reproduce the configuration and verify the write successfully completes without timing out.