### PR TITLE
 Fix JNI local reference leak in ByteBuffer multiGet result helper

### DIFF
--- a/java/rocksjni/jni_multiget_helpers.cc
+++ b/java/rocksjni/jni_multiget_helpers.cc
@@ -186,12 +186,17 @@ void MultiGetJNIValues::fillByteBuffersAndStatusObjects(
     jintArray jvalue_sizes, jobjectArray jstatuses) {
   std::vector<jint> value_size;
   for (int i = 0; i < static_cast<jint>(values.size()); i++) {
-    auto jstatus = ROCKSDB_NAMESPACE::StatusJni::construct(env, s[i]);
+    jobject jstatus = ROCKSDB_NAMESPACE::StatusJni::construct(env, s[i]);
     if (jstatus == nullptr) {
       // exception in context
       return;
     }
     env->SetObjectArrayElement(jstatuses, i, jstatus);
+    env->DeleteLocalRef(jstatus);
+    if (env->ExceptionCheck()) {
+      // ArrayIndexOutOfBoundsException is thrown
+      return;
+    }
 
     if (s[i].ok()) {
       jobject jvalue_bytebuf = env->GetObjectArrayElement(jvalues, i);
@@ -205,6 +210,7 @@ void MultiGetJNIValues::fillByteBuffersAndStatusObjects(
             env,
             "Invalid value(s) argument (argument is not a valid direct "
             "ByteBuffer)");
+        env->DeleteLocalRef(jvalue_bytebuf);
         return;
       }
       void* jvalue_address = env->GetDirectBufferAddress(jvalue_bytebuf);
@@ -213,6 +219,7 @@ void MultiGetJNIValues::fillByteBuffersAndStatusObjects(
             env,
             "Invalid value(s) argument (argument is not a valid direct "
             "ByteBuffer)");
+        env->DeleteLocalRef(jvalue_bytebuf);
         return;
       }
 
@@ -223,10 +230,15 @@ void MultiGetJNIValues::fillByteBuffersAndStatusObjects(
       if (values[i].size() > INTEGER_MAX_VALUE) {
         // Indicate that the result size is bigger than can be represented in a
         // java integer by setting the status to incomplete and the size to -1
-        env->SetObjectArrayElement(
-            jstatuses, i,
-            ROCKSDB_NAMESPACE::StatusJni::construct(
-                env, Status::Incomplete("result too large to represent")));
+        jobject jincomplete_status = ROCKSDB_NAMESPACE::StatusJni::construct(
+            env, Status::Incomplete("result too large to represent"));
+        if (jincomplete_status == nullptr) {
+          // exception in context
+          env->DeleteLocalRef(jvalue_bytebuf);
+          return;
+        }
+        env->SetObjectArrayElement(jstatuses, i, jincomplete_status);
+        env->DeleteLocalRef(jincomplete_status);
         value_size.push_back(-1);
       } else {
         value_size.push_back(static_cast<jint>(values[i].size()));
@@ -234,6 +246,7 @@ void MultiGetJNIValues::fillByteBuffersAndStatusObjects(
       auto copy_bytes =
           std::min(static_cast<jlong>(values[i].size()), jvalue_capacity);
       memcpy(jvalue_address, values[i].data(), copy_bytes);
+      env->DeleteLocalRef(jvalue_bytebuf);
     } else {
       // bad status for this
       value_size.push_back(0);


### PR DESCRIPTION
`MultiGetJNIValues::fillByteBuffersAndStatusObjects()` (in `java/rocksjni/jni_multiget_helpers.cc`) builds a `Status` local ref for every key in the batch, and a `ByteBuffer` local ref for every successful one, but never calls `DeleteLocalRef` on either — including on the early-return paths when an exception is already pending. Since this runs once per key in the caller's batch, a big `multiGet()` call holds all of those refs live for the whole native call.

The `byteArrays()` helper right above it does the same kind of loop for the same API and already deletes its per-iteration ref on both the exception and success paths, so this looks like it was just missed rather than intentional. There's also an inline `StatusJni::construct()` call further down (the "result too large to represent" branch) with the same leak, and its result wasn't null-checked before being handed to `SetObjectArrayElement()`.

This fixes it by deleting each local ref as soon as it's no longer needed:
- the per-key `jstatus`, right after it's stored
- `jvalue_bytebuf`, after the memcpy and on both `ThrowNew` early-return
  paths where it was being dropped
- the inline "too large" status, now pulled into a named variable so it
  can be null-checked and deleted like the others

Also changed `auto jstatus` to `jobject jstatus` per this repo's style guidance against `auto` for declared types in production code.

Didn't reach for `PushLocalFrame`/`PopLocalFrame` here — there's no existing use of it anywhere in `java/rocksjni/`, and matching the sibling helper's existing pattern is the smaller, easier-to-review fix.

Fixes #15068

**Testing:** `make rocksdbjava` builds clean, and the existing `MultiGetTest` suite (which covers the ByteBuffer multiGet path, including missing keys and non-default column families) passes 14/14. I didn't add a new test for this specifically — a local-ref leak isn't something a normal pass/fail assertion can see, and a large-batch `-Xcheck:jni` run didn't discriminate between the buggy and fixed code either (HotSpot just grows the local ref table rather than hitting a hard cap). Verified this by inspection against `byteArrays()`'s existing correct pattern instead.