### PR TITLE
Add rocksdb_slicetransform_create_capped_prefix() to the C API

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -8315,6 +8315,15 @@ rocksdb_slicetransform_t* rocksdb_slicetransform_create_fixed_prefix(
   return wrapper;
 }
 
+rocksdb_slicetransform_t* rocksdb_slicetransform_create_capped_prefix(
+    size_t cap_len) {
+  SliceTransformWrapper* wrapper = new SliceTransformWrapper;
+  wrapper->rep_ = ROCKSDB_NAMESPACE::NewCappedPrefixTransform(cap_len);
+  wrapper->state_ = nullptr;
+  wrapper->destructor_ = &SliceTransformWrapper::DoNothing;
+  return wrapper;
+}
+
 rocksdb_slicetransform_t* rocksdb_slicetransform_create_noop() {
   SliceTransformWrapper* wrapper = new SliceTransformWrapper;
   wrapper->rep_ = ROCKSDB_NAMESPACE::NewNoopTransform();

--- a/db/c_test.c
+++ b/db/c_test.c
@@ -3500,6 +3500,62 @@ int main(int argc, char** argv) {
     rocksdb_destroy_db(options, dbname, &err);
   }
 
+  StartPhase("capped_prefix");
+  {
+    // Unlike rocksdb_slicetransform_create_fixed_prefix, a capped-prefix
+    // transform is InDomain for every key, including ones shorter than the
+    // cap -- exercise it with a key shorter than the cap ("ba", 2 bytes,
+    // cap 3) alongside longer keys sharing its leading bytes. Uses its own
+    // fresh options (default skiplist memtable + block-based table, not the
+    // shared `options` variable's hash_skip_list_rep/plain_table_factory
+    // left over from the "prefix" phase above) so entries aren't partitioned
+    // into separate prefix buckets and iteration order is plain bytewise,
+    // isolating the extractor itself.
+    rocksdb_options_t* capped_options = rocksdb_options_create();
+    rocksdb_options_set_create_if_missing(capped_options, 1);
+    rocksdb_options_set_prefix_extractor(
+        capped_options, rocksdb_slicetransform_create_capped_prefix(3));
+
+    db = rocksdb_open(capped_options, dbname, &err);
+    CheckNoError(err);
+
+    rocksdb_put(db, woptions, "ba", 2, "bar", 3, &err);
+    CheckNoError(err);
+    rocksdb_put(db, woptions, "bar1", 4, "bar", 3, &err);
+    CheckNoError(err);
+    rocksdb_put(db, woptions, "bar2", 4, "bar", 3, &err);
+    CheckNoError(err);
+    rocksdb_put(db, woptions, "foo1", 4, "foo", 3, &err);
+    CheckNoError(err);
+
+    CheckGet(db, roptions, "ba", "bar");
+
+    rocksdb_iterator_t* iter = rocksdb_create_iterator(db, roptions);
+    CheckCondition(!rocksdb_iter_valid(iter));
+
+    rocksdb_iter_seek(iter, "ba", 2);
+    rocksdb_iter_get_error(iter, &err);
+    CheckNoError(err);
+    CheckCondition(rocksdb_iter_valid(iter));
+    CheckIter(iter, "ba", "bar");
+    rocksdb_iter_next(iter);
+    CheckIter(iter, "bar1", "bar");
+    rocksdb_iter_next(iter);
+    CheckIter(iter, "bar2", "bar");
+    rocksdb_iter_next(iter);
+    CheckIter(iter, "foo1", "foo");
+    rocksdb_iter_next(iter);
+    CheckCondition(!rocksdb_iter_valid(iter));
+    rocksdb_iter_get_error(iter, &err);
+    CheckNoError(err);
+    rocksdb_iter_destroy(iter);
+
+    rocksdb_close(db);
+    rocksdb_destroy_db(capped_options, dbname, &err);
+    CheckNoError(err);
+    rocksdb_options_destroy(capped_options);
+  }
+
   // Check memory usage stats
   StartPhase("approximate_memory_usage");
   {

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -3790,6 +3790,8 @@ rocksdb_slicetransform_create(void* state, void (*destructor)(void*),
 extern ROCKSDB_LIBRARY_API rocksdb_slicetransform_t*
 rocksdb_slicetransform_create_fixed_prefix(size_t);
 extern ROCKSDB_LIBRARY_API rocksdb_slicetransform_t*
+rocksdb_slicetransform_create_capped_prefix(size_t);
+extern ROCKSDB_LIBRARY_API rocksdb_slicetransform_t*
 rocksdb_slicetransform_create_noop(void);
 extern ROCKSDB_LIBRARY_API void rocksdb_slicetransform_destroy(
     rocksdb_slicetransform_t*);

--- a/tools/c_api_gen/c_base.cc
+++ b/tools/c_api_gen/c_base.cc
@@ -6813,6 +6813,15 @@ rocksdb_slicetransform_t* rocksdb_slicetransform_create_fixed_prefix(
   return wrapper;
 }
 
+rocksdb_slicetransform_t* rocksdb_slicetransform_create_capped_prefix(
+    size_t cap_len) {
+  SliceTransformWrapper* wrapper = new SliceTransformWrapper;
+  wrapper->rep_ = ROCKSDB_NAMESPACE::NewCappedPrefixTransform(cap_len);
+  wrapper->state_ = nullptr;
+  wrapper->destructor_ = &SliceTransformWrapper::DoNothing;
+  return wrapper;
+}
+
 rocksdb_slicetransform_t* rocksdb_slicetransform_create_noop() {
   SliceTransformWrapper* wrapper = new SliceTransformWrapper;
   wrapper->rep_ = ROCKSDB_NAMESPACE::NewNoopTransform();

--- a/tools/c_api_gen/c_base.h
+++ b/tools/c_api_gen/c_base.h
@@ -2788,6 +2788,8 @@ rocksdb_slicetransform_create(void* state, void (*destructor)(void*),
 extern ROCKSDB_LIBRARY_API rocksdb_slicetransform_t*
 rocksdb_slicetransform_create_fixed_prefix(size_t);
 extern ROCKSDB_LIBRARY_API rocksdb_slicetransform_t*
+rocksdb_slicetransform_create_capped_prefix(size_t);
+extern ROCKSDB_LIBRARY_API rocksdb_slicetransform_t*
 rocksdb_slicetransform_create_noop(void);
 extern ROCKSDB_LIBRARY_API void rocksdb_slicetransform_destroy(
     rocksdb_slicetransform_t*);

--- a/unreleased_history/public_api_changes/capped_prefix_c_api.md
+++ b/unreleased_history/public_api_changes/capped_prefix_c_api.md
@@ -1,0 +1,1 @@
+Added `rocksdb_slicetransform_create_capped_prefix()` to the C API, exposing `NewCappedPrefixTransform()` alongside the existing `rocksdb_slicetransform_create_fixed_prefix()`.


### PR DESCRIPTION
Adds `rocksdb_slicetransform_create_capped_prefix()` to the C API, mirroring the existing fixed-prefix function. Verified via a new `c_test` phase.