### PR TITLE
Fix native memory leak in RocksJava thread-local comparator buffers

### DIFF
--- a/java/rocksjni/comparatorjnicallback.cc
+++ b/java/rocksjni/comparatorjnicallback.cc
@@ -85,6 +85,7 @@ ComparatorJniCallback::ComparatorJniCallback(
           _env->DeleteGlobalRef(tlb->jbuf);
           JniUtil::releaseJniEnv(tlb->jvm, attached_thread);
         }
+        delete tlb;
       };
 
       m_tl_buf_a = new ThreadLocalPtr(unref);


### PR DESCRIPTION
Fixes a native memory leak in RocksJava: when a `Comparator` is configured with
thread-local reusable buffers (`ReusedSynchronisationType.THREAD_LOCAL`), the
native `ThreadLocalBuf` wrapper allocated per thread in
`ComparatorJniCallback::GetBuffer` was never freed.

The `ThreadLocalPtr` unref handler correctly released the JNI global reference
and the direct-buffer backing memory, but never deleted the `ThreadLocalBuf`
object itself:

```cpp
UnrefHandler unref = [](void* ptr) {
  ThreadLocalBuf* tlb = reinterpret_cast<ThreadLocalBuf*>(ptr);
  ...
  _env->DeleteGlobalRef(tlb->jbuf);
  JniUtil::releaseJniEnv(tlb->jvm, attached_thread);
  // tlb itself was never deleted
};
```
Fixes #14975