### PR TITLE
Skip recovery `SetNextFile` for OPTIONS-only advances (#15163)

### DIFF
--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -379,9 +379,16 @@ TEST_F(DBBasicTest,
       dbname_ + "/" + OptionsFileName(stale_options_number + 1),
       /*should_sync=*/true));
 
+  RecoveryOptimizationCounters counters;
+  counters.Install();
   Reopen(options);
+  counters.Uninstall();
+
   const uint64_t current_options_number =
       dbfull()->GetVersionSet()->options_file_number();
+  ASSERT_EQ(1, counters.next_file_number.load());
+  ASSERT_GT(dbfull()->GetVersionSet()->current_next_file_number(),
+            stale_options_number + 1);
   ASSERT_GT(current_options_number, 0u);
   ASSERT_OK(env_->FileExists(OptionsFileName(dbname_, current_options_number)));
 
@@ -392,6 +399,36 @@ TEST_F(DBBasicTest,
   std::unique_ptr<Checkpoint> checkpoint_guard(checkpoint);
   ASSERT_OK(checkpoint_guard->CreateCheckpoint(checkpoint_dir));
   ASSERT_OK(DestroyDir(env_, checkpoint_dir));
+  ASSERT_EQ("v", Get("k"));
+}
+
+TEST_F(DBBasicTest,
+       OptimizeManifestForRecoveryReservesTempOptionsFileNumbersInMemory) {
+  Options options = CurrentOptions();
+  options.create_if_missing = true;
+  options.optimize_manifest_for_recovery = true;
+  DestroyAndReopen(options);
+  ASSERT_OK(Put("k", "v"));
+  ASSERT_OK(Flush());
+
+  const uint64_t next_before_close =
+      dbfull()->GetVersionSet()->current_next_file_number();
+  Close();
+
+  const uint64_t stale_temp_options_number = next_before_close + 100;
+  ASSERT_OK(
+      WriteStringToFile(env_, "" /*data*/,
+                        TempOptionsFileName(dbname_, stale_temp_options_number),
+                        /*should_sync=*/true));
+
+  RecoveryOptimizationCounters counters;
+  counters.Install();
+  Reopen(options);
+  counters.Uninstall();
+
+  ASSERT_EQ(1, counters.next_file_number.load());
+  ASSERT_GT(dbfull()->GetVersionSet()->current_next_file_number(),
+            stale_temp_options_number);
   ASSERT_EQ("v", Get("k"));
 }
 

--- a/db/db_impl/db_impl_files.cc
+++ b/db/db_impl/db_impl_files.cc
@@ -1192,6 +1192,7 @@ Status DBImpl::MaybeUpdateNextFileNumber(RecoveryContext* recovery_ctx) {
   const uint64_t prev_next_file_number = versions_->current_next_file_number();
   uint64_t largest_file_number = prev_next_file_number;
   bool on_disk_file_advanced_counter = false;
+  bool manifest_relevant_file_advanced_counter = false;
   Status s;
   for (const auto& path : CollectAllDBPaths()) {
     std::vector<std::string> files;
@@ -1213,6 +1214,9 @@ Status DBImpl::MaybeUpdateNextFileNumber(RecoveryContext* recovery_ctx) {
       // NewFileNumber() would collide with it.
       if (number >= prev_next_file_number) {
         on_disk_file_advanced_counter = true;
+        if (type != kOptionsFile && type != kTempFile) {
+          manifest_relevant_file_advanced_counter = true;
+        }
       }
       largest_file_number = std::max(largest_file_number, number);
       if ((type == kTableFile || type == kBlobFile)) {
@@ -1234,7 +1238,8 @@ Status DBImpl::MaybeUpdateNextFileNumber(RecoveryContext* recovery_ctx) {
       mutable_db_options_.optimize_manifest_for_recovery &&
       !immutable_db_options_.best_efforts_recovery;
 
-  if (!optimize_manifest_for_recovery || on_disk_file_advanced_counter) {
+  if (!optimize_manifest_for_recovery ||
+      manifest_relevant_file_advanced_counter) {
     if (largest_file_number >= prev_next_file_number) {
       versions_->next_file_number_.store(largest_file_number + 1);
     }
@@ -1247,6 +1252,9 @@ Status DBImpl::MaybeUpdateNextFileNumber(RecoveryContext* recovery_ctx) {
     assert(default_cfd);
     recovery_ctx->UpdateVersionEdits(default_cfd, edit);
   } else {
+    if (on_disk_file_advanced_counter) {
+      versions_->next_file_number_.store(largest_file_number + 1);
+    }
     TEST_SYNC_POINT("DBImpl::Recovery:SkippedNoopEdit:NextFileNumber");
   }
   return s;


### PR DESCRIPTION
Summary:

Reintroduces the `optimize_manifest_for_recovery` optimization for `OPTIONS-*` and temp files without letting `VersionSet::NewFileNumber()` collide with files already present in the DB directory.

Recovery now distinguishes between files that require a persisted `SetNextFile` edit and files that only need the in-memory allocator reserved. If only `OPTIONS-*` or temp files are above the recovered `next_file_number_`, recovery advances `next_file_number_` in memory and still skips the MANIFEST edit.

Differential Revision: D117887276


