### PR TITLE
Add custom read context to ReadOptions (#15173)

### DIFF
--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -2226,10 +2226,10 @@ struct ReadOptions {
   // NOTE: for all pointer members of ReadOptions (e.g. snapshot, timestamp,
   // iterate_lower_bound, iterate_upper_bound, table_filter, ...), when the
   // pointer is non-nullptr the caller retains ownership of the pointed-to
-  // object and is responsible for keeping it alive and unchanged for as long as
-  // the read operation using these options is in progress (which, for an
-  // iterator, is the lifetime of the iterator). This keeps ReadOptions cheap to
-  // copy (internal to RocksDB).
+  // object and, unless documented otherwise, is responsible for keeping it
+  // alive and unchanged for as long as the read operation using these options
+  // is in progress (which, for an iterator, is the lifetime of the iterator).
+  // This keeps ReadOptions cheap to copy (internal to RocksDB).
 
   // *** BEGIN options relevant to point lookups as well as scans ***
 
@@ -2337,6 +2337,16 @@ struct ReadOptions {
   // parallel if the keys in the MultiGet batch are in different levels. It
   // comes at the expense of slightly higher CPU overhead.
   bool optimize_multiget_for_io = true;
+
+  // EXPERIMENTAL
+  //
+  // An opaque, non-owning context passed to all table implementations for this
+  // read. RocksDB does not interpret, manage, or synchronize access to this
+  // context. It is intended to let external table implementations consume
+  // application-defined read options. The caller is responsible for keeping the
+  // context alive for the duration of the read operation (or iterator lifetime)
+  // and for any required synchronization.
+  void* custom_context = nullptr;
 
   // *** END options relevant to point lookups (as well as scans) ***
   // *** BEGIN options only relevant to iterators or scans ***

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -8282,12 +8282,16 @@ class ExternalTableTest : public DBTestBase {
     ExternalTableIterator* NewIterator(
         const ReadOptions& read_options,
         const SliceTransform* /*prefix_extractor*/) override {
+      TEST_SYNC_POINT_CALLBACK("DummyExternalTableReader::NewIterator",
+                               const_cast<ReadOptions*>(&read_options));
       return new DummyExternalTableIterator(read_options, kv_map_);
     }
 
-    Status Get(const ReadOptions& /*read_options*/, const Slice& key,
+    Status Get(const ReadOptions& read_options, const Slice& key,
                const SliceTransform* /*prefix_extractor*/,
                PinnableSlice* value) override {
+      TEST_SYNC_POINT_CALLBACK("DummyExternalTableReader::Get",
+                               const_cast<ReadOptions*>(&read_options));
       auto iter = kv_map_.find(key.ToString());
       if (iter != kv_map_.end()) {
         value->PinSelf(iter->second);
@@ -9126,6 +9130,86 @@ TEST_F(ExternalTableTest, DBIterTest) {
   iter->Next();
   ASSERT_FALSE(iter->Valid());
   ASSERT_OK(iter->status());
+  iter.reset();
+
+  ASSERT_OK(db->DestroyColumnFamilyHandle(cfh));
+  ASSERT_OK(db->Close());
+}
+
+TEST_F(ExternalTableTest, ReadOptionsCustomContext) {
+  if (encrypted_env_) {
+    ROCKSDB_GTEST_SKIP("Test requires non-encrypted environment");
+    return;
+  }
+  Options options = GetDefaultOptions();
+  std::string dbname = test::PerThreadDBPath("external_table_test");
+  std::string ingest_file = dbname + "test.immutable";
+  dbname += "_db";
+  ASSERT_OK(DestroyDB(dbname, options));
+
+  std::shared_ptr<ExternalTableFactory> factory =
+      std::make_shared<DummyExternalTableFactory>(
+          /*support_property_block=*/true);
+  options.table_factory = NewExternalTableFactory(factory);
+
+  std::unique_ptr<SstFileWriter> writer(
+      new SstFileWriter(EnvOptions(), options));
+  ASSERT_OK(writer->Open(ingest_file));
+  ASSERT_OK(writer->Put("foo", "bar"));
+  ASSERT_OK(writer->Finish());
+  writer.reset();
+
+  std::unique_ptr<DB> db;
+  options.create_if_missing = true;
+  ASSERT_OK(DB::Open(options, dbname, &db));
+  ASSERT_NE(db, nullptr);
+  ColumnFamilyHandle* cfh = nullptr;
+  ASSERT_OK(db->CreateColumnFamily(options, "new_cf", &cfh));
+
+  IngestExternalFileOptions ifo;
+  ifo.allow_db_generated_files = true;
+  ifo.fill_cache = false;
+  ASSERT_OK(db->IngestExternalFile(cfh, {ingest_file}, ifo));
+
+  int get_context = 0;
+  int iterator_context = 0;
+  int get_call_count = 0;
+  int new_iterator_call_count = 0;
+  SyncPoint::GetInstance()->SetCallBack(
+      "DummyExternalTableReader::Get", [&](void* arg) {
+        ReadOptions* read_options = static_cast<ReadOptions*>(arg);
+        EXPECT_EQ(read_options->custom_context, &get_context);
+        ++get_call_count;
+      });
+  SyncPoint::GetInstance()->SetCallBack(
+      "DummyExternalTableReader::NewIterator", [&](void* arg) {
+        ReadOptions* read_options = static_cast<ReadOptions*>(arg);
+        EXPECT_EQ(read_options->custom_context, &iterator_context);
+        ++new_iterator_call_count;
+      });
+  SyncPoint::GetInstance()->EnableProcessing();
+  Defer cleanup_sync_point([] {
+    SyncPoint::GetInstance()->DisableProcessing();
+    SyncPoint::GetInstance()->ClearAllCallBacks();
+  });
+
+  ReadOptions get_options;
+  ASSERT_EQ(get_options.custom_context, nullptr);
+  get_options.custom_context = &get_context;
+  std::string value;
+  ASSERT_OK(db->Get(get_options, cfh, "foo", &value));
+  ASSERT_EQ(value, "bar");
+  ASSERT_EQ(get_call_count, 1);
+
+  ReadOptions iterator_options;
+  iterator_options.custom_context = &iterator_context;
+  std::unique_ptr<Iterator> iter(db->NewIterator(iterator_options, cfh));
+  ASSERT_NE(iter, nullptr);
+  iter->Seek("foo");
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_OK(iter->status());
+  ASSERT_EQ(iter->value(), "bar");
+  ASSERT_EQ(new_iterator_call_count, 1);
   iter.reset();
 
   ASSERT_OK(db->DestroyColumnFamilyHandle(cfh));

--- a/tools/c_api_gen/auto_simple_bindings_blocklist.json
+++ b/tools/c_api_gen/auto_simple_bindings_blocklist.json
@@ -58,6 +58,11 @@
           "field": "read_scoped_block_buffer_provider",
           "policy": "manual",
           "reason": "Field type 'ReadScopedBlockBufferProvider *' is a pointer/owning handle to a complex type; needs an explicit C ownership and lifetime design rather than a simple scalar/enum/string wrapper."
+        },
+        {
+          "field": "custom_context",
+          "policy": "manual",
+          "reason": "Opaque non-owning pointer needs an explicit C ownership and lifetime design rather than a generated binding."
         }
       ]
     },

--- a/unreleased_history/public_api_changes/read_options_custom_context.md
+++ b/unreleased_history/public_api_changes/read_options_custom_context.md
@@ -1,0 +1,1 @@
+Added `ReadOptions::custom_context`, an opaque, non-owning pointer passed through table reads so external table implementations can consume application-defined read options.


### PR DESCRIPTION
Summary:

Add an opaque, non-owning `ReadOptions::custom_context` pointer that is passed to table implementations so external table readers can consume application-defined read options. Document its lifetime and synchronization contract, and keep the unsupported pointer out of generated C bindings.

Reviewed By: xingbowang

Differential Revision: D118341098


