### PR TITLE
Preferred-phase scheduling for periodic (time-based) compaction

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -96,6 +96,7 @@ cpp_library_wrapper(name="rocksdb_lib", srcs=[
         "db/merge_operator.cc",
         "db/multi_scan.cc",
         "db/output_validator.cc",
+        "db/periodic_compaction_phaser.cc",
         "db/periodic_task_scheduler.cc",
         "db/range_del_aggregator.cc",
         "db/range_tombstone_fragmenter.cc",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -838,6 +838,7 @@ set(SOURCES
         db/merge_operator.cc
         db/multi_scan.cc
         db/output_validator.cc
+        db/periodic_compaction_phaser.cc
         db/periodic_task_scheduler.cc
         db/range_del_aggregator.cc
         db/range_tombstone_fragmenter.cc

--- a/c_api_gen/c_generated_option_structs_auto.cc.inc
+++ b/c_api_gen/c_generated_option_structs_auto.cc.inc
@@ -866,17 +866,6 @@ uint64_t rocksdb_options_get_max_compaction_trigger_wakeup_seconds(
   return opt->rep.max_compaction_trigger_wakeup_seconds;
 }
 
-void rocksdb_options_set_compaction_schedule_seed(rocksdb_options_t* opt,
-                                                  const char* v) {
-  opt->rep.compaction_schedule_seed = v;
-}
-
-const char* rocksdb_options_get_compaction_schedule_seed(rocksdb_options_t* opt,
-                                                         size_t* size) {
-  *size = opt->rep.compaction_schedule_seed.size();
-  return opt->rep.compaction_schedule_seed.data();
-}
-
 void rocksdb_options_set_periodic_compaction_phase_recovery_percent(
     rocksdb_options_t* opt, int v) {
   opt->rep.periodic_compaction_phase_recovery_percent = v;

--- a/c_api_gen/c_generated_option_structs_auto.cc.inc
+++ b/c_api_gen/c_generated_option_structs_auto.cc.inc
@@ -866,6 +866,27 @@ uint64_t rocksdb_options_get_max_compaction_trigger_wakeup_seconds(
   return opt->rep.max_compaction_trigger_wakeup_seconds;
 }
 
+void rocksdb_options_set_compaction_schedule_seed(rocksdb_options_t* opt,
+                                                  const char* v) {
+  opt->rep.compaction_schedule_seed = v;
+}
+
+const char* rocksdb_options_get_compaction_schedule_seed(rocksdb_options_t* opt,
+                                                         size_t* size) {
+  *size = opt->rep.compaction_schedule_seed.size();
+  return opt->rep.compaction_schedule_seed.data();
+}
+
+void rocksdb_options_set_periodic_compaction_phase_recovery_percent(
+    rocksdb_options_t* opt, int v) {
+  opt->rep.periodic_compaction_phase_recovery_percent = v;
+}
+
+int rocksdb_options_get_periodic_compaction_phase_recovery_percent(
+    rocksdb_options_t* opt) {
+  return opt->rep.periodic_compaction_phase_recovery_percent;
+}
+
 void rocksdb_options_set_follower_refresh_catchup_period_ms(
     rocksdb_options_t* opt, uint64_t v) {
   opt->rep.follower_refresh_catchup_period_ms = v;

--- a/c_api_gen/c_generated_option_structs_auto.h.inc
+++ b/c_api_gen/c_generated_option_structs_auto.h.inc
@@ -274,13 +274,6 @@ extern ROCKSDB_LIBRARY_API const char*
 rocksdb_options_get_daily_offpeak_time_utc(rocksdb_options_t* opt,
                                            size_t* size);
 
-extern ROCKSDB_LIBRARY_API void rocksdb_options_set_compaction_schedule_seed(
-    rocksdb_options_t* opt, const char* v);
-
-extern ROCKSDB_LIBRARY_API const char*
-rocksdb_options_get_compaction_schedule_seed(rocksdb_options_t* opt,
-                                             size_t* size);
-
 extern ROCKSDB_LIBRARY_API void
 rocksdb_options_set_periodic_compaction_phase_recovery_percent(
     rocksdb_options_t* opt, int v);

--- a/c_api_gen/c_generated_option_structs_auto.h.inc
+++ b/c_api_gen/c_generated_option_structs_auto.h.inc
@@ -274,6 +274,21 @@ extern ROCKSDB_LIBRARY_API const char*
 rocksdb_options_get_daily_offpeak_time_utc(rocksdb_options_t* opt,
                                            size_t* size);
 
+extern ROCKSDB_LIBRARY_API void rocksdb_options_set_compaction_schedule_seed(
+    rocksdb_options_t* opt, const char* v);
+
+extern ROCKSDB_LIBRARY_API const char*
+rocksdb_options_get_compaction_schedule_seed(rocksdb_options_t* opt,
+                                             size_t* size);
+
+extern ROCKSDB_LIBRARY_API void
+rocksdb_options_set_periodic_compaction_phase_recovery_percent(
+    rocksdb_options_t* opt, int v);
+
+extern ROCKSDB_LIBRARY_API int
+rocksdb_options_get_periodic_compaction_phase_recovery_percent(
+    rocksdb_options_t* opt);
+
 extern ROCKSDB_LIBRARY_API void
 rocksdb_options_set_follower_refresh_catchup_period_ms(rocksdb_options_t* opt,
                                                        uint64_t v);

--- a/c_api_gen/c_generated_roundtrip_tests.c.inc
+++ b/c_api_gen/c_generated_roundtrip_tests.c.inc
@@ -673,6 +673,13 @@ static void rocksdb_roundtrip_test_rocksdb_options(void) {
   CheckCondition(rocksdb_options_get_cf_allow_ingest_behind(obj) == 1);
   rocksdb_options_set_cf_allow_ingest_behind(obj, 0);
   CheckCondition(rocksdb_options_get_cf_allow_ingest_behind(obj) == 0);
+  rocksdb_options_set_compaction_schedule_seed(obj, "test");
+  {
+    size_t rt_len = 0;
+    const char* rt_v =
+        rocksdb_options_get_compaction_schedule_seed(obj, &rt_len);
+    CheckCondition(rt_len == 4 && rt_v != NULL && memcmp(rt_v, "test", 4) == 0);
+  }
   rocksdb_options_set_compaction_verify_record_count(obj, 1);
   CheckCondition(rocksdb_options_get_compaction_verify_record_count(obj) == 1);
   rocksdb_options_set_compaction_verify_record_count(obj, 0);
@@ -839,6 +846,12 @@ static void rocksdb_roundtrip_test_rocksdb_options(void) {
   CheckCondition(rocksdb_options_get_paranoid_memory_checks(obj) == 1);
   rocksdb_options_set_paranoid_memory_checks(obj, 0);
   CheckCondition(rocksdb_options_get_paranoid_memory_checks(obj) == 0);
+  rocksdb_options_set_periodic_compaction_phase_recovery_percent(obj, 1);
+  CheckCondition(
+      rocksdb_options_get_periodic_compaction_phase_recovery_percent(obj) == 1);
+  rocksdb_options_set_periodic_compaction_phase_recovery_percent(obj, 0);
+  CheckCondition(
+      rocksdb_options_get_periodic_compaction_phase_recovery_percent(obj) == 0);
   rocksdb_options_set_persist_stats_to_disk(obj, 1);
   CheckCondition(rocksdb_options_get_persist_stats_to_disk(obj) == 1);
   rocksdb_options_set_persist_stats_to_disk(obj, 0);

--- a/c_api_gen/c_generated_roundtrip_tests.c.inc
+++ b/c_api_gen/c_generated_roundtrip_tests.c.inc
@@ -673,13 +673,6 @@ static void rocksdb_roundtrip_test_rocksdb_options(void) {
   CheckCondition(rocksdb_options_get_cf_allow_ingest_behind(obj) == 1);
   rocksdb_options_set_cf_allow_ingest_behind(obj, 0);
   CheckCondition(rocksdb_options_get_cf_allow_ingest_behind(obj) == 0);
-  rocksdb_options_set_compaction_schedule_seed(obj, "test");
-  {
-    size_t rt_len = 0;
-    const char* rt_v =
-        rocksdb_options_get_compaction_schedule_seed(obj, &rt_len);
-    CheckCondition(rt_len == 4 && rt_v != NULL && memcmp(rt_v, "test", 4) == 0);
-  }
   rocksdb_options_set_compaction_verify_record_count(obj, 1);
   CheckCondition(rocksdb_options_get_compaction_verify_record_count(obj) == 1);
   rocksdb_options_set_compaction_verify_record_count(obj, 0);

--- a/db/c.cc
+++ b/db/c.cc
@@ -9933,6 +9933,27 @@ uint64_t rocksdb_options_get_max_compaction_trigger_wakeup_seconds(
   return opt->rep.max_compaction_trigger_wakeup_seconds;
 }
 
+void rocksdb_options_set_compaction_schedule_seed(rocksdb_options_t* opt,
+                                                  const char* v) {
+  opt->rep.compaction_schedule_seed = v;
+}
+
+const char* rocksdb_options_get_compaction_schedule_seed(rocksdb_options_t* opt,
+                                                         size_t* size) {
+  *size = opt->rep.compaction_schedule_seed.size();
+  return opt->rep.compaction_schedule_seed.data();
+}
+
+void rocksdb_options_set_periodic_compaction_phase_recovery_percent(
+    rocksdb_options_t* opt, int v) {
+  opt->rep.periodic_compaction_phase_recovery_percent = v;
+}
+
+int rocksdb_options_get_periodic_compaction_phase_recovery_percent(
+    rocksdb_options_t* opt) {
+  return opt->rep.periodic_compaction_phase_recovery_percent;
+}
+
 void rocksdb_options_set_follower_refresh_catchup_period_ms(
     rocksdb_options_t* opt, uint64_t v) {
   opt->rep.follower_refresh_catchup_period_ms = v;

--- a/db/c.cc
+++ b/db/c.cc
@@ -9933,17 +9933,6 @@ uint64_t rocksdb_options_get_max_compaction_trigger_wakeup_seconds(
   return opt->rep.max_compaction_trigger_wakeup_seconds;
 }
 
-void rocksdb_options_set_compaction_schedule_seed(rocksdb_options_t* opt,
-                                                  const char* v) {
-  opt->rep.compaction_schedule_seed = v;
-}
-
-const char* rocksdb_options_get_compaction_schedule_seed(rocksdb_options_t* opt,
-                                                         size_t* size) {
-  *size = opt->rep.compaction_schedule_seed.size();
-  return opt->rep.compaction_schedule_seed.data();
-}
-
 void rocksdb_options_set_periodic_compaction_phase_recovery_percent(
     rocksdb_options_t* opt, int v) {
   opt->rep.periodic_compaction_phase_recovery_percent = v;

--- a/db/compaction/compaction_picker_test.cc
+++ b/db/compaction/compaction_picker_test.cc
@@ -90,7 +90,8 @@ class CompactionPickerTestBase : public testing::Test {
         &icmp_, ucmp_, options_.num_levels, style, nullptr, false,
         EpochNumberRequirement::kMustPresent, ioptions_.clock,
         options_.bottommost_file_compaction_delay,
-        OffpeakTimeOption(mutable_db_options_.daily_offpeak_time_utc)));
+        OffpeakTimeOption(mutable_db_options_.daily_offpeak_time_utc),
+        PeriodicCompactionPhaseParams{}));
     vstorage_->PrepareForVersionAppend(ioptions_, mutable_cf_options_);
   }
 
@@ -101,7 +102,8 @@ class CompactionPickerTestBase : public testing::Test {
         &icmp_, ucmp_, options_.num_levels, ioptions_.compaction_style,
         vstorage_.get(), false, EpochNumberRequirement::kMustPresent,
         ioptions_.clock, options_.bottommost_file_compaction_delay,
-        OffpeakTimeOption(mutable_db_options_.daily_offpeak_time_utc)));
+        OffpeakTimeOption(mutable_db_options_.daily_offpeak_time_utc),
+        PeriodicCompactionPhaseParams{}));
   }
 
   void DeleteVersionStorage() {

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -5585,8 +5585,7 @@ TEST_F(DBCompactionTest, LevelPeriodicCompaction) {
 TEST_F(DBCompactionTest, PeriodicCompactionPhaseTriggerTime) {
   // Unit-tests PeriodicCompactionPhaser::TriggerTime, the core of
   // preferred-phase periodic compaction (see
-  // DBOptions::compaction_schedule_seed /
-  // periodic_compaction_phase_recovery_percent).
+  // DBOptions::periodic_compaction_phase_recovery_percent).
   using Params = PeriodicCompactionPhaseParams;
   const uint64_t kN = 1000;  // periodic_compaction_seconds
 
@@ -5690,80 +5689,20 @@ TEST_F(DBCompactionTest, PeriodicCompactionPhaseTriggerTime) {
   }
 }
 
-TEST_F(DBCompactionTest, PeriodicCompactionPhaseExplicitSeed) {
-  // Unit-tests VersionStorageInfo::TryParseExplicitPhaseSeed -- the explicit
-  // phase-position form of DBOptions::compaction_schedule_seed, where a value
-  // "0.<digits>" is a fraction in [0, 1) used directly as the preferred phase.
-  using VSI = PeriodicCompactionPhaser;
-
-  // Rejected forms (fall through to the normal token/hash seed path) must
-  // return false and leave the out-param untouched. Covers a bare "0.",
-  // missing/extra dots, signs, scientific notation, trailing junk/space, and
-  // normal seeds.
-  for (const char* bad :
-       {"",     "0",         "0.",          ".5",         "1.5",  "00.5",
-        "00.0", "0.5e2",     "0.5E2",       "0.5e-1",     "0.5f", "0.5 ",
-        " 0.5", "-0.5",      "+0.5",        "0.5.5",      "0.-5", "0..5",
-        "0x.5", "__db_id__", "__db_name__", "custom_seed"}) {
-    uint64_t h = 0xABCDu;
-    ASSERT_FALSE(VSI::TryParseExplicitPhaseSeed(bad, &h))
-        << "should reject: '" << bad << "'";
-    ASSERT_EQ(h, uint64_t{0xABCDu});  // untouched on rejection
-  }
-
-  // Accepted forms map to phase == floor(fraction * n) for any interval n. The
-  // integer method is exact; the <=1 tolerance is only for the double reference
-  // `want` (float rounding of frac*n), not the method itself.
-  struct Case {
-    const char* seed;
-    double frac;
-  };
-  const std::vector<Case> cases = {
-      {"0.0", 0.0},     {"0.5", 0.5},   {"0.25", 0.25},
-      {"0.75", 0.75},   {"0.1", 0.1},   {"0.333", 0.333},
-      {"0.999", 0.999}, {"0.500", 0.5}, {"0.05", 0.05}};
-  for (const Case& c : cases) {
-    uint64_t seed_hash = 0;
-    ASSERT_TRUE(VSI::TryParseExplicitPhaseSeed(c.seed, &seed_hash))
-        << "should accept: '" << c.seed << "'";
-    for (uint64_t n :
-         {uint64_t{100}, uint64_t{1000}, uint64_t{86400}, uint64_t{604800}}) {
-      const uint64_t got = FastRange64(seed_hash, n);
-      const uint64_t want = static_cast<uint64_t>(c.frac * n);
-      ASSERT_LT(got, n);
-      const uint64_t diff = got > want ? got - want : want - got;
-      ASSERT_LE(diff, uint64_t{1}) << "seed=" << c.seed << " n=" << n
-                                   << " got=" << got << " want=" << want;
-    }
-  }
-
-  // With the +1 rounding, clean fractions map to their exact phase.
-  const uint64_t kN = 1000;
-  uint64_t h00 = 0, h25 = 0, h50 = 0, h75 = 0;
-  ASSERT_TRUE(VSI::TryParseExplicitPhaseSeed("0.0", &h00));
-  ASSERT_TRUE(VSI::TryParseExplicitPhaseSeed("0.25", &h25));
-  ASSERT_TRUE(VSI::TryParseExplicitPhaseSeed("0.5", &h50));
-  ASSERT_TRUE(VSI::TryParseExplicitPhaseSeed("0.75", &h75));
-  ASSERT_EQ(FastRange64(h00, kN), uint64_t{0});
-  ASSERT_EQ(FastRange64(h25, kN), uint64_t{250});
-  ASSERT_EQ(FastRange64(h50, kN), uint64_t{500});
-  ASSERT_EQ(FastRange64(h75, kN), uint64_t{750});
-}
-
 TEST_F(DBCompactionTest, PeriodicCompactionPhaseCfSpread) {
-  // Unit-tests VersionStorageInfo::CfPhaseSeedHash: a DB's column families are
-  // spread quasi-uniformly around the DB base phase via the golden-ratio
-  // recurrence, for any base (hashed or explicit) and any number of CFs.
-  using VSI = PeriodicCompactionPhaser;
+  // Unit-tests PeriodicCompactionPhaser::CfPhaseSeedHash: a DB's column
+  // families are spread quasi-uniformly around the DB base phase via the
+  // golden-ratio recurrence, for any base and any number of CFs.
+  using Phaser = PeriodicCompactionPhaser;
 
   // cf_id 0 leaves the base phase unchanged; distinct cf_ids -> distinct
   // phases.
   for (uint64_t base : {uint64_t{0}, uint64_t{0x9e3779b97f4a7c15ULL},
                         uint64_t{12345678901234567ULL}, ~uint64_t{0}}) {
-    ASSERT_EQ(VSI::CfPhaseSeedHash(base, 0), base);
+    ASSERT_EQ(Phaser::CfPhaseSeedHash(base, 0), base);
     std::vector<uint64_t> hs;
     for (uint32_t id = 0; id < 64; ++id) {
-      hs.push_back(VSI::CfPhaseSeedHash(base, id));
+      hs.push_back(Phaser::CfPhaseSeedHash(base, id));
     }
     std::sort(hs.begin(), hs.end());
     for (size_t i = 1; i < hs.size(); ++i) {
@@ -5778,7 +5717,7 @@ TEST_F(DBCompactionTest, PeriodicCompactionPhaseCfSpread) {
       const uint64_t n = 100000;
       std::vector<uint64_t> phases;
       for (uint32_t id = 0; id < N; ++id) {
-        phases.push_back(FastRange64(VSI::CfPhaseSeedHash(base, id), n));
+        phases.push_back(FastRange64(Phaser::CfPhaseSeedHash(base, id), n));
       }
       std::sort(phases.begin(), phases.end());
       uint64_t max_gap = n - phases.back() + phases.front();  // wrap-around gap
@@ -5792,19 +5731,16 @@ TEST_F(DBCompactionTest, PeriodicCompactionPhaseCfSpread) {
 }
 
 TEST_F(DBCompactionTest, PeriodicCompactionPhaseOptions) {
-  // Verifies the two DB options are plumbed and dynamically settable.
+  // Verifies periodic_compaction_phase_recovery_percent is plumbed and
+  // dynamically settable.
   Options options = CurrentOptions();
-  options.compaction_schedule_seed = "__db_id__";
   options.periodic_compaction_phase_recovery_percent = 25;
   DestroyAndReopen(options);
-  ASSERT_EQ(dbfull()->GetDBOptions().compaction_schedule_seed, "__db_id__");
   ASSERT_EQ(dbfull()->GetDBOptions().periodic_compaction_phase_recovery_percent,
             25);
 
   ASSERT_OK(dbfull()->SetDBOptions(
-      {{"compaction_schedule_seed", "custom_seed"},
-       {"periodic_compaction_phase_recovery_percent", "0"}}));
-  ASSERT_EQ(dbfull()->GetDBOptions().compaction_schedule_seed, "custom_seed");
+      {{"periodic_compaction_phase_recovery_percent", "0"}}));
   ASSERT_EQ(dbfull()->GetDBOptions().periodic_compaction_phase_recovery_percent,
             0);
 }

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -14,6 +14,7 @@
 #include "db/blob/blob_index.h"
 #include "db/db_test_util.h"
 #include "db/dbformat.h"
+#include "db/periodic_compaction_phaser.h"
 #include "db/table_cache.h"
 #include "env/mock_env.h"
 #include "file/filename.h"
@@ -29,6 +30,8 @@
 #include "test_util/sync_point.h"
 #include "test_util/testutil.h"
 #include "util/concurrent_task_limiter_impl.h"
+#include "util/fastrange.h"
+#include "util/hash.h"
 #include "util/random.h"
 #include "utilities/fault_injection_env.h"
 #include "utilities/fault_injection_fs.h"
@@ -5483,6 +5486,7 @@ TEST_F(DBCompactionTest, LevelPeriodicCompaction) {
     for (bool if_open_all_files : {false, true}) {
       Options options = CurrentOptions();
       options.periodic_compaction_seconds = 48 * 60 * 60;  // 2 days
+      options.periodic_compaction_phase_recovery_percent = 0;
       if (if_open_all_files) {
         options.max_open_files = -1;  // needed for ttl compaction
       } else {
@@ -5578,6 +5582,233 @@ TEST_F(DBCompactionTest, LevelPeriodicCompaction) {
   }
 }
 
+TEST_F(DBCompactionTest, PeriodicCompactionPhaseTriggerTime) {
+  // Unit-tests PeriodicCompactionPhaser::TriggerTime, the core of
+  // preferred-phase periodic compaction (see
+  // DBOptions::compaction_schedule_seed /
+  // periodic_compaction_phase_recovery_percent).
+  using Params = PeriodicCompactionPhaseParams;
+  const uint64_t kN = 1000;  // periodic_compaction_seconds
+
+  // The trigger-time helper treats seed_hash as an opaque value; use a fixed
+  // constant and derive the resulting preferred-phase target the same way
+  // production does (FastRange64 of the seed over the interval).
+  const uint64_t kSeed = 0x9e3779b97f4a7c15ULL;
+  const uint64_t target = FastRange64(kSeed, kN);
+  ASSERT_LT(target, kN);
+
+  // recovery_percent == 0 => classic behavior: trigger at file_mod + N.
+  {
+    Params p;
+    p.seed_hash = kSeed;
+    p.recovery_percent = 0;
+    for (uint64_t fm : {uint64_t{1}, uint64_t{7}, uint64_t{12345}}) {
+      ASSERT_EQ(PeriodicCompactionPhaser::TriggerTime(fm, kN, p), fm + kN);
+    }
+  }
+
+  // Steady state (anchor in the distant past): trigger is pulled earlier by
+  // recovery_percent% of the phase offset, and never later than the deadline.
+  {
+    Params p;
+    p.seed_hash = kSeed;
+    p.recovery_percent = 50;
+    p.anchor_time = 0;
+    const uint64_t fm = 500;
+    const uint64_t natural = fm + kN;
+    const uint64_t offset = (fm % kN + kN - target) % kN;
+    const uint64_t expected = natural - offset * 50 / 100;
+    ASSERT_EQ(PeriodicCompactionPhaser::TriggerTime(fm, kN, p), expected);
+    ASSERT_LE(expected, natural);
+  }
+
+  // Geometric convergence: repeatedly re-stamp the file at its trigger time and
+  // confirm the phase error is non-increasing and converges to (near) zero.
+  for (int recovery_percent : {50, 100}) {
+    Params p;
+    p.seed_hash = kSeed;
+    p.recovery_percent = recovery_percent;
+    p.anchor_time = 0;
+    uint64_t fm = 123;
+    uint64_t prev_error = kN;
+    for (int cycle = 0; cycle < 64; ++cycle) {
+      const uint64_t trig = PeriodicCompactionPhaser::TriggerTime(fm, kN, p);
+      ASSERT_LE(trig, fm + kN);  // never later than the deadline
+      const uint64_t error = (trig % kN + kN - target) % kN;
+      ASSERT_LE(error, prev_error);
+      prev_error = error;
+      fm = trig;
+    }
+    // rp=100 pulls the whole gap so it reaches the phase exactly; smaller rates
+    // decay geometrically and leave a tiny integer-rounding residue.
+    if (recovery_percent == 100) {
+      ASSERT_EQ(prev_error, uint64_t{0});
+    } else {
+      ASSERT_LE(prev_error, uint64_t{1});
+    }
+  }
+
+  // Already past the hard deadline when phasing took effect (e.g. the DB was
+  // down, or periodic_compaction_seconds was turned down): instead of firing
+  // the whole cohort immediately, spread it over the first quarter-period after
+  // the anchor on an absolute (epoch-aligned) grid of period N/4.
+  {
+    Params p;
+    p.seed_hash = kSeed;
+    p.recovery_percent = 50;
+    p.anchor_time = 200;
+    const uint64_t n = 100;
+    const uint64_t grid = n / 4;  // 25
+    const uint64_t phase = FastRange64(kSeed, grid);
+    // natural deadline (10 + 100 = 110) is before the anchor (200).
+    const uint64_t expected = 200 + (phase + grid - 200 % grid) % grid;
+    const uint64_t trig = PeriodicCompactionPhaser::TriggerTime(10, n, p);
+    ASSERT_EQ(trig, expected);
+    ASSERT_GE(trig, uint64_t{200});  // never before the anchor
+    ASSERT_LT(trig, 200 + grid);     // within N/4 of the anchor
+  }
+
+  // Past due against the recovery target but not yet at the deadline => spread
+  // across [anchor, deadline] using the phase; never later than the deadline.
+  {
+    const uint64_t n = 100;
+    const uint64_t small_target = FastRange64(kSeed, n);
+    const uint64_t fm = small_target + 50 + 3 * n;  // phase offset == 50
+    const uint64_t natural = fm + n;
+    const uint64_t anchor =
+        natural - 25;  // recovery target (natural-50) < anchor
+    Params p;
+    p.seed_hash = kSeed;
+    p.recovery_percent = 100;
+    p.anchor_time = anchor;
+    ASSERT_EQ((fm % n + n - small_target) % n, uint64_t{50});
+    const uint64_t expected = anchor + FastRange64(kSeed, natural - anchor);
+    const uint64_t trig = PeriodicCompactionPhaser::TriggerTime(fm, n, p);
+    ASSERT_EQ(trig, expected);
+    ASSERT_GE(trig, anchor);
+    ASSERT_LT(trig, natural);
+  }
+}
+
+TEST_F(DBCompactionTest, PeriodicCompactionPhaseExplicitSeed) {
+  // Unit-tests VersionStorageInfo::TryParseExplicitPhaseSeed -- the explicit
+  // phase-position form of DBOptions::compaction_schedule_seed, where a value
+  // "0.<digits>" is a fraction in [0, 1) used directly as the preferred phase.
+  using VSI = PeriodicCompactionPhaser;
+
+  // Rejected forms (fall through to the normal token/hash seed path) must
+  // return false and leave the out-param untouched. Covers a bare "0.",
+  // missing/extra dots, signs, scientific notation, trailing junk/space, and
+  // normal seeds.
+  for (const char* bad :
+       {"",     "0",         "0.",          ".5",         "1.5",  "00.5",
+        "00.0", "0.5e2",     "0.5E2",       "0.5e-1",     "0.5f", "0.5 ",
+        " 0.5", "-0.5",      "+0.5",        "0.5.5",      "0.-5", "0..5",
+        "0x.5", "__db_id__", "__db_name__", "custom_seed"}) {
+    uint64_t h = 0xABCDu;
+    ASSERT_FALSE(VSI::TryParseExplicitPhaseSeed(bad, &h))
+        << "should reject: '" << bad << "'";
+    ASSERT_EQ(h, uint64_t{0xABCDu});  // untouched on rejection
+  }
+
+  // Accepted forms map to phase == floor(fraction * n) for any interval n. The
+  // integer method is exact; the <=1 tolerance is only for the double reference
+  // `want` (float rounding of frac*n), not the method itself.
+  struct Case {
+    const char* seed;
+    double frac;
+  };
+  const std::vector<Case> cases = {
+      {"0.0", 0.0},     {"0.5", 0.5},   {"0.25", 0.25},
+      {"0.75", 0.75},   {"0.1", 0.1},   {"0.333", 0.333},
+      {"0.999", 0.999}, {"0.500", 0.5}, {"0.05", 0.05}};
+  for (const Case& c : cases) {
+    uint64_t seed_hash = 0;
+    ASSERT_TRUE(VSI::TryParseExplicitPhaseSeed(c.seed, &seed_hash))
+        << "should accept: '" << c.seed << "'";
+    for (uint64_t n :
+         {uint64_t{100}, uint64_t{1000}, uint64_t{86400}, uint64_t{604800}}) {
+      const uint64_t got = FastRange64(seed_hash, n);
+      const uint64_t want = static_cast<uint64_t>(c.frac * n);
+      ASSERT_LT(got, n);
+      const uint64_t diff = got > want ? got - want : want - got;
+      ASSERT_LE(diff, uint64_t{1}) << "seed=" << c.seed << " n=" << n
+                                   << " got=" << got << " want=" << want;
+    }
+  }
+
+  // With the +1 rounding, clean fractions map to their exact phase.
+  const uint64_t kN = 1000;
+  uint64_t h00 = 0, h25 = 0, h50 = 0, h75 = 0;
+  ASSERT_TRUE(VSI::TryParseExplicitPhaseSeed("0.0", &h00));
+  ASSERT_TRUE(VSI::TryParseExplicitPhaseSeed("0.25", &h25));
+  ASSERT_TRUE(VSI::TryParseExplicitPhaseSeed("0.5", &h50));
+  ASSERT_TRUE(VSI::TryParseExplicitPhaseSeed("0.75", &h75));
+  ASSERT_EQ(FastRange64(h00, kN), uint64_t{0});
+  ASSERT_EQ(FastRange64(h25, kN), uint64_t{250});
+  ASSERT_EQ(FastRange64(h50, kN), uint64_t{500});
+  ASSERT_EQ(FastRange64(h75, kN), uint64_t{750});
+}
+
+TEST_F(DBCompactionTest, PeriodicCompactionPhaseCfSpread) {
+  // Unit-tests VersionStorageInfo::CfPhaseSeedHash: a DB's column families are
+  // spread quasi-uniformly around the DB base phase via the golden-ratio
+  // recurrence, for any base (hashed or explicit) and any number of CFs.
+  using VSI = PeriodicCompactionPhaser;
+
+  // cf_id 0 leaves the base phase unchanged; distinct cf_ids -> distinct
+  // phases.
+  for (uint64_t base : {uint64_t{0}, uint64_t{0x9e3779b97f4a7c15ULL},
+                        uint64_t{12345678901234567ULL}, ~uint64_t{0}}) {
+    ASSERT_EQ(VSI::CfPhaseSeedHash(base, 0), base);
+    std::vector<uint64_t> hs;
+    for (uint32_t id = 0; id < 64; ++id) {
+      hs.push_back(VSI::CfPhaseSeedHash(base, id));
+    }
+    std::sort(hs.begin(), hs.end());
+    for (size_t i = 1; i < hs.size(); ++i) {
+      ASSERT_NE(hs[i], hs[i - 1]) << "duplicate CF phase seed at base=" << base;
+    }
+  }
+
+  // Low-discrepancy: for N CFs the phases over an interval are well spread --
+  // no gap larger than ~2x the average (a hash would allow chance clustering).
+  for (uint64_t base : {uint64_t{0}, uint64_t{0xdeadbeefcafef00dULL}}) {
+    for (uint32_t N : {uint32_t{3}, uint32_t{8}, uint32_t{16}, uint32_t{40}}) {
+      const uint64_t n = 100000;
+      std::vector<uint64_t> phases;
+      for (uint32_t id = 0; id < N; ++id) {
+        phases.push_back(FastRange64(VSI::CfPhaseSeedHash(base, id), n));
+      }
+      std::sort(phases.begin(), phases.end());
+      uint64_t max_gap = n - phases.back() + phases.front();  // wrap-around gap
+      for (size_t i = 1; i < phases.size(); ++i) {
+        max_gap = std::max(max_gap, phases[i] - phases[i - 1]);
+      }
+      ASSERT_LE(max_gap, 2 * (n / N))
+          << "base=" << base << " N=" << N << " max_gap=" << max_gap;
+    }
+  }
+}
+
+TEST_F(DBCompactionTest, PeriodicCompactionPhaseOptions) {
+  // Verifies the two DB options are plumbed and dynamically settable.
+  Options options = CurrentOptions();
+  options.compaction_schedule_seed = "__db_id__";
+  options.periodic_compaction_phase_recovery_percent = 25;
+  DestroyAndReopen(options);
+  ASSERT_EQ(dbfull()->GetDBOptions().compaction_schedule_seed, "__db_id__");
+  ASSERT_EQ(dbfull()->GetDBOptions().periodic_compaction_phase_recovery_percent,
+            25);
+
+  ASSERT_OK(dbfull()->SetDBOptions(
+      {{"compaction_schedule_seed", "custom_seed"},
+       {"periodic_compaction_phase_recovery_percent", "0"}}));
+  ASSERT_EQ(dbfull()->GetDBOptions().compaction_schedule_seed, "custom_seed");
+  ASSERT_EQ(dbfull()->GetDBOptions().periodic_compaction_phase_recovery_percent,
+            0);
+}
+
 TEST_F(DBCompactionTest, LevelPeriodicCompactionOffpeak) {
   // This test simply checks if offpeak adjustment works in Leveled
   // Compactions. For testing offpeak periodic compactions in various
@@ -5595,6 +5826,7 @@ TEST_F(DBCompactionTest, LevelPeriodicCompactionOffpeak) {
     Options options = CurrentOptions();
     options.ttl = 0;
     options.periodic_compaction_seconds = 5 * kSecondsPerDay;  // 5 days
+    options.periodic_compaction_phase_recovery_percent = 0;
     // In the case where all files are opened and doing DB restart
     // forcing the file creation time in manifest file to be 0 to
     // simulate the case of reading from an old version.
@@ -5742,6 +5974,7 @@ TEST_F(DBCompactionTest, LevelPeriodicCompactionWithOldDB) {
   // Forward the clock by 2 days.
   env_->MockSleepForSeconds(2 * 24 * 60 * 60);
   options.periodic_compaction_seconds = 1 * 24 * 60 * 60;  // 1 day
+  options.periodic_compaction_phase_recovery_percent = 0;
 
   Reopen(options);
   ASSERT_OK(dbfull()->TEST_WaitForCompact());
@@ -5760,6 +5993,7 @@ TEST_F(DBCompactionTest, LevelPeriodicAndTtlCompaction) {
   Options options = CurrentOptions();
   options.ttl = 10 * 60 * 60;                          // 10 hours
   options.periodic_compaction_seconds = 48 * 60 * 60;  // 2 days
+  options.periodic_compaction_phase_recovery_percent = 0;
   options.max_open_files = -1;  // needed for both periodic and ttl compactions
   env_->SetMockSleep();
   options.env = env_;
@@ -5842,6 +6076,7 @@ TEST_F(DBCompactionTest, LevelTtlBooster) {
   Options options = CurrentOptions();
   options.ttl = 10 * 60 * 60;                           // 10 hours
   options.periodic_compaction_seconds = 480 * 60 * 60;  // very long
+  options.periodic_compaction_phase_recovery_percent = 0;
   options.level0_file_num_compaction_trigger = 2;
   options.max_bytes_for_level_base = 5 * uint64_t{kNumKeysPerFile * kValueSize};
   options.max_open_files = -1;  // needed for both periodic and ttl compactions
@@ -12391,6 +12626,7 @@ TEST_F(DBCompactionTest, PeriodicTask) {
   options.statistics = CreateDBStatistics();
   int kPeriodicCompactionSeconds = 7 * 24 * 60 * 60;  // 1 week
   options.periodic_compaction_seconds = kPeriodicCompactionSeconds;
+  options.periodic_compaction_phase_recovery_percent = 0;
   options.num_levels = 50;
   auto listener = std::make_shared<PeriodicCompactionListener>();
   options.listeners.push_back(listener);

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -1677,6 +1677,21 @@ Status DBImpl::SetOptions(
     VersionEdit dummy_edit;
     dummy_edit.MarkNoManifestWriteDummy();
     TEST_SYNC_POINT_CALLBACK("DBImpl::SetOptions:dummy_edit", &dummy_edit);
+    // If any CF is changing periodic_compaction_seconds, (re)anchor phasing to
+    // now BEFORE the new Version is built below, so the new Version's scoring
+    // spreads a turn-down's newly past-due cohort over the phase grid (within
+    // ~N/4 of now) instead of firing it all at once (a herd). Anchoring is
+    // DB-level and benign to CFs that are not changing their interval.
+    bool changing_periodic_compaction_seconds = false;
+    for (const auto& cfd_opts : column_family_datas) {
+      if (cfd_opts.second->count("periodic_compaction_seconds") > 0) {
+        changing_periodic_compaction_seconds = true;
+        break;
+      }
+    }
+    if (changing_periodic_compaction_seconds) {
+      versions_->ReanchorCompactionPhase();
+    }
     for (const auto& cfd_opts : column_family_datas) {
       auto* cfd = cfd_opts.first;
       const auto* options_map_ptr = cfd_opts.second;

--- a/db/import_column_family_job.cc
+++ b/db/import_column_family_job.cc
@@ -196,7 +196,8 @@ Status ImportColumnFamilyJob::Run() {
         nullptr /* src_vstorage */, cfd_->ioptions().force_consistency_checks,
         EpochNumberRequirement::kMightMissing, cfd_->ioptions().clock,
         cfd_->GetLatestMutableCFOptions().bottommost_file_compaction_delay,
-        cfd_->current()->version_set()->offpeak_time_option());
+        cfd_->current()->version_set()->offpeak_time_option(),
+        PeriodicCompactionPhaseParams{});
     for (size_t j = 0; s.ok() && j < files_to_import_[i].size(); ++j) {
       const auto& f = files_to_import_[i][j];
       const auto& file_metadata = *metadatas_[i][j];

--- a/db/periodic_compaction_phaser.cc
+++ b/db/periodic_compaction_phaser.cc
@@ -1,0 +1,164 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include "db/periodic_compaction_phaser.h"
+
+#include <algorithm>
+
+#include "rocksdb/options.h"  // kDbNameForScheduleSeed / kDbIdForScheduleSeed
+#include "util/fastrange.h"
+#include "util/hash.h"
+#include "util/math128.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+bool PeriodicCompactionPhaser::SetConfig(const std::string& seed,
+                                         int recovery_percent) {
+  const bool changed = seed != seed_ || recovery_percent != recovery_percent_;
+  seed_ = seed;
+  recovery_percent_ = recovery_percent;
+  return changed;
+}
+
+PeriodicCompactionPhaseParams PeriodicCompactionPhaser::ParamsForCf(
+    uint32_t cf_id) const {
+  PeriodicCompactionPhaseParams params;
+  if (recovery_percent_ <= 0) {
+    // Phasing disabled; return default (disabled) params.
+    return params;
+  }
+  // Resolve the DB-level base phase (a fixed-point fraction * 2^64).
+  uint64_t db_base_phase = 0;
+  if (!TryParseExplicitPhaseSeed(seed_, &db_base_phase)) {
+    // Not an explicit "0.<frac>" base: hash the seed, applying whole-value
+    // token substitution (mirrors db_host_id / kHostnameForDbHostId). db_id_ is
+    // read live so the default "__db_id__" resolves against the current
+    // identity.
+    const std::string* resolved = &seed_;
+    if (seed_ == kDbNameForScheduleSeed) {
+      resolved = &dbname_;
+    } else if (seed_ == kDbIdForScheduleSeed) {
+      resolved = &db_id_;
+    }
+    db_base_phase = Hash64(resolved->data(), resolved->size());
+  }
+  // Spread this CF quasi-uniformly around the DB base phase (golden ratio), so
+  // the DB-level seed is meaningful however it is set (hashed or an explicit
+  // base) and CFs of one DB do not share a phase.
+  params.seed_hash = CfPhaseSeedHash(db_base_phase, cf_id);
+  params.anchor_time = anchor_time_;
+  params.recovery_percent = std::min(recovery_percent_, 100);
+  return params;
+}
+
+uint64_t PeriodicCompactionPhaser::TriggerTime(
+    uint64_t file_modification_time, uint64_t periodic_compaction_seconds,
+    const PeriodicCompactionPhaseParams& params) {
+  const uint64_t n = periodic_compaction_seconds;
+  // Unphased deadline: file age reaches periodic_compaction_seconds. This is a
+  // hard upper bound on age; phasing only ever triggers earlier.
+  const uint64_t natural_trigger = file_modification_time + n;
+  const int recovery_percent = params.recovery_percent;
+  if (recovery_percent <= 0 || n == 0) {
+    return natural_trigger;
+  }
+  // Preferred-phase time within each period, floor(p*n) with p == seed / 2^64.
+  const uint64_t target = FastRange64(params.seed_hash, n);
+  // Distance (in [0, n)) from the natural deadline back to the nearest
+  // preferred-phase time at or before it.
+  const uint64_t offset = (file_modification_time % n + n - target) % n;
+  // Close recovery_percent% of that gap, triggering earlier. Over successive
+  // re-stamped cycles the phase error decays geometrically toward the phase.
+  // (A "snap to the exact phase" refinement was considered and rejected: under
+  // unpredictable scheduling/queueing latency -- the delay between a file
+  // becoming due and its periodic compaction actually running -- a snap can
+  // split the fleet between the phase and a latency-induced fixed point
+  // (re-herding, the opposite of the goal), whereas the plain geometric pull
+  // degrades gracefully to a uniform, still well-spread shift.)
+  const uint64_t early_pull =
+      offset * static_cast<uint64_t>(std::min(recovery_percent, 100)) / 100;
+  const uint64_t recovery_trigger = natural_trigger - early_pull;
+  const uint64_t anchor = params.anchor_time;
+  if (natural_trigger <= anchor) {
+    // A whole cohort can be past its deadline when phasing took effect: after
+    // the DB was down (e.g. DC power-outage recovery) or after
+    // periodic_compaction_seconds was turned down. Instead of firing the cohort
+    // immediately (a herd), spread it over the first quarter-period after the
+    // anchor, on an absolute (epoch-aligned) grid of period n/4 with a stable
+    // per-(DB, CF) phase: bounded lateness (<= ~n/4) in exchange for
+    // anti-herding. The grid is absolute (not anchor + offset) so a rapidly
+    // restarting DB is not perpetually re-anchored just short of its trigger
+    // and thereby starved -- the grid point is a fixed wall-clock time that
+    // arrives regardless of restarts.
+    const uint64_t grid = n / 4;
+    if (grid == 0) {
+      return anchor;
+    }
+    const uint64_t phase = FastRange64(params.seed_hash, grid);
+    // Smallest t >= anchor with t % grid == phase.
+    return anchor + (phase + grid - anchor % grid) % grid;
+  } else if (recovery_trigger >= anchor) {
+    return recovery_trigger;
+  }
+  // Not yet past due, but the recovery target lands before the anchor: spread
+  // the catch-up across [anchor, natural deadline] using the phase (no
+  // recovery), so enabling phasing fleet-wide does not fire everything at once,
+  // and never later than the natural deadline.
+  return anchor + FastRange64(params.seed_hash, natural_trigger - anchor);
+}
+
+bool PeriodicCompactionPhaser::TryParseExplicitPhaseSeed(
+    const std::string& seed, uint64_t* seed_hash) {
+  // Match "0.<digits>": leading "0.", then at least one character, all decimal
+  // digits. This deliberately rejects a sign, an exponent ("0.5e3"), a bare
+  // "0.", and any trailing characters, so ordinary token/hash seeds fall
+  // through unchanged.
+  if (seed.size() < 3 || seed[0] != '0' || seed[1] != '.') {
+    return false;
+  }
+  // Accumulate the fraction as a 19-digit fixed-point integer frac_e19 ==
+  // floor(fraction * 10^19), reading the first up-to-19 digits and padding
+  // zeros on the right. 19 digits is the most that fits in uint64_t (10^19 <
+  // 2^64). Excess digits are validated but drop below 2^64 precision, so
+  // ignored.
+  uint64_t frac_e19 = 0;
+  int ndigits = 0;
+  for (size_t i = 2; i < seed.size(); ++i) {
+    if (seed[i] < '0' || seed[i] > '9') {
+      return false;
+    }
+    if (ndigits < 19) {
+      frac_e19 = frac_e19 * 10 + static_cast<uint64_t>(seed[i] - '0');
+      ++ndigits;
+    }
+  }
+  for (; ndigits < 19; ++ndigits) {
+    frac_e19 *= 10;
+  }
+  // Map fraction p in [0, 1) to seed_hash == floor(p * 2^64) so that
+  // FastRange64(seed_hash, n) == floor(p * n) for any period n. Computed
+  // exactly in integer math via a 128-bit intermediate: p * 2^64 == frac_e19 *
+  // 2^64 / 10^19 == (frac_e19 * floor(2^127 / 10^19)) >> 63. The magic constant
+  // is floor(2^127 / 10^19); flooring it makes the shifted product undershoot
+  // by ~1 ULP, so add 1 to round it back up -- then exact fractions land
+  // cleanly (0.5 -> 2^63, not 2^63 - 1). The largest input (all-nines) shifts
+  // to 2^64 - 3, so the +1 still cannot overflow uint64_t.
+  constexpr uint64_t kTwoPow127DivTen19 = 17014118346046923173ULL;
+  *seed_hash =
+      Lower64of128(Multiply64to128(frac_e19, kTwoPow127DivTen19) >> 63) + 1;
+  return true;
+}
+
+uint64_t PeriodicCompactionPhaser::CfPhaseSeedHash(uint64_t db_base_phase,
+                                                   uint32_t cf_id) {
+  // Golden-ratio conjugate ((sqrt(5)-1)/2) as a fixed-point fraction * 2^64.
+  // The additive recurrence db_base + cf_id * kGolden (wrapping mod 2^64, i.e.
+  // mod 1) is a low-discrepancy Weyl/Kronecker sequence, so a DB's CFs are
+  // spread quasi-uniformly around the base phase for any number of CFs.
+  constexpr uint64_t kGoldenRatioU64 = 0x9E3779B97F4A7C15ULL;
+  return db_base_phase + static_cast<uint64_t>(cf_id) * kGoldenRatioU64;
+}
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/db/periodic_compaction_phaser.cc
+++ b/db/periodic_compaction_phaser.cc
@@ -7,17 +7,13 @@
 
 #include <algorithm>
 
-#include "rocksdb/options.h"  // kDbNameForScheduleSeed / kDbIdForScheduleSeed
 #include "util/fastrange.h"
 #include "util/hash.h"
-#include "util/math128.h"
 
 namespace ROCKSDB_NAMESPACE {
 
-bool PeriodicCompactionPhaser::SetConfig(const std::string& seed,
-                                         int recovery_percent) {
-  const bool changed = seed != seed_ || recovery_percent != recovery_percent_;
-  seed_ = seed;
+bool PeriodicCompactionPhaser::SetConfig(int recovery_percent) {
+  const bool changed = recovery_percent != recovery_percent_;
   recovery_percent_ = recovery_percent;
   return changed;
 }
@@ -29,24 +25,14 @@ PeriodicCompactionPhaseParams PeriodicCompactionPhaser::ParamsForCf(
     // Phasing disabled; return default (disabled) params.
     return params;
   }
-  // Resolve the DB-level base phase (a fixed-point fraction * 2^64).
-  uint64_t db_base_phase = 0;
-  if (!TryParseExplicitPhaseSeed(seed_, &db_base_phase)) {
-    // Not an explicit "0.<frac>" base: hash the seed, applying whole-value
-    // token substitution (mirrors db_host_id / kHostnameForDbHostId). db_id_ is
-    // read live so the default "__db_id__" resolves against the current
-    // identity.
-    const std::string* resolved = &seed_;
-    if (seed_ == kDbNameForScheduleSeed) {
-      resolved = &dbname_;
-    } else if (seed_ == kDbIdForScheduleSeed) {
-      resolved = &db_id_;
-    }
-    db_base_phase = Hash64(resolved->data(), resolved->size());
-  }
-  // Spread this CF quasi-uniformly around the DB base phase (golden ratio), so
-  // the DB-level seed is meaningful however it is set (hashed or an explicit
-  // base) and CFs of one DB do not share a phase.
+  // DB-level base phase (a fixed-point fraction * 2^64), hashed from the DB ID.
+  // The DB ID is stable across re-open and physical cloning/migration but
+  // distinct across DBs, so DBs configured alike do not herd. db_id_ is read
+  // live because it is populated after construction (during DB::Open): versions
+  // built before it is known hash an empty id and self-heal on later versions.
+  const uint64_t db_base_phase = Hash64(db_id_.data(), db_id_.size());
+  // Spread this CF quasi-uniformly around the DB base phase (golden ratio) so
+  // CFs of one DB do not share a phase.
   params.seed_hash = CfPhaseSeedHash(db_base_phase, cf_id);
   params.anchor_time = anchor_time_;
   params.recovery_percent = std::min(recovery_percent_, 100);
@@ -107,48 +93,6 @@ uint64_t PeriodicCompactionPhaser::TriggerTime(
   // recovery), so enabling phasing fleet-wide does not fire everything at once,
   // and never later than the natural deadline.
   return anchor + FastRange64(params.seed_hash, natural_trigger - anchor);
-}
-
-bool PeriodicCompactionPhaser::TryParseExplicitPhaseSeed(
-    const std::string& seed, uint64_t* seed_hash) {
-  // Match "0.<digits>": leading "0.", then at least one character, all decimal
-  // digits. This deliberately rejects a sign, an exponent ("0.5e3"), a bare
-  // "0.", and any trailing characters, so ordinary token/hash seeds fall
-  // through unchanged.
-  if (seed.size() < 3 || seed[0] != '0' || seed[1] != '.') {
-    return false;
-  }
-  // Accumulate the fraction as a 19-digit fixed-point integer frac_e19 ==
-  // floor(fraction * 10^19), reading the first up-to-19 digits and padding
-  // zeros on the right. 19 digits is the most that fits in uint64_t (10^19 <
-  // 2^64). Excess digits are validated but drop below 2^64 precision, so
-  // ignored.
-  uint64_t frac_e19 = 0;
-  int ndigits = 0;
-  for (size_t i = 2; i < seed.size(); ++i) {
-    if (seed[i] < '0' || seed[i] > '9') {
-      return false;
-    }
-    if (ndigits < 19) {
-      frac_e19 = frac_e19 * 10 + static_cast<uint64_t>(seed[i] - '0');
-      ++ndigits;
-    }
-  }
-  for (; ndigits < 19; ++ndigits) {
-    frac_e19 *= 10;
-  }
-  // Map fraction p in [0, 1) to seed_hash == floor(p * 2^64) so that
-  // FastRange64(seed_hash, n) == floor(p * n) for any period n. Computed
-  // exactly in integer math via a 128-bit intermediate: p * 2^64 == frac_e19 *
-  // 2^64 / 10^19 == (frac_e19 * floor(2^127 / 10^19)) >> 63. The magic constant
-  // is floor(2^127 / 10^19); flooring it makes the shifted product undershoot
-  // by ~1 ULP, so add 1 to round it back up -- then exact fractions land
-  // cleanly (0.5 -> 2^63, not 2^63 - 1). The largest input (all-nines) shifts
-  // to 2^64 - 3, so the +1 still cannot overflow uint64_t.
-  constexpr uint64_t kTwoPow127DivTen19 = 17014118346046923173ULL;
-  *seed_hash =
-      Lower64of128(Multiply64to128(frac_e19, kTwoPow127DivTen19) >> 63) + 1;
-  return true;
 }
 
 uint64_t PeriodicCompactionPhaser::CfPhaseSeedHash(uint64_t db_base_phase,

--- a/db/periodic_compaction_phaser.h
+++ b/db/periodic_compaction_phaser.h
@@ -1,0 +1,100 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+#include "rocksdb/rocksdb_namespace.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+// Parameters controlling randomized-but-stable phasing of periodic
+// (time-based) compaction, derived per Version from
+// DBOptions::compaction_schedule_seed and
+// periodic_compaction_phase_recovery_percent together with the DB/CF identity.
+// recovery_percent == 0 disables phasing (exact legacy behavior).
+struct PeriodicCompactionPhaseParams {
+  // Stable per-(DB, CF) hash seeding the preferred phase.
+  uint64_t seed_hash = 0;
+  // Unix time (seconds) at which phasing took effect for this DB (DB::Open, or
+  // the last relevant SetDBOptions change). Used to spread the initial
+  // catch-up burst across [anchor_time, natural deadline].
+  uint64_t anchor_time = 0;
+  // Percent [0, 100] of the phase gap closed per trigger; 0 disables phasing.
+  int recovery_percent = 0;
+};
+
+// De-herds periodic (time-based) compaction across a fleet: gives each (DB, CF)
+// a stable "preferred phase" within periodic_compaction_seconds and steers
+// compactions toward it, never past the deadline (see
+// DBOptions::compaction_schedule_seed /
+// periodic_compaction_phase_recovery_percent). This owns the DB-level phasing
+// config (seed + recovery percent) and the phasing anchor; the per-file trigger
+// math and seed derivation are stateless static helpers. Lives on VersionSet,
+// which caches the resulting per-CF params on each Version.
+class PeriodicCompactionPhaser {
+ public:
+  // dbname/db_id are referenced live (for whole-value __db_name__/__db_id__
+  // substitution) and must outlive this phaser -- both are owned by the same
+  // VersionSet. db_id may be populated after construction; it is read lazily.
+  PeriodicCompactionPhaser(const std::string& dbname, const std::string& db_id)
+      : dbname_(dbname), db_id_(db_id) {}
+
+  // Apply the (mutable) DB options. Returns true if the seed or recovery
+  // percent changed -- in which case the caller should Reanchor() and refresh
+  // cached params. Does not itself move the anchor.
+  bool SetConfig(const std::string& seed, int recovery_percent);
+
+  // Move the phasing anchor to `now` (unix seconds).
+  void Reanchor(uint64_t now) { anchor_time_ = now; }
+
+  int recovery_percent() const { return recovery_percent_; }
+
+  // Phasing params for a column family (by id): the DB base phase resolved from
+  // the seed, spread by cf_id (golden ratio), plus the current anchor and
+  // recovery percent. Returns disabled params when phasing is off.
+  PeriodicCompactionPhaseParams ParamsForCf(uint32_t cf_id) const;
+
+  // --- Stateless helpers (static; unit-tested directly) ---
+
+  // Wall-clock time (unix seconds) at which a file with the given modification
+  // time becomes eligible for periodic compaction under `params`, NOT
+  // accounting for the offpeak pull. When params.recovery_percent == 0 (phasing
+  // disabled) this is file_modification_time + periodic_compaction_seconds
+  // (classic behavior); otherwise it is pulled earlier toward the preferred
+  // phase and is never later than the classic deadline.
+  static uint64_t TriggerTime(uint64_t file_modification_time,
+                              uint64_t periodic_compaction_seconds,
+                              const PeriodicCompactionPhaseParams& params);
+
+  // Explicit phase-position form of compaction_schedule_seed: a string
+  // "0.<digits>" (leading "0.", then only decimal digits -- no sign, exponent,
+  // or trailing characters) is a fraction in [0, 1) used directly as the base
+  // phase. Returns true and sets *seed_hash (such that FastRange64(*seed_hash,
+  // n) == floor(fraction * n) for any period n) on match; false (leaving
+  // *seed_hash untouched) otherwise.
+  static bool TryParseExplicitPhaseSeed(const std::string& seed,
+                                        uint64_t* seed_hash);
+
+  // Spreads a DB's column families quasi-uniformly around a DB-level base phase
+  // via the golden-ratio additive (Weyl/Kronecker) recurrence: cf phase ==
+  // db_base_phase + cf_id * (phi conjugate), all in fixed point (fraction *
+  // 2^64) so the mod-1 wrap is the natural uint64 overflow. Low-discrepancy for
+  // any number of CFs.
+  static uint64_t CfPhaseSeedHash(uint64_t db_base_phase, uint32_t cf_id);
+
+ private:
+  const std::string& dbname_;
+  const std::string& db_id_;
+  std::string seed_;
+  int recovery_percent_ = 0;
+  // Unix time (seconds) at which phasing took effect for this DB (construction
+  // or last relevant SetDBOptions change); spreads the initial catch-up burst.
+  uint64_t anchor_time_ = 0;
+};
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/db/periodic_compaction_phaser.h
+++ b/db/periodic_compaction_phaser.h
@@ -14,9 +14,9 @@ namespace ROCKSDB_NAMESPACE {
 
 // Parameters controlling randomized-but-stable phasing of periodic
 // (time-based) compaction, derived per Version from
-// DBOptions::compaction_schedule_seed and
-// periodic_compaction_phase_recovery_percent together with the DB/CF identity.
-// recovery_percent == 0 disables phasing (exact legacy behavior).
+// DBOptions::periodic_compaction_phase_recovery_percent together with the DB ID
+// and column-family id. recovery_percent == 0 disables phasing (exact legacy
+// behavior).
 struct PeriodicCompactionPhaseParams {
   // Stable per-(DB, CF) hash seeding the preferred phase.
   uint64_t seed_hash = 0;
@@ -30,32 +30,35 @@ struct PeriodicCompactionPhaseParams {
 
 // De-herds periodic (time-based) compaction across a fleet: gives each (DB, CF)
 // a stable "preferred phase" within periodic_compaction_seconds and steers
-// compactions toward it, never past the deadline (see
-// DBOptions::compaction_schedule_seed /
-// periodic_compaction_phase_recovery_percent). This owns the DB-level phasing
-// config (seed + recovery percent) and the phasing anchor; the per-file trigger
-// math and seed derivation are stateless static helpers. Lives on VersionSet,
-// which caches the resulting per-CF params on each Version.
+// compactions toward it, never past the deadline (enabled by
+// DBOptions::periodic_compaction_phase_recovery_percent). The DB-level base
+// phase is derived from the DB ID -- stable across re-open and physical
+// cloning/migration but distinct across DBs -- and each column family is spread
+// around it by cf id. This owns the DB-level recovery percent and the phasing
+// anchor; the per-file trigger math and phase derivation are stateless static
+// helpers. Lives on VersionSet, which caches the resulting per-CF params on
+// each Version.
 class PeriodicCompactionPhaser {
  public:
-  // dbname/db_id are referenced live (for whole-value __db_name__/__db_id__
-  // substitution) and must outlive this phaser -- both are owned by the same
-  // VersionSet. db_id may be populated after construction; it is read lazily.
-  PeriodicCompactionPhaser(const std::string& dbname, const std::string& db_id)
-      : dbname_(dbname), db_id_(db_id) {}
+  // db_id is referenced live (it is populated after construction, during
+  // DB::Open, and is read lazily) and must outlive this phaser -- it is owned
+  // by the same VersionSet.
+  explicit PeriodicCompactionPhaser(const std::string& db_id) : db_id_(db_id) {}
 
-  // Apply the (mutable) DB options. Returns true if the seed or recovery
-  // percent changed -- in which case the caller should Reanchor() and refresh
-  // cached params. Does not itself move the anchor.
-  bool SetConfig(const std::string& seed, int recovery_percent);
+  // Apply the (mutable) recovery percent. Returns true if it changed -- in
+  // which case the caller should Reanchor() and refresh cached params. Does not
+  // itself move the anchor.
+  //
+  // A setting of 25 to 33 will set this phaser to "stun"
+  bool SetConfig(int recovery_percent);
 
   // Move the phasing anchor to `now` (unix seconds).
   void Reanchor(uint64_t now) { anchor_time_ = now; }
 
   int recovery_percent() const { return recovery_percent_; }
 
-  // Phasing params for a column family (by id): the DB base phase resolved from
-  // the seed, spread by cf_id (golden ratio), plus the current anchor and
+  // Phasing params for a column family (by id): the DB base phase (hashed from
+  // the DB ID) spread by cf_id (golden ratio), plus the current anchor and
   // recovery percent. Returns disabled params when phasing is off.
   PeriodicCompactionPhaseParams ParamsForCf(uint32_t cf_id) const;
 
@@ -71,15 +74,6 @@ class PeriodicCompactionPhaser {
                               uint64_t periodic_compaction_seconds,
                               const PeriodicCompactionPhaseParams& params);
 
-  // Explicit phase-position form of compaction_schedule_seed: a string
-  // "0.<digits>" (leading "0.", then only decimal digits -- no sign, exponent,
-  // or trailing characters) is a fraction in [0, 1) used directly as the base
-  // phase. Returns true and sets *seed_hash (such that FastRange64(*seed_hash,
-  // n) == floor(fraction * n) for any period n) on match; false (leaving
-  // *seed_hash untouched) otherwise.
-  static bool TryParseExplicitPhaseSeed(const std::string& seed,
-                                        uint64_t* seed_hash);
-
   // Spreads a DB's column families quasi-uniformly around a DB-level base phase
   // via the golden-ratio additive (Weyl/Kronecker) recurrence: cf phase ==
   // db_base_phase + cf_id * (phi conjugate), all in fixed point (fraction *
@@ -88,9 +82,7 @@ class PeriodicCompactionPhaser {
   static uint64_t CfPhaseSeedHash(uint64_t db_base_phase, uint32_t cf_id);
 
  private:
-  const std::string& dbname_;
   const std::string& db_id_;
-  std::string seed_;
   int recovery_percent_ = 0;
   // Unix time (seconds) at which phasing took effect for this DB (construction
   // or last relevant SetDBOptions change); spreads the initial catch-up burst.

--- a/db/repair.cc
+++ b/db/repair.cc
@@ -701,7 +701,8 @@ class Repairer {
           nullptr /* src_vstorage */, cfd->ioptions().force_consistency_checks,
           EpochNumberRequirement::kMightMissing, cfd->ioptions().clock,
           /*bottommost_file_compaction_delay=*/0,
-          cfd->current()->version_set()->offpeak_time_option());
+          cfd->current()->version_set()->offpeak_time_option(),
+          PeriodicCompactionPhaseParams{});
       Status s;
       VersionEdit dummy_edit;
       for (const auto* table : cf_id_and_tables.second) {

--- a/db/version_builder_test.cc
+++ b/db/version_builder_test.cc
@@ -45,7 +45,8 @@ class VersionBuilderTest : public testing::Test {
         vstorage_(&icmp_, ucmp_, options_.num_levels, kCompactionStyleLevel,
                   nullptr, false, EpochNumberRequirement::kMustPresent,
                   ioptions_.clock, options_.bottommost_file_compaction_delay,
-                  OffpeakTimeOption(options_.daily_offpeak_time_utc)),
+                  OffpeakTimeOption(options_.daily_offpeak_time_utc),
+                  PeriodicCompactionPhaseParams{}),
         file_num_(1) {
     mutable_cf_options_.RefreshDerivedOptions(ioptions_);
     size_being_compacted_.resize(options_.num_levels);
@@ -328,7 +329,8 @@ TEST_F(VersionBuilderTest, ApplyAndSaveTo) {
   VersionStorageInfo new_vstorage(
       &icmp_, ucmp_, options_.num_levels, kCompactionStyleLevel, nullptr, false,
       EpochNumberRequirement::kMightMissing, nullptr, 0,
-      OffpeakTimeOption(options_.daily_offpeak_time_utc));
+      OffpeakTimeOption(options_.daily_offpeak_time_utc),
+      PeriodicCompactionPhaseParams{});
   ASSERT_OK(version_builder.Apply(&version_edit));
   ASSERT_OK(version_builder.SaveTo(&new_vstorage));
 
@@ -380,7 +382,8 @@ TEST_F(VersionBuilderTest, ApplyAndSaveToDynamic) {
   VersionStorageInfo new_vstorage(
       &icmp_, ucmp_, options_.num_levels, kCompactionStyleLevel, nullptr, false,
       EpochNumberRequirement::kMightMissing, nullptr, 0,
-      OffpeakTimeOption(options_.daily_offpeak_time_utc));
+      OffpeakTimeOption(options_.daily_offpeak_time_utc),
+      PeriodicCompactionPhaseParams{});
   ASSERT_OK(version_builder.Apply(&version_edit));
   ASSERT_OK(version_builder.SaveTo(&new_vstorage));
 
@@ -436,7 +439,8 @@ TEST_F(VersionBuilderTest, ApplyAndSaveToDynamic2) {
   VersionStorageInfo new_vstorage(
       &icmp_, ucmp_, options_.num_levels, kCompactionStyleLevel, nullptr, false,
       EpochNumberRequirement::kMightMissing, nullptr, 0,
-      OffpeakTimeOption(options_.daily_offpeak_time_utc));
+      OffpeakTimeOption(options_.daily_offpeak_time_utc),
+      PeriodicCompactionPhaseParams{});
   ASSERT_OK(version_builder.Apply(&version_edit));
   ASSERT_OK(version_builder.SaveTo(&new_vstorage));
 
@@ -494,7 +498,8 @@ TEST_F(VersionBuilderTest, ApplyMultipleAndSaveTo) {
   VersionStorageInfo new_vstorage(
       &icmp_, ucmp_, options_.num_levels, kCompactionStyleLevel, nullptr, false,
       EpochNumberRequirement::kMightMissing, nullptr, 0,
-      OffpeakTimeOption(options_.daily_offpeak_time_utc));
+      OffpeakTimeOption(options_.daily_offpeak_time_utc),
+      PeriodicCompactionPhaseParams{});
   ASSERT_OK(version_builder.Apply(&version_edit));
   ASSERT_OK(version_builder.SaveTo(&new_vstorage));
 
@@ -518,7 +523,8 @@ TEST_F(VersionBuilderTest, ApplyDeleteAndSaveTo) {
   VersionStorageInfo new_vstorage(
       &icmp_, ucmp_, options_.num_levels, kCompactionStyleLevel, nullptr, false,
       EpochNumberRequirement::kMightMissing, nullptr, 0,
-      OffpeakTimeOption(options_.daily_offpeak_time_utc));
+      OffpeakTimeOption(options_.daily_offpeak_time_utc),
+      PeriodicCompactionPhaseParams{});
 
   VersionEdit version_edit;
   version_edit.AddFile(
@@ -687,7 +693,8 @@ TEST_F(VersionBuilderTest, ApplyFileDeletionAndAddition) {
   VersionStorageInfo new_vstorage(
       &icmp_, ucmp_, options_.num_levels, kCompactionStyleLevel, &vstorage_,
       force_consistency_checks, EpochNumberRequirement::kMightMissing, nullptr,
-      0, OffpeakTimeOption(options_.daily_offpeak_time_utc));
+      0, OffpeakTimeOption(options_.daily_offpeak_time_utc),
+      PeriodicCompactionPhaseParams{});
 
   ASSERT_OK(builder.SaveTo(&new_vstorage));
 
@@ -832,7 +839,8 @@ TEST_F(VersionBuilderTest, ApplyFileAdditionAndDeletion) {
   VersionStorageInfo new_vstorage(
       &icmp_, ucmp_, options_.num_levels, kCompactionStyleLevel, &vstorage_,
       force_consistency_checks, EpochNumberRequirement::kMightMissing, nullptr,
-      0, OffpeakTimeOption(options_.daily_offpeak_time_utc));
+      0, OffpeakTimeOption(options_.daily_offpeak_time_utc),
+      PeriodicCompactionPhaseParams{});
 
   ASSERT_OK(builder.SaveTo(&new_vstorage));
 
@@ -877,7 +885,8 @@ TEST_F(VersionBuilderTest, ApplyBlobFileAddition) {
   VersionStorageInfo new_vstorage(
       &icmp_, ucmp_, options_.num_levels, kCompactionStyleLevel, &vstorage_,
       force_consistency_checks, EpochNumberRequirement::kMightMissing, nullptr,
-      0, OffpeakTimeOption(options_.daily_offpeak_time_utc));
+      0, OffpeakTimeOption(options_.daily_offpeak_time_utc),
+      PeriodicCompactionPhaseParams{});
 
   ASSERT_OK(builder.SaveTo(&new_vstorage));
 
@@ -1017,7 +1026,8 @@ TEST_F(VersionBuilderTest, ApplyBlobFileGarbageFileInBase) {
   VersionStorageInfo new_vstorage(
       &icmp_, ucmp_, options_.num_levels, kCompactionStyleLevel, &vstorage_,
       force_consistency_checks, EpochNumberRequirement::kMightMissing, nullptr,
-      0, OffpeakTimeOption(options_.daily_offpeak_time_utc));
+      0, OffpeakTimeOption(options_.daily_offpeak_time_utc),
+      PeriodicCompactionPhaseParams{});
 
   ASSERT_OK(builder.SaveTo(&new_vstorage));
 
@@ -1091,7 +1101,8 @@ TEST_F(VersionBuilderTest, ApplyBlobFileGarbageFileAdditionApplied) {
   VersionStorageInfo new_vstorage(
       &icmp_, ucmp_, options_.num_levels, kCompactionStyleLevel, &vstorage_,
       force_consistency_checks, EpochNumberRequirement::kMightMissing, nullptr,
-      0, OffpeakTimeOption(options_.daily_offpeak_time_utc));
+      0, OffpeakTimeOption(options_.daily_offpeak_time_utc),
+      PeriodicCompactionPhaseParams{});
 
   ASSERT_OK(builder.SaveTo(&new_vstorage));
 
@@ -1272,7 +1283,8 @@ TEST_F(VersionBuilderTest, SaveBlobFilesTo) {
   VersionStorageInfo new_vstorage(
       &icmp_, ucmp_, options_.num_levels, kCompactionStyleLevel, &vstorage_,
       force_consistency_checks, EpochNumberRequirement::kMightMissing, nullptr,
-      0, OffpeakTimeOption(options_.daily_offpeak_time_utc));
+      0, OffpeakTimeOption(options_.daily_offpeak_time_utc),
+      PeriodicCompactionPhaseParams{});
 
   ASSERT_OK(builder.SaveTo(&new_vstorage));
 
@@ -1321,7 +1333,8 @@ TEST_F(VersionBuilderTest, SaveBlobFilesTo) {
   VersionStorageInfo new_vstorage_2(
       &icmp_, ucmp_, options_.num_levels, kCompactionStyleLevel, &new_vstorage,
       force_consistency_checks, EpochNumberRequirement::kMightMissing, nullptr,
-      0, OffpeakTimeOption(options_.daily_offpeak_time_utc));
+      0, OffpeakTimeOption(options_.daily_offpeak_time_utc),
+      PeriodicCompactionPhaseParams{});
 
   ASSERT_OK(second_builder.SaveTo(&new_vstorage_2));
 
@@ -1349,7 +1362,8 @@ TEST_F(VersionBuilderTest, SaveBlobFilesTo) {
       &icmp_, ucmp_, options_.num_levels, kCompactionStyleLevel,
       &new_vstorage_2, force_consistency_checks,
       EpochNumberRequirement::kMightMissing, nullptr, 0,
-      OffpeakTimeOption(options_.daily_offpeak_time_utc));
+      OffpeakTimeOption(options_.daily_offpeak_time_utc),
+      PeriodicCompactionPhaseParams{});
 
   ASSERT_OK(third_builder.SaveTo(&new_vstorage_3));
 
@@ -1431,7 +1445,8 @@ TEST_F(VersionBuilderTest, SaveBlobFilesToConcurrentJobs) {
   VersionStorageInfo new_vstorage(
       &icmp_, ucmp_, options_.num_levels, kCompactionStyleLevel, &vstorage_,
       force_consistency_checks, EpochNumberRequirement::kMightMissing, nullptr,
-      0, OffpeakTimeOption(options_.daily_offpeak_time_utc));
+      0, OffpeakTimeOption(options_.daily_offpeak_time_utc),
+      PeriodicCompactionPhaseParams{});
 
   ASSERT_OK(builder.SaveTo(&new_vstorage));
 
@@ -1535,7 +1550,8 @@ TEST_F(VersionBuilderTest, CheckConsistencyForBlobFiles) {
   VersionStorageInfo new_vstorage(
       &icmp_, ucmp_, options_.num_levels, kCompactionStyleLevel, &vstorage_,
       force_consistency_checks, EpochNumberRequirement::kMightMissing, nullptr,
-      0, OffpeakTimeOption(options_.daily_offpeak_time_utc));
+      0, OffpeakTimeOption(options_.daily_offpeak_time_utc),
+      PeriodicCompactionPhaseParams{});
 
   ASSERT_OK(builder.SaveTo(&new_vstorage));
 
@@ -1575,7 +1591,8 @@ TEST_F(VersionBuilderTest, CheckConsistencyForBlobFilesInconsistentLinks) {
   VersionStorageInfo new_vstorage(
       &icmp_, ucmp_, options_.num_levels, kCompactionStyleLevel, &vstorage_,
       force_consistency_checks, EpochNumberRequirement::kMightMissing, nullptr,
-      0, OffpeakTimeOption(options_.daily_offpeak_time_utc));
+      0, OffpeakTimeOption(options_.daily_offpeak_time_utc),
+      PeriodicCompactionPhaseParams{});
 
   const Status s = builder.SaveTo(&new_vstorage);
   ASSERT_TRUE(s.IsCorruption());
@@ -1617,7 +1634,8 @@ TEST_F(VersionBuilderTest, CheckConsistencyForBlobFilesAllGarbage) {
   VersionStorageInfo new_vstorage(
       &icmp_, ucmp_, options_.num_levels, kCompactionStyleLevel, &vstorage_,
       force_consistency_checks, EpochNumberRequirement::kMightMissing, nullptr,
-      0, OffpeakTimeOption(options_.daily_offpeak_time_utc));
+      0, OffpeakTimeOption(options_.daily_offpeak_time_utc),
+      PeriodicCompactionPhaseParams{});
 
   const Status s = builder.SaveTo(&new_vstorage);
   ASSERT_TRUE(s.IsCorruption());
@@ -1667,7 +1685,8 @@ TEST_F(VersionBuilderTest, CheckConsistencyForBlobFilesAllGarbageLinkedSsts) {
   VersionStorageInfo new_vstorage(
       &icmp_, ucmp_, options_.num_levels, kCompactionStyleLevel, &vstorage_,
       force_consistency_checks, EpochNumberRequirement::kMightMissing, nullptr,
-      0, OffpeakTimeOption(options_.daily_offpeak_time_utc));
+      0, OffpeakTimeOption(options_.daily_offpeak_time_utc),
+      PeriodicCompactionPhaseParams{});
 
   const Status s = builder.SaveTo(&new_vstorage);
   ASSERT_TRUE(s.IsCorruption());
@@ -1831,7 +1850,8 @@ TEST_F(VersionBuilderTest, MaintainLinkedSstsForBlobFiles) {
   VersionStorageInfo new_vstorage(
       &icmp_, ucmp_, options_.num_levels, kCompactionStyleLevel, &vstorage_,
       force_consistency_checks, EpochNumberRequirement::kMightMissing, nullptr,
-      0, OffpeakTimeOption(options_.daily_offpeak_time_utc));
+      0, OffpeakTimeOption(options_.daily_offpeak_time_utc),
+      PeriodicCompactionPhaseParams{});
 
   ASSERT_OK(builder.SaveTo(&new_vstorage));
 
@@ -1884,7 +1904,8 @@ TEST_F(VersionBuilderTest, CheckConsistencyForFileDeletedTwice) {
       &icmp_, ucmp_, options_.num_levels, kCompactionStyleLevel, nullptr,
       true /* force_consistency_checks */,
       EpochNumberRequirement::kMightMissing, nullptr, 0,
-      OffpeakTimeOption(options_.daily_offpeak_time_utc));
+      OffpeakTimeOption(options_.daily_offpeak_time_utc),
+      PeriodicCompactionPhaseParams{});
   ASSERT_OK(version_builder.Apply(&version_edit));
   ASSERT_OK(version_builder.SaveTo(&new_vstorage));
 
@@ -1896,7 +1917,8 @@ TEST_F(VersionBuilderTest, CheckConsistencyForFileDeletedTwice) {
       &icmp_, ucmp_, options_.num_levels, kCompactionStyleLevel, nullptr,
       true /* force_consistency_checks */,
       EpochNumberRequirement::kMightMissing, nullptr, 0,
-      OffpeakTimeOption(options_.daily_offpeak_time_utc));
+      OffpeakTimeOption(options_.daily_offpeak_time_utc),
+      PeriodicCompactionPhaseParams{});
   ASSERT_NOK(version_builder2.Apply(&version_edit));
 
   UnrefFilesInVersion(&new_vstorage);
@@ -1936,7 +1958,8 @@ TEST_F(VersionBuilderTest, CheckConsistencyForL0FilesSortedByEpochNumber) {
       &icmp_, ucmp_, options_.num_levels, kCompactionStyleLevel,
       nullptr /* src_vstorage */, true /* force_consistency_checks */,
       EpochNumberRequirement::kMightMissing, nullptr, 0,
-      OffpeakTimeOption(options_.daily_offpeak_time_utc));
+      OffpeakTimeOption(options_.daily_offpeak_time_utc),
+      PeriodicCompactionPhaseParams{});
 
   ASSERT_OK(version_builder_1.Apply(&version_edit_1));
   s = version_builder_1.SaveTo(&new_vstorage_1);
@@ -1975,7 +1998,8 @@ TEST_F(VersionBuilderTest, CheckConsistencyForL0FilesSortedByEpochNumber) {
       &icmp_, ucmp_, options_.num_levels, kCompactionStyleLevel,
       nullptr /* src_vstorage */, true /* force_consistency_checks */,
       EpochNumberRequirement::kMightMissing, nullptr, 0,
-      OffpeakTimeOption(options_.daily_offpeak_time_utc));
+      OffpeakTimeOption(options_.daily_offpeak_time_utc),
+      PeriodicCompactionPhaseParams{});
 
   ASSERT_OK(version_builder_2.Apply(&version_edit_2));
   s = version_builder_2.SaveTo(&new_vstorage_2);

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -71,6 +71,8 @@
 #include "util/cast_util.h"
 #include "util/coding.h"
 #include "util/coro_utils.h"
+#include "util/fastrange.h"
+#include "util/hash.h"
 #include "util/stop_watch.h"
 #include "util/string_util.h"
 #include "util/user_comparator_wrapper.h"
@@ -2673,7 +2675,8 @@ VersionStorageInfo::VersionStorageInfo(
     bool _force_consistency_checks,
     EpochNumberRequirement epoch_number_requirement, SystemClock* clock,
     uint32_t bottommost_file_compaction_delay,
-    OffpeakTimeOption offpeak_time_option)
+    OffpeakTimeOption offpeak_time_option,
+    PeriodicCompactionPhaseParams periodic_compaction_phase_params)
     : internal_comparator_(internal_comparator),
       user_comparator_(user_comparator),
       // cfd is nullptr if Version is dummy
@@ -2706,7 +2709,8 @@ VersionStorageInfo::VersionStorageInfo(
       finalized_(false),
       force_consistency_checks_(_force_consistency_checks),
       epoch_number_requirement_(epoch_number_requirement),
-      offpeak_time_option_(std::move(offpeak_time_option)) {
+      offpeak_time_option_(std::move(offpeak_time_option)),
+      periodic_compaction_phase_params_(periodic_compaction_phase_params) {
   if (ref_vstorage != nullptr) {
     accumulated_file_size_ = ref_vstorage->accumulated_file_size_;
     accumulated_raw_key_size_ = ref_vstorage->accumulated_raw_key_size_;
@@ -2752,7 +2756,10 @@ Version::Version(ColumnFamilyData* column_family_data, VersionSet* vset,
           cfd_ == nullptr ? nullptr : cfd_->ioptions().clock,
           cfd_ == nullptr ? 0
                           : mutable_cf_options.bottommost_file_compaction_delay,
-          vset->offpeak_time_option()),
+          vset->offpeak_time_option(),
+          cfd_ == nullptr
+              ? PeriodicCompactionPhaseParams{}
+              : vset->GetPeriodicCompactionPhaseParams(cfd_->GetID())),
       vset_(vset),
       next_(this),
       prev_(this),
@@ -3822,18 +3829,21 @@ void VersionStorageInfo::ComputeFilesMarkedForPeriodicCompaction(
     return;
   }
 
-  const uint64_t allowed_time_limit =
-      current_time - periodic_compaction_seconds;
-
-  // Find the adjust_allowed_time_limit such that it includes files that are
-  // going to expire by the time next daily offpeak starts.
+  // Existing offpeak behavior pulls a file's deadline earlier by the time until
+  // the next daily offpeak window (so a whole TTL's worth can be marked at the
+  // start of offpeak).
   const OffpeakTimeInfo offpeak_time_info =
       offpeak_time_option_.GetOffpeakTimeInfo(current_time);
-  const uint64_t adjusted_allowed_time_limit =
-      allowed_time_limit +
-      (offpeak_time_info.is_now_offpeak
-           ? offpeak_time_info.seconds_till_next_offpeak_start
-           : 0);
+  const uint64_t offpeak_pull =
+      offpeak_time_info.is_now_offpeak
+          ? offpeak_time_info.seconds_till_next_offpeak_start
+          : 0;
+
+  // Preferred-phase scheduling (see DBOptions::compaction_schedule_seed). When
+  // recovery_percent == 0 this is disabled and marking matches the classic
+  // "file age >= periodic_compaction_seconds" behavior (adjusted for offpeak).
+  const PeriodicCompactionPhaseParams& phase_params =
+      periodic_compaction_phase_params_;
 
   for (int level = 0; level <= last_level; level++) {
     for (auto f : files_[level]) {
@@ -3860,8 +3870,13 @@ void VersionStorageInfo::ComputeFilesMarkedForPeriodicCompaction(
             continue;
           }
         }
-        if (file_modification_time > 0 &&
-            file_modification_time < adjusted_allowed_time_limit) {
+        if (file_modification_time == 0) {
+          continue;
+        }
+
+        const uint64_t trigger_time = PeriodicCompactionPhaser::TriggerTime(
+            file_modification_time, periodic_compaction_seconds, phase_params);
+        if (current_time + offpeak_pull > trigger_time) {
           files_marked_for_periodic_compaction_.emplace_back(level, f);
         }
       }
@@ -5616,7 +5631,66 @@ void VersionSet::UpdatedMutableDbOptions(
   manifest_preallocation_size_ = updated_options.manifest_preallocation_size;
   verify_manifest_content_on_close_ =
       updated_options.verify_manifest_content_on_close;
+
+  if (periodic_compaction_phaser_.SetConfig(
+          updated_options.compaction_schedule_seed,
+          updated_options.periodic_compaction_phase_recovery_percent)) {
+    // (Re)anchor phasing so that switching it on (at open or via SetDBOptions)
+    // spreads the initial periodic-compaction catch-up burst over time rather
+    // than triggering it all at once.
+    int64_t now = 0;
+    if (clock_ != nullptr && clock_->GetCurrentTime(&now).ok()) {
+      periodic_compaction_phaser_.Reanchor(static_cast<uint64_t>(now));
+    }
+    if (mu != nullptr) {
+      // Live SetDBOptions change (not construction): push the refreshed phase
+      // params into each column family's current Version so the change takes
+      // effect on the next periodic re-evaluation (which recomputes scores on
+      // the current Version) rather than only when the next Version is built.
+      // Safe because periodic_compaction_phase_params_ is read only under the
+      // DB mutex, which is held here.
+      for (auto* cfd : *column_family_set_) {
+        if (cfd->IsDropped()) {
+          continue;
+        }
+        Version* v = cfd->current();
+        if (v != nullptr) {
+          v->storage_info_.periodic_compaction_phase_params_ =
+              GetPeriodicCompactionPhaseParams(cfd->GetID());
+        }
+      }
+    }
+  }
+
   TuneMaxManifestFileSize();
+}
+
+PeriodicCompactionPhaseParams VersionSet::GetPeriodicCompactionPhaseParams(
+    uint32_t cf_id) const {
+  return periodic_compaction_phaser_.ParamsForCf(cf_id);
+}
+
+void VersionSet::ReanchorCompactionPhase() {
+  // Caller holds the DB mutex. Move the phasing anchor to now and refresh each
+  // CF's current Version's cached params, mirroring the refresh done for
+  // seed/recovery changes in UpdatedMutableDbOptions(). Used when a CF's
+  // periodic_compaction_seconds changes, so a turn-down's newly past-due cohort
+  // is spread rather than fired at once. Re-anchoring is DB-level and benign to
+  // CFs whose interval did not change (their not-past-due files keep phasing).
+  int64_t now = 0;
+  if (clock_ != nullptr && clock_->GetCurrentTime(&now).ok()) {
+    periodic_compaction_phaser_.Reanchor(static_cast<uint64_t>(now));
+  }
+  for (auto* cfd : *column_family_set_) {
+    if (cfd->IsDropped()) {
+      continue;
+    }
+    Version* v = cfd->current();
+    if (v != nullptr) {
+      v->storage_info_.periodic_compaction_phase_params_ =
+          GetPeriodicCompactionPhaseParams(cfd->GetID());
+    }
+  }
 }
 
 void VersionSet::TuneMaxManifestFileSize() {

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -3839,7 +3839,8 @@ void VersionStorageInfo::ComputeFilesMarkedForPeriodicCompaction(
           ? offpeak_time_info.seconds_till_next_offpeak_start
           : 0;
 
-  // Preferred-phase scheduling (see DBOptions::compaction_schedule_seed). When
+  // Preferred-phase scheduling (see
+  // DBOptions::periodic_compaction_phase_recovery_percent). When
   // recovery_percent == 0 this is disabled and marking matches the classic
   // "file age >= periodic_compaction_seconds" behavior (adjusted for offpeak).
   const PeriodicCompactionPhaseParams& phase_params =
@@ -5633,7 +5634,6 @@ void VersionSet::UpdatedMutableDbOptions(
       updated_options.verify_manifest_content_on_close;
 
   if (periodic_compaction_phaser_.SetConfig(
-          updated_options.compaction_schedule_seed,
           updated_options.periodic_compaction_phase_recovery_percent)) {
     // (Re)anchor phasing so that switching it on (at open or via SetDBOptions)
     // spreads the initial periodic-compaction catch-up burst over time rather

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -41,6 +41,7 @@
 #include "db/error_handler.h"
 #include "db/file_indexer.h"
 #include "db/log_reader.h"
+#include "db/periodic_compaction_phaser.h"
 #include "db/range_del_aggregator.h"
 #include "db/read_callback.h"
 #include "db/table_cache.h"
@@ -127,15 +128,15 @@ enum EpochNumberRequirement {
 // compaction, blob files, etc.
 class VersionStorageInfo {
  public:
-  VersionStorageInfo(const InternalKeyComparator* internal_comparator,
-                     const Comparator* user_comparator, int num_levels,
-                     CompactionStyle compaction_style,
-                     VersionStorageInfo* src_vstorage,
-                     bool _force_consistency_checks,
-                     EpochNumberRequirement epoch_number_requirement,
-                     SystemClock* clock,
-                     uint32_t bottommost_file_compaction_delay,
-                     OffpeakTimeOption offpeak_time_option);
+  VersionStorageInfo(
+      const InternalKeyComparator* internal_comparator,
+      const Comparator* user_comparator, int num_levels,
+      CompactionStyle compaction_style, VersionStorageInfo* src_vstorage,
+      bool _force_consistency_checks,
+      EpochNumberRequirement epoch_number_requirement, SystemClock* clock,
+      uint32_t bottommost_file_compaction_delay,
+      OffpeakTimeOption offpeak_time_option,
+      PeriodicCompactionPhaseParams periodic_compaction_phase_params);
   // No copying allowed
   VersionStorageInfo(const VersionStorageInfo&) = delete;
   void operator=(const VersionStorageInfo&) = delete;
@@ -830,6 +831,8 @@ class VersionStorageInfo {
   EpochNumberRequirement epoch_number_requirement_;
 
   OffpeakTimeOption offpeak_time_option_;
+
+  PeriodicCompactionPhaseParams periodic_compaction_phase_params_;
 
   friend class Version;
   friend class VersionSet;
@@ -1680,6 +1683,19 @@ class VersionSet {
     offpeak_time_option_.SetFromOffpeakTimeString(daily_offpeak_time_utc);
   }
 
+  // Thin forwarder to periodic_compaction_phaser_.ParamsForCf(cf_id): the
+  // per-CF phasing params (base phase from the seed + golden-ratio CF spread +
+  // anchor + recovery percent). Returns disabled params when phasing is off.
+  PeriodicCompactionPhaseParams GetPeriodicCompactionPhaseParams(
+      uint32_t cf_id) const;
+
+  // (Re)anchor periodic-compaction phasing to now and refresh the cached phase
+  // params on every column family's current Version. Called when a CF's
+  // periodic_compaction_seconds changes via SetOptions, so a turn-down's newly
+  // past-due cohort is spread (over the phase grid within ~N/4 of now) instead
+  // of firing all at once. Caller must hold the DB mutex.
+  void ReanchorCompactionPhase();
+
   const ImmutableDBOptions* db_options() const { return db_options_; }
 
   static uint64_t GetNumLiveVersions(Version* dummy_versions);
@@ -1830,6 +1846,9 @@ class VersionSet {
   SystemClock* const clock_;
   const std::string dbname_;
   std::string db_id_;
+  // Periodic-compaction phasing. Declared right after dbname_/db_id_ because it
+  // holds live references to them (for __db_name__/__db_id__ substitution).
+  PeriodicCompactionPhaser periodic_compaction_phaser_{dbname_, db_id_};
   const ImmutableDBOptions* const db_options_;
   std::atomic<uint64_t> next_file_number_;
   // Any WAL number smaller than this should be ignored during recovery,

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -1684,8 +1684,9 @@ class VersionSet {
   }
 
   // Thin forwarder to periodic_compaction_phaser_.ParamsForCf(cf_id): the
-  // per-CF phasing params (base phase from the seed + golden-ratio CF spread +
-  // anchor + recovery percent). Returns disabled params when phasing is off.
+  // per-CF phasing params (DB base phase from the DB ID, golden-ratio CF
+  // spread, anchor, and recovery percent). Returns disabled params when phasing
+  // is off.
   PeriodicCompactionPhaseParams GetPeriodicCompactionPhaseParams(
       uint32_t cf_id) const;
 
@@ -1846,9 +1847,9 @@ class VersionSet {
   SystemClock* const clock_;
   const std::string dbname_;
   std::string db_id_;
-  // Periodic-compaction phasing. Declared right after dbname_/db_id_ because it
-  // holds live references to them (for __db_name__/__db_id__ substitution).
-  PeriodicCompactionPhaser periodic_compaction_phaser_{dbname_, db_id_};
+  // Periodic-compaction phasing. Declared right after db_id_ because it holds a
+  // live reference to it (the DB base phase is hashed from the DB ID).
+  PeriodicCompactionPhaser periodic_compaction_phaser_{db_id_};
   const ImmutableDBOptions* const db_options_;
   std::atomic<uint64_t> next_file_number_;
   // Any WAL number smaller than this should be ignored during recovery,

--- a/db/version_set_test.cc
+++ b/db/version_set_test.cc
@@ -139,7 +139,7 @@ class VersionStorageInfoTestBase : public testing::Test {
                   /*_force_consistency_checks=*/false,
                   EpochNumberRequirement::kMustPresent, ioptions_.clock,
                   mutable_cf_options_.bottommost_file_compaction_delay,
-                  OffpeakTimeOption()) {}
+                  OffpeakTimeOption(), PeriodicCompactionPhaseParams{}) {}
 
   ~VersionStorageInfoTestBase() override {
     for (int i = 0; i < vstorage_.num_levels(); ++i) {

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -212,6 +212,8 @@ DECLARE_bool(sync);
 DECLARE_bool(use_fsync);
 DECLARE_uint64(stats_dump_period_sec);
 DECLARE_uint64(max_compaction_trigger_wakeup_seconds);
+DECLARE_string(compaction_schedule_seed);
+DECLARE_int32(periodic_compaction_phase_recovery_percent);
 DECLARE_uint64(bytes_per_sync);
 DECLARE_uint64(wal_bytes_per_sync);
 DECLARE_int32(kill_random_test);

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -212,7 +212,6 @@ DECLARE_bool(sync);
 DECLARE_bool(use_fsync);
 DECLARE_uint64(stats_dump_period_sec);
 DECLARE_uint64(max_compaction_trigger_wakeup_seconds);
-DECLARE_string(compaction_schedule_seed);
 DECLARE_int32(periodic_compaction_phase_recovery_percent);
 DECLARE_uint64(bytes_per_sync);
 DECLARE_uint64(wal_bytes_per_sync);

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -1496,6 +1496,15 @@ DEFINE_uint64(
     ROCKSDB_NAMESPACE::Options().max_compaction_trigger_wakeup_seconds,
     "Sets DB option max_compaction_trigger_wakeup_seconds.");
 
+DEFINE_string(compaction_schedule_seed,
+              ROCKSDB_NAMESPACE::Options().compaction_schedule_seed,
+              "Sets DB option compaction_schedule_seed.");
+
+DEFINE_int32(
+    periodic_compaction_phase_recovery_percent,
+    ROCKSDB_NAMESPACE::Options().periodic_compaction_phase_recovery_percent,
+    "Sets DB option periodic_compaction_phase_recovery_percent.");
+
 DEFINE_bool(verification_only, false,
             "If true, tests will only execute verification step");
 extern "C" bool RocksDbIOUringEnable() { return true; }

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -1496,10 +1496,6 @@ DEFINE_uint64(
     ROCKSDB_NAMESPACE::Options().max_compaction_trigger_wakeup_seconds,
     "Sets DB option max_compaction_trigger_wakeup_seconds.");
 
-DEFINE_string(compaction_schedule_seed,
-              ROCKSDB_NAMESPACE::Options().compaction_schedule_seed,
-              "Sets DB option compaction_schedule_seed.");
-
 DEFINE_int32(
     periodic_compaction_phase_recovery_percent,
     ROCKSDB_NAMESPACE::Options().periodic_compaction_phase_recovery_percent,

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -6385,7 +6385,6 @@ void InitializeOptionsFromFlags(
       static_cast<unsigned int>(FLAGS_stats_dump_period_sec);
   options.max_compaction_trigger_wakeup_seconds =
       FLAGS_max_compaction_trigger_wakeup_seconds;
-  options.compaction_schedule_seed = FLAGS_compaction_schedule_seed;
   options.periodic_compaction_phase_recovery_percent =
       FLAGS_periodic_compaction_phase_recovery_percent;
   options.ttl = FLAGS_compaction_ttl;

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -6385,6 +6385,9 @@ void InitializeOptionsFromFlags(
       static_cast<unsigned int>(FLAGS_stats_dump_period_sec);
   options.max_compaction_trigger_wakeup_seconds =
       FLAGS_max_compaction_trigger_wakeup_seconds;
+  options.compaction_schedule_seed = FLAGS_compaction_schedule_seed;
+  options.periodic_compaction_phase_recovery_percent =
+      FLAGS_periodic_compaction_phase_recovery_percent;
   options.ttl = FLAGS_compaction_ttl;
   options.enable_pipelined_write = FLAGS_enable_pipelined_write;
   options.enable_write_thread_adaptive_yield =

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -5259,6 +5259,21 @@ extern ROCKSDB_LIBRARY_API const char*
 rocksdb_options_get_daily_offpeak_time_utc(rocksdb_options_t* opt,
                                            size_t* size);
 
+extern ROCKSDB_LIBRARY_API void rocksdb_options_set_compaction_schedule_seed(
+    rocksdb_options_t* opt, const char* v);
+
+extern ROCKSDB_LIBRARY_API const char*
+rocksdb_options_get_compaction_schedule_seed(rocksdb_options_t* opt,
+                                             size_t* size);
+
+extern ROCKSDB_LIBRARY_API void
+rocksdb_options_set_periodic_compaction_phase_recovery_percent(
+    rocksdb_options_t* opt, int v);
+
+extern ROCKSDB_LIBRARY_API int
+rocksdb_options_get_periodic_compaction_phase_recovery_percent(
+    rocksdb_options_t* opt);
+
 extern ROCKSDB_LIBRARY_API void
 rocksdb_options_set_follower_refresh_catchup_period_ms(rocksdb_options_t* opt,
                                                        uint64_t v);

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -5259,13 +5259,6 @@ extern ROCKSDB_LIBRARY_API const char*
 rocksdb_options_get_daily_offpeak_time_utc(rocksdb_options_t* opt,
                                            size_t* size);
 
-extern ROCKSDB_LIBRARY_API void rocksdb_options_set_compaction_schedule_seed(
-    rocksdb_options_t* opt, const char* v);
-
-extern ROCKSDB_LIBRARY_API const char*
-rocksdb_options_get_compaction_schedule_seed(rocksdb_options_t* opt,
-                                             size_t* size);
-
 extern ROCKSDB_LIBRARY_API void
 rocksdb_options_set_periodic_compaction_phase_recovery_percent(
     rocksdb_options_t* opt, int v);

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -457,13 +457,6 @@ struct DbPath {
 
 extern const char* const kHostnameForDbHostId;
 
-// Whole-value substitution tokens for DBOptions::compaction_schedule_seed. If
-// the entire seed string equals one of these, it is replaced with the DB name
-// or the DB ID (from the IDENTITY file) respectively when deriving the
-// per-(DB, CF) compaction schedule phase.
-extern const char* const kDbNameForScheduleSeed;
-extern const char* const kDbIdForScheduleSeed;
-
 enum class CompactionServiceJobStatus : char {
   kSuccess,
   kFailure,
@@ -1861,55 +1854,36 @@ struct DBOptions {
   uint64_t max_compaction_trigger_wakeup_seconds = 43200;
 
   // EXPERIMENTAL
-  // Seed for randomizing the phase of periodic (time-based) compaction across
-  // DBs and column families, so that DBs configured alike do not all trigger
-  // their periodic_compaction_seconds compactions at the same wall-clock times
-  // (a "thundering herd"). The seed sets a DB-level base phase; each column
-  // family is then spread quasi-uniformly around it by its cf id via a
-  // golden-ratio recurrence, so different CFs in the same DB get well-separated
-  // phases regardless of how the seed is set.
+  // Enables and tunes preferred-phase scheduling of periodic (time-based)
+  // compaction, which de-herds periodic_compaction_seconds compactions across a
+  // fleet of similarly-configured DBs (a recurring "thundering herd" is
+  // especially costly with remote compaction). Each (DB, column family) is
+  // given a stable-but-well-spread preferred phase within
+  // periodic_compaction_seconds and compactions are steered toward it. The
+  // phase is derived from the DB ID -- stable across re-open and physical
+  // cloning/migration (at least when write_dbid_to_manifest=true), but distinct
+  // across DBs -- and each column family is spread quasi-uniformly around the
+  // DB's base phase by a golden-ratio recurrence, so different CFs of one DB
+  // get well-separated phases. No user tuning of the phase itself is needed.
   //
-  // Ideally this stays stable for a DB as it is re-opened and even moved
-  // between hosts, to reduce extra compaction triggers, but different for
-  // different DBs within a host and across hosts, to reduce compaction herding.
-  // Advanced users can provide a string to hash, but the default should suffice
-  // in almost all cases.
+  // This value is the percent (0-100) of the gap between a file's unphased
+  // trigger time and its preferred-phase time that is closed on each
+  // periodic-compaction trigger, always by triggering *earlier* -- never later
+  // than periodic_compaction_seconds, which remains a soft upper bound on data
+  // age. Because each compaction re-stamps the file, the phase error then
+  // decays geometrically toward the preferred phase over successive cycles.
   //
-  // Whole-value substitution (like db_host_id): if the entire string equals
-  //   "__db_name__" it is replaced with the DB name (the path passed to
-  //                 DB::Open), or
-  //   "__db_id__"   it is replaced with the DB ID (from the IDENTITY file);
-  // any other value is used verbatim as the seed. The default is "__db_id__"
-  // which at least identifies the *ancestry* of a DB (in the presence of
-  // physical cloning). Physical migration from one machine to another
-  // generally preserves DB ID (at least when write_dbid_to_manifest=true),
-  // while DB name can often change on migration between hosts.
-  //
-  // Explicit phase (advanced): a value of the form "0.<digits>" -- a leading
-  // "0.", then only decimal digits, e.g. "0.0", "0.25", "0.5" (no sign or
-  // scientific notation) -- is parsed as a fraction in [0, 1) and used as this
-  // DB's base phase (in place of hashing the seed); the DB's CFs are still
-  // spread around that base by the same golden-ratio recurrence. This lets an
-  // operator hand-assign non-overlapping phases across the DBs on a host. It is
-  // rarely worthwhile: in environments where DBs are physically relocated, a
-  // fixed phase can force an extra compaction on relocation as the phase
-  // shifts, so the hashed default is usually preferable.
-  //
-  // The derived phase only takes effect when
-  // periodic_compaction_phase_recovery_percent > 0.
-  //
-  // Dynamically changeable through SetDBOptions() API.
-  std::string compaction_schedule_seed = kDbIdForScheduleSeed;
-
-  // EXPERIMENTAL
-  // Controls how aggressively periodic (time-based) compaction converges to its
-  // preferred phase (see compaction_schedule_seed). On each periodic-compaction
-  // trigger for a file, this percent (0-100) of the gap between the file's
-  // unphased trigger time and its preferred-phase time is closed, always by
-  // triggering *earlier* -- never later than periodic_compaction_seconds, which
-  // remains a hard upper bound on data age. Because each compaction re-stamps
-  // the file, the phase error then decays geometrically toward the preferred
-  // phase over successive cycles.
+  // "Never later" holds in steady state. It can be exceeded only for files
+  // already past due when phasing (re)anchors -- which it does on DB open, on
+  // enabling phasing, and on any change to periodic_compaction_seconds. The
+  // cases that matter are reopening a DB whose files aged out while it was
+  // down (e.g. DC power-outage recovery) and turning the interval *down*
+  // (which retroactively makes older files past due). Rather than compact that
+  // whole cohort at once (a herd), phasing spreads it over the first quarter
+  // of the interval after the anchor, on a stable per-(DB, CF) grid --
+  // expedited but herd-avoiding -- so such a file may be rewritten up to a
+  // quarter-interval past its (revised) deadline. To enforce the age limit
+  // immediately at such a transition, trigger a manual compaction.
   //
   // 0 disables phasing entirely (exact legacy behavior; this is the kill
   // switch). 100 snaps to the preferred phase in a single cycle, which can

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -455,14 +455,14 @@ struct DbPath {
   DbPath(const std::string& p, uint64_t t) : path(p), target_size(t) {}
 };
 
-extern const char* kHostnameForDbHostId;
+extern const char* const kHostnameForDbHostId;
 
 // Whole-value substitution tokens for DBOptions::compaction_schedule_seed. If
 // the entire seed string equals one of these, it is replaced with the DB name
 // or the DB ID (from the IDENTITY file) respectively when deriving the
 // per-(DB, CF) compaction schedule phase.
-extern const char* kDbNameForScheduleSeed;
-extern const char* kDbIdForScheduleSeed;
+extern const char* const kDbNameForScheduleSeed;
+extern const char* const kDbIdForScheduleSeed;
 
 enum class CompactionServiceJobStatus : char {
   kSuccess,

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -457,6 +457,13 @@ struct DbPath {
 
 extern const char* kHostnameForDbHostId;
 
+// Whole-value substitution tokens for DBOptions::compaction_schedule_seed. If
+// the entire seed string equals one of these, it is replaced with the DB name
+// or the DB ID (from the IDENTITY file) respectively when deriving the
+// per-(DB, CF) compaction schedule phase.
+extern const char* kDbNameForScheduleSeed;
+extern const char* kDbIdForScheduleSeed;
+
 enum class CompactionServiceJobStatus : char {
   kSuccess,
   kFailure,
@@ -1852,6 +1859,80 @@ struct DBOptions {
   //
   // Dynamically changeable through SetDBOptions() API.
   uint64_t max_compaction_trigger_wakeup_seconds = 43200;
+
+  // EXPERIMENTAL
+  // Seed for randomizing the phase of periodic (time-based) compaction across
+  // DBs and column families, so that DBs configured alike do not all trigger
+  // their periodic_compaction_seconds compactions at the same wall-clock times
+  // (a "thundering herd"). The seed sets a DB-level base phase; each column
+  // family is then spread quasi-uniformly around it by its cf id via a
+  // golden-ratio recurrence, so different CFs in the same DB get well-separated
+  // phases regardless of how the seed is set.
+  //
+  // Ideally this stays stable for a DB as it is re-opened and even moved
+  // between hosts, to reduce extra compaction triggers, but different for
+  // different DBs within a host and across hosts, to reduce compaction herding.
+  // Advanced users can provide a string to hash, but the default should suffice
+  // in almost all cases.
+  //
+  // Whole-value substitution (like db_host_id): if the entire string equals
+  //   "__db_name__" it is replaced with the DB name (the path passed to
+  //                 DB::Open), or
+  //   "__db_id__"   it is replaced with the DB ID (from the IDENTITY file);
+  // any other value is used verbatim as the seed. The default is "__db_id__"
+  // which at least identifies the *ancestry* of a DB (in the presence of
+  // physical cloning). Physical migration from one machine to another
+  // generally preserves DB ID (at least when write_dbid_to_manifest=true),
+  // while DB name can often change on migration between hosts.
+  //
+  // Explicit phase (advanced): a value of the form "0.<digits>" -- a leading
+  // "0.", then only decimal digits, e.g. "0.0", "0.25", "0.5" (no sign or
+  // scientific notation) -- is parsed as a fraction in [0, 1) and used as this
+  // DB's base phase (in place of hashing the seed); the DB's CFs are still
+  // spread around that base by the same golden-ratio recurrence. This lets an
+  // operator hand-assign non-overlapping phases across the DBs on a host. It is
+  // rarely worthwhile: in environments where DBs are physically relocated, a
+  // fixed phase can force an extra compaction on relocation as the phase
+  // shifts, so the hashed default is usually preferable.
+  //
+  // The derived phase only takes effect when
+  // periodic_compaction_phase_recovery_percent > 0.
+  //
+  // Dynamically changeable through SetDBOptions() API.
+  std::string compaction_schedule_seed = kDbIdForScheduleSeed;
+
+  // EXPERIMENTAL
+  // Controls how aggressively periodic (time-based) compaction converges to its
+  // preferred phase (see compaction_schedule_seed). On each periodic-compaction
+  // trigger for a file, this percent (0-100) of the gap between the file's
+  // unphased trigger time and its preferred-phase time is closed, always by
+  // triggering *earlier* -- never later than periodic_compaction_seconds, which
+  // remains a hard upper bound on data age. Because each compaction re-stamps
+  // the file, the phase error then decays geometrically toward the preferred
+  // phase over successive cycles.
+  //
+  // 0 disables phasing entirely (exact legacy behavior; this is the kill
+  // switch). 100 snaps to the preferred phase in a single cycle, which can
+  // recompact some files well before their normal interval and is generally not
+  // recommended. Values are clamped to [0, 100].
+  //
+  // Lower values converge more slowly but incur less extra compaction work,
+  // especially under write-driven or bursty workloads that keep re-randomizing
+  // a file's phase (where a high recovery rate wastefully "chases" the moving
+  // phase). ~33 is a good balance of spreading speed vs. extra work: almost
+  // always widely spread after a few periods while almost always below 5%
+  // extra compaction work overall, trending toward 0% in the long term for
+  // most workloads.
+  //
+  // This feature might become obsolete if a future feature is able to have
+  // compaction pressure, whether local or remote, feed back into compaction
+  // scheduling.
+  //
+  // Recommended setting: 33
+  // Default: feature disabled
+  //
+  // Dynamically changeable through SetDBOptions() API.
+  int periodic_compaction_phase_recovery_percent = 0;
 
   // EXPERIMENTAL
 

--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -153,10 +153,6 @@ static std::unordered_map<std::string, OptionTypeInfo>
                    max_compaction_trigger_wakeup_seconds),
           OptionType::kUInt64T, OptionVerificationType::kNormal,
           OptionTypeFlags::kMutable}},
-        {"compaction_schedule_seed",
-         {offsetof(struct MutableDBOptions, compaction_schedule_seed),
-          OptionType::kString, OptionVerificationType::kNormal,
-          OptionTypeFlags::kMutable}},
         {"periodic_compaction_phase_recovery_percent",
          {offsetof(struct MutableDBOptions,
                    periodic_compaction_phase_recovery_percent),
@@ -1129,7 +1125,6 @@ MutableDBOptions::MutableDBOptions(const DBOptions& options)
       daily_offpeak_time_utc(options.daily_offpeak_time_utc),
       max_compaction_trigger_wakeup_seconds(
           options.max_compaction_trigger_wakeup_seconds),
-      compaction_schedule_seed(options.compaction_schedule_seed),
       periodic_compaction_phase_recovery_percent(
           options.periodic_compaction_phase_recovery_percent) {}
 
@@ -1193,8 +1188,6 @@ void MutableDBOptions::Dump(Logger* log) const {
   ROCKS_LOG_HEADER(log,
                    "Options.max_compaction_trigger_wakeup_seconds: %" PRIu64,
                    max_compaction_trigger_wakeup_seconds);
-  ROCKS_LOG_HEADER(log, "               Options.compaction_schedule_seed: %s",
-                   compaction_schedule_seed.c_str());
   ROCKS_LOG_HEADER(log,
                    "Options.periodic_compaction_phase_recovery_percent: %d",
                    periodic_compaction_phase_recovery_percent);

--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -153,6 +153,15 @@ static std::unordered_map<std::string, OptionTypeInfo>
                    max_compaction_trigger_wakeup_seconds),
           OptionType::kUInt64T, OptionVerificationType::kNormal,
           OptionTypeFlags::kMutable}},
+        {"compaction_schedule_seed",
+         {offsetof(struct MutableDBOptions, compaction_schedule_seed),
+          OptionType::kString, OptionVerificationType::kNormal,
+          OptionTypeFlags::kMutable}},
+        {"periodic_compaction_phase_recovery_percent",
+         {offsetof(struct MutableDBOptions,
+                   periodic_compaction_phase_recovery_percent),
+          OptionType::kInt, OptionVerificationType::kNormal,
+          OptionTypeFlags::kMutable}},
         {"fast_sst_open",
          {offsetof(struct MutableDBOptions, fast_sst_open),
           OptionType::kBoolean, OptionVerificationType::kNormal,
@@ -1119,7 +1128,10 @@ MutableDBOptions::MutableDBOptions(const DBOptions& options)
           options.remote_compaction_manifest_floor),
       daily_offpeak_time_utc(options.daily_offpeak_time_utc),
       max_compaction_trigger_wakeup_seconds(
-          options.max_compaction_trigger_wakeup_seconds) {}
+          options.max_compaction_trigger_wakeup_seconds),
+      compaction_schedule_seed(options.compaction_schedule_seed),
+      periodic_compaction_phase_recovery_percent(
+          options.periodic_compaction_phase_recovery_percent) {}
 
 void MutableDBOptions::Dump(Logger* log) const {
   ROCKS_LOG_HEADER(log, "            Options.max_background_jobs: %d",
@@ -1181,6 +1193,11 @@ void MutableDBOptions::Dump(Logger* log) const {
   ROCKS_LOG_HEADER(log,
                    "Options.max_compaction_trigger_wakeup_seconds: %" PRIu64,
                    max_compaction_trigger_wakeup_seconds);
+  ROCKS_LOG_HEADER(log, "               Options.compaction_schedule_seed: %s",
+                   compaction_schedule_seed.c_str());
+  ROCKS_LOG_HEADER(log,
+                   "Options.periodic_compaction_phase_recovery_percent: %d",
+                   periodic_compaction_phase_recovery_percent);
   ROCKS_LOG_HEADER(log, "                         Options.fast_sst_open: %d",
                    fast_sst_open);
   ROCKS_LOG_HEADER(log, "      Options.remote_compaction_manifest_floor: %d",

--- a/options/db_options.h
+++ b/options/db_options.h
@@ -159,7 +159,6 @@ struct MutableDBOptions {
   bool remote_compaction_manifest_floor;
   std::string daily_offpeak_time_utc;
   uint64_t max_compaction_trigger_wakeup_seconds;
-  std::string compaction_schedule_seed;
   int periodic_compaction_phase_recovery_percent;
 };
 

--- a/options/db_options.h
+++ b/options/db_options.h
@@ -159,6 +159,8 @@ struct MutableDBOptions {
   bool remote_compaction_manifest_floor;
   std::string daily_offpeak_time_utc;
   uint64_t max_compaction_trigger_wakeup_seconds;
+  std::string compaction_schedule_seed;
+  int periodic_compaction_phase_recovery_percent;
 };
 
 Status GetStringFromMutableDBOptions(const ConfigOptions& config_options,

--- a/options/options.cc
+++ b/options/options.cc
@@ -35,6 +35,9 @@
 
 namespace ROCKSDB_NAMESPACE {
 
+const char* kDbNameForScheduleSeed = "__db_name__";
+const char* kDbIdForScheduleSeed = "__db_id__";
+
 AdvancedColumnFamilyOptions::AdvancedColumnFamilyOptions() {
   assert(memtable_factory.get() != nullptr);
 }

--- a/options/options.cc
+++ b/options/options.cc
@@ -35,9 +35,6 @@
 
 namespace ROCKSDB_NAMESPACE {
 
-const char* const kDbNameForScheduleSeed = "__db_name__";
-const char* const kDbIdForScheduleSeed = "__db_id__";
-
 AdvancedColumnFamilyOptions::AdvancedColumnFamilyOptions() {
   assert(memtable_factory.get() != nullptr);
 }

--- a/options/options.cc
+++ b/options/options.cc
@@ -35,8 +35,8 @@
 
 namespace ROCKSDB_NAMESPACE {
 
-const char* kDbNameForScheduleSeed = "__db_name__";
-const char* kDbIdForScheduleSeed = "__db_id__";
+const char* const kDbNameForScheduleSeed = "__db_name__";
+const char* const kDbIdForScheduleSeed = "__db_id__";
 
 AdvancedColumnFamilyOptions::AdvancedColumnFamilyOptions() {
   assert(memtable_factory.get() != nullptr);

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -205,6 +205,10 @@ void BuildDBOptions(const ImmutableDBOptions& immutable_db_options,
       mutable_db_options.max_compaction_trigger_wakeup_seconds;
   options.remote_compaction_manifest_floor =
       mutable_db_options.remote_compaction_manifest_floor;
+  options.compaction_schedule_seed =
+      mutable_db_options.compaction_schedule_seed;
+  options.periodic_compaction_phase_recovery_percent =
+      mutable_db_options.periodic_compaction_phase_recovery_percent;
   options.follower_refresh_catchup_period_ms =
       immutable_db_options.follower_refresh_catchup_period_ms;
   options.follower_catchup_retry_count =

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -205,8 +205,6 @@ void BuildDBOptions(const ImmutableDBOptions& immutable_db_options,
       mutable_db_options.max_compaction_trigger_wakeup_seconds;
   options.remote_compaction_manifest_floor =
       mutable_db_options.remote_compaction_manifest_floor;
-  options.compaction_schedule_seed =
-      mutable_db_options.compaction_schedule_seed;
   options.periodic_compaction_phase_recovery_percent =
       mutable_db_options.periodic_compaction_phase_recovery_percent;
   options.follower_refresh_catchup_period_ms =

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -359,6 +359,8 @@ TEST_F(OptionsSettableTest, DBOptionsAllFieldsSettable) {
       {offsetof(struct DBOptions, compaction_service),
        sizeof(std::shared_ptr<CompactionService>)},
       {offsetof(struct DBOptions, daily_offpeak_time_utc), sizeof(std::string)},
+      {offsetof(struct DBOptions, compaction_schedule_seed),
+       sizeof(std::string)},
       {offsetof(struct DBOptions, calculate_sst_write_lifetime_hint_set),
        sizeof(CompactionStyleSet)},
   };
@@ -489,6 +491,8 @@ TEST_F(OptionsSettableTest, DBOptionsAllFieldsSettable) {
       "enforce_single_del_contracts=false;"
       "daily_offpeak_time_utc=08:30-19:00;"
       "max_compaction_trigger_wakeup_seconds=43200;"
+      "compaction_schedule_seed=__db_name__;"
+      "periodic_compaction_phase_recovery_percent=25;"
       "follower_refresh_catchup_period_ms=123;"
       "follower_catchup_retry_count=456;"
       "follower_catchup_retry_wait_ms=789;"

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -359,8 +359,6 @@ TEST_F(OptionsSettableTest, DBOptionsAllFieldsSettable) {
       {offsetof(struct DBOptions, compaction_service),
        sizeof(std::shared_ptr<CompactionService>)},
       {offsetof(struct DBOptions, daily_offpeak_time_utc), sizeof(std::string)},
-      {offsetof(struct DBOptions, compaction_schedule_seed),
-       sizeof(std::string)},
       {offsetof(struct DBOptions, calculate_sst_write_lifetime_hint_set),
        sizeof(CompactionStyleSet)},
   };
@@ -491,7 +489,6 @@ TEST_F(OptionsSettableTest, DBOptionsAllFieldsSettable) {
       "enforce_single_del_contracts=false;"
       "daily_offpeak_time_utc=08:30-19:00;"
       "max_compaction_trigger_wakeup_seconds=43200;"
-      "compaction_schedule_seed=__db_name__;"
       "periodic_compaction_phase_recovery_percent=25;"
       "follower_refresh_catchup_period_ms=123;"
       "follower_catchup_retry_count=456;"

--- a/src.mk
+++ b/src.mk
@@ -86,6 +86,7 @@ LIB_SOURCES =                                                   \
   db/merge_operator.cc                                          \
   db/multi_scan.cc						\
   db/output_validator.cc                                        \
+  db/periodic_compaction_phaser.cc                              \
   db/periodic_task_scheduler.cc                                 \
   db/range_del_aggregator.cc                                    \
   db/range_tombstone_fragmenter.cc                              \

--- a/table/format.cc
+++ b/table/format.cc
@@ -41,7 +41,7 @@
 
 namespace ROCKSDB_NAMESPACE {
 
-const char* kHostnameForDbHostId = "__hostname__";
+const char* const kHostnameForDbHostId = "__hostname__";
 
 bool ShouldReportDetailedTime(Env* env, Statistics* stats) {
   return env != nullptr && stats != nullptr &&

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -2024,11 +2024,6 @@ DEFINE_uint64(
     max_compaction_trigger_wakeup_seconds,
     ROCKSDB_NAMESPACE::Options().max_compaction_trigger_wakeup_seconds,
     "Maximum interval in seconds between periodic compaction trigger checks.");
-DEFINE_string(compaction_schedule_seed,
-              ROCKSDB_NAMESPACE::Options().compaction_schedule_seed,
-              "Sets DB option compaction_schedule_seed (seed for randomizing "
-              "the phase of periodic compaction; supports __db_name__ and "
-              "__db_id__ whole-value substitution).");
 DEFINE_int32(
     periodic_compaction_phase_recovery_percent,
     ROCKSDB_NAMESPACE::Options().periodic_compaction_phase_recovery_percent,
@@ -5295,7 +5290,6 @@ class Benchmark {
         static_cast<unsigned int>(FLAGS_stats_dump_period_sec);
     options.max_compaction_trigger_wakeup_seconds =
         FLAGS_max_compaction_trigger_wakeup_seconds;
-    options.compaction_schedule_seed = FLAGS_compaction_schedule_seed;
     options.periodic_compaction_phase_recovery_percent =
         FLAGS_periodic_compaction_phase_recovery_percent;
     options.stats_persist_period_sec =
@@ -5305,7 +5299,6 @@ class Benchmark {
         static_cast<size_t>(FLAGS_stats_history_buffer_size);
     options.avoid_flush_during_recovery = FLAGS_avoid_flush_during_recovery;
     options.avoid_flush_during_shutdown = FLAGS_avoid_flush_during_shutdown;
-
     options.compression_opts.level = FLAGS_compression_level;
     options.compression_opts.max_dict_bytes = FLAGS_compression_max_dict_bytes;
     options.compression_opts.zstd_max_train_bytes =

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -2024,6 +2024,16 @@ DEFINE_uint64(
     max_compaction_trigger_wakeup_seconds,
     ROCKSDB_NAMESPACE::Options().max_compaction_trigger_wakeup_seconds,
     "Maximum interval in seconds between periodic compaction trigger checks.");
+DEFINE_string(compaction_schedule_seed,
+              ROCKSDB_NAMESPACE::Options().compaction_schedule_seed,
+              "Sets DB option compaction_schedule_seed (seed for randomizing "
+              "the phase of periodic compaction; supports __db_name__ and "
+              "__db_id__ whole-value substitution).");
+DEFINE_int32(
+    periodic_compaction_phase_recovery_percent,
+    ROCKSDB_NAMESPACE::Options().periodic_compaction_phase_recovery_percent,
+    "Sets DB option periodic_compaction_phase_recovery_percent (0 disables "
+    "periodic compaction phasing).");
 DEFINE_uint64(stats_persist_period_sec,
               ROCKSDB_NAMESPACE::Options().stats_persist_period_sec,
               "Gap between persisting stats in seconds");
@@ -5285,6 +5295,9 @@ class Benchmark {
         static_cast<unsigned int>(FLAGS_stats_dump_period_sec);
     options.max_compaction_trigger_wakeup_seconds =
         FLAGS_max_compaction_trigger_wakeup_seconds;
+    options.compaction_schedule_seed = FLAGS_compaction_schedule_seed;
+    options.periodic_compaction_phase_recovery_percent =
+        FLAGS_periodic_compaction_phase_recovery_percent;
     options.stats_persist_period_sec =
         static_cast<unsigned int>(FLAGS_stats_persist_period_sec);
     options.persist_stats_to_disk = FLAGS_persist_stats_to_disk;

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -395,6 +395,12 @@ default_params = {
     "daily_offpeak_time_utc": lambda: random.choice(
         ["", "", "00:00-23:59", "04:00-08:00", "23:30-03:15"]
     ),
+    "compaction_schedule_seed": lambda: random.choice(
+        ["__db_name__", "__db_id__", "", "crashtest_seed", "0.5"]
+    ),
+    "periodic_compaction_phase_recovery_percent": lambda: random.choice(
+        [0, 25, 33, 50, 100]
+    ),
     # 0 = never (used by some), 10 = often (for threading bugs), 600 = default
     "stats_dump_period_sec": lambda: random.choice([0, 10, 600]),
     "compaction_ttl": lambda: random.choice([0, 0, 1, 2, 10, 100, 1000]),

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -395,9 +395,6 @@ default_params = {
     "daily_offpeak_time_utc": lambda: random.choice(
         ["", "", "00:00-23:59", "04:00-08:00", "23:30-03:15"]
     ),
-    "compaction_schedule_seed": lambda: random.choice(
-        ["__db_name__", "__db_id__", "", "crashtest_seed", "0.5"]
-    ),
     "periodic_compaction_phase_recovery_percent": lambda: random.choice(
         [0, 25, 33, 50, 100]
     ),

--- a/unreleased_history/new_features/compaction_schedule_seed.md
+++ b/unreleased_history/new_features/compaction_schedule_seed.md
@@ -1,0 +1,1 @@
+A new experimental feature alters periodic compaction scheduling to spread out trigger times and avoid recurring "thundering herd" triggers, especially with remote compaction. See new experimental DB options `compaction_schedule_seed` and `periodic_compaction_phase_recovery_percent`.

--- a/unreleased_history/new_features/compaction_schedule_seed.md
+++ b/unreleased_history/new_features/compaction_schedule_seed.md
@@ -1,1 +1,0 @@
-A new experimental feature alters periodic compaction scheduling to spread out trigger times and avoid recurring "thundering herd" triggers, especially with remote compaction. See new experimental DB options `compaction_schedule_seed` and `periodic_compaction_phase_recovery_percent`.

--- a/unreleased_history/new_features/periodic_compaction_phasing.md
+++ b/unreleased_history/new_features/periodic_compaction_phasing.md
@@ -1,0 +1,1 @@
+A new experimental feature spreads out periodic (time-based) compaction trigger times across a fleet of similarly-configured DBs to avoid recurring "thundering herd" triggers, especially with remote compaction. See the new experimental DB option `periodic_compaction_phase_recovery_percent`.


### PR DESCRIPTION
## Summary

`periodic_compaction_seconds` softly guarantees every SST is rewritten at least
once per interval. Across a fleet of similarly-configured DBs, many events line
those intervals up in lockstep -- a shared enable, a coordinated restart (e.g.
DC power-outage recovery), or just similar write history -- so the periodic
compactions all come due together, a recurring "thundering herd" that is
especially painful with remote compaction (SEV S698635).

The obvious fixes trade one problem for another. Spreading the herd out means
some files get compacted off their natural schedule, which is wasted work; and a
clumsy spread just relocates the herd or spawns a new one. So the real goal is
narrow: **de-herd while keeping "badness" -- extra and/or late compaction --
small, and without inducing fresh herding at any step.**

This change adds an EXPERIMENTAL, opt-in mechanism that gives each
`(DB, column family)` a stable, well-spread *preferred phase* within the interval and steers
periodic compactions toward it. It is randomized and *uncoordinated* (DBs never
talk to each other), which both keeps it simple and, as it turns out, de-herds
far more cheaply than adding jitter to the interval. It is controlled by a single
mutable DBOption and is **off by default**:

- `periodic_compaction_phase_recovery_percent` (default `0` = disabled / kill
  switch; recommended `33`; clamped to `[0, 100]`) -- how aggressively each
  trigger converges toward the phase, as a percent of the remaining gap, only
  ever pulling the trigger *earlier*. `0` reproduces the classic scheduler
  exactly; `100` jumps to the phase in one cycle; lower values approach gradually
  with much less extra work.

The preferred phase itself needs no tuning: it is derived from the DB ID (stable
across re-open and physical cloning/migration, but distinct across DBs) and each
column family is offset from the DB's base phase, so the CFs of one DB don't fire
together. (An earlier draft exposed a `compaction_schedule_seed` string option
for choosing the phase source; it was over-engineered for the one behavior anyone
needed, and as a mutable string it also broke OPTIONS-file round-trip
verification in crash testing. It has been removed in favor of always using the
DB ID.)

## The two kinds of badness

"Badness" here is the fraction of compaction work that is ideally unnecessary:
over-compaction (rewriting a file earlier than the interval required) plus a
penalty for lateness (going overdue past the interval). Steady state is 0; both
"never compact" and "compact twice as often as needed" approach 1. De-herding
inherently spends a little badness to spread load out; every design choice below
exists to bound one of those two costs *without* re-clustering the fleet.

The scenario names cited in the design bullets below (`upgrade_dynamic_r33`,
`naive_upgrade_r25`, `burst_r*`, `turndown_r33`, `turnup_r33`, ...) all come from
the out-of-tree simulator; see its results page (the "Simulator and
visualization" section below, with an interactive plot per scenario) for the
evidence behind each claim.

## Design

- **A stable per-(DB, CF) preferred phase = one fixed attractor per DB.** Each DB
  gets a base phase from its DB ID; each CF is offset from it. Because the target
  is fixed (not re-rolled each cycle) and unique per DB, the fleet converges to a
  uniform spread and then compacts *on time* -- badness decays toward ~0. This is
  the crucial contrast with naive per-cycle jitter, which de-herds but never stops
  jittering and so pays a permanent over-compaction cost (see
  `naive_upgrade_r25`: flat ~12-14%, only diffusive spreading) vs.
  `upgrade_dynamic_r33`, whose badness decays to ~0 for the same anti-herding.

- **Converge gradually, and only ever earlier.** Each trigger closes a
  `recovery_percent` *fraction* of the gap to the phase, reaching it over a few
  cycles rather than in one burst, and never later than
  `periodic_compaction_seconds` in steady state. A lower rate does less extra
  work, which matters when the phase keeps moving (write-driven / bursty
  workloads), where a high rate wastefully "chases" it -- the burst sweep shows
  `burst_r25 < burst_r33 < burst_r50 < burst_r100` in sustained badness. `33` is
  the default balance: quick spreading, low extra work.

- **Fractional recovery (not "snap") is latency-tolerant and doesn't re-herd.**
  Closing a fraction of the gap gives a single stable convergence point, so
  real-world scheduling/queueing latency -- the delay between a file becoming due
  and its compaction actually running -- merely shifts the whole fleet uniformly
  instead of re-clustering it. A tried "snap onto the phase when in range" variant
  converged a bit faster with no latency but re-herded around the snap
  threshold under latency; it was rejected. Graceful degradation beat peak speed.

- **Spread a suddenly-due cohort instead of bursting it (bounded lateness).**
  Enabling the feature, turning `periodic_compaction_seconds` down, or catching up
  after downtime can leave a whole cohort past due at the same instant. Firing it
  all at once would just be the herd again, so such a cohort is spread over the
  first quarter-interval (~N/4) after the phasing anchor on an *absolute*,
  epoch-aligned per-(DB, CF) grid. This trades a bounded lateness (<= ~N/4 past
  the deadline, so the interval is a *soft* upper bound during these transients)
  for anti-herding, and the absolute grid keeps a rapidly restarting DB from being
  perpetually re-deferred and starved. `turndown_r33` shows the past-due cohort
  smeared over N/4 rather than bursting; `turnup_r33` confirms a turn-up creates
  no past-due cohort (deadlines only grow) and so no burst. For immediate
  enforcement at such a transition, trigger a manual compaction.

- **Off by default, with a kill switch.** Inert unless
  `periodic_compaction_phase_recovery_percent > 0`; at `0` behavior is identical
  to the classic scheduler.

## Implementation notes

- Phase math is integer-only (`Hash64` + `FastRange64`); floating point is avoided
  for its pitfalls. The per-CF offset is a golden-ratio (Weyl/Kronecker) additive
  sequence -- low-discrepancy for any number of CFs.
- Logic lives in `db/periodic_compaction_phaser.{h,cc}`
  (`PeriodicCompactionPhaser`), which owns the recovery percent and the phasing
  anchor and exposes the stateless trigger-time math; `VersionSet` holds one and
  caches the per-CF result on each `Version`. The anchor is (re)set to now on DB
  open, on a recovery-percent change, and on any `periodic_compaction_seconds`
  change -- the three events that can create a past-due cohort.
- Plumbed through the C API, `db_bench`, `db_stress`, and `db_crashtest`.

## Simulator and visualization (out-of-tree, not part of this change)

A standalone simulator drives 40 real RocksDB instances through a real
periodic-task scheduler, records every compaction (periodic vs write-driven), and
scores the badness metric above across ~17 scenarios: dynamic/restart enable,
interval turn-down/turn-up via `SetOptions`, on-cadence writes, random write
bursts with a recovery-rate sweep, and the naive-jitter baseline. It is the basis
for the numbers cited above. Interactive HTML:
https://htmlpreview.github.io/?https://github.com/facebook/rocksdb/blob/5759c6a62d9ff36cecf030b80453cc819b2f66ae/pc_phase_sim.html

## Test plan

New unit tests in `db/db_compaction_test.cc` exercise the pure logic directly:

- `PeriodicCompactionPhaseTriggerTime` -- `recovery_percent==0` reproduces legacy
  `file_mod + N`; steady-state early pull; geometric convergence (non-increasing
  error, exact for rp=100 and <=1 residue otherwise); the past-due `N/4` grid; the
  enable-transient spread; never later than the deadline in steady state.
- `PeriodicCompactionPhaseCfSpread` -- golden-ratio CF spread: cf 0 == base,
  distinct phases, max gap <= 2x average (low discrepancy).
- `PeriodicCompactionPhaseOptions` -- the option is plumbed and dynamically
  settable (round-trip through `SetDBOptions()`).

`db_crashtest.py` randomizes `periodic_compaction_phase_recovery_percent` across
`{0, 25, 33, 50, 100}` so both the disabled and phased paths get fuzzed. The
existing `LevelPeriodicCompactionOffpeak` test continues to cover composition with
offpeak forward-pull (with phasing disabled). Fleet-level de-herding and the
badness numbers are validated by the out-of-tree simulator above rather than in
unit tests.