### PR TITLE
Account partitioned filter reads in PerfContext timing

### DIFF
--- a/db/db_bloom_filter_test.cc
+++ b/db/db_bloom_filter_test.cc
@@ -2542,9 +2542,13 @@ TEST_P(DBBloomFilterTestVaryPrefixAndFormatVer, PartitionedMultiGet) {
       values[i] = PinnableSlice();
     }
 
+    get_perf_context()->Reset();
+    const PerfLevel previous_perf_level = GetPerfLevel();
+    SetPerfLevel(PerfLevel::kEnableTime);
     db_->MultiGet(ropts, Q, column_families.data(), key_slices.data(),
                   values.data(),
                   /*timestamps=*/nullptr, statuses.data(), true);
+    SetPerfLevel(previous_perf_level);
 
     // Confirm correct status results
     uint32_t number_not_found = 0;
@@ -2574,6 +2578,8 @@ TEST_P(DBBloomFilterTestVaryPrefixAndFormatVer, PartitionedMultiGet) {
     // Confirm no duplicate loading same filter partition
     uint64_t filter_accesses = PopTicker(options, BLOCK_CACHE_FILTER_HIT) +
                                PopTicker(options, BLOCK_CACHE_FILTER_MISS);
+    // Partition reads must contribute to the filter-block timing metric.
+    EXPECT_GT(get_perf_context()->read_filter_block_nanos, 0);
     if (stride == 1) {
       EXPECT_EQ(filter_accesses, 1);
     } else {

--- a/table/block_based/partitioned_filter_block.cc
+++ b/table/block_based/partitioned_filter_block.cc
@@ -485,6 +485,11 @@ Status PartitionedFilterBlockReader::GetFilterPartitionBlock(
     }
   }
 
+  // The top-level partition index is timed by ReadFilterBlock(). Filter
+  // partitions bypass that helper, so account for their cache or SST reads
+  // here.
+  PERF_TIMER_GUARD(read_filter_block_nanos);
+
   const Status s = table()->RetrieveBlock(
       prefetch_buffer, read_options, fltr_blk_handle,
       /* decomp */ nullptr, filter_block, get_context, lookup_context,


### PR DESCRIPTION
## Summary

Instrument partitioned Bloom-filter block retrievals with read_filter_block_nanos so PerfContext includes time spent looking up these blocks in the block cache or reading them from SST files.

Root cause:
The top-level filter-partition index is read through ReadFilterBlock, which already owns the timing guard. Individual filter partitions bypass that helper and call RetrieveBlock directly. Once the top-level index is cached, workloads can therefore report filter block reads and cache hits while read_filter_block_nanos remains zero.

Implementation:
Place the timer at the partition retrieval boundary, after the pinned filter-map fast path and immediately around RetrieveBlock. This keeps the metric aligned with actual cache or SST retrieval work without charging accesses to already-pinned partition objects.

Testing:
Extend the partitioned MultiGet test to enable time-level PerfContext collection and verify that partition reads populate read_filter_block_nanos across whole-key and prefix-filter configurations and table format versions.


## Test plan

- `make check-sources`
- `build_tools/rocksptest.sh db_bloom_filter_test`
- `ASSERT_STATUS_CHECKED=1 build_tools/rockstest.sh db_bloom_filter_test --gtest_filter=*PartitionedMultiGet*`

