### PR TITLE
Fix GetEntity snapshot isolation for WritePrepared transactions (#15136)

### DIFF
--- a/db/coro_db.cc
+++ b/db/coro_db.cc
@@ -73,6 +73,61 @@ folly::coro::Task<Status> CoroDB::CoGet(DB* db, const ReadOptions& options,
   return CoGet(db, options, db->DefaultColumnFamily(), key, value, timestamp);
 }
 
+folly::coro::Task<Status> CoroDB::CoGetEntity(DB* db,
+                                              const ReadOptions& options,
+                                              ColumnFamilyHandle* column_family,
+                                              const Slice& key,
+                                              PinnableWideColumns* columns) {
+  assert(db != nullptr);
+  CoroDB* coro_db = db->GetCoroDB();
+  auto* file_system = db->GetFileSystem();
+  auto* read_executor =
+      file_system == nullptr ? nullptr : file_system->GetReadExecutor();
+  auto* read_event_base =
+      read_executor == nullptr ? nullptr : read_executor->getEventBase();
+
+  Status status;
+  if (coro_db == nullptr || read_event_base == nullptr) {
+    status = db->GetEntity(options, column_family, key, columns);
+  } else {
+    status = co_await folly::coro::co_nothrow(folly::coro::co_withExecutor(
+        folly::Executor::getKeepAliveToken(read_event_base),
+        coro_db->GetEntityCoroutine(options, column_family, key, columns)));
+  }
+  co_return status;
+}
+
+folly::coro::Task<Status> CoroDB::CoGetEntity(DB* db,
+                                              const ReadOptions& options,
+                                              const Slice& key,
+                                              PinnableWideColumns* columns) {
+  assert(db != nullptr);
+  return CoGetEntity(db, options, db->DefaultColumnFamily(), key, columns);
+}
+
+folly::coro::Task<Status> CoroDB::CoGetEntity(DB* db,
+                                              const ReadOptions& options,
+                                              const Slice& key,
+                                              PinnableAttributeGroups* result) {
+  assert(db != nullptr);
+  CoroDB* coro_db = db->GetCoroDB();
+  auto* file_system = db->GetFileSystem();
+  auto* read_executor =
+      file_system == nullptr ? nullptr : file_system->GetReadExecutor();
+  auto* read_event_base =
+      read_executor == nullptr ? nullptr : read_executor->getEventBase();
+
+  Status status;
+  if (coro_db == nullptr || read_event_base == nullptr) {
+    status = db->GetEntity(options, key, result);
+  } else {
+    status = co_await folly::coro::co_nothrow(folly::coro::co_withExecutor(
+        folly::Executor::getKeepAliveToken(read_event_base),
+        coro_db->GetEntityCoroutine(options, key, result)));
+  }
+  co_return status;
+}
+
 folly::coro::Task<std::vector<Status>> CoroDB::CoMultiGet(
     DB* db, const ReadOptions& options,
     const std::vector<ColumnFamilyHandle*>& column_families,

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -2736,36 +2736,6 @@ ColumnFamilyHandle* DBImpl::PersistentStatsColumnFamily() const {
   return persist_stats_cf_handle_;
 }
 
-Status DBImpl::GetEntity(const ReadOptions& _read_options,
-                         ColumnFamilyHandle* column_family, const Slice& key,
-                         PinnableWideColumns* columns) {
-  if (!column_family) {
-    return Status::InvalidArgument(
-        "Cannot call GetEntity without a column family handle");
-  }
-  if (!columns) {
-    return Status::InvalidArgument(
-        "Cannot call GetEntity without a PinnableWideColumns object");
-  }
-  if (_read_options.io_activity != Env::IOActivity::kUnknown &&
-      _read_options.io_activity != Env::IOActivity::kGetEntity) {
-    return Status::InvalidArgument(
-        "Can only call GetEntity with `ReadOptions::io_activity` set to "
-        "`Env::IOActivity::kUnknown` or `Env::IOActivity::kGetEntity`");
-  }
-  ReadOptions read_options(_read_options);
-  if (read_options.io_activity == Env::IOActivity::kUnknown) {
-    read_options.io_activity = Env::IOActivity::kGetEntity;
-  }
-  columns->Reset();
-
-  GetImplOptions get_impl_options;
-  get_impl_options.column_family = column_family;
-  get_impl_options.columns = columns;
-
-  return GetImpl(read_options, key, get_impl_options);
-}
-
 Status DBImpl::GetEntityLazyImpl(const ReadOptions& read_options,
                                  ColumnFamilyHandle* column_family,
                                  const Slice& key, LazyWideColumns* result) {
@@ -2921,73 +2891,6 @@ void DBImpl::MultiGetEntityLazy(const ReadOptions& _read_options,
   if (own_snapshot) {
     ReleaseSnapshot(snapshot);
   }
-}
-
-Status DBImpl::GetEntity(const ReadOptions& _read_options, const Slice& key,
-                         PinnableAttributeGroups* result) {
-  if (!result) {
-    return Status::InvalidArgument(
-        "Cannot call GetEntity without PinnableAttributeGroups object");
-  }
-  Status s;
-  const size_t num_column_families = result->size();
-  if (_read_options.io_activity != Env::IOActivity::kUnknown &&
-      _read_options.io_activity != Env::IOActivity::kGetEntity) {
-    s = Status::InvalidArgument(
-        "Can only call GetEntity with `ReadOptions::io_activity` set to "
-        "`Env::IOActivity::kUnknown` or `Env::IOActivity::kGetEntity`");
-    for (size_t i = 0; i < num_column_families; ++i) {
-      (*result)[i].SetStatus(s);
-    }
-    return s;
-  }
-  // return early if no CF was passed in
-  if (num_column_families == 0) {
-    return s;
-  }
-  ReadOptions read_options(_read_options);
-  if (read_options.io_activity == Env::IOActivity::kUnknown) {
-    read_options.io_activity = Env::IOActivity::kGetEntity;
-  }
-  std::vector<Slice> keys;
-  std::vector<ColumnFamilyHandle*> column_families;
-  for (size_t i = 0; i < num_column_families; ++i) {
-    // If any of the CFH is null, break early since the entire query will fail
-    if (!(*result)[i].column_family()) {
-      s = Status::InvalidArgument(
-          "DB failed to query because one or more group(s) have null column "
-          "family handle");
-      (*result)[i].SetStatus(
-          Status::InvalidArgument("Column family handle cannot be null"));
-      break;
-    }
-    // Adding the same key slice for different CFs
-    keys.emplace_back(key);
-    column_families.emplace_back((*result)[i].column_family());
-  }
-  if (!s.ok()) {
-    for (size_t i = 0; i < num_column_families; ++i) {
-      if ((*result)[i].status().ok()) {
-        (*result)[i].SetStatus(
-            Status::Incomplete("DB not queried due to invalid argument(s) in "
-                               "one or more of the attribute groups"));
-      }
-    }
-    return s;
-  }
-  std::vector<PinnableWideColumns> columns(num_column_families);
-  std::vector<Status> statuses(num_column_families);
-  MultiGetCommon(
-      read_options, num_column_families, column_families.data(), keys.data(),
-      /* values */ nullptr, columns.data(),
-      /* timestamps */ nullptr, statuses.data(), /* sorted_input */ false);
-  // Set results
-  for (size_t i = 0; i < num_column_families; ++i) {
-    (*result)[i].Reset();
-    (*result)[i].SetStatus(statuses[i]);
-    (*result)[i].SetColumns(std::move(columns[i]));
-  }
-  return s;
 }
 
 bool DBImpl::ShouldReferenceSuperVersion(const MergeContext& merge_context) {

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -291,11 +291,15 @@ class DBImpl : public DB
                                   std::string* timestamp);
 
   using DB::GetEntity;
-  Status GetEntity(const ReadOptions& options,
-                   ColumnFamilyHandle* column_family, const Slice& key,
-                   PinnableWideColumns* columns) override;
-  Status GetEntity(const ReadOptions& options, const Slice& key,
-                   PinnableAttributeGroups* result) override;
+  DECLARE_SYNC_AND_ASYNC_OVERRIDE(Status, GetEntity,
+                                  const ReadOptions& _read_options,
+                                  ColumnFamilyHandle* column_family,
+                                  const Slice& key,
+                                  PinnableWideColumns* columns);
+  DECLARE_SYNC_AND_ASYNC_OVERRIDE(Status, GetEntity,
+                                  const ReadOptions& _read_options,
+                                  const Slice& key,
+                                  PinnableAttributeGroups* result);
 
   Status GetEntityLazy(const ReadOptions& options,
                        ColumnFamilyHandle* column_family, const Slice& key,

--- a/db/db_impl/db_impl_sync_and_async.h
+++ b/db/db_impl/db_impl_sync_and_async.h
@@ -48,6 +48,113 @@ DEFINE_SYNC_AND_ASYNC(Status, DBImpl::Get)
                      timestamp);
 }
 
+DEFINE_SYNC_AND_ASYNC(Status, DBImpl::GetEntity)
+(const ReadOptions& _read_options, ColumnFamilyHandle* column_family,
+ const Slice& key, PinnableWideColumns* columns) {
+#ifdef WITH_COROUTINES
+  INSTALL_COROUTINE_STATS_CONTEXT_SCOPE(
+      immutable_db_options_.fs->GetReadExecutor(), immutable_db_options_.env);
+#endif
+  if (!column_family) {
+    CO_RETURN Status::InvalidArgument(
+        "Cannot call GetEntity without a column family handle");
+  }
+  if (!columns) {
+    CO_RETURN Status::InvalidArgument(
+        "Cannot call GetEntity without a PinnableWideColumns object");
+  }
+  if (_read_options.io_activity != Env::IOActivity::kUnknown &&
+      _read_options.io_activity != Env::IOActivity::kGetEntity) {
+    CO_RETURN Status::InvalidArgument(
+        "Can only call GetEntity with `ReadOptions::io_activity` set to "
+        "`Env::IOActivity::kUnknown` or `Env::IOActivity::kGetEntity`");
+  }
+  ReadOptions read_options(_read_options);
+  if (read_options.io_activity == Env::IOActivity::kUnknown) {
+    read_options.io_activity = Env::IOActivity::kGetEntity;
+  }
+  columns->Reset();
+
+  GetImplOptions get_impl_options;
+  get_impl_options.column_family = column_family;
+  get_impl_options.columns = columns;
+
+  CO_RETURN CO_AWAIT(GetImpl, read_options, key, get_impl_options);
+}
+
+DEFINE_SYNC_AND_ASYNC(Status, DBImpl::GetEntity)
+(const ReadOptions& _read_options, const Slice& key,
+ PinnableAttributeGroups* result) {
+#ifdef WITH_COROUTINES
+  INSTALL_COROUTINE_STATS_CONTEXT_SCOPE(
+      immutable_db_options_.fs->GetReadExecutor(), immutable_db_options_.env);
+#endif
+  if (!result) {
+    CO_RETURN Status::InvalidArgument(
+        "Cannot call GetEntity without PinnableAttributeGroups object");
+  }
+  Status s;
+  const size_t num_column_families = result->size();
+  if (_read_options.io_activity != Env::IOActivity::kUnknown &&
+      _read_options.io_activity != Env::IOActivity::kGetEntity) {
+    s = Status::InvalidArgument(
+        "Can only call GetEntity with `ReadOptions::io_activity` set to "
+        "`Env::IOActivity::kUnknown` or `Env::IOActivity::kGetEntity`");
+    for (size_t i = 0; i < num_column_families; ++i) {
+      (*result)[i].SetStatus(s);
+    }
+    CO_RETURN s;
+  }
+  // return early if no CF was passed in
+  if (num_column_families == 0) {
+    CO_RETURN s;
+  }
+  ReadOptions read_options(_read_options);
+  if (read_options.io_activity == Env::IOActivity::kUnknown) {
+    read_options.io_activity = Env::IOActivity::kGetEntity;
+  }
+  std::vector<Slice> keys;
+  std::vector<ColumnFamilyHandle*> column_families;
+  for (size_t i = 0; i < num_column_families; ++i) {
+    // If any of the CFH is null, break early since the entire query will fail
+    if (!(*result)[i].column_family()) {
+      s = Status::InvalidArgument(
+          "DB failed to query because one or more group(s) have null column "
+          "family handle");
+      (*result)[i].SetStatus(
+          Status::InvalidArgument("Column family handle cannot be null"));
+      break;
+    }
+    // Adding the same key slice for different CFs
+    keys.emplace_back(key);
+    column_families.emplace_back((*result)[i].column_family());
+  }
+  if (!s.ok()) {
+    for (size_t i = 0; i < num_column_families; ++i) {
+      if ((*result)[i].status().ok()) {
+        (*result)[i].SetStatus(
+            Status::Incomplete("DB not queried due to invalid argument(s) in "
+                               "one or more of the attribute groups"));
+      }
+    }
+    CO_RETURN s;
+  }
+  std::vector<PinnableWideColumns> columns(num_column_families);
+  std::vector<Status> statuses(num_column_families);
+  CO_AWAIT(MultiGetCommon, read_options, num_column_families,
+           column_families.data(), keys.data(),
+           /* values */ nullptr, columns.data(),
+           /* timestamps */ nullptr, statuses.data(),
+           /* sorted_input */ false);
+  // Set results
+  for (size_t i = 0; i < num_column_families; ++i) {
+    (*result)[i].Reset();
+    (*result)[i].SetStatus(statuses[i]);
+    (*result)[i].SetColumns(std::move(columns[i]));
+  }
+  CO_RETURN s;
+}
+
 DEFINE_SYNC_AND_ASYNC(Status, DBImpl::GetImpl)
 (const ReadOptions& read_options, ColumnFamilyHandle* column_family,
  const Slice& key, PinnableSlice* value, std::string* timestamp) {

--- a/include/rocksdb/coro_db.h
+++ b/include/rocksdb/coro_db.h
@@ -130,6 +130,20 @@ class CoroDB {
                       /*timestamps=*/nullptr, statuses, sorted_input);
   }
 
+  static folly::coro::Task<Status> CoGetEntity(
+      DB* db, const ReadOptions& options, ColumnFamilyHandle* column_family,
+      const Slice& key, PinnableWideColumns* columns);
+
+  static folly::coro::Task<Status> CoGetEntity(DB* db,
+                                               const ReadOptions& options,
+                                               const Slice& key,
+                                               PinnableWideColumns* columns);
+
+  static folly::coro::Task<Status> CoGetEntity(DB* db,
+                                               const ReadOptions& options,
+                                               const Slice& key,
+                                               PinnableAttributeGroups* result);
+
  protected:
   friend class DB;
   template <typename Base>
@@ -148,6 +162,14 @@ class CoroDB {
       ColumnFamilyHandle** column_families, const Slice* keys,
       PinnableSlice* values, std::string* timestamps, Status* statuses,
       bool sorted_input) = 0;
+
+  virtual folly::coro::Task<Status> GetEntityCoroutine(
+      const ReadOptions& options, ColumnFamilyHandle* column_family,
+      const Slice& key, PinnableWideColumns* columns) = 0;
+
+  virtual folly::coro::Task<Status> GetEntityCoroutine(
+      const ReadOptions& options, const Slice& key,
+      PinnableAttributeGroups* result) = 0;
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/utilities/coro_stackable_db.h
+++ b/include/rocksdb/utilities/coro_stackable_db.h
@@ -43,6 +43,22 @@ class CoroStackableDBBase : public Base, public CoroDB {
                                       values, timestamps, statuses,
                                       sorted_input);
   }
+
+  folly::coro::Task<Status> GetEntityCoroutine(
+      const ReadOptions& options, ColumnFamilyHandle* column_family,
+      const Slice& key, PinnableWideColumns* columns) override {
+    CoroDB* coro_db = this->db_->GetCoroDB();
+    assert(coro_db != nullptr);
+    return coro_db->GetEntityCoroutine(options, column_family, key, columns);
+  }
+
+  folly::coro::Task<Status> GetEntityCoroutine(
+      const ReadOptions& options, const Slice& key,
+      PinnableAttributeGroups* result) override {
+    CoroDB* coro_db = this->db_->GetCoroDB();
+    assert(coro_db != nullptr);
+    return coro_db->GetEntityCoroutine(options, key, result);
+  }
 };
 
 using CoroStackableDB = CoroStackableDBBase<StackableDB>;

--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -4371,6 +4371,196 @@ TEST_P(WritePreparedTransactionTest,
   }
 }
 
+namespace {
+// Two column families holding value1/cf2_value1, a prepared but uncommitted
+// transaction writing value2/cf2_value2 over them, and a snapshot taken above
+// the prepared sequence.
+struct PreparedEntityScenario {
+  ColumnFamilyHandle* cf2 = nullptr;
+  std::unique_ptr<Transaction> txn;
+  const Snapshot* snapshot = nullptr;
+  ReadOptions snapshot_read_options;
+
+  void TearDown(DB* db) {
+    txn.reset();  // References cf2, so it has to go before the handle.
+    db->ReleaseSnapshot(snapshot);
+    ASSERT_OK(db->DestroyColumnFamilyHandle(cf2));
+  }
+};
+
+void SetUpPreparedEntityScenario(TransactionDB* db, const Options& options,
+                                 PreparedEntityScenario* scenario) {
+  ASSERT_OK(db->CreateColumnFamily(ColumnFamilyOptions(options), "cf2",
+                                   &scenario->cf2));
+
+  WriteOptions write_options;
+  ASSERT_OK(db->Put(write_options, "key1", "value1"));
+  ASSERT_OK(db->Put(write_options, scenario->cf2, "key1", "cf2_value1"));
+
+  scenario->txn.reset(
+      db->BeginTransaction(write_options, TransactionOptions()));
+  ASSERT_NE(scenario->txn, nullptr);
+  ASSERT_OK(scenario->txn->SetName("prepared_txn"));
+  ASSERT_OK(scenario->txn->Put("key1", "value2"));
+  ASSERT_OK(scenario->txn->Put(scenario->cf2, "key1", "cf2_value2"));
+  ASSERT_OK(scenario->txn->Prepare());
+
+  // Publishes a sequence number above the prepared one. Without it the
+  // two_write_queues configurations leave the prepared sequence unpublished,
+  // hence above the snapshot, where a plain sequence check hides it anyway.
+  ASSERT_OK(db->Put(write_options, "unrelated_key", "unrelated_value"));
+
+  scenario->snapshot = db->GetSnapshot();
+  ASSERT_NE(scenario->snapshot, nullptr);
+  scenario->snapshot_read_options.snapshot = scenario->snapshot;
+}
+
+// Verifies `key` in both column families through both GetEntity overloads.
+void VerifyGetEntity(DB* db, const ReadOptions& read_options,
+                     ColumnFamilyHandle* cf2, const Slice& key,
+                     const std::string& expected_default,
+                     const std::string& expected_cf2) {
+  {
+    PinnableWideColumns columns;
+    ASSERT_OK(
+        db->GetEntity(read_options, db->DefaultColumnFamily(), key, &columns));
+    ASSERT_FALSE(columns.columns().empty());
+    ASSERT_EQ(columns.columns()[0].value().ToString(), expected_default);
+  }
+
+  PinnableAttributeGroups result;
+  result.emplace_back(db->DefaultColumnFamily());
+  result.emplace_back(cf2);
+  ASSERT_OK(db->GetEntity(read_options, key, &result));
+  // Read both statuses before asserting on values, so that a mismatch fails
+  // the test instead of aborting an ASSERT_STATUS_CHECKED build.
+  ASSERT_OK(result[0].status());
+  ASSERT_OK(result[1].status());
+  ASSERT_FALSE(result[0].columns().empty());
+  ASSERT_EQ(result[0].columns()[0].value().ToString(), expected_default);
+  ASSERT_FALSE(result[1].columns().empty());
+  ASSERT_EQ(result[1].columns()[0].value().ToString(), expected_cf2);
+}
+
+#if USE_COROUTINES
+// Coroutine counterpart of VerifyGetEntity, covering the same two overrides.
+void CoVerifyGetEntity(DB* db, const ReadOptions& read_options,
+                       ColumnFamilyHandle* cf2, const Slice& key,
+                       const std::string& expected_default,
+                       const std::string& expected_cf2) {
+  {
+    PinnableWideColumns columns;
+    ASSERT_OK(folly::coro::blockingWait(CoroDB::CoGetEntity(
+        db, read_options, db->DefaultColumnFamily(), key, &columns)));
+    ASSERT_FALSE(columns.columns().empty());
+    ASSERT_EQ(columns.columns()[0].value().ToString(), expected_default);
+  }
+
+  PinnableAttributeGroups result;
+  result.emplace_back(db->DefaultColumnFamily());
+  result.emplace_back(cf2);
+  ASSERT_OK(folly::coro::blockingWait(
+      CoroDB::CoGetEntity(db, read_options, key, &result)));
+  ASSERT_OK(result[0].status());
+  ASSERT_OK(result[1].status());
+  ASSERT_FALSE(result[0].columns().empty());
+  ASSERT_EQ(result[0].columns()[0].value().ToString(), expected_default);
+  ASSERT_FALSE(result[1].columns().empty());
+  ASSERT_EQ(result[1].columns()[0].value().ToString(), expected_cf2);
+}
+#endif  // USE_COROUTINES
+}  // namespace
+
+// GetEntity must not expose a prepared-but-uncommitted write. It sits below
+// the reader's snapshot, so only WritePreparedTxnReadCallback can hide it.
+TEST_P(WritePreparedTransactionTest, GetEntitySkipsPreparedUncommitted) {
+  PreparedEntityScenario scenario;
+  ASSERT_NO_FATAL_FAILURE(SetUpPreparedEntityScenario(db, options, &scenario));
+  ColumnFamilyHandle* cf2 = scenario.cf2;
+
+  {
+    SCOPED_TRACE("prepared, not yet committed");
+    VerifyGetEntity(db, scenario.snapshot_read_options, cf2, "key1", "value1",
+                    "cf2_value1");
+    VerifyGetEntity(db, ReadOptions(), cf2, "key1", "value1", "cf2_value1");
+  }
+
+  {
+    SCOPED_TRACE("null column family handle");
+    // A null handle fails the query without any column family being read.
+    PinnableAttributeGroups result;
+    result.emplace_back(db->DefaultColumnFamily());
+    result.emplace_back(nullptr);
+    Status s = db->GetEntity(scenario.snapshot_read_options, "key1", &result);
+    ASSERT_TRUE(s.IsInvalidArgument());
+    ASSERT_TRUE(result[1].status().IsInvalidArgument());
+    ASSERT_TRUE(result[0].status().IsIncomplete());
+  }
+
+  ASSERT_OK(scenario.txn->Commit());
+
+  {
+    SCOPED_TRACE("committed after the snapshot was taken");
+    VerifyGetEntity(db, scenario.snapshot_read_options, cf2, "key1", "value1",
+                    "cf2_value1");
+    VerifyGetEntity(db, ReadOptions(), cf2, "key1", "value2", "cf2_value2");
+  }
+
+  scenario.TearDown(db);
+}
+
+#if USE_COROUTINES
+TEST_P(WritePreparedTransactionTest, GetEntityCoroutine) {
+  options.env = Env::Default();
+  // CoroDB::CoGetEntity silently falls back to the synchronous DB API when the
+  // FileSystem exposes no read executor, and the executor is only created by
+  // SetReadIOExecutorThreads. Without this the test would pass while never
+  // entering GetEntityCoroutine.
+  options.env->GetFileSystem()->SetReadIOExecutorThreads(1);
+  if (options.env->GetFileSystem()->GetReadExecutor() == nullptr) {
+    ROCKSDB_GTEST_SKIP(
+        "FileSystem has no read executor; coroutine reads would fall back to "
+        "the synchronous path");
+    return;
+  }
+  ASSERT_OK(ReOpen());
+
+  ASSERT_NE(nullptr, db->GetCoroDB());
+  ASSERT_NE(nullptr, db->GetFileSystem()->GetReadExecutor());
+
+  PreparedEntityScenario scenario;
+  ASSERT_NO_FATAL_FAILURE(SetUpPreparedEntityScenario(db, options, &scenario));
+  ColumnFamilyHandle* cf2 = scenario.cf2;
+
+  // Each scenario runs through both the synchronous and the coroutine
+  // overrides, so the two are held to the same expectations under one env.
+  auto verify = [&](const ReadOptions& read_options,
+                    const std::string& expected_default,
+                    const std::string& expected_cf2) {
+    VerifyGetEntity(db, read_options, cf2, "key1", expected_default,
+                    expected_cf2);
+    CoVerifyGetEntity(db, read_options, cf2, "key1", expected_default,
+                      expected_cf2);
+  };
+
+  {
+    SCOPED_TRACE("prepared, not yet committed");
+    verify(scenario.snapshot_read_options, "value1", "cf2_value1");
+    verify(ReadOptions(), "value1", "cf2_value1");
+  }
+
+  ASSERT_OK(scenario.txn->Commit());
+
+  {
+    SCOPED_TRACE("committed after the snapshot was taken");
+    verify(scenario.snapshot_read_options, "value1", "cf2_value1");
+    verify(ReadOptions(), "value2", "cf2_value2");
+  }
+
+  scenario.TearDown(db);
+}
+#endif  // USE_COROUTINES
+
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {

--- a/utilities/transactions/write_prepared_txn_db.h
+++ b/utilities/transactions/write_prepared_txn_db.h
@@ -100,6 +100,15 @@ class WritePreparedTxnDB : public WritePreparedTxnDBBase {
                                   std::string* timestamp);
   using DB::GetAsync;
 
+  using DB::GetEntity;
+  DECLARE_SYNC_AND_ASYNC_OVERRIDE(Status, GetEntity, const ReadOptions& options,
+                                  ColumnFamilyHandle* column_family,
+                                  const Slice& key,
+                                  PinnableWideColumns* columns);
+  DECLARE_SYNC_AND_ASYNC_OVERRIDE(Status, GetEntity, const ReadOptions& options,
+                                  const Slice& key,
+                                  PinnableAttributeGroups* result);
+
   using DB::MultiGet;
   DECLARE_SYNC_AND_ASYNC_OVERRIDE(void, MultiGet,
                                   const ReadOptions& _read_options,

--- a/utilities/transactions/write_prepared_txn_db_sync_and_async.h
+++ b/utilities/transactions/write_prepared_txn_db_sync_and_async.h
@@ -38,6 +38,140 @@ DEFINE_SYNC_AND_ASYNC(Status, WritePreparedTxnDB::Get)
   CO_RETURN CO_AWAIT(GetImpl, read_options, column_family, key, value);
 }
 
+DEFINE_SYNC_AND_ASYNC(Status, WritePreparedTxnDB::GetEntity)
+(const ReadOptions& options, ColumnFamilyHandle* column_family,
+ const Slice& key, PinnableWideColumns* columns) {
+#ifdef WITH_COROUTINES
+  INSTALL_COROUTINE_STATS_CONTEXT_SCOPE(
+      db_impl_->GetFileSystem()->GetReadExecutor(), db_impl_->GetEnv());
+#endif
+  if (!column_family) {
+    CO_RETURN Status::InvalidArgument(
+        "Cannot call GetEntity without a column family handle");
+  }
+  if (!columns) {
+    CO_RETURN Status::InvalidArgument(
+        "Cannot call GetEntity without a PinnableWideColumns object");
+  }
+  if (options.io_activity != Env::IOActivity::kUnknown &&
+      options.io_activity != Env::IOActivity::kGetEntity) {
+    CO_RETURN Status::InvalidArgument(
+        "Can only call GetEntity with `ReadOptions::io_activity` set to "
+        "`Env::IOActivity::kUnknown` or `Env::IOActivity::kGetEntity`");
+  }
+  ReadOptions read_options(options);
+  if (read_options.io_activity == Env::IOActivity::kUnknown) {
+    read_options.io_activity = Env::IOActivity::kGetEntity;
+  }
+  columns->Reset();
+
+  SequenceNumber min_uncommitted;
+  SequenceNumber snap_seq;
+  const SnapshotBackup backed_by_snapshot =
+      AssignMinMaxSeqs(read_options.snapshot, &min_uncommitted, &snap_seq);
+  WritePreparedTxnReadCallback callback(this, snap_seq, min_uncommitted,
+                                        backed_by_snapshot);
+  DBImpl::GetImplOptions get_impl_options;
+  get_impl_options.column_family = column_family;
+  get_impl_options.columns = columns;
+  get_impl_options.callback = &callback;
+  Status s = CO_AWAIT(db_impl_->GetImpl, read_options, key, get_impl_options);
+  if (LIKELY(callback.valid() && ValidateSnapshot(callback.max_visible_seq(),
+                                                  backed_by_snapshot))) {
+    CO_RETURN s;
+  }
+
+  s.PermitUncheckedError();
+  WPRecordTick(TXN_GET_TRY_AGAIN);
+  CO_RETURN Status::TryAgain();
+}
+
+DEFINE_SYNC_AND_ASYNC(Status, WritePreparedTxnDB::GetEntity)
+(const ReadOptions& options, const Slice& key,
+ PinnableAttributeGroups* result) {
+#ifdef WITH_COROUTINES
+  INSTALL_COROUTINE_STATS_CONTEXT_SCOPE(
+      db_impl_->GetFileSystem()->GetReadExecutor(), db_impl_->GetEnv());
+#endif
+  if (!result) {
+    CO_RETURN Status::InvalidArgument(
+        "Cannot call GetEntity without PinnableAttributeGroups object");
+  }
+  Status s;
+  const size_t num_column_families = result->size();
+  if (options.io_activity != Env::IOActivity::kUnknown &&
+      options.io_activity != Env::IOActivity::kGetEntity) {
+    s = Status::InvalidArgument(
+        "Can only call GetEntity with `ReadOptions::io_activity` set to "
+        "`Env::IOActivity::kUnknown` or `Env::IOActivity::kGetEntity`");
+    for (size_t i = 0; i < num_column_families; ++i) {
+      (*result)[i].SetStatus(s);
+    }
+    CO_RETURN s;
+  }
+  if (num_column_families == 0) {
+    CO_RETURN s;
+  }
+  ReadOptions read_options(options);
+  if (read_options.io_activity == Env::IOActivity::kUnknown) {
+    read_options.io_activity = Env::IOActivity::kGetEntity;
+  }
+
+  SequenceNumber min_uncommitted;
+  SequenceNumber snap_seq;
+  const SnapshotBackup backed_by_snapshot =
+      AssignMinMaxSeqs(read_options.snapshot, &min_uncommitted, &snap_seq);
+
+  for (size_t i = 0; i < num_column_families; ++i) {
+    if (!(*result)[i].column_family()) {
+      s = Status::InvalidArgument(
+          "DB failed to query because one or more group(s) have null column "
+          "family handle");
+      (*result)[i].SetStatus(
+          Status::InvalidArgument("Column family handle cannot be null"));
+      break;
+    }
+  }
+  if (!s.ok()) {
+    for (size_t i = 0; i < num_column_families; ++i) {
+      if ((*result)[i].status().ok()) {
+        (*result)[i].SetStatus(
+            Status::Incomplete("DB not queried due to invalid argument(s) in "
+                               "one or more of the attribute groups"));
+      }
+    }
+    CO_RETURN s;
+  }
+
+  for (size_t i = 0; i < num_column_families; ++i) {
+    (*result)[i].Reset();
+    PinnableWideColumns columns;
+    WritePreparedTxnReadCallback callback(this, snap_seq, min_uncommitted,
+                                          backed_by_snapshot);
+    DBImpl::GetImplOptions get_impl_options;
+    get_impl_options.column_family = (*result)[i].column_family();
+    get_impl_options.columns = &columns;
+    get_impl_options.callback = &callback;
+    Status get_s =
+        CO_AWAIT(db_impl_->GetImpl, read_options, key, get_impl_options);
+    if (UNLIKELY(!callback.valid() ||
+                 !ValidateSnapshot(callback.max_visible_seq(),
+                                   backed_by_snapshot))) {
+      // Snapshot validation failed for this column family. Surface TryAgain
+      // for this attribute group only and leave the other column families'
+      // results intact, matching the per-key semantics of
+      // WritePreparedTxnDB::MultiGet and DBImpl::GetEntity.
+      get_s.PermitUncheckedError();
+      (*result)[i].SetStatus(Status::TryAgain());
+      WPRecordTick(TXN_GET_TRY_AGAIN);
+      continue;
+    }
+    (*result)[i].SetStatus(get_s);
+    (*result)[i].SetColumns(std::move(columns));
+  }
+  CO_RETURN s;
+}
+
 DEFINE_SYNC_AND_ASYNC(Status, WritePreparedTxnDB::GetImpl)
 (const ReadOptions& options, ColumnFamilyHandle* column_family,
  const Slice& key, PinnableSlice* value) {


### PR DESCRIPTION
Summary:

`WritePreparedTxnDB` overrides `Get` and `MultiGet` to install a
`WritePreparedTxnReadCallback` that performs visibility checking for
prepared-but-uncommitted data. However, `GetEntity` (both the single-CF
`PinnableWideColumns` variant and the multi-CF `PinnableAttributeGroups`
variant) was never overridden, causing it to fall through to
`StackableDB::GetEntity` which delegates to the inner `DBImpl` without
any WritePrepared visibility callback.

This means `GetEntity` could read prepared-but-uncommitted data, violating
snapshot isolation. The bug surfaces in the crash test with the combination:
`--use_txn=1 --txn_write_policy=1 --use_attribute_group=1 --use_get_entity=1
--unordered_write=1 --two_write_queues=1 --test_batches_snapshots=1`

The fix adds `GetEntity` overrides to `WritePreparedTxnDB` that create a
`WritePreparedTxnReadCallback` and pass it via `GetImplOptions::callback`,
matching the pattern used by the existing `Get` override.

Reviewed By: xingbowang

Differential Revision: D116324596


