### PR TITLE
Add DBOptions::partition_wal_usage for per-record WAL ordering numbers (wal_index)

### DIFF
--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -2491,6 +2491,8 @@ IOStatus DBImpl::CreateWALWriter(const DBOptions& db_options,
         immutable_db_options_.manual_wal_flush,
         immutable_db_options_.wal_compression,
         immutable_db_options_.track_and_verify_wals);
+    new_wal->writer->SetPartitionWALUsage(
+        immutable_db_options_.partition_wal_usage);
   }
 
   return io_s;
@@ -2503,6 +2505,9 @@ IOStatus DBImpl::StartWALFile(const WriteOptions& write_options,
   IOStatus io_s = new_log->AddCompressionTypeRecord(write_options);
   TEST_SYNC_POINT_CALLBACK("DBImpl::StartWALFile:AfterCompressionTypeRecord",
                            &io_s);
+  if (io_s.ok()) {
+    io_s = new_log->MaybeAddWALIndexMarkerRecord(write_options);
+  }
   if (io_s.ok()) {
     io_s = new_log->MaybeAddPredecessorWALInfo(write_options,
                                                predecessor_wal_info);

--- a/db/log_format.h
+++ b/db/log_format.h
@@ -43,6 +43,13 @@ enum RecordType : uint8_t {
   kUserDefinedTimestampSizeType = 10,
   kRecyclableUserDefinedTimestampSizeType = 11,
 
+  // Marks a WAL file as carrying per-record ordering numbers (wal_index / LSN).
+  // Kept < 128 and without the safe-ignore bit so that older readers treat it
+  // as an unknown record type and report corruption instead of silently
+  // misinterpreting the file.
+  kWALIndexMarkerType = 12,
+  kRecyclableWALIndexMarkerType = 13,
+
   // For WAL verification
   kPredecessorWALInfoType = 130,
   kRecyclePredecessorWALInfoType = 131,
@@ -52,6 +59,14 @@ constexpr uint8_t kRecordTypeSafeIgnoreMask = 1 << 7;
 constexpr uint8_t kMaxRecordType = kRecyclePredecessorWALInfoType;
 
 constexpr unsigned int kBlockSize = 32768;
+
+// Magic payload stored in the WAL-index marker record. Chosen to be greppable
+// via `strings`/`grep` for offline file identification.
+inline constexpr char kWALIndexMarkerMagic[] = "WAL_LSN_V1";
+
+// Number of bytes of the fixed64 wal_index prefixed to each logical record when
+// WAL index is enabled.
+constexpr uint32_t kWALIndexSize = 8;
 
 // Header is checksum (4 bytes), length (2 bytes), type (1 byte)
 constexpr int kHeaderSize = 4 + 2 + 1;

--- a/db/log_reader.cc
+++ b/db/log_reader.cc
@@ -117,6 +117,7 @@ bool Reader::ReadRecord(Slice* record, std::string* scratch,
         prospective_record_offset = physical_record_offset;
         scratch->clear();
         *record = fragment;
+        MaybeStripAndVerifyWALIndex(record, record_checksum);
         last_record_offset_ = prospective_record_offset;
         first_record_read_ = true;
         return true;
@@ -164,6 +165,7 @@ bool Reader::ReadRecord(Slice* record, std::string* scratch,
           }
           scratch->append(fragment.data(), fragment.size());
           *record = Slice(*scratch);
+          MaybeStripAndVerifyWALIndex(record, record_checksum);
           last_record_offset_ = prospective_record_offset;
           first_record_read_ = true;
           return true;
@@ -232,6 +234,17 @@ bool Reader::ReadRecord(Slice* record, std::string* scratch,
             ReportCorruption(fragment.size(), s.getState());
           }
         }
+        break;  // switch
+      }
+
+      case kWALIndexMarkerType:
+      case kRecyclableWALIndexMarkerType: {
+        // Identifies the file as carrying per-record wal_index values. The
+        // marker itself does not consume a wal_index.
+        prospective_record_offset = physical_record_offset;
+        scratch->clear();
+        last_record_offset_ = prospective_record_offset;
+        file_has_wal_index_ = true;
         break;  // switch
       }
 
@@ -411,6 +424,38 @@ void Reader::MaybeVerifyPredecessorWALInfo(
   }
 }
 
+void Reader::MaybeStripAndVerifyWALIndex(Slice* record,
+                                         uint64_t* record_checksum) {
+  if (!file_has_wal_index_) {
+    return;
+  }
+  if (record->size() < kWALIndexSize) {
+    ReportCorruption(record->size(),
+                     "WAL_Index record too small to contain wal_index");
+    return;
+  }
+  uint64_t wal_index = DecodeFixed64(record->data());
+  record->remove_prefix(kWALIndexSize);
+
+  if (!first_wal_index_read_) {
+    // A reader may open in the middle of a stream, so accept the first observed
+    // wal_index as-is.
+    first_wal_index_read_ = true;
+  } else if (wal_index != expected_next_wal_index_) {
+    std::string reason = "WAL_Index gap detected: expected wal_index " +
+                         std::to_string(expected_next_wal_index_) +
+                         " but found " + std::to_string(wal_index);
+    ReportCorruption(record->size(), reason.c_str());
+    wal_index_gap_ = true;
+  }
+  last_read_wal_index_ = wal_index;
+  expected_next_wal_index_ = wal_index + 1;
+
+  if (record_checksum != nullptr) {
+    *record_checksum = XXH3_64bits(record->data(), record->size());
+  }
+}
+
 uint64_t Reader::LastRecordOffset() { return last_record_offset_; }
 
 uint64_t Reader::LastRecordEnd() {
@@ -571,7 +616,8 @@ uint8_t Reader::ReadPhysicalRecord(Slice* result, size_t* drop_size,
     const bool is_recyclable_type =
         ((type >= kRecyclableFullType && type <= kRecyclableLastType) ||
          type == kRecyclableUserDefinedTimestampSizeType ||
-         type == kRecyclePredecessorWALInfoType);
+         type == kRecyclePredecessorWALInfoType ||
+         type == kRecyclableWALIndexMarkerType);
     if (is_recyclable_type) {
       header_size = kRecyclableHeaderSize;
       if (first_record_read_ && !recycled_) {
@@ -639,7 +685,9 @@ uint8_t Reader::ReadPhysicalRecord(Slice* result, size_t* drop_size,
         type == kPredecessorWALInfoType ||
         type == kRecyclePredecessorWALInfoType ||
         type == kUserDefinedTimestampSizeType ||
-        type == kRecyclableUserDefinedTimestampSizeType) {
+        type == kRecyclableUserDefinedTimestampSizeType ||
+        type == kWALIndexMarkerType ||
+        type == kRecyclableWALIndexMarkerType) {
       *result = Slice(header + header_size, length);
       return type;
     } else {
@@ -753,6 +801,7 @@ bool FragmentBufferedReader::ReadRecord(Slice* record, std::string* scratch,
         }
         fragments_.clear();
         *record = fragment;
+        MaybeStripAndVerifyWALIndex(record, nullptr);
         prospective_record_offset = physical_record_offset;
         last_record_offset_ = prospective_record_offset;
         first_record_read_ = true;
@@ -789,6 +838,7 @@ bool FragmentBufferedReader::ReadRecord(Slice* record, std::string* scratch,
           scratch->assign(fragments_.data(), fragments_.size());
           fragments_.clear();
           *record = Slice(*scratch);
+          MaybeStripAndVerifyWALIndex(record, nullptr);
           last_record_offset_ = prospective_record_offset;
           first_record_read_ = true;
           in_fragmented_record_ = false;
@@ -861,6 +911,16 @@ bool FragmentBufferedReader::ReadRecord(Slice* record, std::string* scratch,
             ReportCorruption(fragment.size(), s.getState());
           }
         }
+        break;
+      }
+
+      case kWALIndexMarkerType:
+      case kRecyclableWALIndexMarkerType: {
+        fragments_.clear();
+        prospective_record_offset = physical_record_offset;
+        last_record_offset_ = prospective_record_offset;
+        in_fragmented_record_ = false;
+        file_has_wal_index_ = true;
         break;
       }
 
@@ -978,7 +1038,8 @@ bool FragmentBufferedReader::TryReadFragment(Slice* fragment, size_t* drop_size,
   int header_size = kHeaderSize;
   if ((type >= kRecyclableFullType && type <= kRecyclableLastType) ||
       type == kRecyclableUserDefinedTimestampSizeType ||
-      type == kRecyclePredecessorWALInfoType) {
+      type == kRecyclePredecessorWALInfoType ||
+      type == kRecyclableWALIndexMarkerType) {
     if (first_record_read_ && !recycled_) {
       // A recycled log should have started with a recycled record
       *fragment_type_or_err = kBadRecord;
@@ -1037,7 +1098,8 @@ bool FragmentBufferedReader::TryReadFragment(Slice* fragment, size_t* drop_size,
       type == kPredecessorWALInfoType ||
       type == kRecyclePredecessorWALInfoType ||
       type == kUserDefinedTimestampSizeType ||
-      type == kRecyclableUserDefinedTimestampSizeType) {
+      type == kRecyclableUserDefinedTimestampSizeType ||
+      type == kWALIndexMarkerType || type == kRecyclableWALIndexMarkerType) {
     *fragment = Slice(header + header_size, length);
     *fragment_type_or_err = type;
     return true;

--- a/db/log_reader.h
+++ b/db/log_reader.h
@@ -131,6 +131,22 @@ class Reader {
     return !first_record_read_ && compression_type_record_read_;
   }
 
+  // WAL index (LSN) accessors. See db/log_writer.h for the format.
+  //
+  // True once the WAL-index marker record has been seen, i.e. this file carries
+  // per-record ordering numbers.
+  bool FileHasWALIndex() const { return file_has_wal_index_; }
+  bool HasWALIndexMarker() const { return file_has_wal_index_; }
+  // Setting this is a no-op: the reader auto-detects the format from the marker
+  // record. Provided for API symmetry with the writer.
+  void SetPartitionWALUsage(PartitionWALUsage /*usage*/) {}
+  // wal_index extracted from the most recently returned logical record.
+  uint64_t GetLastReadWALIndex() const { return last_read_wal_index_; }
+  uint64_t GetLastWALIndex() const { return last_read_wal_index_; }
+  // Sticky: true if a gap in the wal_index sequence has ever been detected.
+  bool HasWALIndexGap() const { return wal_index_gap_; }
+  bool HasGap() const { return wal_index_gap_; }
+
  protected:
   std::shared_ptr<Logger> info_log_;
   const std::unique_ptr<SequentialFileReader> file_;
@@ -189,6 +205,19 @@ class Reader {
   // is only for WAL logs.
   UnorderedMap<uint32_t, size_t> recorded_cf_to_ts_sz_;
 
+  // WAL index (LSN) state. See db/log_writer.h.
+  // Set once the WAL-index marker record has been seen, meaning subsequent
+  // logical records carry a leading wal_index that must be stripped.
+  bool file_has_wal_index_ = false;
+  // Whether at least one wal_index has been observed in this file.
+  bool first_wal_index_read_ = false;
+  // wal_index expected on the next logical record.
+  uint64_t expected_next_wal_index_ = 0;
+  // wal_index extracted from the most recent logical record.
+  uint64_t last_read_wal_index_ = 0;
+  // Sticky flag set when a gap in the wal_index sequence has been detected.
+  bool wal_index_gap_ = false;
+
   // Extend record types with the following special values
   enum : uint8_t {
     kEof = kMaxRecordType + 1,
@@ -235,6 +264,12 @@ class Reader {
   void MaybeVerifyPredecessorWALInfo(
       WALRecoveryMode wal_recovery_mode, Slice fragment,
       const PredecessorWALInfo& recorded_predecessor_wal_info);
+
+  // If this file carries WAL index, extract and strip the leading wal_index
+  // from *record, recompute *record_checksum over the stripped payload (when
+  // non-null), and report a corruption if the wal_index is not the expected
+  // successor of the previously observed one.
+  void MaybeStripAndVerifyWALIndex(Slice* record, uint64_t* record_checksum);
 };
 
 class FragmentBufferedReader : public Reader {

--- a/db/log_test.cc
+++ b/db/log_test.cc
@@ -277,6 +277,13 @@ class LogTest
                    &recorded_ts_sz));
     EXPECT_EQ(expected_ts_sz, recorded_ts_sz);
   }
+
+  // Turns on wal_index on the writer and emits the identifying marker record.
+  // For compressed logs, call this after AddCompressionTypeRecord.
+  void EnableWALIndex() {
+    writer_->SetPartitionWALUsage(PartitionWALUsage::kPartitionByWALIndexHash);
+    ASSERT_OK(writer_->MaybeAddWALIndexMarkerRecord(WriteOptions()));
+  }
 };
 
 TEST_P(LogTest, Empty) { ASSERT_EQ("EOF", Read()); }
@@ -812,6 +819,92 @@ TEST_P(LogTest, TimestampSizeRecordPadding) {
   CheckRecordAndTimestampSize(second_str, ts_sz);
 }
 
+// Basic round-trip: with wal_index enabled, each logical record carries a
+// monotonically increasing index starting at 1, and the reader strips it so
+// upper layers observe the original payload.
+TEST_P(LogTest, WALIndexReadWrite) {
+  EnableWALIndex();
+  Write("foo");
+  Write("bar");
+  Write("");
+  Write("xxxx");
+
+  ASSERT_EQ(4U, writer_->GetLastWALIndex());
+  ASSERT_EQ(5U, writer_->GetNextWALIndex());
+
+  ASSERT_EQ("foo", Read());
+  ASSERT_TRUE(reader_->FileHasWALIndex());
+  ASSERT_EQ(1U, reader_->GetLastReadWALIndex());
+  ASSERT_EQ("bar", Read());
+  ASSERT_EQ(2U, reader_->GetLastReadWALIndex());
+  ASSERT_EQ("", Read());
+  ASSERT_EQ(3U, reader_->GetLastReadWALIndex());
+  ASSERT_EQ("xxxx", Read());
+  ASSERT_EQ(4U, reader_->GetLastReadWALIndex());
+  ASSERT_EQ("EOF", Read());
+  ASSERT_FALSE(reader_->HasWALIndexGap());
+  ASSERT_EQ(0U, DroppedBytes());
+}
+
+// When wal_index is disabled the WAL is bit-for-bit vanilla: no marker record,
+// no greppable magic, and the reader reports no wal_index.
+TEST_P(LogTest, WALIndexDisabledStaysVanilla) {
+  Write("foo");
+  Write("bar");
+
+  ASSERT_EQ(std::string::npos, get_reader_contents()->ToString().find("WAL_LSN_V1"));
+
+  ASSERT_EQ("foo", Read());
+  ASSERT_FALSE(reader_->FileHasWALIndex());
+  ASSERT_EQ("bar", Read());
+  ASSERT_EQ(0U, reader_->GetLastReadWALIndex());
+  ASSERT_EQ("EOF", Read());
+  ASSERT_FALSE(reader_->HasWALIndexGap());
+}
+
+// The marker magic is discoverable via offline tools (grep/strings) so a file
+// can be identified as carrying wal_index from its contents alone.
+TEST_P(LogTest, WALIndexMarkerIsGreppable) {
+  EnableWALIndex();
+  Write("foo");
+  ASSERT_NE(std::string::npos, get_reader_contents()->ToString().find("WAL_LSN_V1"));
+}
+
+// A hole in the index (simulated by skipping a value on the writer) is reported
+// as corruption and latches a sticky gap flag, while the record is still
+// delivered to upper layers.
+TEST_P(LogTest, WALIndexGapDetected) {
+  EnableWALIndex();
+  Write("a");
+  writer_->SetNextWALIndex(3);
+  Write("b");
+
+  ASSERT_EQ("a", Read());
+  ASSERT_EQ(1U, reader_->GetLastReadWALIndex());
+  ASSERT_FALSE(reader_->HasWALIndexGap());
+
+  ASSERT_EQ("b", Read());
+  ASSERT_EQ(3U, reader_->GetLastReadWALIndex());
+  ASSERT_TRUE(reader_->HasWALIndexGap());
+  ASSERT_EQ("OK", MatchError("gap"));
+}
+
+// The index survives records that span multiple 32KiB blocks (fragmented into
+// first/middle/last physical records).
+TEST_P(LogTest, WALIndexLargeRecord) {
+  EnableWALIndex();
+  const std::string big = BigString("abcd", 100 * 1000);
+  Write("small");
+  Write(big);
+
+  ASSERT_EQ("small", Read());
+  ASSERT_EQ(1U, reader_->GetLastReadWALIndex());
+  ASSERT_EQ(big, Read());
+  ASSERT_EQ(2U, reader_->GetLastReadWALIndex());
+  ASSERT_EQ("EOF", Read());
+  ASSERT_FALSE(reader_->HasWALIndexGap());
+}
+
 // Do NOT enable compression for this instantiation.
 INSTANTIATE_TEST_CASE_P(
     Log, LogTest,
@@ -1204,6 +1297,35 @@ TEST_P(CompressionLogTest, ChecksumMismatch) {
     ASSERT_EQ(0U, DroppedBytes());
     ASSERT_EQ("", ReportMessage());
   }
+}
+
+// wal_index round-trips through WAL compression, including a record large
+// enough to fragment across blocks. The reader recomputes the per-record
+// checksum over the stripped payload so it still matches upper-layer
+// expectations.
+TEST_P(CompressionLogTest, WALIndexReadWrite) {
+  CompressionType compression_type = std::get<2>(GetParam());
+  if (!StreamingCompressionTypeSupported(compression_type)) {
+    ROCKSDB_GTEST_SKIP("Test requires support for compression type");
+    return;
+  }
+  ASSERT_OK(SetupTestEnv());
+  EnableWALIndex();
+
+  const std::string big = BigString("bar", 60 * 1000);
+  Write("foo");
+  Write(big);
+  Write("baz");
+
+  ASSERT_EQ("foo", Read());
+  ASSERT_TRUE(reader_->FileHasWALIndex());
+  ASSERT_EQ(1U, reader_->GetLastReadWALIndex());
+  ASSERT_EQ(big, Read());
+  ASSERT_EQ(2U, reader_->GetLastReadWALIndex());
+  ASSERT_EQ("baz", Read());
+  ASSERT_EQ(3U, reader_->GetLastReadWALIndex());
+  ASSERT_EQ("EOF", Read());
+  ASSERT_FALSE(reader_->HasWALIndexGap());
 }
 
 INSTANTIATE_TEST_CASE_P(

--- a/db/log_writer.cc
+++ b/db/log_writer.cc
@@ -34,7 +34,10 @@ Writer::Writer(std::unique_ptr<WritableFileWriter>&& dest, uint64_t log_number,
       compression_type_(compression_type),
       compress_(),
       track_and_verify_wals_(track_and_verify_wals),
-      last_seqno_recorded_(0) {
+      last_seqno_recorded_(0),
+      partition_wal_usage_(PartitionWALUsage::kNone),
+      next_wal_index_(1),
+      last_wal_index_(0) {
   for (uint8_t i = 0; i <= kMaxRecordType; i++) {
     char t = static_cast<char>(i);
     type_crc_[i] = crc32c::Value(&t, 1);
@@ -90,8 +93,24 @@ IOStatus Writer::AddRecord(const WriteOptions& write_options,
   if (!s.ok()) {
     return s;
   }
-  const char* ptr = slice.data();
-  size_t left = slice.size();
+
+  // When WAL index is enabled, prepend a monotonically increasing ordering
+  // number (wal_index) to the logical record. It becomes part of the payload,
+  // so it survives fragmentation and WAL compression, and the reader strips it
+  // before handing the record to upper layers.
+  std::string indexed_payload;
+  uint64_t assigned_wal_index = 0;
+  Slice payload = slice;
+  if (WALIndexEnabled()) {
+    assigned_wal_index = next_wal_index_.fetch_add(1, std::memory_order_relaxed);
+    indexed_payload.reserve(kWALIndexSize + slice.size());
+    PutFixed64(&indexed_payload, assigned_wal_index);
+    indexed_payload.append(slice.data(), slice.size());
+    payload = Slice(indexed_payload);
+  }
+
+  const char* ptr = payload.data();
+  size_t left = payload.size();
 
   // Fragment the record if necessary and emit it.  Note that if slice
   // is empty, we still want to iterate once to emit a single
@@ -138,7 +157,7 @@ IOStatus Writer::AddRecord(const WriteOptions& write_options,
       // physical records (left=0).
       if (compress_ && (compress_start || left == 0)) {
         compress_remaining = compress_->Compress(
-            slice.data(), slice.size(), compressed_buffer_.get(), &left);
+            payload.data(), payload.size(), compressed_buffer_.get(), &left);
 
         if (compress_remaining < 0) {
           // Set failure status
@@ -183,8 +202,46 @@ IOStatus Writer::AddRecord(const WriteOptions& write_options,
 
   if (s.ok()) {
     last_seqno_recorded_ = std::max(last_seqno_recorded_, seqno);
+    if (WALIndexEnabled()) {
+      last_wal_index_.store(assigned_wal_index, std::memory_order_relaxed);
+    }
   }
 
+  return s;
+}
+
+IOStatus Writer::MaybeAddWALIndexMarkerRecord(
+    const WriteOptions& write_options) {
+  if (!WALIndexEnabled()) {
+    return IOStatus::OK();
+  }
+
+  IOStatus s = MaybeHandleSeenFileWriterError();
+  if (!s.ok()) {
+    return s;
+  }
+
+  std::string encode(kWALIndexMarkerMagic, sizeof(kWALIndexMarkerMagic) - 1);
+
+  s = MaybeSwitchToNewBlock(write_options, encode);
+  if (!s.ok()) {
+    return s;
+  }
+
+  RecordType type = recycle_log_files_ ? kRecyclableWALIndexMarkerType
+                                       : kWALIndexMarkerType;
+  s = EmitPhysicalRecord(write_options, type, encode.data(), encode.size());
+  if (!s.ok()) {
+    return s;
+  }
+
+  if (!manual_flush_) {
+    IOOptions io_opts;
+    s = WritableFileWriter::PrepareIOOptions(write_options, io_opts);
+    if (s.ok()) {
+      s = dest_->Flush(io_opts);
+    }
+  }
   return s;
 }
 
@@ -320,7 +377,8 @@ IOStatus Writer::EmitPhysicalRecord(const WriteOptions& write_options,
 
   uint32_t crc = type_crc_[t];
   if (t < kRecyclableFullType || t == kSetCompressionType ||
-      t == kPredecessorWALInfoType || t == kUserDefinedTimestampSizeType) {
+      t == kPredecessorWALInfoType || t == kUserDefinedTimestampSizeType ||
+      t == kWALIndexMarkerType) {
     // Legacy record format
     assert(block_offset_ + kHeaderSize + n <= kBlockSize);
     header_size = kHeaderSize;

--- a/db/log_writer.h
+++ b/db/log_writer.h
@@ -8,6 +8,7 @@
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 #pragma once
 
+#include <atomic>
 #include <cstdint>
 #include <memory>
 #include <unordered_map>
@@ -18,6 +19,7 @@
 #include "rocksdb/compression_type.h"
 #include "rocksdb/env.h"
 #include "rocksdb/io_status.h"
+#include "rocksdb/options.h"
 #include "rocksdb/slice.h"
 #include "rocksdb/status.h"
 #include "util/compression.h"
@@ -110,6 +112,38 @@ class Writer {
       const WriteOptions& write_options,
       const UnorderedMap<uint32_t, size_t>& cf_to_ts_sz);
 
+  // When WAL index is enabled, emits the leading marker record that identifies
+  // this file as carrying per-record ordering numbers (wal_index / LSN). The
+  // marker does not consume a wal_index. No-op when WAL index is disabled.
+  IOStatus MaybeAddWALIndexMarkerRecord(const WriteOptions& write_options);
+
+  // Controls whether logical records carry a wal_index (LSN). `kNone` keeps the
+  // vanilla WAL format for downgrade safety; any other value enables it.
+  void SetPartitionWALUsage(PartitionWALUsage usage) {
+    partition_wal_usage_ = usage;
+  }
+  PartitionWALUsage GetPartitionWALUsage() const { return partition_wal_usage_; }
+  bool WALIndexEnabled() const {
+    return partition_wal_usage_ != PartitionWALUsage::kNone;
+  }
+  void SetWALIndexEnabled(bool enabled) {
+    partition_wal_usage_ = enabled ? PartitionWALUsage::kPartitionByWALIndexHash
+                                   : PartitionWALUsage::kNone;
+  }
+
+  // The next wal_index that will be assigned to a logical record. Starts at 1.
+  void SetNextWALIndex(uint64_t next) {
+    next_wal_index_.store(next, std::memory_order_relaxed);
+  }
+  void SetWALIndex(uint64_t next) { SetNextWALIndex(next); }
+  uint64_t GetNextWALIndex() const {
+    return next_wal_index_.load(std::memory_order_relaxed);
+  }
+  // The wal_index most recently assigned to a written record (0 if none).
+  uint64_t GetLastWALIndex() const {
+    return last_wal_index_.load(std::memory_order_relaxed);
+  }
+
   WritableFileWriter* file() { return dest_.get(); }
   const WritableFileWriter* file() const { return dest_.get(); }
 
@@ -169,6 +203,14 @@ class Writer {
   bool track_and_verify_wals_;
 
   SequenceNumber last_seqno_recorded_;
+
+  // See `DBOptions::partition_wal_usage`.
+  PartitionWALUsage partition_wal_usage_;
+  // Next wal_index (LSN) to assign to a logical record. Atomic so the counter
+  // stays consistent if multiple writers append to the same log.
+  std::atomic<uint64_t> next_wal_index_;
+  // Last wal_index actually assigned to a written record (0 if none).
+  std::atomic<uint64_t> last_wal_index_;
 };
 
 }  // namespace log

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -387,6 +387,7 @@ DECLARE_uint64(wp_commit_cache_bits);
 DECLARE_bool(adaptive_readahead);
 DECLARE_bool(async_io);
 DECLARE_string(wal_compression);
+DECLARE_string(partition_wal_usage);
 DECLARE_bool(verify_sst_unique_id_in_manifest);
 DECLARE_bool(fast_sst_open);
 

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -1441,6 +1441,11 @@ DEFINE_bool(
 DEFINE_string(wal_compression, "none",
               "Algorithm to use for WAL compression. none to disable.");
 
+DEFINE_string(partition_wal_usage, "none",
+              "WAL index (LSN) usage. 'none' to disable (vanilla WAL format); "
+              "'partition_by_wal_index_hash' to tag each WAL record with a "
+              "monotonically increasing ordering number.");
+
 DEFINE_bool(
     verify_sst_unique_id_in_manifest, false,
     "Enable DB options `verify_sst_unique_id_in_manifest`, if true, during "

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -6481,6 +6481,18 @@ void InitializeOptionsFromFlags(
   options.wal_compression =
       StringToCompressionType(FLAGS_wal_compression.c_str());
 
+  if (FLAGS_partition_wal_usage == "none" ||
+      FLAGS_partition_wal_usage == "kNone") {
+    options.partition_wal_usage = PartitionWALUsage::kNone;
+  } else if (FLAGS_partition_wal_usage == "partition_by_wal_index_hash" ||
+             FLAGS_partition_wal_usage == "kPartitionByWALIndexHash") {
+    options.partition_wal_usage = PartitionWALUsage::kPartitionByWALIndexHash;
+  } else {
+    fprintf(stderr, "Unknown partition_wal_usage: %s\n",
+            FLAGS_partition_wal_usage.c_str());
+    exit(1);
+  }
+
   options.last_level_temperature =
       StringToTemperature(FLAGS_last_level_temperature.c_str());
   options.default_write_temperature =

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -447,6 +447,17 @@ enum class WALRecoveryMode : char {
   kSkipAnyCorruptedRecords = 0x03,
 };
 
+// Controls whether each WAL record carries an extra monotonically increasing
+// ordering number (wal_index / LSN) persisted on disk.
+enum class PartitionWALUsage : char {
+  // Disabled. The WAL keeps the vanilla on-disk format so that files stay
+  // readable by (and are bit-for-bit compatible with) older RocksDB versions.
+  kNone = 0x00,
+  // Enabled. Every logical WAL record is prefixed with a wal_index, and the
+  // file is tagged with a marker record identifying the new format.
+  kPartitionByWALIndexHash = 0x01,
+};
+
 struct DbPath {
   std::string path;
   uint64_t target_size;  // Target size of total files under the path, in byte.
@@ -1579,6 +1590,13 @@ struct DBOptions {
   // versions (>= RocksDB 7.4.0 for ZSTD) regardless of this setting when
   // the WAL is read.
   CompressionType wal_compression = kNoCompression;
+
+  // Controls whether each WAL record carries an extra monotonically increasing
+  // ordering number (wal_index / LSN) persisted on disk. `kNone` (default)
+  // keeps the vanilla WAL format for downgrade safety; any other value enables
+  // the ordering number and tags the WAL file with an identifying marker
+  // record. Leaves the per-key sequence number and SST format untouched.
+  PartitionWALUsage partition_wal_usage = PartitionWALUsage::kNone;
 
   // Set to true to re-instate an old behavior of keeping complete, synced WAL
   // files open for write until they are collected for deletion by a

--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -35,6 +35,15 @@ static std::unordered_map<std::string, WALRecoveryMode>
         {"kSkipAnyCorruptedRecords",
          WALRecoveryMode::kSkipAnyCorruptedRecords}};
 
+static std::unordered_map<std::string, PartitionWALUsage>
+    partition_wal_usage_string_map = {
+        {"None", PartitionWALUsage::kNone},
+        {"kNone", PartitionWALUsage::kNone},
+        {"partition_by_wal_index_hash",
+         PartitionWALUsage::kPartitionByWALIndexHash},
+        {"kPartitionByWALIndexHash",
+         PartitionWALUsage::kPartitionByWALIndexHash}};
+
 static std::unordered_map<std::string, CacheTier> cache_tier_string_map = {
     {"kVolatileTier", CacheTier::kVolatileTier},
     {"kVolatileCompressedTier", CacheTier::kVolatileCompressedTier},
@@ -436,6 +445,14 @@ static std::unordered_map<std::string, OptionTypeInfo>
          {offsetof(struct ImmutableDBOptions, wal_compression),
           OptionType::kCompressionType, OptionVerificationType::kNormal,
           OptionTypeFlags::kNone}},
+        {"partition_wal_usage",
+         OptionTypeInfo::Enum<PartitionWALUsage>(
+             offsetof(struct ImmutableDBOptions, partition_wal_usage),
+             &partition_wal_usage_string_map)},
+        {"Partition_WAL_Usage",
+         OptionTypeInfo::Enum<PartitionWALUsage>(
+             offsetof(struct ImmutableDBOptions, partition_wal_usage),
+             &partition_wal_usage_string_map)},
         {"background_close_inactive_wals",
          {offsetof(struct ImmutableDBOptions, background_close_inactive_wals),
           OptionType::kBoolean, OptionVerificationType::kNormal,
@@ -831,6 +848,7 @@ ImmutableDBOptions::ImmutableDBOptions(const DBOptions& options)
       two_write_queues(options.two_write_queues),
       manual_wal_flush(options.manual_wal_flush),
       wal_compression(options.wal_compression),
+      partition_wal_usage(options.partition_wal_usage),
       background_close_inactive_wals(options.background_close_inactive_wals),
       atomic_flush(options.atomic_flush),
       avoid_unnecessary_blocking_io(options.avoid_unnecessary_blocking_io),
@@ -1011,6 +1029,8 @@ void ImmutableDBOptions::Dump(Logger* log) const {
                    manual_wal_flush);
   ROCKS_LOG_HEADER(log, "            Options.wal_compression: %d",
                    wal_compression);
+  ROCKS_LOG_HEADER(log, "            Options.partition_wal_usage: %d",
+                   static_cast<int>(partition_wal_usage));
   ROCKS_LOG_HEADER(log,
                    "            Options.background_close_inactive_wals: %d",
                    background_close_inactive_wals);

--- a/options/db_options.h
+++ b/options/db_options.h
@@ -86,6 +86,7 @@ struct ImmutableDBOptions {
   bool two_write_queues;
   bool manual_wal_flush;
   CompressionType wal_compression;
+  PartitionWALUsage partition_wal_usage;
   bool background_close_inactive_wals;
   bool atomic_flush;
   bool avoid_unnecessary_blocking_io;

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -473,6 +473,7 @@ TEST_F(OptionsSettableTest, DBOptionsAllFieldsSettable) {
       "two_write_queues=false;"
       "manual_wal_flush=false;"
       "wal_compression=kZSTD;"
+      "partition_wal_usage=kPartitionByWALIndexHash;"
       "background_close_inactive_wals=true;"
       "seq_per_batch=false;"
       "atomic_flush=false;"

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -978,6 +978,13 @@ DEFINE_string(wal_compression, "none",
 static enum ROCKSDB_NAMESPACE::CompressionType FLAGS_wal_compression_e =
     ROCKSDB_NAMESPACE::kNoCompression;
 
+DEFINE_string(partition_wal_usage, "none",
+              "WAL index (LSN) usage. 'none' to disable (vanilla WAL format); "
+              "'partition_by_wal_index_hash' to tag each WAL record with a "
+              "monotonically increasing ordering number.");
+static enum ROCKSDB_NAMESPACE::PartitionWALUsage FLAGS_partition_wal_usage_e =
+    ROCKSDB_NAMESPACE::PartitionWALUsage::kNone;
+
 DEFINE_string(wal_dir, "", "If not empty, use the given dir for WAL");
 
 DEFINE_string(truth_db, "/dev/shm/truth_db/dbbench",
@@ -5338,6 +5345,7 @@ class Benchmark {
         FLAGS_use_direct_io_for_flush_and_compaction;
     options.manual_wal_flush = FLAGS_manual_wal_flush;
     options.wal_compression = FLAGS_wal_compression_e;
+    options.partition_wal_usage = FLAGS_partition_wal_usage_e;
     options.ttl = FLAGS_fifo_compaction_ttl;
     options.compaction_options_fifo = CompactionOptionsFIFO(
         FLAGS_fifo_compaction_max_table_files_size_mb * 1024 * 1024,
@@ -11190,6 +11198,19 @@ int db_bench_tool(int argc, char** argv, ToolHooks& hooks) {
 
   FLAGS_wal_compression_e =
       StringToCompressionType(FLAGS_wal_compression.c_str());
+
+  if (FLAGS_partition_wal_usage == "none" ||
+      FLAGS_partition_wal_usage == "kNone") {
+    FLAGS_partition_wal_usage_e = ROCKSDB_NAMESPACE::PartitionWALUsage::kNone;
+  } else if (FLAGS_partition_wal_usage == "partition_by_wal_index_hash" ||
+             FLAGS_partition_wal_usage == "kPartitionByWALIndexHash") {
+    FLAGS_partition_wal_usage_e =
+        ROCKSDB_NAMESPACE::PartitionWALUsage::kPartitionByWALIndexHash;
+  } else {
+    fprintf(stderr, "Cannot parse partition_wal_usage: %s\n",
+            FLAGS_partition_wal_usage.c_str());
+    exit(1);
+  }
 
   FLAGS_compressed_secondary_cache_compression_type_e = StringToCompressionType(
       FLAGS_compressed_secondary_cache_compression_type.c_str());

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -475,6 +475,9 @@ default_params = {
     "adaptive_readahead": lambda: random.choice([0, 1]),
     "async_io": lambda: random.choice([0, 1]),
     "wal_compression": lambda: random.choice(["none", "zstd"]),
+    "partition_wal_usage": lambda: random.choice(
+        ["none", "partition_by_wal_index_hash"]
+    ),
     "verify_sst_unique_id_in_manifest": 1,  # always do unique_id verification
     "fast_sst_open": lambda: random.choice([0, 1]),
     "secondary_cache_uri": lambda: random.choice(

--- a/unreleased_history/new_features/partition_wal_usage.md
+++ b/unreleased_history/new_features/partition_wal_usage.md
@@ -1,0 +1,1 @@
+Added `DBOptions::partition_wal_usage`. When set to a value other than `kNone`, each WAL record is tagged with a monotonically increasing ordering number (wal_index) that is persisted on disk and verified on recovery to detect missing records. The default `kNone` keeps the WAL bit-for-bit compatible with the previous format for downgrade safety.


### PR DESCRIPTION
Summary:
Adds a new `DBOptions::partition_wal_usage` (`PartitionWALUsage` enum) that
controls whether each logical WAL record carries a monotonically increasing
ordering number (wal_index / LSN) persisted on disk.

- `kNone` (default) keeps the WAL bit-for-bit compatible with the previous
  format for downgrade safety.
- `kPartitionByWALIndexHash` enables the feature: `log::Writer` prepends a
  fixed64 wal_index to every logical record (starting at 1, incremented per
  `AddRecord`), and emits a leading marker record (`kWALIndexMarkerType` /
  `kRecyclableWALIndexMarkerType`, magic `WAL_LSN_V1`) that identifies the file
  as carrying wal_index. The marker type is `< 128` without the safe-ignore
  bit, so older binaries report corruption instead of misreading the file.

On the read side, `log::Reader` detects the marker, strips the wal_index from
each logical record so upper layers observe the original payload, recomputes the
per-record checksum over the stripped payload, and reports a corruption (with a
sticky gap flag) when the observed wal_index is not the expected successor. The
index survives block fragmentation, recyclable headers, and WAL compression.
The marker and file-level meta records do not consume a wal_index.

The option is parseable from an options string (both `partition_wal_usage` and
`Partition_WAL_Usage`, values `kNone`/`None` and
`kPartitionByWALIndexHash`/`partition_by_wal_index_hash`), and is wired into
`db_bench`, `db_stress`, and `db_crashtest.py`.

Differential Revision: D117410129


