### PR TITLE
Reuse one top-level filter-partition index iterator in MultiGet 

### DIFF
--- a/table/block_based/partitioned_filter_block.cc
+++ b/table/block_based/partitioned_filter_block.cc
@@ -427,32 +427,43 @@ void PartitionedFilterBlockReader::PrefixesMayMatch(
            &FullFilterBlockReader::PrefixesMayMatch);
 }
 
-BlockHandle PartitionedFilterBlockReader::GetFilterPartitionHandle(
+void PartitionedFilterBlockReader::NewFilterPartitionIndexIterator(
     const CachableEntry<Block_kFilterPartitionIndex>& filter_block,
-    const Slice& entry) const {
-  IndexBlockIter iter;
+    IndexBlockIter* iter) const {
   const InternalKeyComparator* const comparator = internal_comparator();
   Statistics* kNullStats = nullptr;
   filter_block.GetValue()->NewIndexIterator(
       comparator->user_comparator(),
       table()->get_rep()->get_global_seqno(BlockType::kFilterPartitionIndex),
-      &iter, kNullStats, true /* total_order_seek */,
-      false /* have_first_key */, index_key_includes_seq(),
-      index_value_is_full(), false /* block_contents_pinned */,
-      user_defined_timestamps_persisted(), nullptr /* prefix_index */,
-      BlockBasedTableOptions::kBinary, index_value_delta_escape());
-  iter.Seek(entry);
-  if (UNLIKELY(!iter.Valid())) {
+      iter, kNullStats, true /* total_order_seek */, false /* have_first_key */,
+      index_key_includes_seq(), index_value_is_full(),
+      false /* block_contents_pinned */, user_defined_timestamps_persisted(),
+      nullptr /* prefix_index */, BlockBasedTableOptions::kBinary,
+      index_value_delta_escape());
+}
+
+BlockHandle PartitionedFilterBlockReader::SeekFilterPartitionHandle(
+    IndexBlockIter* iter, const Slice& entry) const {
+  iter->Seek(entry);
+  if (UNLIKELY(!iter->Valid())) {
     // entry is larger than all the keys. However its prefix might still be
     // present in the last partition. If this is called by PrefixMayMatch this
     // is necessary for correct behavior. Otherwise it is unnecessary but safe.
     // Assuming this is an unlikely case for full key search, the performance
     // overhead should be negligible.
-    iter.SeekToLast();
+    iter->SeekToLast();
   }
-  assert(iter.Valid());
-  BlockHandle fltr_blk_handle = iter.value().handle;
+  assert(iter->Valid());
+  BlockHandle fltr_blk_handle = iter->value().handle;
   return fltr_blk_handle;
+}
+
+BlockHandle PartitionedFilterBlockReader::GetFilterPartitionHandle(
+    const CachableEntry<Block_kFilterPartitionIndex>& filter_block,
+    const Slice& entry) const {
+  IndexBlockIter iter;
+  NewFilterPartitionIndexIterator(filter_block, &iter);
+  return SeekFilterPartitionHandle(&iter, entry);
 }
 
 Status PartitionedFilterBlockReader::GetFilterPartitionBlock(
@@ -535,6 +546,9 @@ void PartitionedFilterBlockReader::MayMatch(
     return;  // Any/all may match
   }
 
+  IndexBlockIter filter_index_iter;
+  NewFilterPartitionIndexIterator(filter_block, &filter_index_iter);
+
   auto start_iter_same_handle = range->begin();
   BlockHandle prev_filter_handle = BlockHandle::NullBlockHandle();
 
@@ -542,9 +556,8 @@ void PartitionedFilterBlockReader::MayMatch(
   // share block cache lookup and use full filter multiget on the partition
   // filter.
   for (auto iter = start_iter_same_handle; iter != range->end(); ++iter) {
-    // TODO: re-use one top-level index iterator
     BlockHandle this_filter_handle =
-        GetFilterPartitionHandle(filter_block, iter->ikey);
+        SeekFilterPartitionHandle(&filter_index_iter, iter->ikey);
     if (!prev_filter_handle.IsNull() &&
         this_filter_handle != prev_filter_handle) {
       MultiGetRange subrange(*range, start_iter_same_handle, iter);

--- a/table/block_based/partitioned_filter_block.h
+++ b/table/block_based/partitioned_filter_block.h
@@ -186,6 +186,13 @@ class PartitionedFilterBlockReader
   BlockHandle GetFilterPartitionHandle(
       const CachableEntry<Block_kFilterPartitionIndex>& filter_block,
       const Slice& entry) const;
+  // Initializes `iter` over the top-level filter partition index in
+  // `filter_block`, for use with `SeekFilterPartitionHandle`.
+  void NewFilterPartitionIndexIterator(
+      const CachableEntry<Block_kFilterPartitionIndex>& filter_block,
+      IndexBlockIter* iter) const;
+  BlockHandle SeekFilterPartitionHandle(IndexBlockIter* iter,
+                                        const Slice& entry) const;
   Status GetFilterPartitionBlock(
       FilePrefetchBuffer* prefetch_buffer, const BlockHandle& handle,
       GetContext* get_context, BlockCacheLookupContext* lookup_context,

--- a/table/block_based/partitioned_filter_block_test.cc
+++ b/table/block_based/partitioned_filter_block_test.cc
@@ -6,6 +6,7 @@
 #include "table/block_based/partitioned_filter_block.h"
 
 #include <map>
+#include <set>
 
 #include "block_cache.h"
 #include "index_builder.h"
@@ -252,6 +253,54 @@ class PartitionedFilterBlockTest
     }
   }
 
+  // Queries `reader` with a MultiGet range over `query_keys` (user keys
+  // without timestamp, in sorted order) via the whole-key `KeysMayMatch`
+  // path, and returns the subset of keys the filter reports as possibly
+  // present (i.e. the keys not filtered out).
+  std::set<std::string> MultiGetMayMatch(
+      PartitionedFilterBlockReader* reader,
+      const std::vector<std::string>& query_keys) {
+    ReadOptions read_options = test::kReadOptionsNoIo;
+    std::string min_ts(ts_sz_, '\0');
+    Slice min_ts_slice(min_ts);
+    if (ts_sz_ > 0) {
+      read_options.timestamp = &min_ts_slice;
+    }
+
+    autovector<Slice, MultiGetContext::MAX_BATCH_SIZE> ukeys;
+    autovector<PinnableSlice, MultiGetContext::MAX_BATCH_SIZE> values;
+    autovector<Status, MultiGetContext::MAX_BATCH_SIZE> statuses;
+    autovector<KeyContext, MultiGetContext::MAX_BATCH_SIZE> key_context;
+    autovector<KeyContext*, MultiGetContext::MAX_BATCH_SIZE> sorted_keys;
+    values.resize(query_keys.size());
+    statuses.resize(query_keys.size());
+    for (const auto& key : query_keys) {
+      ukeys.emplace_back(key);
+    }
+    for (size_t i = 0; i < query_keys.size(); ++i) {
+      key_context.emplace_back(/*column_family=*/nullptr, ukeys[i], &values[i],
+                               /*columns=*/nullptr, /*timestamp=*/nullptr,
+                               &statuses[i]);
+    }
+    for (auto& key_ctx : key_context) {
+      sorted_keys.emplace_back(&key_ctx);
+    }
+    MultiGetContext ctx(&sorted_keys, /*begin=*/0, sorted_keys.size(),
+                        /*snapshot=*/0, read_options, /*fs=*/nullptr,
+                        /*stats=*/nullptr);
+    MultiGetContext::Range range = ctx.GetMultiGetRange();
+    reader->KeysMayMatch(&range, /*lookup_context=*/nullptr, read_options);
+    for (const auto& status : statuses) {
+      status.PermitUncheckedOk();
+    }
+
+    std::set<std::string> may_match_keys;
+    for (auto iter = range.begin(); iter != range.end(); ++iter) {
+      may_match_keys.insert(iter->ukey_without_ts.ToString());
+    }
+    return may_match_keys;
+  }
+
   int TestBlockPerKey() {
     std::unique_ptr<PartitionedIndexBuilder> pib(NewIndexBuilder());
     std::unique_ptr<PartitionedFilterBlockBuilder> builder(
@@ -464,6 +513,53 @@ TEST_P(PartitionedFilterBlockTest, PrefixInWrongPartitionBug) {
                                        /*lookup_context=*/nullptr,
                                        ReadOptions()));
   }
+}
+
+// Exercises the MultiGet whole-key path (`KeysMayMatch` -> `MayMatch` over a
+// `MultiGetRange`), which reuses a single top-level filter-partition index
+// iterator across every key in the range. The range spans multiple filter
+// partitions, so consulting a wrong partition for any key would surface as a
+// false-negative Get (an added key incorrectly filtered out).
+TEST_P(PartitionedFilterBlockTest, MultiGetSpanningPartitions) {
+  // A small metadata block size cuts a filter partition after (almost) every
+  // key, forcing the range to span several partitions.
+  table_options_.metadata_block_size = 1;
+  std::unique_ptr<PartitionedIndexBuilder> pib(NewIndexBuilder());
+  std::unique_ptr<PartitionedFilterBlockBuilder> builder(NewBuilder(pib.get()));
+
+  std::vector<std::string> keys = PrepareKeys(keys_without_ts, kKeyNum);
+  int i = 0;
+  builder->Add(StripTimestampFromUserKey(keys[i], ts_sz_));
+  CutABlock(pib.get(), keys[i], keys[i + 1]);
+  i++;
+  builder->Add(StripTimestampFromUserKey(keys[i], ts_sz_));
+  CutABlock(pib.get(), keys[i], keys[i + 1]);
+  i++;
+  builder->Add(StripTimestampFromUserKey(keys[i], ts_sz_));
+  builder->Add(StripTimestampFromUserKey(keys[i], ts_sz_));
+  CutABlock(pib.get(), keys[i], keys[i + 1]);
+  i++;
+  builder->Add(StripTimestampFromUserKey(keys[i], ts_sz_));
+  CutABlock(pib.get(), keys[i]);
+
+  std::unique_ptr<PartitionedFilterBlockReader> reader(
+      NewReader(builder.get(), pib.get()));
+
+  // Every added key must be reported as possibly present; a false negative
+  // here would mean a wrong filter partition was consulted for that key.
+  const std::vector<std::string> added_keys(keys_without_ts,
+                                            keys_without_ts + kKeyNum);
+  const std::set<std::string> expected(added_keys.begin(), added_keys.end());
+  ASSERT_EQ(MultiGetMayMatch(reader.get(), added_keys), expected);
+
+  // Keys that were never added should be filtered out (assuming a good hash
+  // function).
+  const std::vector<std::string> missing_keys(
+      missing_keys_without_ts, missing_keys_without_ts + kMissingKeyNum);
+  ASSERT_TRUE(MultiGetMayMatch(reader.get(), missing_keys).empty());
+
+  // Confirm the range really did span at least 3 filter partitions.
+  ASSERT_GE(CountNumOfIndexPartitions(pib.get()), 3);
 }
 
 TEST_P(PartitionedFilterBlockTest, OneBlockPerKey) {


### PR DESCRIPTION
On the MultiGet filter path (`BlockBasedTable::MultiGet` ->
`PartitionedFilterBlockReader::MayMatch(MultiGetRange)`), `GetFilterPartitionHandle` was called once per key, and each call constructed a fresh top-level filter-partition `IndexBlockIter` via `Block::NewIndexIterator` before seeking. For a range of K keys that is K iterator constructions where one suffices.

`GetFilterPartitionHandle` is split into `NewFilterPartitionIndexIterator`, which constructs and initializes the index iterator, and `SeekFilterPartitionHandle`, which performs the per-key `Seek` / `Valid` / `SeekToLast` / `value` lookup.
`GetFilterPartitionHandle` now composes the two, so the single-key path is unchanged. `MayMatch(MultiGetRange)` creates the `IndexBlockIter` once before the loop and reuses it across all keys, eliminating K-1 iterator constructions and destructions per range. This resolves the existing  `// TODO: re-use one top-level index iterator`.

Reusing the iterator is safe because `IndexBlockIter::Seek` is position independent. `SeekImpl` resets `status_` to OK, performs a full binary search over the restart array without seeding from the current position, and `SeekToRestartPoint` sets the entry index absolutely. The `SeekToLast` fallback for keys past the end of the index likewise re-anchors and resets `status_`. Delta-encoded block handles remain correct because each `Seek` re-anchors at a restart point, where the entry is stored unshared and the handle is decoded in full rather than as a delta. The `CachableEntry` backing the iterator outlives the loop.

No behavior change: this is a pure CPU optimization and filter results are identical.

Summary: Pull Request resolved: https://github.com/facebook/rocksdb/pull/15137

Reviewed By: pdillinger

Differential Revision: D115489931


