### PR TITLE
Skip duration reporting for no-op POSIX file flushes

### DIFF
--- a/db/listener_test.cc
+++ b/db/listener_test.cc
@@ -1319,7 +1319,8 @@ class TestFileOperationListener : public EventListener {
     if (EndsWith(info.path, ".blob")) {
       ++blob_file_flushes_;
     }
-    ReportDuration(info);
+    // WritableFile::Flush() is a no-op on POSIX and Windows, so its duration
+    // can be zero. See #15139.
   }
 
   void OnFileCloseFinish(const FileOperationInfo& info) override {


### PR DESCRIPTION
## Description

`ReportDuration()` in `TestFileOperationListener` (`db/listener_test.cc`) asserts that every file operation has a strictly positive duration:

```cpp
ASSERT_GT(info.duration.count(), 0);
```

`PosixWritableFile::Flush()` is an intentional no-op — it performs no underlying operation and returns `IOStatus::OK()` immediately. Since there may be effectively no work between the start and finish timestamps, the measured duration can legitimately be `0ns`. On Apple Silicon, this happens consistently, causing `EventListenerTest.OnFileOperationTest` to fail:

```text
Expected: (info.duration.count()) > (0), actual: 0 vs 0
```

This PR removes the `ReportDuration(info)` call from `OnFileFlushFinish` only. Duration reporting remains unchanged for the other file-operation callbacks.

Relaxing the assertion globally to `ASSERT_GE(..., 0)` was considered, but that would weaken the check for operations where a positive duration is still expected. Scoping the change specifically to the known no-op `Flush()` keeps the existing duration checks meaningful for the other operations.

## Motivation and Context

Addresses #15139.

`EventListenerTest` uses the default POSIX environment path through `DBTestBase`, so the failure occurs on the actual POSIX file implementation rather than being caused by test-specific file-operation behavior.

This is related to the behavior discussed in #7133, where the POSIX no-op `Flush()` was also identified as a case where a zero duration can occur.

## Testing

Verified on an Apple Silicon M2 Mac:

```text
❯ ./listener_test --gtest_filter=EventListenerTest.OnFileOperationTest
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from EventListenerTest
[ RUN      ] EventListenerTest.OnFileOperationTest
[       OK ] EventListenerTest.OnFileOperationTest (114 ms)
[----------] 1 test from EventListenerTest (114 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (114 ms total)
[  PASSED  ] 1 test.
```

- 50 consecutive runs of the targeted test — 50/50 passed
- `git diff --check` — clean
- RocksDB pre-push format check — clean