### PR TITLE
Fix remote compaction input record count mismatch due to uninitialized `FileMetaData` stats (#15130)

### DIFF
--- a/db/db_impl/db_impl_secondary.cc
+++ b/db/db_impl/db_impl_secondary.cc
@@ -1424,6 +1424,22 @@ Status DBImplSecondary::CompactWithoutInstallation(
                                   /*managed_snapshot=*/nullptr,
                                   kMaxSequenceNumber, std::move(snapshots));
 
+  // Ensure FileMetaData stats (num_entries, num_range_deletions) are
+  // initialized for all input files. These stats are not persisted in the
+  // MANIFEST and are loaded lazily from table properties. The Compaction
+  // constructor's FilterInputsForCompactionIterator() relies on
+  // FileIsStandAloneRangeTombstone() which needs these fields to be populated.
+  // Without this, the remote worker may not filter the same files as the
+  // primary host, leading to input record count verification failures.
+  {
+    const ReadOptions read_options(Env::IOActivity::kCompaction);
+    for (const auto& level_files : input_files) {
+      for (FileMetaData* file_meta : level_files.files) {
+        version->MaybeInitializeFileMetaData(read_options, file_meta);
+      }
+    }
+  }
+
   // TODO - consider serializing the entire Compaction object and using it as
   // input instead of recreating it in the remote worker
   std::unique_ptr<Compaction> c;

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -1123,6 +1123,9 @@ class Version {
   friend class VersionSet;
   friend class VersionEditHandler;
   friend class VersionEditHandlerPointInTime;
+  // Needs MaybeInitializeFileMetaData() to initialize input file stats before
+  // constructing a Compaction on the remote worker.
+  friend class DBImplSecondary;
 
   const InternalKeyComparator* internal_comparator() const {
     return storage_info_.internal_comparator_;


### PR DESCRIPTION
Summary:

## Summary

Fix a corruption error in remote compaction where `FilterInputsForCompactionIterator` produces different results on the primary host vs. the remote worker.

**Root Cause:**

When a standalone range tombstone file completely shadows another input file, `FilterInputsForCompactionIterator()` removes the shadowed file from `input_levels_`. This filtering relies on `FileIsStandAloneRangeTombstone()`, which checks `num_entries == num_range_deletions == 1`.

On the primary host, these `FileMetaData` fields are always populated (set during flush/compaction when the file was created). On the remote worker, however, these fields are NOT persisted in the MANIFEST and are only lazily loaded from table properties via `UpdateAccumulatedStats()` during DB open, which is capped at 20 files (`kMaxInitCount`).

If the standalone range tombstone file is not among those first 20 initialized files, its `num_entries` remains 0 on the remote worker. This causes `FileIsStandAloneRangeTombstone()` to return false, so the remote worker does NOT filter the shadowed file and processes all its keys. Meanwhile the primary's expected record count is computed from its (filtered) view, leading to:

```
Corruption: Compaction number of input keys does not match number of keys
processed. Expected 0 but processed 12.
```

**Fix:**

Before constructing the `Compaction` object on the remote worker, explicitly initialize `FileMetaData` stats from table properties for all input files. This ensures `FilterInputsForCompactionIterator` produces consistent filtering results on both sides.

**Introduced by:** D83375779 (2025-09-29), which enabled `FilterInputsForCompactionIterator` on the remote worker by passing `earliest_snapshot` to `PickCompactionForCompactFiles`.

Reviewed By: xingbowang

Differential Revision: D116252973


