### PR TITLE
Pass SST block CRC32C checksums to file writer (#15155)

### DIFF
--- a/db/builder.cc
+++ b/db/builder.cc
@@ -207,7 +207,8 @@ Status BuildTable(
           std::move(file), fname, file_options, ioptions.clock, io_tracer,
           ioptions.stats, Histograms::SST_WRITE_MICROS, ioptions.listeners,
           ioptions.file_checksum_gen_factory.get(),
-          tmp_set.Contains(FileType::kTableFile), false));
+          tmp_set.Contains(FileType::kTableFile),
+          tmp_set.Contains(FileType::kTableFile)));
 
       builder = NewTableBuilder(tboptions, file_writer.get());
     }

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -2634,7 +2634,8 @@ Status CompactionJob::OpenCompactionOutputFile(SubcompactionState* sub_compact,
       std::move(writable_file), fname, fo_copy, db_options_.clock, io_tracer_,
       db_options_.stats, Histograms::SST_WRITE_MICROS, listeners,
       db_options_.file_checksum_gen_factory.get(),
-      tmp_set.Contains(FileType::kTableFile), false));
+      tmp_set.Contains(FileType::kTableFile),
+      tmp_set.Contains(FileType::kTableFile)));
 
   // TODO(hx235): pass in the correct `oldest_key_time` instead of `0`
   const ReadOptions read_options(Env::IOActivity::kCompaction);

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -4760,7 +4760,8 @@ Status DBImpl::BackgroundCompaction(bool* made_progress,
             immutable_db_options_.stats, Histograms::SST_WRITE_MICROS,
             c->immutable_options().listeners,
             immutable_db_options_.file_checksum_gen_factory.get(),
-            tmp_set.Contains(FileType::kTableFile), false));
+            tmp_set.Contains(FileType::kTableFile),
+            tmp_set.Contains(FileType::kTableFile)));
       }
 
       ROCKS_LOG_BUFFER(

--- a/file/writable_file_writer.cc
+++ b/file/writable_file_writer.cc
@@ -10,7 +10,9 @@
 #include "file/writable_file_writer.h"
 
 #include <algorithm>
+#include <cstdio>
 #include <mutex>
+#include <string>
 
 #include "db/version_edit.h"
 #include "file/file_util.h"
@@ -43,6 +45,47 @@ inline Histograms GetFileWriteHistograms(Histograms file_writer_hist,
   return Histograms::HISTOGRAM_ENUM_MAX;
 }
 
+constexpr char kDestinationBufferChecksumMismatch[] =
+    "Checksum handoff detected data corruption after copying data into "
+    "WritableFileWriter destination buffer";
+constexpr char kLogicalAppendChecksumMismatch[] =
+    "Checksum handoff detected logical append checksum mismatch after copying "
+    "caller data into WritableFileWriter buffers";
+
+static IOStatus ChecksumMismatchStatus(size_t size,
+                                       Crc32cChecksum expected_checksum,
+                                       uint32_t actual_crc32c,
+                                       const std::string& file_name,
+                                       const char* mismatch_message) {
+  char expected_checksum_buf[11];
+  char actual_crc32c_buf[11];
+  snprintf(expected_checksum_buf, sizeof(expected_checksum_buf), "0x%08x",
+           static_cast<unsigned int>(expected_checksum.value));
+  snprintf(actual_crc32c_buf, sizeof(actual_crc32c_buf), "0x%08x",
+           static_cast<unsigned int>(actual_crc32c));
+  std::string message = mismatch_message;
+  message.append(": file=")
+      .append(file_name)
+      .append(" size=")
+      .append(std::to_string(size))
+      .append(" expected_crc32c=")
+      .append(expected_checksum_buf)
+      .append(" actual_crc32c=")
+      .append(actual_crc32c_buf);
+  return IOStatus::Corruption(message);
+}
+
+static IOStatus ValidateDataChecksum(const Slice& data, Crc32cChecksum checksum,
+                                     const std::string& file_name,
+                                     const char* mismatch_message) {
+  const uint32_t actual_crc32c = crc32c::Value(data.data(), data.size());
+  if (actual_crc32c == checksum.value) {
+    return IOStatus::OK();
+  }
+  return ChecksumMismatchStatus(data.size(), checksum, actual_crc32c, file_name,
+                                mismatch_message);
+}
+
 IOStatus WritableFileWriter::Create(const std::shared_ptr<FileSystem>& fs,
                                     const std::string& fname,
                                     const FileOptions& file_opts,
@@ -63,6 +106,18 @@ IOStatus WritableFileWriter::Create(const std::shared_ptr<FileSystem>& fs,
 
 IOStatus WritableFileWriter::Append(const IOOptions& opts, const Slice& data,
                                     uint32_t crc32c_checksum) {
+  Crc32cChecksum checksum(crc32c_checksum);
+  return AppendSlice(opts, data, crc32c_checksum == 0 ? nullptr : &checksum);
+}
+
+IOStatus WritableFileWriter::Append(const IOOptions& opts, const Slice& data,
+                                    Crc32cChecksum crc32c_checksum) {
+  return AppendSlice(opts, data, &crc32c_checksum);
+}
+
+IOStatus WritableFileWriter::AppendSlice(
+    const IOOptions& opts, const Slice& data_slice,
+    const Crc32cChecksum* crc32c_checksum) {
   if (seen_error()) {
     return GetWriterHasPreviousErrorStatus();
   }
@@ -71,15 +126,14 @@ IOStatus WritableFileWriter::Append(const IOOptions& opts, const Slice& data,
                GetFileWriteHistograms(hist_type_, opts.io_activity));
 
   const IOOptions io_options = FinalizeIOOptions(opts);
-  const char* src = data.data();
-  size_t left = data.size();
+  const char* src = data_slice.data();
+  size_t left = data_slice.size();
   IOStatus s;
   pending_sync_ = true;
 
   TEST_KILL_RANDOM_WITH_WEIGHT("WritableFileWriter::Append:0", REDUCE_ODDS2);
 
-  // Calculate the checksum of appended data
-  UpdateFileChecksum(data);
+  UpdateFileChecksum(data_slice);
 
   {
     IOSTATS_TIMER_GUARD(prepare_write_nanos);
@@ -125,23 +179,47 @@ IOStatus WritableFileWriter::Append(const IOOptions& opts, const Slice& data,
   }
 
   if (perform_data_verification_ && buffered_data_with_checksum_ &&
-      crc32c_checksum != 0) {
-    // Since we want to use the checksum of the input data, we cannot break it
-    // into several pieces. We will only write them in the buffer when buffer
-    // size is enough. Otherwise, we will directly write it down.
+      crc32c_checksum != nullptr) {
     if (use_direct_io() || (buf_.Capacity() - buf_.CurrentSize()) >= left) {
       if ((buf_.Capacity() - buf_.CurrentSize()) >= left) {
+        size_t copied_offset = buf_.CurrentSize();
         size_t appended = buf_.Append(src, left);
         if (appended != left) {
           s = IOStatus::Corruption("Write buffer append failure");
         }
-        buffered_data_crc32c_checksum_ = crc32c::Crc32cCombine(
-            buffered_data_crc32c_checksum_, crc32c_checksum, appended);
+        if (s.ok()) {
+          Slice copied_data(buf_.BufferStart() + copied_offset, appended);
+          s = ValidateCopiedDataChecksum(copied_data, *crc32c_checksum);
+        }
+        if (s.ok()) {
+          buffered_data_crc32c_checksum_ = crc32c::Crc32cCombine(
+              buffered_data_crc32c_checksum_, crc32c_checksum->value, appended);
+        } else {
+          buf_.Size(0);
+          buffered_data_crc32c_checksum_ = 0;
+        }
       } else {
-        while (left > 0) {
-          size_t appended = buf_.Append(src, left);
-          buffered_data_crc32c_checksum_ =
-              crc32c::Extend(buffered_data_crc32c_checksum_, src, appended);
+        uint32_t logical_append_crc32c = 0;
+        while (s.ok() && left > 0) {
+          if (buf_.CurrentSize() == buf_.Capacity()) {
+            s = Flush(io_options);
+            continue;
+          }
+          const size_t copied_offset = buf_.CurrentSize();
+          const size_t append_size =
+              std::min(left, buf_.Capacity() - buf_.CurrentSize());
+          size_t appended = buf_.Append(src, append_size);
+          if (appended != append_size) {
+            s = IOStatus::Corruption("Write buffer append failure");
+            break;
+          }
+          Slice copied_data(buf_.BufferStart() + copied_offset, appended);
+          const uint32_t appended_crc32c =
+              crc32c::Value(copied_data.data(), copied_data.size());
+          buffered_data_crc32c_checksum_ = crc32c::Crc32cCombine(
+              buffered_data_crc32c_checksum_, appended_crc32c, appended);
+          logical_append_crc32c = crc32c::Crc32cCombine(
+              logical_append_crc32c, appended_crc32c, appended);
           left -= appended;
           src += appended;
 
@@ -152,10 +230,17 @@ IOStatus WritableFileWriter::Append(const IOOptions& opts, const Slice& data,
             }
           }
         }
+        if (s.ok() && logical_append_crc32c != crc32c_checksum->value) {
+          s = ChecksumMismatchStatus(data_slice.size(), *crc32c_checksum,
+                                     logical_append_crc32c, file_name_,
+                                     kLogicalAppendChecksumMismatch);
+          buf_.Size(0);
+          buffered_data_crc32c_checksum_ = 0;
+        }
       }
     } else {
       assert(buf_.CurrentSize() == 0);
-      buffered_data_crc32c_checksum_ = crc32c_checksum;
+      buffered_data_crc32c_checksum_ = crc32c_checksum->value;
       s = WriteBufferedWithChecksum(io_options, src, left);
     }
   } else {
@@ -197,7 +282,7 @@ IOStatus WritableFileWriter::Append(const IOOptions& opts, const Slice& data,
   TEST_KILL_RANDOM("WritableFileWriter::Append:1");
   if (s.ok()) {
     uint64_t cur_size = filesize_.load(std::memory_order_acquire);
-    filesize_.store(cur_size + data.size(), std::memory_order_release);
+    filesize_.store(cur_size + data_slice.size(), std::memory_order_release);
   } else {
     set_seen_error(s);
   }
@@ -772,6 +857,12 @@ void WritableFileWriter::Crc32cHandoffChecksumCalculation(const char* data,
                                                           char* buf) {
   uint32_t v_crc32c = crc32c::Extend(0, data, size);
   EncodeFixed32(buf, v_crc32c);
+}
+
+IOStatus WritableFileWriter::ValidateCopiedDataChecksum(
+    const Slice& copied_data, Crc32cChecksum checksum) {
+  return ValidateDataChecksum(copied_data, checksum, file_name_,
+                              kDestinationBufferChecksumMismatch);
 }
 
 // This flushes the accumulated data in the buffer. We pad data with zeros if

--- a/file/writable_file_writer.h
+++ b/file/writable_file_writer.h
@@ -30,6 +30,12 @@ namespace ROCKSDB_NAMESPACE {
 class Statistics;
 class SystemClock;
 
+struct Crc32cChecksum {
+  explicit Crc32cChecksum(uint32_t _value) : value(_value) {}
+
+  uint32_t value;
+};
+
 // WritableFileWriter is a wrapper on top of Env::WritableFile. It provides
 // facilities to:
 // - Handle Buffered and Direct writes.
@@ -136,6 +142,10 @@ class WritableFileWriter {
   void UpdateFileChecksum(const Slice& data);
   void Crc32cHandoffChecksumCalculation(const char* data, size_t size,
                                         char* buf);
+  IOStatus ValidateCopiedDataChecksum(const Slice& copied_data,
+                                      Crc32cChecksum checksum);
+  IOStatus AppendSlice(const IOOptions& opts, const Slice& data,
+                       const Crc32cChecksum* crc32c_checksum);
 
   std::string file_name_;
   FSWritableFilePtr writable_file_;
@@ -258,6 +268,8 @@ class WritableFileWriter {
   // will calculate the checksum internally.
   IOStatus Append(const IOOptions& opts, const Slice& data,
                   uint32_t crc32c_checksum = 0);
+  IOStatus Append(const IOOptions& opts, const Slice& data,
+                  Crc32cChecksum crc32c_checksum);
 
   IOStatus Pad(const IOOptions& opts, const size_t pad_bytes,
                const size_t max_pad_size);

--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -63,6 +63,7 @@
 #include "util/bit_fields.h"
 #include "util/coding.h"
 #include "util/compression.h"
+#include "util/crc32c.h"
 #include "util/defer.h"
 #include "util/random.h"
 #include "util/semaphore.h"
@@ -78,6 +79,18 @@ extern const std::string kHashIndexPrefixesMetadataBlock;
 namespace {
 
 constexpr size_t kBlockTrailerSize = BlockBasedTable::kBlockTrailerSize;
+
+void NotifyFileAppendForTest(const Slice& data,
+                             const Crc32cChecksum* crc32c_checksum) {
+#ifndef NDEBUG
+  std::pair<Slice, const Crc32cChecksum*> append_info(data, crc32c_checksum);
+  TEST_SYNC_POINT_CALLBACK("BlockBasedTableBuilder::Append:Before",
+                           &append_info);
+#else
+  (void)data;
+  (void)crc32c_checksum;
+#endif
+}
 
 // ===================== AutoSkip compression =====================
 // Fixed-point scale for the continuous compression-ratio estimate q_hat and the
@@ -2274,7 +2287,7 @@ void BlockBasedTableBuilder::WriteBlock(const Slice& uncompressed_block_data,
   // Single-threaded context only
   assert(!r->IsParallelCompressionActive());
   CompressionType type = kNoCompression;
-  uint32_t contents_checksum = 0;
+  uint32_t block_contents_crc32c = 0;
   bool is_data_block = block_type == BlockType::kData;
   // NOTE: only index and data blocks are currently compressed
   assert(is_data_block || block_type == BlockType::kIndex);
@@ -2290,7 +2303,7 @@ void BlockBasedTableBuilder::WriteBlock(const Slice& uncompressed_block_data,
         uncompressed_block_data, is_data_block,
         is_data_block ? r->data_block_working_area
                       : r->index_block_working_area,
-        &r->single_threaded_compressed_output, &type, &contents_checksum);
+        &r->single_threaded_compressed_output, &type, &block_contents_crc32c);
     r->SetStatus(compress_status);
     if (UNLIKELY(!ok())) {
       return;
@@ -2303,7 +2316,9 @@ void BlockBasedTableBuilder::WriteBlock(const Slice& uncompressed_block_data,
       type == kNoCompression ? uncompressed_block_data
                              : Slice(r->single_threaded_compressed_output),
       type, handle, block_type, &uncompressed_block_data, skip_delta_encoding,
-      type == kNoCompression ? nullptr : &contents_checksum);
+      type == kNoCompression || r->table_options.checksum != kCRC32c
+          ? nullptr
+          : &block_contents_crc32c);
   r->single_threaded_compressed_output.Reset();
   if (is_data_block) {
     r->props.data_size = r->get_offset();
@@ -2349,14 +2364,16 @@ void BlockBasedTableBuilder::BGWorker(WorkingAreaPair& working_area) {
       Slice compressed = block_rep->compressed;
       Slice uncompressed = block_rep->uncompressed;
       bool skip_delta_encoding = false;
+      const bool has_precomputed_block_contents_crc32c =
+          block_rep->compression_type != kNoCompression &&
+          rep_->table_options.checksum == kCRC32c;
       ios = WriteMaybeCompressedBlockImpl(
           block_rep->compression_type == kNoCompression ? uncompressed
                                                         : compressed,
           block_rep->compression_type, &rep_->pending_handle, BlockType::kData,
           &uncompressed, &skip_delta_encoding,
-          block_rep->compression_type == kNoCompression
-              ? nullptr
-              : &block_rep->contents_checksum);
+          has_precomputed_block_contents_crc32c ? &block_rep->contents_checksum
+                                                : nullptr);
       if (LIKELY(ios.ok())) {
         rep_->props.data_size = rep_->get_offset();
         rep_->props.uncompressed_data_size += block_rep->uncompressed.size();
@@ -2454,9 +2471,10 @@ Status BlockBasedTableBuilder::CompressAndVerifyBlock(
           &type);
 
       if (type != kNoCompression) {
-        *result_checksum = ComputeBuiltinChecksumWithLastByte(
-            r->table_options.checksum, compressed_output->data(),
-            compressed_output->size(), /*last_byte*/ type);
+        if (r->table_options.checksum == kCRC32c) {
+          *result_checksum = crc32c::Value(compressed_output->data(),
+                                           compressed_output->size());
+        }
         TEST_SYNC_POINT_CALLBACK(
             "BlockBasedTableBuilder::CompressAndVerifyBlock:"
             "TamperWithCompressedDataBeforeVerify",
@@ -2568,19 +2586,21 @@ Status BlockBasedTableBuilder::CompressAndVerifyBlock(
 void BlockBasedTableBuilder::WriteMaybeCompressedBlock(
     const Slice& block_contents, CompressionType comp_type, BlockHandle* handle,
     BlockType block_type, const Slice* uncompressed_block_data,
-    bool* skip_delta_encoding, const uint32_t* precomputed_checksum) {
+    bool* skip_delta_encoding,
+    const uint32_t* precomputed_block_contents_crc32c) {
   // Must have pre-checked status in single-threaded context
   assert(status().ok());
   assert(io_status().ok());
   rep_->SetIOStatus(WriteMaybeCompressedBlockImpl(
       block_contents, comp_type, handle, block_type, uncompressed_block_data,
-      skip_delta_encoding, precomputed_checksum));
+      skip_delta_encoding, precomputed_block_contents_crc32c));
 }
 
 IOStatus BlockBasedTableBuilder::WriteMaybeCompressedBlockImpl(
     const Slice& block_contents, CompressionType comp_type, BlockHandle* handle,
     BlockType block_type, const Slice* uncompressed_block_data,
-    bool* skip_delta_encoding, const uint32_t* precomputed_checksum) {
+    bool* skip_delta_encoding,
+    const uint32_t* precomputed_block_contents_crc32c) {
   // File format contains a sequence of blocks where each block has:
   //    block_data: uint8[n]
   //    compression_type: uint8
@@ -2650,24 +2670,39 @@ IOStatus BlockBasedTableBuilder::WriteMaybeCompressedBlockImpl(
     uncompressed_block_data = &block_contents;
     assert(comp_type == kNoCompression);
   }
-  assert(precomputed_checksum == nullptr || comp_type != kNoCompression);
+  assert(precomputed_block_contents_crc32c == nullptr ||
+         r->table_options.checksum == kCRC32c);
 
   r->compression_types_used.Add(comp_type);
   std::array<char, kBlockTrailerSize> trailer;
-  trailer[0] = comp_type;
-  uint32_t checksum =
-      precomputed_checksum != nullptr
-          ? *precomputed_checksum
-          : ComputeBuiltinChecksumWithLastByte(
-                r->table_options.checksum, block_contents.data(),
-                block_contents.size(), /*last_byte*/ comp_type);
+  const char compression_type = comp_type;
+  trailer[0] = compression_type;
+  uint32_t block_contents_crc32c = 0;
+  uint32_t checksum = 0;
+  if (r->table_options.checksum == kCRC32c) {
+    block_contents_crc32c =
+        precomputed_block_contents_crc32c != nullptr
+            ? *precomputed_block_contents_crc32c
+            : crc32c::Value(block_contents.data(), block_contents.size());
+    checksum = crc32c::Mask(crc32c::Extend(
+        block_contents_crc32c, &compression_type, sizeof(compression_type)));
+  } else {
+    checksum = ComputeBuiltinChecksumWithLastByte(
+        r->table_options.checksum, block_contents.data(), block_contents.size(),
+        /*last_byte*/ comp_type);
+  }
   checksum += ChecksumModifierForContext(r->base_context_checksum, offset);
 
-  // TODO: consider a variant of this function that puts the trailer after
-  // block_contents (if it comes from a std::string) so we only need one
-  // r->file->Append call
   {
-    io_s = r->file->Append(io_options, block_contents);
+    if (r->table_options.checksum == kCRC32c) {
+      Crc32cChecksum block_contents_checksum(block_contents_crc32c);
+      NotifyFileAppendForTest(block_contents, &block_contents_checksum);
+      io_s =
+          r->file->Append(io_options, block_contents, block_contents_checksum);
+    } else {
+      NotifyFileAppendForTest(block_contents, nullptr);
+      io_s = r->file->Append(io_options, block_contents);
+    }
     if (UNLIKELY(!io_s.ok())) {
       return io_s;
     }
@@ -2681,12 +2716,29 @@ IOStatus BlockBasedTableBuilder::WriteMaybeCompressedBlockImpl(
     }
   }
 
+  uint32_t trailer_crc32c = 0;
+  if (r->table_options.checksum == kCRC32c) {
+    char encoded_checksum[sizeof(uint32_t)];
+    EncodeFixed32(encoded_checksum, checksum);
+    trailer_crc32c =
+        crc32c::Extend(0, &compression_type, sizeof(compression_type));
+    trailer_crc32c = crc32c::Extend(trailer_crc32c, encoded_checksum,
+                                    sizeof(encoded_checksum));
+  }
   EncodeFixed32(trailer.data() + 1, checksum);
   TEST_SYNC_POINT_CALLBACK(
       "BlockBasedTableBuilder::WriteMaybeCompressedBlock:TamperWithChecksum",
       trailer.data());
   {
-    io_s = r->file->Append(io_options, Slice(trailer.data(), trailer.size()));
+    const Slice trailer_to_write(trailer.data(), trailer.size());
+    if (r->table_options.checksum == kCRC32c) {
+      Crc32cChecksum trailer_checksum(trailer_crc32c);
+      NotifyFileAppendForTest(trailer_to_write, &trailer_checksum);
+      io_s = r->file->Append(io_options, trailer_to_write, trailer_checksum);
+    } else {
+      NotifyFileAppendForTest(trailer_to_write, nullptr);
+      io_s = r->file->Append(io_options, trailer_to_write);
+    }
     if UNLIKELY (!io_s.ok()) {
       return io_s;
     }
@@ -3297,6 +3349,7 @@ void BlockBasedTableBuilder::WriteFooter(BlockHandle& metaindex_block_handle,
                            &footer_gap);
   if (footer_gap > 0) {
     std::string gap_bytes(footer_gap, '\0');
+    NotifyFileAppendForTest(Slice(gap_bytes), nullptr);
     ios = r->file->Append(io_options, Slice(gap_bytes));
     if (!ios.ok()) {
       r->SetIOStatus(ios);
@@ -3314,6 +3367,7 @@ void BlockBasedTableBuilder::WriteFooter(BlockHandle& metaindex_block_handle,
     r->SetStatus(s);
     return;
   }
+  NotifyFileAppendForTest(footer.GetSlice(), nullptr);
   ios = r->file->Append(io_options, footer.GetSlice());
   if (ios.ok()) {
     r->pre_compression_size += footer.GetSlice().size();

--- a/table/block_based/block_based_table_builder.h
+++ b/table/block_based/block_based_table_builder.h
@@ -158,12 +158,12 @@ class BlockBasedTableBuilder : public TableBuilder {
       const Slice& block_contents, CompressionType, BlockHandle* handle,
       BlockType block_type, const Slice* uncompressed_block_data = nullptr,
       bool* skip_delta_encoding = nullptr,
-      const uint32_t* precomputed_checksum = nullptr);
+      const uint32_t* precomputed_block_contents_crc32c = nullptr);
   IOStatus WriteMaybeCompressedBlockImpl(
       const Slice& block_contents, CompressionType, BlockHandle* handle,
       BlockType block_type, const Slice* uncompressed_block_data = nullptr,
       bool* skip_delta_encoding = nullptr,
-      const uint32_t* precomputed_checksum = nullptr);
+      const uint32_t* precomputed_block_contents_crc32c = nullptr);
 
   void SetupCacheKeyPrefix(const TableBuilderOptions& tbo);
 

--- a/table/sst_file_writer.cc
+++ b/table/sst_file_writer.cc
@@ -432,7 +432,8 @@ Status SstFileWriter::Open(const std::string& file_path, Temperature temp) {
       std::move(sst_file), file_path, r->env_options, r->ioptions.clock,
       nullptr /* io_tracer */, r->ioptions.stats, Histograms::SST_WRITE_MICROS,
       r->ioptions.listeners, r->ioptions.file_checksum_gen_factory.get(),
-      tmp_set.Contains(FileType::kTableFile), false));
+      tmp_set.Contains(FileType::kTableFile),
+      tmp_set.Contains(FileType::kTableFile)));
 
   // TODO(tec) : If table_factory is using compressed block cache, we will
   // be adding the external sst file blocks into it, which is wasteful.

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -81,6 +81,7 @@
 #include "test_util/testutil.h"
 #include "util/coding.h"
 #include "util/compression.h"
+#include "util/crc32c.h"
 #include "util/defer.h"
 #include "util/file_checksum_helper.h"
 #include "util/random.h"
@@ -6555,6 +6556,627 @@ TEST_P(BlockBasedTableTest, CompressionRatioThreshold) {
           EXPECT_NEAR2(len + approx_sst_overhead, table_file_size, len / 10);
         }
       }
+    }
+  }
+}
+
+namespace {
+
+constexpr char kCrc32cHandoffDestinationBufferMismatch[] =
+    "Checksum handoff detected data corruption after copying data into "
+    "WritableFileWriter destination buffer";
+
+std::string ChecksumTypeToString(ChecksumType checksum_type) {
+  switch (checksum_type) {
+    case kNoChecksum:
+      return "no_checksum";
+    case kCRC32c:
+      return "crc32c";
+    case kxxHash:
+      return "xxhash";
+    case kxxHash64:
+      return "xxhash64";
+    case kXXH3:
+      return "xxh3";
+    default:
+      return "unsupported";
+  }
+}
+
+std::vector<ChecksumType> GetSupportedChecksumHandoffTestChecksumTypes() {
+  std::vector<ChecksumType> checksum_types;
+  for (ChecksumType checksum_type : GetSupportedChecksums()) {
+    if (checksum_type != kNoChecksum) {
+      checksum_types.push_back(checksum_type);
+    }
+  }
+  return checksum_types;
+}
+
+std::string ChecksumHandoffTestParamName(
+    const testing::TestParamInfo<ChecksumType>& info) {
+  return ChecksumTypeToString(info.param);
+}
+
+CompressionType GetSupportedNonNoCompressionForChecksumHandoffTest() {
+  for (CompressionType type : GetSupportedCompressions()) {
+    if (type != kNoCompression) {
+      return type;
+    }
+  }
+  return kNoCompression;
+}
+
+std::string ChecksumHandoffTestValue(size_t i) {
+  return std::string(10000, static_cast<char>('a' + i));
+}
+
+std::vector<std::pair<std::string, std::string>> ChecksumHandoffTestKvs() {
+  std::vector<std::pair<std::string, std::string>> kvs;
+  kvs.reserve(5);
+  for (size_t i = 0; i < 5; ++i) {
+    kvs.emplace_back("key" + std::to_string(i), ChecksumHandoffTestValue(i));
+  }
+  return kvs;
+}
+
+BlockBasedTableOptions GetChecksumHandoffTableOptions(
+    ChecksumType checksum_type) {
+  BlockBasedTableOptions table_options;
+  table_options.checksum = checksum_type;
+  table_options.flush_block_policy_factory =
+      std::make_shared<FlushBlockEveryKeyPolicyFactory>();
+  return table_options;
+}
+
+struct RecordedChecksumHandoffAppend {
+  uint64_t offset = 0;
+  std::string data;
+  bool has_crc32c = false;
+  uint32_t crc32c = 0;
+};
+
+using BlockBasedTableBuilderAppendCallbackArg =
+    std::pair<Slice, const Crc32cChecksum*>;
+
+class NullSink : public FSWritableFile {
+ public:
+  IOStatus Truncate(uint64_t size, const IOOptions& /*opts*/,
+                    IODebugContext* /*dbg*/) override {
+    size_ = size;
+    return IOStatus::OK();
+  }
+
+  IOStatus Close(const IOOptions& /*opts*/, IODebugContext* /*dbg*/) override {
+    return IOStatus::OK();
+  }
+
+  IOStatus Flush(const IOOptions& /*opts*/, IODebugContext* /*dbg*/) override {
+    return IOStatus::OK();
+  }
+
+  IOStatus Sync(const IOOptions& /*opts*/, IODebugContext* /*dbg*/) override {
+    return IOStatus::OK();
+  }
+
+  using FSWritableFile::Append;
+  IOStatus Append(const Slice& data, const IOOptions& /*opts*/,
+                  IODebugContext* /*dbg*/) override {
+    size_ += data.size();
+    return IOStatus::OK();
+  }
+
+  uint64_t GetFileSize(const IOOptions& /*options*/,
+                       IODebugContext* /*dbg*/) override {
+    return size_;
+  }
+
+ private:
+  uint64_t size_ = 0;
+};
+
+struct ChecksumHandoffTable {
+  std::string contents;
+  std::vector<std::string> internal_keys;
+  std::vector<BlockHandle> data_blocks;
+  std::vector<RecordedChecksumHandoffAppend> recorded_appends;
+};
+
+enum class ChecksumHandoffBuildCorruption {
+  kNone,
+  kCompressionType,
+  kBlockChecksum,
+};
+
+Status BuildChecksumHandoffTable(ChecksumType checksum_type,
+                                 CompressionType compression_type,
+                                 ChecksumHandoffTable* table,
+                                 ChecksumHandoffBuildCorruption corruption =
+                                     ChecksumHandoffBuildCorruption::kNone) {
+  assert(table != nullptr);
+  *table = ChecksumHandoffTable();
+
+  BlockBasedTableOptions table_options =
+      GetChecksumHandoffTableOptions(checksum_type);
+
+  Options options;
+  options.env = Env::Default();
+  options.compression = compression_type;
+  options.table_factory.reset(NewBlockBasedTableFactory(table_options));
+
+  uint64_t next_append_offset = 0;
+  SyncPoint::GetInstance()->SetCallBack(
+      "BlockBasedTableBuilder::Append:Before", [&](void* arg) {
+        auto* append_info =
+            static_cast<BlockBasedTableBuilderAppendCallbackArg*>(arg);
+        RecordedChecksumHandoffAppend recorded_append;
+        recorded_append.offset = next_append_offset;
+        recorded_append.data.assign(append_info->first.data(),
+                                    append_info->first.size());
+        if (append_info->second != nullptr) {
+          recorded_append.has_crc32c = true;
+          recorded_append.crc32c = append_info->second->value;
+        }
+        table->contents.append(recorded_append.data);
+        next_append_offset += recorded_append.data.size();
+        table->recorded_appends.push_back(std::move(recorded_append));
+      });
+  bool corrupted_trailer = false;
+  if (checksum_type == kCRC32c &&
+      corruption != ChecksumHandoffBuildCorruption::kNone) {
+    SyncPoint::GetInstance()->SetCallBack(
+        "BlockBasedTableBuilder::WriteMaybeCompressedBlock:"
+        "TamperWithChecksum",
+        [&](void* arg) {
+          if (corrupted_trailer) {
+            return;
+          }
+          auto* trailer = static_cast<char*>(arg);
+          if (corruption == ChecksumHandoffBuildCorruption::kCompressionType) {
+            trailer[0] = static_cast<char>(
+                static_cast<unsigned char>(trailer[0]) ^ 0x80U);
+          } else {
+            trailer[1] = static_cast<char>(
+                static_cast<unsigned char>(trailer[1]) ^ 0x80U);
+          }
+          corrupted_trailer = true;
+        });
+  }
+  SyncPoint::GetInstance()->EnableProcessing();
+  Defer cleanup_sync_point([] {
+    SyncPoint::GetInstance()->DisableProcessing();
+    SyncPoint::GetInstance()->ClearAllCallBacks();
+  });
+
+  std::unique_ptr<FSWritableFile> holder(new NullSink());
+  std::unique_ptr<WritableFileWriter> file_writer(
+      new WritableFileWriter(std::move(holder), "test_file_name", FileOptions(),
+                             SystemClock::Default().get(), nullptr, nullptr,
+                             Histograms::HISTOGRAM_ENUM_MAX, {}, nullptr,
+                             /*perform_data_verification=*/true,
+                             /*buffered_data_with_checksum=*/true));
+
+  ImmutableOptions ioptions(options);
+  MutableCFOptions moptions(options);
+  InternalKeyComparator ikc(options.comparator);
+  InternalTblPropCollFactories internal_tbl_prop_coll_factories;
+
+  const ReadOptions read_options;
+  const WriteOptions write_options;
+  std::unique_ptr<TableBuilder> builder(options.table_factory->NewTableBuilder(
+      TableBuilderOptions(ioptions, moptions, read_options, write_options, ikc,
+                          &internal_tbl_prop_coll_factories, compression_type,
+                          options.compression_opts, kUnknownColumnFamily,
+                          "test_cf", -1 /* level */, kUnknownNewestKeyTime),
+      file_writer.get()));
+
+  for (const auto& kv : ChecksumHandoffTestKvs()) {
+    InternalKey key(kv.first, 1 /* sequence number */, kTypeValue);
+    const std::string encoded_key = key.Encode().ToString();
+    table->internal_keys.push_back(encoded_key);
+    builder->Add(encoded_key, kv.second);
+    if (!builder->status().ok()) {
+      Status s = builder->status();
+      builder->Abandon();
+      return s;
+    }
+  }
+  Status s = builder->Finish();
+  if (s.ok()) {
+    s = file_writer->Flush(IOOptions());
+  }
+  if (s.ok() && table->contents.size() != file_writer->GetFileSize()) {
+    s = Status::Corruption("Incomplete checksum handoff append recording");
+  }
+  if (!s.ok()) {
+    return s;
+  }
+
+  std::unique_ptr<TableReader> reader;
+  BlockBasedTableOptions reader_table_options =
+      GetChecksumHandoffTableOptions(checksum_type);
+  Options reader_options;
+  reader_options.env = Env::Default();
+  reader_options.compression = compression_type;
+  reader_options.table_factory.reset(
+      NewBlockBasedTableFactory(reader_table_options));
+  ImmutableOptions reader_ioptions(reader_options);
+  MutableCFOptions reader_moptions(reader_options);
+  InternalKeyComparator reader_ikc(reader_options.comparator);
+  std::unique_ptr<FSRandomAccessFile> source(new test::StringSource(
+      table->contents, 1 /* uniq_id */, reader_ioptions.allow_mmap_reads));
+  std::unique_ptr<RandomAccessFileReader> file_reader(
+      new RandomAccessFileReader(std::move(source), "test_file_name"));
+  s = reader_options.table_factory->NewTableReader(
+      TableReaderOptions(
+          reader_ioptions, reader_moptions.prefix_extractor,
+          reader_moptions.compression_manager.get(), EnvOptions(), reader_ikc,
+          0 /* block_protection_bytes_per_key */,
+          /*skip_filters*/ false, /*immortal*/ false,
+          false /* force_direct_prefetch */, -1 /* level */,
+          nullptr /* block_cache_tracer */, reader_moptions.write_buffer_size,
+          "" /* cur_db_session_id */, 1 /* cur_file_num */, kNullUniqueId64x2),
+      std::move(file_reader), table->contents.size(), &reader);
+  if (!s.ok()) {
+    return s;
+  }
+
+  BlockBasedTable* bbt = static_cast<BlockBasedTable*>(reader.get());
+  for (const std::string& key : table->internal_keys) {
+    BlockHandle block_handle;
+    bbt->TEST_GetDataBlockHandle(read_options, key, block_handle);
+    if (table->data_blocks.empty() ||
+        table->data_blocks.back() != block_handle) {
+      table->data_blocks.push_back(block_handle);
+    }
+  }
+  return Status::OK();
+}
+
+Status VerifyChecksumHandoffTableContents(ChecksumType checksum_type,
+                                          const std::string& contents,
+                                          CompressionType compression_type) {
+  BlockBasedTableOptions table_options =
+      GetChecksumHandoffTableOptions(checksum_type);
+  Options options;
+  options.env = Env::Default();
+  options.compression = compression_type;
+  options.table_factory.reset(NewBlockBasedTableFactory(table_options));
+  ImmutableOptions ioptions(options);
+  MutableCFOptions moptions(options);
+  InternalKeyComparator ikc(options.comparator);
+  std::unique_ptr<FSRandomAccessFile> source(new test::StringSource(
+      contents, 1 /* uniq_id */, ioptions.allow_mmap_reads));
+  std::unique_ptr<RandomAccessFileReader> file_reader(
+      new RandomAccessFileReader(std::move(source), "test_file_name"));
+  std::unique_ptr<TableReader> table_reader;
+  Status s = options.table_factory->NewTableReader(
+      TableReaderOptions(ioptions, moptions.prefix_extractor,
+                         moptions.compression_manager.get(), EnvOptions(), ikc,
+                         0 /* block_protection_bytes_per_key */,
+                         /*skip_filters*/ false, /*immortal*/ false,
+                         false /* force_direct_prefetch */, -1 /* level */,
+                         nullptr /* block_cache_tracer */,
+                         moptions.write_buffer_size, "" /* cur_db_session_id */,
+                         1 /* cur_file_num */, kNullUniqueId64x2),
+      std::move(file_reader), contents.size(), &table_reader);
+  if (!s.ok()) {
+    return s;
+  }
+
+  ReadOptions read_options;
+  read_options.verify_checksums = true;
+  std::unique_ptr<InternalIterator> iter(table_reader->NewIterator(
+      read_options, nullptr /* prefix_extractor */, nullptr /* arena */,
+      /*skip_filters*/ false, TableReaderCaller::kUncategorized));
+
+  iter->SeekToFirst();
+  for (const auto& kv : ChecksumHandoffTestKvs()) {
+    if (!iter->status().ok()) {
+      return iter->status();
+    }
+    if (!iter->Valid()) {
+      return Status::Corruption("Expected another key in checksum handoff SST");
+    }
+    ParsedInternalKey parsed_key;
+    s = ParseInternalKey(iter->key(), &parsed_key, true /* log_err_key */);
+    if (!s.ok()) {
+      return s;
+    }
+    if (parsed_key.user_key.ToString() != kv.first) {
+      return Status::Corruption("Unexpected key in checksum handoff SST");
+    }
+    if (iter->value().ToString() != kv.second) {
+      return Status::Corruption("Unexpected value in checksum handoff SST");
+    }
+    iter->Next();
+  }
+  if (!iter->status().ok()) {
+    return iter->status();
+  }
+  if (iter->Valid()) {
+    return Status::Corruption("Unexpected extra key in checksum handoff SST");
+  }
+  return Status::OK();
+}
+
+enum class ChecksumHandoffReplayCorruption {
+  kNone,
+  kBlockPayload,
+  kCompressionType,
+  kBlockChecksum,
+};
+
+struct ChecksumHandoffReplayOptions {
+  ChecksumHandoffReplayCorruption corruption =
+      ChecksumHandoffReplayCorruption::kNone;
+  size_t block_index = 0;
+  size_t byte_offset = 0;
+};
+
+void FlipByte(std::string* data, size_t offset) {
+  assert(data != nullptr);
+  assert(offset < data->size());
+  (*data)[offset] =
+      static_cast<char>(static_cast<unsigned char>((*data)[offset]) ^ 0x80U);
+}
+
+void MaybeCorruptRecordedAppend(
+    const RecordedChecksumHandoffAppend& recorded_append,
+    const BlockHandle& target_handle,
+    const ChecksumHandoffReplayOptions& options, std::string* data) {
+  assert(data != nullptr);
+  if (options.corruption == ChecksumHandoffReplayCorruption::kNone) {
+    return;
+  }
+
+  const uint64_t block_offset = target_handle.offset();
+  const size_t block_size = static_cast<size_t>(target_handle.size());
+  const uint64_t trailer_offset = block_offset + block_size;
+
+  if (options.corruption == ChecksumHandoffReplayCorruption::kBlockPayload &&
+      recorded_append.offset == block_offset &&
+      recorded_append.data.size() == block_size) {
+    assert(block_size > 0);
+    FlipByte(data, options.byte_offset % data->size());
+  } else if (options.corruption ==
+                 ChecksumHandoffReplayCorruption::kCompressionType &&
+             recorded_append.offset == trailer_offset &&
+             recorded_append.data.size() ==
+                 BlockBasedTable::kBlockTrailerSize) {
+    FlipByte(data, 0);
+  } else if (options.corruption ==
+                 ChecksumHandoffReplayCorruption::kBlockChecksum &&
+             recorded_append.offset == trailer_offset &&
+             recorded_append.data.size() ==
+                 BlockBasedTable::kBlockTrailerSize) {
+    FlipByte(data, 1 + options.byte_offset %
+                           (BlockBasedTable::kBlockTrailerSize - 1));
+  }
+}
+
+Status ReplayChecksumHandoffTable(const ChecksumHandoffTable& table,
+                                  const ChecksumHandoffReplayOptions& options,
+                                  std::string* contents) {
+  assert(contents != nullptr);
+  assert(options.corruption == ChecksumHandoffReplayCorruption::kNone ||
+         options.block_index < table.data_blocks.size());
+  contents->clear();
+
+  test::StringSink* sink = new test::StringSink();
+  std::unique_ptr<FSWritableFile> holder(sink);
+  std::unique_ptr<WritableFileWriter> file_writer(
+      new WritableFileWriter(std::move(holder), "test_file_name", FileOptions(),
+                             SystemClock::Default().get(), nullptr, nullptr,
+                             Histograms::HISTOGRAM_ENUM_MAX, {}, nullptr,
+                             /*perform_data_verification=*/true,
+                             /*buffered_data_with_checksum=*/true));
+
+  for (const RecordedChecksumHandoffAppend& recorded_append :
+       table.recorded_appends) {
+    std::string data = recorded_append.data;
+    if (options.corruption != ChecksumHandoffReplayCorruption::kNone) {
+      MaybeCorruptRecordedAppend(recorded_append,
+                                 table.data_blocks[options.block_index],
+                                 options, &data);
+    }
+    Status s;
+    if (recorded_append.has_crc32c) {
+      s = file_writer->Append(IOOptions(), Slice(data),
+                              Crc32cChecksum(recorded_append.crc32c));
+    } else {
+      s = file_writer->Append(IOOptions(), Slice(data));
+    }
+    if (!s.ok()) {
+      return s;
+    }
+  }
+
+  Status s = file_writer->Flush(IOOptions());
+  if (s.ok()) {
+    *contents = sink->contents();
+  }
+  return s;
+}
+
+}  // namespace
+
+class BlockBasedTableChecksumHandoffTest
+    : public BlockBasedTableTestBase,
+      public testing::WithParamInterface<ChecksumType> {};
+
+INSTANTIATE_TEST_CASE_P(
+    SupportedChecksums, BlockBasedTableChecksumHandoffTest,
+    testing::ValuesIn(GetSupportedChecksumHandoffTestChecksumTypes()),
+    ChecksumHandoffTestParamName);
+
+TEST_P(BlockBasedTableChecksumHandoffTest,
+       Crc32cHandoffDetectsCompressedBlockCorruption) {
+  const ChecksumType checksum_type = GetParam();
+  SCOPED_TRACE(ChecksumTypeToString(checksum_type));
+  const CompressionType compression_type =
+      GetSupportedNonNoCompressionForChecksumHandoffTest();
+  if (compression_type == kNoCompression) {
+    ROCKSDB_GTEST_SKIP("No supported compression");
+    return;
+  }
+
+  ChecksumHandoffTable table;
+  ASSERT_OK(BuildChecksumHandoffTable(checksum_type, compression_type, &table));
+  ASSERT_FALSE(table.data_blocks.empty());
+
+  std::string contents;
+  const Status s = ReplayChecksumHandoffTable(
+      table,
+      ChecksumHandoffReplayOptions{
+          ChecksumHandoffReplayCorruption::kBlockPayload,
+          /*block_index=*/0,
+          /*byte_offset=*/0},
+      &contents);
+  if (checksum_type == kCRC32c) {
+    ASSERT_TRUE(s.IsCorruption()) << s.ToString();
+    ASSERT_NE(s.ToString().find(kCrc32cHandoffDestinationBufferMismatch),
+              std::string::npos)
+        << s.ToString();
+  } else {
+    ASSERT_OK(s);
+    ASSERT_TRUE(VerifyChecksumHandoffTableContents(checksum_type, contents,
+                                                   compression_type)
+                    .IsCorruption());
+  }
+}
+
+TEST_P(BlockBasedTableChecksumHandoffTest, Crc32cHandoffReadsBackBlocks) {
+  const ChecksumType checksum_type = GetParam();
+  SCOPED_TRACE(ChecksumTypeToString(checksum_type));
+  ChecksumHandoffTable table;
+  ASSERT_OK(BuildChecksumHandoffTable(checksum_type, kNoCompression, &table));
+
+  std::string contents;
+  ASSERT_OK(ReplayChecksumHandoffTable(table, ChecksumHandoffReplayOptions(),
+                                       &contents));
+  ASSERT_OK(VerifyChecksumHandoffTableContents(checksum_type, contents,
+                                               kNoCompression));
+}
+
+TEST_P(BlockBasedTableChecksumHandoffTest,
+       Crc32cHandoffDetectsCompressionTypeCorruption) {
+  const ChecksumType checksum_type = GetParam();
+  SCOPED_TRACE(ChecksumTypeToString(checksum_type));
+  ChecksumHandoffTable table;
+  ASSERT_OK(BuildChecksumHandoffTable(checksum_type, kNoCompression, &table));
+  ASSERT_FALSE(table.data_blocks.empty());
+
+  std::string contents;
+  const Status s = ReplayChecksumHandoffTable(
+      table,
+      ChecksumHandoffReplayOptions{
+          ChecksumHandoffReplayCorruption::kCompressionType,
+          /*block_index=*/0,
+          /*byte_offset=*/0},
+      &contents);
+  if (checksum_type == kCRC32c) {
+    ASSERT_TRUE(s.IsCorruption()) << s.ToString();
+    ASSERT_NE(s.ToString().find(kCrc32cHandoffDestinationBufferMismatch),
+              std::string::npos)
+        << s.ToString();
+  } else {
+    ASSERT_OK(s);
+    ASSERT_TRUE(VerifyChecksumHandoffTableContents(checksum_type, contents,
+                                                   kNoCompression)
+                    .IsCorruption());
+  }
+}
+
+TEST_P(BlockBasedTableChecksumHandoffTest,
+       Crc32cHandoffDetectsBlockChecksumTrailerCorruption) {
+  const ChecksumType checksum_type = GetParam();
+  SCOPED_TRACE(ChecksumTypeToString(checksum_type));
+  ChecksumHandoffTable table;
+  ASSERT_OK(BuildChecksumHandoffTable(checksum_type, kNoCompression, &table));
+  ASSERT_FALSE(table.data_blocks.empty());
+
+  std::string contents;
+  const Status s = ReplayChecksumHandoffTable(
+      table,
+      ChecksumHandoffReplayOptions{
+          ChecksumHandoffReplayCorruption::kBlockChecksum,
+          /*block_index=*/0,
+          /*byte_offset=*/1},
+      &contents);
+
+  if (checksum_type == kCRC32c) {
+    ASSERT_TRUE(s.IsCorruption()) << s.ToString();
+    ASSERT_NE(s.ToString().find(kCrc32cHandoffDestinationBufferMismatch),
+              std::string::npos)
+        << s.ToString();
+  } else {
+    ASSERT_OK(s);
+    ASSERT_TRUE(VerifyChecksumHandoffTableContents(checksum_type, contents,
+                                                   kNoCompression)
+                    .IsCorruption());
+  }
+}
+
+TEST_F(BlockBasedTableTestBase,
+       Crc32cHandoffDetectsTrailerBufferCorruptionDuringBuild) {
+  for (ChecksumHandoffBuildCorruption corruption :
+       {ChecksumHandoffBuildCorruption::kCompressionType,
+        ChecksumHandoffBuildCorruption::kBlockChecksum}) {
+    ChecksumHandoffTable table;
+    const Status s =
+        BuildChecksumHandoffTable(kCRC32c, kNoCompression, &table, corruption);
+    ASSERT_TRUE(s.IsCorruption()) << s.ToString();
+    ASSERT_NE(s.ToString().find(kCrc32cHandoffDestinationBufferMismatch),
+              std::string::npos)
+        << s.ToString();
+  }
+}
+
+TEST_P(BlockBasedTableChecksumHandoffTest, Crc32cHandoffRandomizedReplay) {
+  const ChecksumType checksum_type = GetParam();
+  const uint32_t seed = static_cast<uint32_t>(test::RandomSeed() + 6707);
+  Random rnd(seed);
+  SCOPED_TRACE("seed=" + std::to_string(seed) +
+               " checksum_type=" + ChecksumTypeToString(checksum_type));
+
+  const CompressionType non_no_compression_type =
+      GetSupportedNonNoCompressionForChecksumHandoffTest();
+  const std::array<CompressionType, 2> compression_types = {
+      {kNoCompression, non_no_compression_type}};
+  for (int i = 0; i < 20; ++i) {
+    const CompressionType compression_type = compression_types[rnd.Uniform(
+        static_cast<int>(non_no_compression_type == kNoCompression ? 1 : 2))];
+    ChecksumHandoffTable table;
+    ASSERT_OK(
+        BuildChecksumHandoffTable(checksum_type, compression_type, &table));
+    ASSERT_FALSE(table.data_blocks.empty());
+
+    const auto corruption =
+        static_cast<ChecksumHandoffReplayCorruption>(1 + rnd.Uniform(3));
+    const size_t block_index =
+        rnd.Uniform(static_cast<int>(table.data_blocks.size()));
+    const size_t block_size =
+        static_cast<size_t>(table.data_blocks[block_index].size());
+    const size_t byte_offset =
+        block_size == 0 ? 0 : rnd.Uniform(static_cast<int>(block_size));
+
+    std::string contents;
+    const Status s = ReplayChecksumHandoffTable(
+        table,
+        ChecksumHandoffReplayOptions{corruption, block_index, byte_offset},
+        &contents);
+
+    if (checksum_type == kCRC32c) {
+      ASSERT_TRUE(s.IsCorruption()) << s.ToString();
+      ASSERT_NE(s.ToString().find(kCrc32cHandoffDestinationBufferMismatch),
+                std::string::npos)
+          << s.ToString();
+    } else {
+      ASSERT_OK(s);
+      ASSERT_TRUE(VerifyChecksumHandoffTableContents(checksum_type, contents,
+                                                     compression_type)
+                      .IsCorruption());
     }
   }
 }

--- a/unreleased_history/new_features/sst_checksum_handoff.md
+++ b/unreleased_history/new_features/sst_checksum_handoff.md
@@ -1,0 +1,1 @@
+Added checksum handoff support for SST file writes when `BlockBasedTableOptions::checksum` is `kCRC32c`, allowing block and trailer CRC32C checksums to be passed from the table builder to the file writer for buffered-data validation and filesystem in-flight write protection.

--- a/util/file_reader_writer_test.cc
+++ b/util/file_reader_writer_test.cc
@@ -4,6 +4,8 @@
 //  (found in the LICENSE.Apache file in the root directory).
 //
 #include <algorithm>
+#include <memory>
+#include <string>
 #include <vector>
 
 #include "db/db_test_util.h"
@@ -334,11 +336,106 @@ TEST_F(WritableFileWriterTest, BufferWithZeroCapacityDirectIO) {
   }
 }
 
+TEST_F(WritableFileWriterTest,
+       AppendWithChecksumDirectIOSplitValidatesProvidedChecksum) {
+  class FakeWF : public FSWritableFile {
+   public:
+    using FSWritableFile::Append;
+    IOStatus Append(const Slice& /*data*/, const IOOptions& /*options*/,
+                    IODebugContext* /*dbg*/) override {
+      return IOStatus::NotSupported("Append");
+    }
+
+    using FSWritableFile::PositionedAppend;
+    IOStatus PositionedAppend(const Slice& data, uint64_t pos,
+                              const IOOptions& /*options*/,
+                              const DataVerificationInfo& /*verification_info*/,
+                              IODebugContext* /*dbg*/) override {
+      EXPECT_EQ(pos % GetRequiredBufferAlignment(), 0u);
+      EXPECT_EQ(data.size() % GetRequiredBufferAlignment(), 0u);
+      positioned_appends_++;
+      size_ = std::max(size_, pos + static_cast<uint64_t>(data.size()));
+      return IOStatus::OK();
+    }
+
+    IOStatus Truncate(uint64_t size, const IOOptions& /*options*/,
+                      IODebugContext* /*dbg*/) override {
+      size_ = size;
+      return IOStatus::OK();
+    }
+    IOStatus Close(const IOOptions& /*options*/,
+                   IODebugContext* /*dbg*/) override {
+      return IOStatus::OK();
+    }
+    IOStatus Flush(const IOOptions& /*options*/,
+                   IODebugContext* /*dbg*/) override {
+      return IOStatus::OK();
+    }
+    IOStatus Sync(const IOOptions& /*options*/,
+                  IODebugContext* /*dbg*/) override {
+      return IOStatus::OK();
+    }
+    void SetIOPriority(Env::IOPriority /*pri*/) override {}
+    uint64_t GetFileSize(const IOOptions& /*options*/,
+                         IODebugContext* /*dbg*/) override {
+      return size_;
+    }
+    void GetPreallocationStatus(size_t* /*block_size*/,
+                                size_t* /*last_allocated_block*/) override {}
+    size_t GetUniqueId(char* /*id*/, size_t /*max_size*/) const override {
+      return 0;
+    }
+    IOStatus InvalidateCache(size_t /*offset*/, size_t /*length*/) override {
+      return IOStatus::OK();
+    }
+    bool use_direct_io() const override { return true; }
+    size_t GetRequiredBufferAlignment() const override { return 512; }
+
+    int positioned_appends() const { return positioned_appends_; }
+
+   private:
+    uint64_t size_ = 0;
+    int positioned_appends_ = 0;
+  };
+
+  constexpr int kWritableFileMaxBufferSize = 1024;
+  constexpr int kDataSize = kWritableFileMaxBufferSize + 128;
+  constexpr size_t kCorruptedByteOffset = kWritableFileMaxBufferSize;
+
+  EnvOptions env_options;
+  env_options.use_direct_writes = true;
+  env_options.writable_file_max_buffer_size = kWritableFileMaxBufferSize;
+
+  FakeWF* wf = new FakeWF();
+  std::unique_ptr<WritableFileWriter> writer(new WritableFileWriter(
+      std::unique_ptr<FSWritableFile>(wf), "test_file_name", env_options,
+      SystemClock::Default().get(), nullptr, nullptr,
+      Histograms::HISTOGRAM_ENUM_MAX, {}, nullptr,
+      /*perform_data_verification=*/true,
+      /*buffered_data_with_checksum=*/true));
+
+  Random rnd(301);
+  std::string data = rnd.RandomString(kDataSize);
+  const uint32_t crc32c_checksum = crc32c::Value(data.data(), data.size());
+  data[kCorruptedByteOffset] = static_cast<char>(
+      static_cast<unsigned char>(data[kCorruptedByteOffset]) ^ 0x80U);
+
+  const IOStatus s =
+      writer->Append(IOOptions(), Slice(data), Crc32cChecksum(crc32c_checksum));
+  ASSERT_TRUE(s.IsCorruption()) << s.ToString();
+  ASSERT_NE(s.ToString().find(
+                "Checksum handoff detected logical append checksum mismatch "
+                "after copying caller data into WritableFileWriter buffers"),
+            std::string::npos)
+      << s.ToString();
+  ASSERT_GT(wf->positioned_appends(), 0);
+}
+
 class DBWritableFileWriterTest : public DBTestBase {
  public:
   DBWritableFileWriterTest()
       : DBTestBase("db_secondary_cache_test", /*env_do_fsync=*/true) {
-    fault_fs_.reset(new FaultInjectionTestFS(env_->GetFileSystem()));
+    fault_fs_ = std::make_shared<FaultInjectionTestFS>(env_->GetFileSystem());
     fault_env_.reset(new CompositeEnvWrapper(env_, fault_fs_));
   }
 


### PR DESCRIPTION
Summary:

SST block writing now hands checksum coverage across the table-builder to file-writer boundary when the block checksum algorithm is CRC32C.

The block builder passes the raw CRC32C of the block contents to `WritableFileWriter::Append()`, which validates the copied destination-buffer contents and accumulates that checksum into the filesystem handoff checksum instead of recomputing it after the copy. The trailer is still appended separately; table building computes and passes the trailer handoff checksum independently, while preserving the existing persisted block-checksum encoding. Non-CRC32C block checksum algorithms continue to use the existing file-writer checksum path.

Destination-buffer validation failures return a stage-specific corruption `Status` that includes the file path. Flush and compaction propagate that status through their existing background error handling, so the same message is logged without adding local duplicate log sites.

The SST tests record the builder append stream through sync-point callbacks while writing to a null sink, then replay those exact append calls into a file-backed writer to cover successful handoff, block-content corruption, compression-type corruption, trailer-checksum corruption, non-CRC32C fallback behavior, and a small randomized boundary-injection loop.

Reviewed By: xingbowang

Differential Revision: D116969191


