### PR TITLE
Revert PR 15106 (Ignore OPTIONS files for manifest recovery advance) (#15158)

### DIFF
--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -21,6 +21,7 @@
 #include "rocksdb/merge_operator.h"
 #include "rocksdb/perf_context.h"
 #include "rocksdb/table.h"
+#include "rocksdb/utilities/checkpoint.h"
 #include "rocksdb/utilities/debug.h"
 #include "table/block_based/block_based_table_reader.h"
 #include "table/block_based/block_builder.h"
@@ -356,10 +357,11 @@ TEST_F(DBBasicTest,
 }
 
 TEST_F(DBBasicTest,
-       OptimizeManifestForRecoveryIgnoresOptionsFilesForNextFileNumber) {
+       OptimizeManifestForRecoveryKeepsCurrentOptionsFileWithStaleOptions) {
   Options options = CurrentOptions();
   options.create_if_missing = true;
   options.optimize_manifest_for_recovery = true;
+  options.avoid_unnecessary_blocking_io = false;
   DestroyAndReopen(options);
   ASSERT_OK(Put("k", "v"));
   ASSERT_OK(Flush());
@@ -368,20 +370,28 @@ TEST_F(DBBasicTest,
       dbfull()->GetVersionSet()->current_next_file_number();
   Close();
 
-  const uint64_t options_number = next_before_close + 100;
-  ASSERT_OK(WriteStringToFile(env_, "" /*data*/,
-                              dbname_ + "/" + OptionsFileName(options_number),
-                              /*should_sync=*/true));
-  ASSERT_OK(WriteStringToFile(env_, "" /*data*/,
-                              TempOptionsFileName(dbname_, options_number + 1),
-                              /*should_sync=*/true));
+  const uint64_t stale_options_number = next_before_close + 100;
+  ASSERT_OK(WriteStringToFile(
+      env_, "" /*data*/, dbname_ + "/" + OptionsFileName(stale_options_number),
+      /*should_sync=*/true));
+  ASSERT_OK(WriteStringToFile(
+      env_, "" /*data*/,
+      dbname_ + "/" + OptionsFileName(stale_options_number + 1),
+      /*should_sync=*/true));
 
-  RecoveryOptimizationCounters counters;
-  counters.Install();
   Reopen(options);
-  counters.Uninstall();
+  const uint64_t current_options_number =
+      dbfull()->GetVersionSet()->options_file_number();
+  ASSERT_GT(current_options_number, 0u);
+  ASSERT_OK(env_->FileExists(OptionsFileName(dbname_, current_options_number)));
 
-  ASSERT_EQ(1, counters.next_file_number.load());
+  const std::string checkpoint_dir = dbname_ + "_checkpoint";
+  ASSERT_OK(DestroyDir(env_, checkpoint_dir));
+  Checkpoint* checkpoint = nullptr;
+  ASSERT_OK(Checkpoint::Create(db_.get(), &checkpoint));
+  std::unique_ptr<Checkpoint> checkpoint_guard(checkpoint);
+  ASSERT_OK(checkpoint_guard->CreateCheckpoint(checkpoint_dir));
+  ASSERT_OK(DestroyDir(env_, checkpoint_dir));
   ASSERT_EQ("v", Get("k"));
 }
 

--- a/db/db_impl/db_impl_files.cc
+++ b/db/db_impl/db_impl_files.cc
@@ -1211,9 +1211,7 @@ Status DBImpl::MaybeUpdateNextFileNumber(RecoveryContext* recovery_ctx) {
       // Use >= so a crashed-mid-allocation file at exactly
       // prev_next_file_number triggers the advance -- otherwise the next
       // NewFileNumber() would collide with it.
-      const bool must_reserve_file_number =
-          type != kOptionsFile && type != kTempFile;
-      if (must_reserve_file_number && number >= prev_next_file_number) {
+      if (number >= prev_next_file_number) {
         on_disk_file_advanced_counter = true;
       }
       largest_file_number = std::max(largest_file_number, number);

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -5732,9 +5732,7 @@ void StressTest::RecordManifestStateBeforeReopen() {
   if (reuse_manifest && optimize_manifest) {
     // Check if ALL conditions for complete avoidance are met.
     // If so, use STRICT mode where failures are fatal.
-    const bool no_fault_injection = !NeedsFaultInjection();
     const bool no_manifest_writes_expected =
-        no_fault_injection &&
         FLAGS_avoid_flush_during_recovery &&  // No flush during recovery
         !FLAGS_write_dbid_to_manifest;        // No DB_ID write on open
     // Note: avoid_flush_during_shutdown is NOT required for STRICT mode.

--- a/db_stress_tool/db_stress_test_base.h
+++ b/db_stress_tool/db_stress_test_base.h
@@ -429,7 +429,8 @@ class StressTest {
     // - Not in best_efforts_recovery mode
     // - avoid_flush_during_recovery=true (no flush during recovery)
     // - write_dbid_to_manifest=0 (no DB_ID write on open)
-    // - all fault injection flags are disabled
+    // - metadata_write_fault_one_in=0 (no fault injection)
+    // - open_metadata_write_fault_one_in=0 (no fault injection)
     // - MANIFEST not corrupted, not at size limit
     // Note: avoid_flush_during_shutdown is NOT required. If it leaves data
     // in WAL but avoid_flush_during_recovery=true prevents flushing it,


### PR DESCRIPTION
Summary:

Reverts `https://github.com/facebook/rocksdb/pull/15106`, which ignored `OPTIONS-*` and temp files when deciding whether recovery must advance `next_file_number_`.

Crash-test failures show backup/checkpoint failing to copy the current `OPTIONS-*` file after options cleanup, because `DeleteObsoleteOptionsFiles()` ignores `next_file_number_` and `options_file_number_` when choosing which files to keep. The failing commands use `optimize_manifest_for_recovery=1`, so restore the previous conservative file-number reservation behavior while we investigate a narrower fix.

Differential Revision: D117807052


