### PR TITLE
Prune resolved 2PC recovery state on secondaries

### DIFF
--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1156,10 +1156,12 @@ class DBImpl : public DB
     }
   };
 
+  using RecoveredTransactionMap =
+      std::unordered_map<std::string, RecoveredTransaction*>;
+
   bool allow_2pc() const { return immutable_db_options_.allow_2pc; }
 
-  std::unordered_map<std::string, RecoveredTransaction*>
-  recovered_transactions() {
+  RecoveredTransactionMap recovered_transactions() {
     return recovered_transactions_;
   }
 
@@ -1190,16 +1192,24 @@ class DBImpl : public DB
     logs_with_prep_tracker_.MarkLogAsContainingPrepSection(log);
   }
 
-  void DeleteRecoveredTransaction(const std::string& name) {
-    auto it = recovered_transactions_.find(name);
+  // Deletes the recovered transaction `it` points to and returns the iterator
+  // following it, like std::unordered_map::erase().
+  RecoveredTransactionMap::iterator DeleteRecoveredTransaction(
+      RecoveredTransactionMap::iterator it) {
     assert(it != recovered_transactions_.end());
     auto* trx = it->second;
-    recovered_transactions_.erase(it);
+    RecoveredTransactionMap::iterator next = recovered_transactions_.erase(it);
     for (const auto& info : trx->batches_) {
       logs_with_prep_tracker_.MarkLogAsHavingPrepSectionFlushed(
           info.second.log_number_);
     }
     delete trx;
+    return next;
+  }
+
+  void DeleteRecoveredTransaction(const std::string& name) {
+    RecoveredTransactionMap::iterator it = recovered_transactions_.find(name);
+    DeleteRecoveredTransaction(it);
   }
 
   void DeleteAllRecoveredTransactions() {
@@ -1527,8 +1537,7 @@ class DBImpl : public DB
   FileSystemPtr fs_;
   MutableDBOptions mutable_db_options_;
   Statistics* stats_;
-  std::unordered_map<std::string, RecoveredTransaction*>
-      recovered_transactions_;
+  RecoveredTransactionMap recovered_transactions_;
   std::unique_ptr<Tracer> tracer_;
   InstrumentedMutex trace_mutex_;
   BlockCacheTracer block_cache_tracer_;

--- a/db/db_impl/db_impl_secondary.cc
+++ b/db/db_impl/db_impl_secondary.cc
@@ -760,6 +760,10 @@ Status DBImplSecondary::TryCatchUpWithPrimary() {
         // before replaying any record, so one WAL the primary deleted mid-round
         // means nothing was replayed at all.
         DeleteResolvedRecoveredTransactions();
+        // Secondary catch-up does not run the primary paths that prune the
+        // completed tracker prefix. Replay can complete an entry without
+        // leaving a recovered transaction; an outstanding prepare stops it.
+        (void)logs_with_prep_tracker_.FindMinLogContainingOutstandingPrep();
       }
     }
   }

--- a/db/db_impl/db_impl_secondary.cc
+++ b/db/db_impl/db_impl_secondary.cc
@@ -473,6 +473,38 @@ void DBImplSecondary::MaybeWarnAboutRetainedMemtables(
                  installed_log_number);
 }
 
+void DBImplSecondary::DeleteResolvedRecoveredTransactions() {
+  mutex_.AssertHeld();
+  if (recovered_transactions_.empty()) {
+    return;
+  }
+  const uint64_t min_log_number_to_keep = versions_->min_log_number_to_keep();
+  size_t deleted = 0;
+  for (RecoveredTransactionMap::iterator it = recovered_transactions_.begin();
+       it != recovered_transactions_.end();) {
+    assert(!it->second->batches_.empty());
+    bool all_batches_below_watermark = true;
+    for (const auto& batch_info : it->second->batches_) {
+      if (batch_info.second.log_number_ >= min_log_number_to_keep) {
+        all_batches_below_watermark = false;
+        break;
+      }
+    }
+    if (all_batches_below_watermark) {
+      it = DeleteRecoveredTransaction(it);
+      ++deleted;
+    } else {
+      ++it;
+    }
+  }
+  if (deleted > 0) {
+    ROCKS_LOG_INFO(immutable_db_options_.info_log,
+                   "Dropped %" ROCKSDB_PRIszt
+                   " recovered transaction(s) prepared before WAL %" PRIu64,
+                   deleted, min_log_number_to_keep);
+  }
+}
+
 Iterator* DBImplSecondary::NewIterator(const ReadOptions& _read_options,
                                        ColumnFamilyHandle* column_family) {
   if (_read_options.io_activity != Env::IOActivity::kUnknown &&
@@ -656,8 +688,10 @@ Status DBImplSecondary::TryCatchUpWithPrimary() {
 
     // list wal_dir to discover new WALs and apply new changes to the secondary
     // instance
+    bool replayed_every_wal_found = false;
     if (s.ok()) {
       s = FindAndRecoverLogFiles(&cfds_changed, &job_context);
+      replayed_every_wal_found = s.ok();
       if (s.IsPathNotFound()) {
         ROCKS_LOG_INFO(
             immutable_db_options_.info_log,
@@ -719,6 +753,13 @@ Status DBImplSecondary::TryCatchUpWithPrimary() {
         auto& sv_context = job_context.superversion_contexts.back();
         cfd->InstallSuperVersion(&sv_context, &mutex_);
         sv_context.NewSuperVersion();
+      }
+      if (replayed_every_wal_found) {
+        // A WAL this round left unreplayed can still hold the marker that
+        // resolves a prepared section: RecoverLogFiles() opens every reader
+        // before replaying any record, so one WAL the primary deleted mid-round
+        // means nothing was replayed at all.
+        DeleteResolvedRecoveredTransactions();
       }
     }
   }

--- a/db/db_impl/db_impl_secondary.cc
+++ b/db/db_impl/db_impl_secondary.cc
@@ -82,7 +82,9 @@ Status DBImplSecondary::FindAndRecoverLogFiles(
   Status s;
   std::vector<uint64_t> logs;
   s = FindNewLogNumbers(&logs);
-  if (s.ok() && !logs.empty()) {
+  if (s.ok()) {
+    // Empty recovery rounds still prune resolved transactions and completed
+    // prep tracking.
     SequenceNumber next_sequence(kMaxSequenceNumber);
     s = RecoverLogFiles(logs, &next_sequence, cfds_changed, job_context);
   }
@@ -204,6 +206,8 @@ Status DBImplSecondary::RecoverLogFiles(
     }
     assert(reader != nullptr);
   }
+
+  DeleteResolvedRecoveredTransactions();
 
   const UnorderedMap<uint32_t, size_t>& running_ts_sz =
       versions_->GetRunningColumnFamiliesTimestampSize();
@@ -473,6 +477,18 @@ void DBImplSecondary::MaybeWarnAboutRetainedMemtables(
                  installed_log_number);
 }
 
+// The primary keeps min_log_number_to_keep at or below every unresolved prepare
+// and every prepare with unflushed committed data. A recovered transaction
+// entirely below it is therefore committed and flushed, or rolled back; see
+// PrecomputeMinLogNumberToKeep2PC(). FindNewLogNumbers() uses the same
+// threshold, so no marker below it can be replayed. If a resolution marker
+// appears in a later WAL, its handler tolerates missing recovery state.
+// Committed writes are skipped because the column family's log number is
+// already past their WAL.
+//
+// Drop before replay so a reused name starts a new generation instead of
+// merging with stale state. Open every reader first so a round that cannot
+// replay drops nothing.
 void DBImplSecondary::DeleteResolvedRecoveredTransactions() {
   mutex_.AssertHeld();
   if (recovered_transactions_.empty()) {
@@ -498,10 +514,10 @@ void DBImplSecondary::DeleteResolvedRecoveredTransactions() {
     }
   }
   if (deleted > 0) {
-    ROCKS_LOG_INFO(immutable_db_options_.info_log,
-                   "Dropped %" ROCKSDB_PRIszt
-                   " recovered transaction(s) prepared before WAL %" PRIu64,
-                   deleted, min_log_number_to_keep);
+    ROCKS_LOG_DEBUG(immutable_db_options_.info_log,
+                    "Dropped %" ROCKSDB_PRIszt
+                    " recovered transaction(s) prepared before WAL %" PRIu64,
+                    deleted, min_log_number_to_keep);
   }
 }
 
@@ -755,14 +771,9 @@ Status DBImplSecondary::TryCatchUpWithPrimary() {
         sv_context.NewSuperVersion();
       }
       if (replayed_every_wal_found) {
-        // A WAL this round left unreplayed can still hold the marker that
-        // resolves a prepared section: RecoverLogFiles() opens every reader
-        // before replaying any record, so one WAL the primary deleted mid-round
-        // means nothing was replayed at all.
-        DeleteResolvedRecoveredTransactions();
         // Secondary catch-up does not run the primary paths that prune the
-        // completed tracker prefix. Replay can complete an entry without
-        // leaving a recovered transaction; an outstanding prepare stops it.
+        // completed tracker prefix. Replay and pre-replay cleanup add
+        // completions; an outstanding prepare stops the scan.
         (void)logs_with_prep_tracker_.FindMinLogContainingOutstandingPrep();
       }
     }

--- a/db/db_impl/db_impl_secondary.h
+++ b/db/db_impl/db_impl_secondary.h
@@ -372,6 +372,24 @@ class DBImplSecondary : public DBImpl {
   void MaybeWarnAboutRetainedMemtables(ColumnFamilyData* cfd,
                                        uint64_t installed_log_number);
 
+  // Drops every recovered transaction whose batches all sit below
+  // min_log_number_to_keep. The primary holds that watermark at or below the
+  // WAL of every prepared section it has not both resolved and flushed, so a
+  // prepared section below it is one the primary resolved; see
+  // PrecomputeMinLogNumberToKeep2PC(). FindNewLogNumbers() gates WAL discovery
+  // on the same watermark, so a marker below it can never be replayed here
+  // either, and this threshold must stay no looser than that gate. The marker
+  // resolving a prepared section below the watermark can instead be in a WAL
+  // above it, but only in one this round already replayed or one the primary
+  // has since purged, which no round can replay: the watermark passes a
+  // prepared section only once the primary has durably resolved and flushed
+  // it, and a round reads the watermark from the MANIFEST before listing the
+  // WAL dir.
+  //
+  // REQUIRES: mutex_ held
+  // REQUIRES: called after a round that replayed every WAL it found
+  void DeleteResolvedRecoveredTransactions();
+
   // Run compaction without installation, the output files will be placed in the
   // secondary DB path. The LSM tree won't be changed, the secondary DB is still
   // in read-only mode.

--- a/db/db_impl/db_impl_secondary.h
+++ b/db/db_impl/db_impl_secondary.h
@@ -324,7 +324,9 @@ class DBImplSecondary : public DBImpl {
       std::unordered_set<ColumnFamilyData*>* cfds_changed,
       JobContext* job_context);
   Status FindNewLogNumbers(std::vector<uint64_t>* logs);
-  // After manifest recovery, replay WALs and refresh log_readers_ if necessary
+  // Replays WALs after manifest recovery, refreshes log_readers_ as needed, and
+  // drops recovered transactions the primary resolved. Cleanup runs even when
+  // `log_numbers` is empty.
   // REQUIRES: log_numbers are sorted in ascending order
   Status RecoverLogFiles(const std::vector<uint64_t>& log_numbers,
                          SequenceNumber* next_sequence,
@@ -372,22 +374,11 @@ class DBImplSecondary : public DBImpl {
   void MaybeWarnAboutRetainedMemtables(ColumnFamilyData* cfd,
                                        uint64_t installed_log_number);
 
-  // Drops every recovered transaction whose batches all sit below
-  // min_log_number_to_keep. The primary holds that watermark at or below the
-  // WAL of every prepared section it has not both resolved and flushed, so a
-  // prepared section below it is one the primary resolved; see
-  // PrecomputeMinLogNumberToKeep2PC(). FindNewLogNumbers() gates WAL discovery
-  // on the same watermark, so a marker below it can never be replayed here
-  // either, and this threshold must stay no looser than that gate. The marker
-  // resolving a prepared section below the watermark can instead be in a WAL
-  // above it, but only in one this round already replayed or one the primary
-  // has since purged, which no round can replay: the watermark passes a
-  // prepared section only once the primary has durably resolved and flushed
-  // it, and a round reads the watermark from the MANIFEST before listing the
-  // WAL dir.
+  // Drops recovered transactions the primary resolved and flushed.
   //
   // REQUIRES: mutex_ held
-  // REQUIRES: called after a round that replayed every WAL it found
+  // REQUIRES: every WAL reader for the round opened successfully
+  // REQUIRES: called before replaying records from the round
   void DeleteResolvedRecoveredTransactions();
 
   // Run compaction without installation, the output files will be placed in the

--- a/db/db_secondary_test.cc
+++ b/db/db_secondary_test.cc
@@ -1542,6 +1542,34 @@ TEST_F(DBSecondaryTest, DropsRecoveredTransactionAfterCommitWalIsPurged) {
   ASSERT_GT(db_secondary_full()->GetVersionSet()->min_log_number_to_keep(),
             commit_log_number);
   ASSERT_EQ(nullptr, db_secondary_full()->GetRecoveredTransaction("t2"));
+  ASSERT_EQ(0, db_secondary_full()->TEST_LogsWithPrepSize());
+  ASSERT_EQ(0, db_secondary_full()->TEST_PreparedSectionCompletedSize());
+}
+
+// Commit replay deletes the recovered transaction and records its prepare WAL
+// as complete. A secondary never runs the primary flush and write paths that
+// normally prune that tracking state, so catch-up must do it.
+TEST_F(DBSecondaryTest, PrunesRecoveredTransactionTrackingAfterCommitReplay) {
+  Options options = CurrentOptions();
+  options.disable_auto_compactions = true;
+
+  TransactionDB* txn_db = nullptr;
+  ASSERT_NO_FATAL_FAILURE(RecreatePrimaryAsTransactionDB(options, &txn_db));
+  OpenSecondaryFor2PC(options);
+
+  std::unique_ptr<Transaction> txn;
+  ASSERT_NO_FATAL_FAILURE(
+      PrepareTransactionAndCatchUp(txn_db, "t5", "k3", "v3", &txn));
+  ASSERT_EQ(1, db_secondary_full()->TEST_LogsWithPrepSize());
+  ASSERT_EQ(0, db_secondary_full()->TEST_PreparedSectionCompletedSize());
+
+  ASSERT_OK(txn->Commit());
+  txn.reset();
+  ASSERT_OK(db_->FlushWAL(/*sync=*/true));
+  ASSERT_OK(db_secondary_->TryCatchUpWithPrimary());
+  ASSERT_EQ(nullptr, db_secondary_full()->GetRecoveredTransaction("t5"));
+  ASSERT_EQ(0, db_secondary_full()->TEST_LogsWithPrepSize());
+  ASSERT_EQ(0, db_secondary_full()->TEST_PreparedSectionCompletedSize());
 }
 
 // A transaction whose prepare is still outstanding must be kept, no matter how

--- a/db/db_secondary_test.cc
+++ b/db/db_secondary_test.cc
@@ -1546,6 +1546,46 @@ TEST_F(DBSecondaryTest, DropsRecoveredTransactionAfterCommitWalIsPurged) {
   ASSERT_EQ(0, db_secondary_full()->TEST_PreparedSectionCompletedSize());
 }
 
+// A primary can reuse a transaction name after commit unregisters it. If the
+// secondary missed the old marker, it must remove that generation before
+// replaying a new prepare with the same name.
+TEST_F(DBSecondaryTest, ReusesTransactionNameAfterResolvedBatchIsPurged) {
+  Options options = CurrentOptions();
+  options.disable_auto_compactions = true;
+
+  TransactionDB* txn_db = nullptr;
+  ASSERT_NO_FATAL_FAILURE(RecreatePrimaryAsTransactionDB(options, &txn_db));
+  OpenSecondaryFor2PC(options);
+
+  std::unique_ptr<Transaction> old_txn;
+  ASSERT_NO_FATAL_FAILURE(
+      PrepareTransactionAndCatchUp(txn_db, "t6", "reuse", "v1", &old_txn));
+  uint64_t old_commit_log_number = 0;
+  ASSERT_NO_FATAL_FAILURE(
+      CommitAndPurgeMarkerWal(txn_db, &old_txn, &old_commit_log_number));
+
+  std::unique_ptr<Transaction> new_txn;
+  ASSERT_NO_FATAL_FAILURE(
+      PrepareTransactionAndCatchUp(txn_db, "t6", "reuse", "v2", &new_txn));
+  // The drop, not a replayed marker, is what removed the old generation.
+  ASSERT_GT(db_secondary_full()->GetVersionSet()->min_log_number_to_keep(),
+            old_commit_log_number);
+  DBImpl::RecoveredTransaction* recovered =
+      db_secondary_full()->GetRecoveredTransaction("t6");
+  ASSERT_NE(nullptr, recovered);
+  ASSERT_EQ(1, recovered->batches_.size());
+  VerifySecondaryValue("reuse", "v1");
+
+  ASSERT_OK(new_txn->Commit());
+  new_txn.reset();
+  ASSERT_OK(db_->FlushWAL(/*sync=*/true));
+  ASSERT_OK(db_secondary_->TryCatchUpWithPrimary());
+  ASSERT_EQ(nullptr, db_secondary_full()->GetRecoveredTransaction("t6"));
+  VerifySecondaryValue("reuse", "v2");
+  ASSERT_EQ(0, db_secondary_full()->TEST_LogsWithPrepSize());
+  ASSERT_EQ(0, db_secondary_full()->TEST_PreparedSectionCompletedSize());
+}
+
 // Commit replay deletes the recovered transaction and records its prepare WAL
 // as complete. A secondary never runs the primary flush and write paths that
 // normally prune that tracking state, so catch-up must do it.
@@ -1580,7 +1620,7 @@ TEST_F(DBSecondaryTest, KeepsRecoveredTransactionWhilePrepareIsOutstanding) {
 
   TransactionDB* txn_db = nullptr;
   ASSERT_NO_FATAL_FAILURE(RecreatePrimaryAsTransactionDB(options, &txn_db));
-  DBImpl* primary = static_cast_with_check<DBImpl>(txn_db->GetRootDB());
+  DBImpl* primary = static_cast_with_check<DBImpl>(db_->GetRootDB());
 
   OpenSecondaryFor2PC(options);
 

--- a/db/db_secondary_test.cc
+++ b/db/db_secondary_test.cc
@@ -100,6 +100,56 @@ class DBSecondaryTestBase : public DBBasicTestWithTimestampBase {
     db_.reset(*txn_db);
   }
 
+  // Opens a secondary that can replay the primary's 2PC markers.
+  // OpenAsSecondary() does not force allow_2pc the way TransactionDB::Open()
+  // does for the primary, and without it MarkBeginPrepare() rejects the
+  // prepared section with NotSupported.
+  void OpenSecondaryFor2PC(const Options& options) {
+    Options secondary_options = options;
+    secondary_options.max_open_files = -1;
+    secondary_options.allow_2pc = true;
+    OpenSecondary(secondary_options);
+  }
+
+  // Prepares a transaction named `name` on the primary and catches the
+  // secondary up to it, so that `*txn` awaits resolution and the secondary
+  // holds its prepared batch as a recovered transaction. Call under
+  // ASSERT_NO_FATAL_FAILURE.
+  void PrepareTransactionAndCatchUp(TransactionDB* txn_db,
+                                    const std::string& name,
+                                    const std::string& key,
+                                    const std::string& value,
+                                    std::unique_ptr<Transaction>* txn) {
+    txn->reset(txn_db->BeginTransaction(WriteOptions(), TransactionOptions()));
+    ASSERT_NE(nullptr, txn->get());
+    ASSERT_OK((*txn)->SetName(name));
+    ASSERT_OK((*txn)->Put(key, value));
+    ASSERT_OK((*txn)->Prepare());
+    ASSERT_OK(db_->FlushWAL(/*sync=*/true));
+    ASSERT_OK(db_secondary_->TryCatchUpWithPrimary());
+    ASSERT_NE(nullptr, db_secondary_full()->GetRecoveredTransaction(name));
+  }
+
+  // Commits `*txn` on the primary and flushes, then purges the WAL holding its
+  // commit marker, so that no later round can replay that marker. Reports the
+  // purged WAL's log number in `*commit_log_number`. Call under
+  // ASSERT_NO_FATAL_FAILURE.
+  void CommitAndPurgeMarkerWal(TransactionDB* txn_db,
+                               std::unique_ptr<Transaction>* txn,
+                               uint64_t* commit_log_number) {
+    DBImpl* primary = static_cast_with_check<DBImpl>(txn_db->GetRootDB());
+    ASSERT_OK((*txn)->Commit());
+    txn->reset();
+    *commit_log_number = primary->TEST_GetCurrentLogNumber();
+    ASSERT_OK(db_->Flush(FlushOptions()));
+    ASSERT_OK(db_->Put(WriteOptions(), "spacer", "s"));
+    ASSERT_OK(db_->Flush(FlushOptions()));
+    primary->TEST_DeleteObsoleteFiles();
+    ASSERT_OK(primary->TEST_WaitForPurge());
+    ASSERT_TRUE(env_->FileExists(LogFileName(dbname_, *commit_log_number))
+                    .IsNotFound());
+  }
+
   // Checks that the secondary reads `expected` for `key` through both Get() and
   // an iterator. The two paths order the active memtable against the file set
   // differently, so they can disagree on a stale memtable entry.
@@ -1151,6 +1201,53 @@ TEST_F(DBSecondaryCatchUpFaultTest, ReconcilesMemtableAfterFailedRound) {
   VerifySecondaryValue("foo", "v2");
 }
 
+// A round whose WAL discovery reports a purged path replays nothing, yet
+// reports success. A marker still eligible for replay has not had its chance to
+// resolve its prepared section, so that round must drop no recovered
+// transaction, however far the watermark has moved past its prepare.
+TEST_F(DBSecondaryCatchUpFaultTest,
+       KeepsRecoveredTransactionAfterUnreplayedRound) {
+  Options options = CurrentOptions();
+  options.disable_auto_compactions = true;
+
+  TransactionDB* txn_db = nullptr;
+  ASSERT_NO_FATAL_FAILURE(RecreatePrimaryAsTransactionDB(options, &txn_db));
+
+  Options secondary_options = options;
+  secondary_options.env = fault_env_.get();
+  OpenSecondaryFor2PC(secondary_options);
+
+  std::unique_ptr<Transaction> txn;
+  ASSERT_NO_FATAL_FAILURE(
+      PrepareTransactionAndCatchUp(txn_db, "t4", "k3", "v3", &txn));
+
+  // Leave the transaction resolved and its marker's WAL purged, so any round
+  // that replayed every WAL it found would drop it.
+  uint64_t commit_log_number = 0;
+  ASSERT_NO_FATAL_FAILURE(
+      CommitAndPurgeMarkerWal(txn_db, &txn, &commit_log_number));
+
+  // Discovery fails the way a WAL purged mid-round fails, which the round
+  // reports as success after replaying nothing.
+  SyncPoint::GetInstance()->SetCallBack(
+      "DBImplSecondary::FindAndRecoverLogFiles:Begin", [this](void* /*arg*/) {
+        fault_fs_->SetFilesystemActive(
+            false, IOStatus::PathNotFound("injected purged WAL"));
+      });
+  SyncPoint::GetInstance()->EnableProcessing();
+  ASSERT_OK(db_secondary_->TryCatchUpWithPrimary());
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+  fault_fs_->SetFilesystemActive(true);
+  ASSERT_GT(db_secondary_full()->GetVersionSet()->min_log_number_to_keep(),
+            commit_log_number);
+  ASSERT_NE(nullptr, db_secondary_full()->GetRecoveredTransaction("t4"));
+
+  // The next round replays every WAL it finds, so it may drop the transaction.
+  ASSERT_OK(db_secondary_->TryCatchUpWithPrimary());
+  ASSERT_EQ(nullptr, db_secondary_full()->GetRecoveredTransaction("t4"));
+}
+
 // The column family's log number advances as soon as the flush record is read,
 // even when the flushed file cannot be opened and no Version reflecting it can
 // be installed. The active memtable then holds the only readable copy of what
@@ -1382,24 +1479,13 @@ TEST_F(DBSecondaryTest, KeepsMemtableAfterTwoPhaseCommitReplay) {
   ASSERT_OK(db_->Put(WriteOptions(), "seed", "s"));
   ASSERT_OK(db_->Flush(FlushOptions()));
 
-  Options secondary_options = options;
-  secondary_options.max_open_files = -1;
-  // OpenAsSecondary() does not force allow_2pc the way TransactionDB::Open()
-  // does for the primary, and without it MarkBeginPrepare() rejects the
-  // prepared section with NotSupported before the gate is ever reached.
-  secondary_options.allow_2pc = true;
-  OpenSecondary(secondary_options);
+  OpenSecondaryFor2PC(options);
 
   // The prepared batch names the default column family, so the secondary
   // records this WAL for it, but buffers the entries instead of inserting.
-  std::unique_ptr<Transaction> txn(
-      txn_db->BeginTransaction(WriteOptions(), TransactionOptions()));
-  ASSERT_NE(nullptr, txn);
-  ASSERT_OK(txn->SetName("t1"));
-  ASSERT_OK(txn->Put("x", "2"));
-  ASSERT_OK(txn->Prepare());
-  ASSERT_OK(db_->FlushWAL(/*sync=*/true));
-  ASSERT_OK(db_secondary_->TryCatchUpWithPrimary());
+  std::unique_ptr<Transaction> txn;
+  ASSERT_NO_FATAL_FAILURE(
+      PrepareTransactionAndCatchUp(txn_db, "t1", "x", "2", &txn));
   ASSERT_TRUE(
       GetSecondaryCfd(db_secondary_->DefaultColumnFamily())->mem()->IsEmpty());
 
@@ -1423,6 +1509,80 @@ TEST_F(DBSecondaryTest, KeepsMemtableAfterTwoPhaseCommitReplay) {
 
   ASSERT_OK(db_secondary_->TryCatchUpWithPrimary());
   VerifySecondaryValue("x", "2");
+}
+
+// A secondary that observes a prepare but never its commit marker holds the
+// prepared batch until close: DeleteRecoveredTransaction() runs only from
+// MarkCommit() and MarkRollback(). Once the primary commits, flushes, and
+// purges the WAL holding the marker nothing can resolve the batch, so a
+// long-lived secondary accumulates them without bound while serving correct
+// reads from the SST.
+TEST_F(DBSecondaryTest, DropsRecoveredTransactionAfterCommitWalIsPurged) {
+  Options options = CurrentOptions();
+  options.disable_auto_compactions = true;
+
+  TransactionDB* txn_db = nullptr;
+  ASSERT_NO_FATAL_FAILURE(RecreatePrimaryAsTransactionDB(options, &txn_db));
+
+  OpenSecondaryFor2PC(options);
+
+  std::unique_ptr<Transaction> txn;
+  ASSERT_NO_FATAL_FAILURE(
+      PrepareTransactionAndCatchUp(txn_db, "t2", "k1", "v2", &txn));
+
+  // The primary commits and flushes, then the WAL holding the marker is purged
+  // before the secondary catches up again, so the marker is never replayed.
+  uint64_t commit_log_number = 0;
+  ASSERT_NO_FATAL_FAILURE(
+      CommitAndPurgeMarkerWal(txn_db, &txn, &commit_log_number));
+
+  ASSERT_OK(db_secondary_->TryCatchUpWithPrimary());
+  VerifySecondaryValue("k1", "v2");
+  // The drop reads the secondary's own watermark, replicated by the MANIFEST.
+  ASSERT_GT(db_secondary_full()->GetVersionSet()->min_log_number_to_keep(),
+            commit_log_number);
+  ASSERT_EQ(nullptr, db_secondary_full()->GetRecoveredTransaction("t2"));
+}
+
+// A transaction whose prepare is still outstanding must be kept, no matter how
+// much unrelated data the primary flushes and purges.
+TEST_F(DBSecondaryTest, KeepsRecoveredTransactionWhilePrepareIsOutstanding) {
+  Options options = CurrentOptions();
+  options.disable_auto_compactions = true;
+
+  TransactionDB* txn_db = nullptr;
+  ASSERT_NO_FATAL_FAILURE(RecreatePrimaryAsTransactionDB(options, &txn_db));
+  DBImpl* primary = static_cast_with_check<DBImpl>(txn_db->GetRootDB());
+
+  OpenSecondaryFor2PC(options);
+
+  std::unique_ptr<Transaction> txn;
+  ASSERT_NO_FATAL_FAILURE(
+      PrepareTransactionAndCatchUp(txn_db, "t3", "k2", "w2", &txn));
+  const uint64_t prepare_log_number = primary->TEST_GetCurrentLogNumber();
+
+  for (int i = 0; i < 3; ++i) {
+    ASSERT_OK(db_->Put(WriteOptions(), "spacer" + std::to_string(i), "s"));
+    ASSERT_OK(db_->Flush(FlushOptions()));
+  }
+  primary->TEST_DeleteObsoleteFiles();
+  ASSERT_OK(primary->TEST_WaitForPurge());
+
+  ASSERT_OK(db_secondary_->TryCatchUpWithPrimary());
+  // The watermark the drop reads stops exactly at the prepare's WAL, which is
+  // what makes comparing against it with `>=` load-bearing.
+  ASSERT_EQ(prepare_log_number,
+            db_secondary_full()->GetVersionSet()->min_log_number_to_keep());
+  ASSERT_NE(nullptr, db_secondary_full()->GetRecoveredTransaction("t3"));
+
+  // MarkCommit() resolves it and applies the batch, so an early drop would have
+  // lost "k2".
+  ASSERT_OK(txn->Commit());
+  txn.reset();
+  ASSERT_OK(db_->FlushWAL(/*sync=*/true));
+  ASSERT_OK(db_secondary_->TryCatchUpWithPrimary());
+  ASSERT_EQ(nullptr, db_secondary_full()->GetRecoveredTransaction("t3"));
+  VerifySecondaryValue("k2", "w2");
 }
 
 // Once the primary flushes and drops a WAL, its files are the authority for

--- a/unreleased_history/bug_fixes/secondary_retains_recovered_transactions.md
+++ b/unreleased_history/bug_fixes/secondary_retains_recovered_transactions.md
@@ -1,0 +1,1 @@
+Fixed unbounded retention of recovered transaction write batches by a long-lived secondary opened with `allow_2pc` that misses their commit or rollback markers.

--- a/unreleased_history/bug_fixes/secondary_retains_recovered_transactions.md
+++ b/unreleased_history/bug_fixes/secondary_retains_recovered_transactions.md
@@ -1,1 +1,1 @@
-Fixed unbounded retention of recovered transaction write batches by a long-lived secondary opened with `allow_2pc` that misses their commit or rollback markers.
+Fixed unbounded retention of recovered transaction state by a long-lived secondary opened with `allow_2pc`.


### PR DESCRIPTION
Summary:
Previously, during WAL replay, a secondary stored each 2PC prepare in
`recovered_transactions_`. Replaying the matching commit or rollback marker
deletes it. If the primary purges that marker's WAL before the secondary reads
it, the prepared `WriteBatch` and its tracker entry remain until the secondary
closes. This retention case was flagged by @xingbowang in #15066. Even when
the marker is replayed, the secondary records completion but previously did not
prune the completed prefix from `logs_with_prep_tracker_`.

This change deletes recovered transactions whose prepare WALs are all below
`min_log_number_to_keep` after opening every discovered WAL reader but before
replaying records. The primary keeps that watermark at or below every
unresolved prepare and every prepare with unflushed committed data, so an entry
below it is committed and flushed, or rolled back. Deleting before replay lets
a reused transaction name start a new generation instead of merging into stale
state. If a reader cannot be opened, no recovered transaction is deleted.

After a round successfully replays every discovered WAL, the secondary also
prunes the completed prefix from `logs_with_prep_tracker_`. This covers
completions from normal commit or rollback replay and from the watermark-based
cleanup. The oldest outstanding prepare stops the pruning scan.

Test Plan:
Added coverage for missed-marker cleanup, transaction-name reuse before replay,
the exact watermark boundary, a catch-up round that reports success after
replaying no WALs, and tracker pruning after normal commit replay. The
missed-marker case verifies cleanup of both retained structures.
