### PR TITLE
Handle async prefetch failures safely

### DIFF
--- a/file/file_prefetch_buffer.cc
+++ b/file/file_prefetch_buffer.cc
@@ -11,6 +11,8 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cstdio>
+#include <exception>
 
 #include "file/random_access_file_reader.h"
 #include "monitoring/histogram.h"
@@ -21,6 +23,74 @@
 #include "util/rate_limiter_impl.h"
 
 namespace ROCKSDB_NAMESPACE {
+
+FilePrefetchBuffer::~FilePrefetchBuffer() {
+  // Abort any pending async read request before destroying the class object.
+  // Both successful AbortIO and Poll calls guarantee callbacks have finished.
+  // If AbortIO fails, Poll all handles before releasing callback state and
+  // buffers. If Poll also fails, continuing destruction cannot be made safe:
+  // the filesystem API has no way to transfer ownership of the pending
+  // callbacks, which refer to this object and its buffers.
+  if (fs_ != nullptr) {
+    std::vector<BufferInfo*> bufs_with_io_handles;
+    for (BufferInfo* buf : bufs_) {
+      if (buf->io_handle_ != nullptr) {
+        bufs_with_io_handles.emplace_back(buf);
+      }
+    }
+    Status abort_status = AbortAllIOs();
+    if (!abort_status.ok()) {
+      Status poll_status = PollAllIOs();
+      if (!poll_status.ok()) {
+        std::fprintf(
+            stderr,
+            "FilePrefetchBuffer could not finish pending asynchronous I/O: "
+            "AbortIO failed with %s; Poll failed with %s\n",
+            abort_status.ToString().c_str(), poll_status.ToString().c_str());
+        std::terminate();
+      }
+    }
+    for (BufferInfo* buf : bufs_with_io_handles) {
+      buf->ClearBuffer();
+    }
+  }
+
+  // Prefetch buffer bytes discarded.
+  uint64_t bytes_discarded = 0;
+  // Iterated over buffers.
+  for (auto& buf : bufs_) {
+    if (buf->DoesBufferContainData()) {
+      // If last read was from this block and some bytes are still unconsumed.
+      if (prev_offset_ >= buf->offset_ &&
+          prev_offset_ + prev_len_ < buf->offset_ + buf->CurrentSize()) {
+        bytes_discarded +=
+            buf->CurrentSize() - (prev_offset_ + prev_len_ - buf->offset_);
+      }
+      // If last read was from previous blocks and this block is unconsumed.
+      else if (prev_offset_ < buf->offset_ &&
+               prev_offset_ + prev_len_ <= buf->offset_) {
+        bytes_discarded += buf->CurrentSize();
+      }
+    }
+  }
+
+  RecordInHistogram(stats_, PREFETCHED_BYTES_DISCARDED, bytes_discarded);
+
+  for (auto& buf : bufs_) {
+    delete buf;
+    buf = nullptr;
+  }
+
+  for (auto& buf : free_bufs_) {
+    delete buf;
+    buf = nullptr;
+  }
+
+  if (overlap_buf_ != nullptr) {
+    delete overlap_buf_;
+    overlap_buf_ = nullptr;
+  }
+}
 
 void FilePrefetchBuffer::PrepareBufferForRead(
     BufferInfo* buf, size_t alignment, uint64_t offset, size_t roundup_len,
@@ -141,6 +211,8 @@ Status FilePrefetchBuffer::ReadAsync(BufferInfo* buf, const IOOptions& opts,
                                      RandomAccessFileReader* reader,
                                      uint64_t read_len, uint64_t start_offset) {
   TEST_SYNC_POINT("FilePrefetchBuffer::ReadAsync");
+  assert(!buf->async_read_in_progress_);
+  buf->ResetAsyncReadStatus();
   // callback for async read request.
   auto fp = std::bind(&FilePrefetchBuffer::PrefetchAsyncCallback, this,
                       std::placeholders::_1, std::placeholders::_2);
@@ -159,7 +231,17 @@ Status FilePrefetchBuffer::ReadAsync(BufferInfo* buf, const IOOptions& opts,
     if (usage_ == FilePrefetchBufferUsage::kUserScanPrefetch) {
       RecordTick(stats_, PREFETCH_BYTES, read_len);
     }
-    buf->async_read_in_progress_ = true;
+    if (buf->io_handle_ == nullptr) {
+      // The default ReadAsync implementation completes synchronously and does
+      // not create a handle. Its callback has already populated the status.
+      IOStatus async_read_status = buf->TakeAsyncReadStatus();
+      if (!async_read_status.ok()) {
+        buf->ClearBuffer();
+        return async_read_status;
+      }
+    } else {
+      buf->async_read_in_progress_ = true;
+    }
   } else if (s.IsNotSupported()) {
     // Async IO is not available (e.g., io_uring failed to initialize).
     // Fall back to synchronous read so the buffer is populated inline
@@ -174,6 +256,24 @@ Status FilePrefetchBuffer::ReadAsync(BufferInfo* buf, const IOOptions& opts,
     }
   }
   return s;
+}
+
+Status FilePrefetchBuffer::CleanupAfterAsyncReadFailure(
+    BufferInfo* buf, Status async_read_status) {
+  assert(!bufs_.empty());
+  assert(buf == GetLastBuffer());
+  DestroyAndClearIOHandle(buf);
+  FreeLastBuffer();
+
+  // A multi-buffer prefetch can have earlier requests in flight when a later
+  // submission fails. Cancel them so an error return does not leave a partial
+  // prefetch operation active.
+  Status abort_status = AbortAllIOs();
+  if (!abort_status.ok()) {
+    return abort_status;
+  }
+  FreeEmptyBuffers();
+  return async_read_status;
 }
 
 Status FilePrefetchBuffer::Prefetch(const IOOptions& opts,
@@ -259,7 +359,7 @@ void FilePrefetchBuffer::CopyDataToOverlapBuffer(BufferInfo* src,
 // Clear the buffers if it contains outdated data. Outdated data can be because
 // previous sequential reads were read from the cache instead of these buffer.
 // In that case outdated IOs should be aborted.
-void FilePrefetchBuffer::AbortOutdatedIO(uint64_t offset) {
+Status FilePrefetchBuffer::AbortOutdatedIO(uint64_t offset) {
   std::vector<void*> handles;
   std::vector<BufferInfo*> tmp_buf;
   for (auto& buf : bufs_) {
@@ -272,7 +372,9 @@ void FilePrefetchBuffer::AbortOutdatedIO(uint64_t offset) {
   if (!handles.empty()) {
     StopWatch sw(clock_, stats_, ASYNC_PREFETCH_ABORT_MICROS);
     Status s = fs_->AbortIO(handles);
-    assert(s.ok());
+    if (!s.ok()) {
+      return s;
+    }
   }
 
   for (auto& buf : tmp_buf) {
@@ -282,9 +384,10 @@ void FilePrefetchBuffer::AbortOutdatedIO(uint64_t offset) {
     }
     buf->ClearBuffer();
   }
+  return Status::OK();
 }
 
-void FilePrefetchBuffer::AbortAllIOs() {
+Status FilePrefetchBuffer::AbortAllIOs() {
   std::vector<void*> handles;
   for (auto& buf : bufs_) {
     if (buf->async_read_in_progress_ && buf->io_handle_ != nullptr) {
@@ -294,7 +397,9 @@ void FilePrefetchBuffer::AbortAllIOs() {
   if (!handles.empty()) {
     StopWatch sw(clock_, stats_, ASYNC_PREFETCH_ABORT_MICROS);
     Status s = fs_->AbortIO(handles);
-    assert(s.ok());
+    if (!s.ok()) {
+      return s;
+    }
   }
 
   for (auto& buf : bufs_) {
@@ -302,7 +407,34 @@ void FilePrefetchBuffer::AbortAllIOs() {
       DestroyAndClearIOHandle(buf);
     }
     buf->async_read_in_progress_ = false;
+    buf->ResetAsyncReadStatus();
   }
+  return Status::OK();
+}
+
+Status FilePrefetchBuffer::PollAllIOs() {
+  std::vector<void*> handles;
+  for (auto& buf : bufs_) {
+    if (buf->async_read_in_progress_ && buf->io_handle_ != nullptr) {
+      handles.emplace_back(buf->io_handle_);
+    }
+  }
+  if (!handles.empty()) {
+    StopWatch sw(clock_, stats_, POLL_WAIT_MICROS);
+    Status s = fs_->Poll(handles, handles.size());
+    if (!s.ok()) {
+      return s;
+    }
+  }
+
+  for (auto& buf : bufs_) {
+    if (buf->io_handle_ != nullptr && buf->del_fn_ != nullptr) {
+      DestroyAndClearIOHandle(buf);
+    }
+    buf->async_read_in_progress_ = false;
+    buf->ResetAsyncReadStatus();
+  }
+  return Status::OK();
 }
 
 // Clear the buffers if it contains outdated data wrt offset. Outdated data can
@@ -312,7 +444,7 @@ void FilePrefetchBuffer::AbortAllIOs() {
 // offset - the offset requested to be read. This API makes sure that the
 // front/first buffer in bufs_ should contain this offset, otherwise, all
 // buffers will be freed.
-void FilePrefetchBuffer::ClearOutdatedData(uint64_t offset, size_t length) {
+Status FilePrefetchBuffer::ClearOutdatedData(uint64_t offset, size_t length) {
   while (!IsBufferQueueEmpty()) {
     BufferInfo* buf = GetFirstBuffer();
     // Offset is greater than this buffer's end offset.
@@ -324,18 +456,19 @@ void FilePrefetchBuffer::ClearOutdatedData(uint64_t offset, size_t length) {
   }
 
   if (IsBufferQueueEmpty() || NumBuffersAllocated() == 1) {
-    return;
+    return Status::OK();
   }
 
   BufferInfo* buf = GetFirstBuffer();
 
   if (buf->async_read_in_progress_) {
     FreeEmptyBuffers();
-    return;
+    return Status::OK();
   }
 
   // Below handles the case for Overlapping buffers (NumBuffersAllocated > 1).
   bool abort_io = false;
+  bool clear_first_buffer = false;
 
   if (buf->DoesBufferContainData() && buf->IsOffsetInBuffer(offset)) {
     BufferInfo* next_buf = bufs_[1];
@@ -348,12 +481,18 @@ void FilePrefetchBuffer::ClearOutdatedData(uint64_t offset, size_t length) {
   } else {
     // buffer with offset doesn't contain data or offset doesn't lie in this
     // buffer.
-    buf->ClearBuffer();
+    clear_first_buffer = true;
     abort_io = true;
   }
 
   if (abort_io) {
-    AbortAllIOs();
+    Status s = AbortAllIOs();
+    if (!s.ok()) {
+      return s;
+    }
+    if (clear_first_buffer) {
+      buf->ClearBuffer();
+    }
     // Clear all buffers after first.
     for (size_t i = 1; i < bufs_.size(); ++i) {
       bufs_[i]->ClearBuffer();
@@ -361,6 +500,7 @@ void FilePrefetchBuffer::ClearOutdatedData(uint64_t offset, size_t length) {
   }
   FreeEmptyBuffers();
   assert(IsBufferQueueEmpty() || buf->IsOffsetInBuffer(offset));
+  return Status::OK();
 }
 
 Status FilePrefetchBuffer::PollIfNeeded(uint64_t offset, size_t length) {
@@ -379,9 +519,8 @@ Status FilePrefetchBuffer::PollIfNeeded(uint64_t offset, size_t length) {
       TEST_SYNC_POINT_CALLBACK("FilePrefetchBuffer::PollIfNeeded:IOStatus",
                                &io_s);
       if (!io_s.ok()) {
-        // On Poll failure, clean up the handle and abort.
-        // DestroyAndClearIOHandle also sets async_read_in_progress_ to false.
-        DestroyAndClearIOHandle(buf);
+        // Poll failure does not guarantee completion. Keep the handle and
+        // buffer alive so a later abort or poll can safely finish the request.
         return io_s;
       }
     }
@@ -389,12 +528,19 @@ Status FilePrefetchBuffer::PollIfNeeded(uint64_t offset, size_t length) {
     // Reset and Release io_handle after the Poll API as request has been
     // completed.
     DestroyAndClearIOHandle(buf);
+
+    IOStatus async_read_status = buf->TakeAsyncReadStatus();
+    if (!async_read_status.ok()) {
+      // Do not retain partial data from a failed read. A later request can
+      // safely retry after this status has been returned to the caller.
+      buf->ClearBuffer();
+      return async_read_status;
+    }
   }
 
   // Always call outdated data after Poll as Buffers might be out of sync w.r.t
   // offset and length.
-  ClearOutdatedData(offset, length);
-  return Status::OK();
+  return ClearOutdatedData(offset, length);
 }
 
 // ReadAheadSizeTuning API calls readaheadsize_cb_
@@ -593,9 +739,7 @@ Status FilePrefetchBuffer::HandleOverlappingAsyncData(
       if (read_len > 0) {
         s = ReadAsync(new_buf, opts, reader, read_len, start_offset);
         if (!s.ok()) {
-          DestroyAndClearIOHandle(new_buf);
-          FreeLastBuffer();
-          return s;
+          return CleanupAfterAsyncReadFailure(new_buf, std::move(s));
         }
       }
     }
@@ -636,10 +780,16 @@ Status FilePrefetchBuffer::PrefetchInternal(const IOOptions& opts,
 
   // Abort outdated IO.
   if (!explicit_prefetch_submitted_) {
-    AbortOutdatedIO(offset);
+    s = AbortOutdatedIO(offset);
+    if (!s.ok()) {
+      return s;
+    }
     FreeEmptyBuffers();
   }
-  ClearOutdatedData(offset, length);
+  s = ClearOutdatedData(offset, length);
+  if (!s.ok()) {
+    return s;
+  }
 
   // Handle overlapping data over two buffers (async prefetching case).
   s = HandleOverlappingAsyncData(opts, reader, offset, length, readahead_size,
@@ -769,7 +919,10 @@ Status FilePrefetchBuffer::PrefetchInternal(const IOOptions& opts,
     s = Read(buf, opts, reader, read_len1, aligned_useful_len1, start_offset1,
              use_fs_buffer);
     if (!s.ok()) {
-      AbortAllIOs();
+      Status abort_status = AbortAllIOs();
+      if (!abort_status.ok()) {
+        return abort_status;
+      }
       FreeAllBuffers();
       return s;
     }
@@ -823,7 +976,15 @@ bool FilePrefetchBuffer::TryReadFromCacheUntracked(
     // buffers will be outdated.
     // Random offset called. So abort the IOs.
     if (prev_offset_ != offset) {
-      AbortAllIOs();
+      Status abort_status = AbortAllIOs();
+      if (!abort_status.ok()) {
+        if (status != nullptr) {
+          *status = abort_status;
+        } else {
+          abort_status.PermitUncheckedError();
+        }
+        return false;
+      }
       FreeAllBuffers();
       explicit_prefetch_submitted_ = false;
       return false;
@@ -912,6 +1073,10 @@ bool FilePrefetchBuffer::TryReadFromCacheUntracked(
 void FilePrefetchBuffer::PrefetchAsyncCallback(FSReadRequest& req,
                                                void* cb_arg) {
   BufferInfo* buf = static_cast<BufferInfo*>(cb_arg);
+  if (!req.status.ok()) {
+    assert(buf->async_read_error_ == nullptr);
+    buf->async_read_error_ = std::make_unique<IOStatus>(req.status);
+  }
 
 #ifndef NDEBUG
   if (req.result.size() < req.len) {
@@ -949,6 +1114,13 @@ Status FilePrefetchBuffer::PrefetchAsync(const IOOptions& opts,
 
   TEST_SYNC_POINT("FilePrefetchBuffer::PrefetchAsync:Start");
 
+  // Cancel any pending async read to make code simpler as buffers can be out
+  // of sync.
+  Status s = AbortAllIOs();
+  if (!s.ok()) {
+    return s;
+  }
+
   num_file_reads_ = 0;
   explicit_prefetch_submitted_ = false;
   bool is_eligible_for_prefetching = false;
@@ -959,12 +1131,12 @@ Status FilePrefetchBuffer::PrefetchAsync(const IOOptions& opts,
     is_eligible_for_prefetching = true;
   }
 
-  // Cancel any pending async read to make code simpler as buffers can be out
-  // of sync.
-  AbortAllIOs();
   // Free empty buffers after aborting IOs.
   FreeEmptyBuffers();
-  ClearOutdatedData(offset, n);
+  s = ClearOutdatedData(offset, n);
+  if (!s.ok()) {
+    return s;
+  }
 
   // - Since PrefetchAsync can be called on non sequential reads. So offset can
   //   be less than first buffers' offset. In that case it clears all
@@ -1010,7 +1182,6 @@ Status FilePrefetchBuffer::PrefetchAsync(const IOOptions& opts,
 
   std::string msg;
 
-  Status s;
   size_t alignment = GetRequiredBufferAlignment(reader);
   size_t readahead_size = is_eligible_for_prefetching ? readahead_size_ / 2 : 0;
   size_t offset_to_read = static_cast<size_t>(offset);
@@ -1055,9 +1226,7 @@ Status FilePrefetchBuffer::PrefetchAsync(const IOOptions& opts,
     if (read_len1 > 0) {
       s = ReadAsync(buf, opts, reader, read_len1, start_offset1);
       if (!s.ok()) {
-        DestroyAndClearIOHandle(buf);
-        FreeLastBuffer();
-        return s;
+        return CleanupAfterAsyncReadFailure(buf, std::move(s));
       }
       explicit_prefetch_submitted_ = true;
       prev_len_ = 0;
@@ -1100,9 +1269,7 @@ Status FilePrefetchBuffer::PrefetchRemBuffers(const IOOptions& opts,
       TEST_SYNC_POINT("FilePrefetchBuffer::PrefetchAsync:ExtraPrefetching");
       s = ReadAsync(new_buf, opts, reader, read_len2, start_offset2);
       if (!s.ok()) {
-        DestroyAndClearIOHandle(new_buf);
-        FreeLastBuffer();
-        return s;
+        return CleanupAfterAsyncReadFailure(new_buf, std::move(s));
       }
     }
     end_offset1 = end_offset2;

--- a/file/file_prefetch_buffer.h
+++ b/file/file_prefetch_buffer.h
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <atomic>
 #include <deque>
+#include <memory>
 #include <sstream>
 #include <string>
 
@@ -65,6 +66,25 @@ struct BufferInfo {
     buffer_.Clear();
     initial_end_offset_ = 0;
     async_req_len_ = 0;
+    ResetAsyncReadStatus();
+  }
+
+  void ResetAsyncReadStatus() {
+    if (async_read_error_ != nullptr) {
+      // Async read errors are intentionally discarded when the corresponding
+      // speculative request is cancelled or its buffer is no longer needed.
+      async_read_error_->PermitUncheckedError();
+      async_read_error_.reset();
+    }
+  }
+
+  IOStatus TakeAsyncReadStatus() {
+    if (async_read_error_ == nullptr) {
+      return IOStatus::OK();
+    }
+    IOStatus status = std::move(*async_read_error_);
+    async_read_error_.reset();
+    return status;
   }
 
   AlignedBuffer buffer_;
@@ -78,6 +98,11 @@ struct BufferInfo {
   // async_read_in_progress can be used as mutex. Callback can update the buffer
   // and its size but async_read_in_progress is only set by main thread.
   bool async_read_in_progress_ = false;
+
+  // Completion error populated by PrefetchAsyncCallback(). It is consumed
+  // after Poll() confirms the callback has finished. Successful reads do not
+  // allocate error state.
+  std::unique_ptr<IOStatus> async_read_error_;
 
   // io_handle is allocated and used by underlying file system in case of
   // asynchronous reads.
@@ -230,66 +255,7 @@ class FilePrefetchBuffer {
     }
   }
 
-  ~FilePrefetchBuffer() {
-    // Abort any pending async read request before destroying the class object.
-    if (fs_ != nullptr) {
-      std::vector<void*> handles;
-      for (auto& buf : bufs_) {
-        if (buf->async_read_in_progress_ && buf->io_handle_ != nullptr) {
-          handles.emplace_back(buf->io_handle_);
-        }
-      }
-      if (!handles.empty()) {
-        StopWatch sw(clock_, stats_, ASYNC_PREFETCH_ABORT_MICROS);
-        Status s = fs_->AbortIO(handles);
-        assert(s.ok());
-      }
-
-      for (auto& buf : bufs_) {
-        if (buf->io_handle_ != nullptr) {
-          DestroyAndClearIOHandle(buf);
-          buf->ClearBuffer();
-        }
-        buf->async_read_in_progress_ = false;
-      }
-    }
-
-    // Prefetch buffer bytes discarded.
-    uint64_t bytes_discarded = 0;
-    // Iterated over buffers.
-    for (auto& buf : bufs_) {
-      if (buf->DoesBufferContainData()) {
-        // If last read was from this block and some bytes are still unconsumed.
-        if (prev_offset_ >= buf->offset_ &&
-            prev_offset_ + prev_len_ < buf->offset_ + buf->CurrentSize()) {
-          bytes_discarded +=
-              buf->CurrentSize() - (prev_offset_ + prev_len_ - buf->offset_);
-        }
-        // If last read was from previous blocks and this block is unconsumed.
-        else if (prev_offset_ < buf->offset_ &&
-                 prev_offset_ + prev_len_ <= buf->offset_) {
-          bytes_discarded += buf->CurrentSize();
-        }
-      }
-    }
-
-    RecordInHistogram(stats_, PREFETCHED_BYTES_DISCARDED, bytes_discarded);
-
-    for (auto& buf : bufs_) {
-      delete buf;
-      buf = nullptr;
-    }
-
-    for (auto& buf : free_bufs_) {
-      delete buf;
-      buf = nullptr;
-    }
-
-    if (overlap_buf_ != nullptr) {
-      delete overlap_buf_;
-      overlap_buf_ = nullptr;
-    }
-  }
+  ~FilePrefetchBuffer();
 
   bool Enabled() const { return enable_; }
 
@@ -424,11 +390,13 @@ class FilePrefetchBuffer {
                             size_t roundup_len, bool refit_tail,
                             bool use_fs_buffer, uint64_t& aligned_useful_len);
 
-  void AbortOutdatedIO(uint64_t offset);
+  Status AbortOutdatedIO(uint64_t offset);
 
-  void AbortAllIOs();
+  Status AbortAllIOs();
 
-  void ClearOutdatedData(uint64_t offset, size_t len);
+  Status PollAllIOs();
+
+  Status ClearOutdatedData(uint64_t offset, size_t len);
 
   // It calls Poll API to check for any pending asynchronous request.
   Status PollIfNeeded(uint64_t offset, size_t len);
@@ -445,6 +413,9 @@ class FilePrefetchBuffer {
   Status ReadAsync(BufferInfo* buf, const IOOptions& opts,
                    RandomAccessFileReader* reader, uint64_t read_len,
                    uint64_t start_offset);
+
+  Status CleanupAfterAsyncReadFailure(BufferInfo* buf,
+                                      Status async_read_status);
 
   // Copy the data from src to overlap_buf_.
   void CopyDataToOverlapBuffer(BufferInfo* src, uint64_t& offset,

--- a/file/prefetch_test.cc
+++ b/file/prefetch_test.cc
@@ -3266,6 +3266,8 @@ TEST_P(PrefetchTest, TraceReadAsyncWithCallbackWrapper) {
 }
 #endif  // GFLAGS
 
+class ControlledAsyncFileSystem;
+
 class FilePrefetchBufferTest : public testing::Test {
  public:
   void SetUp() override {
@@ -3292,13 +3294,23 @@ class FilePrefetchBufferTest : public testing::Test {
 
   void Read(const std::string& fname, const FileOptions& opts,
             std::unique_ptr<RandomAccessFileReader>* reader) {
+    ReadWithFileSystem(fname, opts, fs(), reader);
+  }
+
+  void ReadWithFileSystem(const std::string& fname, const FileOptions& opts,
+                          FileSystem* file_system,
+                          std::unique_ptr<RandomAccessFileReader>* reader) {
     std::string fpath = Path(fname);
     std::unique_ptr<FSRandomAccessFile> f;
-    ASSERT_OK(fs_->NewRandomAccessFile(fpath, opts, &f, nullptr));
+    ASSERT_OK(file_system->NewRandomAccessFile(fpath, opts, &f, nullptr));
     reader->reset(new RandomAccessFileReader(
         std::move(f), fpath, env_->GetSystemClock().get(),
         /*io_tracer=*/nullptr, stats_.get()));
   }
+
+  std::shared_ptr<ControlledAsyncFileSystem> CreateControlledAsyncReader(
+      const std::string& fname,
+      std::unique_ptr<RandomAccessFileReader>* reader);
 
   void AssertResult(const std::string& content,
                     const std::vector<FSReadRequest>& reqs) {
@@ -3320,6 +3332,488 @@ class FilePrefetchBufferTest : public testing::Test {
 
   std::string Path(const std::string& fname) { return test_dir_ + "/" + fname; }
 };
+
+struct PrefetchAsyncHandle {
+  FSRandomAccessFile* target = nullptr;
+  IOOptions opts;
+  uint64_t offset = 0;
+  size_t len = 0;
+  char* scratch = nullptr;
+  std::function<void(FSReadRequest&, void*)> callback;
+  void* callback_arg = nullptr;
+  bool completed = false;
+};
+
+class ControlledAsyncRandomAccessFile : public FSRandomAccessFileOwnerWrapper {
+ public:
+  ControlledAsyncRandomAccessFile(std::unique_ptr<FSRandomAccessFile>&& file,
+                                  ControlledAsyncFileSystem* fs)
+      : FSRandomAccessFileOwnerWrapper(std::move(file)), fs_(fs) {}
+
+  IOStatus ReadAsync(FSReadRequest& req, const IOOptions& opts,
+                     std::function<void(FSReadRequest&, void*)> cb,
+                     void* cb_arg, void** io_handle, IOHandleDeleter* del_fn,
+                     IODebugContext* dbg) override;
+
+ private:
+  ControlledAsyncFileSystem* fs_;
+};
+
+// Keeps asynchronous reads pending until Poll() or AbortIO() so cancellation
+// and completion failures can be tested without io_uring.
+class ControlledAsyncFileSystem : public FileSystemWrapper {
+ public:
+  explicit ControlledAsyncFileSystem(const std::shared_ptr<FileSystem>& target)
+      : FileSystemWrapper(target) {}
+
+  const char* Name() const override { return "ControlledAsyncFileSystem"; }
+
+  IOStatus NewRandomAccessFile(const std::string& fname,
+                               const FileOptions& opts,
+                               std::unique_ptr<FSRandomAccessFile>* result,
+                               IODebugContext* dbg) override {
+    std::unique_ptr<FSRandomAccessFile> file;
+    IOStatus s = target()->NewRandomAccessFile(fname, opts, &file, dbg);
+    if (s.ok()) {
+      result->reset(new ControlledAsyncRandomAccessFile(std::move(file), this));
+    }
+    return s;
+  }
+
+  IOStatus AbortIO(std::vector<void*>& io_handles) override {
+    ++abort_calls_;
+    if (abort_failures_remaining_ > 0) {
+      --abort_failures_remaining_;
+      return IOStatus::IOError("Injected AbortIO failure");
+    }
+    for (void* io_handle : io_handles) {
+      Complete(static_cast<PrefetchAsyncHandle*>(io_handle),
+               /*aborted=*/true);
+    }
+    return IOStatus::OK();
+  }
+
+  IOStatus Poll(std::vector<void*>& io_handles,
+                size_t /*min_completions*/) override {
+    ++poll_calls_;
+    if (poll_failures_remaining_ > 0) {
+      --poll_failures_remaining_;
+      return IOStatus::IOError("Injected Poll failure");
+    }
+    for (void* io_handle : io_handles) {
+      Complete(static_cast<PrefetchAsyncHandle*>(io_handle),
+               /*aborted=*/false);
+    }
+    return IOStatus::OK();
+  }
+
+  void Add(PrefetchAsyncHandle* handle) { pending_.push_back(handle); }
+
+  bool MaybeCompleteInline(
+      FSRandomAccessFile* target, FSReadRequest& req, const IOOptions& opts,
+      const std::function<void(FSReadRequest&, void*)>& callback,
+      void* callback_arg) {
+    if (!complete_reads_inline_) {
+      return false;
+    }
+    if (read_completion_failures_remaining_ > 0) {
+      --read_completion_failures_remaining_;
+      req.status = IOStatus::IOError("Injected async read completion failure");
+    } else {
+      req.status = target->Read(req.offset, req.len, opts, &req.result,
+                                req.scratch, nullptr);
+    }
+    ++completion_calls_;
+    callback(req, callback_arg);
+    return true;
+  }
+
+  void Delete(PrefetchAsyncHandle* handle) {
+    if (!handle->completed) {
+      deleted_before_completion_ = true;
+    }
+    auto it = std::find(pending_.begin(), pending_.end(), handle);
+    if (it != pending_.end()) {
+      pending_.erase(it);
+    }
+    ++delete_calls_;
+    delete handle;
+  }
+
+  void FailNextAbort() { ++abort_failures_remaining_; }
+  void FailNextPoll() { ++poll_failures_remaining_; }
+  void FailNextReadCompletion() { ++read_completion_failures_remaining_; }
+  void CompleteReadsInline() { complete_reads_inline_ = true; }
+
+  size_t pending_count() const { return pending_.size(); }
+  size_t abort_calls() const { return abort_calls_; }
+  size_t poll_calls() const { return poll_calls_; }
+  size_t delete_calls() const { return delete_calls_; }
+  size_t completion_calls() const { return completion_calls_; }
+  size_t aborted_completion_calls() const { return aborted_completion_calls_; }
+  bool deleted_before_completion() const { return deleted_before_completion_; }
+
+ private:
+  void Complete(PrefetchAsyncHandle* handle, bool aborted) {
+    if (handle->completed) {
+      return;
+    }
+    auto it = std::find(pending_.begin(), pending_.end(), handle);
+    if (it != pending_.end()) {
+      pending_.erase(it);
+    }
+
+    FSReadRequest req;
+    req.offset = handle->offset;
+    req.len = handle->len;
+    req.scratch = handle->scratch;
+    if (aborted) {
+      req.status = IOStatus::Aborted();
+      ++aborted_completion_calls_;
+    } else if (read_completion_failures_remaining_ > 0) {
+      --read_completion_failures_remaining_;
+      req.status = IOStatus::IOError("Injected async read completion failure");
+    } else {
+      req.status =
+          handle->target->Read(handle->offset, handle->len, handle->opts,
+                               &req.result, handle->scratch, nullptr);
+    }
+    handle->completed = true;
+    ++completion_calls_;
+    handle->callback(req, handle->callback_arg);
+  }
+
+  std::vector<PrefetchAsyncHandle*> pending_;
+  size_t abort_failures_remaining_ = 0;
+  size_t poll_failures_remaining_ = 0;
+  size_t read_completion_failures_remaining_ = 0;
+  size_t abort_calls_ = 0;
+  size_t poll_calls_ = 0;
+  size_t delete_calls_ = 0;
+  size_t completion_calls_ = 0;
+  size_t aborted_completion_calls_ = 0;
+  bool complete_reads_inline_ = false;
+  bool deleted_before_completion_ = false;
+};
+
+std::shared_ptr<ControlledAsyncFileSystem>
+FilePrefetchBufferTest::CreateControlledAsyncReader(
+    const std::string& fname, std::unique_ptr<RandomAccessFileReader>* reader) {
+  std::shared_ptr<ControlledAsyncFileSystem> fault_fs =
+      std::make_shared<ControlledAsyncFileSystem>(FileSystem::Default());
+  ReadWithFileSystem(fname, FileOptions(), fault_fs.get(), reader);
+  return fault_fs;
+}
+
+IOStatus ControlledAsyncRandomAccessFile::ReadAsync(
+    FSReadRequest& req, const IOOptions& opts,
+    std::function<void(FSReadRequest&, void*)> cb, void* cb_arg,
+    void** io_handle, IOHandleDeleter* del_fn, IODebugContext* /*dbg*/) {
+  if (fs_->MaybeCompleteInline(target(), req, opts, cb, cb_arg)) {
+    return IOStatus::OK();
+  }
+
+  PrefetchAsyncHandle* handle = new PrefetchAsyncHandle();
+  handle->target = target();
+  handle->opts = opts;
+  handle->offset = req.offset;
+  handle->len = req.len;
+  handle->scratch = req.scratch;
+  handle->callback = std::move(cb);
+  handle->callback_arg = cb_arg;
+  *io_handle = handle;
+  *del_fn = [fs = fs_](void* arg) {
+    fs->Delete(static_cast<PrefetchAsyncHandle*>(arg));
+  };
+  fs_->Add(handle);
+  return IOStatus::OK();
+}
+
+TEST_F(FilePrefetchBufferTest, AbortAllIOFailureIsPropagated) {
+  const std::string fname = "abort-all-io-failure";
+  Write(fname, Random(0).RandomString(32768));
+
+  std::unique_ptr<RandomAccessFileReader> reader;
+  std::shared_ptr<ControlledAsyncFileSystem> fault_fs =
+      CreateControlledAsyncReader(fname, &reader);
+
+  {
+    ReadaheadParams readahead_params;
+    readahead_params.initial_readahead_size = 8192;
+    readahead_params.max_readahead_size = 8192;
+    FilePrefetchBuffer fpb(readahead_params, /*enable=*/true,
+                           /*track_min_offset=*/false, fault_fs.get());
+
+    Slice result;
+    ASSERT_TRUE(fpb.PrefetchAsync(IOOptions(), reader.get(), 0, 4096, &result)
+                    .IsTryAgain());
+    ASSERT_EQ(fault_fs->pending_count(), 1);
+
+    fault_fs->FailNextAbort();
+    Status s =
+        fpb.PrefetchAsync(IOOptions(), reader.get(), 8192, 4096, &result);
+    ASSERT_TRUE(s.IsIOError());
+    ASSERT_NE(s.ToString().find("Injected AbortIO failure"), std::string::npos);
+    EXPECT_EQ(fault_fs->pending_count(), 1);
+    EXPECT_EQ(fault_fs->completion_calls(), 0);
+    EXPECT_EQ(fault_fs->delete_calls(), 0);
+    EXPECT_FALSE(fault_fs->deleted_before_completion());
+  }
+
+  EXPECT_EQ(fault_fs->pending_count(), 0);
+  EXPECT_EQ(fault_fs->aborted_completion_calls(), 1);
+  EXPECT_EQ(fault_fs->delete_calls(), 1);
+  EXPECT_FALSE(fault_fs->deleted_before_completion());
+}
+
+TEST_F(FilePrefetchBufferTest, AbortOutdatedIOFailureIsPropagated) {
+  const std::string fname = "abort-outdated-io-failure";
+  Write(fname, Random(0).RandomString(64 * 1024));
+
+  std::unique_ptr<RandomAccessFileReader> reader;
+  std::shared_ptr<ControlledAsyncFileSystem> fault_fs =
+      CreateControlledAsyncReader(fname, &reader);
+
+  {
+    ReadaheadParams readahead_params;
+    readahead_params.initial_readahead_size = 8192;
+    readahead_params.max_readahead_size = 8192;
+    readahead_params.num_buffers = 2;
+    FilePrefetchBuffer fpb(readahead_params, /*enable=*/true,
+                           /*track_min_offset=*/false, fault_fs.get());
+
+    Slice result;
+    Status s;
+    ASSERT_TRUE(
+        fpb.TryReadFromCache(IOOptions(), reader.get(), 0, 4096, &result, &s));
+    ASSERT_OK(s);
+    ASSERT_EQ(fault_fs->pending_count(), 1);
+
+    fault_fs->FailNextAbort();
+    ASSERT_FALSE(fpb.TryReadFromCache(IOOptions(), reader.get(), 32768, 4096,
+                                      &result, &s));
+    ASSERT_TRUE(s.IsIOError());
+    ASSERT_NE(s.ToString().find("Injected AbortIO failure"), std::string::npos);
+    EXPECT_EQ(fault_fs->pending_count(), 1);
+    EXPECT_EQ(fault_fs->completion_calls(), 0);
+    EXPECT_EQ(fault_fs->delete_calls(), 0);
+    EXPECT_FALSE(fault_fs->deleted_before_completion());
+  }
+
+  EXPECT_EQ(fault_fs->pending_count(), 0);
+  EXPECT_EQ(fault_fs->aborted_completion_calls(), 1);
+  EXPECT_EQ(fault_fs->delete_calls(), 1);
+  EXPECT_FALSE(fault_fs->deleted_before_completion());
+}
+
+TEST_F(FilePrefetchBufferTest, PollFailureKeepsAsyncRequestAlive) {
+  const std::string fname = "poll-failure-keeps-request-alive";
+  Write(fname, Random(0).RandomString(32768));
+
+  std::unique_ptr<RandomAccessFileReader> reader;
+  std::shared_ptr<ControlledAsyncFileSystem> fault_fs =
+      CreateControlledAsyncReader(fname, &reader);
+
+  {
+    ReadaheadParams readahead_params;
+    readahead_params.initial_readahead_size = 8192;
+    readahead_params.max_readahead_size = 8192;
+    FilePrefetchBuffer fpb(readahead_params, /*enable=*/true,
+                           /*track_min_offset=*/false, fault_fs.get());
+
+    Slice result;
+    ASSERT_TRUE(fpb.PrefetchAsync(IOOptions(), reader.get(), 0, 4096, &result)
+                    .IsTryAgain());
+    ASSERT_EQ(fault_fs->pending_count(), 1);
+
+    fault_fs->FailNextPoll();
+    Status s;
+    ASSERT_FALSE(
+        fpb.TryReadFromCache(IOOptions(), reader.get(), 0, 4096, &result, &s));
+    ASSERT_TRUE(s.IsIOError());
+    ASSERT_NE(s.ToString().find("Injected Poll failure"), std::string::npos);
+    EXPECT_EQ(fault_fs->pending_count(), 1);
+    EXPECT_EQ(fault_fs->completion_calls(), 0);
+    EXPECT_EQ(fault_fs->delete_calls(), 0);
+    EXPECT_FALSE(fault_fs->deleted_before_completion());
+  }
+
+  EXPECT_EQ(fault_fs->pending_count(), 0);
+  EXPECT_EQ(fault_fs->aborted_completion_calls(), 1);
+  EXPECT_EQ(fault_fs->delete_calls(), 1);
+  EXPECT_FALSE(fault_fs->deleted_before_completion());
+}
+
+TEST_F(FilePrefetchBufferTest, AsyncReadCompletionFailureIsPropagated) {
+  const std::string fname = "async-read-completion-failure";
+  const std::string content = Random(0).RandomString(32768);
+  Write(fname, content);
+
+  std::unique_ptr<RandomAccessFileReader> reader;
+  std::shared_ptr<ControlledAsyncFileSystem> fault_fs =
+      CreateControlledAsyncReader(fname, &reader);
+
+  ReadaheadParams readahead_params;
+  readahead_params.initial_readahead_size = 8192;
+  readahead_params.max_readahead_size = 8192;
+  FilePrefetchBuffer fpb(readahead_params, /*enable=*/true,
+                         /*track_min_offset=*/false, fault_fs.get());
+
+  fault_fs->FailNextReadCompletion();
+  Slice result;
+  ASSERT_TRUE(fpb.PrefetchAsync(IOOptions(), reader.get(), 0, 4096, &result)
+                  .IsTryAgain());
+  ASSERT_EQ(fault_fs->pending_count(), 1);
+
+  Status s;
+  ASSERT_FALSE(
+      fpb.TryReadFromCache(IOOptions(), reader.get(), 0, 4096, &result, &s));
+  ASSERT_TRUE(s.IsIOError());
+  ASSERT_NE(s.ToString().find("Injected async read completion failure"),
+            std::string::npos);
+  EXPECT_EQ(fault_fs->pending_count(), 0);
+  EXPECT_EQ(fault_fs->completion_calls(), 1);
+  EXPECT_EQ(fault_fs->delete_calls(), 1);
+
+  s = Status::OK();
+  ASSERT_TRUE(
+      fpb.TryReadFromCache(IOOptions(), reader.get(), 0, 4096, &result, &s));
+  ASSERT_OK(s);
+  ASSERT_EQ(result, Slice(content.data(), 4096));
+}
+
+TEST_F(FilePrefetchBufferTest,
+       BackgroundAsyncReadCompletionFailureIsPropagated) {
+  const std::string fname = "background-async-read-completion-failure";
+  const std::string content = Random(0).RandomString(32768);
+  Write(fname, content);
+
+  std::unique_ptr<RandomAccessFileReader> reader;
+  std::shared_ptr<ControlledAsyncFileSystem> fault_fs =
+      CreateControlledAsyncReader(fname, &reader);
+
+  ReadaheadParams readahead_params;
+  readahead_params.initial_readahead_size = 8192;
+  readahead_params.max_readahead_size = 8192;
+  readahead_params.num_buffers = 2;
+  FilePrefetchBuffer fpb(readahead_params, /*enable=*/true,
+                         /*track_min_offset=*/false, fault_fs.get());
+
+  fault_fs->FailNextReadCompletion();
+  Slice result;
+  Status s;
+  ASSERT_TRUE(
+      fpb.TryReadFromCache(IOOptions(), reader.get(), 0, 4096, &result, &s));
+  ASSERT_OK(s);
+  ASSERT_EQ(result, Slice(content.data(), 4096));
+  ASSERT_EQ(fault_fs->pending_count(), 1);
+
+  ASSERT_FALSE(
+      fpb.TryReadFromCache(IOOptions(), reader.get(), 8192, 4096, &result, &s));
+  ASSERT_TRUE(s.IsIOError());
+  ASSERT_NE(s.ToString().find("Injected async read completion failure"),
+            std::string::npos);
+  EXPECT_EQ(fault_fs->pending_count(), 0);
+  EXPECT_EQ(fault_fs->completion_calls(), 1);
+  EXPECT_EQ(fault_fs->delete_calls(), 1);
+}
+
+TEST_F(FilePrefetchBufferTest, InlineAsyncReadCompletionFailureIsPropagated) {
+  const std::string fname = "inline-async-read-completion-failure";
+  Write(fname, Random(0).RandomString(32768));
+
+  std::unique_ptr<RandomAccessFileReader> reader;
+  std::shared_ptr<ControlledAsyncFileSystem> fault_fs =
+      CreateControlledAsyncReader(fname, &reader);
+  fault_fs->CompleteReadsInline();
+  fault_fs->FailNextReadCompletion();
+
+  ReadaheadParams readahead_params;
+  readahead_params.initial_readahead_size = 8192;
+  readahead_params.max_readahead_size = 8192;
+  FilePrefetchBuffer fpb(readahead_params, /*enable=*/true,
+                         /*track_min_offset=*/false, fault_fs.get());
+
+  Slice result;
+  Status s = fpb.PrefetchAsync(IOOptions(), reader.get(), 0, 4096, &result);
+  ASSERT_TRUE(s.IsIOError());
+  ASSERT_NE(s.ToString().find("Injected async read completion failure"),
+            std::string::npos);
+  EXPECT_EQ(fault_fs->pending_count(), 0);
+  EXPECT_EQ(fault_fs->completion_calls(), 1);
+  EXPECT_EQ(fault_fs->delete_calls(), 0);
+}
+
+TEST_F(FilePrefetchBufferTest, LaterAsyncSubmissionFailureAbortsEarlierReads) {
+  const std::string fname = "later-async-submission-failure";
+  Write(fname, Random(0).RandomString(32768));
+
+  std::unique_ptr<RandomAccessFileReader> reader;
+  std::shared_ptr<ControlledAsyncFileSystem> fault_fs =
+      CreateControlledAsyncReader(fname, &reader);
+
+  size_t read_async_calls = 0;
+  SyncPoint::GetInstance()->SetCallBack(
+      "RandomAccessFileReader::ReadAsync:InjectStatus", [&](void* arg) {
+        ++read_async_calls;
+        if (read_async_calls == 2) {
+          *static_cast<IOStatus*>(arg) =
+              IOStatus::IOError("Injected async read submission failure");
+        }
+      });
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  ReadaheadParams readahead_params;
+  readahead_params.initial_readahead_size = 8192;
+  readahead_params.max_readahead_size = 8192;
+  readahead_params.num_buffers = 2;
+  FilePrefetchBuffer fpb(readahead_params, /*enable=*/true,
+                         /*track_min_offset=*/false, fault_fs.get());
+
+  Slice result;
+  Status s = fpb.PrefetchAsync(IOOptions(), reader.get(), 0, 4096, &result);
+  ASSERT_TRUE(s.IsIOError());
+  ASSERT_NE(s.ToString().find("Injected async read submission failure"),
+            std::string::npos);
+  EXPECT_EQ(read_async_calls, 2);
+  EXPECT_EQ(fault_fs->abort_calls(), 1);
+  EXPECT_EQ(fault_fs->pending_count(), 0);
+  EXPECT_EQ(fault_fs->aborted_completion_calls(), 1);
+  EXPECT_EQ(fault_fs->delete_calls(), 1);
+  EXPECT_FALSE(fault_fs->deleted_before_completion());
+}
+
+TEST_F(FilePrefetchBufferTest, DestructorPollsAfterAbortIOFailure) {
+  const std::string fname = "destructor-polls-after-abort-failure";
+  const std::string content = Random(0).RandomString(32768);
+  Write(fname, content);
+
+  std::unique_ptr<RandomAccessFileReader> reader;
+  std::shared_ptr<ControlledAsyncFileSystem> fault_fs =
+      CreateControlledAsyncReader(fname, &reader);
+
+  {
+    ReadaheadParams readahead_params;
+    readahead_params.initial_readahead_size = 8192;
+    readahead_params.max_readahead_size = 8192;
+    FilePrefetchBuffer fpb(readahead_params, /*enable=*/true,
+                           /*track_min_offset=*/false, fault_fs.get());
+
+    Slice result;
+    ASSERT_TRUE(fpb.PrefetchAsync(IOOptions(), reader.get(), 0, 4096, &result)
+                    .IsTryAgain());
+    ASSERT_EQ(fault_fs->pending_count(), 1);
+    fault_fs->FailNextAbort();
+  }
+
+  EXPECT_EQ(fault_fs->abort_calls(), 1);
+  EXPECT_EQ(fault_fs->poll_calls(), 1);
+  EXPECT_EQ(fault_fs->pending_count(), 0);
+  EXPECT_EQ(fault_fs->completion_calls(), 1);
+  EXPECT_EQ(fault_fs->aborted_completion_calls(), 0);
+  EXPECT_EQ(fault_fs->delete_calls(), 1);
+  EXPECT_FALSE(fault_fs->deleted_before_completion());
+}
 
 TEST_F(FilePrefetchBufferTest, SeekWithBlockCacheHit) {
   std::string fname = "seek-with-block-cache-hit";


### PR DESCRIPTION
## Summary

FilePrefetchBuffer owns the I/O handles, callback state, and scratch buffers used by asynchronous prefetch reads. Poll and AbortIO are runtime operations whose successful return establishes callback completion; an error does not.

Problem: cancellation results were guarded only by assertions. Release builds could ignore an AbortIO failure and clear or destroy request state that an outstanding callback still referenced. Poll failure likewise destroyed the handle even though completion was not guaranteed. Separately, callback completion status was ignored, including synchronous inline completion, and failure to submit a later buffer could leave earlier requests from the same multi-buffer prefetch active.

Impact: callbacks could access released FilePrefetchBuffer state, resulting in use-after-free, crashes, or memory corruption. Async read errors could be masked and failed or partial buffer state treated as usable. A failed multi-buffer operation could also leave sibling I/O running after the caller had received an error.

Fix: make cancellation and outdated-data helpers return Status and propagate poll, abort, and submission failures without releasing live handles, buffers, or callback state. Poll errors preserve the request for a later poll or abort. The destructor attempts AbortIO, falls back to Poll, and terminates with diagnostics if neither can establish safe completion.

Record callback status only when completion fails, consume it after Poll confirms callback completion, clear failed buffers, and handle default inline ReadAsync completion immediately. When a later multi-buffer submission fails, remove the failed buffer and abort earlier sibling requests. Expected cancellation status is discarded safely, while successful requests retain the allocation-free path. Synchronous fallback, EOF behavior, and public APIs remain unchanged.

Tests: add a controlled async filesystem covering AbortAllIOs and outdated-I/O failure propagation, Poll failure lifetime preservation, destructor fallback, inline and background completion errors, and later-submission cleanup. The complete prefetch_test suite passes normally and with ASSERT_STATUS_CHECKED=1; source and whitespace checks pass as well.


## Test plan

- Complete `prefetch_test` suite.
- Complete `prefetch_test` suite with `ASSERT_STATUS_CHECKED=1`.
- Source and whitespace checks.

