### PR TITLE
Reject oversized memtable entries

### DIFF
--- a/db/db_memtable_test.cc
+++ b/db/db_memtable_test.cc
@@ -3,6 +3,7 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
+#include <limits>
 #include <memory>
 #include <string>
 
@@ -122,6 +123,32 @@ class TestPrefixExtractor : public SliceTransform {
     return static_cast<const char*>(memchr(key.data(), '_', key.size()));
   }
 };
+
+TEST_F(DBMemTableTest, RejectsOversizedEncodedEntry) {
+  Options options;
+  InternalKeyComparator cmp(options.comparator);
+  ImmutableOptions ioptions(options);
+  WriteBufferManager wb(options.db_write_buffer_size);
+  std::unique_ptr<MemTable> mem =
+      std::make_unique<MemTable>(cmp, ioptions, MutableCFOptions(options), &wb,
+                                 kMaxSequenceNumber, 0 /* column_family_id */);
+
+  constexpr size_t kMaxUint32 = std::numeric_limits<uint32_t>::max();
+  const char dummy = 'x';
+
+  // Slice does not own or access the described storage. These artificial
+  // lengths exercise validation without allocating or copying gigabytes.
+  Status s = mem->Add(1, kTypeValue, Slice(&dummy, 1),
+                      Slice(&dummy, kMaxUint32), nullptr /* kv_prot_info */);
+  ASSERT_TRUE(s.IsInvalidArgument());
+
+  s = mem->Add(2, kTypeValue, Slice(&dummy, kMaxUint32 - kNumInternalBytes + 1),
+               Slice(), nullptr /* kv_prot_info */);
+  ASSERT_TRUE(s.IsInvalidArgument());
+
+  ASSERT_EQ(0U, mem->NumEntries());
+  ASSERT_EQ(0U, mem->GetDataSize());
+}
 
 // Test that ::Add properly returns false when inserting duplicate keys
 TEST_F(DBMemTableTest, DuplicateSeq) {

--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -1125,12 +1125,24 @@ Status MemTable::Add(SequenceNumber s, ValueType type,
   //  value_size   : varint32 of value.size()
   //  value bytes  : char[value.size()]
   //  checksum     : char[moptions_.protection_bytes_per_key]
-  uint32_t key_size = static_cast<uint32_t>(key.size());
-  uint32_t val_size = static_cast<uint32_t>(value.size());
-  uint32_t internal_key_size = key_size + 8;
-  const uint32_t encoded_len = VarintLength(internal_key_size) +
-                               internal_key_size + VarintLength(val_size) +
-                               val_size + moptions_.protection_bytes_per_key;
+  constexpr uint64_t kMaxEncodedEntrySize =
+      std::numeric_limits<uint32_t>::max();
+  if (UNLIKELY(key.size() > kMaxEncodedEntrySize - kNumInternalBytes ||
+               value.size() > kMaxEncodedEntrySize)) {
+    return Status::InvalidArgument("memtable entry is too large");
+  }
+
+  const uint32_t key_size = static_cast<uint32_t>(key.size());
+  const uint32_t val_size = static_cast<uint32_t>(value.size());
+  const uint32_t internal_key_size = key_size + kNumInternalBytes;
+  const uint64_t encoded_len64 = VarintLength(internal_key_size) +
+                                 uint64_t{internal_key_size} +
+                                 VarintLength(val_size) + uint64_t{val_size} +
+                                 moptions_.protection_bytes_per_key;
+  if (UNLIKELY(encoded_len64 > kMaxEncodedEntrySize)) {
+    return Status::InvalidArgument("memtable entry is too large");
+  }
+  const uint32_t encoded_len = static_cast<uint32_t>(encoded_len64);
   char* buf = nullptr;
   std::unique_ptr<MemTableRep>& table =
       type == kTypeRangeDeletion ? range_del_table_ : table_;

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -678,6 +678,8 @@ class MemTable final : public ReadOnlyMemTable {
   // Returns `Status::TryAgain` if the `seq`, `key` combination already exists
   // in the memtable and `MemTableRepFactory::CanHandleDuplicatedKey()` is true.
   // The next attempt should try a larger value for `seq`.
+  // Returns `Status::InvalidArgument` if the key, value, or full encoded entry
+  // cannot be represented by the memtable entry format.
   Status Add(SequenceNumber seq, ValueType type, const Slice& key,
              const Slice& value, const ProtectionInfoKVOS64* kv_prot_info,
              bool allow_concurrent = false,


### PR DESCRIPTION
## Summary

Memtable entries encode their internal-key and value lengths as varint32, while MemTable::Add receives Slice lengths as size_t. Previously, it narrowed the key and value lengths and calculated the complete allocation size in uint32_t before allocating storage. A key that no longer fits after adding the eight-byte internal-key suffix, or a key/value pair whose complete encoding exceeds UINT32_MAX, could therefore wrap the calculated allocation size. Subsequent encoding and copying could write beyond the undersized allocation or silently truncate data.

WriteBatch validates individual key and value lengths on common public write paths, but that is not sufficient: it does not validate the aggregate memtable encoding size and MemTable::Add is also reached by internal and recovery paths. MemTable::Add is the final common boundary before allocation and copying, so validate the sizes there before narrowing or mutating the memtable. Compute the complete encoded length in uint64_t and return Status::InvalidArgument when the entry cannot be represented by the uint32-based format.

Keep the existing post-encoding assertion unchanged. It verifies private encoder bookkeeping for inputs that already satisfy the format contract. It cannot replace the runtime validation because it executes after allocation and copying, compares already-narrowed unsigned values that can hide wraparound, and is compiled out of release builds. The runtime checks reject invalid data safely, while the assertion continues to catch internal implementation mistakes during development.

The regression test covers an individually representable value whose aggregate entry size overflows, and a key whose internal-key length overflows. It also verifies rejection happens before the memtable is modified.


## Test plan

- Built `db_memtable_test` and ran `DBMemTableTest.RejectsOversizedEncodedEntry` in normal and `ASSERT_STATUS_CHECKED=1` configurations.
- Compiled production `memtable.o` with `DEBUG_LEVEL=0`.

