### PR TITLE
Experimental compaction-time stream aggregation (#15165)

### DIFF
--- a/db/builder.cc
+++ b/db/builder.cc
@@ -242,6 +242,7 @@ Status BuildTable(
         ioptions.enforce_single_del_contracts,
         /*manual_compaction_canceled=*/kManualCompactionCanceledFalse,
         true /* must_count_input_entries */,
+        CompactionIterator::ValuePreparation::kApply,
         /*compaction=*/nullptr, compaction_filter.get(),
         /*shutting_down=*/nullptr, db_options.info_log, full_history_ts_low,
         std::nullopt, version, tboptions.read_options.io_activity);

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -37,6 +37,7 @@
 #include "options/options_helper.h"
 #include "port/port.h"
 #include "rocksdb/convenience.h"
+#include "rocksdb/stream_aggregation.h"
 #include "rocksdb/table.h"
 #include "table/merging_iterator.h"
 #include "util/autovector.h"
@@ -1593,6 +1594,36 @@ Status ColumnFamilyData::ValidateOptions(
           "Not persisting user-defined timestamps"
           "feature only support user-defined timestamps formatted as "
           "uint64_t.");
+    }
+  }
+
+  if (cf_options.stream_aggregation_factory != nullptr) {
+    if (cf_options.compaction_style != kCompactionStyleLevel &&
+        cf_options.compaction_style != kCompactionStyleUniversal) {
+      return Status::NotSupported(
+          "StreamAggregation requires leveled or universal compaction");
+    }
+    if (ucmp->timestamp_size() != 0) {
+      return Status::NotSupported(
+          "StreamAggregation does not support user-defined timestamps");
+    }
+    if (db_options.allow_ingest_behind || cf_options.cf_allow_ingest_behind) {
+      return Status::NotSupported(
+          "StreamAggregation does not support ingest-behind");
+    }
+    if (cf_options.preclude_last_level_data_seconds != 0 ||
+        cf_options.preserve_internal_time_seconds != 0) {
+      return Status::NotSupported(
+          "StreamAggregation does not support sequence-time placement or "
+          "preservation");
+    }
+    StreamAggregationFactory::ValidationContext validation_context;
+    validation_context.blob_files_enabled = cf_options.enable_blob_files;
+    validation_context.user_timestamp_size = ucmp->timestamp_size();
+    Status validation_status =
+        cf_options.stream_aggregation_factory->Validate(validation_context);
+    if (!validation_status.ok()) {
+      return validation_status;
     }
   }
 

--- a/db/compaction/compaction.cc
+++ b/db/compaction/compaction.cc
@@ -17,6 +17,7 @@
 #include "logging/logging.h"
 #include "rocksdb/compaction_filter.h"
 #include "rocksdb/sst_partitioner.h"
+#include "rocksdb/stream_aggregation.h"
 #include "test_util/sync_point.h"
 #include "util/string_util.h"
 
@@ -568,6 +569,10 @@ bool Compaction::IsTrivialMove() const {
     return false;
   }
 
+  if (ShouldUseStreamAggregation()) {
+    return false;
+  }
+
   if (is_manual_compaction_ &&
       (immutable_options_.compaction_filter != nullptr ||
        immutable_options_.compaction_filter_factory != nullptr)) {
@@ -896,6 +901,26 @@ std::unique_ptr<CompactionFilter> Compaction::CreateCompactionFilter() const {
       context);
 }
 
+std::unique_ptr<StreamAggregation> Compaction::CreateStreamAggregation() const {
+  if (!ShouldUseStreamAggregation()) {
+    return nullptr;
+  }
+
+  StreamAggregationFactory::Context context;
+  context.is_full_compaction = is_full_compaction_;
+  context.is_manual_compaction = is_manual_compaction_;
+  context.is_bottommost_level = bottommost_level_;
+  context.input_start_level = start_level_;
+  context.output_level = output_level_;
+  context.column_family_id = cfd_->GetID();
+  return immutable_options_.stream_aggregation_factory->Create(context);
+}
+
+bool Compaction::ShouldUseStreamAggregation() const {
+  return HasStreamAggregation() && is_full_compaction_ &&
+         !SupportsPerKeyPlacement() && !enable_blob_garbage_collection();
+}
+
 std::unique_ptr<SstPartitioner> Compaction::CreateSstPartitioner() const {
   if (!immutable_options_.sst_partitioner_factory) {
     return nullptr;
@@ -916,6 +941,10 @@ bool Compaction::IsOutputLevelEmpty() const {
 
 bool Compaction::ShouldFormSubcompactions() const {
   if (cfd_ == nullptr) {
+    return false;
+  }
+
+  if (ShouldUseStreamAggregation()) {
     return false;
   }
 

--- a/db/compaction/compaction.h
+++ b/db/compaction/compaction.h
@@ -78,6 +78,8 @@ class Version;
 class ColumnFamilyData;
 class VersionStorageInfo;
 class CompactionFilter;
+class StreamAggregation;
+class StreamAggregationFactory;
 
 // A Compaction encapsulates metadata about a compaction.
 class Compaction {
@@ -330,6 +332,14 @@ class Compaction {
 
   // Create a CompactionFilter from compaction_filter_factory
   std::unique_ptr<CompactionFilter> CreateCompactionFilter() const;
+
+  bool HasStreamAggregation() const {
+    return immutable_options_.stream_aggregation_factory != nullptr;
+  }
+
+  bool ShouldUseStreamAggregation() const;
+
+  std::unique_ptr<StreamAggregation> CreateStreamAggregation() const;
 
   // Create a SstPartitioner from sst_partitioner_factory
   std::unique_ptr<SstPartitioner> CreateSstPartitioner() const;

--- a/db/compaction/compaction_iterator.cc
+++ b/db/compaction/compaction_iterator.cc
@@ -122,6 +122,15 @@ size_t CompactionBlobResolver::NumColumns() const {
   return columns_->size();
 }
 
+uint64_t CompactionBlobResolver::resolved_bytes() const {
+  uint64_t bytes = 0;
+  for (const auto& [column_index, value] : resolved_cache_) {
+    (void)column_index;
+    bytes += value->size();
+  }
+  return bytes;
+}
+
 CompactionIterator::CompactionIterator(
     InternalIterator* input, const Comparator* cmp, MergeHelper* merge_helper,
     SequenceNumber last_sequence, std::vector<SequenceNumber>* snapshots,
@@ -133,8 +142,8 @@ CompactionIterator::CompactionIterator(
     BlobFileBuilder* blob_file_builder, bool allow_data_in_errors,
     bool enforce_single_del_contracts,
     const std::atomic<bool>& manual_compaction_canceled,
-    bool must_count_input_entries, const Compaction* compaction,
-    const CompactionFilter* compaction_filter,
+    bool must_count_input_entries, ValuePreparation value_preparation,
+    const Compaction* compaction, const CompactionFilter* compaction_filter,
     const std::atomic<bool>* shutting_down,
     const std::shared_ptr<Logger> info_log,
     const std::string* full_history_ts_low,
@@ -147,9 +156,9 @@ CompactionIterator::CompactionIterator(
           allow_data_in_errors, enforce_single_del_contracts,
           manual_compaction_canceled,
           compaction ? std::make_unique<RealCompaction>(compaction) : nullptr,
-          must_count_input_entries, compaction_filter, shutting_down, info_log,
-          full_history_ts_low, preserve_seqno_min, input_version,
-          blob_read_io_activity) {}
+          must_count_input_entries, value_preparation, compaction_filter,
+          shutting_down, info_log, full_history_ts_low, preserve_seqno_min,
+          input_version, blob_read_io_activity) {}
 
 CompactionIterator::CompactionIterator(
     InternalIterator* input, const Comparator* cmp, MergeHelper* merge_helper,
@@ -163,6 +172,7 @@ CompactionIterator::CompactionIterator(
     bool enforce_single_del_contracts,
     const std::atomic<bool>& manual_compaction_canceled,
     std::unique_ptr<CompactionProxy> compaction, bool must_count_input_entries,
+    ValuePreparation value_preparation,
     const CompactionFilter* compaction_filter,
     const std::atomic<bool>* shutting_down,
     const std::shared_ptr<Logger> info_log,
@@ -198,6 +208,7 @@ CompactionIterator::CompactionIterator(
       enforce_single_del_contracts_(enforce_single_del_contracts),
       timestamp_size_(cmp_ ? cmp_->timestamp_size() : 0),
       full_history_ts_low_(full_history_ts_low),
+      defer_value_preparation_(value_preparation == ValuePreparation::kDefer),
       current_user_key_sequence_(0),
       current_user_key_snapshot_(0),
       merge_out_iter_(merge_helper_),
@@ -269,7 +280,11 @@ void CompactionIterator::ResetRecordCounts() {
 
 void CompactionIterator::SeekToFirst() {
   NextFromInput();
-  PrepareOutput();
+  if (defer_value_preparation_) {
+    PrepareOutputSequenceNumber();
+  } else {
+    PrepareOutput();
+  }
 }
 
 void CompactionIterator::Next() {
@@ -340,7 +355,11 @@ void CompactionIterator::Next() {
     has_outputted_key_ = true;
   }
 
-  PrepareOutput();
+  if (defer_value_preparation_) {
+    PrepareOutputSequenceNumber();
+  } else {
+    PrepareOutput();
+  }
 }
 
 bool CompactionIterator::InvokeFilterIfNeeded(bool* need_skip,
@@ -1896,73 +1915,76 @@ void CompactionIterator::PrepareOutput() {
       }
     }
 
-    // Zeroing out the sequence number leads to better compression.
-    // If this is the bottommost level (no files in lower levels)
-    // and the earliest snapshot is larger than this seqno
-    // and the userkey differs from the last userkey in compaction
-    // then we can squash the seqno to zero.
-    //
-    // This is safe for TransactionDB write-conflict checking since transactions
-    // only care about sequence number larger than any active snapshots.
-    //
-    // Can we do the same for levels above bottom level as long as
-    // KeyNotExistsBeyondOutputLevel() return true?
-    if (Valid() && bottommost_level_ &&
-        DefinitelyInSnapshot(ikey_.sequence, earliest_snapshot_) &&
-        ikey_.type != kTypeMerge && current_key_committed_ && !is_range_del_) {
-      assert(compaction_ != nullptr && !compaction_->allow_ingest_behind());
-      if (ikey_.type == kTypeDeletion ||
-          (ikey_.type == kTypeSingleDeletion && timestamp_size_ == 0)) {
-        ROCKS_LOG_FATAL(
-            info_log_,
-            "Unexpected key %s for seq-zero optimization. "
-            "earliest_snapshot %" PRIu64
-            ", earliest_write_conflict_snapshot %" PRIu64
-            " job_snapshot %" PRIu64
-            ". timestamp_size: %d full_history_ts_low_ %s. validity %x",
-            ikey_.DebugString(allow_data_in_errors_, true).c_str(),
-            earliest_snapshot_, earliest_write_conflict_snapshot_,
-            job_snapshot_, static_cast<int>(timestamp_size_),
-            full_history_ts_low_ != nullptr
-                ? Slice(*full_history_ts_low_).ToString(true).c_str()
-                : "null",
-            validity_info_.rep);
-        assert(false);
-      }
+    PrepareOutputSequenceNumber();
+  }
+}
 
-      bool zeroed_seqno = false;
-      // Whether the sequence number can actually be zeroed out here is decided
-      // by the shared BottommostSeqnoCanBeZeroed() predicate, which the
-      // bottommost-file marking logic
-      // (VersionStorageInfo::ComputeBottommostFilesMarkedForCompaction) also
-      // consults. Keeping both on one predicate ensures a file is only marked
-      // for a compaction that can make progress; otherwise the file would be
-      // re-marked forever (infinite compaction loop).
-      if (BottommostSeqnoCanBeZeroed(
-              ikey_.sequence, preserve_seqno_after_, timestamp_size_,
-              full_history_ts_low_ != nullptr, cmp_with_history_ts_low_ < 0)) {
-        if (!timestamp_size_) {
-          current_key_.UpdateInternalKey(0, ikey_.type);
-        } else {
-          // For UDT, the seqno and timestamp could only be zeroed out after the
-          // key is below history_ts_low_.
-          // For the same user key (excluding timestamp), the timestamp-based
-          // history can be collapsed to save some space if the timestamp is
-          // older than *full_history_ts_low_.
-          const std::string kTsMin(timestamp_size_, static_cast<char>(0));
-          const Slice ts_slice = kTsMin;
-          ikey_.SetTimestamp(ts_slice);
-          current_key_.UpdateInternalKey(0, ikey_.type, &ts_slice);
-        }
-        zeroed_seqno = true;
-      }
+void CompactionIterator::PrepareOutputSequenceNumber() {
+  // Zeroing out the sequence number leads to better compression.
+  // If this is the bottommost level (no files in lower levels)
+  // and the earliest snapshot is larger than this seqno
+  // and the userkey differs from the last userkey in compaction
+  // then we can squash the seqno to zero.
+  //
+  // This is safe for TransactionDB write-conflict checking since transactions
+  // only care about sequence number larger than any active snapshots.
+  //
+  // Can we do the same for levels above bottom level as long as
+  // KeyNotExistsBeyondOutputLevel() return true?
+  if (Valid() && bottommost_level_ &&
+      DefinitelyInSnapshot(ikey_.sequence, earliest_snapshot_) &&
+      ikey_.type != kTypeMerge && current_key_committed_ && !is_range_del_) {
+    assert(compaction_ != nullptr && !compaction_->allow_ingest_behind());
+    if (ikey_.type == kTypeDeletion ||
+        (ikey_.type == kTypeSingleDeletion && timestamp_size_ == 0)) {
+      ROCKS_LOG_FATAL(
+          info_log_,
+          "Unexpected key %s for seq-zero optimization. "
+          "earliest_snapshot %" PRIu64
+          ", earliest_write_conflict_snapshot %" PRIu64 " job_snapshot %" PRIu64
+          ". timestamp_size: %d full_history_ts_low_ %s. validity %x",
+          ikey_.DebugString(allow_data_in_errors_, true).c_str(),
+          earliest_snapshot_, earliest_write_conflict_snapshot_, job_snapshot_,
+          static_cast<int>(timestamp_size_),
+          full_history_ts_low_ != nullptr
+              ? Slice(*full_history_ts_low_).ToString(true).c_str()
+              : "null",
+          validity_info_.rep);
+      assert(false);
+    }
 
-      if (zeroed_seqno) {
-        ikey_.sequence = 0;
-        last_key_seq_zeroed_ = true;
-        TEST_SYNC_POINT_CALLBACK("CompactionIterator::PrepareOutput:ZeroingSeq",
-                                 &ikey_);
+    bool zeroed_seqno = false;
+    // Whether the sequence number can actually be zeroed out here is decided
+    // by the shared BottommostSeqnoCanBeZeroed() predicate, which the
+    // bottommost-file marking logic
+    // (VersionStorageInfo::ComputeBottommostFilesMarkedForCompaction) also
+    // consults. Keeping both on one predicate ensures a file is only marked
+    // for a compaction that can make progress; otherwise the file would be
+    // re-marked forever (infinite compaction loop).
+    if (BottommostSeqnoCanBeZeroed(
+            ikey_.sequence, preserve_seqno_after_, timestamp_size_,
+            full_history_ts_low_ != nullptr, cmp_with_history_ts_low_ < 0)) {
+      if (!timestamp_size_) {
+        current_key_.UpdateInternalKey(0, ikey_.type);
+      } else {
+        // For UDT, the seqno and timestamp could only be zeroed out after the
+        // key is below history_ts_low_.
+        // For the same user key (excluding timestamp), the timestamp-based
+        // history can be collapsed to save some space if the timestamp is
+        // older than *full_history_ts_low_.
+        const std::string kTsMin(timestamp_size_, static_cast<char>(0));
+        const Slice ts_slice = kTsMin;
+        ikey_.SetTimestamp(ts_slice);
+        current_key_.UpdateInternalKey(0, ikey_.type, &ts_slice);
       }
+      zeroed_seqno = true;
+    }
+
+    if (zeroed_seqno) {
+      ikey_.sequence = 0;
+      last_key_seq_zeroed_ = true;
+      TEST_SYNC_POINT_CALLBACK("CompactionIterator::PrepareOutput:ZeroingSeq",
+                               &ikey_);
     }
   }
 }

--- a/db/compaction/compaction_iterator.h
+++ b/db/compaction/compaction_iterator.h
@@ -59,6 +59,7 @@ class CompactionBlobResolver : public WideColumnBlobResolver {
     }
     return *resolve_error_;
   }
+  uint64_t resolved_bytes() const;
 
   // Reset the resolver for a new entity. Clears resolved cache.
   void Reset(const Slice& user_key, const std::vector<WideColumn>* columns,
@@ -141,6 +142,11 @@ class SequenceIterWrapper : public InternalIterator {
 
 class CompactionIterator {
  public:
+  enum class ValuePreparation {
+    kApply,
+    kDefer,
+  };
+
   // A wrapper around Compaction. Has a much smaller interface, only what
   // CompactionIterator uses. Tests can override it.
   class CompactionProxy {
@@ -267,7 +273,8 @@ class CompactionIterator {
       BlobFileBuilder* blob_file_builder, bool allow_data_in_errors,
       bool enforce_single_del_contracts,
       const std::atomic<bool>& manual_compaction_canceled,
-      bool must_count_input_entries, const Compaction* compaction = nullptr,
+      bool must_count_input_entries, ValuePreparation value_preparation,
+      const Compaction* compaction = nullptr,
       const CompactionFilter* compaction_filter = nullptr,
       const std::atomic<bool>* shutting_down = nullptr,
       const std::shared_ptr<Logger> info_log = nullptr,
@@ -289,7 +296,7 @@ class CompactionIterator {
       bool enforce_single_del_contracts,
       const std::atomic<bool>& manual_compaction_canceled,
       std::unique_ptr<CompactionProxy> compaction,
-      bool must_count_input_entries,
+      bool must_count_input_entries, ValuePreparation value_preparation,
       const CompactionFilter* compaction_filter = nullptr,
       const std::atomic<bool>* shutting_down = nullptr,
       const std::shared_ptr<Logger> info_log = nullptr,
@@ -358,6 +365,8 @@ class CompactionIterator {
 
   // Do final preparations before presenting the output to the callee.
   void PrepareOutput();
+
+  void PrepareOutputSequenceNumber();
 
   // Passes the output value to the blob file builder (if any), and replaces it
   // with the corresponding blob reference if it has been actually written to a
@@ -506,6 +515,10 @@ class CompactionIterator {
   // is in `NextFromInput()` and `PrepareOutput()`.
   // If nullptr, NO GC will be performed and all history will be preserved.
   const std::string* const full_history_ts_low_;
+
+  // A StreamAggregation consumes logical records before physical
+  // output preparation.
+  const bool defer_value_preparation_;
 
   // State
   //

--- a/db/compaction/compaction_iterator_test.cc
+++ b/db/compaction/compaction_iterator_test.cc
@@ -307,8 +307,9 @@ class CompactionIteratorTest : public testing::TestWithParam<bool> {
         nullptr /* blob_file_builder */, true /*allow_data_in_errors*/,
         true /*enforce_single_del_contracts*/,
         /*manual_compaction_canceled=*/kManualCompactionCanceledFalse_,
-        std::move(compaction), /*must_count_input_entries=*/false, filter,
-        &shutting_down_, /*info_log=*/nullptr, full_history_ts_low));
+        std::move(compaction), /*must_count_input_entries=*/false,
+        CompactionIterator::ValuePreparation::kApply, filter, &shutting_down_,
+        /*info_log=*/nullptr, full_history_ts_low));
   }
 
   void AddSnapshot(SequenceNumber snapshot,
@@ -1844,6 +1845,7 @@ class WideColumnEntityBlobExtractionTest : public testing::Test {
         &blob_file_builder, true /*allow_data_in_errors*/,
         true /*enforce_single_del_contracts*/, manual_compaction_canceled,
         nullptr /*compaction*/, false /*must_count_input_entries*/,
+        CompactionIterator::ValuePreparation::kApply,
         nullptr /*compaction_filter*/, &shutting_down);
 
     c_iter.SeekToFirst();
@@ -2292,7 +2294,8 @@ class WideColumnEntityBlobGCTest : public testing::Test {
         blob_file_builder.get(), true /*allow_data_in_errors*/,
         true /*enforce_single_del_contracts*/, manual_compaction_canceled,
         std::move(fake_compaction), false /*must_count_input_entries*/,
-        compaction_filter, &shutting_down);
+        CompactionIterator::ValuePreparation::kApply, compaction_filter,
+        &shutting_down);
 
     c_iter.SeekToFirst();
     while (c_iter.Valid()) {
@@ -2727,7 +2730,8 @@ TEST_F(WideColumnEntityBlobGCTest,
       kMaxSequenceNumber, kMaxSequenceNumber, kMaxSequenceNumber, nullptr,
       Env::Default(), false, range_del_agg.get(), nullptr /*blob_file_builder*/,
       true, true, manual_compaction_canceled, std::move(fake_compaction), false,
-      &keep_filter, &shutting_down);
+      CompactionIterator::ValuePreparation::kApply, &keep_filter,
+      &shutting_down);
 
   c_iter.SeekToFirst();
   ASSERT_TRUE(c_iter.Valid());

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <cinttypes>
+#include <deque>
 #include <memory>
 #include <optional>
 #include <set>
@@ -18,8 +19,11 @@
 #include <vector>
 
 #include "db/blob/blob_counting_iterator.h"
+#include "db/blob/blob_fetcher.h"
 #include "db/blob/blob_file_addition.h"
 #include "db/blob/blob_file_builder.h"
+#include "db/blob/blob_index.h"
+#include "db/blob/prefetch_buffer_collection.h"
 #include "db/builder.h"
 #include "db/compaction/clipping_iterator.h"
 #include "db/compaction/compaction_state.h"
@@ -33,6 +37,8 @@
 #include "db/range_del_aggregator.h"
 #include "db/version_edit.h"
 #include "db/version_set.h"
+#include "db/wide/wide_column_serialization.h"
+#include "db/wide/wide_columns_helper.h"
 #include "file/file_util.h"
 #include "file/filename.h"
 #include "file/read_write_util.h"
@@ -50,6 +56,7 @@
 #include "rocksdb/options.h"
 #include "rocksdb/statistics.h"
 #include "rocksdb/status.h"
+#include "rocksdb/stream_aggregation.h"
 #include "rocksdb/table.h"
 #include "rocksdb/utilities/options_type.h"
 #include "table/format.h"
@@ -135,6 +142,295 @@ const char* GetCompactionProximalOutputRangeTypeString(
 // Static constant for compaction abort flag - always false, used for
 // compaction service jobs that don't support abort signaling
 const std::atomic<int> CompactionJob::kCompactionAbortedFalse{0};
+
+namespace {
+
+using Aggregation = StreamAggregation;
+
+struct BufferedAggregationInput {
+  std::string user_key;
+  SequenceNumber sequence = 0;
+  ValueType internal_value_type = kTypeValue;
+  std::string value_storage;
+  Slice plain_value;
+  WideColumns columns;
+  std::vector<std::pair<size_t, BlobIndex>> blob_columns;
+  std::unique_ptr<CompactionBlobResolver> blob_resolver;
+  uint64_t accounted_resolved_bytes = 0;
+
+  Status Initialize(BlobFetcher* blob_fetcher,
+                    PrefetchBufferCollection* prefetch_buffers,
+                    CompactionIterationStats* iter_stats) {
+    if (internal_value_type == kTypeValue) {
+      plain_value = Slice(value_storage);
+      return Status::OK();
+    }
+
+    if (internal_value_type != kTypeWideColumnEntity) {
+      return Status::NotSupported(
+          "StreamAggregation input must be a value or wide-column "
+          "entity");
+    }
+
+    Slice entity(value_storage);
+    Status s =
+        WideColumnSerialization::Deserialize(entity, columns, &blob_columns);
+    if (!s.ok()) {
+      return s;
+    }
+
+    if (!blob_columns.empty()) {
+      blob_resolver = std::make_unique<CompactionBlobResolver>();
+      blob_resolver->Init(blob_fetcher, prefetch_buffers, iter_stats);
+      blob_resolver->Reset(Slice(user_key), &columns, &blob_columns,
+                           /*track_resolve_error=*/true);
+    }
+
+    return Status::OK();
+  }
+
+  Aggregation::Input GetPublicInput() {
+    Aggregation::Input input;
+    input.user_key = Slice(user_key);
+    input.sequence = sequence;
+    if (internal_value_type == kTypeValue) {
+      input.value_type = Aggregation::ValueType::kValue;
+      input.value = &plain_value;
+    } else {
+      input.value_type = Aggregation::ValueType::kWideColumnEntity;
+      input.columns = &columns;
+      input.blob_resolver = blob_resolver.get();
+    }
+    return input;
+  }
+
+  uint64_t RawBytes() const { return user_key.size() + value_storage.size(); }
+
+  uint64_t UpdateResolvedBytes() {
+    if (blob_resolver == nullptr) {
+      return 0;
+    }
+    const uint64_t current_resolved_bytes = blob_resolver->resolved_bytes();
+    assert(current_resolved_bytes >= accounted_resolved_bytes);
+    const uint64_t newly_resolved_bytes =
+        current_resolved_bytes - accounted_resolved_bytes;
+    accounted_resolved_bytes = current_resolved_bytes;
+    return newly_resolved_bytes;
+  }
+
+  uint64_t BufferedBytes() const {
+    return RawBytes() + accounted_resolved_bytes;
+  }
+};
+
+Status ValidateAggregationOutput(
+    const std::vector<Aggregation::Input>& inputs, size_t num_consumed,
+    const std::vector<Aggregation::OutputSegment>& outputs,
+    uint64_t max_output_bytes, const Comparator* user_comparator) {
+  assert(user_comparator != nullptr);
+
+  if (num_consumed > inputs.size()) {
+    return Status::InvalidArgument(
+        "StreamAggregation consumed beyond its input batch");
+  }
+  if (num_consumed == 0) {
+    if (!outputs.empty()) {
+      return Status::InvalidArgument(
+          "StreamAggregation cannot emit output without consuming "
+          "input");
+    }
+    return Status::OK();
+  }
+  if (outputs.empty()) {
+    return Status::InvalidArgument(
+        "StreamAggregation must return output segments");
+  }
+
+  size_t expected_begin = 0;
+  uint64_t output_bytes = 0;
+  auto add_output_bytes = [&](uint64_t bytes) -> bool {
+    if (bytes > max_output_bytes - output_bytes) {
+      return false;
+    }
+    output_bytes += bytes;
+    return true;
+  };
+  const Slice* previous_output_key = nullptr;
+  auto validate_output_key = [&](const Slice& output_key) -> Status {
+    if (previous_output_key != nullptr &&
+        user_comparator->Compare(*previous_output_key, output_key) >= 0) {
+      return Status::InvalidArgument(
+          "StreamAggregation output keys must be strictly ordered");
+    }
+    previous_output_key = &output_key;
+    return Status::OK();
+  };
+  for (const auto& output : outputs) {
+    if (output.input_begin != expected_begin ||
+        output.input_end <= output.input_begin ||
+        output.input_end > num_consumed) {
+      return Status::InvalidArgument(
+          "StreamAggregation output segments must exactly partition "
+          "the consumed input prefix");
+    }
+
+    switch (output.action) {
+      case Aggregation::OutputAction::kKeep:
+      case Aggregation::OutputAction::kDrop:
+        if (!output.value.empty() || !output.columns.empty()) {
+          return Status::InvalidArgument(
+              "StreamAggregation keep/drop segments cannot contain "
+              "an output value");
+        }
+        if (output.action == Aggregation::OutputAction::kKeep) {
+          for (size_t i = output.input_begin; i < output.input_end; ++i) {
+            Status status = validate_output_key(inputs[i].user_key);
+            if (!status.ok()) {
+              return status;
+            }
+          }
+        }
+        break;
+      case Aggregation::OutputAction::kEmit:
+        if (output.anchor_input_index < output.input_begin ||
+            output.anchor_input_index >= output.input_end) {
+          return Status::InvalidArgument(
+              "StreamAggregation output anchor must belong to its "
+              "input segment");
+        }
+        {
+          Status status =
+              validate_output_key(inputs[output.anchor_input_index].user_key);
+          if (!status.ok()) {
+            return status;
+          }
+        }
+        if (output.value_type == Aggregation::ValueType::kValue) {
+          if (!output.columns.empty()) {
+            return Status::InvalidArgument(
+                "StreamAggregation value output cannot contain wide "
+                "columns");
+          }
+          if (output.value.size() > std::numeric_limits<uint32_t>::max()) {
+            return Status::InvalidArgument(
+                "StreamAggregation output value exceeds 4GB");
+          }
+          if (!add_output_bytes(output.value.size())) {
+            return Status::InvalidArgument(
+                "StreamAggregation output exceeds its configured "
+                "byte limit");
+          }
+        } else if (output.value_type ==
+                   Aggregation::ValueType::kWideColumnEntity) {
+          if (!output.value.empty()) {
+            return Status::InvalidArgument(
+                "StreamAggregation entity output cannot contain a "
+                "plain value");
+          }
+
+          WideColumns columns;
+          columns.reserve(output.columns.size());
+          for (const auto& column : output.columns) {
+            columns.emplace_back(column.first, column.second);
+            if (!add_output_bytes(column.first.size()) ||
+                !add_output_bytes(column.second.size())) {
+              return Status::InvalidArgument(
+                  "StreamAggregation output exceeds its configured "
+                  "byte limit");
+            }
+          }
+          WideColumnsHelper::SortColumns(columns);
+          std::string serialized;
+          Status s = WideColumnSerialization::Serialize(columns, serialized);
+          if (!s.ok()) {
+            return s;
+          }
+        } else {
+          return Status::InvalidArgument(
+              "StreamAggregation returned an invalid output value "
+              "type");
+        }
+        break;
+      default:
+        return Status::InvalidArgument(
+            "StreamAggregation returned an invalid output action");
+    }
+
+    expected_begin = output.input_end;
+  }
+
+  if (expected_begin != num_consumed) {
+    return Status::InvalidArgument(
+        "StreamAggregation output segments do not cover every "
+        "consumed input");
+  }
+
+  return Status::OK();
+}
+
+Status BuildAggregationOutputValue(const Aggregation::OutputSegment& output,
+                                   const Slice& user_key,
+                                   BlobFileBuilder* blob_file_builder,
+                                   ValueType* internal_value_type,
+                                   std::string* value) {
+  assert(output.action == Aggregation::OutputAction::kEmit);
+  assert(internal_value_type != nullptr);
+  assert(value != nullptr);
+
+  value->clear();
+  if (output.value_type == Aggregation::ValueType::kValue) {
+    *internal_value_type = kTypeValue;
+    *value = output.value;
+
+    if (blob_file_builder != nullptr) {
+      std::string blob_index;
+      Status s = blob_file_builder->Add(user_key, *value, &blob_index);
+      if (!s.ok()) {
+        return s;
+      }
+      if (!blob_index.empty()) {
+        *internal_value_type = kTypeBlobIndex;
+        *value = std::move(blob_index);
+      }
+    }
+    return Status::OK();
+  }
+
+  WideColumns columns;
+  columns.reserve(output.columns.size());
+  for (const auto& column : output.columns) {
+    columns.emplace_back(column.first, column.second);
+  }
+  WideColumnsHelper::SortColumns(columns);
+
+  std::vector<std::pair<size_t, BlobIndex>> blob_columns;
+  if (blob_file_builder != nullptr) {
+    for (size_t i = 0; i < columns.size(); ++i) {
+      std::string blob_index_encoding;
+      Status s = blob_file_builder->Add(user_key, columns[i].value(),
+                                        &blob_index_encoding);
+      if (!s.ok()) {
+        return s;
+      }
+      if (!blob_index_encoding.empty()) {
+        BlobIndex blob_index;
+        s = blob_index.DecodeFrom(blob_index_encoding);
+        if (!s.ok()) {
+          return s;
+        }
+        blob_columns.emplace_back(i, std::move(blob_index));
+      }
+    }
+  }
+
+  *internal_value_type = kTypeWideColumnEntity;
+  if (blob_columns.empty()) {
+    return WideColumnSerialization::Serialize(columns, *value);
+  }
+  return WideColumnSerialization::SerializeV2(columns, blob_columns, *value);
+}
+
+}  // namespace
 
 CompactionJob::CompactionJob(
     int job_id, Compaction* compaction, const ImmutableDBOptions& db_options,
@@ -1443,6 +1739,9 @@ void CompactionJob::NotifyOnSubcompactionCompleted(
 }
 
 bool CompactionJob::ShouldUseLocalCompaction(SubcompactionState* sub_compact) {
+  if (sub_compact->compaction->ShouldUseStreamAggregation()) {
+    return true;
+  }
   if (db_options_.compaction_service) {
     CompactionServiceJobStatus comp_status =
         ProcessKeyValueCompactionWithCompactionService(sub_compact);
@@ -1642,7 +1941,7 @@ std::unique_ptr<CompactionIterator> CompactionJob::CreateCompactionIterator(
     SubcompactionState* sub_compact, ColumnFamilyData* cfd,
     InternalIterator* input, const CompactionFilter* compaction_filter,
     MergeHelper& merge, std::unique_ptr<BlobFileBuilder>& blob_file_builder,
-    const WriteOptions& write_options) {
+    const WriteOptions& write_options, bool use_stream_aggregation) {
   CreateBlobFileBuilder(sub_compact, cfd, blob_file_builder, write_options);
 
   const std::string* const full_history_ts_low =
@@ -1655,12 +1954,16 @@ std::unique_ptr<CompactionIterator> CompactionJob::CreateCompactionIterator(
       job_context_->earliest_write_conflict_snapshot,
       job_context_->GetJobSnapshotSequence(), job_context_->snapshot_checker,
       env_, ShouldReportDetailedTime(env_, stats_), sub_compact->RangeDelAgg(),
-      blob_file_builder.get(), db_options_.allow_data_in_errors,
+      use_stream_aggregation ? nullptr : blob_file_builder.get(),
+      db_options_.allow_data_in_errors,
       db_options_.enforce_single_del_contracts, manual_compaction_canceled_,
       sub_compact->compaction
           ->DoesInputReferenceBlobFiles() /* must_count_input_entries */,
+      use_stream_aggregation ? CompactionIterator::ValuePreparation::kDefer
+                             : CompactionIterator::ValuePreparation::kApply,
       sub_compact->compaction, compaction_filter, shutting_down_,
-      db_options_.info_log, full_history_ts_low, preserve_seqno_after_);
+      db_options_.info_log, full_history_ts_low, preserve_seqno_after_,
+      /*input_version=*/nullptr, Env::IOActivity::kCompaction);
 }
 
 std::pair<CompactionFileOpenFunc, CompactionFileCloseFunc>
@@ -1770,9 +2073,12 @@ Status CompactionJob::ProcessKeyValue(
     // and `close_file_func`.
     // TODO: it would be better to have the compaction file open/close moved
     // into `CompactionOutputs` which has the output file information.
-    status = sub_compact->AddToOutput(*c_iter, use_proximal_output,
-                                      open_file_func, close_file_func,
-                                      prev_iter_output_internal_key);
+    const CompactionOutputRecord output_record{
+        c_iter->key(), c_iter->value(), c_iter->ikey(),
+        c_iter->IsDeleteRangeSentinelKey()};
+    status = sub_compact->AddToOutput(
+        output_record, *c_iter, use_proximal_output, open_file_func,
+        close_file_func, prev_iter_output_internal_key);
     if (!status.ok()) {
       break;
     }
@@ -1795,6 +2101,344 @@ Status CompactionJob::ProcessKeyValue(
       break;
     }
 #endif  // NDEBUG
+  }
+
+  return status;
+}
+
+Status CompactionJob::SetupAndValidateStreamAggregation(
+    SubcompactionState* sub_compact,
+    std::unique_ptr<StreamAggregation>* aggregation) {
+  assert(sub_compact != nullptr);
+  assert(sub_compact->compaction != nullptr);
+  assert(aggregation != nullptr);
+
+  aggregation->reset();
+  const Compaction* compaction = sub_compact->compaction;
+  if (!compaction->ShouldUseStreamAggregation()) {
+    return Status::OK();
+  }
+
+  if (compaction->immutable_options().allow_ingest_behind ||
+      compaction->immutable_options().cf_allow_ingest_behind) {
+    return Status::NotSupported(
+        "StreamAggregation does not support ingest-behind");
+  }
+  if (!job_context_->snapshot_seqs.empty() ||
+      job_context_->snapshot_checker != nullptr ||
+      job_context_->earliest_write_conflict_snapshot != kMaxSequenceNumber) {
+    return Status::OK();
+  }
+
+  *aggregation = compaction->CreateStreamAggregation();
+  if (!*aggregation) {
+    return Status::InvalidArgument("StreamAggregationFactory returned null");
+  }
+  if ((*aggregation)->MaxBatchOutputBytes() == 0) {
+    aggregation->reset();
+    return Status::InvalidArgument(
+        "StreamAggregation output byte limit must be non-zero");
+  }
+
+  return Status::OK();
+}
+
+Status CompactionJob::ProcessKeyValueWithStreamAggregation(
+    SubcompactionState* sub_compact, ColumnFamilyData* cfd,
+    CompactionIterator* c_iter, StreamAggregation* aggregation,
+    BlobFileBuilder* blob_file_builder,
+    const CompactionFileOpenFunc& open_file_func,
+    const CompactionFileCloseFunc& close_file_func, uint64_t& prev_cpu_micros) {
+  assert(sub_compact != nullptr);
+  assert(cfd != nullptr);
+  assert(c_iter != nullptr);
+  assert(aggregation != nullptr);
+
+  const uint64_t kCronEveryMask = (1 << 10) - 1;
+#ifndef NDEBUG
+  const std::optional<const Slice> end = sub_compact->end;
+#endif
+
+  ReadOptions blob_read_options;
+  blob_read_options.fill_cache = false;
+  blob_read_options.io_activity = Env::IOActivity::kCompaction;
+  OwningVersionBlobFetcher blob_fetcher(
+      sub_compact->compaction->input_version(), std::move(blob_read_options));
+
+  std::unique_ptr<PrefetchBufferCollection> prefetch_buffers;
+  const uint64_t readahead_size = sub_compact->compaction->mutable_cf_options()
+                                      .blob_compaction_readahead_size;
+  if (readahead_size != 0 &&
+      !sub_compact->compaction->immutable_options().allow_mmap_reads) {
+    prefetch_buffers =
+        std::make_unique<PrefetchBufferCollection>(readahead_size);
+  }
+
+  constexpr size_t kInitialInputRecords = 256;
+  constexpr uint64_t kInitialInputBytes = 1024 * 1024;
+  std::pair<size_t, uint64_t> input_buffer_limits{
+      StreamAggregation::kMaxBufferedInputRecords,
+      StreamAggregation::kMaxBufferedInputBytes};
+  TEST_SYNC_POINT_CALLBACK(
+      "CompactionJob::ProcessKeyValueWithStreamAggregation:"
+      "InputBufferLimits",
+      &input_buffer_limits);
+  if (input_buffer_limits.first == 0 || input_buffer_limits.second == 0 ||
+      input_buffer_limits.first > StreamAggregation::kMaxBufferedInputRecords ||
+      input_buffer_limits.second > StreamAggregation::kMaxBufferedInputBytes) {
+    return Status::InvalidArgument(
+        "StreamAggregation input buffer limits are invalid");
+  }
+
+  size_t target_input_records =
+      std::min(kInitialInputRecords, input_buffer_limits.first);
+  uint64_t target_input_bytes =
+      std::min(kInitialInputBytes, input_buffer_limits.second);
+  std::deque<BufferedAggregationInput> pending_inputs;
+  uint64_t pending_input_bytes = 0;
+  std::vector<StreamAggregation::Input> input_views;
+  std::vector<StreamAggregation::OutputSegment> outputs;
+  IterKey prev_iter_output_key;
+  ParsedInternalKey prev_iter_output_internal_key;
+  CompactionIterationStats* const aggregation_stats =
+      &sub_compact->stream_aggregation_stats;
+
+  auto add_output_record = [&](const Slice& user_key, SequenceNumber sequence,
+                               ValueType value_type,
+                               const Slice& value) -> Status {
+    InternalKey internal_key(user_key, sequence, value_type);
+    const ParsedInternalKey parsed_key(user_key, sequence, value_type);
+    const CompactionOutputRecord output_record{
+        internal_key.Encode(), value, parsed_key, /*is_range_del=*/false};
+
+    Status s = sub_compact->AddToOutput(
+        output_record, *c_iter, /*use_proximal_output=*/false, open_file_func,
+        close_file_func, prev_iter_output_internal_key);
+    if (!s.ok()) {
+      return s;
+    }
+
+    prev_iter_output_key.SetInternalKey(output_record.key,
+                                        &prev_iter_output_internal_key);
+    prev_iter_output_internal_key.sequence = sequence;
+    prev_iter_output_internal_key.type = value_type;
+    return Status::OK();
+  };
+
+  auto next_input_raw_bytes = [&]() -> uint64_t {
+    assert(c_iter->Valid());
+    return static_cast<uint64_t>(c_iter->user_key().size()) +
+           static_cast<uint64_t>(c_iter->value().size());
+  };
+
+  auto input_buffer_at_limit = [&]() -> bool {
+    if (pending_inputs.size() >= input_buffer_limits.first ||
+        pending_input_bytes >= input_buffer_limits.second) {
+      return true;
+    }
+    if (!c_iter->Valid()) {
+      return false;
+    }
+    const uint64_t next_bytes = next_input_raw_bytes();
+    return next_bytes > input_buffer_limits.second ||
+           next_bytes > input_buffer_limits.second - pending_input_bytes;
+  };
+
+  auto fill_input_buffer = [&]() -> Status {
+    while (c_iter->Valid()) {
+      assert(!end.has_value() ||
+             cfd->user_comparator()->Compare(c_iter->user_key(), *end) < 0);
+
+      if (c_iter->IsDeleteRangeSentinelKey()) {
+        c_iter->Next();
+        continue;
+      }
+
+      const ParsedInternalKey& ikey = c_iter->ikey();
+      if (ikey.type != kTypeValue && ikey.type != kTypeWideColumnEntity) {
+        return Status::NotSupported(
+            "StreamAggregation encountered an unsupported value "
+            "type");
+      }
+
+      const uint64_t raw_bytes = next_input_raw_bytes();
+      if (raw_bytes > input_buffer_limits.second) {
+        return Status::MemoryLimit(
+            "StreamAggregation input exceeds the byte limit");
+      }
+      if (pending_inputs.size() >= input_buffer_limits.first ||
+          raw_bytes > input_buffer_limits.second - pending_input_bytes) {
+        break;
+      }
+      if (pending_inputs.size() >= target_input_records ||
+          (!pending_inputs.empty() &&
+           (pending_input_bytes >= target_input_bytes ||
+            raw_bytes > target_input_bytes - pending_input_bytes))) {
+        break;
+      }
+
+      pending_inputs.emplace_back();
+      BufferedAggregationInput& buffered = pending_inputs.back();
+      buffered.user_key.assign(c_iter->user_key().data(),
+                               c_iter->user_key().size());
+      buffered.sequence = ikey.sequence;
+      buffered.internal_value_type = ikey.type;
+      buffered.value_storage.assign(c_iter->value().data(),
+                                    c_iter->value().size());
+      Status status = buffered.Initialize(&blob_fetcher, prefetch_buffers.get(),
+                                          aggregation_stats);
+      if (!status.ok()) {
+        return status;
+      }
+
+      pending_input_bytes += buffered.RawBytes();
+      c_iter->Next();
+    }
+    return Status::OK();
+  };
+
+  Status status;
+  while (status.ok() && !cfd->IsDropped() &&
+         (c_iter->Valid() || !pending_inputs.empty()) &&
+         c_iter->status().ok()) {
+    if (compaction_aborted_.load(std::memory_order_acquire) > 0 ||
+        cfd->compaction_aborted() > 0) {
+      return Status::Incomplete(Status::SubCode::kCompactionAborted);
+    }
+
+    status = fill_input_buffer();
+    if (!status.ok()) {
+      return status;
+    }
+
+    if (pending_inputs.empty()) {
+      break;
+    }
+    if (!c_iter->status().ok()) {
+      return c_iter->status();
+    }
+
+    input_views.clear();
+    input_views.reserve(pending_inputs.size());
+    for (auto& input : pending_inputs) {
+      input_views.push_back(input.GetPublicInput());
+    }
+
+    size_t num_consumed = 0;
+    outputs.clear();
+    const bool end_of_input = !c_iter->Valid();
+    if (end_of_input) {
+      status = aggregation->Finish(input_views, &outputs);
+      num_consumed = input_views.size();
+    } else {
+      status = aggregation->Aggregate(input_views, &num_consumed, &outputs);
+    }
+    if (!status.ok()) {
+      return status;
+    }
+    for (size_t i = 0; i < input_views.size(); ++i) {
+      if (pending_inputs[i].blob_resolver != nullptr) {
+        status = pending_inputs[i].blob_resolver->resolve_status();
+        if (!status.ok()) {
+          return status;
+        }
+      }
+      const uint64_t newly_resolved_bytes =
+          pending_inputs[i].UpdateResolvedBytes();
+      if (pending_input_bytes > input_buffer_limits.second ||
+          newly_resolved_bytes >
+              input_buffer_limits.second - pending_input_bytes) {
+        return Status::MemoryLimit(
+            "StreamAggregation resolved blob values exceed the "
+            "input byte limit");
+      }
+      pending_input_bytes += newly_resolved_bytes;
+    }
+    status = ValidateAggregationOutput(input_views, num_consumed, outputs,
+                                       aggregation->MaxBatchOutputBytes(),
+                                       cfd->user_comparator());
+    if (!status.ok()) {
+      return status;
+    }
+
+    if (num_consumed == 0) {
+      if (input_buffer_at_limit()) {
+        return Status::MemoryLimit(
+            "StreamAggregation requested more input after reaching "
+            "the input buffer limit");
+      }
+
+      const size_t doubled_records =
+          target_input_records > input_buffer_limits.first / 2
+              ? input_buffer_limits.first
+              : target_input_records * 2;
+      target_input_records =
+          std::min(input_buffer_limits.first,
+                   std::max(doubled_records, pending_inputs.size() + 1));
+
+      const uint64_t next_bytes = next_input_raw_bytes();
+      assert(next_bytes <= input_buffer_limits.second - pending_input_bytes);
+      const uint64_t required_bytes = pending_input_bytes + next_bytes;
+      const uint64_t doubled_bytes =
+          target_input_bytes > input_buffer_limits.second / 2
+              ? input_buffer_limits.second
+              : target_input_bytes * 2;
+      target_input_bytes = std::min(input_buffer_limits.second,
+                                    std::max(doubled_bytes, required_bytes));
+      continue;
+    }
+
+    for (const auto& output : outputs) {
+      if (output.action == StreamAggregation::OutputAction::kKeep) {
+        for (size_t i = output.input_begin; i < output.input_end; ++i) {
+          const auto& input = pending_inputs[i];
+          status = add_output_record(Slice(input.user_key), input.sequence,
+                                     input.internal_value_type,
+                                     Slice(input.value_storage));
+          if (!status.ok()) {
+            return status;
+          }
+        }
+        continue;
+      }
+
+      if (output.action == StreamAggregation::OutputAction::kDrop) {
+        aggregation_stats->num_record_drop_user +=
+            static_cast<int64_t>(output.input_end - output.input_begin);
+        continue;
+      }
+
+      const Slice anchor_key(
+          pending_inputs[output.anchor_input_index].user_key);
+      ValueType output_value_type = kTypeValue;
+      std::string output_value;
+      status =
+          BuildAggregationOutputValue(output, anchor_key, blob_file_builder,
+                                      &output_value_type, &output_value);
+      if (!status.ok()) {
+        return status;
+      }
+      status = add_output_record(
+          anchor_key, pending_inputs[output.anchor_input_index].sequence,
+          output_value_type, Slice(output_value));
+      if (!status.ok()) {
+        return status;
+      }
+    }
+
+    for (size_t i = 0; i < num_consumed; ++i) {
+      pending_input_bytes -= pending_inputs.front().BufferedBytes();
+      pending_inputs.pop_front();
+    }
+
+    const uint64_t num_records = c_iter->iter_stats().num_input_records;
+    if ((num_records & kCronEveryMask) == kCronEveryMask) {
+      UpdateSubcompactionJobStatsIncrementally(
+          c_iter, &sub_compact->compaction_job_stats,
+          db_options_.clock->CPUMicros(), prev_cpu_micros);
+      RecordDroppedKeys(*aggregation_stats, &sub_compact->compaction_job_stats);
+      aggregation_stats->num_record_drop_user = 0;
+    }
   }
 
   return status;
@@ -1826,9 +2470,11 @@ void CompactionJob::FinalizeSubcompactionJobStats(
   sub_compact->compaction_job_stats.num_input_records +=
       c_iter->NumInputEntryScanned();
   sub_compact->compaction_job_stats.num_blobs_read =
-      c_iter_stats.num_blobs_read;
+      c_iter_stats.num_blobs_read +
+      sub_compact->stream_aggregation_stats.num_blobs_read;
   sub_compact->compaction_job_stats.total_blob_bytes_read =
-      c_iter_stats.total_blob_bytes_read;
+      c_iter_stats.total_blob_bytes_read +
+      sub_compact->stream_aggregation_stats.total_blob_bytes_read;
   sub_compact->compaction_job_stats.num_input_deletion_records =
       c_iter_stats.num_input_deletion_records;
   sub_compact->compaction_job_stats.num_corrupt_keys =
@@ -1844,6 +2490,10 @@ void CompactionJob::FinalizeSubcompactionJobStats(
 
   RecordTick(stats_, FILTER_OPERATION_TOTAL_TIME,
              c_iter_stats.total_filter_time);
+
+  RecordDroppedKeys(sub_compact->stream_aggregation_stats,
+                    &sub_compact->compaction_job_stats);
+  sub_compact->stream_aggregation_stats.num_record_drop_user = 0;
 
   if (c_iter_stats.num_blobs_relocated > 0) {
     RecordTick(stats_, BLOB_DB_GC_NUM_KEYS_RELOCATED,
@@ -1963,6 +2613,14 @@ void CompactionJob::ProcessKeyValueCompaction(SubcompactionState* sub_compact) {
     return;
   }
 
+  std::unique_ptr<StreamAggregation> stream_aggregation;
+  Status aggregation_status =
+      SetupAndValidateStreamAggregation(sub_compact, &stream_aggregation);
+  if (!aggregation_status.ok()) {
+    sub_compact->status = aggregation_status;
+    return;
+  }
+
   NotifyOnSubcompactionBegin(sub_compact);
 
   SubcompactionKeyBoundaries boundaries(sub_compact->start, sub_compact->end);
@@ -1994,9 +2652,9 @@ void CompactionJob::ProcessKeyValueCompaction(SubcompactionState* sub_compact) {
       compact_->compaction->level(), db_options_.stats);
   std::unique_ptr<BlobFileBuilder> blob_file_builder;
 
-  auto c_iter =
-      CreateCompactionIterator(sub_compact, cfd, input_iter, compaction_filter,
-                               merge, blob_file_builder, write_options);
+  auto c_iter = CreateCompactionIterator(
+      sub_compact, cfd, input_iter, compaction_filter, merge, blob_file_builder,
+      write_options, stream_aggregation != nullptr);
   assert(c_iter);
   c_iter->SeekToFirst();
 
@@ -2008,8 +2666,15 @@ void CompactionJob::ProcessKeyValueCompaction(SubcompactionState* sub_compact) {
   auto [open_file_func, close_file_func] =
       CreateFileHandlers(sub_compact, boundaries);
 
-  status = ProcessKeyValue(sub_compact, cfd, c_iter.get(), open_file_func,
-                           close_file_func, prev_cpu_micros);
+  if (stream_aggregation != nullptr) {
+    status = ProcessKeyValueWithStreamAggregation(
+        sub_compact, cfd, c_iter.get(), stream_aggregation.get(),
+        blob_file_builder.get(), open_file_func, close_file_func,
+        prev_cpu_micros);
+  } else {
+    status = ProcessKeyValue(sub_compact, cfd, c_iter.get(), open_file_func,
+                             close_file_func, prev_cpu_micros);
+  }
 
   status = FinalizeProcessKeyValueStatus(cfd, input_iter, c_iter.get(), status);
 
@@ -2291,6 +2956,9 @@ bool CompactionJob::ShouldUpdateSubcompactionProgress(
     const ParsedInternalKey& prev_iter_output_internal_key,
     const Slice& next_table_min_internal_key, const FileMetaData* meta) const {
   const auto* cfd = sub_compact->compaction->column_family_data();
+  if (sub_compact->compaction->ShouldUseStreamAggregation()) {
+    return false;
+  }
   // No need to update when the progress will not get persisted
   if (compaction_progress_writer_ == nullptr) {
     return false;
@@ -3098,6 +3766,11 @@ Status CompactionJob::MaybeResumeSubcompactionProgressOnInputIterator(
       subcompaction_progress.proximal_output_level_progress
               .GetNumProcessedOutputRecords() == 0) {
     return Status::NotFound("No subcompaction progress to resume");
+  }
+
+  if (sub_compact->compaction->ShouldUseStreamAggregation()) {
+    return Status::NotSupported(
+        "StreamAggregation does not support resumable compaction");
   }
 
   ROCKS_LOG_INFO(db_options_.info_log, "[%s] [JOB %d] Resuming compaction : %s",

--- a/db/compaction/compaction_job.h
+++ b/db/compaction/compaction_job.h
@@ -57,6 +57,7 @@ class TableCache;
 class Version;
 class VersionEdit;
 class VersionSet;
+class StreamAggregation;
 
 class SubcompactionState;
 
@@ -395,7 +396,7 @@ class CompactionJob {
       SubcompactionState* sub_compact, ColumnFamilyData* cfd,
       InternalIterator* input_iter, const CompactionFilter* compaction_filter,
       MergeHelper& merge, std::unique_ptr<BlobFileBuilder>& blob_file_builder,
-      const WriteOptions& write_options);
+      const WriteOptions& write_options, bool use_stream_aggregation);
   std::pair<CompactionFileOpenFunc, CompactionFileCloseFunc> CreateFileHandlers(
       SubcompactionState* sub_compact, SubcompactionKeyBoundaries& boundaries);
   Status ProcessKeyValue(SubcompactionState* sub_compact, ColumnFamilyData* cfd,
@@ -403,6 +404,16 @@ class CompactionJob {
                          const CompactionFileOpenFunc& open_file_func,
                          const CompactionFileCloseFunc& close_file_func,
                          uint64_t& prev_cpu_micros);
+  Status SetupAndValidateStreamAggregation(
+      SubcompactionState* sub_compact,
+      std::unique_ptr<StreamAggregation>* aggregation);
+  Status ProcessKeyValueWithStreamAggregation(
+      SubcompactionState* sub_compact, ColumnFamilyData* cfd,
+      CompactionIterator* c_iter, StreamAggregation* aggregation,
+      BlobFileBuilder* blob_file_builder,
+      const CompactionFileOpenFunc& open_file_func,
+      const CompactionFileCloseFunc& close_file_func,
+      uint64_t& prev_cpu_micros);
   void UpdateSubcompactionJobStatsIncrementally(
       CompactionIterator* c_iter, CompactionJobStats* compaction_job_stats,
       uint64_t cur_cpu_micros, uint64_t& prev_cpu_micros);

--- a/db/compaction/compaction_outputs.cc
+++ b/db/compaction/compaction_outputs.cc
@@ -232,9 +232,8 @@ uint64_t CompactionOutputs::GetCurrentKeyGrandparentOverlappedBytes(
   return overlapped_bytes;
 }
 
-bool CompactionOutputs::ShouldStopBefore(const CompactionIterator& c_iter) {
-  assert(c_iter.Valid());
-  const Slice& internal_key = c_iter.key();
+bool CompactionOutputs::ShouldStopBefore(const CompactionOutputRecord& record) {
+  const Slice& internal_key = record.key;
 #ifndef NDEBUG
   bool should_stop = false;
   std::pair<bool*, const Slice> p{&should_stop, internal_key};
@@ -272,13 +271,13 @@ bool CompactionOutputs::ShouldStopBefore(const CompactionIterator& c_iter) {
       // Fast path: no per-key copy or virtual call. A partition is requested at
       // the first key that no longer shares the established prefix. An empty
       // prefix means no further partitions (every key "starts with" it).
-      if (UNLIKELY(!c_iter.user_key().starts_with(partitioner_prefix_))) {
+      if (UNLIKELY(!record.user_key().starts_with(partitioner_prefix_))) {
         return true;
       }
     } else {
       // Slow path: per-key callback (and copy elsewhere)
       if (UNLIKELY(partitioner_->ShouldPartition(PartitionerRequest(
-                       last_key_for_partitioner_, c_iter.user_key(),
+                       last_key_for_partitioner_, record.user_key(),
                        current_output_file_size_)) == kRequired)) {
         return true;
       }
@@ -374,22 +373,23 @@ bool CompactionOutputs::ShouldStopBefore(const CompactionIterator& c_iter) {
 }
 
 Status CompactionOutputs::AddToOutput(
-    const CompactionIterator& c_iter,
+    const CompactionOutputRecord& record, const CompactionIterator& source_iter,
     const CompactionFileOpenFunc& open_file_func,
     const CompactionFileCloseFunc& close_file_func,
     const ParsedInternalKey& prev_iter_output_internal_key) {
   Status s;
-  bool is_range_del = c_iter.IsDeleteRangeSentinelKey();
+  bool is_range_del = record.is_range_del;
   if (is_range_del && compaction_->bottommost_level()) {
     // We don't consider range tombstone for bottommost level since:
     // 1. there is no grandparent and hence no overlap to consider
     // 2. range tombstone may be dropped at bottommost level.
     return s;
   }
-  const Slice& key = c_iter.key();
-  if (ShouldStopBefore(c_iter) && HasBuilder()) {
-    s = close_file_func(c_iter.InputStatus(), prev_iter_output_internal_key,
-                        key, &c_iter, *this);
+  const Slice& key = record.key;
+  if (ShouldStopBefore(record) && HasBuilder()) {
+    s = close_file_func(source_iter.InputStatus(),
+                        prev_iter_output_internal_key, key, &source_iter,
+                        *this);
     if (!s.ok()) {
       return s;
     }
@@ -421,7 +421,7 @@ Status CompactionOutputs::AddToOutput(
     // just recomputes the same still-valid prefix.
     if (partitioner_) {
       OptSlice prefix =
-          partitioner_->ShouldPartitionByPrefix(c_iter.user_key());
+          partitioner_->ShouldPartitionByPrefix(record.user_key());
       partitioner_prefix_valid_ = prefix.has_value();
       if (partitioner_prefix_valid_) {
         partitioner_prefix_.assign(prefix->data(), prefix->size());
@@ -429,12 +429,12 @@ Status CompactionOutputs::AddToOutput(
     }
   }
 
-  // c_iter may emit range deletion keys, so update `last_key_for_partitioner_`
-  // here before returning below when `is_range_del` is true. Only needed in the
+  // The record may be a range deletion key, so update
+  // `last_key_for_partitioner_` before returning below. Only needed in the
   // fallback mode; the prefix fast path does not use it.
   if (partitioner_ && !partitioner_prefix_valid_) {
-    last_key_for_partitioner_.assign(c_iter.user_key().data_,
-                                     c_iter.user_key().size_);
+    last_key_for_partitioner_.assign(record.user_key().data_,
+                                     record.user_key().size_);
   }
 
   if (UNLIKELY(is_range_del)) {
@@ -442,7 +442,7 @@ Status CompactionOutputs::AddToOutput(
   }
 
   assert(builder_ != nullptr);
-  const Slice& value = c_iter.value();
+  const Slice& value = record.value;
   s = current_output().validator.Add(key, value);
   if (!s.ok()) {
     return s;
@@ -460,7 +460,7 @@ Status CompactionOutputs::AddToOutput(
     return s;
   }
 
-  const ParsedInternalKey& ikey = c_iter.ikey();
+  const ParsedInternalKey& ikey = record.ikey;
   if (ikey.type == kTypeValuePreferredSeqno) {
     SequenceNumber preferred_seqno = ParsePackedValueForSeqno(value);
     smallest_preferred_seqno_ =

--- a/db/compaction/compaction_outputs.h
+++ b/db/compaction/compaction_outputs.h
@@ -19,6 +19,16 @@
 namespace ROCKSDB_NAMESPACE {
 
 class CompactionOutputs;
+
+struct CompactionOutputRecord {
+  Slice key;
+  Slice value;
+  ParsedInternalKey ikey;
+  bool is_range_del = false;
+
+  Slice user_key() const { return ikey.user_key; }
+};
+
 using CompactionFileOpenFunc = std::function<Status(CompactionOutputs&)>;
 using CompactionFileCloseFunc =
     std::function<Status(const Status&, const ParsedInternalKey&, const Slice&,
@@ -243,7 +253,7 @@ class CompactionOutputs {
 
   // Returns true iff we should stop building the current output
   // before processing the current key in compaction iterator.
-  bool ShouldStopBefore(const CompactionIterator& c_iter);
+  bool ShouldStopBefore(const CompactionOutputRecord& record);
 
   void Cleanup() {
     if (builder_ != nullptr) {
@@ -271,9 +281,10 @@ class CompactionOutputs {
   uint64_t GetCurrentKeyGrandparentOverlappedBytes(
       const Slice& internal_key) const;
 
-  // Add current key from compaction_iterator to the output file. If needed
-  // close and open new compaction output with the functions provided.
-  Status AddToOutput(const CompactionIterator& c_iter,
+  // Add a compaction output record to the output file. If needed, close and
+  // open compaction output files with the functions provided.
+  Status AddToOutput(const CompactionOutputRecord& record,
+                     const CompactionIterator& source_iter,
                      const CompactionFileOpenFunc& open_file_func,
                      const CompactionFileCloseFunc& close_file_func,
                      const ParsedInternalKey& prev_iter_output_internal_key);

--- a/db/compaction/subcompaction_state.cc
+++ b/db/compaction/subcompaction_state.cc
@@ -106,14 +106,15 @@ Slice SubcompactionState::LargestUserKey() const {
 }
 
 Status SubcompactionState::AddToOutput(
-    const CompactionIterator& iter, bool use_proximal_output,
-    const CompactionFileOpenFunc& open_file_func,
+    const CompactionOutputRecord& record, const CompactionIterator& source_iter,
+    bool use_proximal_output, const CompactionFileOpenFunc& open_file_func,
     const CompactionFileCloseFunc& close_file_func,
     const ParsedInternalKey& prev_iter_output_internal_key) {
   // update target output
   current_outputs_ =
       use_proximal_output ? &proximal_level_outputs_ : &compaction_outputs_;
-  return current_outputs_->AddToOutput(iter, open_file_func, close_file_func,
+  return current_outputs_->AddToOutput(record, source_iter, open_file_func,
+                                       close_file_func,
                                        prev_iter_output_internal_key);
 }
 

--- a/db/compaction/subcompaction_state.h
+++ b/db/compaction/subcompaction_state.h
@@ -69,6 +69,9 @@ class SubcompactionState {
   // compaction job stats for this sub-compaction
   CompactionJobStats compaction_job_stats;
 
+  // Statistics produced after logical CompactionIterator processing.
+  CompactionIterationStats stream_aggregation_stats;
+
   // sub-compaction job id, which is used to identify different sub-compaction
   // within the same compaction job.
   const uint32_t sub_job_id;
@@ -234,8 +237,10 @@ class SubcompactionState {
     return subcompaction_progress_;
   }
 
-  // Add compaction_iterator key/value to the `Current` output group.
-  Status AddToOutput(const CompactionIterator& iter, bool use_proximal_output,
+  // Add a record to the `Current` output group.
+  Status AddToOutput(const CompactionOutputRecord& record,
+                     const CompactionIterator& source_iter,
+                     bool use_proximal_output,
                      const CompactionFileOpenFunc& open_file_func,
                      const CompactionFileCloseFunc& close_file_func,
                      const ParsedInternalKey& prev_iter_output_internal_key);

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -25,7 +25,9 @@
 #include "rocksdb/experimental.h"
 #include "rocksdb/file_checksum.h"
 #include "rocksdb/iostats_context.h"
+#include "rocksdb/lazy_wide_columns.h"
 #include "rocksdb/sst_file_writer.h"
+#include "rocksdb/stream_aggregation.h"
 #include "test_util/mock_time_env.h"
 #include "test_util/sync_point.h"
 #include "test_util/testutil.h"
@@ -13198,6 +13200,1089 @@ TEST_F(DBCompactionTest, CompactionFilterLargeValueRejected) {
   Status s = db_->CompactRange(CompactRangeOptions(), nullptr, nullptr);
   ASSERT_TRUE(s.IsCorruption()) << s.ToString();
   ASSERT_TRUE(s.ToString().find("4GB") != std::string::npos) << s.ToString();
+}
+
+namespace {
+
+class TestStreamAggregation : public StreamAggregation {
+ public:
+  Status Aggregate(const std::vector<Input>& inputs, size_t* num_consumed,
+                   std::vector<OutputSegment>* outputs) override {
+    assert(num_consumed != nullptr);
+    assert(outputs != nullptr);
+    assert(!inputs.empty());
+
+    *num_consumed = inputs.size();
+    outputs->clear();
+
+    for (size_t i = 0; i < inputs.size();) {
+      if (inputs[i].user_key == "a" && i + 1 < inputs.size() &&
+          inputs[i + 1].user_key == "b") {
+        assert(inputs[i].value != nullptr);
+        assert(inputs[i + 1].value != nullptr);
+        OutputSegment packed;
+        packed.input_begin = i;
+        packed.input_end = i + 2;
+        packed.anchor_input_index = i;
+        packed.action = OutputAction::kEmit;
+        packed.value_type = ValueType::kValue;
+        packed.value = inputs[i].value->ToString();
+        packed.value.append(inputs[i + 1].value->data(),
+                            inputs[i + 1].value->size());
+        outputs->push_back(std::move(packed));
+        i += 2;
+      } else {
+        OutputSegment output;
+        output.input_begin = i;
+        output.input_end = i + 1;
+        output.action = inputs[i].user_key == "c" ? OutputAction::kDrop
+                                                  : OutputAction::kKeep;
+        outputs->push_back(std::move(output));
+        ++i;
+      }
+    }
+
+    return Status::OK();
+  }
+};
+
+class TestStreamAggregationFactory : public StreamAggregationFactory {
+ public:
+  explicit TestStreamAggregationFactory(int* create_count)
+      : create_count_(create_count) {}
+
+  const char* Name() const override { return "TestStreamAggregationFactory"; }
+
+  std::unique_ptr<StreamAggregation> Create(
+      const Context& context) const override {
+    assert(context.is_full_compaction);
+    ++*create_count_;
+    return std::make_unique<TestStreamAggregation>();
+  }
+
+ private:
+  int* create_count_;
+};
+
+class StreamAggregationTestFilter : public CompactionFilter {
+ public:
+  Decision FilterV2(int /*level*/, const Slice& key, ValueType /*value_type*/,
+                    const Slice& /*existing_value*/, std::string* new_value,
+                    std::string* /*skip_until*/) const override {
+    if (key == "a") {
+      *new_value = "filtered-a";
+      return Decision::kChangeValue;
+    }
+    if (key == "c") {
+      return Decision::kRemove;
+    }
+    return Decision::kKeep;
+  }
+
+  const char* Name() const override { return "StreamAggregationTestFilter"; }
+};
+
+class GroupedHistoryStreamAggregation : public StreamAggregation {
+ public:
+  Status Aggregate(const std::vector<Input>& inputs, size_t* num_consumed,
+                   std::vector<OutputSegment>* outputs) override {
+    *num_consumed = inputs.size();
+    outputs->clear();
+
+    for (size_t group_begin = 0; group_begin < inputs.size();) {
+      const std::string group = Group(inputs[group_begin].user_key);
+      size_t group_end = group_begin + 1;
+      while (group_end < inputs.size() &&
+             Group(inputs[group_end].user_key) == group) {
+        ++group_end;
+      }
+
+      OutputSegment output;
+      output.input_begin = group_begin;
+      output.input_end = group_end;
+      if (group_end - group_begin == 1) {
+        output.action = OutputAction::kKeep;
+      } else {
+        output.anchor_input_index = group_begin;
+        output.action = OutputAction::kEmit;
+        output.value_type = ValueType::kValue;
+        for (size_t i = group_begin; i < group_end; ++i) {
+          assert(inputs[i].value != nullptr);
+          if (!output.value.empty()) {
+            output.value.append(",");
+          }
+          output.value.append(inputs[i].value->data(), inputs[i].value->size());
+        }
+      }
+      outputs->push_back(std::move(output));
+      group_begin = group_end;
+    }
+
+    return Status::OK();
+  }
+
+ private:
+  static std::string Group(const Slice& key) {
+    const std::string key_string = key.ToString();
+    const size_t timestamp_separator = key_string.rfind('|');
+    assert(timestamp_separator != std::string::npos);
+    return key_string.substr(0, timestamp_separator);
+  }
+};
+
+class GroupedHistoryStreamAggregationFactory : public StreamAggregationFactory {
+ public:
+  const char* Name() const override {
+    return "GroupedHistoryStreamAggregationFactory";
+  }
+
+  std::unique_ptr<StreamAggregation> Create(
+      const Context& /*context*/) const override {
+    return std::make_unique<GroupedHistoryStreamAggregation>();
+  }
+};
+
+class InvalidStreamAggregation : public StreamAggregation {
+ public:
+  Status Aggregate(const std::vector<Input>& inputs, size_t* num_consumed,
+                   std::vector<OutputSegment>* outputs) override {
+    *num_consumed = inputs.size();
+    outputs->clear();
+    OutputSegment invalid;
+    invalid.input_begin = 1;
+    invalid.input_end = inputs.size();
+    invalid.action = OutputAction::kKeep;
+    outputs->push_back(std::move(invalid));
+    return Status::OK();
+  }
+};
+
+class InvalidStreamAggregationFactory : public StreamAggregationFactory {
+ public:
+  const char* Name() const override {
+    return "InvalidStreamAggregationFactory";
+  }
+
+  std::unique_ptr<StreamAggregation> Create(
+      const Context& /*context*/) const override {
+    return std::make_unique<InvalidStreamAggregation>();
+  }
+};
+
+class InvalidAnchorStreamAggregation : public StreamAggregation {
+ public:
+  Status Aggregate(const std::vector<Input>& inputs, size_t* num_consumed,
+                   std::vector<OutputSegment>* outputs) override {
+    *num_consumed = inputs.size();
+    outputs->clear();
+
+    OutputSegment invalid;
+    invalid.input_end = inputs.size();
+    invalid.anchor_input_index = inputs.size();
+    invalid.action = OutputAction::kEmit;
+    invalid.value = "invalid";
+    outputs->push_back(std::move(invalid));
+    return Status::OK();
+  }
+};
+
+class InvalidAnchorStreamAggregationFactory : public StreamAggregationFactory {
+ public:
+  const char* Name() const override {
+    return "InvalidAnchorStreamAggregationFactory";
+  }
+
+  std::unique_ptr<StreamAggregation> Create(
+      const Context& /*context*/) const override {
+    return std::make_unique<InvalidAnchorStreamAggregation>();
+  }
+};
+
+class DropAllStreamAggregation : public StreamAggregation {
+ public:
+  Status Aggregate(const std::vector<Input>& inputs, size_t* num_consumed,
+                   std::vector<OutputSegment>* outputs) override {
+    *num_consumed = inputs.size();
+    outputs->clear();
+
+    OutputSegment dropped;
+    dropped.input_end = inputs.size();
+    dropped.action = OutputAction::kDrop;
+    outputs->push_back(std::move(dropped));
+    return Status::OK();
+  }
+};
+
+class DropAllStreamAggregationFactory : public StreamAggregationFactory {
+ public:
+  const char* Name() const override {
+    return "DropAllStreamAggregationFactory";
+  }
+
+  std::unique_ptr<StreamAggregation> Create(
+      const Context& /*context*/) const override {
+    return std::make_unique<DropAllStreamAggregation>();
+  }
+};
+
+class AlwaysNeedsMoreStreamAggregation : public StreamAggregation {
+ public:
+  Status Aggregate(const std::vector<Input>& /*inputs*/, size_t* num_consumed,
+                   std::vector<OutputSegment>* outputs) override {
+    *num_consumed = 0;
+    outputs->clear();
+    return Status::OK();
+  }
+};
+
+class AlwaysNeedsMoreStreamAggregationFactory
+    : public StreamAggregationFactory {
+ public:
+  const char* Name() const override {
+    return "AlwaysNeedsMoreStreamAggregationFactory";
+  }
+
+  std::unique_ptr<StreamAggregation> Create(
+      const Context& /*context*/) const override {
+    return std::make_unique<AlwaysNeedsMoreStreamAggregation>();
+  }
+};
+
+class RefillStreamAggregation : public StreamAggregation {
+ public:
+  RefillStreamAggregation(std::vector<size_t>* aggregate_batch_sizes,
+                          size_t* finish_batch_size)
+      : aggregate_batch_sizes_(aggregate_batch_sizes),
+        finish_batch_size_(finish_batch_size) {}
+
+  Status Aggregate(const std::vector<Input>& inputs, size_t* num_consumed,
+                   std::vector<OutputSegment>* outputs) override {
+    aggregate_batch_sizes_->push_back(inputs.size());
+    *num_consumed = std::min<size_t>(128, inputs.size());
+    outputs->clear();
+
+    OutputSegment kept;
+    kept.input_end = *num_consumed;
+    kept.action = OutputAction::kKeep;
+    outputs->push_back(std::move(kept));
+    return Status::OK();
+  }
+
+  Status Finish(const std::vector<Input>& inputs,
+                std::vector<OutputSegment>* outputs) override {
+    *finish_batch_size_ = inputs.size();
+    outputs->clear();
+
+    OutputSegment kept;
+    kept.input_end = inputs.size();
+    kept.action = OutputAction::kKeep;
+    outputs->push_back(std::move(kept));
+    return Status::OK();
+  }
+
+ private:
+  std::vector<size_t>* aggregate_batch_sizes_;
+  size_t* finish_batch_size_;
+};
+
+class RefillStreamAggregationFactory : public StreamAggregationFactory {
+ public:
+  RefillStreamAggregationFactory(std::vector<size_t>* aggregate_batch_sizes,
+                                 size_t* finish_batch_size)
+      : aggregate_batch_sizes_(aggregate_batch_sizes),
+        finish_batch_size_(finish_batch_size) {}
+
+  const char* Name() const override { return "RefillStreamAggregationFactory"; }
+
+  std::unique_ptr<StreamAggregation> Create(
+      const Context& /*context*/) const override {
+    return std::make_unique<RefillStreamAggregation>(aggregate_batch_sizes_,
+                                                     finish_batch_size_);
+  }
+
+ private:
+  std::vector<size_t>* aggregate_batch_sizes_;
+  size_t* finish_batch_size_;
+};
+
+class LookaheadStreamAggregation : public StreamAggregation {
+ public:
+  LookaheadStreamAggregation(size_t* aggregate_calls,
+                             bool* requested_more_input)
+      : aggregate_calls_(aggregate_calls),
+        requested_more_input_(requested_more_input) {}
+
+  Status Aggregate(const std::vector<Input>& inputs, size_t* num_consumed,
+                   std::vector<OutputSegment>* outputs) override {
+    ++*aggregate_calls_;
+    outputs->clear();
+
+    size_t boundary = 0;
+    while (boundary < inputs.size() && inputs[boundary].user_key != "z") {
+      ++boundary;
+    }
+    if (boundary == inputs.size()) {
+      *requested_more_input_ = true;
+      *num_consumed = 0;
+      return Status::OK();
+    }
+    if (boundary == 0) {
+      *num_consumed = 1;
+      OutputSegment kept;
+      kept.input_end = 1;
+      kept.action = OutputAction::kKeep;
+      outputs->push_back(std::move(kept));
+      return Status::OK();
+    }
+
+    *num_consumed = boundary;
+    AddPackedPrefix(boundary, outputs);
+    return Status::OK();
+  }
+
+  Status Finish(const std::vector<Input>& inputs,
+                std::vector<OutputSegment>* outputs) override {
+    outputs->clear();
+
+    size_t boundary = 0;
+    while (boundary < inputs.size() && inputs[boundary].user_key != "z") {
+      ++boundary;
+    }
+    if (boundary > 0) {
+      AddPackedPrefix(boundary, outputs);
+    }
+    if (boundary < inputs.size()) {
+      OutputSegment kept;
+      kept.input_begin = boundary;
+      kept.input_end = inputs.size();
+      kept.action = OutputAction::kKeep;
+      outputs->push_back(std::move(kept));
+    }
+    return Status::OK();
+  }
+
+ private:
+  static void AddPackedPrefix(size_t input_end,
+                              std::vector<OutputSegment>* outputs) {
+    OutputSegment packed;
+    packed.input_end = input_end;
+    packed.anchor_input_index = input_end / 2;
+    packed.action = OutputAction::kEmit;
+    packed.value_type = ValueType::kValue;
+    packed.value = std::to_string(input_end);
+    outputs->push_back(std::move(packed));
+  }
+
+  size_t* aggregate_calls_;
+  bool* requested_more_input_;
+};
+
+class LookaheadStreamAggregationFactory : public StreamAggregationFactory {
+ public:
+  LookaheadStreamAggregationFactory(size_t* aggregate_calls,
+                                    bool* requested_more_input)
+      : aggregate_calls_(aggregate_calls),
+        requested_more_input_(requested_more_input) {}
+
+  const char* Name() const override {
+    return "LookaheadStreamAggregationFactory";
+  }
+
+  std::unique_ptr<StreamAggregation> Create(
+      const Context& /*context*/) const override {
+    return std::make_unique<LookaheadStreamAggregation>(aggregate_calls_,
+                                                        requested_more_input_);
+  }
+
+ private:
+  size_t* aggregate_calls_;
+  bool* requested_more_input_;
+};
+
+class RejectingValidationStreamAggregationFactory
+    : public StreamAggregationFactory {
+ public:
+  RejectingValidationStreamAggregationFactory(bool* validate_called,
+                                              size_t* create_calls)
+      : validate_called_(validate_called), create_calls_(create_calls) {}
+
+  const char* Name() const override {
+    return "RejectingValidationStreamAggregationFactory";
+  }
+
+  Status Validate(const ValidationContext& context) const override {
+    *validate_called_ = true;
+    if (context.user_timestamp_size != 0) {
+      return Status::NotSupported("unexpected timestamp configuration");
+    }
+    return Status::InvalidArgument("aggregation contract evaluation failed");
+  }
+
+  std::unique_ptr<StreamAggregation> Create(
+      const Context& /*context*/) const override {
+    ++*create_calls_;
+    return std::make_unique<AlwaysNeedsMoreStreamAggregation>();
+  }
+
+ private:
+  bool* validate_called_;
+  size_t* create_calls_;
+};
+
+class WideEntityStreamAggregation : public StreamAggregation {
+ public:
+  explicit WideEntityStreamAggregation(std::vector<bool>* resolved_blob_columns)
+      : resolved_blob_columns_(resolved_blob_columns) {}
+
+  Status Aggregate(const std::vector<Input>& inputs, size_t* num_consumed,
+                   std::vector<OutputSegment>* outputs) override {
+    assert(!inputs.empty());
+    *num_consumed = inputs.size();
+    outputs->clear();
+
+    for (size_t i = 0; i < inputs.size();) {
+      if (i + 2 < inputs.size() && inputs[i].user_key == "a" &&
+          inputs[i + 1].user_key == "b" && inputs[i + 2].user_key == "c") {
+        std::string payload;
+        for (size_t j : {i, i + 2}) {
+          assert(inputs[j].value_type == ValueType::kWideColumnEntity);
+          assert(inputs[j].columns != nullptr);
+
+          size_t payload_index = inputs[j].columns->size();
+          for (size_t column_index = 0;
+               column_index < inputs[j].columns->size(); ++column_index) {
+            if ((*inputs[j].columns)[column_index].name() == "payload") {
+              payload_index = column_index;
+              break;
+            }
+          }
+          assert(payload_index < inputs[j].columns->size());
+
+          Slice payload_slice;
+          if (inputs[j].blob_resolver != nullptr &&
+              inputs[j].blob_resolver->IsBlobColumn(payload_index)) {
+            Status s = inputs[j].blob_resolver->ResolveColumn(payload_index,
+                                                              &payload_slice);
+            if (!s.ok()) {
+              return s;
+            }
+            (*resolved_blob_columns_)[j - i] = true;
+          } else {
+            payload_slice = (*inputs[j].columns)[payload_index].value();
+          }
+          payload.append(payload_slice.data(), payload_slice.size());
+        }
+
+        OutputSegment packed;
+        packed.input_begin = i;
+        packed.input_end = i + 3;
+        packed.anchor_input_index = i + 1;
+        packed.action = OutputAction::kEmit;
+        packed.value_type = ValueType::kWideColumnEntity;
+        packed.columns.emplace_back(kDefaultWideColumnName.ToString(), "2");
+        packed.columns.emplace_back("payload", std::move(payload));
+        outputs->push_back(std::move(packed));
+        i += 3;
+      } else {
+        OutputSegment kept;
+        kept.input_begin = i;
+        kept.input_end = i + 1;
+        kept.action = OutputAction::kKeep;
+        outputs->push_back(std::move(kept));
+        ++i;
+      }
+    }
+
+    return Status::OK();
+  }
+
+ private:
+  std::vector<bool>* resolved_blob_columns_;
+};
+
+class WideEntityStreamAggregationFactory : public StreamAggregationFactory {
+ public:
+  explicit WideEntityStreamAggregationFactory(
+      std::vector<bool>* resolved_blob_columns)
+      : resolved_blob_columns_(resolved_blob_columns) {}
+
+  const char* Name() const override {
+    return "WideEntityStreamAggregationFactory";
+  }
+
+  std::unique_ptr<StreamAggregation> Create(
+      const Context& /*context*/) const override {
+    return std::make_unique<WideEntityStreamAggregation>(
+        resolved_blob_columns_);
+  }
+
+ private:
+  std::vector<bool>* resolved_blob_columns_;
+};
+
+}  // namespace
+
+TEST_F(DBCompactionTest, StreamAggregationPackDropAndKeep) {
+  int create_count = 0;
+  Options options = CurrentOptions();
+  options.disable_auto_compactions = true;
+  options.num_levels = 3;
+  options.stream_aggregation_factory =
+      std::make_shared<TestStreamAggregationFactory>(&create_count);
+  DestroyAndReopen(options);
+
+  ASSERT_OK(Put("a", "va"));
+  ASSERT_OK(Put("b", "vb"));
+  ASSERT_OK(Put("c", "vc"));
+  ASSERT_OK(Put("d", "vd"));
+  ASSERT_OK(Flush());
+
+  CompactRangeOptions compact_options;
+  compact_options.bottommost_level_compaction =
+      BottommostLevelCompaction::kForce;
+  ASSERT_OK(db_->CompactRange(compact_options, nullptr, nullptr));
+
+  ASSERT_GE(create_count, 1);
+  ASSERT_EQ(Get("a"), "vavb");
+  ASSERT_EQ(Get("b"), "NOT_FOUND");
+  ASSERT_EQ(Get("c"), "NOT_FOUND");
+  ASSERT_EQ(Get("d"), "vd");
+}
+
+TEST_F(DBCompactionTest, StreamAggregationUniversalSingleLevel) {
+  int create_count = 0;
+  Options options = CurrentOptions();
+  options.compaction_style = kCompactionStyleUniversal;
+  options.compaction_options_universal.allow_trivial_move = true;
+  options.disable_auto_compactions = true;
+  options.num_levels = 1;
+  options.stream_aggregation_factory =
+      std::make_shared<TestStreamAggregationFactory>(&create_count);
+  DestroyAndReopen(options);
+
+  ASSERT_OK(Put("a", "va"));
+  ASSERT_OK(Put("b", "vb"));
+  ASSERT_OK(Flush());
+  ASSERT_OK(Put("c", "vc"));
+  ASSERT_OK(Put("d", "vd"));
+  ASSERT_OK(Flush());
+
+  CompactRangeOptions compact_options;
+  compact_options.bottommost_level_compaction =
+      BottommostLevelCompaction::kForce;
+  ASSERT_OK(db_->CompactRange(compact_options, nullptr, nullptr));
+
+  ASSERT_GE(create_count, 1);
+  ASSERT_EQ(Get("a"), "vavb");
+  ASSERT_EQ(Get("b"), "NOT_FOUND");
+  ASSERT_EQ(Get("c"), "NOT_FOUND");
+  ASSERT_EQ(Get("d"), "vd");
+}
+
+TEST_F(DBCompactionTest, StreamAggregationRunsInAutomaticFullCompaction) {
+  int create_count = 0;
+  Options options = CurrentOptions();
+  options.compaction_style = kCompactionStyleUniversal;
+  options.compaction_options_universal.allow_trivial_move = true;
+  options.level0_file_num_compaction_trigger = 2;
+  options.num_levels = 1;
+  options.stream_aggregation_factory =
+      std::make_shared<TestStreamAggregationFactory>(&create_count);
+  DestroyAndReopen(options);
+
+  ASSERT_OK(Put("a", "va"));
+  ASSERT_OK(Flush());
+  ASSERT_OK(Put("b", "vb"));
+  ASSERT_OK(Flush());
+  ASSERT_OK(dbfull()->TEST_WaitForCompact());
+
+  ASSERT_GE(create_count, 1);
+  ASSERT_EQ(Get("a"), "vavb");
+  ASSERT_EQ(Get("b"), "NOT_FOUND");
+}
+
+TEST_F(DBCompactionTest, StreamAggregationUniversalMultiLevel) {
+  int create_count = 0;
+  Options options = CurrentOptions();
+  options.compaction_style = kCompactionStyleUniversal;
+  options.compaction_options_universal.allow_trivial_move = true;
+  options.disable_auto_compactions = true;
+  options.num_levels = 4;
+  options.stream_aggregation_factory =
+      std::make_shared<TestStreamAggregationFactory>(&create_count);
+  DestroyAndReopen(options);
+
+  ASSERT_OK(Put("a", "va"));
+  ASSERT_OK(Put("b", "vb"));
+  ASSERT_OK(Flush());
+  ASSERT_OK(Put("c", "vc"));
+  ASSERT_OK(Put("d", "vd"));
+  ASSERT_OK(Flush());
+
+  CompactRangeOptions compact_options;
+  compact_options.bottommost_level_compaction =
+      BottommostLevelCompaction::kForce;
+  ASSERT_OK(db_->CompactRange(compact_options, nullptr, nullptr));
+
+  ASSERT_GE(create_count, 1);
+  ASSERT_EQ(NumTableFilesAtLevel(0), 0);
+  ASSERT_GT(NumTableFilesAtLevel(options.num_levels - 1), 0);
+  ASSERT_EQ(Get("a"), "vavb");
+  ASSERT_EQ(Get("b"), "NOT_FOUND");
+  ASSERT_EQ(Get("c"), "NOT_FOUND");
+  ASSERT_EQ(Get("d"), "vd");
+}
+
+TEST_F(DBCompactionTest, StreamAggregationRunsAfterCompactionFilter) {
+  StreamAggregationTestFilter filter;
+  int create_count = 0;
+  Options options = CurrentOptions();
+  options.compaction_style = kCompactionStyleUniversal;
+  options.compaction_filter = &filter;
+  options.disable_auto_compactions = true;
+  options.num_levels = 4;
+  options.stream_aggregation_factory =
+      std::make_shared<TestStreamAggregationFactory>(&create_count);
+  DestroyAndReopen(options);
+
+  ASSERT_OK(Put("a", "va"));
+  ASSERT_OK(Put("b", "vb"));
+  ASSERT_OK(Put("c", "vc"));
+  ASSERT_OK(Put("d", "vd"));
+  ASSERT_OK(Flush());
+
+  CompactRangeOptions compact_options;
+  compact_options.bottommost_level_compaction =
+      BottommostLevelCompaction::kForce;
+  ASSERT_OK(db_->CompactRange(compact_options, nullptr, nullptr));
+
+  ASSERT_GE(create_count, 1);
+  ASSERT_EQ(Get("a"), "filtered-avb");
+  ASSERT_EQ(Get("b"), "NOT_FOUND");
+  ASSERT_EQ(Get("c"), "NOT_FOUND");
+  ASSERT_EQ(Get("d"), "vd");
+}
+
+TEST_F(DBCompactionTest, StreamAggregationSkipsRangeTombstoneSentinels) {
+  int create_count = 0;
+  Options options = CurrentOptions();
+  options.disable_auto_compactions = true;
+  options.stream_aggregation_factory =
+      std::make_shared<TestStreamAggregationFactory>(&create_count);
+  DestroyAndReopen(options);
+
+  ASSERT_OK(Put("a", "va"));
+  ASSERT_OK(Put("b", "vb"));
+  ASSERT_OK(Put("d", "vd"));
+  ASSERT_OK(Flush());
+  ASSERT_OK(
+      db_->DeleteRange(WriteOptions(), db_->DefaultColumnFamily(), "a", "b"));
+  ASSERT_OK(Flush());
+
+  CompactRangeOptions compact_options;
+  compact_options.bottommost_level_compaction =
+      BottommostLevelCompaction::kForce;
+  ASSERT_OK(db_->CompactRange(compact_options, nullptr, nullptr));
+
+  ASSERT_GE(create_count, 1);
+  ASSERT_EQ(Get("a"), "NOT_FOUND");
+  ASSERT_EQ(Get("b"), "vb");
+  ASSERT_EQ(Get("d"), "vd");
+}
+
+TEST_F(DBCompactionTest, StreamAggregationSkipsNonFullCompactions) {
+  int create_count = 0;
+  Options options = CurrentOptions();
+  options.compaction_style = kCompactionStyleUniversal;
+  options.disable_auto_compactions = true;
+  options.num_levels = 4;
+  options.stream_aggregation_factory =
+      std::make_shared<TestStreamAggregationFactory>(&create_count);
+  DestroyAndReopen(options);
+
+  ASSERT_OK(Put("a", "va"));
+  ASSERT_OK(Put("b", "vb"));
+  ASSERT_OK(Flush());
+  ASSERT_OK(Put("c", "vc"));
+  ASSERT_OK(Put("d", "vd"));
+  ASSERT_OK(Flush());
+
+  ColumnFamilyMetaData metadata;
+  db_->GetColumnFamilyMetaData(&metadata);
+  ASSERT_EQ(metadata.levels[0].files.size(), 2U);
+  ASSERT_OK(db_->CompactFiles(CompactionOptions(),
+                              {metadata.levels[0].files.front().name}, 0));
+  ASSERT_EQ(create_count, 0);
+  ASSERT_EQ(Get("a"), "va");
+  ASSERT_EQ(Get("b"), "vb");
+
+  CompactRangeOptions compact_options;
+  compact_options.bottommost_level_compaction =
+      BottommostLevelCompaction::kForce;
+  ASSERT_OK(db_->CompactRange(compact_options, nullptr, nullptr));
+  ASSERT_GE(create_count, 1);
+  ASSERT_EQ(Get("a"), "vavb");
+  ASSERT_EQ(Get("b"), "NOT_FOUND");
+}
+
+TEST_F(DBCompactionTest, StreamAggregationUsesFirstKeyAsGroupAnchor) {
+  Options options = CurrentOptions();
+  options.disable_auto_compactions = true;
+  options.num_levels = 3;
+  options.stream_aggregation_factory =
+      std::make_shared<GroupedHistoryStreamAggregationFactory>();
+  DestroyAndReopen(options);
+
+  // The ordered suffix makes the first key the group's output anchor.
+  ASSERT_OK(Put("entity-a|0001", "event-300"));
+  ASSERT_OK(Put("entity-a|0002", "event-200"));
+  ASSERT_OK(Put("entity-a|0003", "event-100"));
+  ASSERT_OK(Put("entity-b|0001", "event-400"));
+  ASSERT_OK(Flush());
+
+  CompactRangeOptions compact_options;
+  compact_options.bottommost_level_compaction =
+      BottommostLevelCompaction::kForce;
+  ASSERT_OK(db_->CompactRange(compact_options, nullptr, nullptr));
+
+  ASSERT_EQ(Get("entity-a|0001"), "event-300,event-200,event-100");
+  ASSERT_EQ(Get("entity-a|0002"), "NOT_FOUND");
+  ASSERT_EQ(Get("entity-a|0003"), "NOT_FOUND");
+  ASSERT_EQ(Get("entity-b|0001"), "event-400");
+}
+
+TEST_F(DBCompactionTest, StreamAggregationRejectsInvalidSegments) {
+  Options options = CurrentOptions();
+  options.disable_auto_compactions = true;
+  options.num_levels = 3;
+  options.stream_aggregation_factory =
+      std::make_shared<InvalidStreamAggregationFactory>();
+  DestroyAndReopen(options);
+
+  ASSERT_OK(Put("a", "va"));
+  ASSERT_OK(Put("b", "vb"));
+  ASSERT_OK(Flush());
+
+  CompactRangeOptions compact_options;
+  compact_options.bottommost_level_compaction =
+      BottommostLevelCompaction::kForce;
+  Status s = db_->CompactRange(compact_options, nullptr, nullptr);
+  ASSERT_TRUE(s.IsInvalidArgument()) << s.ToString();
+
+  ASSERT_EQ(Get("a"), "va");
+  ASSERT_EQ(Get("b"), "vb");
+}
+
+TEST_F(DBCompactionTest, StreamAggregationRejectsInvalidAnchor) {
+  Options options = CurrentOptions();
+  options.disable_auto_compactions = true;
+  options.stream_aggregation_factory =
+      std::make_shared<InvalidAnchorStreamAggregationFactory>();
+  DestroyAndReopen(options);
+
+  ASSERT_OK(Put("a", "va"));
+  ASSERT_OK(Put("b", "vb"));
+  ASSERT_OK(Flush());
+
+  CompactRangeOptions compact_options;
+  compact_options.bottommost_level_compaction =
+      BottommostLevelCompaction::kForce;
+  Status status = db_->CompactRange(compact_options, nullptr, nullptr);
+  ASSERT_TRUE(status.IsInvalidArgument()) << status.ToString();
+  ASSERT_EQ(Get("a"), "va");
+  ASSERT_EQ(Get("b"), "vb");
+}
+
+TEST_F(DBCompactionTest, StreamAggregationDropsAllWithoutTombstones) {
+  Options options = CurrentOptions();
+  options.disable_auto_compactions = true;
+  options.num_levels = 3;
+  options.statistics = CreateDBStatistics();
+  options.stream_aggregation_factory =
+      std::make_shared<DropAllStreamAggregationFactory>();
+  DestroyAndReopen(options);
+
+  ASSERT_OK(Put("a", "va"));
+  ASSERT_OK(Put("b", "vb"));
+  ASSERT_OK(Flush());
+  ASSERT_GT(TotalTableFiles(), 0);
+
+  CompactRangeOptions compact_options;
+  compact_options.bottommost_level_compaction =
+      BottommostLevelCompaction::kForce;
+  ASSERT_OK(db_->CompactRange(compact_options, nullptr, nullptr));
+
+  ASSERT_EQ(Get("a"), "NOT_FOUND");
+  ASSERT_EQ(Get("b"), "NOT_FOUND");
+  ASSERT_EQ(TotalTableFiles(), 0);
+  ASSERT_EQ(options.statistics->getTickerCount(COMPACTION_KEY_DROP_USER), 2U);
+}
+
+TEST_F(DBCompactionTest, StreamAggregationValidationFailsAtOpen) {
+  bool validate_called = false;
+  size_t create_calls = 0;
+  Options options = CurrentOptions();
+  options.disable_auto_compactions = true;
+  options.stream_aggregation_factory =
+      std::make_shared<RejectingValidationStreamAggregationFactory>(
+          &validate_called, &create_calls);
+  Status status = TryReopen(options);
+  ASSERT_TRUE(status.IsInvalidArgument()) << status.ToString();
+  ASSERT_TRUE(validate_called);
+  ASSERT_EQ(create_calls, 0U);
+}
+
+TEST_F(DBCompactionTest, StreamAggregationRefillsAfterConsumption) {
+  std::vector<size_t> aggregate_batch_sizes;
+  size_t finish_batch_size = 0;
+  Options options = CurrentOptions();
+  options.disable_auto_compactions = true;
+  options.num_levels = 3;
+  options.stream_aggregation_factory =
+      std::make_shared<RefillStreamAggregationFactory>(&aggregate_batch_sizes,
+                                                       &finish_batch_size);
+  DestroyAndReopen(options);
+
+  for (int i = 0; i < 500; ++i) {
+    ASSERT_OK(Put(Key(i), "v"));
+  }
+  ASSERT_OK(Flush());
+
+  CompactRangeOptions compact_options;
+  compact_options.bottommost_level_compaction =
+      BottommostLevelCompaction::kForce;
+  ASSERT_OK(db_->CompactRange(compact_options, nullptr, nullptr));
+
+  ASSERT_GE(aggregate_batch_sizes.size(), 2U);
+  ASSERT_EQ(aggregate_batch_sizes[0], 256U);
+  ASSERT_EQ(aggregate_batch_sizes[1], 256U);
+  ASSERT_GT(finish_batch_size, 0U);
+  ASSERT_EQ(Get(Key(0)), "v");
+  ASSERT_EQ(Get(Key(499)), "v");
+}
+
+TEST_F(DBCompactionTest, StreamAggregationRequestsMoreLookahead) {
+  size_t aggregate_calls = 0;
+  bool requested_more_input = false;
+  Options options = CurrentOptions();
+  options.compaction_style = kCompactionStyleUniversal;
+  options.compaction_options_universal.allow_trivial_move = true;
+  options.disable_auto_compactions = true;
+  options.num_levels = 1;
+  options.stream_aggregation_factory =
+      std::make_shared<LookaheadStreamAggregationFactory>(
+          &aggregate_calls, &requested_more_input);
+  DestroyAndReopen(options);
+
+  for (int i = 0; i < 300; ++i) {
+    ASSERT_OK(Put(Key(i), "v"));
+  }
+  ASSERT_OK(Put("z", "tail"));
+  ASSERT_OK(Flush());
+
+  CompactRangeOptions compact_options;
+  compact_options.bottommost_level_compaction =
+      BottommostLevelCompaction::kForce;
+  ASSERT_OK(db_->CompactRange(compact_options, nullptr, nullptr));
+
+  ASSERT_EQ(aggregate_calls, 1U);
+  ASSERT_TRUE(requested_more_input);
+  ASSERT_EQ(Get(Key(150)), "300");
+  ASSERT_EQ(Get(Key(0)), "NOT_FOUND");
+  ASSERT_EQ(Get(Key(299)), "NOT_FOUND");
+  ASSERT_EQ(Get("z"), "tail");
+
+  Arena arena;
+  ReadOptions read_options;
+  ScopedArenaPtr<InternalIterator> iter(
+      dbfull()->NewInternalIterator(read_options, &arena, kMaxSequenceNumber));
+  iter->SeekToFirst();
+  bool found_anchor = false;
+  while (iter->Valid()) {
+    if (iter->user_key() == Key(150)) {
+      ParsedInternalKey parsed_key(Slice(), 0, kTypeValue);
+      ASSERT_OK(ParseInternalKey(iter->key(), &parsed_key,
+                                 /*log_err_key=*/true));
+      ASSERT_EQ(parsed_key.sequence, 0U);
+      found_anchor = true;
+      break;
+    }
+    iter->Next();
+  }
+  ASSERT_OK(iter->status());
+  ASSERT_TRUE(found_anchor);
+}
+
+TEST_F(DBCompactionTest, StreamAggregationRejectsDeferredEOF) {
+  Options options = CurrentOptions();
+  options.disable_auto_compactions = true;
+  options.stream_aggregation_factory =
+      std::make_shared<AlwaysNeedsMoreStreamAggregationFactory>();
+  DestroyAndReopen(options);
+
+  ASSERT_OK(Put("a", "va"));
+  ASSERT_OK(Put("b", "vb"));
+  ASSERT_OK(Flush());
+
+  CompactRangeOptions compact_options;
+  compact_options.bottommost_level_compaction =
+      BottommostLevelCompaction::kForce;
+  Status status = db_->CompactRange(compact_options, nullptr, nullptr);
+  ASSERT_TRUE(status.IsInvalidArgument()) << status.ToString();
+  ASSERT_EQ(Get("a"), "va");
+  ASSERT_EQ(Get("b"), "vb");
+}
+
+TEST_F(DBCompactionTest, StreamAggregationRejectsBufferLimit) {
+  Options options = CurrentOptions();
+  options.disable_auto_compactions = true;
+  options.stream_aggregation_factory =
+      std::make_shared<AlwaysNeedsMoreStreamAggregationFactory>();
+  DestroyAndReopen(options);
+
+  for (int i = 0; i < 5; ++i) {
+    ASSERT_OK(Put(Key(i), "v"));
+  }
+  ASSERT_OK(Flush());
+
+  SyncPoint::GetInstance()->SetCallBack(
+      "CompactionJob::ProcessKeyValueWithStreamAggregation:"
+      "InputBufferLimits",
+      [](void* arg) {
+        auto* limits = static_cast<std::pair<size_t, uint64_t>*>(arg);
+        limits->first = 4;
+      });
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  CompactRangeOptions compact_options;
+  compact_options.bottommost_level_compaction =
+      BottommostLevelCompaction::kForce;
+  Status status = db_->CompactRange(compact_options, nullptr, nullptr);
+
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+
+  ASSERT_TRUE(status.IsMemoryLimit()) << status.ToString();
+  ASSERT_EQ(Get(Key(0)), "v");
+  ASSERT_EQ(Get(Key(4)), "v");
+}
+
+TEST_F(DBCompactionTest, StreamAggregationLazyWideColumnBlobInput) {
+  std::vector<bool> resolved_blob_columns(3, false);
+  Options options = CurrentOptions();
+  options.disable_auto_compactions = true;
+  options.num_levels = 3;
+  options.enable_blob_files = true;
+  options.blob_file_starting_level = 0;
+  options.min_blob_size = 32;
+  options.max_open_files = -1;
+  options.stream_aggregation_factory =
+      std::make_shared<WideEntityStreamAggregationFactory>(
+          &resolved_blob_columns);
+  DestroyAndReopen(options);
+
+  const std::string payload_a(100, 'a');
+  const std::string payload_b(100, 'b');
+  const std::string payload_c(100, 'c');
+  ASSERT_OK(
+      db_->PutEntity(WriteOptions(), db_->DefaultColumnFamily(), "a",
+                     {{kDefaultWideColumnName, "1"}, {"payload", payload_a}}));
+  ASSERT_OK(
+      db_->PutEntity(WriteOptions(), db_->DefaultColumnFamily(), "b",
+                     {{kDefaultWideColumnName, "1"}, {"payload", payload_b}}));
+  ASSERT_OK(
+      db_->PutEntity(WriteOptions(), db_->DefaultColumnFamily(), "c",
+                     {{kDefaultWideColumnName, "1"}, {"payload", payload_c}}));
+  ASSERT_OK(Flush());
+
+  CompactRangeOptions compact_options;
+  compact_options.bottommost_level_compaction =
+      BottommostLevelCompaction::kForce;
+  ASSERT_OK(db_->CompactRange(compact_options, nullptr, nullptr));
+  ASSERT_TRUE(resolved_blob_columns[0]);
+  ASSERT_FALSE(resolved_blob_columns[1]);
+  ASSERT_TRUE(resolved_blob_columns[2]);
+
+  LazyWideColumns lazy;
+  ASSERT_OK(db_->GetEntityLazy(ReadOptions(), db_->DefaultColumnFamily(), "b",
+                               &lazy));
+  ASSERT_EQ(lazy.size(), 2U);
+  ASSERT_EQ(lazy[0].name(), kDefaultWideColumnName);
+  ASSERT_FALSE(lazy[0].is_reference());
+  ASSERT_EQ(*lazy[0].inline_value(), "2");
+  ASSERT_EQ(lazy[1].name(), "payload");
+  ASSERT_TRUE(lazy[1].is_reference());
+
+  PinnableSlice payload;
+  ASSERT_OK(lazy.ResolveColumn(lazy[1], &payload));
+  ASSERT_EQ(payload, payload_a + payload_c);
+  ASSERT_EQ(Get("a"), "NOT_FOUND");
+  ASSERT_EQ(Get("c"), "NOT_FOUND");
+}
+
+TEST_F(DBCompactionTest, StreamAggregationSkipsForcedIntegratedBlobGC) {
+  int create_count = 0;
+  Options options = CurrentOptions();
+  options.disable_auto_compactions = true;
+  options.enable_blob_files = true;
+  options.blob_file_starting_level = 0;
+  options.min_blob_size = 32;
+  options.max_open_files = -1;
+  options.stream_aggregation_factory =
+      std::make_shared<TestStreamAggregationFactory>(&create_count);
+  DestroyAndReopen(options);
+
+  const std::string value_a(100, 'a');
+  const std::string value_b(100, 'b');
+  ASSERT_OK(Put("a", value_a));
+  ASSERT_OK(Put("b", value_b));
+  ASSERT_OK(Flush());
+  const std::string updated_value_a(100, 'c');
+  ASSERT_OK(Put("a", updated_value_a));
+  ASSERT_OK(Flush());
+
+  CompactRangeOptions compact_options;
+  compact_options.bottommost_level_compaction =
+      BottommostLevelCompaction::kForce;
+  compact_options.blob_garbage_collection_policy =
+      BlobGarbageCollectionPolicy::kForce;
+  ASSERT_OK(db_->CompactRange(compact_options, nullptr, nullptr));
+
+  ASSERT_EQ(create_count, 0);
+  ASSERT_EQ(Get("a"), updated_value_a);
+  ASSERT_EQ(Get("b"), value_b);
+}
+
+TEST_F(DBCompactionTest, StreamAggregationSkipsActiveSnapshot) {
+  int create_count = 0;
+  Options options = CurrentOptions();
+  options.disable_auto_compactions = true;
+  options.stream_aggregation_factory =
+      std::make_shared<TestStreamAggregationFactory>(&create_count);
+  DestroyAndReopen(options);
+
+  ASSERT_OK(Put("a", "va"));
+  ASSERT_OK(Put("b", "vb"));
+  ASSERT_OK(Flush());
+
+  const Snapshot* snapshot = db_->GetSnapshot();
+  ASSERT_NE(snapshot, nullptr);
+
+  CompactRangeOptions compact_options;
+  compact_options.bottommost_level_compaction =
+      BottommostLevelCompaction::kForce;
+  Status s = db_->CompactRange(compact_options, nullptr, nullptr);
+  ASSERT_OK(s);
+  ASSERT_EQ(create_count, 0);
+
+  db_->ReleaseSnapshot(snapshot);
+  ASSERT_EQ(Get("a"), "va");
+  ASSERT_EQ(Get("b"), "vb");
+
+  ASSERT_OK(db_->CompactRange(compact_options, nullptr, nullptr));
+  ASSERT_GE(create_count, 1);
+  ASSERT_EQ(Get("a"), "vavb");
+  ASSERT_EQ(Get("b"), "NOT_FOUND");
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -527,6 +527,7 @@ Status FlushJob::MemPurge() {
         ioptions.enforce_single_del_contracts,
         /*manual_compaction_canceled=*/kManualCompactionCanceledFalse,
         false /* must_count_input_entries */,
+        CompactionIterator::ValuePreparation::kApply,
         /*compaction=*/nullptr, compaction_filter.get(),
         /*shutting_down=*/nullptr, ioptions.info_log, full_history_ts_low);
 

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -1346,6 +1346,10 @@ DEFINE_bool(enable_compaction_filter, false,
             "If true, configures a compaction filter that returns a kRemove "
             "decision for deleted keys.");
 
+DEFINE_bool(use_keep_stream_aggregation, false,
+            "If true, configures a keep-all StreamAggregation and uses full "
+            "ranges for CompactRange operations.");
+
 DEFINE_bool(paranoid_file_checks, true,
             "After writing every SST file, reopen it and read all the keys "
             "and validate checksums");

--- a/db_stress_tool/db_stress_shared_state.h
+++ b/db_stress_tool/db_stress_shared_state.h
@@ -54,6 +54,7 @@ DECLARE_int32(inject_error_severity);
 DECLARE_bool(tolerate_non_injected_io_errors_for_remote_dbs);
 DECLARE_bool(disable_auto_compactions);
 DECLARE_bool(enable_compaction_filter);
+DECLARE_bool(use_keep_stream_aggregation);
 
 namespace ROCKSDB_NAMESPACE {
 class StressTest;

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -23,6 +23,7 @@
 #include "rocksdb/io_status.h"
 #include "rocksdb/options.h"
 #include "rocksdb/slice_transform.h"
+#include "rocksdb/stream_aggregation.h"
 #include "util/compression.h"
 #ifdef GFLAGS
 #include "db_stress_tool/db_stress_common.h"
@@ -60,6 +61,28 @@ namespace ROCKSDB_NAMESPACE {
 namespace {
 
 constexpr int kMaxAbortResumeCompactionsSleepMicros = 3 * 1000 * 1000;
+
+class KeepStreamAggregation : public StreamAggregation {
+ public:
+  Status Aggregate(const std::vector<Input>& inputs, size_t* num_consumed,
+                   std::vector<OutputSegment>* outputs) override {
+    *num_consumed = inputs.size();
+    outputs->clear();
+    outputs->emplace_back();
+    outputs->back().input_end = inputs.size();
+    return Status::OK();
+  }
+};
+
+class KeepStreamAggregationFactory : public StreamAggregationFactory {
+ public:
+  const char* Name() const override { return "KeepStreamAggregationFactory"; }
+
+  std::unique_ptr<StreamAggregation> Create(
+      const Context& /*context*/) const override {
+    return std::make_unique<KeepStreamAggregation>();
+  }
+};
 
 class ScopedThreadOperation {
  public:
@@ -4934,7 +4957,12 @@ void StressTest::TestCompactRange(ThreadState* thread, int64_t rand_key,
                         << static_cast<int>(cro.blob_garbage_collection_policy)
                         << ", blob_garbage_collection_age_cutoff: "
                         << cro.blob_garbage_collection_age_cutoff;
-  Status status = db_->CompactRange(cro, column_family, &start_key, &end_key);
+  const Slice* compaction_start =
+      FLAGS_use_keep_stream_aggregation ? nullptr : &start_key;
+  const Slice* compaction_end =
+      FLAGS_use_keep_stream_aggregation ? nullptr : &end_key;
+  Status status =
+      db_->CompactRange(cro, column_family, compaction_start, compaction_end);
 
   // Verify before the fail-fast: a corruption that CompactRange itself returns
   // must be recorded (CORRUPTION) before we flag failure, or it mis-buckets.
@@ -6522,6 +6550,10 @@ void InitializeOptionsFromFlags(
   if (FLAGS_enable_compaction_filter) {
     options.compaction_filter_factory =
         std::make_shared<DbStressCompactionFilterFactory>();
+  }
+  if (FLAGS_use_keep_stream_aggregation) {
+    options.stream_aggregation_factory =
+        std::make_shared<KeepStreamAggregationFactory>();
   }
 
   options.best_efforts_recovery = FLAGS_best_efforts_recovery;

--- a/include/rocksdb/compaction_filter.h
+++ b/include/rocksdb/compaction_filter.h
@@ -26,8 +26,8 @@ class Slice;
 class SliceTransform;
 
 // Interface for lazily resolving blob values within wide-column entities.
-// This allows compaction filters to access blob column values on-demand,
-// avoiding unnecessary I/O for blob columns that the filter doesn't need.
+// This allows compaction callbacks to access blob column values on-demand,
+// avoiding unnecessary I/O for blob columns that the callback doesn't need.
 //
 // Usage in CompactionFilter::FilterV4():
 //   if (blob_resolver != nullptr) {
@@ -39,17 +39,16 @@ class SliceTransform;
 //     }
 //   }
 //
-// Thread safety: A resolver instance is used by a single thread (the
-// compaction thread). All resolved values remain valid until FilterV4
-// returns. Multiple columns can be resolved and their values compared
-// without copying.
+// Thread safety: A resolver instance is used by a single compaction thread.
+// All resolved values remain valid until the current callback returns.
+// Multiple columns can be resolved and their values compared without copying.
 class WideColumnBlobResolver {
  public:
   virtual ~WideColumnBlobResolver() = default;
 
   // Resolve the value for the column at the given index.
   // Returns OK on success, with resolved_value pointing to the data.
-  // The resolved_value remains valid until FilterV4 returns.
+  // The resolved_value remains valid until the current callback returns.
   //
   // For blob columns: fetches the blob value from the blob file.
   // For non-blob (inline) columns: returns the inline value directly.
@@ -65,7 +64,7 @@ class WideColumnBlobResolver {
   virtual Status ResolveColumn(size_t column_index, Slice* resolved_value) = 0;
 
   // Resolve multiple columns in the order provided by `column_indices`.
-  // The returned slices remain valid until FilterV4 returns.
+  // The returned slices remain valid until the current callback returns.
   //
   // The default implementation calls ResolveColumn() repeatedly. Resolver
   // implementations may override this to batch or optimize I/O in the future.

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -41,6 +41,7 @@ namespace ROCKSDB_NAMESPACE {
 class Cache;
 class CompactionFilter;
 class CompactionFilterFactory;
+class StreamAggregationFactory;
 class Comparator;
 class ConcurrentTaskLimiter;
 class Env;
@@ -168,6 +169,23 @@ struct ColumnFamilyOptions : public AdvancedColumnFamilyOptions {
   //
   // Default: nullptr
   std::shared_ptr<CompactionFilterFactory> compaction_filter_factory = nullptr;
+
+  // EXPERIMENTAL and subject to change.
+  //
+  // When non-null, RocksDB applies a StreamAggregation while rewriting every
+  // SST file in a full compaction. Non-full compactions preserve the ordinary
+  // one-record-at-a-time output path. Full compactions using this option run
+  // locally with one subcompaction so the callback observes one ordered input
+  // stream. Compactions with active snapshots preserve ordinary compaction
+  // behavior instead of aggregating.
+  //
+  // Later writes to retained anchor keys must understand the transformed
+  // representation. If a CompactionFilter is configured, it runs before
+  // aggregation; aggregate outputs are not filtered a second time.
+  //
+  // Default: nullptr
+  std::shared_ptr<StreamAggregationFactory> stream_aggregation_factory =
+      nullptr;
 
   // -------------------
   // Parameters that affect performance

--- a/include/rocksdb/stream_aggregation.h
+++ b/include/rocksdb/stream_aggregation.h
@@ -1,0 +1,197 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// This source code is licensed under both the GPLv2 (found in the
+// COPYING file in the root directory) and Apache 2.0 License
+// (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "rocksdb/compaction_filter.h"
+#include "rocksdb/rocksdb_namespace.h"
+#include "rocksdb/slice.h"
+#include "rocksdb/status.h"
+#include "rocksdb/types.h"
+#include "rocksdb/wide_columns.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+// EXPERIMENTAL and subject to change.
+//
+// StreamAggregation replaces contiguous groups of compaction output records
+// with aggregate records anchored at a subset of the input user keys. It is a
+// physical-schema transformation: applications must use a logical reader that
+// understands both the original row representation and aggregate records.
+// Ordinary point Get(), iteration, snapshots, and deletes on absorbed user
+// keys are not preserved by this interface.
+//
+// The application must ensure ordinary writes to retained anchor keys cannot
+// replace an entire transformed group. Subsequent updates must use the
+// application's logical row/chunk write path.
+//
+// A factory is configured through ColumnFamilyOptions. RocksDB invokes it for
+// full compactions, where the inputs include every SST in the column family.
+// Non-full compactions proceed without stream aggregation.
+//
+// Range tombstones are processed by RocksDB and are not included in the input
+// passed to StreamAggregation. When integrated blob garbage collection is
+// enabled, full compactions proceed without stream aggregation so blob
+// references are relocated by the ordinary compaction path.
+//
+// When a CompactionFilter is configured, it runs on individual records before
+// they reach StreamAggregation. Records removed by the filter are absent from
+// the aggregation input, and changed values are visible to the aggregator.
+// Values emitted by StreamAggregation are not filtered again.
+class StreamAggregation {
+ public:
+  static constexpr size_t kInvalidInputIndex =
+      std::numeric_limits<size_t>::max();
+  static constexpr size_t kMaxBufferedInputRecords = 100000;
+  static constexpr uint64_t kMaxBufferedInputBytes = 10 * 1024 * 1024;
+
+  enum class ValueType {
+    kValue,
+    kWideColumnEntity,
+  };
+
+  // One logical record produced by CompactionIterator after same-user-key
+  // history, merges, deletes, and sequence-number elision have been processed,
+  // but before output blob extraction.
+  //
+  // All pointers and Slices remain valid only for the duration of the current
+  // Aggregate() or Finish() call. For a wide-column entity, columns contains
+  // every column. When blob_resolver is non-null, blob-backed columns contain
+  // their serialized BlobIndex in columns and must be read through
+  // blob_resolver. Inline columns can be inspected directly without blob I/O.
+  struct Input {
+    Slice user_key;
+    SequenceNumber sequence = 0;
+    ValueType value_type = ValueType::kValue;
+    const Slice* value = nullptr;
+    const WideColumns* columns = nullptr;
+    WideColumnBlobResolver* blob_resolver = nullptr;
+  };
+
+  enum class OutputAction {
+    // Emit every input in this segment unchanged.
+    kKeep,
+
+    // Emit one replacement at an input user key selected by
+    // OutputSegment::anchor_input_index. RocksDB uses the anchor input's
+    // sequence number after normal compaction elision. Applications with
+    // timestamp-ordered keys can select the newest surviving input as the
+    // anchor. RocksDB does not interpret the user key. RocksDB also
+    // materializes output blob columns.
+    kEmit,
+
+    // Emit nothing for this segment. This is intended for retention trimming
+    // in a bottommost compaction where older versions cannot resurface.
+    kDrop,
+  };
+
+  // Describes one contiguous segment in the consumed input prefix. Segments
+  // returned from Aggregate() must be ordered, non-overlapping, and exactly
+  // partition [0, *num_consumed).
+  //
+  // For kEmit, anchor_input_index must be in [input_begin, input_end). For
+  // kValue, `value` is used and `columns` must be empty. For
+  // kWideColumnEntity, `columns` is used and `value` must be empty. kKeep and
+  // kDrop require both output value fields to be empty and ignore
+  // anchor_input_index.
+  struct OutputSegment {
+    size_t input_begin = 0;
+    size_t input_end = 0;
+    size_t anchor_input_index = kInvalidInputIndex;
+    OutputAction action = OutputAction::kKeep;
+    ValueType value_type = ValueType::kValue;
+    std::string value;
+    std::vector<std::pair<std::string, std::string>> columns;
+  };
+
+  virtual ~StreamAggregation() = default;
+
+  // Aggregates a non-empty, comparator-ordered batch. The implementation sets
+  // *num_consumed to a prefix length in [0, inputs.size()]. Returning zero
+  // with no output requests more lookahead. RocksDB retains the entire batch,
+  // appends more input, and calls Aggregate() again until the hard input
+  // buffer limits above are reached.
+  //
+  // When *num_consumed is positive, output segments must exactly partition
+  // [0, *num_consumed). They are structurally validated before RocksDB writes
+  // output for the consumed prefix.
+  //
+  // Implementations must be deterministic, bounded, side-effect free, and
+  // must not retain pointers or Slices after this call returns. Exceptions
+  // must not propagate into RocksDB.
+  virtual Status Aggregate(const std::vector<Input>& inputs,
+                           size_t* num_consumed,
+                           std::vector<OutputSegment>* outputs) = 0;
+
+  // Finalizes a non-empty batch after RocksDB reaches the end of one compaction
+  // job's input range. A compaction request can execute more than one job. On
+  // success, outputs must exactly partition every input. The default
+  // implementation calls Aggregate() once and rejects a partial or deferred
+  // result.
+  virtual Status Finish(const std::vector<Input>& inputs,
+                        std::vector<OutputSegment>* outputs) {
+    size_t num_consumed = 0;
+    Status status = Aggregate(inputs, &num_consumed, outputs);
+    if (!status.ok()) {
+      return status;
+    }
+    if (num_consumed != inputs.size()) {
+      return Status::InvalidArgument(
+          "StreamAggregation did not consume all input at EOF");
+    }
+    return Status::OK();
+  }
+
+  // Limits transformed output memory. This limit must be non-zero.
+  virtual uint64_t MaxBatchOutputBytes() const { return 8 * 1024 * 1024; }
+};
+
+// EXPERIMENTAL and subject to change.
+class StreamAggregationFactory {
+ public:
+  struct ValidationContext {
+    bool blob_files_enabled = false;
+    size_t user_timestamp_size = 0;
+    size_t max_buffered_input_records =
+        StreamAggregation::kMaxBufferedInputRecords;
+    uint64_t max_buffered_input_bytes =
+        StreamAggregation::kMaxBufferedInputBytes;
+  };
+
+  struct Context {
+    bool is_full_compaction = false;
+    bool is_manual_compaction = false;
+    bool is_bottommost_level = false;
+    int input_start_level = -1;
+    int output_level = -1;
+    uint32_t column_family_id = 0;
+  };
+
+  virtual ~StreamAggregationFactory() = default;
+
+  virtual const char* Name() const = 0;
+
+  // Called while validating column-family options. Implementations can
+  // validate schema/codec configuration and run application-provided contract
+  // evaluation cases. RocksDB still validates every runtime result.
+  virtual Status Validate(const ValidationContext& /*context*/) const {
+    return Status::OK();
+  }
+
+  // A separate aggregation is created for each full compaction. The
+  // experimental implementation disables subcompactions for those jobs.
+  virtual std::unique_ptr<StreamAggregation> Create(
+      const Context& context) const = 0;
+};
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -1125,6 +1125,7 @@ ImmutableCFOptions::ImmutableCFOptions(const ColumnFamilyOptions& cf_options)
       merge_operator(cf_options.merge_operator),
       compaction_filter(cf_options.compaction_filter),
       compaction_filter_factory(cf_options.compaction_filter_factory),
+      stream_aggregation_factory(cf_options.stream_aggregation_factory),
       min_write_buffer_number_to_merge(
           cf_options.min_write_buffer_number_to_merge),
       max_write_buffer_size_to_maintain(

--- a/options/cf_options.h
+++ b/options/cf_options.h
@@ -38,6 +38,8 @@ struct ImmutableCFOptions {
 
   std::shared_ptr<CompactionFilterFactory> compaction_filter_factory;
 
+  std::shared_ptr<StreamAggregationFactory> stream_aggregation_factory;
+
   int min_write_buffer_number_to_merge;
 
   int64_t max_write_buffer_size_to_maintain;

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -347,6 +347,7 @@ void UpdateColumnFamilyOptions(const ImmutableCFOptions& ioptions,
   cf_opts->merge_operator = ioptions.merge_operator;
   cf_opts->compaction_filter = ioptions.compaction_filter;
   cf_opts->compaction_filter_factory = ioptions.compaction_filter_factory;
+  cf_opts->stream_aggregation_factory = ioptions.stream_aggregation_factory;
   cf_opts->min_write_buffer_number_to_merge =
       ioptions.min_write_buffer_number_to_merge;
   cf_opts->max_write_buffer_size_to_maintain =

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -566,6 +566,8 @@ TEST_F(OptionsSettableTest, ColumnFamilyOptionsAllFieldsSettable) {
        sizeof(const CompactionFilter*)},
       {offsetof(struct ColumnFamilyOptions, compaction_filter_factory),
        sizeof(std::shared_ptr<CompactionFilterFactory>)},
+      {offsetof(struct ColumnFamilyOptions, stream_aggregation_factory),
+       sizeof(std::shared_ptr<StreamAggregationFactory>)},
       {offsetof(struct ColumnFamilyOptions, compression_manager),
        sizeof(std::shared_ptr<CompressionManager>)},
       {offsetof(struct ColumnFamilyOptions, prefix_extractor),

--- a/options/options_test.cc
+++ b/options/options_test.cc
@@ -22,6 +22,7 @@
 #include "rocksdb/convenience.h"
 #include "rocksdb/file_checksum.h"
 #include "rocksdb/memtablerep.h"
+#include "rocksdb/stream_aggregation.h"
 #include "rocksdb/utilities/leveldb_options.h"
 #include "rocksdb/utilities/object_registry.h"
 #include "rocksdb/utilities/options_type.h"
@@ -52,6 +53,18 @@ namespace ROCKSDB_NAMESPACE {
 static_assert(std::is_trivially_copyable_v<ReadOptions>);
 
 class OptionsTest : public testing::Test {};
+
+class OptionsTestStreamAggregationFactory : public StreamAggregationFactory {
+ public:
+  const char* Name() const override {
+    return "OptionsTestStreamAggregationFactory";
+  }
+
+  std::unique_ptr<StreamAggregation> Create(
+      const Context& /*context*/) const override {
+    return nullptr;
+  }
+};
 
 class UnregisteredTableFactory : public TableFactory {
  public:
@@ -1601,10 +1614,14 @@ TEST_F(OptionsTest, CFOptionsComposeImmutable) {
   ColumnFamilyOptions base_opts, new_opts;
   DBOptions dummy;  // Needed to create ImmutableCFOptions
   test::RandomInitCFOptions(&base_opts, dummy, &rnd);
+  base_opts.stream_aggregation_factory =
+      std::make_shared<OptionsTestStreamAggregationFactory>();
   MutableCFOptions m_opts(base_opts);
   ImmutableCFOptions i_opts(base_opts);
   UpdateColumnFamilyOptions(i_opts, &new_opts);
   UpdateColumnFamilyOptions(m_opts, &new_opts);
+  ASSERT_EQ(new_opts.stream_aggregation_factory,
+            base_opts.stream_aggregation_factory);
   ASSERT_OK(RocksDBOptionsParser::VerifyCFOptions(config_options, base_opts,
                                                   new_opts));
   delete new_opts.compaction_filter;

--- a/tools/c_api_gen/auto_simple_bindings_blocklist.json
+++ b/tools/c_api_gen/auto_simple_bindings_blocklist.json
@@ -240,6 +240,11 @@
           "reason": "Uses custom components or nested option objects that need hand-designed C bridging."
         },
         {
+          "field": "stream_aggregation_factory",
+          "policy": "manual",
+          "reason": "Uses a C++ callback factory that requires a hand-designed C API."
+        },
+        {
           "field": "bottommost_compression_opts",
           "policy": "manual",
           "reason": "Uses custom components or nested option objects that need hand-designed C bridging."

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -69,6 +69,7 @@
 #include "rocksdb/sst_file_writer.h"
 #include "rocksdb/sst_partitioner.h"
 #include "rocksdb/stats_history.h"
+#include "rocksdb/stream_aggregation.h"
 #include "rocksdb/table.h"
 #include "rocksdb/tool_hooks.h"
 #include "rocksdb/utilities/backup_engine.h"
@@ -935,6 +936,10 @@ DEFINE_bool(read_cache_direct_read, true,
             "Whether to use Direct IO for reading from read cache");
 
 DEFINE_bool(use_keep_filter, false, "Whether to use a noop compaction filter");
+
+DEFINE_bool(use_keep_stream_aggregation, false,
+            "Whether to use a keep-all StreamAggregation for full "
+            "compactions");
 
 static bool ValidateCacheNumshardbits(const char* flagname, int32_t value) {
   if (value >= 20) {
@@ -3814,6 +3819,28 @@ class Benchmark {
     const char* Name() const override { return "KeepFilter"; }
   };
 
+  class KeepStreamAggregation : public StreamAggregation {
+   public:
+    Status Aggregate(const std::vector<Input>& inputs, size_t* num_consumed,
+                     std::vector<OutputSegment>* outputs) override {
+      *num_consumed = inputs.size();
+      outputs->clear();
+      outputs->emplace_back();
+      outputs->back().input_end = inputs.size();
+      return Status::OK();
+    }
+  };
+
+  class KeepStreamAggregationFactory : public StreamAggregationFactory {
+   public:
+    const char* Name() const override { return "KeepStreamAggregationFactory"; }
+
+    std::unique_ptr<StreamAggregation> Create(
+        const Context& /*context*/) const override {
+      return std::make_unique<KeepStreamAggregation>();
+    }
+  };
+
   static std::shared_ptr<MemoryAllocator> GetCacheAllocator() {
     std::shared_ptr<MemoryAllocator> allocator;
 
@@ -6016,6 +6043,11 @@ class Benchmark {
         options.file_checksum_gen_factory.reset(
             new FileChecksumGenCrc32cFactory());
       }
+    }
+
+    if (FLAGS_use_keep_stream_aggregation) {
+      options.stream_aggregation_factory =
+          std::make_shared<KeepStreamAggregationFactory>();
     }
 
     if (FLAGS_num_multi_db <= 1) {

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -258,6 +258,7 @@ default_params = {
     "num_dbs": 1,
     "enable_pipelined_write": lambda: random.randint(0, 1),
     "enable_compaction_filter": lambda: random.choice([0, 0, 0, 1]),
+    "use_keep_stream_aggregation": lambda: random.choice([0, 0, 0, 1]),
     "enable_compaction_on_deletion_trigger": lambda: random.choice([0, 0, 0, 1]),
     # `inplace_update_support` is incompatible with a wide range of features.
     # The current sanitization process is not sufficient to reliably handle


### PR DESCRIPTION
Summary:

Introduce an experimental RocksDB `StreamAggregation` callback for transforming contiguous logical records during full compactions. A factory is configured on `ColumnFamilyOptions`; RocksDB invokes it automatically only when a compaction includes every SST in the column family. The callback can keep, replace, or drop contiguous input segments with bounded buffering and output validation. Leveled and Universal compaction are supported. Non-full compactions proceed normally, active snapshots fall back to ordinary compaction, and a configured `CompactionFilter` runs before aggregation.

Differential Revision: D117881204


