### PR TITLE
Add bootstrap configuration for RocksDB external tables

### DIFF
--- a/include/rocksdb/external_table.h
+++ b/include/rocksdb/external_table.h
@@ -270,6 +270,23 @@ class ExternalTableFactory : public Customizable {
   virtual ExternalTableBuilder* NewTableBuilder(
       const ExternalTableBuilderOptions& builder_options,
       const std::string& file_path, FSWritableFile* file) const = 0;
+
+  // Configures this factory using an implementation-defined string. RocksDB
+  // calls this method while preparing the table factory, before it is used to
+  // create table readers or builders. The configuration is immutable after
+  // the DB is opened and is persisted in the RocksDB OPTIONS file.
+  //
+  // Implementations must copy any needed data from config and should make this
+  // method idempotent because RocksDB may prepare an object more than once.
+  // The configuration must not contain secrets because OPTIONS files are
+  // stored as plaintext.
+  virtual Status Configure(const std::string& config) {
+    if (config.empty()) {
+      return Status::OK();
+    }
+    return Status::NotSupported(
+        "External table factory does not support configuration");
+  }
 };
 
 // Allocate a TableFactory that wraps around an ExternalTableFactory. Use this

--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -134,6 +134,22 @@ static Status ParseCompressionOptions(const std::string& value,
   return Status::OK();
 }
 
+static Status CloneTableFactoryForOptionsUpdate(
+    TableFactory* table_factory,
+    std::shared_ptr<TableFactory>* cloned_factory) {
+  assert(table_factory != nullptr);
+  assert(cloned_factory != nullptr);
+
+  std::unique_ptr<TableFactory> clone = table_factory->Clone();
+  if (clone == nullptr) {
+    return Status::InvalidArgument(
+        "Table factory does not support option updates: " +
+        std::string(table_factory->Name()));
+  }
+  *cloned_factory = std::move(clone);
+  return Status::OK();
+}
+
 static Status TableFactoryParseFn(const ConfigOptions& opts,
                                   const std::string& name,
                                   const std::string& value, void* addr) {
@@ -170,7 +186,11 @@ static Status TableFactoryParseFn(const ConfigOptions& opts,
     if (table_factory->get() != nullptr) {
       std::string factory_name = table_factory->get()->Name();
       if (factory_name == TableFactory::kBlockBasedTableName()) {
-        new_factory = table_factory->get()->Clone();
+        s = CloneTableFactoryForOptionsUpdate(table_factory->get(),
+                                              &new_factory);
+        if (!s.ok()) {
+          return s;
+        }
       } else {
         s = Status::InvalidArgument("Cannot modify " + factory_name + " as " +
                                     name);
@@ -185,7 +205,11 @@ static Status TableFactoryParseFn(const ConfigOptions& opts,
     if (table_factory->get() != nullptr) {
       std::string factory_name = table_factory->get()->Name();
       if (factory_name == TableFactory::kPlainTableName()) {
-        new_factory = table_factory->get()->Clone();
+        s = CloneTableFactoryForOptionsUpdate(table_factory->get(),
+                                              &new_factory);
+        if (!s.ok()) {
+          return s;
+        }
       } else {
         s = Status::InvalidArgument("Cannot modify " + factory_name + " as " +
                                     name);
@@ -204,7 +228,10 @@ static Status TableFactoryParseFn(const ConfigOptions& opts,
       s = TableFactory::CreateFromString(opts, value, &new_factory);
     }
   } else if (table_factory->get() != nullptr) {
-    new_factory = table_factory->get()->Clone();
+    s = CloneTableFactoryForOptionsUpdate(table_factory->get(), &new_factory);
+    if (!s.ok()) {
+      return s;
+    }
     // Presumably passing a value for a specific field of the table factory
     s = new_factory->ConfigureOption(opts, name, value);
   } else {

--- a/table/external_table.cc
+++ b/table/external_table.cc
@@ -6,18 +6,22 @@
 #include "rocksdb/external_table.h"
 
 #include <chrono>
+#include <cstddef>
+#include <unordered_map>
 
 #include "db/dbformat.h"
 #include "logging/logging.h"
 #include "rocksdb/listener.h"
 #include "rocksdb/statistics.h"
 #include "rocksdb/table.h"
+#include "rocksdb/utilities/options_type.h"
 #include "table/block_based/block.h"
 #include "table/get_context.h"
 #include "table/internal_iterator.h"
 #include "table/meta_blocks.h"
 #include "table/table_builder.h"
 #include "table/table_reader.h"
+#include "util/string_util.h"
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -640,13 +644,45 @@ class ExternalTableBuilderAdapter : public TableBuilder {
       table_properties_collectors_;
 };
 
+struct ExternalTableFactoryAdapterOptions {
+  static const char* kName() { return "ExternalTableFactoryAdapterOptions"; }
+
+  std::string config;
+};
+
+static const std::unordered_map<std::string, OptionTypeInfo>&
+GetExternalTableFactoryAdapterOptionsTypeInfo() {
+  static const std::unordered_map<std::string, OptionTypeInfo> type_info = {
+      {"external_table_config",
+       OptionTypeInfo(offsetof(ExternalTableFactoryAdapterOptions, config),
+                      OptionType::kString)
+           .SetSerializeFunc([](const ConfigOptions&, const std::string&,
+                                const void* addr, std::string* value) {
+             const std::string* config = static_cast<const std::string*>(addr);
+             *value = "{" + EscapeOptionString(*config) + "}";
+             return Status::OK();
+           })}};
+  return type_info;
+}
+
 class ExternalTableFactoryAdapter : public TableFactory {
  public:
   explicit ExternalTableFactoryAdapter(
       std::shared_ptr<ExternalTableFactory> inner)
-      : inner_(std::move(inner)) {}
+      : inner_(std::move(inner)) {
+    RegisterOptions(&options_,
+                    &GetExternalTableFactoryAdapterOptionsTypeInfo());
+  }
 
   const char* Name() const override { return inner_->Name(); }
+
+  Status PrepareOptions(const ConfigOptions& config_options) override {
+    Status status = TableFactory::PrepareOptions(config_options);
+    if (status.ok()) {
+      status = inner_->Configure(options_.config);
+    }
+    return status;
+  }
 
   using TableFactory::NewTableReader;
   Status NewTableReader(
@@ -746,6 +782,7 @@ class ExternalTableFactoryAdapter : public TableFactory {
   };
 
   std::shared_ptr<ExternalTableFactory> inner_;
+  ExternalTableFactoryAdapterOptions options_;
 };
 
 }  // namespace

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -33,6 +33,7 @@
 #include "monitoring/statistics_impl.h"
 #include "options/cf_options.h"
 #include "options/options_helper.h"
+#include "options/options_parser.h"
 #include "port/port.h"
 #include "port/stack_trace.h"
 #include "rocksdb/cache.h"
@@ -7374,6 +7375,72 @@ class ExternalTableTest : public DBTestBase {
     bool read_via_options_fs_;
   };
 
+  class ConfigurableDummyExternalTableFactory
+      : public DummyExternalTableFactory {
+   public:
+    ConfigurableDummyExternalTableFactory()
+        : DummyExternalTableFactory(/*support_property_block=*/false) {}
+
+    static const char* kClassName() {
+      return "ConfigurableDummyExternalTableFactory";
+    }
+
+    static const char* kValidConfig() { return "mode=fast;limit=7"; }
+
+    static const char* kAlternateValidConfig() {
+      return "mode=compact;limit=11";
+    }
+
+    static std::string ValidFactoryConfig() {
+      return "{id=" + std::string(kClassName()) + ";external_table_config={" +
+             kValidConfig() + "}}";
+    }
+
+    static std::string SerializedValidConfig() {
+      return SerializeConfig(kValidConfig());
+    }
+
+    static std::string SerializedAlternateValidConfig() {
+      return SerializeConfig(kAlternateValidConfig());
+    }
+
+    const char* Name() const override { return kClassName(); }
+
+    Status Configure(const std::string& config) override {
+      if (config.empty() || config == kValidConfig() ||
+          config == kAlternateValidConfig()) {
+        config_ = config;
+        return Status::OK();
+      }
+      return Status::InvalidArgument("Invalid dummy external table config");
+    }
+
+    const std::string& config() const { return config_; }
+
+   private:
+    static std::string SerializeConfig(const std::string& config) {
+      return "{" + config + "}";
+    }
+
+    std::string config_;
+  };
+
+  static void RegisterConfigurableDummyExternalTableFactory() {
+    static FactoryFunc<TableFactory> registration =
+        ObjectLibrary::Default()->AddFactory<TableFactory>(
+            ConfigurableDummyExternalTableFactory::kClassName(),
+            [](const std::string& /*uri*/, std::unique_ptr<TableFactory>* guard,
+               std::string* /*errmsg*/) {
+              std::shared_ptr<ExternalTableFactory> inner =
+                  std::make_shared<ConfigurableDummyExternalTableFactory>();
+              std::unique_ptr<TableFactory> factory =
+                  NewExternalTableFactory(std::move(inner));
+              guard->reset(factory.release());
+              return guard->get();
+            });
+    (void)registration;
+  }
+
   class CountingFileReadListener : public EventListener {
    public:
     bool ShouldBeNotifiedOnFileIO() override { return true; }
@@ -7425,6 +7492,157 @@ class ExternalTableTest : public DBTestBase {
     mutable PinnedDummyExternalTableReader* last_reader_ = nullptr;
   };
 };
+
+TEST_F(ExternalTableTest, BootstrapConfig) {
+  RegisterConfigurableDummyExternalTableFactory();
+
+  ConfigOptions config_options;
+  std::shared_ptr<TableFactory> table_factory;
+  ASSERT_OK(TableFactory::CreateFromString(
+      config_options,
+      ConfigurableDummyExternalTableFactory::ValidFactoryConfig(),
+      &table_factory));
+  ASSERT_NE(table_factory, nullptr);
+
+  std::string serialized_config;
+  ASSERT_OK(table_factory->GetOption(config_options, "external_table_config",
+                                     &serialized_config));
+  ASSERT_EQ(serialized_config,
+            ConfigurableDummyExternalTableFactory::SerializedValidConfig());
+
+  std::shared_ptr<TableFactory> invalid_factory;
+  const std::string invalid_config =
+      "{id=" +
+      std::string(ConfigurableDummyExternalTableFactory::kClassName()) +
+      ";external_table_config={mode=invalid}}";
+  ASSERT_NOK(TableFactory::CreateFromString(config_options, invalid_config,
+                                            &invalid_factory));
+}
+
+TEST_F(ExternalTableTest, BootstrapConfigOptionsFileRoundTrip) {
+  RegisterConfigurableDummyExternalTableFactory();
+
+  DBOptions db_options;
+  db_options.env = env_;
+  ConfigOptions config_options(db_options);
+  std::shared_ptr<TableFactory> table_factory;
+  ASSERT_OK(TableFactory::CreateFromString(
+      config_options,
+      ConfigurableDummyExternalTableFactory::ValidFactoryConfig(),
+      &table_factory));
+
+  ColumnFamilyOptions cf_options;
+  cf_options.table_factory = table_factory;
+  const std::vector<std::string> cf_names{"default"};
+  const std::vector<ColumnFamilyOptions> all_cf_options{cf_options};
+  const std::string options_file =
+      test::PerThreadDBPath("external_table_config_options");
+  std::shared_ptr<FileSystem> fs = db_options.env->GetFileSystem();
+  ASSERT_OK(PersistRocksDBOptions(WriteOptions(), config_options, db_options,
+                                  cf_names, all_cf_options, options_file,
+                                  fs.get()));
+
+  std::string contents;
+  ASSERT_OK(ReadFileToString(env_, options_file, &contents));
+  ASSERT_NE(contents.find("external_table_config={mode=fast;limit=7}"),
+            std::string::npos);
+
+  RocksDBOptionsParser parser;
+  ASSERT_OK(parser.Parse(config_options, options_file, fs.get()));
+  ASSERT_EQ(parser.cf_opts()->size(), 1U);
+  ASSERT_NE(parser.cf_opts()->front().table_factory, nullptr);
+  std::string loaded_config;
+  ASSERT_OK(parser.cf_opts()->front().table_factory->GetOption(
+      config_options, "external_table_config", &loaded_config));
+  ASSERT_EQ(loaded_config,
+            ConfigurableDummyExternalTableFactory::SerializedValidConfig());
+
+  ASSERT_OK(env_->DeleteFile(options_file));
+}
+
+TEST_F(ExternalTableTest, BootstrapConfigIsImmutable) {
+  RegisterConfigurableDummyExternalTableFactory();
+
+  Options options = GetDefaultOptions();
+  ConfigOptions config_options(options);
+  ASSERT_OK(TableFactory::CreateFromString(
+      config_options,
+      ConfigurableDummyExternalTableFactory::ValidFactoryConfig(),
+      &options.table_factory));
+  options.create_if_missing = true;
+
+  const std::string dbname =
+      test::PerThreadDBPath("external_table_config_immutable");
+  ASSERT_OK(DestroyDB(dbname, options));
+  std::unique_ptr<DB> db;
+  ASSERT_OK(DB::Open(options, dbname, &db));
+  Status update_status =
+      db->SetOptions({{"table_factory.external_table_config", "{mode=slow}"}});
+  ASSERT_TRUE(update_status.IsInvalidArgument()) << update_status.ToString();
+
+  Options current_options = db->GetOptions();
+  std::string current_config;
+  ASSERT_OK(current_options.table_factory->GetOption(
+      config_options, "external_table_config", &current_config));
+  ASSERT_EQ(current_config,
+            ConfigurableDummyExternalTableFactory::SerializedValidConfig());
+
+  ASSERT_OK(db->Close());
+  db.reset();
+  ASSERT_OK(DestroyDB(dbname, options));
+}
+
+TEST_F(ExternalTableTest, BootstrapConfigCanChangeBetweenDBOpens) {
+  Options options = GetDefaultOptions();
+  options.create_if_missing = true;
+
+  std::shared_ptr<ConfigurableDummyExternalTableFactory> first_factory =
+      std::make_shared<ConfigurableDummyExternalTableFactory>();
+  options.table_factory = NewExternalTableFactory(first_factory);
+  ConfigOptions config_options(options);
+  ASSERT_OK(options.table_factory->ConfigureFromString(
+      config_options,
+      "external_table_config=" +
+          ConfigurableDummyExternalTableFactory::SerializedValidConfig()));
+  ASSERT_EQ(first_factory->config(),
+            ConfigurableDummyExternalTableFactory::kValidConfig());
+
+  const std::string dbname =
+      test::PerThreadDBPath("external_table_config_reopen");
+  ASSERT_OK(DestroyDB(dbname, options));
+  std::unique_ptr<DB> db;
+  ASSERT_OK(DB::Open(options, dbname, &db));
+  ASSERT_EQ(first_factory->config(),
+            ConfigurableDummyExternalTableFactory::kValidConfig());
+  ASSERT_OK(db->Close());
+  db.reset();
+
+  std::shared_ptr<ConfigurableDummyExternalTableFactory> second_factory =
+      std::make_shared<ConfigurableDummyExternalTableFactory>();
+  options.table_factory = NewExternalTableFactory(second_factory);
+  ConfigOptions reopen_config_options(options);
+  ASSERT_OK(options.table_factory->ConfigureFromString(
+      reopen_config_options, "external_table_config=" +
+                                 ConfigurableDummyExternalTableFactory::
+                                     SerializedAlternateValidConfig()));
+  ASSERT_EQ(second_factory->config(),
+            ConfigurableDummyExternalTableFactory::kAlternateValidConfig());
+
+  ASSERT_OK(DB::Open(options, dbname, &db));
+  ASSERT_EQ(second_factory->config(),
+            ConfigurableDummyExternalTableFactory::kAlternateValidConfig());
+
+  std::string reopened_config;
+  ASSERT_OK(db->GetOptions().table_factory->GetOption(
+      reopen_config_options, "external_table_config", &reopened_config));
+  ASSERT_EQ(
+      reopened_config,
+      ConfigurableDummyExternalTableFactory::SerializedAlternateValidConfig());
+
+  ASSERT_OK(db->Close());
+  db.reset();
+  ASSERT_OK(DestroyDB(dbname, options));
+}
 
 TEST_F(ExternalTableTest, BasicTest) {
   std::shared_ptr<ExternalTableFactory> factory =

--- a/unreleased_history/public_api_changes/external_table_config.md
+++ b/unreleased_history/public_api_changes/external_table_config.md
@@ -1,0 +1,1 @@
+Added an immutable `external_table_config` option that is persisted in OPTIONS files and passed to external table factories during bootstrap.


### PR DESCRIPTION
Summary: Add an opaque external_table_config option to the external table adapter. RocksDB persists the string in OPTIONS files and passes it to ExternalTableFactory::Configure during bootstrap, allowing implementations such as Nimble to parse implementation-specific settings without adding RocksDB-specific fields. The option is immutable after DB open, and attempted runtime updates fail safely for non-clonable table factories. A reopen test verifies that callers can supply a different valid configuration between DB opens. Initialize the adapter option metadata lazily as const to avoid namespace-scope dynamic initialization and mutable-global lint issues.

Differential Revision: D116362444


