### PR TITLE
Observability for the WriteBufferManager (#15162)

### DIFF
--- a/db/db_flush_test.cc
+++ b/db/db_flush_test.cc
@@ -3305,8 +3305,9 @@ TEST_P(DBAtomicFlushTest, CFDropRaceWithWaitForFlushMemTables) {
   });
   FlushOptions flush_opts;
   flush_opts.allow_write_stall = true;
-  ASSERT_OK(dbfull()->TEST_AtomicFlushMemTables({cfd_default, cfd_pikachu},
-                                                flush_opts));
+  ASSERT_OK(dbfull()->TEST_AtomicFlushMemTables(
+      {cfd_default, cfd_pikachu}, flush_opts,
+      false /* non_blocking_write_thread */));
   drop_cf_thr.join();
   Close();
   SyncPoint::GetInstance()->DisableProcessing();

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -525,7 +525,8 @@ Status DBImpl::ResumeImpl(DBRecoverContext context,
 void DBImpl::WaitForBackgroundWork() {
   // Wait for background work to finish
   while (bg_bottom_compaction_scheduled_ || bg_compaction_scheduled_ ||
-         bg_flush_scheduled_ || bg_pressure_callback_in_progress_) {
+         bg_flush_scheduled_ || bg_wbm_flush_scheduled_ ||
+         bg_pressure_callback_in_progress_) {
     bg_cv_.Wait();
   }
 }
@@ -816,6 +817,21 @@ Status DBImpl::MaybeWriteWalMarkersToManifestOnClose() {
                                 /*new_descriptor_log=*/false);
 }
 
+void DBImpl::MaybeRegisterFlushInitiator() {
+  // Register only fully opened read-write DBs. Do not hold mutex_: the lock
+  // order is registry mutex before DB mutex.
+  if (write_buffer_manager_ == nullptr || read_only_ || !opened_successfully_) {
+    return;
+  }
+  // Replacing a registered initiator would leave a dangling registry entry.
+  assert(wbm_flush_initiator_ == nullptr);
+  if (wbm_flush_initiator_ != nullptr) {
+    return;
+  }
+  wbm_flush_initiator_ = std::make_unique<WBMFlushInitiator>(this);
+  write_buffer_manager_->RegisterFlushInitiator(wbm_flush_initiator_.get());
+}
+
 Status DBImpl::CloseHelper() {
   // Guarantee that there is no background error recovery in progress before
   // continuing with the shutdown
@@ -826,6 +842,12 @@ Status DBImpl::CloseHelper() {
     bg_cv_.Wait();
   }
   mutex_.Unlock();
+
+  // Deregister before teardown and without mutex_ to preserve registry-to-DB
+  // lock ordering.
+  if (write_buffer_manager_ && wbm_flush_initiator_) {
+    write_buffer_manager_->DeregisterFlushInitiator(wbm_flush_initiator_.get());
+  }
 
   // Below check is added as recovery_error_ is not checked and it causes crash
   // in DBSSTTest.DBWithMaxSpaceAllowedWithBlobFiles when space limit is
@@ -853,8 +875,8 @@ Status DBImpl::CloseHelper() {
 
   // Wait for background work to finish
   while (bg_bottom_compaction_scheduled_ || bg_compaction_scheduled_ ||
-         bg_flush_scheduled_ || bg_purge_scheduled_ ||
-         bg_pressure_callback_in_progress_ ||
+         bg_flush_scheduled_ || bg_wbm_flush_scheduled_ ||
+         bg_purge_scheduled_ || bg_pressure_callback_in_progress_ ||
          bg_async_file_open_state_ == AsyncFileOpenState::kScheduled ||
          async_wal_precreate_state_ == AsyncWALPrecreateState::kScheduled ||
          pending_purge_obsolete_files_ ||

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1310,7 +1310,7 @@ class DBImpl : public DB
   // finishes. For example in CompactRange.
   Status TEST_AtomicFlushMemTables(
       const autovector<ColumnFamilyData*>& provided_candidate_cfds,
-      const FlushOptions& flush_opts, bool non_blocking_write_thread = false);
+      const FlushOptions& flush_opts, bool non_blocking_write_thread);
 
   void TEST_BeginWriteStall();
   void TEST_EndWriteStall();

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1310,7 +1310,10 @@ class DBImpl : public DB
   // finishes. For example in CompactRange.
   Status TEST_AtomicFlushMemTables(
       const autovector<ColumnFamilyData*>& provided_candidate_cfds,
-      const FlushOptions& flush_opts);
+      const FlushOptions& flush_opts, bool non_blocking_write_thread = false);
+
+  void TEST_BeginWriteStall();
+  void TEST_EndWriteStall();
 
   // Wait for background threads to complete scheduled work.
   Status TEST_WaitForBackgroundWork();
@@ -1521,6 +1524,23 @@ class DBImpl : public DB
     // state represting whether DB is running or blocked because of stall by
     // WriteBufferManager.
     State state_;
+  };
+
+  // Adapts DBImpl to the shared WriteBufferManager flush registry.
+  class WBMFlushInitiator : public FlushInitiator {
+   public:
+    explicit WBMFlushInitiator(DBImpl* db) : db_(db) {}
+
+    size_t GetFlushableMemUsage() override {
+      return db_->GetFlushableMemUsage();
+    }
+
+    bool ScheduleFlush() override {
+      return db_->ScheduleWriteBufferManagerFlush();
+    }
+
+   private:
+    DBImpl* const db_;
   };
 
   static void TEST_ResetDbSessionIdGen();
@@ -2631,6 +2651,17 @@ class DBImpl : public DB
       const autovector<ColumnFamilyData*>& provided_candidate_cfds = {},
       bool entered_write_thread = false);
 
+  enum class WriteThreadJoinMode { kBlocking, kNonBlocking };
+
+  Status FlushMemTableImpl(ColumnFamilyData* cfd, const FlushOptions& options,
+                           FlushReason flush_reason, bool entered_write_thread,
+                           WriteThreadJoinMode join_mode);
+
+  Status AtomicFlushMemTablesImpl(
+      const FlushOptions& options, FlushReason flush_reason,
+      const autovector<ColumnFamilyData*>& provided_candidate_cfds,
+      bool entered_write_thread, WriteThreadJoinMode join_mode);
+
   // REQUIRES: mutex locked and write queues drained up to the recovery flush
   // fence that is about to switch memtables.
   void MaybeSyncLastSequenceWithAllocatedForRecovery(FlushReason flush_reason);
@@ -2717,6 +2748,15 @@ class DBImpl : public DB
     return static_cast<uint8_t*>(static_cast<void*>(this)) + type;
   }
 
+  // Checks DB-local write queues; manager-wide stall state would reject healthy
+  // DBs. REQUIRES: mutex_ held.
+  bool WouldBlockJoiningWriteThread() {
+    mutex_.AssertHeld();
+    return write_thread_.GetBegunCountOfOutstandingStall() != 0 ||
+           (two_write_queues_ &&
+            nonmem_write_thread_.GetBegunCountOfOutstandingStall() != 0);
+  }
+
   // REQUIRES: mutex locked and in write thread.
   void AssignAtomicFlushSeq(const autovector<ColumnFamilyData*>& cfds);
 
@@ -2725,6 +2765,30 @@ class DBImpl : public DB
 
   // REQUIRES: mutex locked and in write thread.
   Status HandleWriteBufferManagerFlush(WriteContext* write_context);
+
+  // Column families and memory eligible for a WriteBufferManager flush.
+  struct FlushableCFs {
+    ColumnFamilyData* largest = nullptr;  // most mutable memtable memory
+    ColumnFamilyData* oldest = nullptr;   // smallest memtable creation seq
+    size_t largest_mem = 0;
+    size_t total_mem = 0;
+  };
+
+  // Shared selection for bidding and flushing. REQUIRES: mutex_ held.
+  FlushableCFs CollectFlushableCFs();
+
+  // Registers an opened read-write DB without holding mutex_.
+  void MaybeRegisterFlushInitiator();
+
+  // Returns reclaimable memory, or zero when this DB cannot flush.
+  size_t GetFlushableMemUsage();
+
+  // Ensures a WBM flush is in flight; safe from another DB's thread.
+  bool ScheduleWriteBufferManagerFlush();
+
+  static void BGWorkWBMFlush(void* arg);
+  static void UnscheduleWBMFlushCallback(void* arg);
+  void BackgroundCallWBMFlush();
 
   // REQUIRES: mutex locked
   Status PreprocessWrite(const WriteOptions& write_options,
@@ -3608,6 +3672,12 @@ class DBImpl : public DB
   // number of background memtable flush jobs, submitted to the HIGH pool
   int bg_flush_scheduled_ = 0;
 
+  // LOW avoids consuming flush workers or rerouting bottommost compactions.
+  static constexpr Env::Priority kWBMFlushPriority = Env::Priority::LOW;
+
+  // Outstanding cross-DB WBM flush jobs, drained during shutdown.
+  int bg_wbm_flush_scheduled_ = 0;
+
   // stores the number of flushes are currently running
   int num_running_flushes_ = 0;
 
@@ -3794,6 +3864,9 @@ class DBImpl : public DB
 
   // Pointer to WriteBufferManager stalling interface.
   std::unique_ptr<StallInterface> wbm_stall_;
+
+  // Entry owned by this DB and registered with its shared WBM.
+  std::unique_ptr<FlushInitiator> wbm_flush_initiator_;
 
   // seqno_to_time_mapping_ stores the sequence number to time mapping, it's not
   // thread safe, both read and write need db mutex hold.

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -4133,6 +4133,26 @@ void DBImpl::BackgroundCallWBMFlush() {
 
   // The WBM job remains tracked until the resulting flush is scheduled.
   if (has_flushable_cf) {
+    // cfd_to_flush is only set on the non-atomic path; an atomic flush covers
+    // every eligible column family, so there is no single one to name.
+    if (atomic_flush) {
+      ROCKS_LOG_INFO(
+          immutable_db_options_.info_log,
+          "Atomically flushing all column families on behalf of a shared "
+          "WriteBufferManager. Write buffer is using %" ROCKSDB_PRIszt
+          " bytes out of a total of %" ROCKSDB_PRIszt ".",
+          write_buffer_manager_->memory_usage(),
+          write_buffer_manager_->buffer_size());
+    } else {
+      ROCKS_LOG_INFO(
+          immutable_db_options_.info_log,
+          "[%s] Flushing largest column family on behalf of a shared "
+          "WriteBufferManager. Write buffer is using %" ROCKSDB_PRIszt
+          " bytes out of a total of %" ROCKSDB_PRIszt ".",
+          cfd_to_flush->GetName().c_str(),
+          write_buffer_manager_->memory_usage(),
+          write_buffer_manager_->buffer_size());
+    }
     FlushOptions flush_options;
     flush_options.wait = false;
     flush_options.allow_write_stall = true;

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <cinttypes>
 #include <deque>
+#include <memory>
 #include <unordered_map>
 
 #include "db/blob/blob_file_partition_manager.h"
@@ -2032,8 +2033,9 @@ Status DBImpl::CompactFilesImpl(
 Status DBImpl::PauseBackgroundWork() {
   InstrumentedMutexLock guard_lock(&mutex_);
   bg_compaction_paused_++;
+  // A WBM job can seal a memtable, so pause must drain it too.
   while (bg_bottom_compaction_scheduled_ > 0 || bg_compaction_scheduled_ > 0 ||
-         bg_flush_scheduled_ > 0) {
+         bg_flush_scheduled_ > 0 || bg_wbm_flush_scheduled_ > 0) {
     bg_cv_.Wait();
   }
   bg_work_paused_++;
@@ -2728,6 +2730,16 @@ Status DBImpl::FlushMemTable(ColumnFamilyData* cfd,
                              const FlushOptions& flush_options,
                              FlushReason flush_reason,
                              bool entered_write_thread) {
+  return FlushMemTableImpl(cfd, flush_options, flush_reason,
+                           entered_write_thread,
+                           WriteThreadJoinMode::kBlocking);
+}
+
+Status DBImpl::FlushMemTableImpl(ColumnFamilyData* cfd,
+                                 const FlushOptions& flush_options,
+                                 FlushReason flush_reason,
+                                 bool entered_write_thread,
+                                 WriteThreadJoinMode join_mode) {
   // This method should not be called if atomic_flush is true.
   assert(!immutable_db_options_.atomic_flush);
   if (!flush_options.wait && write_controller_.IsStopped()) {
@@ -2763,9 +2775,27 @@ Status DBImpl::FlushMemTable(ColumnFamilyData* cfd,
     WriteThread::Writer w;
     WriteThread::Writer nonmem_w;
     if (needs_to_join_write_thread) {
-      write_thread_.EnterUnbatched(&w, &mutex_);
-      if (two_write_queues_) {
-        nonmem_write_thread_.EnterUnbatched(&nonmem_w, &mutex_);
+      if (join_mode == WriteThreadJoinMode::kNonBlocking) {
+        // Refuse stalls because this job may be needed to release their memory.
+        bool entered = write_thread_.EnterUnbatchedNonBlocking(&w, &mutex_);
+        if (entered && two_write_queues_) {
+          entered = nonmem_write_thread_.EnterUnbatchedNonBlocking(&nonmem_w,
+                                                                   &mutex_);
+          if (!entered) {
+            write_thread_.ExitUnbatched(&w);
+          }
+        }
+        if (!entered) {
+          s.PermitUncheckedOk();
+          return Status::Incomplete(
+              "Write stall in progress, unable to join the write thread to "
+              "switch memtables");
+        }
+      } else {
+        write_thread_.EnterUnbatched(&w, &mutex_);
+        if (two_write_queues_) {
+          nonmem_write_thread_.EnterUnbatched(&nonmem_w, &mutex_);
+        }
       }
     }
     WaitForPendingWrites();
@@ -2895,6 +2925,15 @@ Status DBImpl::AtomicFlushMemTables(
     const FlushOptions& flush_options, FlushReason flush_reason,
     const autovector<ColumnFamilyData*>& provided_candidate_cfds,
     bool entered_write_thread) {
+  return AtomicFlushMemTablesImpl(flush_options, flush_reason,
+                                  provided_candidate_cfds, entered_write_thread,
+                                  WriteThreadJoinMode::kBlocking);
+}
+
+Status DBImpl::AtomicFlushMemTablesImpl(
+    const FlushOptions& flush_options, FlushReason flush_reason,
+    const autovector<ColumnFamilyData*>& provided_candidate_cfds,
+    bool entered_write_thread, WriteThreadJoinMode join_mode) {
   if (!flush_options.wait && write_controller_.IsStopped()) {
     std::ostringstream oss;
     oss << "Writes have been stopped, thus unable to perform manual flush. "
@@ -2925,32 +2964,30 @@ Status DBImpl::AtomicFlushMemTables(
     candidate_cfds = provided_candidate_cfds;
   }
 
+  const auto unref_generated_candidates = [&]() {
+    if (!provided_candidate_cfds.empty()) {
+      return;
+    }
+    for (auto candidate_cfd : candidate_cfds) {
+      candidate_cfd->UnrefAndTryDelete();
+    }
+    candidate_cfds.clear();
+  };
+
   if (!flush_options.allow_write_stall) {
     int num_cfs_to_flush = 0;
     for (auto cfd : candidate_cfds) {
       bool flush_needed = true;
       s = WaitUntilFlushWouldNotStallWrites(cfd, &flush_needed);
       if (!s.ok()) {
-        // Unref the newly generated candidate cfds (when not provided) in
-        // `candidate_cfds`
-        if (provided_candidate_cfds.empty()) {
-          for (auto candidate_cfd : candidate_cfds) {
-            candidate_cfd->UnrefAndTryDelete();
-          }
-        }
+        unref_generated_candidates();
         return s;
       } else if (flush_needed) {
         ++num_cfs_to_flush;
       }
     }
     if (0 == num_cfs_to_flush) {
-      // Unref the newly generated candidate cfds (when not provided) in
-      // `candidate_cfds`
-      if (provided_candidate_cfds.empty()) {
-        for (auto candidate_cfd : candidate_cfds) {
-          candidate_cfd->UnrefAndTryDelete();
-        }
-      }
+      unref_generated_candidates();
       return s;
     }
   }
@@ -2965,9 +3002,28 @@ Status DBImpl::AtomicFlushMemTables(
     WriteThread::Writer w;
     WriteThread::Writer nonmem_w;
     if (needs_to_join_write_thread) {
-      write_thread_.EnterUnbatched(&w, &mutex_);
-      if (two_write_queues_) {
-        nonmem_write_thread_.EnterUnbatched(&nonmem_w, &mutex_);
+      if (join_mode == WriteThreadJoinMode::kNonBlocking) {
+        // Refuse stalls because this job may be needed to release their memory.
+        bool entered = write_thread_.EnterUnbatchedNonBlocking(&w, &mutex_);
+        if (entered && two_write_queues_) {
+          entered = nonmem_write_thread_.EnterUnbatchedNonBlocking(&nonmem_w,
+                                                                   &mutex_);
+          if (!entered) {
+            write_thread_.ExitUnbatched(&w);
+          }
+        }
+        if (!entered) {
+          unref_generated_candidates();
+          s.PermitUncheckedOk();
+          return Status::Incomplete(
+              "Write stall in progress, unable to join the write thread to "
+              "switch memtables");
+        }
+      } else {
+        write_thread_.EnterUnbatched(&w, &mutex_);
+        if (two_write_queues_) {
+          nonmem_write_thread_.EnterUnbatched(&nonmem_w, &mutex_);
+        }
       }
     }
     WaitForPendingWrites();
@@ -2979,13 +3035,7 @@ Status DBImpl::AtomicFlushMemTables(
 
     SelectColumnFamiliesForAtomicFlush(&cfds, candidate_cfds, flush_reason);
 
-    // Unref the newly generated candidate cfds (when not provided) in
-    // `candidate_cfds`
-    if (provided_candidate_cfds.empty()) {
-      for (auto candidate_cfd : candidate_cfds) {
-        candidate_cfd->UnrefAndTryDelete();
-      }
-    }
+    unref_generated_candidates();
 
     for (auto cfd : cfds) {
       if (cfd->mem()->IsEmpty() && cached_recoverable_state_empty_.load() &&
@@ -3962,6 +4012,158 @@ void DBImpl::UnscheduleFlushCallback(void* arg) {
   }
   delete static_cast<FlushThreadArg*>(arg);
   TEST_SYNC_POINT("DBImpl::UnscheduleFlushCallback");
+}
+
+size_t DBImpl::GetFlushableMemUsage() {
+  InstrumentedMutexLock l(&mutex_);
+  if (!opened_successfully_ || read_only_ ||
+      shutdown_initiated_.load(std::memory_order_acquire) ||
+      shutting_down_.load(std::memory_order_acquire) ||
+      reject_new_background_jobs_ || bg_work_paused_ > 0 ||
+      bg_compaction_paused_ > 0 || write_controller_.IsStopped() ||
+      WouldBlockJoiningWriteThread()) {
+    return 0;
+  }
+  const FlushableCFs flushable = CollectFlushableCFs();
+  return immutable_db_options_.atomic_flush ? flushable.total_mem
+                                            : flushable.largest_mem;
+}
+
+DBImpl::FlushableCFs DBImpl::CollectFlushableCFs() {
+  mutex_.AssertHeld();
+  FlushableCFs result;
+  SequenceNumber oldest_seq = kMaxSequenceNumber;
+  for (auto cfd : *versions_->GetColumnFamilySet()) {
+    if (cfd->IsDropped() || !cfd->initialized() || cfd->mem()->IsEmpty()) {
+      continue;
+    }
+    const size_t mem = cfd->mem()->ApproximateMemoryUsageFast();
+    result.total_mem += mem;
+    // Non-atomic flushes skip CFs already flushing.
+    if (cfd->imm()->IsFlushPendingOrRunning()) {
+      continue;
+    }
+    if (result.largest == nullptr || mem > result.largest_mem) {
+      result.largest = cfd;
+      result.largest_mem = mem;
+    }
+    const SequenceNumber seq = cfd->mem()->GetCreationSeq();
+    if (result.oldest == nullptr || seq < oldest_seq) {
+      result.oldest = cfd;
+      oldest_seq = seq;
+    }
+  }
+  return result;
+}
+
+bool DBImpl::ScheduleWriteBufferManagerFlush() {
+  InstrumentedMutexLock l(&mutex_);
+  // Recheck bid eligibility because DB state may have changed.
+  if (shutdown_initiated_.load(std::memory_order_acquire) ||
+      shutting_down_.load(std::memory_order_acquire) ||
+      reject_new_background_jobs_ || !opened_successfully_ || read_only_ ||
+      write_controller_.IsStopped() ||
+      // Reject both the pause drain and fully paused states.
+      bg_work_paused_ > 0 || bg_compaction_paused_ > 0 ||
+      // Never occupy a worker waiting for this DB's stall.
+      WouldBlockJoiningWriteThread()) {
+    return false;
+  }
+  // Coalesce to one outstanding WBM flush per DB.
+  if (bg_wbm_flush_scheduled_ > 0) {
+    return true;
+  }
+  // Do not occupy the flush pool while joining the target write thread.
+  const Env::Priority thread_pri = kWBMFlushPriority;
+  ++bg_wbm_flush_scheduled_;
+  auto fta = std::make_unique<FlushThreadArg>();
+  fta->db_ = this;
+  fta->thread_pri_ = thread_pri;
+  // The worker or cancellation callback takes ownership of fta.
+  env_->Schedule(&DBImpl::BGWorkWBMFlush, fta.release(), thread_pri,
+                 GetTaskTag(TaskType::kDefault) /* tag */,
+                 &DBImpl::UnscheduleWBMFlushCallback);
+  return true;
+}
+
+void DBImpl::BGWorkWBMFlush(void* arg) {
+  const std::unique_ptr<FlushThreadArg> fta(static_cast<FlushThreadArg*>(arg));
+
+  IOSTATS_SET_THREAD_POOL_ID(fta->thread_pri_);
+  TEST_SYNC_POINT("DBImpl::BGWorkWBMFlush");
+  static_cast_with_check<DBImpl>(fta->db_)->BackgroundCallWBMFlush();
+  TEST_SYNC_POINT("DBImpl::BGWorkWBMFlush:done");
+}
+
+void DBImpl::UnscheduleWBMFlushCallback(void* arg) {
+  // REQUIRES: caller holds mutex_; exactly one worker or cancellation path owns
+  // the argument and decrements the counter.
+  const std::unique_ptr<FlushThreadArg> fta(static_cast<FlushThreadArg*>(arg));
+  fta->db_->mutex_.AssertHeld();
+  fta->db_->bg_wbm_flush_scheduled_--;
+  fta->db_->bg_cv_.SignalAll();
+  TEST_SYNC_POINT("DBImpl::UnscheduleWBMFlushCallback");
+}
+
+void DBImpl::BackgroundCallWBMFlush() {
+  const bool atomic_flush = immutable_db_options_.atomic_flush;
+  // Keep the selected non-atomic CF alive across the unlocked flush call.
+  ColumnFamilyData* cfd_to_flush = nullptr;
+  bool has_flushable_cf = false;
+  {
+    InstrumentedMutexLock l(&mutex_);
+    // Recheck scheduling eligibility immediately before selecting a CF.
+    if (!shutdown_initiated_.load(std::memory_order_acquire) &&
+        !shutting_down_.load(std::memory_order_acquire) &&
+        !reject_new_background_jobs_ && opened_successfully_ && !read_only_ &&
+        !write_controller_.IsStopped() && bg_work_paused_ == 0 &&
+        bg_compaction_paused_ == 0 && !WouldBlockJoiningWriteThread()) {
+      // Use the same selection as the bid.
+      const FlushableCFs flushable = CollectFlushableCFs();
+      has_flushable_cf =
+          atomic_flush ? flushable.total_mem > 0 : flushable.largest != nullptr;
+      if (!atomic_flush) {
+        cfd_to_flush = flushable.largest;
+        if (cfd_to_flush != nullptr) {
+          cfd_to_flush->Ref();
+        }
+      }
+    }
+  }
+
+  // The WBM job remains tracked until the resulting flush is scheduled.
+  if (has_flushable_cf) {
+    FlushOptions flush_options;
+    flush_options.wait = false;
+    flush_options.allow_write_stall = true;
+    Status s;
+    if (atomic_flush) {
+      // Empty candidates preserve atomic flush's all-CF selection.
+      s = AtomicFlushMemTablesImpl(
+          flush_options, FlushReason::kWriteBufferManager,
+          {} /* provided_candidate_cfds */, false /* entered_write_thread */,
+          WriteThreadJoinMode::kNonBlocking);
+    } else {
+      s = FlushMemTableImpl(
+          cfd_to_flush, flush_options, FlushReason::kWriteBufferManager,
+          false /* entered_write_thread */, WriteThreadJoinMode::kNonBlocking);
+    }
+    if (!s.ok()) {
+      // Surface failed deferred flushes rather than dropping them silently.
+      ROCKS_LOG_WARN(
+          immutable_db_options_.info_log,
+          "Flush on behalf of a shared WriteBufferManager failed: %s",
+          s.ToString().c_str());
+    }
+    s.PermitUncheckedError();
+  }
+
+  InstrumentedMutexLock l(&mutex_);
+  if (cfd_to_flush != nullptr) {
+    cfd_to_flush->UnrefAndTryDelete();
+  }
+  --bg_wbm_flush_scheduled_;
+  bg_cv_.SignalAll();
 }
 
 Status DBImpl::BackgroundFlush(bool* made_progress, JobContext* job_context,
@@ -5663,9 +5865,10 @@ Status DBImpl::WaitForCompact(
     if (bg_work_paused_ && wait_for_compact_options.abort_on_pause) {
       return Status::Aborted();
     }
+    // A WBM job can enqueue a regular flush, so wait for both to quiesce.
     if ((bg_bottom_compaction_scheduled_ || bg_compaction_scheduled_ ||
-         bg_flush_scheduled_ || unscheduled_compactions_ ||
-         !parked_compaction_cfds_.empty() ||
+         bg_flush_scheduled_ || bg_wbm_flush_scheduled_ ||
+         unscheduled_compactions_ || !parked_compaction_cfds_.empty() ||
          (wait_for_compact_options.wait_for_purge && bg_purge_scheduled_) ||
          unscheduled_flushes_ || error_handler_.IsRecoveryInProgress()) &&
         (error_handler_.GetBGError().ok())) {

--- a/db/db_impl/db_impl_debug.cc
+++ b/db/db_impl/db_impl_debug.cc
@@ -182,9 +182,23 @@ Status DBImpl::TEST_FlushMemTableWithListenerWait(bool allow_write_stall,
 
 Status DBImpl::TEST_AtomicFlushMemTables(
     const autovector<ColumnFamilyData*>& provided_candidate_cfds,
-    const FlushOptions& flush_opts) {
-  return AtomicFlushMemTables(flush_opts, FlushReason::kTest,
-                              provided_candidate_cfds);
+    const FlushOptions& flush_opts, bool non_blocking_write_thread) {
+  const auto join_mode = non_blocking_write_thread
+                             ? WriteThreadJoinMode::kNonBlocking
+                             : WriteThreadJoinMode::kBlocking;
+  return AtomicFlushMemTablesImpl(flush_opts, FlushReason::kTest,
+                                  provided_candidate_cfds,
+                                  false /* entered_write_thread */, join_mode);
+}
+
+void DBImpl::TEST_BeginWriteStall() {
+  InstrumentedMutexLock l(&mutex_);
+  write_thread_.BeginWriteStall();
+}
+
+void DBImpl::TEST_EndWriteStall() {
+  InstrumentedMutexLock l(&mutex_);
+  write_thread_.EndWriteStall();
 }
 
 Status DBImpl::TEST_WaitForBackgroundWork() {

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -3000,6 +3000,8 @@ Status DBImpl::Open(const DBOptions& db_options, const std::string& dbname,
     }
   }
   if (s.ok()) {
+    // Register only after open succeeds and without holding the DB mutex.
+    impl->MaybeRegisterFlushInitiator();
     *dbptr = std::move(impl);
   } else {
     for (auto* h : *handles) {

--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -2126,12 +2126,31 @@ Status DBImpl::PreprocessWrite(const WriteOptions& write_options,
     }
   }
 
+  bool deferred_flush_to_another_db = false;
   if (UNLIKELY(status.ok() && write_buffer_manager_->ShouldFlush())) {
     // Before a new memtable is added in SwitchMemtable(),
     // write_buffer_manager_->ShouldFlush() will keep returning true. If another
     // thread is writing to another DB with the same write buffer, they may also
     // be flushed. We may end up with flushing much more DBs than needed. It's
     // suboptimal but still correct.
+    // Let a larger DB flush first. Do not hold mutex_: registry locks precede
+    // DB locks.
+    deferred_flush_to_another_db =
+        write_buffer_manager_->flush_policy() ==
+            WriteBufferFlushPolicy::kFlushLargestAcrossDBs &&
+        write_buffer_manager_->InitiateFlushOnLargestDB(
+            wbm_flush_initiator_.get());
+    if (!deferred_flush_to_another_db) {
+      InstrumentedMutexLock l(&mutex_);
+      WaitForPendingWrites();
+      status = HandleWriteBufferManagerFlush(write_context);
+    }
+  }
+
+  // Before parking, seal locally so a failed deferred flush cannot deadlock the
+  // shared WBM stall.
+  if (UNLIKELY(status.ok() && deferred_flush_to_another_db &&
+               write_buffer_manager_->ShouldStall())) {
     InstrumentedMutexLock l(&mutex_);
     WaitForPendingWrites();
     status = HandleWriteBufferManagerFlush(write_context);
@@ -2722,25 +2741,14 @@ Status DBImpl::HandleWriteBufferManagerFlush(WriteContext* write_context) {
   if (immutable_db_options_.atomic_flush) {
     SelectColumnFamiliesForAtomicFlush(&cfds);
   } else {
-    ColumnFamilyData* cfd_picked = nullptr;
-    SequenceNumber seq_num_for_cf_picked = kMaxSequenceNumber;
-
-    for (auto cfd : *versions_->GetColumnFamilySet()) {
-      if (cfd->IsDropped()) {
-        continue;
-      }
-      if (!cfd->mem()->IsEmpty() && !cfd->imm()->IsFlushPendingOrRunning()) {
-        // We only consider flush on CFs with bytes in the mutable memtable,
-        // and no immutable memtables for which flush has yet to finish. If
-        // we triggered flush on CFs already trying to flush, we would risk
-        // creating too many immutable memtables leading to write stalls.
-        uint64_t seq = cfd->mem()->GetCreationSeq();
-        if (cfd_picked == nullptr || seq < seq_num_for_cf_picked) {
-          cfd_picked = cfd;
-          seq_num_for_cf_picked = seq;
-        }
-      }
-    }
+    const WriteBufferFlushPolicy policy = write_buffer_manager_->flush_policy();
+    // Cross-DB selection still flushes the largest CF within the chosen DB.
+    const bool flush_largest =
+        policy == WriteBufferFlushPolicy::kFlushLargest ||
+        policy == WriteBufferFlushPolicy::kFlushLargestAcrossDBs;
+    const FlushableCFs flushable = CollectFlushableCFs();
+    ColumnFamilyData* cfd_picked =
+        flush_largest ? flushable.largest : flushable.oldest;
     if (cfd_picked != nullptr) {
       cfds.push_back(cfd_picked);
     }

--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -2934,10 +2934,18 @@ void DBImpl::WriteBufferManagerStallWrites() {
       ->SetState(WBMStallInterface::State::BLOCKED);
   // Then WriteBufferManager will add DB instance to its queue
   // and block this thread by calling WBMStallInterface::Block().
+  const uint64_t stall_start = immutable_db_options_.clock->NowMicros();
   write_buffer_manager_->BeginWriteStall(wbm_stall_.get());
   wbm_stall_->Block();
+  const uint64_t stall_micros =
+      immutable_db_options_.clock->NowMicros() - stall_start;
+  // Recorded separately from STALL_MICROS, which covers only WriteController
+  // (CF-scope) stalls, so the two remain individually attributable.
+  RecordTick(stats_, WRITE_BUFFER_MANAGER_STALL_MICROS, stall_micros);
 
   mutex_.Lock();
+  default_cf_internal_stats_->AddDBStats(
+      InternalStats::kIntStatsWriteBufferManagerStallMicros, stall_micros);
   // Stall has ended. Signal writer threads so that they can add
   // themselves to the WriteThread queue for writes.
   write_thread_.EndWriteStall();

--- a/db/db_write_buffer_manager_test.cc
+++ b/db/db_write_buffer_manager_test.cc
@@ -10,6 +10,7 @@
 #include "db/db_test_util.h"
 #include "db/write_thread.h"
 #include "port/stack_trace.h"
+#include "util/defer.h"
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -843,6 +844,585 @@ TEST_P(DBWriteBufferManagerTest, StopSwitchingMemTablesOnceFlushing) {
   ASSERT_OK(shared_wbm_db->Close());
   ASSERT_OK(DestroyDB(dbname, options));
   shared_wbm_db.reset();
+}
+
+// kFlushLargest must select by mutable memory rather than creation order.
+// Not supported in LITE mode because GetProperty() is unavailable.
+TEST_P(DBWriteBufferManagerTest, FlushLargestMemtablePolicy) {
+  Options options = CurrentOptions();
+  options.arena_block_size = 4 << 10;   // 4KB
+  options.write_buffer_size = 1 << 20;  // 1MB, so per-CF flush is never hit
+  std::shared_ptr<Cache> cache =
+      NewLRUCache(4 << 20 /* capacity (4MB) */, 2 /* num_shard_bits */);
+  cost_cache_ = GetParam();
+  options.write_buffer_manager = std::make_shared<WriteBufferManager>(
+      512 << 10 /* buffer_size (512KB) */, cost_cache_ ? cache : nullptr,
+      false /* allow_stall */, WriteBufferFlushPolicy::kFlushLargest);
+
+  CreateAndReopenWithCF({"cf1", "cf2"}, options);
+
+  // Block the flush background thread so switched memtables stay pending and
+  // remain observable via the num-immutable-mem-table property.
+  test::SleepingBackgroundTask sleeping_task_high;
+  env_->Schedule(&test::SleepingBackgroundTask::DoSleepTask,
+                 &sleeping_task_high, Env::Priority::HIGH);
+
+  // Make cf1 the largest mutable memtable while keeping the total under the WBM
+  // limit (512KB * 7/8 = 448KB) so no flush is triggered yet.
+  ASSERT_OK(
+      Put(0 /* default */, Key(1), DummyString(200 << 10), WriteOptions()));
+  ASSERT_OK(Put(1 /* cf1 */, Key(1), DummyString(300 << 10), WriteOptions()));
+  ASSERT_TRUE(options.write_buffer_manager->ShouldFlush());
+
+  // This write crosses the WBM limit and triggers a flush. Even though it
+  // targets cf2, kFlushLargest must pick cf1, the largest memtable.
+  ASSERT_OK(Put(2 /* cf2 */, Key(1), DummyString(1), WriteOptions()));
+
+  auto num_immutable = [&](int cf) {
+    std::string prop;
+    EXPECT_TRUE(db_->GetProperty(handles_[cf],
+                                 "rocksdb.num-immutable-mem-table", &prop));
+    return prop;
+  };
+  EXPECT_EQ("1", num_immutable(1));  // cf1 (largest) was flushed
+  EXPECT_EQ("0", num_immutable(0));  // default was not
+  EXPECT_EQ("0", num_immutable(2));  // cf2 was not
+
+  sleeping_task_high.WakeUp();
+  sleeping_task_high.WaitUntilDone();
+}
+
+namespace {
+// Records which DB instances have completed a flush, so a test can wait for and
+// assert on cross-DB flush behavior deterministically.
+class FlushedDBRecorder : public EventListener {
+ public:
+  void OnFlushCompleted(DB* db, const FlushJobInfo& info) override {
+    InstrumentedMutexLock l(&mu_);
+    flushed_.insert(db);
+    cf_flushes_[db].insert(info.cf_name);
+    cv_.SignalAll();
+  }
+  void WaitForFlush(DB* db) {
+    InstrumentedMutexLock l(&mu_);
+    while (flushed_.find(db) == flushed_.end()) {
+      cv_.Wait();
+    }
+  }
+  // Waits until `db` has flushed at least `n` distinct column families.
+  void WaitForColumnFamilies(DB* db, size_t n) {
+    InstrumentedMutexLock l(&mu_);
+    while (cf_flushes_[db].size() < n) {
+      cv_.Wait();
+    }
+  }
+  bool HasFlushed(DB* db) {
+    InstrumentedMutexLock l(&mu_);
+    return flushed_.find(db) != flushed_.end();
+  }
+  void Reset() {
+    InstrumentedMutexLock l(&mu_);
+    flushed_.clear();
+    cf_flushes_.clear();
+  }
+
+ private:
+  InstrumentedMutex mu_;
+  InstrumentedCondVar cv_{&mu_};
+  std::set<DB*> flushed_;
+  std::map<DB*, std::set<std::string>> cf_flushes_;
+};
+}  // anonymous namespace
+
+// A write on a smaller DB must flush the largest DB sharing the WBM.
+// Not supported in LITE mode because GetProperty() is unavailable.
+TEST_P(DBWriteBufferManagerTest, FlushLargestAcrossDBsPolicy) {
+  auto recorder = std::make_shared<FlushedDBRecorder>();
+  Options options = CurrentOptions();
+  options.arena_block_size = 4 << 10;   // 4KB
+  options.write_buffer_size = 1 << 20;  // 1MB, so per-CF flush is never hit
+  options.listeners.push_back(recorder);
+  std::shared_ptr<Cache> cache =
+      NewLRUCache(4 << 20 /* capacity (4MB) */, 2 /* num_shard_bits */);
+  cost_cache_ = GetParam();
+  options.write_buffer_manager = std::make_shared<WriteBufferManager>(
+      512 << 10 /* buffer_size (512KB) */, cost_cache_ ? cache : nullptr,
+      false /* allow_stall */, WriteBufferFlushPolicy::kFlushLargestAcrossDBs);
+
+  Reopen(options);
+  std::string other_dbname = test::PerThreadDBPath("wbm_across_dbs_other");
+  ASSERT_OK(DestroyDB(other_dbname, options));
+  std::unique_ptr<DB> other_db;
+  ASSERT_OK(DB::Open(options, other_dbname, &other_db));
+
+  ASSERT_OK(other_db->Put(WriteOptions(), Key(1), DummyString(300 << 10)));
+  ASSERT_OK(Put(Key(1), DummyString(200 << 10), WriteOptions()));
+  ASSERT_TRUE(options.write_buffer_manager->ShouldFlush());
+
+  // Ignore any flush that may have happened during open/setup.
+  recorder->Reset();
+
+  // This crossing write targets db_, but kFlushLargestAcrossDBs must flush
+  // other_db (the larger one) instead, and db_ must defer.
+  ASSERT_OK(Put(Key(2), DummyString(1), WriteOptions()));
+
+  recorder->WaitForFlush(other_db.get());
+  EXPECT_FALSE(recorder->HasFlushed(db_.get()));
+
+  ASSERT_OK(other_db->Close());
+  other_db.reset();
+  ASSERT_OK(DestroyDB(other_dbname, options));
+}
+
+TEST_F(DBWriteBufferManagerTest,
+       AtomicFlushNonBlockingJoinReleasesGeneratedCandidates) {
+  Options options = CurrentOptions();
+  options.atomic_flush = true;
+  CreateAndReopenWithCF({"cf1"}, options);
+
+  auto* impl = dbfull();
+  {
+    impl->TEST_BeginWriteStall();
+    Defer end_stall([&] { impl->TEST_EndWriteStall(); });
+
+    FlushOptions flush_options;
+    flush_options.wait = false;
+    flush_options.allow_write_stall = true;
+    const Status s = impl->TEST_AtomicFlushMemTables(
+        {} /* provided_candidate_cfds */, flush_options,
+        true /* non_blocking_write_thread */);
+    ASSERT_TRUE(s.IsIncomplete());
+  }
+
+  // Closing destroys the ColumnFamilySet and verifies that the failed flush
+  // did not retain a reference to either column family.
+  Close();
+}
+
+// A cross-DB WBM flush must run even when the high-priority pool is empty.
+TEST_P(DBWriteBufferManagerTest, FlushLargestAcrossDBsWithEmptyHighPriPool) {
+  auto recorder = std::make_shared<FlushedDBRecorder>();
+  Options options = CurrentOptions();
+  options.arena_block_size = 4 << 10;   // 4KB
+  options.write_buffer_size = 1 << 20;  // 1MB, so per-CF flush is never hit
+  options.listeners.push_back(recorder);
+  cost_cache_ = GetParam();
+  std::shared_ptr<Cache> cache =
+      NewLRUCache(4 << 20 /* capacity (4MB) */, 2 /* num_shard_bits */);
+  options.write_buffer_manager = std::make_shared<WriteBufferManager>(
+      512 << 10 /* buffer_size (512KB) */, cost_cache_ ? cache : nullptr,
+      false /* allow_stall */, WriteBufferFlushPolicy::kFlushLargestAcrossDBs);
+
+  Reopen(options);
+  std::string other_dbname = test::PerThreadDBPath("wbm_empty_high_pri_other");
+  ASSERT_OK(DestroyDB(other_dbname, options));
+  std::unique_ptr<DB> other_db;
+  ASSERT_OK(DB::Open(options, other_dbname, &other_db));
+
+  ASSERT_OK(other_db->Put(WriteOptions(), Key(1), DummyString(300 << 10)));
+  ASSERT_OK(Put(Key(1), DummyString(200 << 10), WriteOptions()));
+  ASSERT_TRUE(options.write_buffer_manager->ShouldFlush());
+  recorder->Reset();
+
+  // Empty the shared high-priority pool after DB open, and restore it on exit.
+  const int saved_high = env_->GetBackgroundThreads(Env::Priority::HIGH);
+  Defer restore_high_pool(
+      [&] { env_->SetBackgroundThreads(saved_high, Env::Priority::HIGH); });
+  env_->SetBackgroundThreads(0, Env::Priority::HIGH);
+  ASSERT_EQ(0, env_->GetBackgroundThreads(Env::Priority::HIGH));
+
+  ASSERT_OK(Put(Key(2), DummyString(1), WriteOptions()));
+  recorder->WaitForFlush(other_db.get());
+
+  ASSERT_OK(other_db->Close());
+  other_db.reset();
+  ASSERT_OK(DestroyDB(other_dbname, options));
+}
+
+// A write-stopped DB cannot honor a flush and must not win selection.
+TEST_P(DBWriteBufferManagerTest, FlushLargestAcrossDBsSkipsWriteStoppedDB) {
+  Options options = CurrentOptions();
+  options.arena_block_size = 4 << 10;   // 4KB
+  options.write_buffer_size = 1 << 20;  // 1MB, so per-CF flush is never hit
+  cost_cache_ = GetParam();
+  std::shared_ptr<Cache> cache =
+      NewLRUCache(4 << 20 /* capacity (4MB) */, 2 /* num_shard_bits */);
+  options.write_buffer_manager = std::make_shared<WriteBufferManager>(
+      512 << 10 /* buffer_size (512KB) */, cost_cache_ ? cache : nullptr,
+      false /* allow_stall */, WriteBufferFlushPolicy::kFlushLargestAcrossDBs);
+
+  Reopen(options);
+  std::string other_dbname = test::PerThreadDBPath("wbm_write_stopped_other");
+  ASSERT_OK(DestroyDB(other_dbname, options));
+  std::unique_ptr<DB> other_db;
+  ASSERT_OK(DB::Open(options, other_dbname, &other_db));
+
+  ASSERT_OK(other_db->Put(WriteOptions(), Key(1), DummyString(300 << 10)));
+  ASSERT_OK(Put(Key(1), DummyString(200 << 10), WriteOptions()));
+  ASSERT_TRUE(options.write_buffer_manager->ShouldFlush());
+
+  auto* other_dbimpl = static_cast_with_check<DBImpl>(other_db.get());
+  auto stop_token = other_dbimpl->TEST_write_controler().GetStopToken();
+  ASSERT_TRUE(other_dbimpl->TEST_write_controler().IsStopped());
+
+  // Block the flush thread so the memtable switch stays observable.
+  test::SleepingBackgroundTask sleeping_task_high;
+  env_->Schedule(&test::SleepingBackgroundTask::DoSleepTask,
+                 &sleeping_task_high, Env::Priority::HIGH);
+
+  ASSERT_OK(Put(Key(2), DummyString(1), WriteOptions()));
+
+  std::string prop;
+  ASSERT_TRUE(db_->GetProperty("rocksdb.num-immutable-mem-table", &prop));
+  EXPECT_EQ("1", prop) << "db_ should have flushed itself";
+
+  sleeping_task_high.WakeUp();
+  sleeping_task_high.WaitUntilDone();
+  stop_token.reset();
+  ASSERT_OK(other_db->Close());
+  other_db.reset();
+  ASSERT_OK(DestroyDB(other_dbname, options));
+}
+
+// Skip a stalled DB so the selected flush can run and release shared memory.
+TEST_F(DBWriteBufferManagerTest, FlushLargestAcrossDBsSkipsStalledDB) {
+  Options options = CurrentOptions();
+  options.arena_block_size = 4 << 10;
+  options.write_buffer_size = 4 << 20;  // per-CF flush is never hit
+  options.create_if_missing = true;
+  options.create_missing_column_families = true;
+  options.write_buffer_manager = std::make_shared<WriteBufferManager>(
+      1 << 20 /* buffer_size (1MB) */, nullptr /* cache */,
+      true /* allow_stall */, WriteBufferFlushPolicy::kFlushLargestAcrossDBs);
+
+  Reopen(options);
+
+  // Keep mutable memory in other_db after it enters the stall.
+  std::string other_dbname = test::PerThreadDBPath("wbm_stalled_other");
+  ASSERT_OK(DestroyDB(other_dbname, options));
+  std::vector<ColumnFamilyDescriptor> cf_descs = {
+      {kDefaultColumnFamilyName, ColumnFamilyOptions(options)},
+      {"cf1", ColumnFamilyOptions(options)}};
+  std::vector<ColumnFamilyHandle*> other_handles;
+  std::unique_ptr<DB> other_db;
+  ASSERT_OK(
+      DB::Open(options, other_dbname, cf_descs, &other_handles, &other_db));
+
+  // Freeze flushes so the stall remains active for the test.
+  InstrumentedMutex mu;
+  InstrumentedCondVar cv(&mu);
+  bool blocked = false;
+  bool job_done = false;
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->LoadDependency(
+      {{"DBWriteBufferManagerTest::SkipsStalledDB:Done",
+        "DBImpl::BackgroundCallFlush:start"}});
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
+      "WBMStallInterface::BlockDB", [&](void*) {
+        InstrumentedMutexLock l(&mu);
+        blocked = true;
+        cv.SignalAll();
+      });
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::BGWorkWBMFlush:done", [&](void*) {
+        InstrumentedMutexLock l(&mu);
+        job_done = true;
+        cv.SignalAll();
+      });
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
+
+  // Stay below both thresholds until the dedicated staller crosses them.
+  ASSERT_OK(other_db->Put(WriteOptions(), other_handles[1], Key(1),
+                          DummyString(300 << 10)));
+  ASSERT_OK(other_db->Put(WriteOptions(), other_handles[0], Key(1),
+                          DummyString(250 << 10)));
+  ASSERT_OK(Put(Key(1), DummyString(200 << 10), WriteOptions()));
+  ASSERT_FALSE(options.write_buffer_manager->ShouldFlush());
+  ASSERT_FALSE(options.write_buffer_manager->IsStallActive());
+
+  // The first write crosses the limit; the second observes it and parks.
+  port::Thread staller([&] {
+    other_db
+        ->Put(WriteOptions(), other_handles[0], Key(2), DummyString(500 << 10))
+        .PermitUncheckedError();
+    other_db->Put(WriteOptions(), other_handles[0], Key(3), DummyString(1))
+        .PermitUncheckedError();
+  });
+  {
+    InstrumentedMutexLock l(&mu);
+    while (!blocked) {
+      cv.Wait();
+    }
+  }
+  ASSERT_TRUE(options.write_buffer_manager->IsStallActive());
+
+  // The smaller, non-stalled DB must win despite other_db's larger bid.
+  EXPECT_TRUE(options.write_buffer_manager->InitiateFlushOnLargestDB(nullptr));
+  {
+    InstrumentedMutexLock l(&mu);
+    while (!job_done) {
+      cv.Wait();
+    }
+  }
+
+  std::string prop;
+  ASSERT_TRUE(db_->GetProperty("rocksdb.num-immutable-mem-table", &prop));
+  EXPECT_EQ("1", prop) << "the non-stalled DB should have been flushed";
+  ASSERT_TRUE(other_db->GetProperty(other_handles[1],
+                                    "rocksdb.num-immutable-mem-table", &prop));
+  EXPECT_EQ("0", prop) << "a stalled DB must not be handed a cross-DB job";
+
+  options.write_buffer_manager->SetAllowStall(false);
+  staller.join();
+
+  TEST_SYNC_POINT("DBWriteBufferManagerTest::SkipsStalledDB:Done");
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->ClearAllCallBacks();
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();
+  for (auto* handle : other_handles) {
+    ASSERT_OK(other_db->DestroyColumnFamilyHandle(handle));
+  }
+  ASSERT_OK(other_db->Close());
+  other_db.reset();
+  ASSERT_OK(DestroyDB(other_dbname, options));
+}
+
+// A DB that deferred must still seal locally before entering a shared stall.
+TEST_F(DBWriteBufferManagerTest, FlushLargestAcrossDBsSelfFlushesBeforeStall) {
+  Options options = CurrentOptions();
+  options.arena_block_size = 4 << 10;
+  options.write_buffer_size = 4 << 20;  // per-CF flush is never hit
+  options.create_if_missing = true;
+  options.write_buffer_manager = std::make_shared<WriteBufferManager>(
+      1 << 20 /* buffer_size (1MB) */, nullptr /* cache */,
+      true /* allow_stall */, WriteBufferFlushPolicy::kFlushLargestAcrossDBs);
+
+  Reopen(options);
+  std::string other_dbname = test::PerThreadDBPath("wbm_selfflush_other");
+  ASSERT_OK(DestroyDB(other_dbname, options));
+  std::unique_ptr<DB> other_db;
+  ASSERT_OK(DB::Open(options, other_dbname, &other_db));
+
+  // Freeze the larger DB's job so only db_ can release memory.
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->LoadDependency(
+      {{"DBWriteBufferManagerTest::SelfFlushesBeforeStall:Release",
+        "DBImpl::BGWorkWBMFlush"}});
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
+
+  ASSERT_OK(other_db->Put(WriteOptions(), Key(1), DummyString(700 << 10)));
+  ASSERT_OK(Put(Key(1), DummyString(350 << 10), WriteOptions()));
+  ASSERT_TRUE(options.write_buffer_manager->ShouldFlush());
+  ASSERT_TRUE(options.write_buffer_manager->ShouldStall());
+
+  // This write defers to other_db and then has to stall. It can only return if
+  // it sealed its own memtable on the way in.
+  InstrumentedMutex mu;
+  InstrumentedCondVar cv(&mu);
+  bool write_done = false;
+  port::Thread writer([&] {
+    Status s = Put(Key(2), DummyString(1), WriteOptions());
+    InstrumentedMutexLock l(&mu);
+    write_done = true;
+    s.PermitUncheckedError();
+    cv.SignalAll();
+  });
+
+  bool timed_out = false;
+  {
+    InstrumentedMutexLock l(&mu);
+    const uint64_t deadline = env_->NowMicros() + 30 * 1000 * 1000;
+    while (!write_done) {
+      if (cv.TimedWait(deadline)) {
+        timed_out = !write_done;
+        break;
+      }
+    }
+  }
+  EXPECT_FALSE(timed_out)
+      << "writer never came back: it deferred to an idle DB and then parked "
+         "with no flush in flight, so nothing can ever call FreeMem()";
+
+  if (!timed_out) {
+    // Only db_'s local flush can have ended the stall.
+    EXPECT_GT(NumTableFilesAtLevel(0), 0)
+        << "the deferring DB must seal its own memtable rather than rely on "
+           "the other DB's job";
+  }
+
+  options.write_buffer_manager->SetAllowStall(false);
+  TEST_SYNC_POINT("DBWriteBufferManagerTest::SelfFlushesBeforeStall:Release");
+  writer.join();
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->ClearAllCallBacks();
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();
+  ASSERT_OK(other_db->Close());
+  other_db.reset();
+  ASSERT_OK(DestroyDB(other_dbname, options));
+}
+
+// Closing must cancel a queued WBM job and balance its scheduled counter.
+TEST_P(DBWriteBufferManagerTest, FlushLargestAcrossDBsCancelsQueuedJobOnClose) {
+  Options options = CurrentOptions();
+  options.arena_block_size = 4 << 10;   // 4KB
+  options.write_buffer_size = 1 << 20;  // 1MB, so per-CF flush is never hit
+  cost_cache_ = GetParam();
+  std::shared_ptr<Cache> cache =
+      NewLRUCache(4 << 20 /* capacity (4MB) */, 2 /* num_shard_bits */);
+  options.write_buffer_manager = std::make_shared<WriteBufferManager>(
+      512 << 10 /* buffer_size (512KB) */, cost_cache_ ? cache : nullptr,
+      false /* allow_stall */, WriteBufferFlushPolicy::kFlushLargestAcrossDBs);
+
+  std::atomic<int> cancellations{0};
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::UnscheduleWBMFlushCallback",
+      [&](void*) { cancellations.fetch_add(1); });
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
+  Defer cleanup_sync_points([] {
+    ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->ClearAllCallBacks();
+    ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();
+  });
+
+  Reopen(options);
+  std::string other_dbname = test::PerThreadDBPath("wbm_cancel_on_close_other");
+  ASSERT_OK(DestroyDB(other_dbname, options));
+  std::unique_ptr<DB> other_db;
+  ASSERT_OK(DB::Open(options, other_dbname, &other_db));
+
+  // Occupy the low-priority pool so Close() must cancel the queued WBM job.
+  test::SleepingBackgroundTask sleeping_task_low;
+  const int saved_low = env_->GetBackgroundThreads(Env::Priority::LOW);
+  env_->SetBackgroundThreads(1, Env::Priority::LOW);
+  env_->Schedule(&test::SleepingBackgroundTask::DoSleepTask, &sleeping_task_low,
+                 Env::Priority::LOW);
+  sleeping_task_low.WaitUntilSleeping();
+  Defer restore_low_pool([&] {
+    sleeping_task_low.WakeUp();
+    sleeping_task_low.WaitUntilDone();
+    env_->SetBackgroundThreads(saved_low, Env::Priority::LOW);
+  });
+
+  ASSERT_OK(other_db->Put(WriteOptions(), Key(1), DummyString(300 << 10)));
+  ASSERT_OK(Put(Key(1), DummyString(200 << 10), WriteOptions()));
+  ASSERT_TRUE(options.write_buffer_manager->ShouldFlush());
+  ASSERT_OK(Put(Key(2), DummyString(1), WriteOptions()));
+
+  ASSERT_OK(other_db->Close());
+  other_db.reset();
+  EXPECT_GT(cancellations.load(), 0)
+      << "no queued cross-DB flush job was cancelled, so this test did not "
+         "exercise the cancellation path";
+
+  ASSERT_OK(DestroyDB(other_dbname, options));
+}
+
+// A read-only DB consumes shared WBM memory but cannot honor a flush request.
+TEST_P(DBWriteBufferManagerTest, FlushLargestAcrossDBsSkipsReadOnlyDB) {
+  Options options = CurrentOptions();
+  options.arena_block_size = 4 << 10;   // 4KB
+  options.write_buffer_size = 1 << 20;  // 1MB, so per-CF flush is never hit
+  cost_cache_ = GetParam();
+  std::shared_ptr<Cache> cache =
+      NewLRUCache(4 << 20 /* capacity (4MB) */, 2 /* num_shard_bits */);
+
+  // Stage a DB whose data lives only in the WAL, so opening it read-only
+  // rebuilds that data into memtables.
+  std::string ro_dbname = test::PerThreadDBPath("wbm_read_only_db");
+  {
+    Options staging = options;
+    staging.create_if_missing = true;
+    staging.avoid_flush_during_shutdown = true;  // keep the data in the WAL
+    ASSERT_OK(DestroyDB(ro_dbname, staging));
+    std::unique_ptr<DB> staging_db;
+    ASSERT_OK(DB::Open(staging, ro_dbname, &staging_db));
+    ASSERT_OK(staging_db->Put(WriteOptions(), Key(1), DummyString(300 << 10)));
+    ASSERT_OK(staging_db->Close());
+  }
+
+  options.write_buffer_manager = std::make_shared<WriteBufferManager>(
+      512 << 10 /* buffer_size (512KB) */, cost_cache_ ? cache : nullptr,
+      false /* allow_stall */, WriteBufferFlushPolicy::kFlushLargestAcrossDBs);
+  Reopen(options);
+
+  const size_t mem_before = options.write_buffer_manager->memory_usage();
+  std::unique_ptr<DB> read_only_db;
+  ASSERT_OK(DB::OpenForReadOnly(options, ro_dbname, &read_only_db));
+  EXPECT_GT(options.write_buffer_manager->memory_usage(), mem_before);
+
+  // Block the flush thread so the memtable switch stays observable.
+  test::SleepingBackgroundTask sleeping_task_high;
+  env_->Schedule(&test::SleepingBackgroundTask::DoSleepTask,
+                 &sleeping_task_high, Env::Priority::HIGH);
+
+  ASSERT_OK(Put(Key(1), DummyString(200 << 10), WriteOptions()));
+  ASSERT_TRUE(options.write_buffer_manager->ShouldFlush());
+
+  // db_ holds less than the read-only DB, so without the read-only exclusion
+  // the selector would pick a DB that cannot flush and db_ would defer.
+  ASSERT_OK(Put(Key(2), DummyString(1), WriteOptions()));
+
+  std::string prop;
+  ASSERT_TRUE(db_->GetProperty("rocksdb.num-immutable-mem-table", &prop));
+  EXPECT_EQ("1", prop) << "db_ should have flushed itself";
+
+  sleeping_task_high.WakeUp();
+  sleeping_task_high.WaitUntilDone();
+  ASSERT_OK(read_only_db->Close());
+  read_only_db.reset();
+  ASSERT_OK(DestroyDB(ro_dbname, options));
+}
+
+// Rank an atomic-flush DB by the memory reclaimed across all its CFs.
+TEST_P(DBWriteBufferManagerTest, FlushLargestAcrossDBsPicksAtomicFlushDB) {
+  auto recorder = std::make_shared<FlushedDBRecorder>();
+  Options options = CurrentOptions();
+  options.arena_block_size = 4 << 10;   // 4KB
+  options.write_buffer_size = 1 << 20;  // 1MB, so per-CF flush is never hit
+  options.listeners.push_back(recorder);
+  std::shared_ptr<Cache> cache =
+      NewLRUCache(4 << 20 /* capacity (4MB) */, 2 /* num_shard_bits */);
+  cost_cache_ = GetParam();
+  options.write_buffer_manager = std::make_shared<WriteBufferManager>(
+      512 << 10 /* buffer_size (512KB) */, cost_cache_ ? cache : nullptr,
+      false /* allow_stall */, WriteBufferFlushPolicy::kFlushLargestAcrossDBs);
+
+  Reopen(options);
+
+  Options atomic_options = options;
+  atomic_options.atomic_flush = true;
+  atomic_options.create_if_missing = true;
+  atomic_options.create_missing_column_families = true;
+
+  std::string atomic_dbname = test::PerThreadDBPath("wbm_atomic_db");
+  ASSERT_OK(DestroyDB(atomic_dbname, atomic_options));
+  std::vector<ColumnFamilyDescriptor> cf_descs = {
+      {kDefaultColumnFamilyName, ColumnFamilyOptions(atomic_options)},
+      {"cf1", ColumnFamilyOptions(atomic_options)}};
+  std::vector<ColumnFamilyHandle*> atomic_handles;
+  std::unique_ptr<DB> atomic_db;
+  ASSERT_OK(DB::Open(atomic_options, atomic_dbname, cf_descs, &atomic_handles,
+                     &atomic_db));
+
+  // atomic_db reclaims 300KB across two CFs versus db_'s single 200KB CF.
+  ASSERT_OK(atomic_db->Put(WriteOptions(), atomic_handles[0], Key(1),
+                           DummyString(150 << 10)));
+  ASSERT_OK(atomic_db->Put(WriteOptions(), atomic_handles[1], Key(1),
+                           DummyString(150 << 10)));
+  ASSERT_OK(Put(Key(1), DummyString(200 << 10), WriteOptions()));
+  ASSERT_TRUE(options.write_buffer_manager->ShouldFlush());
+
+  // Ignore any flush that may have happened during open/setup.
+  recorder->Reset();
+
+  // The crossing write targets db_, but atomic_db reclaims more, so it is the
+  // one flushed -- and atomically, i.e. both of its column families.
+  ASSERT_OK(Put(Key(2), DummyString(1), WriteOptions()));
+
+  recorder->WaitForColumnFamilies(atomic_db.get(), 2);
+  EXPECT_FALSE(recorder->HasFlushed(db_.get()));
+
+  for (auto* handle : atomic_handles) {
+    ASSERT_OK(atomic_db->DestroyColumnFamilyHandle(handle));
+  }
+  ASSERT_OK(atomic_db->Close());
+  atomic_db.reset();
+  ASSERT_OK(DestroyDB(atomic_dbname, atomic_options));
 }
 
 TEST_F(DBWriteBufferManagerTest, RuntimeChangeableAllowStall) {

--- a/db/db_write_buffer_manager_test.cc
+++ b/db/db_write_buffer_manager_test.cc
@@ -1425,6 +1425,97 @@ TEST_P(DBWriteBufferManagerTest, FlushLargestAcrossDBsPicksAtomicFlushDB) {
   ASSERT_OK(DestroyDB(atomic_dbname, atomic_options));
 }
 
+// Verifies the DB properties that expose WriteBufferManager state. These report
+// the *shared* manager's totals, so they are the only way to observe a
+// WriteBufferManager spanning several DBs as a single entity.
+TEST_F(DBWriteBufferManagerTest, WriteBufferManagerProperties) {
+  constexpr uint64_t kBufferSize = 512 << 10;
+
+  Options options = CurrentOptions();
+  options.arena_block_size = 4 << 10;
+  options.write_buffer_size = 64 << 20;  // never self-triggers a CF flush
+  options.write_buffer_manager = std::make_shared<WriteBufferManager>(
+      kBufferSize, nullptr /* cache */, false /* allow_stall */);
+  DestroyAndReopen(options);
+
+  auto get = [&](const std::string& property) {
+    uint64_t value = 0;
+    EXPECT_TRUE(db_->GetIntProperty(property, &value));
+    return value;
+  };
+
+  EXPECT_EQ(kBufferSize, get(DB::Properties::kWriteBufferManagerBufferSize));
+  EXPECT_EQ(0u, get(DB::Properties::kWriteBufferManagerStallActive));
+
+  WriteOptions wo;
+  wo.disableWAL = true;
+  ASSERT_OK(Put(Key(1), DummyString(200 << 10), wo));
+
+  const uint64_t total = get(DB::Properties::kWriteBufferManagerMemoryUsage);
+  const uint64_t mutable_total =
+      get(DB::Properties::kWriteBufferManagerMutableMemoryUsage);
+  EXPECT_GE(total, 200u << 10);
+  // Nothing has been flushed, so all accounted memory is still mutable.
+  EXPECT_EQ(total, mutable_total);
+
+  // After sealing the memtable the bytes stay accounted (still resident) but
+  // are no longer mutable.
+  ASSERT_OK(static_cast_with_check<DBImpl>(db_.get())->TEST_SwitchMemtable());
+  EXPECT_LT(get(DB::Properties::kWriteBufferManagerMutableMemoryUsage),
+            mutable_total);
+}
+
+// A WriteBufferManager stall is not counted by STALL_MICROS (which covers only
+// WriteController stalls), so verify the dedicated counter records it.
+TEST_F(DBWriteBufferManagerTest, WriteBufferManagerStallMicros) {
+  constexpr int kBigValue = 10000;
+
+  Options options = CurrentOptions();
+  options.statistics = CreateDBStatistics();
+  options.write_buffer_manager = std::make_shared<WriteBufferManager>(
+      1, nullptr /* cache */, true /* allow_stall */);
+  DestroyAndReopen(options);
+
+  // Pause the flush thread so the stall can only be ended by SetAllowStall()
+  // below, making the stall deterministic rather than racing a flush.
+  auto sleeping_task = std::make_unique<test::SleepingBackgroundTask>();
+  env_->SetBackgroundThreads(1, Env::HIGH);
+  env_->Schedule(&test::SleepingBackgroundTask::DoSleepTask,
+                 sleeping_task.get(), Env::Priority::HIGH);
+  sleeping_task->WaitUntilSleeping();
+
+  ASSERT_EQ(
+      0, options.statistics->getTickerCount(WRITE_BUFFER_MANAGER_STALL_MICROS));
+
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->LoadDependency(
+      {{"WBMStallInterface::BlockDB",
+        "DBWriteBufferManagerTest::WriteBufferManagerStallMicros:Unstall"}});
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
+
+  port::Thread writer([&] { ASSERT_OK(Put(Key(0), DummyString(kBigValue))); });
+  port::Thread unstaller([&] {
+    TEST_SYNC_POINT(
+        "DBWriteBufferManagerTest::WriteBufferManagerStallMicros:Unstall");
+    options.write_buffer_manager->SetAllowStall(false);
+  });
+  writer.join();
+  unstaller.join();
+
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->ClearAllCallBacks();
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();
+
+  // The writer above provably blocked in WBMStallInterface::Block(), so the
+  // stall must have been measured and attributed.
+  EXPECT_GT(
+      options.statistics->getTickerCount(WRITE_BUFFER_MANAGER_STALL_MICROS), 0);
+  std::map<std::string, std::string> db_stats;
+  ASSERT_TRUE(db_->GetMapProperty(DB::Properties::kDBStats, &db_stats));
+  EXPECT_GT(std::stoull(db_stats["db.write_buffer_manager_stall_micros"]), 0u);
+
+  sleeping_task->WakeUp();
+  sleeping_task->WaitUntilDone();
+}
+
 TEST_F(DBWriteBufferManagerTest, RuntimeChangeableAllowStall) {
   constexpr int kBigValue = 10000;
 

--- a/db/db_write_test.cc
+++ b/db/db_write_test.cc
@@ -1075,6 +1075,122 @@ INSTANTIATE_TEST_CASE_P(DBWriteTestInstance, DBWriteTest,
                                         DBTestBase::kConcurrentWALWrites,
                                         DBTestBase::kPipelinedWrite));
 
+// A non-blocking unbatched join must refuse an active write stall.
+TEST(WriteThreadTest, EnterUnbatchedNonBlockingRefusesDuringStall) {
+  Options options;
+  ImmutableDBOptions db_options(options);
+  WriteThread write_thread(db_options);
+  InstrumentedMutex mu;
+
+  // No stall: joining succeeds and must be paired with ExitUnbatched().
+  {
+    WriteThread::Writer w;
+    InstrumentedMutexLock l(&mu);
+    ASSERT_TRUE(write_thread.EnterUnbatchedNonBlocking(&w, &mu));
+    ASSERT_OK(w.status);
+    write_thread.ExitUnbatched(&w);
+  }
+
+  // Stalled: refuses rather than parking on stall_cv_. Reaching the assertion
+  // at all is the point -- EnterUnbatched() would never have returned.
+  {
+    InstrumentedMutexLock l(&mu);
+    write_thread.BeginWriteStall();
+    ASSERT_NE(0, write_thread.GetBegunCountOfOutstandingStall());
+
+    WriteThread::Writer w;
+    ASSERT_FALSE(write_thread.EnterUnbatchedNonBlocking(&w, &mu));
+    ASSERT_TRUE(w.status.IsIncomplete());
+
+    // Not linked, so ExitUnbatched() must not be called; ending the stall is
+    // enough to leave the queue clean.
+    write_thread.EndWriteStall();
+    ASSERT_EQ(0, write_thread.GetBegunCountOfOutstandingStall());
+  }
+
+  {
+    WriteThread::Writer w;
+    InstrumentedMutexLock l(&mu);
+    ASSERT_TRUE(write_thread.EnterUnbatchedNonBlocking(&w, &mu));
+    write_thread.ExitUnbatched(&w);
+  }
+}
+
+// A newly started stall must wake and remove a queued non-blocking join.
+TEST(WriteThreadTest, EnterUnbatchedNonBlockingSweptOutByLaterStall) {
+  Options options;
+  ImmutableDBOptions db_options(options);
+  WriteThread write_thread(db_options);
+  InstrumentedMutex mu;
+
+  // Occupy the write thread so the writer under test queues behind it rather
+  // than being linked as leader.
+  WriteThread::Writer leader;
+  mu.Lock();
+  write_thread.EnterUnbatched(&leader, &mu);
+  mu.Unlock();
+
+  InstrumentedMutex signal_mu;
+  InstrumentedCondVar signal_cv(&signal_mu);
+  bool queued = false;
+  bool finished = false;
+  bool entered = true;
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
+      "WriteThread::EnterUnbatched:Wait", [&](void*) {
+        InstrumentedMutexLock l(&signal_mu);
+        queued = true;
+        signal_cv.SignalAll();
+      });
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
+
+  port::Thread follower([&] {
+    WriteThread::Writer w;
+    InstrumentedMutexLock l(&mu);
+    entered = write_thread.EnterUnbatchedNonBlocking(&w, &mu);
+    if (entered) {
+      write_thread.ExitUnbatched(&w);
+    }
+    InstrumentedMutexLock sl(&signal_mu);
+    finished = true;
+    signal_cv.SignalAll();
+  });
+
+  {
+    InstrumentedMutexLock l(&signal_mu);
+    while (!queued) {
+      signal_cv.Wait();
+    }
+  }
+
+  mu.Lock();
+  write_thread.BeginWriteStall();
+  mu.Unlock();
+
+  bool timed_out = false;
+  {
+    InstrumentedMutexLock l(&signal_mu);
+    const uint64_t deadline = Env::Default()->NowMicros() + 30 * 1000 * 1000;
+    while (!finished) {
+      if (signal_cv.TimedWait(deadline)) {
+        timed_out = !finished;
+        break;
+      }
+    }
+  }
+  EXPECT_FALSE(timed_out) << "swept-out writer never woke: it is waiting for a "
+                             "leadership handoff that cannot arrive";
+  EXPECT_FALSE(entered) << "a swept-out writer must report failure, since it "
+                           "is no longer linked and must not be exited";
+
+  follower.join();
+  mu.Lock();
+  write_thread.EndWriteStall();
+  write_thread.ExitUnbatched(&leader);
+  mu.Unlock();
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->ClearAllCallBacks();
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();
+}
+
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {

--- a/db/internal_stats.cc
+++ b/db/internal_stats.cc
@@ -84,6 +84,8 @@ const std::map<InternalStats::InternalDBStatsType, DBStatInfo>
          DBStatInfo{WriteStallStatsMapKeys::CauseConditionCount(
              WriteStallCause::kWriteBufferManagerLimit,
              WriteStallCondition::kStopped)}},
+        {InternalStats::kIntStatsWriteBufferManagerStallMicros,
+         DBStatInfo{"db.write_buffer_manager_stall_micros"}},
 };
 
 namespace {
@@ -322,6 +324,14 @@ static const std::string actual_delayed_write_rate =
     "actual-delayed-write-rate";
 static const std::string is_write_stopped = "is-write-stopped";
 static const std::string estimate_oldest_key_time = "estimate-oldest-key-time";
+static const std::string write_buffer_manager_memory_usage =
+    "write-buffer-manager-memory-usage";
+static const std::string write_buffer_manager_mutable_memory_usage =
+    "write-buffer-manager-mutable-memory-usage";
+static const std::string write_buffer_manager_buffer_size =
+    "write-buffer-manager-buffer-size";
+static const std::string write_buffer_manager_stall_active =
+    "write-buffer-manager-stall-active";
 static const std::string block_cache_capacity = "block-cache-capacity";
 static const std::string block_cache_usage = "block-cache-usage";
 static const std::string block_cache_pinned_usage = "block-cache-pinned-usage";
@@ -436,6 +446,14 @@ const std::string DB::Properties::kIsWriteStopped =
     rocksdb_prefix + is_write_stopped;
 const std::string DB::Properties::kEstimateOldestKeyTime =
     rocksdb_prefix + estimate_oldest_key_time;
+const std::string DB::Properties::kWriteBufferManagerMemoryUsage =
+    rocksdb_prefix + write_buffer_manager_memory_usage;
+const std::string DB::Properties::kWriteBufferManagerMutableMemoryUsage =
+    rocksdb_prefix + write_buffer_manager_mutable_memory_usage;
+const std::string DB::Properties::kWriteBufferManagerBufferSize =
+    rocksdb_prefix + write_buffer_manager_buffer_size;
+const std::string DB::Properties::kWriteBufferManagerStallActive =
+    rocksdb_prefix + write_buffer_manager_stall_active;
 const std::string DB::Properties::kBlockCacheCapacity =
     rocksdb_prefix + block_cache_capacity;
 const std::string DB::Properties::kBlockCacheUsage =
@@ -630,6 +648,19 @@ const UnorderedMap<std::string, DBPropertyInfo>
         {DB::Properties::kEstimateOldestKeyTime,
          {false, nullptr, &InternalStats::HandleEstimateOldestKeyTime, nullptr,
           nullptr}},
+        {DB::Properties::kWriteBufferManagerMemoryUsage,
+         {false, nullptr, &InternalStats::HandleWriteBufferManagerMemoryUsage,
+          nullptr, nullptr}},
+        {DB::Properties::kWriteBufferManagerMutableMemoryUsage,
+         {false, nullptr,
+          &InternalStats::HandleWriteBufferManagerMutableMemoryUsage, nullptr,
+          nullptr}},
+        {DB::Properties::kWriteBufferManagerBufferSize,
+         {false, nullptr, &InternalStats::HandleWriteBufferManagerBufferSize,
+          nullptr, nullptr}},
+        {DB::Properties::kWriteBufferManagerStallActive,
+         {false, nullptr, &InternalStats::HandleWriteBufferManagerStallActive,
+          nullptr, nullptr}},
         {DB::Properties::kBlockCacheCapacity,
          {false, nullptr, &InternalStats::HandleBlockCacheCapacity, nullptr,
           nullptr}},
@@ -1586,6 +1617,53 @@ Cache* InternalStats::GetBlockCacheForStats() {
   assert(table_factory != nullptr);
   // FIXME: need to a shared_ptr if/when block_cache is going to be mutable
   return table_factory->GetOptions<Cache>(TableFactory::kBlockCacheOpts());
+}
+
+WriteBufferManager* InternalStats::GetWriteBufferManagerForStats() {
+  return cfd_->ioptions().write_buffer_manager.get();
+}
+
+bool InternalStats::HandleWriteBufferManagerMemoryUsage(uint64_t* value,
+                                                        DBImpl* /*db*/,
+                                                        Version* /*version*/) {
+  WriteBufferManager* wbm = GetWriteBufferManagerForStats();
+  if (wbm) {
+    *value = static_cast<uint64_t>(wbm->memory_usage());
+    return true;
+  }
+  return false;
+}
+
+bool InternalStats::HandleWriteBufferManagerMutableMemoryUsage(
+    uint64_t* value, DBImpl* /*db*/, Version* /*version*/) {
+  WriteBufferManager* wbm = GetWriteBufferManagerForStats();
+  if (wbm) {
+    *value = static_cast<uint64_t>(wbm->mutable_memtable_memory_usage());
+    return true;
+  }
+  return false;
+}
+
+bool InternalStats::HandleWriteBufferManagerBufferSize(uint64_t* value,
+                                                       DBImpl* /*db*/,
+                                                       Version* /*version*/) {
+  WriteBufferManager* wbm = GetWriteBufferManagerForStats();
+  if (wbm) {
+    *value = static_cast<uint64_t>(wbm->buffer_size());
+    return true;
+  }
+  return false;
+}
+
+bool InternalStats::HandleWriteBufferManagerStallActive(uint64_t* value,
+                                                        DBImpl* /*db*/,
+                                                        Version* /*version*/) {
+  WriteBufferManager* wbm = GetWriteBufferManagerForStats();
+  if (wbm) {
+    *value = wbm->IsStallActive() ? 1 : 0;
+    return true;
+  }
+  return false;
 }
 
 bool InternalStats::HandleBlockCacheCapacity(uint64_t* value, DBImpl* /*db*/,

--- a/db/internal_stats.h
+++ b/db/internal_stats.h
@@ -147,6 +147,10 @@ class InternalStats {
     // So we should improve, rename or clarify it
     kIntStatsWriteStallMicros,
     kIntStatsWriteBufferManagerLimitStopsCounts,
+    // Time writers spent blocked by the WriteBufferManager limit. Tracked
+    // separately because `kIntStatsWriteStallMicros` covers only CF-scope
+    // stalls (see the TODO above).
+    kIntStatsWriteBufferManagerStallMicros,
     kIntStatsNumMax,
   };
 
@@ -694,6 +698,7 @@ class InternalStats {
                              uint64_t* total_stall_count = nullptr);
 
   Cache* GetBlockCacheForStats();
+  WriteBufferManager* GetWriteBufferManagerForStats();
   Cache* GetBlobCacheForStats();
 
   // Per-DB stats
@@ -902,6 +907,14 @@ class InternalStats {
   bool HandleIsWriteStopped(uint64_t* value, DBImpl* db, Version* version);
   bool HandleEstimateOldestKeyTime(uint64_t* value, DBImpl* db,
                                    Version* version);
+  bool HandleWriteBufferManagerMemoryUsage(uint64_t* value, DBImpl* db,
+                                           Version* version);
+  bool HandleWriteBufferManagerMutableMemoryUsage(uint64_t* value, DBImpl* db,
+                                                  Version* version);
+  bool HandleWriteBufferManagerBufferSize(uint64_t* value, DBImpl* db,
+                                          Version* version);
+  bool HandleWriteBufferManagerStallActive(uint64_t* value, DBImpl* db,
+                                           Version* version);
   bool HandleBlockCacheCapacity(uint64_t* value, DBImpl* db, Version* version);
   bool HandleBlockCacheUsage(uint64_t* value, DBImpl* db, Version* version);
   bool HandleBlockCachePinnedUsage(uint64_t* value, DBImpl* db,

--- a/db/write_thread.cc
+++ b/db/write_thread.cc
@@ -905,6 +905,36 @@ void WriteThread::EnterUnbatched(Writer* w, InstrumentedMutex* mu) {
   mu->Lock();
 }
 
+bool WriteThread::EnterUnbatchedNonBlocking(Writer* w, InstrumentedMutex* mu) {
+  assert(w != nullptr && w->batch == nullptr);
+  w->no_slowdown = true;
+  mu->Unlock();
+  const bool linked_as_leader = LinkOne(w, &newest_writer_);
+  // no_slowdown makes LinkOne() reject an existing stall without linking.
+  if (w->state == STATE_COMPLETED) {
+    assert(!linked_as_leader);
+    assert(!w->status.ok());
+    mu->Lock();
+    return false;
+  }
+  if (!linked_as_leader) {
+    TEST_SYNC_POINT("WriteThread::EnterUnbatched:Wait");
+    // A new stall may sweep this queued writer and mark it completed.
+    const uint8_t state =
+        AwaitState(w, STATE_GROUP_LEADER | STATE_COMPLETED, &eu_ctx);
+    if (state == STATE_COMPLETED) {
+      assert(!w->status.ok());
+      mu->Lock();
+      return false;
+    }
+  }
+  if (enable_pipelined_write_) {
+    WaitForMemTableWriters();
+  }
+  mu->Lock();
+  return true;
+}
+
 void WriteThread::ExitUnbatched(Writer* w) {
   assert(w != nullptr);
   Writer* newest_writer = w;

--- a/db/write_thread.h
+++ b/db/write_thread.h
@@ -384,6 +384,10 @@ class WriteThread {
   // REQUIRES: db mutex held
   void EnterUnbatched(Writer* w, InstrumentedMutex* mu);
 
+  // Refuses an existing or newly started stall. Call ExitUnbatched() only when
+  // this returns true; false leaves `w` unlinked with Incomplete status.
+  bool EnterUnbatchedNonBlocking(Writer* w, InstrumentedMutex* mu);
+
   // Completes a Writer begun with EnterUnbatched, unblocking subsequent
   // writers.
   void ExitUnbatched(Writer* w);

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1599,6 +1599,30 @@ class DB {
     //      residing in block cache.
     static const std::string kBlockCacheUsage;
 
+    //  "rocksdb.write-buffer-manager-memory-usage" - returns the total memory
+    //      the WriteBufferManager is accounting for, across every DB sharing
+    //      it. This includes memtables that are being flushed but whose memory
+    //      has not been released yet. Returns 0 if no WriteBufferManager is
+    //      configured.
+    static const std::string kWriteBufferManagerMemoryUsage;
+
+    //  "rocksdb.write-buffer-manager-mutable-memory-usage" - returns the
+    //      portion of the above held by mutable memtables, i.e. the memory a
+    //      flush could still be triggered against. The difference between this
+    //      and kWriteBufferManagerMemoryUsage is memory pinned by in-flight
+    //      flushes. Returns 0 if no WriteBufferManager is configured.
+    static const std::string kWriteBufferManagerMutableMemoryUsage;
+
+    //  "rocksdb.write-buffer-manager-buffer-size" - returns the
+    //      WriteBufferManager's current budget. Flushes are triggered at 7/8 of
+    //      it and, when allow_stall is set, writes stall at it. Returns 0 if no
+    //      WriteBufferManager is configured or it is disabled.
+    static const std::string kWriteBufferManagerBufferSize;
+
+    //  "rocksdb.write-buffer-manager-stall-active" - returns 1 if the
+    //      WriteBufferManager is currently stalling writes, otherwise 0.
+    static const std::string kWriteBufferManagerStallActive;
+
     // "rocksdb.block-cache-pinned-usage" - returns the memory size for the
     //      entries being pinned.
     static const std::string kBlockCachePinnedUsage;
@@ -1702,6 +1726,10 @@ class DB {
   //  "rocksdb.block-cache-capacity"
   //  "rocksdb.block-cache-usage"
   //  "rocksdb.block-cache-pinned-usage"
+  //  "rocksdb.write-buffer-manager-memory-usage"
+  //  "rocksdb.write-buffer-manager-mutable-memory-usage"
+  //  "rocksdb.write-buffer-manager-buffer-size"
+  //  "rocksdb.write-buffer-manager-stall-active"
   //
   //  Properties dedicated for BlobDB:
   //  "rocksdb.num-blob-files"

--- a/include/rocksdb/statistics.h
+++ b/include/rocksdb/statistics.h
@@ -677,6 +677,11 @@ enum Tickers : uint32_t {
   // logical value size minus the bytes actually read.
   BLOB_DB_LAZY_PARTIAL_BYTES_SAVED,
 
+  // Time (microseconds) writers spent blocked by the WriteBufferManager's
+  // memory limit. This is NOT counted by STALL_MICROS, which only covers
+  // WriteController (column-family scope) stalls.
+  WRITE_BUFFER_MANAGER_STALL_MICROS,
+
   TICKER_ENUM_MAX
 };
 

--- a/include/rocksdb/write_buffer_manager.h
+++ b/include/rocksdb/write_buffer_manager.h
@@ -23,6 +23,16 @@
 namespace ROCKSDB_NAMESPACE {
 class CacheReservationManager;
 
+// Selects which mutable memtable to flush when the WBM exceeds its limit.
+enum class WriteBufferFlushPolicy {
+  // Flush the oldest mutable memtable; this is the historical default.
+  kFlushOldest,
+  // Flush the largest mutable memtable in the current DB.
+  kFlushLargest,
+  // Flush the DB that would reclaim the most memory among all sharing this WBM.
+  kFlushLargestAcrossDBs,
+};
+
 // Interface to block and signal DB instances, intended for RocksDB
 // internal use only. Each DB instance contains ptr to StallInterface.
 class StallInterface {
@@ -32,6 +42,27 @@ class StallInterface {
   virtual void Block() = 0;
 
   virtual void Signal() = 0;
+};
+
+// Internal adapter for selecting and flushing a DB sharing a WBM.
+class FlushInitiator {
+ public:
+  FlushInitiator() = default;
+  virtual ~FlushInitiator() = default;
+
+  // Registry entries are raw pointers, so initiators must not move.
+  FlushInitiator(const FlushInitiator&) = delete;
+  FlushInitiator& operator=(const FlushInitiator&) = delete;
+  FlushInitiator(FlushInitiator&&) = delete;
+  FlushInitiator& operator=(FlushInitiator&&) = delete;
+
+  // Returns reclaimable bytes, or zero if this DB cannot flush. Called with the
+  // registry mutex held; implementations may acquire only the DB mutex.
+  virtual size_t GetFlushableMemUsage() = 0;
+
+  // Ensures a flush is in flight. Must not block on the DB write thread or
+  // reacquire the registry mutex; false makes the caller flush itself.
+  virtual bool ScheduleFlush() = 0;
 };
 
 class WriteBufferManager final {
@@ -47,9 +78,14 @@ class WriteBufferManager final {
   // allow_stall: if set true, it will enable stalling of writes when
   // memory_usage() exceeds buffer_size. It will wait for flush to complete and
   // memory usage to drop down.
+  //
   explicit WriteBufferManager(size_t _buffer_size,
                               std::shared_ptr<Cache> cache = {},
                               bool allow_stall = false);
+
+  // flush_policy belongs to this shared manager, not serialized DBOptions.
+  WriteBufferManager(size_t _buffer_size, std::shared_ptr<Cache> cache,
+                     bool allow_stall, WriteBufferFlushPolicy flush_policy);
   // No copying allowed
   WriteBufferManager(const WriteBufferManager&) = delete;
   WriteBufferManager& operator=(const WriteBufferManager&) = delete;
@@ -93,6 +129,15 @@ class WriteBufferManager final {
   void SetAllowStall(bool new_allow_stall) {
     allow_stall_.store(new_allow_stall, std::memory_order_relaxed);
     MaybeEndWriteStall();
+  }
+
+  // Returns the policy used for WBM-triggered flushes.
+  WriteBufferFlushPolicy flush_policy() const {
+    return flush_policy_.load(std::memory_order_relaxed);
+  }
+
+  void SetFlushPolicy(WriteBufferFlushPolicy new_flush_policy) {
+    flush_policy_.store(new_flush_policy, std::memory_order_relaxed);
   }
 
   // Below functions should be called by RocksDB internally.
@@ -159,6 +204,14 @@ class WriteBufferManager final {
 
   void RemoveDBFromQueue(StallInterface* wbm_stall);
 
+  // Internal registry for DBs sharing this manager.
+  void RegisterFlushInitiator(FlushInitiator* initiator);
+  void DeregisterFlushInitiator(FlushInitiator* initiator);
+
+  // Flushes a larger peer and returns true; false means `self` must flush.
+  // Must not be called while holding the caller's DB mutex.
+  bool InitiateFlushOnLargestDB(FlushInitiator* self);
+
  private:
   std::atomic<size_t> buffer_size_;
   std::atomic<size_t> mutable_limit_;
@@ -176,6 +229,11 @@ class WriteBufferManager final {
   // Value should only be changed by BeginWriteStall() and MaybeEndWriteStall()
   // while holding mu_, but it can be read without a lock.
   std::atomic<bool> stall_active_;
+  std::atomic<WriteBufferFlushPolicy> flush_policy_;
+
+  // DBs participating in kFlushLargestAcrossDBs.
+  std::list<FlushInitiator*> flush_initiators_;
+  std::mutex flush_initiators_mu_;
 
   void ReserveMemWithCache(size_t mem);
   void FreeMemWithCache(size_t mem);

--- a/memtable/write_buffer_manager.cc
+++ b/memtable/write_buffer_manager.cc
@@ -21,13 +21,21 @@ namespace ROCKSDB_NAMESPACE {
 WriteBufferManager::WriteBufferManager(size_t _buffer_size,
                                        std::shared_ptr<Cache> cache,
                                        bool allow_stall)
+    : WriteBufferManager(_buffer_size, cache, allow_stall,
+                         WriteBufferFlushPolicy::kFlushOldest) {}
+
+WriteBufferManager::WriteBufferManager(size_t _buffer_size,
+                                       std::shared_ptr<Cache> cache,
+                                       bool allow_stall,
+                                       WriteBufferFlushPolicy flush_policy)
     : buffer_size_(_buffer_size),
       mutable_limit_(buffer_size_ * 7 / 8),
       memory_used_(0),
       memory_active_(0),
       cache_res_mgr_(nullptr),
       allow_stall_(allow_stall),
-      stall_active_(false) {
+      stall_active_(false),
+      flush_policy_(flush_policy) {
   if (cache) {
     // Memtable's memory usage tends to fluctuate frequently
     // therefore we set delayed_decrease = true to save some dummy entry
@@ -180,6 +188,39 @@ void WriteBufferManager::RemoveDBFromQueue(StallInterface* wbm_stall) {
     }
   }
   wbm_stall->Signal();
+}
+
+void WriteBufferManager::RegisterFlushInitiator(FlushInitiator* initiator) {
+  std::lock_guard<std::mutex> lock(flush_initiators_mu_);
+  flush_initiators_.push_back(initiator);
+}
+
+void WriteBufferManager::DeregisterFlushInitiator(FlushInitiator* initiator) {
+  std::lock_guard<std::mutex> lock(flush_initiators_mu_);
+  flush_initiators_.remove(initiator);
+}
+
+bool WriteBufferManager::InitiateFlushOnLargestDB(FlushInitiator* self) {
+  // Hold the registry lock across callbacks to pin raw initiator pointers.
+  std::lock_guard<std::mutex> lock(flush_initiators_mu_);
+  if (self != nullptr && flush_initiators_.size() == 1 &&
+      flush_initiators_.front() == self) {
+    return false;
+  }
+  FlushInitiator* best = nullptr;
+  size_t best_mem = 0;
+  for (FlushInitiator* initiator : flush_initiators_) {
+    size_t mem = initiator->GetFlushableMemUsage();
+    if (best == nullptr || mem > best_mem) {
+      best = initiator;
+      best_mem = mem;
+    }
+  }
+  if (best == nullptr || best == self || best_mem == 0) {
+    return false;
+  }
+  // DB state can change after bidding; propagate a declined schedule.
+  return best->ScheduleFlush();
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/memtable/write_buffer_manager_test.cc
+++ b/memtable/write_buffer_manager_test.cc
@@ -295,6 +295,65 @@ TEST_F(ChargeWriteBufferTest, BasicWithCacheFull) {
             46 * kSizeDummyEntry + kMetaDataChargeOverhead);
 }
 
+namespace {
+// Test double for a DB in the cross-DB flush registry.
+class FakeFlushInitiator : public FlushInitiator {
+ public:
+  FakeFlushInitiator(size_t mem, bool can_flush)
+      : mem_(mem), can_flush_(can_flush) {}
+
+  size_t GetFlushableMemUsage() override { return mem_; }
+  bool ScheduleFlush() override {
+    ++schedule_calls_;
+    return can_flush_;
+  }
+
+  size_t mem_;
+  bool can_flush_;
+  int schedule_calls_ = 0;
+};
+}  // anonymous namespace
+
+// InitiateFlushOnLargestDB() must report true only when a flush is genuinely in
+// flight somewhere else, because the caller skips its own flush when it does.
+TEST_F(WriteBufferManagerTest, InitiateFlushOnLargestDBContract) {
+  WriteBufferManager wbf(100 * 1024 * 1024, nullptr /* cache */,
+                         false /* allow_stall */,
+                         WriteBufferFlushPolicy::kFlushLargestAcrossDBs);
+
+  FakeFlushInitiator self(/*mem=*/100, /*can_flush=*/true);
+  FakeFlushInitiator bigger(/*mem=*/200, /*can_flush=*/true);
+  wbf.RegisterFlushInitiator(&self);
+  wbf.RegisterFlushInitiator(&bigger);
+
+  // The larger DB accepts, so the caller may defer to it.
+  ASSERT_TRUE(wbf.InitiateFlushOnLargestDB(&self));
+  ASSERT_EQ(1, bigger.schedule_calls_);
+  ASSERT_EQ(0, self.schedule_calls_);
+
+  // The larger DB's state changed after it won the bid and it now declines.
+  // The caller must be told so, otherwise nothing would flush at all.
+  bigger.can_flush_ = false;
+  ASSERT_FALSE(wbf.InitiateFlushOnLargestDB(&self));
+  ASSERT_EQ(2, bigger.schedule_calls_);
+  ASSERT_EQ(0, self.schedule_calls_);
+
+  // Caller is itself the largest: it flushes itself rather than deferring.
+  bigger.mem_ = 1;
+  bigger.can_flush_ = true;
+  ASSERT_FALSE(wbf.InitiateFlushOnLargestDB(&self));
+  ASSERT_EQ(2, bigger.schedule_calls_);
+
+  // Nobody has anything to reclaim: there is no one to defer to.
+  self.mem_ = 0;
+  bigger.mem_ = 0;
+  ASSERT_FALSE(wbf.InitiateFlushOnLargestDB(&self));
+  ASSERT_EQ(2, bigger.schedule_calls_);
+
+  wbf.DeregisterFlushInitiator(&self);
+  wbf.DeregisterFlushInitiator(&bigger);
+}
+
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {

--- a/monitoring/statistics.cc
+++ b/monitoring/statistics.cc
@@ -343,6 +343,8 @@ const std::vector<std::pair<Tickers, std::string>> TickersNameMap = {
     {BLOB_DB_LAZY_PARTIAL_READ_COUNT, "rocksdb.blobdb.lazy.partial.read.count"},
     {BLOB_DB_LAZY_PARTIAL_BYTES_SAVED,
      "rocksdb.blobdb.lazy.partial.bytes.saved"},
+    {WRITE_BUFFER_MANAGER_STALL_MICROS,
+     "rocksdb.write_buffer_manager.stall.micros"},
 };
 
 const std::vector<std::pair<Histograms, std::string>> HistogramsNameMap = {

--- a/unreleased_history/public_api_changes/write_buffer_manager_flush_policy.md
+++ b/unreleased_history/public_api_changes/write_buffer_manager_flush_policy.md
@@ -1,0 +1,1 @@
+Added `WriteBufferFlushPolicy` and `WriteBufferManager` policy selection for flushing the oldest or largest column family, including the largest column family across DBs sharing a manager.


### PR DESCRIPTION
Summary:

Today a `WriteBufferManager` is nearly invisible. Its own state (`memory_usage()`, `mutable_memtable_memory_usage()`, `buffer_size()`, `IsStallActive()`) is exported nowhere -- no DB property, no ticker, no LOG line except a single message emitted when an in-line flush actually fires. Time spent blocked on the WBM limit is likewise unmeasured: `STALL_MICROS`, `rocksdb.db.write.stall`, and `db.user_write_stall_micros` all come from `DelayWrite()`, which only covers `WriteController` (CF-scope) stalls -- see the existing TODO on `kIntStatsWriteStallMicros`. And because every existing memtable counter is per-DB, a manager shared across several DBs cannot be observed as a single entity at all.

This diff adds the missing instrumentation.

Four DB properties reporting the shared manager's totals, so one DB can report for the whole manager:
- `rocksdb.write-buffer-manager-memory-usage` -- all accounted memory, including memtables pinned by in-flight flushes
- `rocksdb.write-buffer-manager-mutable-memory-usage` -- the mutable portion; the gap between the two is flush-in-flight memory
- `rocksdb.write-buffer-manager-buffer-size` -- the budget (flush at 7/8, stall at 1/1)
- `rocksdb.write-buffer-manager-stall-active`

They follow the `rocksdb.block-cache-*` pattern exactly (`GetWriteBufferManagerForStats()` mirrors `GetBlockCacheForStats()`), and return false -- i.e. the property is unavailable -- when no `WriteBufferManager` is configured.

Stall duration is now measured in `WriteBufferManagerStallWrites()` and recorded two ways: a new `WRITE_BUFFER_MANAGER_STALL_MICROS` ticker (`rocksdb.write_buffer_manager.stall.micros`) and a new `kIntStatsWriteBufferManagerStallMicros` DB stat (`db.write_buffer_manager_stall_micros`). The `InternalStats` copy matters because it lands in `rocksdb.dbstats` and the periodic LOG dump, so it is visible without a `Statistics` object -- which is the common case, since the fb_rocksdb wrapper does not export tickers unless `--rocksdb_fb303_enable_stats=true`. It is deliberately kept separate from `STALL_MICROS` so WBM and `WriteController` stalls stay individually attributable.

Finally, the cross-DB flush path added in D112396106 now logs which column family it picked, matching the log line the in-line path already had.

Note on Java: the `TickerType` byte enum is exhausted (`FILE_SUBMIT_ASYNC_READ_FALLBACK` occupies `-0x80`, the last slot, and `portal.h` carries a TODO that the ticker count no longer fits in a `jbyte`), so the new ticker is intentionally not mirrored there. This is safe: `toJavaTickerType()` -- the only place an unmapped ticker could alias to `0x0` -- has no callers, and Java clients can only reach tickers they can name.

Differential Revision: D114903210


