### PR TITLE
Avoid restoring coroutine stats on foreign threads (#15145)

### DIFF
--- a/db/perf_context_test.cc
+++ b/db/perf_context_test.cc
@@ -268,6 +268,50 @@ TEST_F(PerfContextTest, CoroutineStatsContextScopeCollectsGetCpuNanos) {
   }
 }
 
+TEST_F(PerfContextTest, CoroutineStatsContextRestoredOnForeignThread) {
+  SetPerfLevel(PerfLevel::kEnableTimeAndCPUTimeExceptForMutex);
+
+  folly::IOThreadPoolExecutor executor(1);
+  folly::EventBase* event_base = executor.getEventBase();
+  ASSERT_NE(nullptr, event_base);
+
+  uint64_t foreign_block_read_count = 0;
+  uint64_t foreign_bytes_read = 0;
+  folly::coro::blockingWait(folly::coro::co_withExecutor(
+      folly::Executor::getKeepAliveToken(event_base),
+      [&foreign_block_read_count, &foreign_bytes_read,
+       stats_config =
+           CaptureCoroutineStatsConfig()]() mutable -> folly::coro::Task<void> {
+        CoroutineStatsContextScope scope(std::move(stats_config),
+                                         Env::Default());
+        get_perf_context()->block_read_count += 3;
+        get_iostats_context()->bytes_read += 5;
+
+        std::shared_ptr<folly::RequestContext> captured_context =
+            folly::RequestContext::saveContext();
+
+        std::thread foreign_thread([&] {
+          get_perf_context()->Reset();
+          get_iostats_context()->Reset();
+          get_perf_context()->block_read_count = 41;
+          get_iostats_context()->bytes_read = 43;
+          {
+            folly::RequestContextScopeGuard guard(captured_context);
+          }
+          foreign_block_read_count = get_perf_context()->block_read_count;
+          foreign_bytes_read = get_iostats_context()->bytes_read;
+        });
+        foreign_thread.join();
+
+        EXPECT_EQ(3, get_perf_context()->block_read_count);
+        EXPECT_EQ(5, get_iostats_context()->bytes_read);
+        co_return;
+      }()));
+
+  EXPECT_EQ(41, foreign_block_read_count);
+  EXPECT_EQ(43, foreign_bytes_read);
+}
+
 #endif
 
 TEST_F(PerfContextTest, AsyncCallbackStatsStartEmptyOnSyncFallback) {

--- a/util/coro_stats_util.cc
+++ b/util/coro_stats_util.cc
@@ -48,11 +48,8 @@ class CoroutineStatsRequestData : public folly::RequestData {
   explicit CoroutineStatsRequestData(CoroutineStatsConfig stats_config,
                                      Env* env)
       : env_(env), perf_level_(stats_config.perf_level) {
-    (void)env_;
     assert(env_ != nullptr);
-#ifndef NDEBUG
     owner_thread_id_ = env_->GetThreadID();
-#endif
     assert(CapturedPerfLevel() > PerfLevel::kUninitialized);
     assert(CapturedPerfLevel() < PerfLevel::kOutOfBounds);
 #ifndef NPERF_CONTEXT
@@ -68,14 +65,21 @@ class CoroutineStatsRequestData : public folly::RequestData {
 
   bool hasCallback() override { return true; }
 
+  // RequestContext may be restored on downstream workers, but these stats are
+  // owned by the thread that created this object.
   void onSet() override {
-    AssertSameThread();
+    if (!IsOwnerThread()) {
+      return;
+    }
     SetPerfLevel(CapturedPerfLevel());
     LoadThreadLocalStats();
     StartGetCpuTimer();
   }
 
   void onUnset() override {
+    if (!IsOwnerThread()) {
+      return;
+    }
     StopGetCpuTimer();
     SaveThreadLocalStats();
   }
@@ -120,13 +124,7 @@ class CoroutineStatsRequestData : public folly::RequestData {
 #endif
   }
 
-  // Folly event bases resume requests on the thread where they suspended.
-  void AssertSameThread() {
-#ifndef NDEBUG
-    const uint64_t current_thread_id = env_->GetThreadID();
-    assert(owner_thread_id_ == current_thread_id);
-#endif
-  }
+  bool IsOwnerThread() const { return env_->GetThreadID() == owner_thread_id_; }
 
   void StartGetCpuTimer() {
 #ifndef NPERF_CONTEXT
@@ -147,9 +145,7 @@ class CoroutineStatsRequestData : public folly::RequestData {
 #ifndef NIOSTATS_CONTEXT
   IOStatsContext iostats_context_;
 #endif
-#ifndef NDEBUG
   uint64_t owner_thread_id_ = 0;
-#endif
 };
 
 #ifndef NDEBUG

--- a/util/coro_stats_util.h
+++ b/util/coro_stats_util.h
@@ -42,6 +42,8 @@ bool IsCoroutineStatsEnabled();
 // request context is used to save the request stats on suspension and reload
 // them with the captured configuration on resumption, so multiple coroutines
 // can share a single executor thread, but each own separate stats contexts.
+// Restores on other threads are ignored; coroutine execution remains
+// owner-thread-affine.
 // Collected stats are published to thread-local storage on destruction.
 class CoroutineStatsContextScope {
  public:


### PR DESCRIPTION
Summary:

## Summary

RocksDB coroutine statistics are stored in `RequestContext`, but their `RequestData` is thread-affine. A filesystem implementation may propagate the context while completing `SubmitReadAsync` on another thread. Installing that context invokes `CoroutineStatsRequestData::onSet()`, whose `AssertSameThread()` detects the thread hop and aborts.

```
Before:

Thread A                                      Thread B
RequestContext
├── caller tracing/attribution data
└── RocksDB coroutine stats ── propagated ──> setContext()
                                                │
                                                ▼
                                      CoroutineStatsRequestData::onSet()
                                                │
                                                ▼
                                      AssertSameThread(A != B)
                                                │
                                                ▼
                                              abort
```

Keep propagating the complete `RequestContext`, including the coroutine-stats token, so filesystem callbacks retain caller tracing and attribution. `CoroutineStatsRequestData` now records its owner using `Env::GetThreadID()` and ignores `onSet()` and `onUnset()` on foreign threads. When `ViaIfAsync` schedules the continuation back onto the RocksDB read EventBase, it restores the saved context on the owner thread before the coroutine continues, so the stats are safely loaded back into RocksDB TLS.

```
After:

Thread A                                      Thread B
caller RequestContext
├── caller data ───────── propagated ───────> caller data
└── RocksDB coroutine stats ─ propagated ───> onSet()/onUnset()
                                                │
                                                ▼
                                      owner thread != current thread
                                                │
                                                ▼
                                               no-op

continuation queued back onto Thread A
        │
        ▼
saved RequestContext restored on owner thread
        │
        ▼
RocksDB coroutine stats reinstalled in TLS
```

Reviewed By: xingbowang

Differential Revision: D117274942


