### PR TITLE
Enable continuous verification for secondary stress tests

### DIFF
--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -525,12 +525,9 @@ class NonBatchedOpsStressTest : public StressTest {
       read_opts.timestamp = &ts;
     }
 
-    std::unique_ptr<ManagedSnapshot> snapshot = nullptr;
-    if (FLAGS_auto_refresh_iterator_with_snapshot) {
-      snapshot = std::make_unique<ManagedSnapshot>(db_);
-      read_opts.snapshot = snapshot->snapshot();
-      read_opts.auto_refresh_iterator_with_snapshot = true;
-    }
+    // Secondary mode does not support snapshots. This verifier reads from the
+    // secondary, so ignore auto_refresh_iterator_with_snapshot here; the
+    // primary iterator verification path still exercises that option.
 
     static Random64 rand64(shared->GetSeed());
 
@@ -557,10 +554,6 @@ class NonBatchedOpsStressTest : public StressTest {
         s.PermitUncheckedError();
       } else {
         // Use range scan
-        if (read_opts.auto_refresh_iterator_with_snapshot) {
-          snapshot = std::make_unique<ManagedSnapshot>(db_);
-          read_opts.snapshot = snapshot->snapshot();
-        }
         std::unique_ptr<Iterator> iter(
             secondary_db_->NewIterator(read_opts, handle));
         // Skip SeekToFirst, SeekToLast, SeekForPrev, and Prev when backward
@@ -593,9 +586,6 @@ class NonBatchedOpsStressTest : public StressTest {
           iter->SeekForPrev(key_str);
           for (int i = 0; i < 5 && iter->Valid(); ++i, iter->Prev()) {
           }
-        }
-        if (read_opts.auto_refresh_iterator_with_snapshot) {
-          read_opts.snapshot = nullptr;
         }
       }
     }

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -1603,9 +1603,6 @@ def finalize_and_sanitize(src_params):
         or dest_params.get("user_timestamp_size", 0)
     ):
         dest_params["ingest_wbwi_one_in"] = 0
-    # Continuous verification fails with secondaries inside NonBatchedOpsStressTest
-    if dest_params.get("test_secondary") == 1:
-        dest_params["continuous_verification_interval"] = 0
     # Opening a read-only DB on the primary's directory needs a plain read-write
     # primary; it is not wired up for transactions, BlobDB, or TTL DBs.
     if (


### PR DESCRIPTION
## Summary

PR #15066 fixed the bug that has caused this combination fails in the past. Re-enable this combination in the stress test.

db_crashtest.py currently disables continuous_verification_interval whenever test_secondary=1. This change removes that quarantine and enables continuous verification for secondary DB stress tests.

The disable predates auto_refresh_iterator_with_snapshot. When auto-refresh was later added, its stress-test integration mechanically added snapshot setup to several iterator paths, including the secondary-  
only NonBatchedOpsStressTest::ContinuouslyVerifyDb() path:

snapshot = std::make_unique<ManagedSnapshot>(db_);
read_opts.snapshot = snapshot->snapshot();

This creates a snapshot from the primary db_ and passes it to an iterator created from secondary_db_. That was never supported: a ReadOptions snapshot must belong to the DB being read, and secondary DB       
iterators explicitly reject non-null snapshots.

The incompatibility went unnoticed because the existing sanitizer made this combination unreachable in recurring crash tests. It was therefore a stress-test integration bug, not evidence that snapshot-       
preserving auto-refresh was supported by secondary DBs.

This change:

- Stops forcing continuous_verification_interval=0 for secondary tests.
- Avoids attaching a primary-owned snapshot to secondary iterators.
- Continues exercising auto_refresh_iterator_with_snapshot through primary iterator paths.

Secondary iterators still support ordinary Iterator::Refresh(), which advances them to the latest caught-up secondary state. Snapshot-preserving automatic refresh remains unsupported.

## Test Plan

- python3 tools/db_crashtest_test.py
- make check-sources
- AUTO_CLEAN=1 make -j192 db_stress
- Targeted blackbox crash test with:
- test_secondary=1
- continuous_verification_interval=1000
- auto_refresh_iterator_with_snapshot=1