### PR TITLE
Fix compacted DB read statistics

### DIFF
--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -1491,6 +1491,200 @@ TEST_F(DBBasicTest, CompactedDB) {
             "Not implemented: Not supported operation in read only mode.");
 }
 
+TEST_F(DBBasicTest, CompactedDBReadStatistics) {
+  Options options = CurrentOptions();
+  options.max_open_files = -1;
+  options.statistics = CreateDBStatistics();
+  BlockBasedTableOptions table_options;
+  table_options.block_cache = NewLRUCache(1 << 20);
+  table_options.cache_index_and_filter_blocks = true;
+  table_options.filter_policy.reset(NewBloomFilterPolicy(10, false));
+  options.table_factory.reset(NewBlockBasedTableFactory(table_options));
+
+  Reopen(options);
+  ASSERT_OK(Put("key", "value"));
+  ASSERT_OK(Flush());
+  ASSERT_EQ(1, NumTableFilesAtLevel(0));
+  Close();
+
+  ASSERT_OK(ReadOnlyReopen(options));
+  ASSERT_EQ("Not implemented: Not supported in compacted db mode.",
+            Put("new", "value").ToString());
+
+  ASSERT_OK(options.statistics->Reset());
+  std::string value;
+  ASSERT_OK(db_->Get(ReadOptions(), "key", &value));
+  ASSERT_EQ("value", value);
+  ASSERT_EQ(1, TestGetTickerCount(options, MEMTABLE_MISS));
+  ASSERT_EQ(1, TestGetTickerCount(options, GET_HIT_L0));
+  ASSERT_EQ(1, TestGetTickerCount(options, NUMBER_KEYS_READ));
+  ASSERT_EQ(5, TestGetTickerCount(options, BYTES_READ));
+  ASSERT_EQ(1, TestGetTickerCount(options, BLOCK_CACHE_DATA_MISS));
+  HistogramData histogram;
+  options.statistics->histogramData(DB_GET, &histogram);
+  ASSERT_EQ(1, histogram.count);
+  options.statistics->histogramData(BYTES_PER_READ, &histogram);
+  ASSERT_EQ(1, histogram.count);
+  ASSERT_EQ(5, histogram.sum);
+
+  ASSERT_OK(options.statistics->Reset());
+  ASSERT_OK(db_->Get(ReadOptions(), "key", &value));
+  ASSERT_EQ("value", value);
+  ASSERT_EQ(1, TestGetTickerCount(options, BLOCK_CACHE_DATA_HIT));
+  ASSERT_EQ(0, TestGetTickerCount(options, BLOCK_CACHE_DATA_MISS));
+
+  ASSERT_OK(options.statistics->Reset());
+  ASSERT_TRUE(db_->Get(ReadOptions(), "before", &value).IsNotFound());
+  ASSERT_EQ(1, TestGetTickerCount(options, MEMTABLE_MISS));
+  ASSERT_EQ(0, TestGetTickerCount(options, GET_HIT_L0));
+  ASSERT_EQ(1, TestGetTickerCount(options, NUMBER_KEYS_READ));
+  ASSERT_EQ(0, TestGetTickerCount(options, BYTES_READ));
+  ASSERT_EQ(0, TestGetTickerCount(options, BLOCK_CACHE_DATA_HIT));
+  ASSERT_EQ(0, TestGetTickerCount(options, BLOCK_CACHE_DATA_MISS));
+  options.statistics->histogramData(DB_GET, &histogram);
+  ASSERT_EQ(1, histogram.count);
+  options.statistics->histogramData(BYTES_PER_READ, &histogram);
+  ASSERT_EQ(1, histogram.count);
+  ASSERT_EQ(0, histogram.sum);
+
+  ASSERT_OK(options.statistics->Reset());
+  table_options.block_cache->EraseUnRefEntries();
+  std::vector<std::string> values;
+  std::vector<Status> statuses = db_->MultiGet(
+      ReadOptions(), {Slice("before"), Slice("key"), Slice("missing")},
+      &values);
+  ASSERT_EQ(3, statuses.size());
+  ASSERT_TRUE(statuses[0].IsNotFound());
+  ASSERT_OK(statuses[1]);
+  ASSERT_EQ("value", values[1]);
+  ASSERT_TRUE(statuses[2].IsNotFound());
+  ASSERT_EQ(3, TestGetTickerCount(options, MEMTABLE_MISS));
+  ASSERT_EQ(1, TestGetTickerCount(options, GET_HIT_L0));
+  ASSERT_EQ(1, TestGetTickerCount(options, NUMBER_MULTIGET_CALLS));
+  ASSERT_EQ(3, TestGetTickerCount(options, NUMBER_MULTIGET_KEYS_READ));
+  ASSERT_EQ(1, TestGetTickerCount(options, NUMBER_MULTIGET_KEYS_FOUND));
+  ASSERT_EQ(5, TestGetTickerCount(options, NUMBER_MULTIGET_BYTES_READ));
+  ASSERT_EQ(0, TestGetTickerCount(options, BLOCK_CACHE_DATA_HIT));
+  ASSERT_EQ(1, TestGetTickerCount(options, BLOCK_CACHE_DATA_MISS));
+  options.statistics->histogramData(DB_MULTIGET, &histogram);
+  ASSERT_EQ(1, histogram.count);
+  options.statistics->histogramData(BYTES_PER_MULTIGET, &histogram);
+  ASSERT_EQ(1, histogram.count);
+  ASSERT_EQ(5, histogram.sum);
+  options.statistics->histogramData(SST_BATCH_SIZE, &histogram);
+  ASSERT_EQ(2, histogram.count);
+  ASSERT_EQ(2, histogram.sum);
+  options.statistics->histogramData(
+      NUM_INDEX_AND_FILTER_BLOCKS_READ_PER_LEVEL, &histogram);
+  ASSERT_EQ(1, histogram.count);
+  ASSERT_GT(histogram.sum, 0);
+  options.statistics->histogramData(NUM_SST_READ_PER_LEVEL, &histogram);
+  ASSERT_EQ(1, histogram.count);
+  ASSERT_EQ(2, histogram.sum);
+  options.statistics->histogramData(NUM_LEVEL_READ_PER_MULTIGET, &histogram);
+  ASSERT_EQ(1, histogram.count);
+  ASSERT_EQ(1, histogram.sum);
+
+  ASSERT_OK(options.statistics->Reset());
+  statuses = db_->MultiGet(ReadOptions(), {Slice("key")}, &values);
+  ASSERT_EQ(1, statuses.size());
+  ASSERT_OK(statuses[0]);
+  ASSERT_EQ("value", values[0]);
+  ASSERT_EQ(1, TestGetTickerCount(options, BLOCK_CACHE_DATA_HIT));
+  ASSERT_EQ(0, TestGetTickerCount(options, BLOCK_CACHE_DATA_MISS));
+
+  ASSERT_OK(options.statistics->Reset());
+  statuses = db_->MultiGet(ReadOptions(), {Slice("before")}, &values);
+  ASSERT_EQ(1, statuses.size());
+  ASSERT_TRUE(statuses[0].IsNotFound());
+  options.statistics->histogramData(SST_BATCH_SIZE, &histogram);
+  ASSERT_EQ(0, histogram.count);
+  options.statistics->histogramData(NUM_SST_READ_PER_LEVEL, &histogram);
+  ASSERT_EQ(0, histogram.count);
+  options.statistics->histogramData(NUM_LEVEL_READ_PER_MULTIGET, &histogram);
+  ASSERT_EQ(0, histogram.count);
+
+  ASSERT_OK(options.statistics->Reset());
+  SetPerfLevel(kEnableTime);
+  get_perf_context()->Reset();
+  const uint64_t get_cpu_nanos = get_perf_context()->get_cpu_nanos;
+  std::vector<Slice> no_keys;
+  statuses = db_->MultiGet(ReadOptions(), no_keys, &values);
+  ASSERT_TRUE(statuses.empty());
+  ASSERT_EQ(get_cpu_nanos, get_perf_context()->get_cpu_nanos);
+  ASSERT_EQ(0, TestGetTickerCount(options, NUMBER_MULTIGET_CALLS));
+  options.statistics->histogramData(DB_MULTIGET, &histogram);
+  ASSERT_EQ(0, histogram.count);
+  SetPerfLevel(kDisable);
+}
+
+TEST_F(DBBasicTest, CompactedDBReadStatisticsByLevel) {
+  SetPerfLevel(kEnableTime);
+  get_perf_context()->EnablePerLevelPerfContext();
+  for (int level : {1, 2}) {
+    Options options = CurrentOptions();
+    options.max_open_files = -1;
+    options.statistics = CreateDBStatistics();
+
+    DestroyAndReopen(options);
+    ASSERT_OK(Put("key", "value"));
+    ASSERT_OK(Flush());
+    MoveFilesToLevel(level);
+    ASSERT_EQ(0, NumTableFilesAtLevel(0));
+    ASSERT_EQ(1, NumTableFilesAtLevel(level));
+    Close();
+
+    ASSERT_OK(ReadOnlyReopen(options));
+    ASSERT_EQ("Not implemented: Not supported in compacted db mode.",
+              Put("new", "value").ToString());
+
+    const Tickers hit_ticker =
+        level == 1 ? GET_HIT_L1 : GET_HIT_L2_AND_UP;
+    ASSERT_OK(options.statistics->Reset());
+    get_perf_context()->Reset();
+    std::string value;
+    ASSERT_OK(db_->Get(ReadOptions(), "key", &value));
+    ASSERT_EQ("value", value);
+    ASSERT_EQ(1, TestGetTickerCount(options, hit_ticker));
+    ASSERT_EQ(1, TestGetTickerCount(options, GET_HIT_L0) +
+                     TestGetTickerCount(options, GET_HIT_L1) +
+                     TestGetTickerCount(options, GET_HIT_L2_AND_UP));
+    ASSERT_GT(get_perf_context()->get_from_output_files_time, 0);
+    ASSERT_GT(get_perf_context()->get_post_process_time, 0);
+    ASSERT_EQ(1, get_perf_context()
+                     ->level_to_perf_context->at(level)
+                     .user_key_return_count);
+    ASSERT_GT(get_perf_context()
+                  ->level_to_perf_context->at(level)
+                  .get_from_table_nanos,
+              0);
+
+    ASSERT_OK(options.statistics->Reset());
+    get_perf_context()->Reset();
+    std::vector<std::string> values;
+    std::vector<Status> statuses =
+        db_->MultiGet(ReadOptions(), {Slice("key")}, &values);
+    ASSERT_EQ(1, statuses.size());
+    ASSERT_OK(statuses[0]);
+    ASSERT_EQ("value", values[0]);
+    ASSERT_EQ(1, TestGetTickerCount(options, hit_ticker));
+    ASSERT_EQ(1, TestGetTickerCount(options, GET_HIT_L0) +
+                     TestGetTickerCount(options, GET_HIT_L1) +
+                     TestGetTickerCount(options, GET_HIT_L2_AND_UP));
+    ASSERT_GT(get_perf_context()->get_from_output_files_time, 0);
+    ASSERT_GT(get_perf_context()->get_post_process_time, 0);
+    ASSERT_EQ(1, get_perf_context()
+                     ->level_to_perf_context->at(level)
+                     .user_key_return_count);
+    ASSERT_GT(get_perf_context()
+                  ->level_to_perf_context->at(level)
+                  .get_from_table_nanos,
+              0);
+  }
+  get_perf_context()->ClearPerLevelPerfContext();
+  SetPerfLevel(kDisable);
+}
+
 TEST_F(DBBasicTest, LevelLimitReopen) {
   Options options = CurrentOptions();
   CreateAndReopenWithCF({"pikachu"}, options);

--- a/db/db_impl/compacted_db_impl.cc
+++ b/db/db_impl/compacted_db_impl.cc
@@ -34,6 +34,16 @@ size_t CompactedDBImpl::FindFile(const Slice& key) {
       files_.files);
 }
 
+void CompactedDBImpl::RecordReadHit() {
+  if (files_level_ == 0) {
+    RecordTick(stats_, GET_HIT_L0);
+  } else if (files_level_ == 1) {
+    RecordTick(stats_, GET_HIT_L1);
+  } else {
+    RecordTick(stats_, GET_HIT_L2_AND_UP);
+  }
+}
+
 Status CompactedDBImpl::Init(const Options& options) {
   SuperVersionContext sv_context(/* create_superversion */ true);
   mutex_.Lock();

--- a/db/db_impl/compacted_db_impl.h
+++ b/db/db_impl/compacted_db_impl.h
@@ -140,6 +140,7 @@ class CompactedDBImpl : public DBImpl {
  private:
   friend class DB;
   inline size_t FindFile(const Slice& key);
+  void RecordReadHit();
   Status Init(const Options& options);
 
   ColumnFamilyData* cfd_;

--- a/db/db_impl/compacted_db_impl_sync_and_async.h
+++ b/db/db_impl/compacted_db_impl_sync_and_async.h
@@ -40,13 +40,6 @@ DEFINE_SYNC_AND_ASYNC(Status, CompactedDBImpl::Get)
     if (!s.ok()) {
       CO_RETURN s;
     }
-    if (read_options.timestamp->size() > 0) {
-      s = FailIfReadCollapsedHistory(cfd_, cfd_->GetSuperVersion(),
-                                     *(read_options.timestamp));
-      if (!s.ok()) {
-        CO_RETURN s;
-      }
-    }
   } else {
     const Status s = FailIfCfHasTs(DefaultColumnFamily());
     if (!s.ok()) {
@@ -60,49 +53,99 @@ DEFINE_SYNC_AND_ASYNC(Status, CompactedDBImpl::Get)
     timestamp->clear();
   }
 
+#if defined(WITHOUT_COROUTINES)
+  PERF_CPU_TIMER_GUARD(get_cpu_nanos, immutable_db_options_.clock);
+#endif
+  StopWatch sw(immutable_db_options_.clock, stats_, DB_GET);
+
+  if (read_options.timestamp && read_options.timestamp->size() > 0) {
+    const Status s = FailIfReadCollapsedHistory(
+        cfd_, cfd_->GetSuperVersion(), *(read_options.timestamp));
+    if (!s.ok()) {
+      CO_RETURN s;
+    }
+  }
+
   GetWithTimestampReadCallback read_cb(kMaxSequenceNumber);
   VersionBlobFetcher blob_fetcher(version_, read_options);
   std::string* ts =
       user_comparator_->timestamp_size() > 0 ? timestamp : nullptr;
   LookupKey lkey(key, kMaxSequenceNumber, read_options.timestamp);
-  GetContext get_context(user_comparator_, nullptr, nullptr, nullptr,
+  GetContext get_context(user_comparator_, nullptr, nullptr, stats_,
                          GetContext::kNotFound, lkey.user_key(), value,
                          /*columns=*/nullptr, ts, nullptr, nullptr, true,
                          nullptr, nullptr, nullptr, nullptr, &read_cb,
                          nullptr /* is_blob_index */, 0 /* tracing_get_id */,
                          &blob_fetcher);
 
-  const FdWithKeyRange& f = files_.files[FindFile(lkey.user_key())];
-  if (user_comparator_->CompareWithoutTimestamp(
-          key, /*a_has_ts=*/false,
-          ExtractUserKeyAndStripTimestamp(f.smallest_key,
-                                          user_comparator_->timestamp_size()),
-          /*b_has_ts=*/false) < 0) {
-    CO_RETURN Status::NotFound();
+  RecordTick(stats_, MEMTABLE_MISS);
+  Status s;
+  {
+    PERF_TIMER_GUARD(get_from_output_files_time);
+    const FdWithKeyRange& f = files_.files[FindFile(lkey.user_key())];
+    if (user_comparator_->CompareWithoutTimestamp(
+            key, /*a_has_ts=*/false,
+            ExtractUserKeyAndStripTimestamp(
+                f.smallest_key, user_comparator_->timestamp_size()),
+            /*b_has_ts=*/false) < 0) {
+      s = Status::NotFound();
+    } else {
+#if defined(WITHOUT_COROUTINES)
+      bool timer_enabled =
+          GetPerfLevel() >= PerfLevel::kEnableTimeExceptForMutex &&
+          get_perf_context()->per_level_perf_context_enabled;
+      StopWatchNano timer(immutable_db_options_.clock,
+                          timer_enabled /* auto_start */);
+#endif
+      TableReader* t = nullptr;
+      TableCache::TypedHandle* handle = nullptr;
+      s = cfd_->table_cache()->FindTable(
+          read_options, cfd_->table_cache()->file_options(),
+          cfd_->internal_comparator(), *f.file_metadata, &handle,
+          version_->GetMutableCFOptions(), &t, false /* no_io */,
+          nullptr /* file_read_hist */, false /* skip_filters */, files_level_,
+          true /* prefetch_index_and_filter_in_cache */,
+          0 /* max_file_size_for_l0_meta_pin */, f.file_metadata->temperature,
+          true /* pin_table_handle */);
+      if (s.ok()) {
+        assert(handle == nullptr);
+        // Use TableReader directly to avoid extra table_cache->Get() overheads
+        s = CO_AWAIT(t->Get, read_options, lkey.internal_key(), &get_context,
+                     nullptr);
+      }
+#if defined(WITHOUT_COROUTINES)
+      if (timer_enabled) {
+        PERF_COUNTER_BY_LEVEL_ADD(get_from_table_nanos, timer.ElapsedNanos(),
+                                  files_level_);
+      }
+#endif
+    }
+    if (stats_ != nullptr) {
+      get_context.ReportCounters();
+    }
+
+    if (s.ok() || s.IsNotFound()) {
+      s = get_context.State() == GetContext::kFound ? Status::OK()
+                                                    : Status::NotFound();
+    }
+    if (s.ok()) {
+      RecordReadHit();
+      PERF_COUNTER_BY_LEVEL_ADD(user_key_return_count, 1, files_level_);
+    }
   }
-  TableReader* t = nullptr;
-  TableCache::TypedHandle* handle = nullptr;
-  Status s = cfd_->table_cache()->FindTable(
-      read_options, cfd_->table_cache()->file_options(),
-      cfd_->internal_comparator(), *f.file_metadata, &handle,
-      version_->GetMutableCFOptions(), &t, false /* no_io */,
-      nullptr /* file_read_hist */, false /* skip_filters */, files_level_,
-      true /* prefetch_index_and_filter_in_cache */,
-      0 /* max_file_size_for_l0_meta_pin */, f.file_metadata->temperature,
-      true /* pin_table_handle */);
-  if (s.ok()) {
-    assert(handle == nullptr);
-    // Use TableReader directly to avoid extra table_cache->Get() overheads
-    s = CO_AWAIT(t->Get, read_options, lkey.internal_key(), &get_context,
-                 nullptr);
+
+  {
+    PERF_TIMER_GUARD(get_post_process_time);
+    RecordTick(stats_, NUMBER_KEYS_READ);
+    size_t size = 0;
+    if (s.ok()) {
+      size = value->size();
+      RecordTick(stats_, BYTES_READ, size);
+      PERF_COUNTER_ADD(get_read_bytes, size);
+    }
+    RecordInHistogram(stats_, BYTES_PER_READ, size);
   }
-  if (!s.ok() && !s.IsNotFound()) {
-    CO_RETURN s;
-  }
-  if (get_context.State() == GetContext::kFound) {
-    CO_RETURN Status::OK();
-  }
-  CO_RETURN Status::NotFound();
+  CO_RETURN s;
 }
 
 DEFINE_SYNC_AND_ASYNC(void, CompactedDBImpl::MultiGet)
@@ -149,6 +192,14 @@ DEFINE_SYNC_AND_ASYNC(void, CompactedDBImpl::MultiGet)
     CO_RETURN;
   }
 
+  if (num_keys == 0) {
+    CO_RETURN;
+  }
+#if defined(WITHOUT_COROUTINES)
+  PERF_CPU_TIMER_GUARD(get_cpu_nanos, immutable_db_options_.clock);
+#endif
+  StopWatch sw(immutable_db_options_.clock, stats_, DB_MULTIGET);
+
   // Clear the timestamps for returning results so that we can distinguish
   // between tombstone or key that has never been written
   if (timestamps) {
@@ -159,50 +210,108 @@ DEFINE_SYNC_AND_ASYNC(void, CompactedDBImpl::MultiGet)
 
   GetWithTimestampReadCallback read_cb(kMaxSequenceNumber);
   VersionBlobFetcher blob_fetcher(version_, read_options);
-  for (size_t i = 0; i < num_keys; ++i) {
-    const Slice& key = keys[i];
-    LookupKey lkey(key, kMaxSequenceNumber, read_options.timestamp);
-    const FdWithKeyRange& f = files_.files[FindFile(lkey.user_key())];
-    if (user_comparator_->CompareWithoutTimestamp(
-            key, /*a_has_ts=*/false,
-            ExtractUserKeyAndStripTimestamp(f.smallest_key,
-                                            user_comparator_->timestamp_size()),
-            /*b_has_ts=*/false) < 0) {
-      statuses[i] = Status::NotFound();
-      continue;
-    }
+  RecordTick(stats_, MEMTABLE_MISS, num_keys);
+  {
+    PERF_TIMER_GUARD(get_from_output_files_time);
+    uint64_t num_filter_read = 0;
+    uint64_t num_index_read = 0;
+    uint64_t num_sst_read = 0;
+    for (size_t i = 0; i < num_keys; ++i) {
+      const Slice& key = keys[i];
+      LookupKey lkey(key, kMaxSequenceNumber, read_options.timestamp);
+      const FdWithKeyRange& f = files_.files[FindFile(lkey.user_key())];
+      if (user_comparator_->CompareWithoutTimestamp(
+              key, /*a_has_ts=*/false,
+              ExtractUserKeyAndStripTimestamp(
+                  f.smallest_key, user_comparator_->timestamp_size()),
+              /*b_has_ts=*/false) < 0) {
+        statuses[i] = Status::NotFound();
+        continue;
+      }
 
-    PinnableSlice& pinnable_val = values[i];
-    std::string* timestamp = timestamps ? &timestamps[i] : nullptr;
-    GetContext get_context(
-        user_comparator_, nullptr, nullptr, nullptr, GetContext::kNotFound,
-        lkey.user_key(), &pinnable_val, /*columns=*/nullptr,
-        user_comparator_->timestamp_size() > 0 ? timestamp : nullptr, nullptr,
-        nullptr, true, nullptr, nullptr, nullptr, nullptr, &read_cb,
-        nullptr /* is_blob_index */, 0 /* tracing_get_id */, &blob_fetcher);
-    TableReader* t = nullptr;
-    TableCache::TypedHandle* handle = nullptr;
-    Status status = cfd_->table_cache()->FindTable(
-        read_options, cfd_->table_cache()->file_options(),
-        cfd_->internal_comparator(), *f.file_metadata, &handle,
-        version_->GetMutableCFOptions(), &t, false /* no_io */,
-        nullptr /* file_read_hist */, false /* skip_filters */, files_level_,
-        true /* prefetch_index_and_filter_in_cache */,
-        0 /* max_file_size_for_l0_meta_pin */, f.file_metadata->temperature,
-        true /* pin_table_handle */);
-    if (status.ok()) {
-      assert(handle == nullptr);
-      // Use TableReader directly to avoid extra table_cache->Get() overheads
-      status = CO_AWAIT(t->Get, read_options, lkey.internal_key(), &get_context,
-                        nullptr);
+      PinnableSlice& pinnable_val = values[i];
+      std::string* timestamp = timestamps ? &timestamps[i] : nullptr;
+      GetContext get_context(
+          user_comparator_, nullptr, nullptr, stats_, GetContext::kNotFound,
+          lkey.user_key(), &pinnable_val, /*columns=*/nullptr,
+          user_comparator_->timestamp_size() > 0 ? timestamp : nullptr,
+          nullptr, nullptr, true, nullptr, nullptr, nullptr, nullptr, &read_cb,
+          nullptr /* is_blob_index */, 0 /* tracing_get_id */, &blob_fetcher);
+#if defined(WITHOUT_COROUTINES)
+      bool timer_enabled =
+          GetPerfLevel() >= PerfLevel::kEnableTimeExceptForMutex &&
+          get_perf_context()->per_level_perf_context_enabled;
+      StopWatchNano timer(immutable_db_options_.clock,
+                          timer_enabled /* auto_start */);
+#endif
+      TableReader* t = nullptr;
+      TableCache::TypedHandle* handle = nullptr;
+      Status status = cfd_->table_cache()->FindTable(
+          read_options, cfd_->table_cache()->file_options(),
+          cfd_->internal_comparator(), *f.file_metadata, &handle,
+          version_->GetMutableCFOptions(), &t, false /* no_io */,
+          nullptr /* file_read_hist */, false /* skip_filters */, files_level_,
+          true /* prefetch_index_and_filter_in_cache */,
+          0 /* max_file_size_for_l0_meta_pin */, f.file_metadata->temperature,
+          true /* pin_table_handle */);
+      if (status.ok()) {
+        assert(handle == nullptr);
+        // Use TableReader directly to avoid extra table_cache->Get() overheads
+        status = CO_AWAIT(t->Get, read_options, lkey.internal_key(),
+                          &get_context, nullptr);
+#ifdef WITH_COROUTINES
+        RecordTick(stats_, MULTIGET_COROUTINE_COUNT);
+#endif
+        if (status.ok()) {
+          RecordInHistogram(stats_, SST_BATCH_SIZE, 1);
+          get_context.AccumulateMultiGetStats(
+              &num_filter_read, &num_index_read, &num_sst_read);
+          // Point Get does not update this MultiGet-specific counter.
+          ++num_sst_read;
+        }
+      }
+#if defined(WITHOUT_COROUTINES)
+      if (timer_enabled) {
+        PERF_COUNTER_BY_LEVEL_ADD(get_from_table_nanos, timer.ElapsedNanos(),
+                                  files_level_);
+      }
+#endif
+      if (stats_ != nullptr) {
+        get_context.ReportCounters();
+      }
+      if (!status.ok() && !status.IsNotFound()) {
+        statuses[i] = status;
+      } else if (get_context.State() == GetContext::kFound) {
+        statuses[i] = Status::OK();
+        RecordReadHit();
+        PERF_COUNTER_BY_LEVEL_ADD(user_key_return_count, 1, files_level_);
+      } else {
+        statuses[i] = Status::NotFound();
+      }
     }
-    if (!status.ok() && !status.IsNotFound()) {
-      statuses[i] = status;
-    } else if (get_context.State() == GetContext::kFound) {
-      statuses[i] = Status::OK();
-    } else {
-      statuses[i] = Status::NotFound();
+    ReportMultiGetLevelStats(stats_, num_filter_read, num_index_read,
+                             num_sst_read);
+    if (num_sst_read > 0) {
+      RecordInHistogram(stats_, NUM_LEVEL_READ_PER_MULTIGET, 1);
     }
+  }
+
+  {
+    PERF_TIMER_GUARD(get_post_process_time);
+    size_t num_found = 0;
+    uint64_t bytes_read = 0;
+    for (size_t i = 0; i < num_keys; ++i) {
+      if (statuses[i].ok()) {
+        ++num_found;
+        bytes_read += values[i].size();
+      }
+    }
+    RecordTick(stats_, NUMBER_MULTIGET_CALLS);
+    RecordTick(stats_, NUMBER_MULTIGET_KEYS_READ, num_keys);
+    RecordTick(stats_, NUMBER_MULTIGET_KEYS_FOUND, num_found);
+    RecordTick(stats_, NUMBER_MULTIGET_BYTES_READ, bytes_read);
+    RecordInHistogram(stats_, BYTES_PER_MULTIGET, bytes_read);
+    PERF_COUNTER_ADD(multiget_read_bytes, bytes_read);
   }
 }
 

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -82,6 +82,18 @@
 
 namespace ROCKSDB_NAMESPACE {
 
+void ReportMultiGetLevelStats(Statistics* statistics,
+                              uint64_t num_filter_read,
+                              uint64_t num_index_read, uint64_t num_sst_read) {
+  if (num_filter_read + num_index_read > 0) {
+    RecordInHistogram(statistics, NUM_INDEX_AND_FILTER_BLOCKS_READ_PER_LEVEL,
+                      num_filter_read + num_index_read);
+  }
+  if (num_sst_read > 0) {
+    RecordInHistogram(statistics, NUM_SST_READ_PER_LEVEL, num_sst_read);
+  }
+}
+
 namespace {
 
 using ScanOptionsMap = std::unordered_map<size_t, MultiScanArgs>;
@@ -3141,17 +3153,11 @@ Status Version::MultiGetAsync(
       num_levels++;
     }
 
-    uint64_t num_meta_reads =
-        std::get<0>(stat.second) + std::get<1>(stat.second);
+    uint64_t num_filter_reads = std::get<0>(stat.second);
+    uint64_t num_index_reads = std::get<1>(stat.second);
     uint64_t num_sst_reads = std::get<2>(stat.second);
-    if (num_meta_reads > 0) {
-      RecordInHistogram(db_statistics_,
-                        NUM_INDEX_AND_FILTER_BLOCKS_READ_PER_LEVEL,
-                        num_meta_reads);
-    }
-    if (num_sst_reads > 0) {
-      RecordInHistogram(db_statistics_, NUM_SST_READ_PER_LEVEL, num_sst_reads);
-    }
+    ReportMultiGetLevelStats(db_statistics_, num_filter_reads, num_index_reads,
+                             num_sst_reads);
   }
   if (num_levels > 0) {
     RecordInHistogram(db_statistics_, NUM_LEVEL_READ_PER_MULTIGET, num_levels);

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -63,6 +63,11 @@
 
 namespace ROCKSDB_NAMESPACE {
 
+// Report detailed I/O statistics accumulated while reading one level.
+void ReportMultiGetLevelStats(Statistics* statistics,
+                              uint64_t num_filter_read,
+                              uint64_t num_index_read, uint64_t num_sst_read);
+
 namespace log {
 class Writer;
 }

--- a/db/version_set_sync_and_async.h
+++ b/db/version_set_sync_and_async.h
@@ -280,13 +280,8 @@ DEFINE_SYNC_AND_ASYNC(Status, Version::MultiGetFromSST)
       }
     }
     batch_size++;
-    num_index_read += get_context.get_context_stats_.num_index_read;
-    num_filter_read += get_context.get_context_stats_.num_filter_read;
-    num_sst_read += get_context.get_context_stats_.num_sst_read;
-    // Reset these stats since they're specific to a level
-    get_context.get_context_stats_.num_index_read = 0;
-    get_context.get_context_stats_.num_filter_read = 0;
-    get_context.get_context_stats_.num_sst_read = 0;
+    get_context.AccumulateMultiGetStats(&num_filter_read, &num_index_read,
+                                        &num_sst_read);
 
     // report the counters before returning
     if (get_context.State() != GetContext::kNotFound &&
@@ -571,14 +566,9 @@ DEFINE_SYNC_AND_ASYNC(void, Version::MultiGet)
             (prev_level != 0 && prev_level != (int)fp.GetHitFileLevel())) {
           // Dump the stats if the search has moved to the next level and
           // reset for next level.
-          if (num_filter_read + num_index_read) {
-            RecordInHistogram(db_statistics_,
-                              NUM_INDEX_AND_FILTER_BLOCKS_READ_PER_LEVEL,
-                              num_index_read + num_filter_read);
-          }
+          ReportMultiGetLevelStats(db_statistics_, num_filter_read,
+                                   num_index_read, num_sst_read);
           if (num_sst_read) {
-            RecordInHistogram(db_statistics_, NUM_SST_READ_PER_LEVEL,
-                              num_sst_read);
             num_level_read++;
           }
           num_filter_read = 0;
@@ -590,13 +580,9 @@ DEFINE_SYNC_AND_ASYNC(void, Version::MultiGet)
     }
 
     // Dump stats for most recent level
-    if (num_filter_read + num_index_read) {
-      RecordInHistogram(db_statistics_,
-                        NUM_INDEX_AND_FILTER_BLOCKS_READ_PER_LEVEL,
-                        num_index_read + num_filter_read);
-    }
+    ReportMultiGetLevelStats(db_statistics_, num_filter_read, num_index_read,
+                             num_sst_read);
     if (num_sst_read) {
-      RecordInHistogram(db_statistics_, NUM_SST_READ_PER_LEVEL, num_sst_read);
       num_level_read++;
     }
     if (num_level_read) {

--- a/table/get_context.cc
+++ b/table/get_context.cc
@@ -352,6 +352,17 @@ void GetContext::ReportCounters() {
   }
 }
 
+void GetContext::AccumulateMultiGetStats(uint64_t* num_filter_read,
+                                         uint64_t* num_index_read,
+                                         uint64_t* num_sst_read) {
+  *num_filter_read += get_context_stats_.num_filter_read;
+  *num_index_read += get_context_stats_.num_index_read;
+  *num_sst_read += get_context_stats_.num_sst_read;
+  get_context_stats_.num_filter_read = 0;
+  get_context_stats_.num_index_read = 0;
+  get_context_stats_.num_sst_read = 0;
+}
+
 bool GetContext::SaveValue(const ParsedInternalKey& parsed_key,
                            const Slice& value, bool* matched,
                            Status* read_status, Cleanable* value_pinner,

--- a/table/get_context.h
+++ b/table/get_context.h
@@ -213,6 +213,11 @@ class GetContext {
 
   void ReportCounters();
 
+  // Add per-level MultiGet details to the totals and reset them for reuse.
+  void AccumulateMultiGetStats(uint64_t* num_filter_read,
+                               uint64_t* num_index_read,
+                               uint64_t* num_sst_read);
+
   bool has_callback() const { return callback_ != nullptr; }
 
   const Slice& ukey_to_get_blob_value() const {


### PR DESCRIPTION
Fixes #15140.

## Summary

Read-only databases that qualify for `CompactedDBImpl` bypass the normal
`DBImpl` read path. The compacted `Get` and `MultiGet` implementations did not
propagate the configured statistics through the complete read accounting path,
so cache, memtable, key and byte, level-hit, MultiGet, latency, and PerfContext
metrics remained zero or incomplete.

This change gives compacted reads the same statistics semantics as the normal
read path. It reports per-key cache counters, operation-level Get and MultiGet
counters and histograms, level hits, per-level SST/index/filter activity, and
the corresponding PerfContext phases. Empty MultiGet calls return before any
operation timer or counter is started.

The existing `Version` and `GetContext` aggregation/reporting logic is exposed
through internal helpers so `CompactedDBImpl` can reuse it instead of carrying
a separate copy. No public API is changed.

## Testing

The regression tests force `DB::OpenForReadOnly` to select `CompactedDBImpl`
and cover L0, L1, and L2 files; found and not-found Get calls; mixed and empty
MultiGet calls; data-cache hits and misses; operation and per-level histograms;
and PerfContext accounting.

The full `db_basic_test` suite passes (289 tests). The new compacted tests pass
100 repeated runs with `COERCE_CONTEXT_SWITCH=1`, and the focused tests pass
with `ASSERT_STATUS_CHECKED=1`. `make check-sources` and `git diff --check` also
pass locally. The shared coroutine implementation was reviewed for consistency,
but it was not compiled or executed because the required Folly coroutine
headers are not available on this machine.
