### PR TITLE
Bound MaintainPoolSize loops by the LRU list and abort on corrupt pool accounting

### DIFF
--- a/cache/lru_cache.cc
+++ b/cache/lru_cache.cc
@@ -296,10 +296,17 @@ void LRUCacheShard::LRU_Insert(LRUHandle* e) {
 }
 
 void LRUCacheShard::MaintainPoolSize() {
-  while (high_pri_pool_usage_ > high_pri_pool_capacity_) {
+  // Both loops are bounded by the LRU list, not just by the usage counters.
+  // The counters are size_t and the invariant tying them to the list is only
+  // checked by asserts, which are compiled out in release builds. Were a loop
+  // to trust its counter alone, a counter that disagreed with the list would
+  // send the walk around the circular list subtracting charges that were never
+  // counted, underflowing the counter and spinning forever while holding
+  // mutex_, which wedges every DB sharing this cache. See #15128.
+  while (high_pri_pool_usage_ > high_pri_pool_capacity_ &&
+         lru_low_pri_->next != &lru_) {
     // Overflow last entry in high-pri pool to low-pri pool.
     lru_low_pri_ = lru_low_pri_->next;
-    assert(lru_low_pri_ != &lru_);
     assert(lru_low_pri_->InHighPriPool());
     lru_low_pri_->SetInHighPriPool(false);
     lru_low_pri_->SetInLowPriPool(true);
@@ -308,16 +315,46 @@ void LRUCacheShard::MaintainPoolSize() {
     low_pri_pool_usage_ += lru_low_pri_->total_charge;
   }
 
-  while (low_pri_pool_usage_ > low_pri_pool_capacity_) {
+  // The second condition is the normal bound: the low-pri pool is the entries
+  // in (lru_bottom_pri_, lru_low_pri_]. The third only matters once the markers
+  // are already out of order, which is the state reported in #15128; without it
+  // the walk runs off the end of the list and reads the sentinel's charge.
+  while (low_pri_pool_usage_ > low_pri_pool_capacity_ &&
+         lru_bottom_pri_ != lru_low_pri_ && lru_bottom_pri_->next != &lru_) {
     // Overflow last entry in low-pri pool to bottom-pri pool.
     lru_bottom_pri_ = lru_bottom_pri_->next;
-    assert(lru_bottom_pri_ != &lru_);
     assert(lru_bottom_pri_->InLowPriPool());
     lru_bottom_pri_->SetInHighPriPool(false);
     lru_bottom_pri_->SetInLowPriPool(false);
     assert(low_pri_pool_usage_ >= lru_bottom_pri_->total_charge);
     low_pri_pool_usage_ -= lru_bottom_pri_->total_charge;
   }
+
+  // A loop only exits with its counter still over capacity by hitting one of
+  // the list bounds above, which means the counter no longer describes the
+  // list. Report it and dump core rather than spinning with mutex_ held or
+  // running on with a shard whose accounting cannot be trusted.
+  if (UNLIKELY(high_pri_pool_usage_ > high_pri_pool_capacity_)) {
+    CrashOnCorruptPoolUsage("high-pri");
+  }
+  if (UNLIKELY(low_pri_pool_usage_ > low_pri_pool_capacity_)) {
+    CrashOnCorruptPoolUsage("low-pri");
+  }
+}
+
+void LRUCacheShard::CrashOnCorruptPoolUsage(const char* pool_name) const {
+  // Printed rather than logged because the shard has no Logger, and these
+  // numbers are worth having even if the core dump is lost.
+  fprintf(stderr,
+          "rocksdb: corrupt %s pool accounting in LRUCacheShard %p; aborting. "
+          "capacity=%zu usage=%zu lru_usage=%zu high_pri_pool_usage=%zu "
+          "high_pri_pool_capacity=%g low_pri_pool_usage=%zu "
+          "low_pri_pool_capacity=%g\n",
+          pool_name, static_cast<const void*>(this), capacity_, usage_,
+          lru_usage_, high_pri_pool_usage_, high_pri_pool_capacity_,
+          low_pri_pool_usage_, low_pri_pool_capacity_);
+  fflush(stderr);
+  std::abort();
 }
 
 void LRUCacheShard::EvictFromLRU(size_t charge,

--- a/cache/lru_cache.cc
+++ b/cache/lru_cache.cc
@@ -219,6 +219,12 @@ size_t LRUCacheShard::TEST_GetLRUSize() {
   return lru_size;
 }
 
+void LRUCacheShard::TEST_SimulateCorruptLowPriPoolUsage(size_t bogus_usage) {
+  DMutexLock l(mutex_);
+  low_pri_pool_usage_ = bogus_usage;
+  MaintainPoolSize();
+}
+
 double LRUCacheShard::GetHighPriPoolRatio() {
   DMutexLock l(mutex_);
   return high_pri_pool_ratio_;

--- a/cache/lru_cache.cc
+++ b/cache/lru_cache.cc
@@ -225,6 +225,13 @@ void LRUCacheShard::TEST_SimulateCorruptLowPriPoolUsage(size_t bogus_usage) {
   MaintainPoolSize();
 }
 
+void LRUCacheShard::TEST_GetPoolUsage(size_t* high_pri_pool_usage,
+                                      size_t* low_pri_pool_usage) {
+  DMutexLock l(mutex_);
+  *high_pri_pool_usage = high_pri_pool_usage_;
+  *low_pri_pool_usage = low_pri_pool_usage_;
+}
+
 double LRUCacheShard::GetHighPriPoolRatio() {
   DMutexLock l(mutex_);
   return high_pri_pool_ratio_;

--- a/cache/lru_cache.h
+++ b/cache/lru_cache.h
@@ -363,6 +363,11 @@ class ALIGN_AS(CACHE_LINE_SIZE) LRUCacheShard final : public CacheShardBase {
   // high-pri pool is no larger than the size specify by high_pri_pool_pct.
   void MaintainPoolSize();
 
+  // Reports the shard's accounting state and aborts. Called only from
+  // MaintainPoolSize(), when a pool usage counter has stopped describing the
+  // LRU list and the shard can no longer be trusted.
+  [[noreturn]] void CrashOnCorruptPoolUsage(const char* pool_name) const;
+
   // Free some space following strict LRU policy until enough space
   // to hold (usage_ + charge) is freed or the lru list is empty
   // This function is not thread safe - it needs to be executed while

--- a/cache/lru_cache.h
+++ b/cache/lru_cache.h
@@ -341,6 +341,11 @@ class ALIGN_AS(CACHE_LINE_SIZE) LRUCacheShard final : public CacheShardBase {
   // Not threadsafe.
   size_t TEST_GetLRUSize();
 
+  // Forces the low-pri pool counter out of sync with the LRU list and then
+  // runs MaintainPoolSize(), for unit test purpose only. MaintainPoolSize()
+  // treats that state as unrecoverable corruption, so this aborts the process.
+  void TEST_SimulateCorruptLowPriPoolUsage(size_t bogus_usage);
+
   // Retrieves high pri pool ratio
   double GetHighPriPoolRatio();
 

--- a/cache/lru_cache.h
+++ b/cache/lru_cache.h
@@ -346,6 +346,12 @@ class ALIGN_AS(CACHE_LINE_SIZE) LRUCacheShard final : public CacheShardBase {
   // treats that state as unrecoverable corruption, so this aborts the process.
   void TEST_SimulateCorruptLowPriPoolUsage(size_t bogus_usage);
 
+  // Retrieves the pool usage counters, for unit test purpose only. These are
+  // what MaintainPoolSize() loops on, so tests can check they agree with the
+  // actual contents of the LRU list.
+  void TEST_GetPoolUsage(size_t* high_pri_pool_usage,
+                         size_t* low_pri_pool_usage);
+
   // Retrieves high pri pool ratio
   double GetHighPriPoolRatio();
 

--- a/cache/lru_cache_test.cc
+++ b/cache/lru_cache_test.cc
@@ -6,6 +6,7 @@
 #include "cache/lru_cache.h"
 
 #include <cstdint>
+#include <cstdlib>
 #include <memory>
 #include <string>
 #include <vector>
@@ -46,13 +47,16 @@ class LRUCacheTest : public testing::Test {
 
   void NewCache(size_t capacity, double high_pri_pool_ratio = 0.0,
                 double low_pri_pool_ratio = 1.0,
-                bool use_adaptive_mutex = kDefaultToAdaptiveMutex) {
+                bool use_adaptive_mutex = kDefaultToAdaptiveMutex,
+                CacheMetadataChargePolicy metadata_charge_policy =
+                    kDontChargeCacheMetadata,
+                bool strict_capacity_limit = false) {
     DeleteCache();
     cache_ = static_cast<LRUCacheShard*>(
         port::cacheline_aligned_alloc(sizeof(LRUCacheShard)));
-    new (cache_) LRUCacheShard(capacity, /*strict_capacity_limit=*/false,
+    new (cache_) LRUCacheShard(capacity, strict_capacity_limit,
                                high_pri_pool_ratio, low_pri_pool_ratio,
-                               use_adaptive_mutex, kDontChargeCacheMetadata,
+                               use_adaptive_mutex, metadata_charge_policy,
                                /*max_upper_hash_bits=*/24,
                                /*allocator*/ nullptr, &eviction_callback_);
   }
@@ -153,6 +157,69 @@ class LRUCacheTest : public testing::Test {
   Cache::EvictionCallback eviction_callback_;
 };
 
+// Recomputes the high/low pri pool usage from the LRU list itself and checks
+// it against the counters MaintainPoolSize() loops on, plus marker ordering
+// and per-region flags. A mismatch here is what makes MaintainPoolSize walk
+// off the end of its region and spin forever (issue #15128).
+class LRUCacheStateValidator {
+ public:
+  static void Validate(LRUCacheShard* cache, size_t* walked) {
+    size_t entries = 0;
+    LRUHandle* lru;
+    LRUHandle* lru_low_pri;
+    LRUHandle* lru_bottom_pri;
+    cache->TEST_GetLRUList(&lru, &lru_low_pri, &lru_bottom_pri);
+    size_t reported_high = 0, reported_low = 0;
+    cache->TEST_GetPoolUsage(&reported_high, &reported_low);
+
+    // 0 = bottom-pri region, 1 = low-pri region, 2 = high-pri region.
+    int region = 0;
+    if (lru_bottom_pri == lru) {
+      region = (lru_low_pri == lru) ? 2 : 1;
+    }
+    size_t actual_high = 0, actual_low = 0;
+    bool saw_bottom_marker = (lru_bottom_pri == lru);
+    bool saw_low_marker = (lru_low_pri == lru);
+    for (LRUHandle* p = lru->next; p != lru; p = p->next) {
+      entries++;
+      if (region == 0) {
+        ASSERT_FALSE(p->InHighPriPool()) << "key=" << p->key().ToString();
+        ASSERT_FALSE(p->InLowPriPool()) << "key=" << p->key().ToString();
+      } else if (region == 1) {
+        ASSERT_TRUE(p->InLowPriPool()) << "key=" << p->key().ToString();
+        ASSERT_FALSE(p->InHighPriPool()) << "key=" << p->key().ToString();
+        actual_low += p->total_charge;
+      } else {
+        ASSERT_TRUE(p->InHighPriPool()) << "key=" << p->key().ToString();
+        ASSERT_FALSE(p->InLowPriPool()) << "key=" << p->key().ToString();
+        actual_high += p->total_charge;
+      }
+      if (p == lru_bottom_pri) {
+        ASSERT_EQ(0, region) << "bottom marker out of order";
+        saw_bottom_marker = true;
+        if (p == lru_low_pri) {
+          saw_low_marker = true;
+          region = 2;
+        } else {
+          region = 1;
+        }
+      } else if (p == lru_low_pri) {
+        ASSERT_EQ(1, region) << "MARKERS OUT OF ORDER (low before bottom)";
+        saw_low_marker = true;
+        region = 2;
+      }
+    }
+    ASSERT_TRUE(saw_bottom_marker) << "lru_bottom_pri_ dangling";
+    ASSERT_TRUE(saw_low_marker) << "lru_low_pri_ dangling";
+    ASSERT_EQ(2, region) << "markers not both reached";
+    ASSERT_EQ(actual_high, reported_high) << "high_pri_pool_usage_ drift";
+    ASSERT_EQ(actual_low, reported_low) << "low_pri_pool_usage_ drift";
+    if (walked != nullptr) {
+      *walked += entries;
+    }
+  }
+};
+
 // A shard whose low-pri counter no longer describes its list used to spin in
 // MaintainPoolSize() forever, holding mutex_ and wedging every user of the
 // cache. It must now abort instead, leaving a core dump to diagnose from.
@@ -163,6 +230,105 @@ TEST_F(LRUCacheTest, CorruptPoolUsageAborts) {
   }
   ASSERT_DEATH(cache_->TEST_SimulateCorruptLowPriPoolUsage(SIZE_MAX),
                "corrupt low-pri pool accounting");
+}
+
+// Randomized stress over the shard's full public API, validating the pool
+// bookkeeping after every single operation.
+TEST_F(LRUCacheTest, PoolBookkeepingStress) {
+  const double kRatios[] = {0.0, 0.25, 0.5, 1.0};
+  const int kSeeds =
+      getenv("LRU_STRESS_SEEDS") ? atoi(getenv("LRU_STRESS_SEEDS")) : 2000;
+  const int kSteps = 400;
+  const int kKeys = 30;
+  size_t validated_entries = 0;
+  for (int seed = 0; seed < kSeeds; seed++) {
+    Random rnd(seed);
+    double hi = kRatios[rnd.Uniform(4)];
+    double lo = kRatios[rnd.Uniform(4)];
+    if (hi + lo > 1.0) {
+      lo = 1.0 - hi;
+    }
+    // Capacity well above the working set so the LRU list actually stays
+    // populated; the pool-region logic is only exercised by long lists.
+    size_t cap = 60 + rnd.Uniform(140);
+    CacheMetadataChargePolicy policy =
+        rnd.OneIn(2) ? kFullChargeCacheMetadata : kDontChargeCacheMetadata;
+    if (policy == kFullChargeCacheMetadata) {
+      cap *= 128;  // metadata alone is ~100 bytes/entry
+    }
+    NewCache(cap, hi, lo, kDefaultToAdaptiveMutex, policy, rnd.OneIn(8));
+    SCOPED_TRACE("seed=" + std::to_string(seed));
+    std::vector<LRUHandle*> pinned;
+    for (int step = 0; step < kSteps; step++) {
+      SCOPED_TRACE("step=" + std::to_string(step));
+      std::string key(1, static_cast<char>('a' + rnd.Uniform(kKeys)));
+      uint32_t roll = rnd.Uniform(100);
+      if (roll < 30) {  // Insert, no handle -> straight onto the LRU list.
+        Cache::Priority pri = static_cast<Cache::Priority>(rnd.Uniform(3));
+        cache_
+            ->Insert(key, 0, nullptr, &kNoopCacheItemHelper, 1 + rnd.Uniform(6),
+                     nullptr, pri)
+            .PermitUncheckedError();
+      } else if (roll < 40) {  // Insert pinned -> enters the list via Release.
+        LRUHandle* h = nullptr;
+        Cache::Priority pri = static_cast<Cache::Priority>(rnd.Uniform(3));
+        cache_
+            ->Insert(key, 0, nullptr, &kNoopCacheItemHelper, 1 + rnd.Uniform(6),
+                     &h, pri)
+            .PermitUncheckedError();
+        if (h != nullptr) {
+          pinned.push_back(h);
+        }
+      } else if (roll < 62) {  // Lookup -> pulls the entry out of the list.
+        LRUHandle* h = cache_->Lookup(key, 0, &kNoopCacheItemHelper, nullptr,
+                                      Cache::Priority::LOW, nullptr);
+        if (h != nullptr) {
+          pinned.push_back(h);
+        }
+      } else if (roll < 84) {  // Release -> re-inserts into the list.
+        if (!pinned.empty()) {
+          size_t i = rnd.Uniform(static_cast<int>(pinned.size()));
+          cache_->Release(pinned[i], true, rnd.OneIn(8));
+          pinned.erase(pinned.begin() + static_cast<long>(i));
+        }
+      } else if (roll < 88) {
+        cache_->Erase(key, 0);
+      } else if (roll < 92) {
+        cache_->SetCapacity(60 + rnd.Uniform(140));
+      } else if (roll < 97) {
+        if (rnd.OneIn(2)) {
+          cache_->SetHighPriorityPoolRatio(kRatios[rnd.Uniform(4)]);
+        } else {
+          cache_->SetLowPriorityPoolRatio(kRatios[rnd.Uniform(4)]);
+        }
+      } else if (roll < 99) {  // Standalone: shares usage_, never in the list.
+        LRUHandle* h =
+            cache_->CreateStandalone(key, 0, nullptr, &kNoopCacheItemHelper,
+                                     1 + rnd.Uniform(6), rnd.OneIn(2));
+        if (h != nullptr) {
+          cache_->Release(h, true, false);
+        }
+      } else if (rnd.OneIn(10)) {
+        cache_->EraseUnRefEntries();
+      }
+      LRUCacheStateValidator::Validate(cache_, &validated_entries);
+      if (HasFatalFailure()) {
+        return;
+      }
+    }
+    for (LRUHandle* h : pinned) {
+      cache_->Release(h, true, false);
+    }
+    LRUCacheStateValidator::Validate(cache_, &validated_entries);
+    if (HasFatalFailure()) {
+      return;
+    }
+  }
+  size_t validations = static_cast<size_t>(kSeeds) * (kSteps + 1);
+  fprintf(stderr, "avg LRU list length during validation: %.1f entries\n",
+          static_cast<double>(validated_entries) / validations);
+  // Guard against a vacuous run: near-empty lists never exercise the pools.
+  ASSERT_GT(validated_entries, validations * 5);
 }
 
 TEST_F(LRUCacheTest, BasicLRU) {

--- a/cache/lru_cache_test.cc
+++ b/cache/lru_cache_test.cc
@@ -5,6 +5,7 @@
 
 #include "cache/lru_cache.h"
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
@@ -151,6 +152,18 @@ class LRUCacheTest : public testing::Test {
  private:
   Cache::EvictionCallback eviction_callback_;
 };
+
+// A shard whose low-pri counter no longer describes its list used to spin in
+// MaintainPoolSize() forever, holding mutex_ and wedging every user of the
+// cache. It must now abort instead, leaving a core dump to diagnose from.
+TEST_F(LRUCacheTest, CorruptPoolUsageAborts) {
+  NewCache(10, /*high_pri_pool_ratio=*/0.5, /*low_pri_pool_ratio=*/0.0);
+  for (char ch = 'a'; ch <= 'e'; ch++) {
+    Insert(ch, Cache::Priority::HIGH);
+  }
+  ASSERT_DEATH(cache_->TEST_SimulateCorruptLowPriPoolUsage(SIZE_MAX),
+               "corrupt low-pri pool accounting");
+}
 
 TEST_F(LRUCacheTest, BasicLRU) {
   NewCache(5);

--- a/unreleased_history/bug_fixes/lru_cache_maintain_pool_size_spin.md
+++ b/unreleased_history/bug_fixes/lru_cache_maintain_pool_size_spin.md
@@ -1,0 +1,1 @@
+Fixed a bug where inconsistent internal accounting in an LRU cache shard could make it loop forever while holding that shard's lock, hanging every user of the cache. The inconsistency is now detected and aborts the process instead.


### PR DESCRIPTION
## Summary

Fixes #15128, where an LRU block cache shared across ~128 DBs wedged every one of them because a thread was spinning in `LRUCacheShard::MaintainPoolSize()` holding the shard mutex.

Both loops there terminated only on a `size_t` usage counter while walking a circular list. The invariant tying those counters to the list is checked only by `assert`, which is compiled out in release. So a counter that disagreed with the list sent the walk past its own region and around the list, subtracting charges never counted into that pool. The counter underflowed, and since `low_pri_pool_ratio` defaults to 0 the capacity is 0, leaving `usage > capacity` true forever with `mutex_` held.

This bounds each loop by the list it walks. The low-pri loop takes two bounds: the pool it drains is the entries in `(lru_bottom_pri_, lru_low_pri_]`, and separately it stops at the end of the list, which matters once the markers are out of order as they were in the report. Without the second one the walk runs off the end and reads the sentinel's uninitialized `total_charge`. If a loop runs out of entries while its counter still claims the pool is over capacity, that counter no longer describes the shard, so it prints the accounting state and aborts. @xingbowang asked for a crash with a core dump rather than silent recovery, which is what this does. `port::Crash()` is not usable for it because SIGTERM does not dump core, so it calls `std::abort()`.

Rather than detect a loop that has run too long, it detects the state that makes the loop unable to end. That fires on the first bad iteration and has nothing to tune.

I could not find what makes the counters diverge in the first place. 40M randomized operations against a shard, checking both counters against the list after each one, produced no divergence, and I found no unsynchronized path: `LRUHandle` appears only under `cache/`, every public `LRUCacheShard` method takes `mutex_`, and `NotifyEvicted` frees each handle once after unlinking. So this guards the amplification, not the trigger. It turns a permanent process-wide hang into a crash with the evidence attached.

## Test plan

`make check` passes, other than failures that reproduce on unmodified HEAD (see below).

A standalone program against a release `librocksdb.a`, differing only in the loop bounds, corrupts `low_pri_pool_usage_` and calls `MaintainPoolSize()`. Unbounded it runs at 99.4% CPU until killed, with all 1699 stack samples in `MaintainPoolSize()`. Bounded:

```
rocksdb: corrupt low-pri pool accounting in LRUCacheShard 0x74101c000; aborting.
capacity=10 usage=5 lru_usage=5 high_pri_pool_usage=5 high_pri_pool_capacity=5
low_pri_pool_usage=18446744073709551615 low_pri_pool_capacity=0
```

Before trusting an abort in production code I ran 40M randomized operations with it in place, across every ratio combination, both metadata charge policies, and strict and non-strict. No spurious abort. None of the bounds are reachable while the counters agree with the list, so consistent shards are unaffected.

Two smaller things worth flagging:

`ValidateLRUList` checked list order and per-entry flags but never the usage counters, which are what these loops run on. The third commit adds a stress test that checks them after every operation. It also asserts on average LRU list length, because an earlier version passed while averaging 0.3 entries per list and exercised almost none of the pool logic.

The death test only exercises the guard indirectly in debug builds: without the bounds the walk trips `assert(lru_bottom_pri_->InLowPriPool())` long before the counter wraps. The spin is specific to release builds, and RocksDB's test infrastructure cannot build in release at all, since `SyncPoint` compiles out under NDEBUG and `db_test_util.cc` fails. That is why the release evidence above needed a standalone harness, and it may be worth a separate look: the checks for this class of bug run only in builds where the bug cannot occur.

On macOS, `make check` also fails two `DBSSTTest` cases, three `EventListenerTest` cases, and `rocksdb_dump_test`, all of which reproduce on unmodified HEAD. `$TMPDIR` ends in `/` there, so `TEST_TMPDIR` contains a doubled slash and `SstFileManager` tracks each file under two spellings; the same tests pass with a `TEST_TMPDIR` that has no trailing slash. Unrelated to this change, happy to file separately.
