### PR TITLE
Blog post for coroutines (#15143)

### DIFF
--- a/docs/_posts/2026-08-24-native-coroutine-reads.markdown
+++ b/docs/_posts/2026-08-24-native-coroutine-reads.markdown
@@ -1,0 +1,170 @@
+---
+title: "Native Async/Coroutine Reads in RocksDB"
+layout: post
+author: joshkang97
+category: blog
+---
+
+A point lookup that misses RocksDB's block cache can spend most of its time waiting for storage. The traditional way to keep more reads in flight is to add threads. That works, but each outstanding read parks a thread, carries a stack, and adds context-switching overhead.
+
+RocksDB now has experimental asynchronous `Get` and `MultiGet` APIs backed by native C++ coroutines. When a read reaches storage, RocksDB can suspend the request, let its read-executor worker run another ready task, and resume the request when the filesystem reports completion. A small executor can therefore maintain more storage queue depth without requiring one blocked application thread per read.
+
+These APIs are available in RocksDB 11.10.0.
+
+This is primarily a throughput feature for I/O-bound point lookups. It does not make an individual device read faster. Its benefit comes from keeping the device busy and using CPU threads for runnable work.
+
+## The API surface
+
+RocksDB exposes the new read path through two public interfaces:
+
+* `DB::GetAsync` and `DB::MultiGetAsync` return immediately on the native path and report completion through `AsyncCallback::OnComplete`.
+* `CoroDB::CoGet` and `CoroDB::CoMultiGet` return lazy `folly::coro::Task` objects. `CoGet` produces a `Status`; `CoMultiGet` fills the same per-key values and statuses as synchronous `MultiGet`.
+
+The callback APIs suit applications that do not expose Folly tasks at their boundaries. The `CoroDB` APIs let coroutine-based callers await RocksDB directly, avoiding an application-side callback-to-`Baton` adapter and its extra completion handoff.
+
+Native execution requires RocksDB to be built with Folly and `USE_COROUTINES=1`.
+
+Neither interface requires `ReadOptions::async_io`. That flag continues to control the older internal async-I/O optimizations for synchronous `MultiGet` and iterators.
+
+The task APIs are lazy: no read begins until a task is awaited or started. Both interfaces take pointer and reference parameters, so keep the DB, column-family handles, `ReadOptions`, keys and their backing storage, output objects, and callback when applicable alive until completion. The current APIs do not provide a handle for cancelling a submitted read; outstanding filesystem requests are driven to completion.
+
+## Two meanings of asynchronous
+
+RocksDB has used coroutines and async I/O internally before. The [2022 asynchronous I/O work](https://rocksdb.org/blog/2022/10/07/asynchronous-io-in-rocksdb.html) lets a synchronous `MultiGet` overlap reads from multiple SST files and lets iterators prefetch in the background. The caller still waits inside the synchronous API until the whole operation finishes.
+
+The new APIs make the operation itself suspendable:
+
+| Interface | Caller contract | Where concurrency comes from |
+| --- | --- | --- |
+| `Get` / `MultiGet` | Returns the completed result | More calling threads |
+| `ReadOptions::async_io` with synchronous `MultiGet` | Caller still waits | Overlapping child I/O inside one call |
+| `GetAsync` / `MultiGetAsync` | Completes through a callback, which can be inline on fallback | Requests scheduled on RocksDB's read executor |
+| `CoroDB::CoGet` / `CoMultiGet` | Returns a lazy Folly task that can be awaited | Suspended tasks multiplexed on the read executor |
+
+The distinction matters. An async wrapper can free the caller while still blocking a worker in the filesystem. Conversely, internal async I/O can overlap storage requests while the public API remains synchronous. The full benefit requires suspendability at both layers.
+
+<div style="overflow-x: auto; margin-left: auto; margin-right: auto; width: 100%;">
+  <a href="/static/images/native-coroutine-reads/sync-vs-coroutine.svg">
+    <img src="/static/images/native-coroutine-reads/sync-vs-coroutine.svg" alt="Three stacked timelines comparing two-block MultiGet requests from one caller thread" style="display: block; min-width: 900px; width: 100%;" />
+  </a>
+</div>
+
+*Each illustrated request fetches one cache-missed block from each of two eligible SST files. `ReadOptions::async_io` overlaps those reads inside one synchronous `MultiGet`, but the caller cannot start B until A returns. In the third row, the caller already runs on a RocksDB read-executor `EventBase`: it dispatches A and B, then the event loop starts their block reads and later invokes both callbacks.*
+{: style="text-align: center"}
+
+## What happens on an SST cache miss
+
+A single native `Get` follows the normal RocksDB lookup path through the memtable, Version, table cache, block-based table reader, and random-access file reader. Most of that work is ordinary synchronous CPU work. The new suspension point is at the filesystem boundary:
+
+1. `CoGet` discovers the concrete DB's coroutine capability and binds the inner read to a read-executor `EventBase`.
+2. RocksDB checks the memtable and caches. On an SST block miss, it submits the storage read and suspends the database coroutine.
+3. While storage is outstanding, that read no longer occupies the executor. The event loop is free to accept and run another ready request.
+4. When the filesystem reports completion, RocksDB posts the suspended read back to the same read-executor `EventBase` thread that submitted the I/O.
+5. RocksDB verifies and decodes the block, populates the cache and user output, and completes the inner task.
+6. The awaiting caller continues on its own executor after the inner task completes.
+
+The database coroutine itself does not migrate between read-executor threads: its pre-I/O and post-I/O slices run on the same selected `EventBase` thread. This affinity avoids an extra cross-thread handoff and its context-switch cost when the read completes. Returning the completed result to the awaiting caller is a separate executor boundary.
+
+<div style="overflow-x: auto; margin-left: auto; margin-right: auto; width: 100%;">
+  <a href="/static/images/native-coroutine-reads/thread-handoff.svg">
+    <img src="/static/images/native-coroutine-reads/thread-handoff.svg" alt="Top-to-bottom sequence showing SubmitReadAsync, coroutine suspension, storage completion, and resumption" style="display: block; min-width: 960px; width: 100%;" />
+  </a>
+</div>
+
+*After `SubmitReadAsync` returns, the database coroutine suspends and the read executor can accept another request. The filesystem completion makes the read runnable again, and RocksDB resumes it to verify and decode the block.*
+{: style="text-align: center"}
+
+The filesystem callback makes the suspended read runnable by posting back to its selected event loop. The same `EventBase` thread that submitted the read performs the post-I/O RocksDB work.
+
+The callback API has a different final handoff. On the native async path, `AsyncCallback::OnComplete` runs inside the detached task on the RocksDB read executor. If there is no coroutine capability or no read executor, RocksDB uses the synchronous API and may invoke `OnComplete` inline before `GetAsync` returns. Callback users must be correct in both cases and must not start another async read from `OnComplete`.
+
+For `MultiGet`, RocksDB additionally creates child tasks for eligible, non-overlapping SST files within a level and awaits them together. This is logical concurrency on an `EventBase`, not one OS thread per SST. Each child can submit one or more block reads, suspend, and let other children or requests run.
+
+## Filesystem integration
+
+Filesystem implementers support two related paths:
+
+* Synchronous `MultiGet` with `ReadOptions::async_io` uses the existing `FSRandomAccessFile::ReadAsync`, `FileSystem::Poll`, and `FileSystem::AbortIO` APIs. The filesystem also advertises `FSSupportedOps::kAsyncIO`.
+* Native `GetAsync`, `MultiGetAsync`, `CoGet`, and `CoMultiGet` additionally require `FileSystem::GetReadExecutor` and `FSRandomAccessFile::SubmitReadAsync`. `SetReadIOExecutorThreads` lets RocksDB apply `DBOptions::read_io_executor_threads` to that executor.
+
+The event-loop-backed `IOExecutor` is necessary because an I/O completion only makes a suspended coroutine ready; it does not resume the coroutine by itself. RocksDB runs each read coroutine on one of the executor's `EventBase`s. After the filesystem invokes the `SubmitReadAsync` callback, RocksDB posts the continuation back to that same event loop. Because an `EventBase` is thread-affine, the coroutine resumes on the thread that submitted the read, avoiding an additional cross-thread context switch.
+
+`SubmitReadAsync` must populate the `FSReadRequest` and invoke its callback exactly once. It returns `true` for a non-blocking submission and `false` when it used the synchronous fallback. If `GetReadExecutor` returns null, the native APIs use their outer synchronous fallback instead.
+
+On supported Linux builds, the default POSIX filesystem supplies these hooks with a Folly `IOExecutor`. Each read-executor `EventBase` attempts to use `folly::IoUringBackend`, which submits and receives completions through io_uring.
+
+## Statistics across suspension
+
+`PerfContext` and `IOStatsContext` traditionally live in thread-local storage (TLS), which works while one operation owns a thread from entry to return. A coroutine read stays on one `EventBase` thread, but it does not own that thread while suspended: request B can reuse the same worker and its TLS before request A resumes.
+
+RocksDB gives each coroutine read its own `PerfContext` and `IOStatsContext`. A Folly `RequestContext` loads those contexts into TLS only while that request is active, saves them before suspension, and restores them on resumption. It also carries the submitting thread's statistics configuration.
+
+Collecting and transferring these request-local statistics adds request-context and TLS bookkeeping. Applications that do not consume them should disable both `PerfContext` and `IOStatsContext` on every read-executor thread for optimal performance.
+
+<div style="overflow-x: auto; margin-left: auto; margin-right: auto; width: 100%;">
+  <a href="/static/images/native-coroutine-reads/tls-across-suspension.svg">
+    <img src="/static/images/native-coroutine-reads/tls-across-suspension.svg" alt="Per-request statistics and CPU accounting survive coroutine interleaving" style="display: block; min-width: 900px; width: 100%;" />
+  </a>
+</div>
+
+*Request contexts prevent two reads interleaved on one event-loop worker from sharing counters. CPU time is accumulated only during the slices in which that request is running.*
+{: style="text-align: center"}
+
+### Wall-clock timers
+
+Suspension does not pause RocksDB's ordinary latency timers. A timer's start point remains in the coroutine frame while the request context saves its counters. After resumption, RocksDB restores those counters and the timer records its full start-to-finish duration. Consequently `PerfContext::get_from_output_files_time`, `PerfContext::block_read_time`, and `IOStatsContext::read_nanos` include storage wait.
+
+### CPU time
+
+Wall time and CPU time need different treatment around a suspension. End-to-end wall time should include the device wait. A CPU timer left running across `co_await`, however, could charge request A for time spent running request B on the same event-loop worker.
+
+At `PerfLevel::kEnableTimeAndCPUTimeExceptForMutex`, RocksDB starts the thread CPU clock when a request's context is installed and stops it before that context is removed. `PerfContext::get_cpu_nanos` is the sum of those active slices. It excludes time waiting for I/O, CPU consumed by another coroutine between A's slices, and work performed later in `OnComplete`.
+
+Some narrower CPU timers that rely on a synchronous scope cannot safely span asynchronous I/O. In particular, `PerfContext::block_read_cpu_time` and `IOStatsContext::cpu_read_nanos` are not supported for async reads.
+
+## Why not increase application threads?
+
+More application threads can also keep more reads in flight, but each cache miss occupies a thread until storage responds. Raising the thread count therefore grows per-thread stack memory, scheduler work, and context switching even though the parked threads are not consuming CPU while they wait. At high concurrency, those costs compete with the CPU work needed to process completed reads.
+
+Thread pools are also difficult to resize dynamically. The useful count changes with device latency, cache-hit ratio, request rate, and the amount of CPU work after each read. Increasing a pool under load can create a burst of runnable work and contention; reducing it safely requires waiting for workers and their in-flight requests to drain. A fixed count chosen for the worst case wastes resources during ordinary operation, while a smaller count can leave storage queue depth unused during a latency spike.
+
+Coroutines separate **concurrency** from **threads**. The application can vary the number of in-flight tasks without continually resizing its OS-thread pool. Suspended reads retain their coroutine frames, while a small read executor stays focused on runnable work. Coroutines still require backpressure, but that limit can describe outstanding requests instead of parked threads.
+
+## Performance
+
+I generated an 11 GB database with 11 million 16-byte keys and 1024-byte values. Compression was disabled, the block size was 4 KiB, reads used direct I/O, and the RocksDB block cache was disabled.
+
+I compared 4, 20, 40, and 60 concurrent tasks on four pinned cores. In the synchronous version, each task is an OS thread. In the coroutine version, the same number of coroutines runs on a four-thread read executor. I tested `MultiGet` batches of 1, 2, 4, and 8 keys; results are key lookups per second.
+
+The coroutine columns include the throughput change relative to the matching synchronous result:
+
+| Tasks | Batch 1 sync | Batch 1 coro | Batch 2 sync | Batch 2 coro | Batch 4 sync | Batch 4 coro | Batch 8 sync | Batch 8 coro |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 4 | 29,198 | 25,199 (-14%) | 30,087 | 50,262 (+67%) | 29,140 | 81,288 (+179%) | 26,019 | 105,366 (+305%) |
+| 20 | 75,094 | 97,137 (+29%) | 85,481 | 127,620 (+49%) | 80,865 | 148,247 (+83%) | 85,569 | 174,112 (+103%) |
+| 40 | 90,827 | 134,714 (+48%) | 94,392 | 162,181 (+72%) | 92,818 | 166,160 (+79%) | 90,856 | 163,306 (+80%) |
+| 60 | 88,461 | 147,062 (+66%) | 89,034 | 170,045 (+91%) | 75,060 | 178,424 (+138%) | 86,409 | 177,344 (+105%) |
+
+For the batch-1 synchronous workload, an OS thread cannot use its core while blocked on I/O. Adding more OS threads overlaps those waits and increases CPU utilization, but also increases context switching.
+
+| Tasks | Average CPU cores | Four-core CPU utilization | Context switches/second |
+| ---: | ---: | ---: | ---: |
+| 4 | 1.03 | 25.9% | 61,192 |
+| 20 | 3.72 | 93.0% | 210,756 |
+| 40 | 3.77 | 94.3% | 212,801 |
+| 60 | 3.81 | 95.2% | 211,355 |
+
+With four threads on four cores, the workload uses only 25.9% of the available CPU. Multiplexing 20 or more threads on the same cores raises utilization above 93%, while increasing context switches from about 61,000 to 211,000 per second.
+
+When there is no extra I/O parallelism to exploit, as with four batch-1 tasks, the synchronous version is faster because it avoids coroutine overhead. Larger batches let `CoMultiGet` expose more concurrent reads, so the coroutine path overtakes the synchronous version. At higher concurrency the gains flatten as the workload approaches saturating the CPUs.
+
+### Async I/O comparison
+
+I also compared synchronous `MultiGet` with `ReadOptions::async_io` against `CoMultiGet`. Async I/O does not support direct I/O, so this comparison used buffered reads and cleared the Linux page cache before every run. The RocksDB block cache was also disabled.
+
+| Tasks | Batch 1 async I/O | Batch 1 coro | Batch 2 async I/O | Batch 2 coro | Batch 4 async I/O | Batch 4 coro | Batch 8 async I/O | Batch 8 coro |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 4 | 35,598 | 34,455 (-3.2%) | 59,121 | 58,214 (-1.5%) | 90,923 | 87,929 (-3.3%) | 133,098 | 116,565 (-12.4%) |
+| 20 | 108,945 | 120,807 (+10.9%) | 123,399 | 140,163 (+13.6%) | 134,297 | 148,535 (+10.6%) | 154,842 | 166,865 (+7.8%) |
+| 40 | 116,002 | 144,819 (+24.8%) | 125,451 | 151,117 (+20.5%) | 136,350 | 190,499 (+39.7%) | 142,375 | 188,398 (+32.3%) |
+| 60 | 113,170 | 154,815 (+36.8%) | 120,759 | 186,808 (+54.7%) | 129,513 | 195,746 (+51.1%) | 145,191 | 200,781 (+38.3%) |

--- a/docs/static/images/native-coroutine-reads/sync-vs-coroutine.svg
+++ b/docs/static/images/native-coroutine-reads/sync-vs-coroutine.svg
@@ -1,0 +1,138 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1100" height="1070" viewBox="0 0 1100 1070" font-family="Helvetica, Arial, sans-serif">
+  <title>Two MultiGet requests from one caller thread</title>
+  <desc>Three stacked timelines compare plain MultiGet, synchronous MultiGet with async_io, and the callback-based MultiGetAsync API. Requests A and B each fetch two cache-missed blocks from separate eligible SST files.</desc>
+  <defs>
+    <marker id="arrow-row" markerWidth="10" markerHeight="10" refX="8" refY="3.5" orient="auto">
+      <path d="M0,0 L8,3.5 L0,7 z" fill="#607d8b"/>
+    </marker>
+  </defs>
+
+  <rect width="1100" height="1070" fill="#ffffff"/>
+  <text x="550" y="28" text-anchor="middle" font-size="21" font-weight="bold" fill="#263238">Two MultiGet requests from one caller thread</text>
+  <text x="550" y="51" text-anchor="middle" font-size="12" fill="#546e7a">A and B each miss one block in each of two eligible SST files.</text>
+
+  <!-- Row 1: plain synchronous MultiGet. -->
+  <rect x="20" y="70" width="1060" height="285" rx="12" fill="#fafafa" stroke="#cfd8dc" stroke-width="1.5"/>
+  <text x="45" y="101" font-size="18" font-weight="bold" fill="#263238">1. Plain MultiGet</text>
+  <text x="1048" y="101" text-anchor="end" font-size="11" font-weight="bold" fill="#b71c1c">synchronous public API</text>
+
+  <rect x="45" y="119" width="320" height="91" rx="7" fill="#eceff1" stroke="#90a4ae"/>
+  <text x="61" y="141" font-size="10" font-family="monospace" fill="#263238">read_options.async_io = false;</text>
+  <text x="61" y="165" font-size="9.5" font-family="monospace" fill="#0d47a1">db-&gt;MultiGet(...A...);  // fetches blocks A1, A2</text>
+  <text x="61" y="189" font-size="9.5" font-family="monospace" fill="#4527a0">db-&gt;MultiGet(...B...);  // fetches blocks B1, B2</text>
+
+  <text x="395" y="136" font-size="11" font-weight="bold" fill="#455a64">Caller</text>
+  <line x1="500" y1="132" x2="1040" y2="132" stroke="#b0bec5" stroke-width="2" marker-end="url(#arrow-row)"/>
+  <rect x="515" y="113" width="236" height="38" rx="5" fill="#fff3e0" stroke="#1565c0" stroke-width="1.5"/>
+  <text x="633" y="128" text-anchor="middle" font-size="10" font-weight="bold" fill="#0d47a1">A: MultiGet waits</text>
+  <text x="633" y="143" text-anchor="middle" font-size="9" fill="#0d47a1">returns after A1 + A2</text>
+  <rect x="751" y="113" width="236" height="38" rx="5" fill="#fff3e0" stroke="#5e35b1" stroke-width="1.5"/>
+  <text x="869" y="128" text-anchor="middle" font-size="10" font-weight="bold" fill="#4527a0">B: MultiGet waits</text>
+  <text x="869" y="143" text-anchor="middle" font-size="9" fill="#4527a0">called only after A returns</text>
+
+  <text x="395" y="195" font-size="11" font-weight="bold" fill="#455a64">Block I/O</text>
+  <line x1="466" y1="191" x2="1040" y2="191" stroke="#cfd8dc" stroke-width="1.5"/>
+  <rect x="530" y="175" width="97" height="32" rx="5" fill="#bbdefb" stroke="#1565c0"/>
+  <text x="579" y="195" text-anchor="middle" font-size="10" fill="#0d47a1">block A1</text>
+  <rect x="627" y="175" width="97" height="32" rx="5" fill="#bbdefb" stroke="#1565c0"/>
+  <text x="676" y="195" text-anchor="middle" font-size="10" fill="#0d47a1">block A2</text>
+  <rect x="766" y="175" width="97" height="32" rx="5" fill="#d1c4e9" stroke="#5e35b1"/>
+  <text x="815" y="195" text-anchor="middle" font-size="10" fill="#4527a0">block B1</text>
+  <rect x="863" y="175" width="97" height="32" rx="5" fill="#d1c4e9" stroke="#5e35b1"/>
+  <text x="912" y="195" text-anchor="middle" font-size="10" fill="#4527a0">block B2</text>
+
+  <rect x="45" y="237" width="990" height="88" rx="7" fill="#ffebee" stroke="#ef9a9a"/>
+  <text x="540" y="262" text-anchor="middle" font-size="13" font-weight="bold" fill="#b71c1c">A completes before the thread can submit B.</text>
+  <text x="540" y="286" text-anchor="middle" font-size="11" fill="#455a64">Without async I/O, the two eligible SST-file reads for A occur one after the other;</text>
+  <text x="540" y="306" text-anchor="middle" font-size="11" fill="#455a64">then the same caller thread runs B and fetches its two blocks.</text>
+
+  <!-- Row 2: synchronous MultiGet with internal async I/O. -->
+  <rect x="20" y="375" width="1060" height="285" rx="12" fill="#fffdf8" stroke="#ffcc80" stroke-width="1.5"/>
+  <text x="45" y="406" font-size="18" font-weight="bold" fill="#263238">2. MultiGet with ReadOptions::async_io</text>
+  <text x="1048" y="406" text-anchor="end" font-size="11" font-weight="bold" fill="#e65100">async I/O inside a synchronous call</text>
+
+  <rect x="45" y="424" width="320" height="91" rx="7" fill="#fff8e1" stroke="#ffb74d"/>
+  <text x="61" y="446" font-size="10" font-family="monospace" fill="#263238">read_options.async_io = true;</text>
+  <text x="61" y="470" font-size="9.5" font-family="monospace" fill="#0d47a1">db-&gt;MultiGet(...A...);  // fetches blocks A1, A2</text>
+  <text x="61" y="494" font-size="9.5" font-family="monospace" fill="#4527a0">db-&gt;MultiGet(...B...);  // fetches blocks B1, B2</text>
+
+  <text x="395" y="441" font-size="11" font-weight="bold" fill="#455a64">Caller</text>
+  <line x1="500" y1="437" x2="1040" y2="437" stroke="#b0bec5" stroke-width="2" marker-end="url(#arrow-row)"/>
+  <rect x="515" y="418" width="236" height="38" rx="5" fill="#fff3e0" stroke="#1565c0" stroke-width="1.5"/>
+  <text x="633" y="433" text-anchor="middle" font-size="10" font-weight="bold" fill="#0d47a1">A: MultiGet waits</text>
+  <text x="633" y="448" text-anchor="middle" font-size="9" fill="#0d47a1">A1 + A2 can overlap</text>
+  <rect x="751" y="418" width="236" height="38" rx="5" fill="#fff3e0" stroke="#5e35b1" stroke-width="1.5"/>
+  <text x="869" y="433" text-anchor="middle" font-size="10" font-weight="bold" fill="#4527a0">B: MultiGet waits</text>
+  <text x="869" y="448" text-anchor="middle" font-size="9" fill="#4527a0">called only after A returns</text>
+
+  <text x="395" y="500" font-size="11" font-weight="bold" fill="#455a64">Block I/O</text>
+  <line x1="466" y1="496" x2="1040" y2="496" stroke="#cfd8dc" stroke-width="1.5"/>
+  <rect x="530" y="473" width="165" height="28" rx="5" fill="#bbdefb" stroke="#1565c0"/>
+  <text x="613" y="491" text-anchor="middle" font-size="10" fill="#0d47a1">block A1</text>
+  <rect x="552" y="503" width="165" height="28" rx="5" fill="#bbdefb" stroke="#1565c0"/>
+  <text x="635" y="521" text-anchor="middle" font-size="10" fill="#0d47a1">block A2</text>
+  <rect x="766" y="473" width="165" height="28" rx="5" fill="#d1c4e9" stroke="#5e35b1"/>
+  <text x="849" y="491" text-anchor="middle" font-size="10" fill="#4527a0">block B1</text>
+  <rect x="788" y="503" width="165" height="28" rx="5" fill="#d1c4e9" stroke="#5e35b1"/>
+  <text x="871" y="521" text-anchor="middle" font-size="10" fill="#4527a0">block B2</text>
+
+  <rect x="45" y="542" width="990" height="88" rx="7" fill="#fff8e1" stroke="#ffb74d"/>
+  <text x="540" y="567" text-anchor="middle" font-size="13" font-weight="bold" fill="#e65100">The two block reads inside A overlap, but the public call still waits.</text>
+  <text x="540" y="591" text-anchor="middle" font-size="11" fill="#455a64">The caller thread does not submit B until A returns. Then async_io overlaps B1 and B2</text>
+  <text x="540" y="611" text-anchor="middle" font-size="11" fill="#455a64">inside the second synchronous MultiGet.</text>
+
+  <!-- Row 3: callback-based async API. -->
+  <rect x="20" y="680" width="1060" height="330" rx="12" fill="#f8fbff" stroke="#90caf9" stroke-width="1.5"/>
+  <text x="45" y="711" font-size="18" font-weight="bold" fill="#263238">3. MultiGetAsync (callback API)</text>
+  <text x="1048" y="711" text-anchor="end" font-size="11" font-weight="bold" fill="#0d47a1">caller runs on the read executor</text>
+
+  <rect x="45" y="729" width="350" height="114" rx="7" fill="#e3f2fd" stroke="#64b5f6"/>
+  <text x="61" y="747" font-size="8.5" fill="#455a64">// Already running on a RocksDB read-executor EventBase</text>
+  <text x="61" y="766" font-size="9.5" font-family="monospace" fill="#0d47a1">db-&gt;MultiGetAsync(...A..., callback_a);</text>
+  <text x="78" y="783" font-size="8.5" font-family="monospace" fill="#0d47a1">// fetches blocks A1, A2</text>
+  <text x="61" y="805" font-size="9.5" font-family="monospace" fill="#4527a0">db-&gt;MultiGetAsync(...B..., callback_b);</text>
+  <text x="78" y="822" font-size="8.5" font-family="monospace" fill="#4527a0">// fetches blocks B1, B2</text>
+  <text x="61" y="838" font-size="8" fill="#455a64">Native path shown; fallback may complete inline.</text>
+
+  <text x="420" y="746" font-size="11" font-weight="bold" fill="#455a64">Caller</text>
+  <line x1="535" y1="742" x2="1040" y2="742" stroke="#b0bec5" stroke-width="2" marker-end="url(#arrow-row)"/>
+  <rect x="550" y="723" width="90" height="38" rx="5" fill="#bbdefb" stroke="#1565c0" stroke-width="1.5"/>
+  <text x="595" y="738" text-anchor="middle" font-size="9" font-weight="bold" fill="#0d47a1">submit A</text>
+  <text x="595" y="753" text-anchor="middle" font-size="8" fill="#0d47a1">return</text>
+  <rect x="640" y="723" width="90" height="38" rx="5" fill="#d1c4e9" stroke="#5e35b1" stroke-width="1.5"/>
+  <text x="685" y="738" text-anchor="middle" font-size="9" font-weight="bold" fill="#4527a0">submit B</text>
+  <text x="685" y="753" text-anchor="middle" font-size="8" fill="#4527a0">return</text>
+  <rect x="730" y="723" width="190" height="38" rx="5" fill="#e8f5e9" stroke="#81c784"/>
+  <text x="825" y="738" text-anchor="middle" font-size="9" font-weight="bold" fill="#2e7d32">A and B in flight</text>
+  <text x="825" y="753" text-anchor="middle" font-size="8" fill="#2e7d32">callbacks complete later</text>
+  <rect x="920" y="723" width="58" height="38" rx="5" fill="#bbdefb" stroke="#1565c0"/>
+  <text x="949" y="738" text-anchor="middle" font-size="8" fill="#0d47a1">callback A</text>
+  <text x="949" y="751" text-anchor="middle" font-size="7" fill="#0d47a1">OnComplete</text>
+  <rect x="978" y="723" width="58" height="38" rx="5" fill="#d1c4e9" stroke="#5e35b1"/>
+  <text x="1007" y="738" text-anchor="middle" font-size="8" fill="#4527a0">callback B</text>
+  <text x="1007" y="751" text-anchor="middle" font-size="7" fill="#4527a0">OnComplete</text>
+
+  <text x="420" y="835" font-size="11" font-weight="bold" fill="#455a64">Block I/O</text>
+  <line x1="491" y1="831" x2="1040" y2="831" stroke="#cfd8dc" stroke-width="1.5"/>
+  <rect x="645" y="807" width="245" height="28" rx="5" fill="#bbdefb" stroke="#1565c0"/>
+  <text x="768" y="825" text-anchor="middle" font-size="10" fill="#0d47a1">block A1</text>
+  <rect x="660" y="837" width="245" height="28" rx="5" fill="#bbdefb" stroke="#1565c0"/>
+  <text x="783" y="855" text-anchor="middle" font-size="10" fill="#0d47a1">block A2</text>
+  <rect x="745" y="867" width="210" height="28" rx="5" fill="#d1c4e9" stroke="#5e35b1"/>
+  <text x="850" y="885" text-anchor="middle" font-size="10" fill="#4527a0">block B1</text>
+  <rect x="760" y="897" width="210" height="28" rx="5" fill="#d1c4e9" stroke="#5e35b1"/>
+  <text x="865" y="915" text-anchor="middle" font-size="10" fill="#4527a0">block B2</text>
+
+  <rect x="45" y="865" width="350" height="113" rx="7" fill="#e3f2fd" stroke="#64b5f6"/>
+  <text x="220" y="891" text-anchor="middle" font-size="13" font-weight="bold" fill="#0d47a1">A and B are both in flight.</text>
+  <text x="220" y="916" text-anchor="middle" font-size="11" fill="#455a64">The thread submits A, then B.</text>
+  <text x="220" y="939" text-anchor="middle" font-size="11" fill="#455a64">Their block reads begin after submission;</text>
+  <text x="220" y="959" text-anchor="middle" font-size="11" fill="#455a64">both callbacks complete later.</text>
+
+  <rect x="300" y="1035" width="16" height="12" rx="2" fill="#bbdefb" stroke="#1565c0"/>
+  <text x="322" y="1045" font-size="10" fill="#546e7a">request A / its blocks</text>
+  <rect x="470" y="1035" width="16" height="12" rx="2" fill="#d1c4e9" stroke="#5e35b1"/>
+  <text x="492" y="1045" font-size="10" fill="#546e7a">request B / its blocks</text>
+  <rect x="640" y="1035" width="16" height="12" fill="#fff3e0" stroke="#fb8c00"/>
+  <text x="662" y="1045" font-size="10" fill="#546e7a">caller waits synchronously</text>
+</svg>

--- a/docs/static/images/native-coroutine-reads/thread-handoff.svg
+++ b/docs/static/images/native-coroutine-reads/thread-handoff.svg
@@ -1,0 +1,103 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1000" height="740" viewBox="0 0 1000 740" font-family="Helvetica, Arial, sans-serif">
+  <title>Suspension and resumption of a native RocksDB coroutine read</title>
+  <desc>The parent coroutine starts an inner RocksDB read on a read-executor EventBase. SubmitReadAsync queues the filesystem read, then the database coroutine suspends and leaves the executor free until completion.</desc>
+  <defs>
+    <marker id="arrow-th" markerWidth="11" markerHeight="11" refX="9" refY="3.5" orient="auto">
+      <path d="M0,0 L9,3.5 L0,7 z" fill="#455a64"/>
+    </marker>
+    <marker id="arrow-blue-th" markerWidth="11" markerHeight="11" refX="9" refY="3.5" orient="auto">
+      <path d="M0,0 L9,3.5 L0,7 z" fill="#1565c0"/>
+    </marker>
+    <marker id="arrow-orange-th" markerWidth="11" markerHeight="11" refX="9" refY="3.5" orient="auto">
+      <path d="M0,0 L9,3.5 L0,7 z" fill="#ef6c00"/>
+    </marker>
+    <marker id="arrow-purple-th" markerWidth="11" markerHeight="11" refX="9" refY="3.5" orient="auto">
+      <path d="M0,0 L9,3.5 L0,7 z" fill="#5e35b1"/>
+    </marker>
+  </defs>
+
+  <rect x="0" y="0" width="1000" height="740" fill="#ffffff"/>
+  <text x="500" y="30" text-anchor="middle" font-size="19" font-weight="bold" fill="#263238">Native CoGet: suspension and resumption</text>
+
+  <rect x="35" y="50" width="205" height="54" rx="8" fill="#e3f2fd" stroke="#1565c0" stroke-width="1.5"/>
+  <text x="138" y="72" text-anchor="middle" font-size="13" font-weight="bold" fill="#0d47a1">Parent coroutine executor</text>
+  <text x="138" y="90" text-anchor="middle" font-size="11" fill="#0d47a1">application task</text>
+
+  <rect x="285" y="50" width="225" height="54" rx="8" fill="#ede7f6" stroke="#5e35b1" stroke-width="1.5"/>
+  <text x="398" y="72" text-anchor="middle" font-size="13" font-weight="bold" fill="#4527a0">RocksDB read executor</text>
+  <text x="398" y="90" text-anchor="middle" font-size="11" fill="#4527a0">one EventBase worker</text>
+
+  <rect x="555" y="50" width="205" height="54" rx="8" fill="#fff3e0" stroke="#ef6c00" stroke-width="1.5"/>
+  <text x="658" y="72" text-anchor="middle" font-size="13" font-weight="bold" fill="#e65100">Filesystem implementation</text>
+  <text x="658" y="90" text-anchor="middle" font-size="11" fill="#e65100">submission and completion</text>
+
+  <rect x="805" y="50" width="160" height="54" rx="8" fill="#eceff1" stroke="#607d8b" stroke-width="1.5"/>
+  <text x="885" y="72" text-anchor="middle" font-size="13" font-weight="bold" fill="#37474f">Kernel / storage</text>
+  <text x="885" y="90" text-anchor="middle" font-size="11" fill="#455a64">for POSIX: io_uring</text>
+
+  <line x1="138" y1="104" x2="138" y2="680" stroke="#90a4ae" stroke-width="1.2" stroke-dasharray="6 5"/>
+  <line x1="398" y1="104" x2="398" y2="680" stroke="#90a4ae" stroke-width="1.2" stroke-dasharray="6 5"/>
+  <line x1="658" y1="104" x2="658" y2="680" stroke="#90a4ae" stroke-width="1.2" stroke-dasharray="6 5"/>
+  <line x1="885" y1="104" x2="885" y2="680" stroke="#90a4ae" stroke-width="1.2" stroke-dasharray="6 5"/>
+
+  <rect x="74" y="128" width="128" height="34" rx="5" fill="#bbdefb" stroke="#1565c0"/>
+  <text x="138" y="150" text-anchor="middle" font-size="11" font-weight="bold" fill="#0d47a1">co_await CoGet()</text>
+  <line x1="202" y1="145" x2="398" y2="145" stroke="#1565c0" stroke-width="2" marker-end="url(#arrow-blue-th)"/>
+  <text x="294" y="136" text-anchor="middle" font-size="10" fill="#0d47a1">bind inner GetCoroutine</text>
+
+  <rect x="315" y="176" width="166" height="46" rx="5" fill="#d1c4e9" stroke="#5e35b1"/>
+  <text x="398" y="195" text-anchor="middle" font-size="11" font-weight="bold" fill="#4527a0">lookup starts</text>
+  <text x="398" y="211" text-anchor="middle" font-size="10" fill="#4527a0">memtable and block cache</text>
+
+  <rect x="315" y="241" width="166" height="38" rx="5" fill="#d1c4e9" stroke="#5e35b1"/>
+  <text x="398" y="265" text-anchor="middle" font-size="11" fill="#4527a0">SST block cache miss</text>
+  <line x1="481" y1="260" x2="581" y2="260" stroke="#455a64" stroke-width="1.8" marker-end="url(#arrow-th)"/>
+
+  <rect x="581" y="235" width="154" height="50" rx="5" fill="#ffe0b2" stroke="#ef6c00" stroke-width="1.5"/>
+  <text x="658" y="256" text-anchor="middle" font-size="11" font-weight="bold" font-family="monospace" fill="#e65100">SubmitReadAsync</text>
+  <text x="658" y="273" text-anchor="middle" font-size="10" fill="#e65100">queue non-blocking read</text>
+
+  <line x1="735" y1="260" x2="885" y2="260" stroke="#ef6c00" stroke-width="1.8" marker-end="url(#arrow-orange-th)"/>
+  <text x="805" y="250" text-anchor="middle" font-size="10" fill="#e65100">submit</text>
+
+  <rect x="315" y="309" width="166" height="52" rx="5" fill="#f3e5f5" stroke="#7e57c2" stroke-width="1.2"/>
+  <text x="398" y="330" text-anchor="middle" font-size="11" font-weight="bold" fill="#4527a0">DB coroutine suspends</text>
+  <text x="398" y="347" text-anchor="middle" font-size="10" fill="#4527a0">storage remains in flight</text>
+
+  <rect x="827" y="300" width="116" height="130" rx="5" fill="#eceff1" stroke="#607d8b"/>
+  <text x="885" y="356" text-anchor="middle" font-size="11" font-weight="bold" fill="#37474f">storage I/O</text>
+  <text x="885" y="374" text-anchor="middle" font-size="10" fill="#455a64">in flight</text>
+
+  <rect x="285" y="375" width="226" height="55" rx="7" fill="#e8f5e9" stroke="#66bb6a" stroke-width="1.5"/>
+  <text x="398" y="396" text-anchor="middle" font-size="11" font-weight="bold" fill="#2e7d32">READ EXECUTOR IS FREE</text>
+  <text x="398" y="414" text-anchor="middle" font-size="10" fill="#2e7d32">accept and run another request</text>
+
+  <rect x="827" y="445" width="116" height="40" rx="5" fill="#eceff1" stroke="#607d8b"/>
+  <text x="885" y="469" text-anchor="middle" font-size="11" fill="#37474f">I/O completes</text>
+
+  <rect x="581" y="440" width="154" height="50" rx="5" fill="#ffe0b2" stroke="#ef6c00"/>
+  <text x="658" y="461" text-anchor="middle" font-size="11" font-weight="bold" fill="#e65100">completion reported</text>
+  <text x="658" y="478" text-anchor="middle" font-size="10" fill="#e65100">read becomes runnable</text>
+  <line x1="827" y1="465" x2="735" y2="465" stroke="#ef6c00" stroke-width="1.8" marker-end="url(#arrow-orange-th)"/>
+  <text x="781" y="455" text-anchor="middle" font-size="9" fill="#e65100">complete</text>
+  <line x1="581" y1="465" x2="398" y2="465" stroke="#5e35b1" stroke-width="1.8" marker-end="url(#arrow-purple-th)"/>
+  <text x="490" y="455" text-anchor="middle" font-size="9" fill="#4527a0">resume on submitting thread</text>
+
+  <rect x="315" y="500" width="166" height="54" rx="5" fill="#d1c4e9" stroke="#5e35b1"/>
+  <text x="398" y="521" text-anchor="middle" font-size="11" font-weight="bold" fill="#4527a0">resume DB coroutine</text>
+  <text x="398" y="538" text-anchor="middle" font-size="10" fill="#4527a0">verify, decode, fill output</text>
+
+  <line x1="398" y1="600" x2="138" y2="600" stroke="#1565c0" stroke-width="2" marker-end="url(#arrow-blue-th)"/>
+  <text x="268" y="590" text-anchor="middle" font-size="10" fill="#0d47a1">return to parent executor</text>
+  <rect x="57" y="615" width="162" height="52" rx="5" fill="#bbdefb" stroke="#1565c0"/>
+  <text x="138" y="636" text-anchor="middle" font-size="11" font-weight="bold" fill="#0d47a1">caller continues</text>
+  <text x="138" y="653" text-anchor="middle" font-size="10" fill="#0d47a1">after the RocksDB read completes</text>
+
+  <rect x="540" y="510" width="410" height="70" rx="7" fill="#fafafa" stroke="#b0bec5" stroke-width="1.2"/>
+  <text x="555" y="531" font-size="10" font-weight="bold" fill="#37474f">POSIX fast path</text>
+  <text x="555" y="549" font-size="10" fill="#455a64">io_uring completion already runs on the same read EventBase worker,</text>
+  <text x="555" y="566" font-size="10" fill="#455a64">so the filesystem-completion and RocksDB lanes collapse onto one thread.</text>
+
+  <rect x="35" y="690" width="930" height="38" rx="6" fill="#e8f5e9" stroke="#66bb6a" stroke-width="1.2"/>
+  <text x="500" y="713" text-anchor="middle" font-size="10" font-weight="bold" fill="#2e7d32">Completion returns to the submitting EventBase thread, avoiding an extra cross-thread handoff.</text>
+</svg>

--- a/docs/static/images/native-coroutine-reads/tls-across-suspension.svg
+++ b/docs/static/images/native-coroutine-reads/tls-across-suspension.svg
@@ -1,0 +1,88 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="940" height="430" viewBox="0 0 940 430" font-family="Helvetica, Arial, sans-serif">
+  <title>How request statistics survive coroutine suspension</title>
+  <desc>A suspended request cannot leave its statistics in thread-local storage because another request can run on that worker. RocksDB swaps per-request statistics and accumulates CPU time only while each request is active.</desc>
+  <defs>
+    <marker id="arrow-tls" markerWidth="10" markerHeight="10" refX="8" refY="3.5" orient="auto">
+      <path d="M0,0 L8,3.5 L0,7 z" fill="#546e7a"/>
+    </marker>
+  </defs>
+
+  <rect x="0" y="0" width="940" height="430" fill="#ffffff"/>
+  <text x="235" y="32" text-anchor="middle" font-size="18" font-weight="bold" fill="#c62828">Unsafe: statistics belong to a thread</text>
+  <text x="705" y="32" text-anchor="middle" font-size="18" font-weight="bold" fill="#1565c0">Coroutine-safe: statistics belong to a request</text>
+
+  <rect x="20" y="52" width="430" height="322" rx="10" fill="#fffafa" stroke="#ef9a9a" stroke-width="1.5"/>
+  <rect x="490" y="52" width="430" height="322" rx="10" fill="#f8fbff" stroke="#90caf9" stroke-width="1.5"/>
+
+  <text x="42" y="84" font-size="12" font-weight="bold" fill="#455a64">Read-executor worker</text>
+  <line x1="42" y1="100" x2="425" y2="100" stroke="#b0bec5" stroke-width="2" marker-end="url(#arrow-tls)"/>
+
+  <rect x="58" y="119" width="110" height="46" rx="5" fill="#bbdefb" stroke="#1565c0"/>
+  <text x="113" y="138" text-anchor="middle" font-size="10" font-weight="bold" fill="#0d47a1">Request A runs</text>
+  <text x="113" y="153" text-anchor="middle" font-size="9" fill="#0d47a1">TLS = A</text>
+  <line x1="168" y1="142" x2="210" y2="142" stroke="#546e7a" stroke-width="1.5" marker-end="url(#arrow-tls)"/>
+  <text x="189" y="132" text-anchor="middle" font-size="9" fill="#546e7a">suspend</text>
+
+  <rect x="218" y="119" width="110" height="46" rx="5" fill="#d1c4e9" stroke="#5e35b1"/>
+  <text x="273" y="138" text-anchor="middle" font-size="10" font-weight="bold" fill="#4527a0">Request B runs</text>
+  <text x="273" y="153" text-anchor="middle" font-size="9" fill="#4527a0">TLS = B</text>
+  <line x1="328" y1="142" x2="370" y2="142" stroke="#546e7a" stroke-width="1.5" marker-end="url(#arrow-tls)"/>
+  <text x="349" y="132" text-anchor="middle" font-size="9" fill="#546e7a">resume A</text>
+
+  <rect x="370" y="119" width="58" height="46" rx="5" fill="#ffcdd2" stroke="#c62828" stroke-width="1.5"/>
+  <text x="399" y="138" text-anchor="middle" font-size="10" font-weight="bold" fill="#b71c1c">A?</text>
+  <text x="399" y="153" text-anchor="middle" font-size="9" fill="#b71c1c">TLS = B</text>
+
+  <rect x="55" y="194" width="360" height="61" rx="6" fill="#ffebee" stroke="#e57373"/>
+  <text x="235" y="214" text-anchor="middle" font-size="11" font-weight="bold" fill="#b71c1c">A suspension point breaks thread-local accounting</text>
+  <text x="235" y="231" text-anchor="middle" font-size="10" fill="#b71c1c">Request B can overwrite A's counters while A waits.</text>
+  <text x="235" y="247" text-anchor="middle" font-size="10" fill="#b71c1c">A resumes on that worker, whose TLS now contains B.</text>
+
+  <text x="52" y="286" font-size="11" font-weight="bold" fill="#37474f">Failures to avoid:</text>
+  <text x="66" y="309" font-size="10" fill="#455a64">- A and B update the same PerfContext</text>
+  <text x="66" y="329" font-size="10" fill="#455a64">- A's CPU timer charges B's work</text>
+  <text x="66" y="349" font-size="10" fill="#455a64">- A's CPU timer charges suspended I/O wait</text>
+
+  <text x="512" y="84" font-size="12" font-weight="bold" fill="#455a64">Same interleaving, isolated state</text>
+  <line x1="512" y1="100" x2="895" y2="100" stroke="#b0bec5" stroke-width="2" marker-end="url(#arrow-tls)"/>
+
+  <rect x="526" y="119" width="120" height="56" rx="5" fill="#bbdefb" stroke="#1565c0"/>
+  <text x="586" y="138" text-anchor="middle" font-size="10" font-weight="bold" fill="#0d47a1">Request A runs</text>
+  <text x="586" y="153" text-anchor="middle" font-size="9" fill="#0d47a1">load A context</text>
+  <text x="586" y="167" text-anchor="middle" font-size="9" fill="#0d47a1">save before suspend</text>
+
+  <line x1="646" y1="147" x2="675" y2="147" stroke="#546e7a" stroke-width="1.5" marker-end="url(#arrow-tls)"/>
+
+  <rect x="681" y="119" width="120" height="56" rx="5" fill="#d1c4e9" stroke="#5e35b1"/>
+  <text x="741" y="138" text-anchor="middle" font-size="10" font-weight="bold" fill="#4527a0">Request B runs</text>
+  <text x="741" y="153" text-anchor="middle" font-size="9" fill="#4527a0">load B context</text>
+  <text x="741" y="167" text-anchor="middle" font-size="9" fill="#4527a0">save before suspend</text>
+
+  <line x1="801" y1="147" x2="830" y2="147" stroke="#546e7a" stroke-width="1.5" marker-end="url(#arrow-tls)"/>
+
+  <rect x="836" y="119" width="68" height="56" rx="5" fill="#bbdefb" stroke="#1565c0"/>
+  <text x="870" y="138" text-anchor="middle" font-size="10" font-weight="bold" fill="#0d47a1">A runs</text>
+  <text x="870" y="153" text-anchor="middle" font-size="9" fill="#0d47a1">reload A</text>
+  <text x="870" y="167" text-anchor="middle" font-size="9" fill="#0d47a1">context</text>
+
+  <rect x="525" y="198" width="360" height="58" rx="6" fill="#e3f2fd" stroke="#64b5f6"/>
+  <text x="705" y="218" text-anchor="middle" font-size="11" font-weight="bold" fill="#0d47a1">Folly RequestContext carries request statistics</text>
+  <text x="705" y="236" text-anchor="middle" font-size="10" fill="#0d47a1">and swaps them into TLS only while that request is active.</text>
+
+  <rect x="525" y="278" width="360" height="68" rx="6" fill="#ede7f6" stroke="#9575cd"/>
+  <text x="705" y="297" text-anchor="middle" font-size="11" font-weight="bold" fill="#4527a0">CPU time includes only A's active slices</text>
+  <rect x="557" y="306" width="90" height="18" rx="3" fill="#bbdefb" stroke="#1565c0"/>
+  <text x="602" y="318" text-anchor="middle" font-size="9" fill="#0d47a1">A slice 1</text>
+  <rect x="647" y="306" width="150" height="18" rx="3" fill="#eceff1" stroke="#90a4ae"/>
+  <text x="722" y="318" text-anchor="middle" font-size="9" fill="#546e7a">I/O wait + B: not charged</text>
+  <rect x="797" y="306" width="60" height="18" rx="3" fill="#bbdefb" stroke="#1565c0"/>
+  <text x="827" y="318" text-anchor="middle" font-size="9" fill="#0d47a1">A slice 2</text>
+  <text x="705" y="340" text-anchor="middle" font-size="10" fill="#4527a0">get_cpu_nanos(A) = slice 1 + slice 2</text>
+
+  <rect x="110" y="395" width="16" height="12" rx="2" fill="#bbdefb" stroke="#1565c0"/>
+  <text x="132" y="405" font-size="10" fill="#546e7a">request A</text>
+  <rect x="212" y="395" width="16" height="12" rx="2" fill="#d1c4e9" stroke="#5e35b1"/>
+  <text x="234" y="405" font-size="10" fill="#546e7a">request B</text>
+  <rect x="314" y="395" width="16" height="12" rx="2" fill="#ffcdd2" stroke="#c62828"/>
+  <text x="336" y="405" font-size="10" fill="#546e7a">state collision</text>
+</svg>

--- a/include/rocksdb/coro_db.h
+++ b/include/rocksdb/coro_db.h
@@ -41,6 +41,11 @@ class CoroStackableDBBase;
 // thread, so reading TLS after awaiting them is not valid. To consume coroutine
 // stats, override the protected CoroStackableDB hook and copy the TLS values
 // immediately after awaiting the wrapped operation, before suspending again.
+//
+// Stats are generally more expensive in coroutine APIs than sync counterpart
+// due to request context overhead. For optimal performance when stats are not
+// needed, set PerfLevel::kDisable and disable I/O stats with
+// get_iostats_context()->disable_iostats = true before each read request.
 class CoroDB {
  public:
   virtual ~CoroDB() = default;

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -45,6 +45,7 @@
 #include "db/version_set.h"
 #include "env/composite_env_wrapper.h"
 #include "monitoring/histogram.h"
+#include "monitoring/iostats_context_imp.h"
 #include "monitoring/statistics_impl.h"
 #include "options/cf_options.h"
 #include "port/port.h"
@@ -1739,6 +1740,8 @@ DEFINE_int32(thread_status_per_interval, 0,
 
 DEFINE_int32(perf_level, ROCKSDB_NAMESPACE::PerfLevel::kDisable,
              "Level of perf collection");
+
+DEFINE_bool(io_stats, true, "Enable IOStatsContext collection");
 
 DEFINE_uint64(soft_pending_compaction_bytes_limit, 64ull * 1024 * 1024 * 1024,
               "Slowdown writes if pending compaction bytes exceed this number");
@@ -4904,6 +4907,7 @@ class Benchmark {
     }
 
     SetPerfLevel(static_cast<PerfLevel>(shared->perf_level));
+    IOSTATS_SET_DISABLE(!FLAGS_io_stats);
     perf_context.EnablePerLevelPerfContext();
     thread->stats.Start(thread->tid);
     {
@@ -7836,6 +7840,7 @@ class Benchmark {
 
   void PrepareCoroutineJobPerfContext(PerfContext* job_perf_context) {
     SetPerfLevel(static_cast<PerfLevel>(FLAGS_perf_level));
+    IOSTATS_SET_DISABLE(!FLAGS_io_stats);
     if (job_perf_context == nullptr) {
       return;
     }


### PR DESCRIPTION
Summary:

## Summary

Adds a RocksDB blog post describing the native async/coroutine read APIs introduced in RocksDB 11.10.0. It covers the callback and `folly::coro::Task` interfaces, differences from `ReadOptions::async_io`, executor and I/O-completion handoffs, filesystem integration, request-local statistics across suspension, and API lifetime constraints.

The post includes three explanatory diagrams and benchmark results comparing synchronous and coroutine point reads across task counts and `MultiGet` batch sizes.

https://www.internalfb.com/intern/px/p/cDGqv/

Differential Revision: D117159178


