### PR TITLE
Learn RocksDB traffic patterns for offpeak telemetry (#15175)

### DIFF
--- a/c_api_gen/c_generated_option_structs_auto.cc.inc
+++ b/c_api_gen/c_generated_option_structs_auto.cc.inc
@@ -856,6 +856,16 @@ const char* rocksdb_options_get_daily_offpeak_time_utc(rocksdb_options_t* opt,
   return opt->rep.daily_offpeak_time_utc.data();
 }
 
+void rocksdb_options_set_dynamic_offpeak_percentile(rocksdb_options_t* opt,
+                                                    uint32_t v) {
+  opt->rep.dynamic_offpeak_percentile = v;
+}
+
+uint32_t rocksdb_options_get_dynamic_offpeak_percentile(
+    rocksdb_options_t* opt) {
+  return opt->rep.dynamic_offpeak_percentile;
+}
+
 void rocksdb_options_set_max_compaction_trigger_wakeup_seconds(
     rocksdb_options_t* opt, uint64_t v) {
   opt->rep.max_compaction_trigger_wakeup_seconds = v;

--- a/c_api_gen/c_generated_option_structs_auto.h.inc
+++ b/c_api_gen/c_generated_option_structs_auto.h.inc
@@ -274,6 +274,12 @@ extern ROCKSDB_LIBRARY_API const char*
 rocksdb_options_get_daily_offpeak_time_utc(rocksdb_options_t* opt,
                                            size_t* size);
 
+extern ROCKSDB_LIBRARY_API void rocksdb_options_set_dynamic_offpeak_percentile(
+    rocksdb_options_t* opt, uint32_t v);
+
+extern ROCKSDB_LIBRARY_API uint32_t
+rocksdb_options_get_dynamic_offpeak_percentile(rocksdb_options_t* opt);
+
 extern ROCKSDB_LIBRARY_API void
 rocksdb_options_set_periodic_compaction_phase_recovery_percent(
     rocksdb_options_t* opt, int v);

--- a/c_api_gen/c_generated_roundtrip_tests.c.inc
+++ b/c_api_gen/c_generated_roundtrip_tests.c.inc
@@ -729,6 +729,10 @@ static void rocksdb_roundtrip_test_rocksdb_options(void) {
   CheckCondition(rocksdb_options_get_disallow_memtable_writes(obj) == 1);
   rocksdb_options_set_disallow_memtable_writes(obj, 0);
   CheckCondition(rocksdb_options_get_disallow_memtable_writes(obj) == 0);
+  rocksdb_options_set_dynamic_offpeak_percentile(obj, 1);
+  CheckCondition(rocksdb_options_get_dynamic_offpeak_percentile(obj) == 1);
+  rocksdb_options_set_dynamic_offpeak_percentile(obj, 0);
+  CheckCondition(rocksdb_options_get_dynamic_offpeak_percentile(obj) == 0);
   rocksdb_options_set_enable_blob_direct_write(obj, 1);
   CheckCondition(rocksdb_options_get_enable_blob_direct_write(obj) == 1);
   rocksdb_options_set_enable_blob_direct_write(obj, 0);

--- a/db/c.cc
+++ b/db/c.cc
@@ -9923,6 +9923,16 @@ const char* rocksdb_options_get_daily_offpeak_time_utc(rocksdb_options_t* opt,
   return opt->rep.daily_offpeak_time_utc.data();
 }
 
+void rocksdb_options_set_dynamic_offpeak_percentile(rocksdb_options_t* opt,
+                                                    uint32_t v) {
+  opt->rep.dynamic_offpeak_percentile = v;
+}
+
+uint32_t rocksdb_options_get_dynamic_offpeak_percentile(
+    rocksdb_options_t* opt) {
+  return opt->rep.dynamic_offpeak_percentile;
+}
+
 void rocksdb_options_set_max_compaction_trigger_wakeup_seconds(
     rocksdb_options_t* opt, uint64_t v) {
   opt->rep.max_compaction_trigger_wakeup_seconds = v;

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -1228,6 +1228,7 @@ Status DBImpl::StartPeriodicTaskScheduler() {
   }
 
 #endif  // !NDEBUG
+  RestoreDynamicOffpeakModel();
   if (mutable_db_options_.stats_dump_period_sec > 0) {
     s = periodic_task_scheduler_.Register(
         PeriodicTaskType::kDumpStats,
@@ -1364,10 +1365,16 @@ void DBImpl::PersistStats() {
   if (!statistics) {
     return;
   }
+  const bool persist_stats_to_disk =
+      immutable_db_options_.persist_stats_to_disk;
   size_t stats_history_size_limit = 0;
+  uint32_t dynamic_offpeak_percentile = 0;
+  uint32_t stats_persist_period_sec = 0;
   {
     InstrumentedMutexLock l(&mutex_);
     stats_history_size_limit = mutable_db_options_.stats_history_buffer_size;
+    dynamic_offpeak_percentile = mutable_db_options_.dynamic_offpeak_percentile;
+    stats_persist_period_sec = mutable_db_options_.stats_persist_period_sec;
   }
 
   std::map<std::string, uint64_t> stats_map;
@@ -1377,30 +1384,92 @@ void DBImpl::PersistStats() {
   ROCKS_LOG_INFO(immutable_db_options_.info_log,
                  "------- PERSISTING STATS -------");
 
-  if (immutable_db_options_.persist_stats_to_disk) {
+  constexpr std::array<const char*, 4> kForegroundByteStats = {
+      "rocksdb.bytes.written", "rocksdb.bytes.read",
+      "rocksdb.number.multiget.bytes.read", "rocksdb.db.iter.bytes.read"};
+  constexpr std::array<const char*, 6> kForegroundOperationStats = {
+      "rocksdb.number.keys.written",
+      "rocksdb.number.keys.read",
+      "rocksdb.number.multiget.keys.read",
+      "rocksdb.number.db.seek",
+      "rocksdb.number.db.next",
+      "rocksdb.number.db.prev"};
+  auto is_foreground_stat = [&](const std::string& name) {
+    return std::find(kForegroundByteStats.begin(), kForegroundByteStats.end(),
+                     name) != kForegroundByteStats.end() ||
+           std::find(kForegroundOperationStats.begin(),
+                     kForegroundOperationStats.end(),
+                     name) != kForegroundOperationStats.end();
+  };
+  std::map<std::string, uint64_t> stats_delta;
+  bool counters_reset = false;
+  if (stats_slice_initialized_) {
+    for (const auto& stat : stats_map) {
+      auto previous = stats_slice_.find(stat.first);
+      if (previous == stats_slice_.end()) {
+        continue;
+      }
+      if (stat.second < previous->second) {
+        counters_reset = counters_reset || is_foreground_stat(stat.first);
+        continue;
+      }
+      stats_delta[stat.first] = stat.second - previous->second;
+    }
+  }
+
+  std::string dynamic_model_to_persist;
+  {
+    InstrumentedMutexLock l(&stats_history_mutex_);
+    const uint64_t elapsed_seconds =
+        now_seconds > stats_slice_time_ ? now_seconds - stats_slice_time_ : 0;
+    if (dynamic_offpeak_percentile > 0 && stats_slice_initialized_ &&
+        !counters_reset && elapsed_seconds > 0 &&
+        stats_persist_period_sec > 0 &&
+        elapsed_seconds <= 2 * stats_persist_period_sec) {
+      auto sum_stats = [&](const auto& names, bool* all_available) {
+        uint64_t total = 0;
+        for (const char* name : names) {
+          auto value = stats_delta.find(name);
+          if (value != stats_delta.end()) {
+            total += value->second;
+          } else {
+            *all_available = false;
+          }
+        }
+        return total;
+      };
+      bool all_available = true;
+      const uint64_t foreground_bytes =
+          sum_stats(kForegroundByteStats, &all_available);
+      const uint64_t foreground_operations =
+          sum_stats(kForegroundOperationStats, &all_available);
+      if (all_available &&
+          dynamic_offpeak_model_.AddSample(
+              stats_slice_time_, now_seconds, foreground_bytes,
+              foreground_operations, dynamic_offpeak_percentile)) {
+        dynamic_model_to_persist = dynamic_offpeak_model_.Encode();
+      }
+    }
+  }
+
+  if (persist_stats_to_disk) {
     WriteBatch batch;
     Status s = Status::OK();
     if (stats_slice_initialized_) {
       ROCKS_LOG_INFO(immutable_db_options_.info_log,
                      "Reading %" ROCKSDB_PRIszt " stats from statistics\n",
                      stats_slice_.size());
-      for (const auto& stat : stats_map) {
+      for (const auto& stat : stats_delta) {
         if (s.ok()) {
           char key[100];
           int length =
               EncodePersistentStatsKey(now_seconds, stat.first, 100, key);
-          // calculate the delta from last time
-          if (stats_slice_.find(stat.first) != stats_slice_.end()) {
-            uint64_t delta = stat.second - stats_slice_[stat.first];
-            s = batch.Put(persist_stats_cf_handle_,
-                          Slice(key, std::min(100, length)),
-                          std::to_string(delta));
-          }
+          s = batch.Put(persist_stats_cf_handle_,
+                        Slice(key, std::min(100, length)),
+                        std::to_string(stat.second));
         }
       }
     }
-    stats_slice_initialized_ = true;
-    std::swap(stats_slice_, stats_map);
     if (s.ok()) {
       // TODO: plumb Env::IOActivity, Env::IOPriority
       WriteOptions wo;
@@ -1417,30 +1486,19 @@ void DBImpl::PersistStats() {
       ROCKS_LOG_INFO(immutable_db_options_.info_log,
                      "Writing %" ROCKSDB_PRIszt " stats with timestamp %" PRIu64
                      " to persistent stats CF succeeded",
-                     stats_slice_.size(), now_seconds);
+                     stats_delta.size(), now_seconds);
     }
     // TODO(Zhongyi): add purging for persisted data
   } else {
     InstrumentedMutexLock l(&stats_history_mutex_);
-    // calculate the delta from last time
     if (stats_slice_initialized_) {
-      std::map<std::string, uint64_t> stats_delta;
-      for (const auto& stat : stats_map) {
-        if (stats_slice_.find(stat.first) != stats_slice_.end()) {
-          stats_delta[stat.first] = stat.second - stats_slice_[stat.first];
-        }
-      }
       ROCKS_LOG_INFO(immutable_db_options_.info_log,
                      "Storing %" ROCKSDB_PRIszt " stats with timestamp %" PRIu64
                      " to in-memory stats history",
-                     stats_slice_.size(), now_seconds);
+                     stats_delta.size(), now_seconds);
       stats_history_[now_seconds] = std::move(stats_delta);
     }
-    stats_slice_initialized_ = true;
-    std::swap(stats_slice_, stats_map);
-    TEST_SYNC_POINT("DBImpl::PersistStats:StatsCopied");
 
-    // delete older stats snapshots to control memory consumption
     size_t stats_history_size = EstimateInMemoryStatsHistorySize();
     bool purge_needed = stats_history_size > stats_history_size_limit;
     ROCKS_LOG_INFO(immutable_db_options_.info_log,
@@ -1455,9 +1513,63 @@ void DBImpl::PersistStats() {
     ROCKS_LOG_INFO(immutable_db_options_.info_log,
                    "[Post-GC] In-memory stats history size: %" ROCKSDB_PRIszt
                    " bytes, slice count: %" ROCKSDB_PRIszt,
-                   stats_history_size, stats_history_.size());
+                   EstimateInMemoryStatsHistorySize(), stats_history_.size());
+  }
+  stats_slice_initialized_ = true;
+  stats_slice_time_ = now_seconds;
+  std::swap(stats_slice_, stats_map);
+  TEST_SYNC_POINT("DBImpl::PersistStats:StatsCopied");
+
+  if (!dynamic_model_to_persist.empty()) {
+    Status s = PersistDynamicOffpeakModel(dynamic_model_to_persist);
+    if (!s.ok()) {
+      ROCKS_LOG_ERROR(immutable_db_options_.info_log,
+                      "Persisting dynamic off-peak model failed -- %s",
+                      s.ToString().c_str());
+    }
   }
   TEST_SYNC_POINT("DBImpl::PersistStats:End");
+}
+
+Status DBImpl::PersistDynamicOffpeakModel(const std::string& encoded_model) {
+  InstrumentedMutexLock l(&mutex_);
+  VersionEdit edit;
+  edit.SetDynamicOffpeakModel(encoded_model);
+  const ReadOptions read_options;
+  const WriteOptions write_options;
+  Status s = versions_->LogAndApplyToDefaultColumnFamily(
+      read_options, write_options, &edit, &mutex_, directories_.GetDbDir());
+  if (!s.ok() && versions_->io_status().IsIOError()) {
+    error_handler_.SetBGError(versions_->io_status(),
+                              BackgroundErrorReason::kManifestWrite);
+  }
+  if (s.ok()) {
+    versions_->SetDynamicOffpeakModel(encoded_model);
+  }
+  return s;
+}
+
+void DBImpl::RestoreDynamicOffpeakModel() {
+  if (dynamic_offpeak_model_restored_) {
+    return;
+  }
+  std::string encoded_model;
+  uint32_t percentile = 0;
+  {
+    InstrumentedMutexLock l(&mutex_);
+    encoded_model = versions_->dynamic_offpeak_model();
+    percentile = mutable_db_options_.dynamic_offpeak_percentile;
+  }
+  if (!encoded_model.empty()) {
+    InstrumentedMutexLock l(&stats_history_mutex_);
+    Status s = dynamic_offpeak_model_.Decode(encoded_model, percentile);
+    if (!s.ok()) {
+      ROCKS_LOG_WARN(immutable_db_options_.info_log,
+                     "Ignoring invalid dynamic off-peak model -- %s",
+                     s.ToString().c_str());
+    }
+  }
+  dynamic_offpeak_model_restored_ = true;
 }
 
 bool DBImpl::FindStatsByTime(uint64_t start_time, uint64_t end_time,
@@ -1813,6 +1925,7 @@ Status DBImpl::SetDBOptions(
   Status persist_options_status = Status::OK();
   bool wal_size_option_changed = false;
   bool wal_other_option_changed = false;
+  bool dynamic_offpeak_config_changed = false;
   WriteContext write_context;
   {
     InstrumentedMutexLock l(&mutex_);
@@ -1863,6 +1976,9 @@ Status DBImpl::SetDBOptions(
       const bool max_compactions_increased =
           new_bg_job_limits.max_compactions >
           current_bg_job_limits.max_compactions;
+      dynamic_offpeak_config_changed =
+          mutable_db_options_.dynamic_offpeak_percentile !=
+          new_options.dynamic_offpeak_percentile;
       const bool offpeak_time_changed =
           versions_->offpeak_time_option().daily_offpeak_time_utc !=
           new_db_options.daily_offpeak_time_utc;
@@ -1964,6 +2080,14 @@ Status DBImpl::SetDBOptions(
       // To get here, we must have had invalid options and will not attempt to
       // persist the options, which means the status is "OK/Uninitialized.
       persist_options_status.PermitUncheckedError();
+    }
+  }
+  if (s.ok() && dynamic_offpeak_config_changed &&
+      new_options.dynamic_offpeak_percentile > 0) {
+    {
+      InstrumentedMutexLock l(&stats_history_mutex_);
+      dynamic_offpeak_model_.RecomputeWindow(
+          new_options.dynamic_offpeak_percentile);
     }
   }
   ROCKS_LOG_INFO(immutable_db_options_.info_log, "SetDBOptions(), inputs:");
@@ -4983,8 +5107,86 @@ bool DBImpl::GetProperty(ColumnFamilyHandle* column_family,
 bool DBImpl::GetMapProperty(ColumnFamilyHandle* column_family,
                             const Slice& property,
                             std::map<std::string, std::string>* value) {
-  const DBPropertyInfo* property_info = GetPropertyInfo(property);
   value->clear();
+  if (property == DB::Properties::kDynamicOffpeak) {
+    const uint64_t now_seconds =
+        immutable_db_options_.clock->NowMicros() / kMicrosInSecond;
+    uint32_t percentile = 0;
+    {
+      InstrumentedMutexLock l(&mutex_);
+      percentile = mutable_db_options_.dynamic_offpeak_percentile;
+    }
+    bool trained = false;
+    bool fresh = false;
+    uint32_t trained_days = 0;
+    uint32_t coverage = 0;
+    uint64_t last_update = 0;
+    std::string learned_window;
+    DynamicOffpeakPrediction prediction;
+    DynamicOffpeakObservation observation;
+    {
+      InstrumentedMutexLock l(&stats_history_mutex_);
+      trained = dynamic_offpeak_model_.IsTrained();
+      fresh = dynamic_offpeak_model_.IsFresh(now_seconds);
+      trained_days = dynamic_offpeak_model_.TrainedDays();
+      coverage = dynamic_offpeak_model_.LastDayCoveragePercent();
+      last_update = dynamic_offpeak_model_.LastUpdateTime();
+      learned_window = dynamic_offpeak_model_.LearnedWindow();
+      prediction = dynamic_offpeak_model_.GetPrediction(now_seconds);
+      observation = dynamic_offpeak_model_.GetLatestObservation();
+    }
+    if (!fresh) {
+      learned_window.clear();
+      prediction = {};
+    }
+    OffpeakTimeOption learned_time(learned_window);
+    const OffpeakTimeInfo learned_time_info =
+        learned_time.GetOffpeakTimeInfo(static_cast<int64_t>(now_seconds));
+    (*value)["mode"] =
+        percentile == 0
+            ? "disabled"
+            : (!trained ? "dynamic_training"
+                        : (fresh ? "dynamic_active" : "dynamic_stale"));
+    (*value)["learned_window_utc"] = learned_window;
+    (*value)["is_now_in_learned_window"] =
+        learned_time_info.is_now_offpeak ? "1" : "0";
+    (*value)["seconds_until_learned_window_start"] =
+        std::to_string(learned_time_info.seconds_till_next_offpeak_start);
+    (*value)["prediction_available"] = prediction.available ? "1" : "0";
+    (*value)["prediction_bucket_start_utc_minutes"] =
+        std::to_string(prediction.bucket_start_utc_minutes);
+    (*value)["predicted_bytes_per_second"] =
+        std::to_string(prediction.bytes_per_second);
+    (*value)["predicted_operations_per_second"] =
+        std::to_string(prediction.operations_per_second);
+    (*value)["latest_observation_available"] =
+        observation.available ? "1" : "0";
+    (*value)["latest_observation_start_epoch_seconds"] =
+        std::to_string(observation.start_time);
+    (*value)["latest_observation_end_epoch_seconds"] =
+        std::to_string(observation.end_time);
+    (*value)["latest_observed_bytes_per_second"] =
+        std::to_string(observation.bytes_per_second);
+    (*value)["latest_observed_operations_per_second"] =
+        std::to_string(observation.operations_per_second);
+    (*value)["configured_percentile"] = std::to_string(percentile);
+    (*value)["trained_days"] = std::to_string(trained_days);
+    (*value)["last_day_coverage_percent"] = std::to_string(coverage);
+    (*value)["last_model_update_epoch_seconds"] = std::to_string(last_update);
+    (*value)["model_age_seconds"] =
+        std::to_string(last_update > 0 && now_seconds >= last_update
+                           ? now_seconds - last_update
+                           : 0);
+    (*value)["model_expires_epoch_seconds"] = std::to_string(
+        last_update > 0 ? last_update + DynamicOffpeakModel::kMaxModelAgeSeconds
+                        : 0);
+    (*value)["bucket_minutes"] =
+        std::to_string(DynamicOffpeakModel::kBucketMinutes);
+    (*value)["smoothing_minutes"] =
+        std::to_string(DynamicOffpeakModel::kSmoothingMinutes);
+    return true;
+  }
+  const DBPropertyInfo* property_info = GetPropertyInfo(property);
   auto cfd =
       static_cast_with_check<ColumnFamilyHandleImpl>(column_family)->cfd();
   if (property_info == nullptr) {

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -54,6 +54,7 @@
 #include "memtable/wbwi_memtable.h"
 #include "monitoring/instrumented_mutex.h"
 #include "options/db_options.h"
+#include "options/offpeak_time_info.h"
 #include "options/options_helper.h"
 #include "port/port.h"
 #include "rocksdb/attribute_groups.h"
@@ -1435,6 +1436,9 @@ class DBImpl : public DB
 
   // persist stats to column family "_persistent_stats"
   void PersistStats();
+
+  Status PersistDynamicOffpeakModel(const std::string& encoded_model);
+  void RestoreDynamicOffpeakModel();
 
   // dump rocksdb.stats to LOG
   void DumpStats();
@@ -3494,6 +3498,9 @@ class DBImpl : public DB
   std::map<std::string, uint64_t> stats_slice_;
 
   bool stats_slice_initialized_ = false;
+  uint64_t stats_slice_time_ = 0;
+  DynamicOffpeakModel dynamic_offpeak_model_;
+  bool dynamic_offpeak_model_restored_ = false;
 
   Directories directories_;
 

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -23,6 +23,7 @@
 #include "monitoring/persistent_stats_history.h"
 #include "monitoring/statistics_impl.h"
 #include "monitoring/thread_status_util.h"
+#include "options/offpeak_time_info.h"
 #include "options/options_helper.h"
 #include "rocksdb/options.h"
 #include "rocksdb/table.h"
@@ -316,6 +317,25 @@ Status DBImpl::ValidateOptions(const DBOptions& db_options) {
     } else if (start_time == end_time) {
       return Status::InvalidArgument(
           "start_time and end_time cannot be the same");
+    }
+  }
+
+  if (db_options.dynamic_offpeak_percentile > 50) {
+    return Status::InvalidArgument(
+        "dynamic_offpeak_percentile must be 0 (disabled) or in the range "
+        "[1, 50]");
+  }
+  if (db_options.dynamic_offpeak_percentile > 0) {
+    if (db_options.statistics == nullptr) {
+      return Status::InvalidArgument(
+          "dynamic_offpeak_percentile requires statistics when enabled");
+    }
+    if (db_options.stats_persist_period_sec == 0 ||
+        db_options.stats_persist_period_sec >
+            DynamicOffpeakModel::kBucketSeconds) {
+      return Status::InvalidArgument(
+          "dynamic_offpeak_percentile requires stats_persist_period_sec in "
+          "the range [1, 900] when enabled");
     }
   }
 

--- a/db/db_options_test.cc
+++ b/db/db_options_test.cc
@@ -1384,6 +1384,118 @@ TEST_F(DBOptionsTest, OffpeakTimes) {
   Close();
 }
 
+TEST_F(DBOptionsTest, DynamicOffpeakOptions) {
+  Options options;
+  ASSERT_EQ(0u, options.dynamic_offpeak_percentile);
+  ASSERT_OK(DBImpl::TEST_ValidateOptions(options));
+
+  options.dynamic_offpeak_percentile = 25;
+  options.statistics = CreateDBStatistics();
+  options.stats_persist_period_sec = 900;
+  ASSERT_OK(DBImpl::TEST_ValidateOptions(options));
+
+  options.daily_offpeak_time_utc = "01:00-02:00";
+  ASSERT_OK(DBImpl::TEST_ValidateOptions(options));
+
+  options.dynamic_offpeak_percentile = 51;
+  ASSERT_TRUE(DBImpl::TEST_ValidateOptions(options).IsInvalidArgument());
+  options.dynamic_offpeak_percentile = 25;
+
+  options.stats_persist_period_sec = 0;
+  ASSERT_TRUE(DBImpl::TEST_ValidateOptions(options).IsInvalidArgument());
+  options.stats_persist_period_sec = 901;
+  ASSERT_TRUE(DBImpl::TEST_ValidateOptions(options).IsInvalidArgument());
+  options.stats_persist_period_sec = 900;
+  options.statistics.reset();
+  ASSERT_TRUE(DBImpl::TEST_ValidateOptions(options).IsInvalidArgument());
+
+  options.dynamic_offpeak_percentile = 0;
+  ASSERT_OK(DBImpl::TEST_ValidateOptions(options));
+}
+
+TEST_F(DBOptionsTest, DynamicOffpeakSetDBOptionsValidation) {
+  Options options;
+  options.env = env_;
+  options.dynamic_offpeak_percentile = 25;
+  options.statistics = CreateDBStatistics();
+  options.stats_persist_period_sec = 900;
+  Reopen(options);
+
+  ASSERT_TRUE(dbfull()
+                  ->SetDBOptions({{"dynamic_offpeak_percentile", "51"}})
+                  .IsInvalidArgument());
+  ASSERT_EQ(25u, dbfull()->GetDBOptions().dynamic_offpeak_percentile);
+
+  ASSERT_TRUE(dbfull()
+                  ->SetDBOptions({{"stats_persist_period_sec", "0"}})
+                  .IsInvalidArgument());
+  ASSERT_EQ(900u, dbfull()->GetDBOptions().stats_persist_period_sec);
+  ASSERT_TRUE(dbfull()
+                  ->SetDBOptions({{"stats_persist_period_sec", "901"}})
+                  .IsInvalidArgument());
+  ASSERT_EQ(900u, dbfull()->GetDBOptions().stats_persist_period_sec);
+
+  ASSERT_OK(dbfull()->SetDBOptions({{"dynamic_offpeak_percentile", "0"}}));
+  ASSERT_EQ(0u, dbfull()->GetDBOptions().dynamic_offpeak_percentile);
+  ASSERT_OK(dbfull()->SetDBOptions({{"stats_persist_period_sec", "0"}}));
+  ASSERT_TRUE(dbfull()
+                  ->SetDBOptions({{"dynamic_offpeak_percentile", "25"}})
+                  .IsInvalidArgument());
+  ASSERT_EQ(0u, dbfull()->GetDBOptions().dynamic_offpeak_percentile);
+}
+
+TEST_F(DBOptionsTest, DynamicOffpeakModel) {
+  DynamicOffpeakModel model;
+  constexpr uint32_t kPercentile = 25;
+  for (uint32_t bucket = 0; bucket < DynamicOffpeakModel::kBucketsPerDay;
+       ++bucket) {
+    const uint64_t start = bucket * DynamicOffpeakModel::kBucketSeconds;
+    const uint64_t load =
+        bucket >= 8 && bucket < 24 ? bucket - 7 : 1000 + bucket;
+    ASSERT_FALSE(model.AddSample(start,
+                                 start + DynamicOffpeakModel::kBucketSeconds,
+                                 load, load, kPercentile));
+  }
+  ASSERT_TRUE(model.AddSample(DynamicOffpeakModel::kSecondsPerDay,
+                              DynamicOffpeakModel::kSecondsPerDay + 1, 1, 1,
+                              kPercentile));
+  ASSERT_TRUE(model.IsTrained());
+  ASSERT_EQ(100u, model.LastDayCoveragePercent());
+  ASSERT_FALSE(model.LearnedWindow().empty());
+  ASSERT_TRUE(model.IsFresh(DynamicOffpeakModel::kSecondsPerDay));
+  ASSERT_FALSE(model.IsFresh(DynamicOffpeakModel::kSecondsPerDay +
+                             DynamicOffpeakModel::kMaxModelAgeSeconds + 1));
+  const DynamicOffpeakPrediction prediction =
+      model.GetPrediction(8 * DynamicOffpeakModel::kBucketSeconds);
+  ASSERT_TRUE(prediction.available);
+  ASSERT_EQ(8 * DynamicOffpeakModel::kBucketMinutes,
+            prediction.bucket_start_utc_minutes);
+  ASSERT_DOUBLE_EQ(1.0 / DynamicOffpeakModel::kBucketSeconds,
+                   prediction.bytes_per_second);
+  ASSERT_DOUBLE_EQ(1.0 / DynamicOffpeakModel::kBucketSeconds,
+                   prediction.operations_per_second);
+
+  DynamicOffpeakModel restored;
+  ASSERT_OK(restored.Decode(model.Encode(), kPercentile));
+  ASSERT_EQ(model.LearnedWindow(), restored.LearnedWindow());
+  ASSERT_EQ(model.TrainedDays(), restored.TrainedDays());
+
+  DynamicOffpeakModel disabled_restored;
+  ASSERT_OK(disabled_restored.Decode(model.Encode(), 0));
+  ASSERT_EQ(model.LearnedWindow(), disabled_restored.LearnedWindow());
+  ASSERT_EQ(model.TrainedDays(), disabled_restored.TrainedDays());
+}
+
+TEST_F(DBOptionsTest, FlatDynamicOffpeakModelUsesWholeDay) {
+  DynamicOffpeakModel model;
+  ASSERT_FALSE(
+      model.AddSample(0, DynamicOffpeakModel::kSecondsPerDay, 100, 100, 25));
+  ASSERT_TRUE(model.AddSample(DynamicOffpeakModel::kSecondsPerDay,
+                              DynamicOffpeakModel::kSecondsPerDay + 1, 1, 1,
+                              25));
+  ASSERT_EQ("00:00-23:59", model.LearnedWindow());
+}
+
 TEST_F(DBOptionsTest, CompactionReadaheadSizeChange) {
   for (bool use_direct_reads : {true, false}) {
     SpecialEnv env(env_);

--- a/db/internal_stats.cc
+++ b/db/internal_stats.cc
@@ -335,6 +335,9 @@ static const std::string live_blob_file_garbage_size =
 static const std::string blob_cache_capacity = "blob-cache-capacity";
 static const std::string blob_cache_usage = "blob-cache-usage";
 static const std::string blob_cache_pinned_usage = "blob-cache-pinned-usage";
+// Keep property names as std::string for consistency with the existing table.
+// NOLINTNEXTLINE(cert-err58-cpp)
+static const std::string dynamic_offpeak = "dynamic-offpeak";
 
 const std::string DB::Properties::kNumFilesAtLevelPrefix =
     rocksdb_prefix + num_files_at_level_prefix;
@@ -352,6 +355,10 @@ const std::string DB::Properties::kCFWriteStallStats =
 const std::string DB::Properties::kDBWriteStallStats =
     rocksdb_prefix + db_write_stall_stats;
 const std::string DB::Properties::kDBStats = rocksdb_prefix + dbstats;
+// Public property names use std::string for API compatibility.
+// NOLINTNEXTLINE(cert-err58-cpp)
+const std::string DB::Properties::kDynamicOffpeak =
+    rocksdb_prefix + dynamic_offpeak;
 const std::string DB::Properties::kLevelStats = rocksdb_prefix + levelstats;
 const std::string DB::Properties::kBlockCacheEntryStats =
     rocksdb_prefix + block_cache_entry_stats;

--- a/db/version_edit.cc
+++ b/db/version_edit.cc
@@ -134,7 +134,7 @@ bool VersionEdit::ShouldEmitPerColumnFamilyRecoveryEdit(
          HasLastSequence() || !GetCompactCursors().empty() || HasDbId() ||
          IsColumnFamilyManipulation() || IsInAtomicGroup() ||
          HasFullHistoryTsLow() || HasPersistUserDefinedTimestamps() ||
-         HasSubcompactionProgress();
+         HasSubcompactionProgress() || HasDynamicOffpeakModel();
 }
 
 bool VersionEdit::EncodeTo(std::string* dst,
@@ -262,6 +262,11 @@ bool VersionEdit::EncodeTo(std::string* dst,
     std::string varint_size;
     PutVarint64(&varint_size, last_compacted_manifest_file_size_);
     PutLengthPrefixedSlice(dst, Slice(varint_size));
+  }
+
+  if (has_dynamic_offpeak_model_) {
+    PutVarint32(dst, kDynamicOffpeakModel);
+    PutLengthPrefixedSlice(dst, dynamic_offpeak_model_);
   }
 
   return true;
@@ -925,6 +930,15 @@ Status VersionEdit::DecodeFrom(const Slice& src) {
         break;
       }
 
+      case kDynamicOffpeakModel:
+        if (GetLengthPrefixedSlice(&input, &str)) {
+          dynamic_offpeak_model_ = str.ToString();
+          has_dynamic_offpeak_model_ = true;
+        } else {
+          msg = "dynamic offpeak model";
+        }
+        break;
+
       default:
         if (tag & kTagSafeIgnoreMask) {
           // Tag from future which can be safely ignored.
@@ -1103,6 +1117,10 @@ std::string VersionEdit::DebugString(bool hex_key) const {
     r.append("\n  LastCompactedManifestFileSize: ");
     AppendNumberTo(&r, last_compacted_manifest_file_size_);
   }
+  if (has_dynamic_offpeak_model_) {
+    r.append("\n  DynamicOffpeakModelBytes: ");
+    AppendNumberTo(&r, dynamic_offpeak_model_.size());
+  }
   r.append("\n}\n");
   return r;
 }
@@ -1261,6 +1279,9 @@ std::string VersionEdit::DebugJSON(int edit_num, bool hex_key) const {
 
   if (has_last_compacted_manifest_file_size_) {
     jw << "LastCompactedManifestFileSize" << last_compacted_manifest_file_size_;
+  }
+  if (has_dynamic_offpeak_model_) {
+    jw << "DynamicOffpeakModelBytes" << dynamic_offpeak_model_.size();
   }
 
   jw.EndObject();

--- a/db/version_edit.h
+++ b/db/version_edit.h
@@ -75,6 +75,7 @@ enum Tag : uint32_t {
   kPersistUserDefinedTimestamps,
   kSubcompactionProgress,
   kLastCompactedManifestFileSize,
+  kDynamicOffpeakModel,
 };
 
 enum SubcompactionProgressPerLevelCustomTag : uint32_t {
@@ -1042,6 +1043,15 @@ class VersionEdit {
     return last_compacted_manifest_file_size_;
   }
 
+  void SetDynamicOffpeakModel(const std::string& model) {
+    has_dynamic_offpeak_model_ = true;
+    dynamic_offpeak_model_ = model;
+  }
+  bool HasDynamicOffpeakModel() const { return has_dynamic_offpeak_model_; }
+  const std::string& GetDynamicOffpeakModel() const {
+    return dynamic_offpeak_model_;
+  }
+
   // Recovery-time per-column-family edits only need to be written when they
   // advance the CF's log number or carry some other manifest state.
   bool ShouldEmitPerColumnFamilyRecoveryEdit(uint64_t current_log_number) const;
@@ -1140,6 +1150,9 @@ class VersionEdit {
 
   bool has_last_compacted_manifest_file_size_ = false;
   uint64_t last_compacted_manifest_file_size_ = 0;
+
+  bool has_dynamic_offpeak_model_ = false;
+  std::string dynamic_offpeak_model_;
 
   // Newly created table files and blob files are eligible for deletion if they
   // are not registered as live files after the background jobs creating them

--- a/db/version_edit_handler.cc
+++ b/db/version_edit_handler.cc
@@ -652,6 +652,9 @@ Status VersionEditHandler::ExtractInfoFromVersionEdit(ColumnFamilyData* cfd,
           edit.GetLastCompactedManifestFileSize();
       version_set_->TuneMaxManifestFileSize();
     }
+    if (edit.HasDynamicOffpeakModel()) {
+      version_set_->dynamic_offpeak_model_ = edit.GetDynamicOffpeakModel();
+    }
     if (!version_edit_params_.HasPrevLogNumber()) {
       version_edit_params_.SetPrevLogNumber(0);
     }

--- a/db/version_edit_test.cc
+++ b/db/version_edit_test.cc
@@ -65,6 +65,19 @@ TEST_F(VersionEditTest, EncodeDecode) {
   TestEncodeDecode(edit);
 }
 
+TEST_F(VersionEditTest, DynamicOffpeakModel) {
+  VersionEdit edit;
+  edit.SetDynamicOffpeakModel("encoded-model");
+  std::string encoded;
+  ASSERT_TRUE(edit.EncodeTo(&encoded));
+
+  VersionEdit decoded;
+  ASSERT_OK(decoded.DecodeFrom(encoded));
+  ASSERT_TRUE(decoded.HasDynamicOffpeakModel());
+  ASSERT_EQ("encoded-model", decoded.GetDynamicOffpeakModel());
+  TestEncodeDecode(edit);
+}
+
 TEST_F(VersionEditTest, EncodeDecodeNewFile4) {
   static const uint64_t kBig = 1ull << 50;
 

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -7546,6 +7546,20 @@ Status VersionSet::WriteCurrentStateToManifest(
     }
   }
 
+  if (!dynamic_offpeak_model_.empty()) {
+    VersionEdit edit;
+    edit.SetDynamicOffpeakModel(dynamic_offpeak_model_);
+    std::string record;
+    if (!edit.EncodeTo(&record)) {
+      return Status::Corruption("Unable to Encode VersionEdit:" +
+                                edit.DebugString(true));
+    }
+    io_s = log->AddRecord(write_options, record);
+    if (!io_s.ok()) {
+      return io_s;
+    }
+  }
+
   // Record the approximate compacted manifest size so it's available at
   // recovery time for TuneMaxManifestFileSize(). This record must come last
   // in WriteCurrentStateToManifest for an accurate size estimate.

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -1730,6 +1730,13 @@ class VersionSet {
   // of firing all at once. Caller must hold the DB mutex.
   void ReanchorCompactionPhase();
 
+  const std::string& dynamic_offpeak_model() const {
+    return dynamic_offpeak_model_;
+  }
+  void SetDynamicOffpeakModel(const std::string& model) {
+    dynamic_offpeak_model_ = model;
+  }
+
   const ImmutableDBOptions* db_options() const { return db_options_; }
 
   static uint64_t GetNumLiveVersions(Version* dummy_versions);
@@ -1992,6 +1999,7 @@ class VersionSet {
 
   // Off-peak time option used for compaction scoring
   OffpeakTimeOption offpeak_time_option_;
+  std::string dynamic_offpeak_model_;
 
   // Pointer to the DB's ErrorHandler.
   ErrorHandler* const error_handler_;

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -5259,6 +5259,12 @@ extern ROCKSDB_LIBRARY_API const char*
 rocksdb_options_get_daily_offpeak_time_utc(rocksdb_options_t* opt,
                                            size_t* size);
 
+extern ROCKSDB_LIBRARY_API void rocksdb_options_set_dynamic_offpeak_percentile(
+    rocksdb_options_t* opt, uint32_t v);
+
+extern ROCKSDB_LIBRARY_API uint32_t
+rocksdb_options_get_dynamic_offpeak_percentile(rocksdb_options_t* opt);
+
 extern ROCKSDB_LIBRARY_API void
 rocksdb_options_set_periodic_compaction_phase_recovery_percent(
     rocksdb_options_t* opt, int v);

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1388,6 +1388,11 @@ class DB {
     //      update the baseline for the interval stats.
     static const std::string kDBStats;
 
+    //  "rocksdb.dynamic-offpeak" - returns a map describing the advisory
+    //      DB-wide learned traffic profile, its predicted current load, and
+    //      the latest observed load. It does not affect compaction policy.
+    static const std::string kDynamicOffpeak;
+
     //  "rocksdb.levelstats" - returns multi-line string containing the number
     //      of files per level and total size of each level (MB).
     static const std::string kLevelStats;

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1831,6 +1831,15 @@ struct DBOptions {
   // this field blank. Default: Empty string (no offpeak).
   std::string daily_offpeak_time_utc = "";
 
+  // Percentile of the learned daily traffic profile considered off-peak.
+  // A value of 0 disables DB-wide stats-derived off-peak telemetry. Values in
+  // the range [1, 50] enable it and require statistics plus
+  // stats_persist_period_sec in the range [1, 900]. The learned window is
+  // exposed through DB::Properties::kDynamicOffpeak and does not affect
+  // compaction policy. Dynamically changeable through SetDBOptions().
+  // Default: 0
+  uint32_t dynamic_offpeak_percentile = 0;
+
   // Maximum interval in seconds between periodic compaction trigger checks.
   // The periodic trigger re-evaluates compaction scores for all column
   // families, which is necessary for features like read-triggered compaction

--- a/java/rocksjni/options.cc
+++ b/java/rocksjni/options.cc
@@ -2306,6 +2306,19 @@ jstring Java_org_rocksdb_Options_dailyOffpeakTimeUTC(JNIEnv* env, jclass,
   return env->NewStringUTF(opt->daily_offpeak_time_utc.c_str());
 }
 
+void Java_org_rocksdb_Options_setDynamicOffpeakPercentile(JNIEnv*, jclass,
+                                                          jlong jhandle,
+                                                          jint percentile) {
+  auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
+  opt->dynamic_offpeak_percentile = static_cast<uint32_t>(percentile);
+}
+
+jint Java_org_rocksdb_Options_dynamicOffpeakPercentile(JNIEnv*, jclass,
+                                                       jlong jhandle) {
+  auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
+  return static_cast<jint>(opt->dynamic_offpeak_percentile);
+}
+
 /*
  * Class:     org_rocksdb_Options
  * Method:    setAvoidFlushDuringShutdown
@@ -7934,6 +7947,19 @@ jstring Java_org_rocksdb_DBOptions_dailyOffpeakTimeUTC(JNIEnv* env, jclass,
                                                        jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   return env->NewStringUTF(opt->daily_offpeak_time_utc.c_str());
+}
+
+void Java_org_rocksdb_DBOptions_setDynamicOffpeakPercentile(JNIEnv*, jclass,
+                                                            jlong jhandle,
+                                                            jint percentile) {
+  auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
+  opt->dynamic_offpeak_percentile = static_cast<uint32_t>(percentile);
+}
+
+jint Java_org_rocksdb_DBOptions_dynamicOffpeakPercentile(JNIEnv*, jclass,
+                                                         jlong jhandle) {
+  auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
+  return static_cast<jint>(opt->dynamic_offpeak_percentile);
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/java/src/main/java/org/rocksdb/DBOptions.java
+++ b/java/src/main/java/org/rocksdb/DBOptions.java
@@ -800,6 +800,19 @@ public class DBOptions extends RocksObject
   }
 
   @Override
+  public DBOptions setDynamicOffpeakPercentile(final int dynamicOffpeakPercentile) {
+    assert (isOwningHandle());
+    setDynamicOffpeakPercentile(nativeHandle_, dynamicOffpeakPercentile);
+    return this;
+  }
+
+  @Override
+  public int dynamicOffpeakPercentile() {
+    assert (isOwningHandle());
+    return dynamicOffpeakPercentile(nativeHandle_);
+  }
+
+  @Override
   public DBOptions setWritableFileMaxBufferSize(final long writableFileMaxBufferSize) {
     assert(isOwningHandle());
     setWritableFileMaxBufferSize(nativeHandle_, writableFileMaxBufferSize);
@@ -1370,6 +1383,9 @@ public class DBOptions extends RocksObject
   private static native void setDailyOffpeakTimeUTC(
       final long handle, final String dailyOffpeakTimeUTC);
   private static native String dailyOffpeakTimeUTC(final long handle);
+  private static native void setDynamicOffpeakPercentile(
+      final long handle, final int dynamicOffpeakPercentile);
+  private static native int dynamicOffpeakPercentile(final long handle);
   private static native void setWritableFileMaxBufferSize(
       final long handle, final long writableFileMaxBufferSize);
   private static native long writableFileMaxBufferSize(final long handle);

--- a/java/src/main/java/org/rocksdb/DBOptionsInterface.java
+++ b/java/src/main/java/org/rocksdb/DBOptionsInterface.java
@@ -1729,4 +1729,14 @@ public interface DBOptionsInterface<T extends DBOptionsInterface<T>> {
    * @return String value of current offpeak time range, "" if none is set.
    */
   String dailyOffpeakTimeUTC();
+
+  /**
+   * Sets the learned daily load percentile considered off-peak. A value of
+   * zero disables dynamic off-peak telemetry; values from 1 through 50 enable
+   * it. The learned window does not affect compaction policy.
+   */
+  T setDynamicOffpeakPercentile(final int dynamicOffpeakPercentile);
+
+  /** Returns the learned daily load percentile considered off-peak. */
+  int dynamicOffpeakPercentile();
 }

--- a/java/src/main/java/org/rocksdb/MutableDBOptions.java
+++ b/java/src/main/java/org/rocksdb/MutableDBOptions.java
@@ -79,7 +79,8 @@ public class MutableDBOptions extends AbstractMutableOptions {
     compaction_readahead_size(ValueType.LONG),
     max_compaction_trigger_wakeup_seconds(ValueType.LONG),
 
-    daily_offpeak_time_utc(ValueType.STRING);
+    daily_offpeak_time_utc(ValueType.STRING),
+    dynamic_offpeak_percentile(ValueType.INT);
 
     private final ValueType valueType;
     DBOption(final ValueType valueType) {
@@ -312,6 +313,16 @@ public class MutableDBOptions extends AbstractMutableOptions {
     @Override
     public String dailyOffpeakTimeUTC() {
       return getString(DBOption.daily_offpeak_time_utc);
+    }
+
+    @Override
+    public MutableDBOptionsBuilder setDynamicOffpeakPercentile(final int dynamicOffpeakPercentile) {
+      return setInt(DBOption.dynamic_offpeak_percentile, dynamicOffpeakPercentile);
+    }
+
+    @Override
+    public int dynamicOffpeakPercentile() {
+      return getInt(DBOption.dynamic_offpeak_percentile);
     }
   }
 }

--- a/java/src/main/java/org/rocksdb/MutableDBOptionsInterface.java
+++ b/java/src/main/java/org/rocksdb/MutableDBOptionsInterface.java
@@ -497,4 +497,14 @@ public interface MutableDBOptionsInterface<T extends MutableDBOptionsInterface<T
    * @return String value of current offpeak time range, "" if none is set.
    */
   String dailyOffpeakTimeUTC();
+
+  /**
+   * Sets the learned daily load percentile considered off-peak. A value of
+   * zero disables dynamic off-peak telemetry; values from 1 through 50 enable
+   * it. The learned window does not affect compaction policy.
+   */
+  T setDynamicOffpeakPercentile(final int dynamicOffpeakPercentile);
+
+  /** Returns the learned daily load percentile considered off-peak. */
+  int dynamicOffpeakPercentile();
 }

--- a/java/src/main/java/org/rocksdb/Options.java
+++ b/java/src/main/java/org/rocksdb/Options.java
@@ -888,6 +888,19 @@ public class Options extends RocksObject
   }
 
   @Override
+  public Options setDynamicOffpeakPercentile(final int dynamicOffpeakPercentile) {
+    assert (isOwningHandle());
+    setDynamicOffpeakPercentile(nativeHandle_, dynamicOffpeakPercentile);
+    return this;
+  }
+
+  @Override
+  public int dynamicOffpeakPercentile() {
+    assert (isOwningHandle());
+    return dynamicOffpeakPercentile(nativeHandle_);
+  }
+
+  @Override
   public Options setWritableFileMaxBufferSize(final long writableFileMaxBufferSize) {
     assert(isOwningHandle());
     setWritableFileMaxBufferSize(nativeHandle_, writableFileMaxBufferSize);
@@ -2287,6 +2300,9 @@ public class Options extends RocksObject
   private static native long compactionReadaheadSize(final long handle);
   private static native void setDailyOffpeakTimeUTC(final long handle, final String offpeakTimeUTC);
   private static native String dailyOffpeakTimeUTC(final long handle);
+  private static native void setDynamicOffpeakPercentile(
+      final long handle, final int dynamicOffpeakPercentile);
+  private static native int dynamicOffpeakPercentile(final long handle);
   private static native void setWritableFileMaxBufferSize(
       final long handle, final long writableFileMaxBufferSize);
   private static native long writableFileMaxBufferSize(final long handle);

--- a/monitoring/stats_history_test.cc
+++ b/monitoring/stats_history_test.cc
@@ -285,6 +285,59 @@ TEST_F(StatsHistoryTest, InMemoryStatsHistoryPurging) {
   // the correct stats snapshot
 }
 
+TEST_F(StatsHistoryTest, DynamicOffpeakModelPersistsAndRecovers) {
+  constexpr uint32_t kPeriodSec = DynamicOffpeakModel::kBucketSeconds;
+  Options options;
+  options.create_if_missing = true;
+  options.statistics = CreateDBStatistics();
+  options.stats_persist_period_sec = kPeriodSec;
+  options.dynamic_offpeak_percentile = 25;
+  options.daily_offpeak_time_utc = "01:00-02:00";
+  options.env = mock_env_.get();
+  Reopen(options);
+
+  dbfull()->TEST_WaitForPeriodicTaskRun(
+      [&] { mock_clock_->MockSleepForSeconds(kPeriodSec - 1); });
+  for (uint32_t bucket = 0; bucket <= DynamicOffpeakModel::kBucketsPerDay;
+       ++bucket) {
+    ASSERT_OK(Put("key" + std::to_string(bucket), "value"));
+    dbfull()->TEST_WaitForPeriodicTaskRun(
+        [&] { mock_clock_->MockSleepForSeconds(kPeriodSec); });
+  }
+
+  std::map<std::string, std::string> property;
+  ASSERT_TRUE(db_->GetMapProperty(DB::Properties::kDynamicOffpeak, &property));
+  ASSERT_EQ("dynamic_active", property["mode"]);
+  ASSERT_FALSE(property["learned_window_utc"].empty());
+  ASSERT_EQ("1", property["trained_days"]);
+  ASSERT_EQ("1", property["prediction_available"]);
+  ASSERT_EQ("1", property["latest_observation_available"]);
+  const std::string learned_window = property["learned_window_utc"];
+  ASSERT_EQ(
+      "01:00-02:00",
+      dbfull()->GetVersionSet()->offpeak_time_option().daily_offpeak_time_utc);
+
+  ASSERT_OK(dbfull()->SetDBOptions({{"bytes_per_sync", "2048"}}));
+  property.clear();
+  ASSERT_TRUE(db_->GetMapProperty(DB::Properties::kDynamicOffpeak, &property));
+  ASSERT_EQ(learned_window, property["learned_window_utc"]);
+  ASSERT_EQ(
+      "01:00-02:00",
+      dbfull()->GetVersionSet()->offpeak_time_option().daily_offpeak_time_utc);
+
+  Reopen(options);
+  property.clear();
+  ASSERT_TRUE(db_->GetMapProperty(DB::Properties::kDynamicOffpeak, &property));
+  ASSERT_EQ("dynamic_active", property["mode"]);
+  ASSERT_EQ(learned_window, property["learned_window_utc"]);
+  ASSERT_EQ("1", property["prediction_available"]);
+  ASSERT_EQ("0", property["latest_observation_available"]);
+  ASSERT_EQ(
+      "01:00-02:00",
+      dbfull()->GetVersionSet()->offpeak_time_option().daily_offpeak_time_utc);
+  Close();
+}
+
 int countkeys(Iterator* iter) {
   int count = 0;
   for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {

--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -148,6 +148,10 @@ static std::unordered_map<std::string, OptionTypeInfo>
          {offsetof(struct MutableDBOptions, daily_offpeak_time_utc),
           OptionType::kString, OptionVerificationType::kNormal,
           OptionTypeFlags::kMutable}},
+        {"dynamic_offpeak_percentile",
+         {offsetof(struct MutableDBOptions, dynamic_offpeak_percentile),
+          OptionType::kUInt32T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kMutable}},
         {"max_compaction_trigger_wakeup_seconds",
          {offsetof(struct MutableDBOptions,
                    max_compaction_trigger_wakeup_seconds),
@@ -1123,6 +1127,7 @@ MutableDBOptions::MutableDBOptions(const DBOptions& options)
       remote_compaction_manifest_floor(
           options.remote_compaction_manifest_floor),
       daily_offpeak_time_utc(options.daily_offpeak_time_utc),
+      dynamic_offpeak_percentile(options.dynamic_offpeak_percentile),
       max_compaction_trigger_wakeup_seconds(
           options.max_compaction_trigger_wakeup_seconds),
       periodic_compaction_phase_recovery_percent(
@@ -1185,6 +1190,8 @@ void MutableDBOptions::Dump(Logger* log) const {
                    optimize_manifest_for_recovery);
   ROCKS_LOG_HEADER(log, "Options.daily_offpeak_time_utc: %s",
                    daily_offpeak_time_utc.c_str());
+  ROCKS_LOG_HEADER(log, "Options.dynamic_offpeak_percentile: %" PRIu32,
+                   dynamic_offpeak_percentile);
   ROCKS_LOG_HEADER(log,
                    "Options.max_compaction_trigger_wakeup_seconds: %" PRIu64,
                    max_compaction_trigger_wakeup_seconds);

--- a/options/db_options.h
+++ b/options/db_options.h
@@ -158,6 +158,7 @@ struct MutableDBOptions {
   bool fast_sst_open;
   bool remote_compaction_manifest_floor;
   std::string daily_offpeak_time_utc;
+  uint32_t dynamic_offpeak_percentile;
   uint64_t max_compaction_trigger_wakeup_seconds;
   int periodic_compaction_phase_recovery_percent;
 };

--- a/options/offpeak_time_info.cc
+++ b/options/offpeak_time_info.cc
@@ -5,7 +5,15 @@
 
 #include "options/offpeak_time_info.h"
 
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <limits>
+#include <vector>
+
 #include "rocksdb/system_clock.h"
+#include "util/coding.h"
 #include "util/string_util.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -54,6 +62,299 @@ OffpeakTimeInfo OffpeakTimeOption::GetOffpeakTimeInfo(
           : ((daily_offpeak_start_time_utc + kSecondsPerDay) -
              seconds_since_midnight);
   return offpeak_time_info;
+}
+
+namespace {
+
+constexpr double kDailyEwmaWeight = 0.25;
+constexpr uint32_t kModelEncodingVersion = 1;
+
+uint64_t EncodeDouble(double value) {
+  uint64_t result;
+  static_assert(sizeof(result) == sizeof(value), "unexpected double size");
+  std::memcpy(&result, &value, sizeof(result));
+  return result;
+}
+
+double DecodeDouble(uint64_t value) {
+  double result;
+  std::memcpy(&result, &value, sizeof(result));
+  return result;
+}
+
+std::string FormatWindow(uint32_t start_bucket, uint32_t bucket_count) {
+  const uint32_t start_minutes =
+      (start_bucket % DynamicOffpeakModel::kBucketsPerDay) *
+      DynamicOffpeakModel::kBucketMinutes;
+  const uint32_t end_minutes =
+      (start_minutes + bucket_count * DynamicOffpeakModel::kBucketMinutes - 1) %
+      (24 * 60);
+  char result[12];
+  std::snprintf(result, sizeof(result), "%02u:%02u-%02u:%02u",
+                start_minutes / 60, start_minutes % 60, end_minutes / 60,
+                end_minutes % 60);
+  return result;
+}
+
+}  // namespace
+
+bool DynamicOffpeakModel::AddSample(uint64_t start_time, uint64_t end_time,
+                                    uint64_t foreground_bytes,
+                                    uint64_t foreground_operations,
+                                    uint32_t percentile) {
+  if (end_time <= start_time) {
+    return false;
+  }
+
+  const double duration = static_cast<double>(end_time - start_time);
+  const double byte_rate = foreground_bytes / duration;
+  const double operation_rate = foreground_operations / duration;
+  latest_observation_ = {true, start_time, end_time, byte_rate, operation_rate};
+  bool model_updated = false;
+  uint64_t cursor = start_time;
+  while (cursor < end_time) {
+    const uint64_t day_start = cursor - cursor % kSecondsPerDay;
+    if (!has_current_day_) {
+      ResetDay(day_start);
+    } else if (day_start != current_day_start_) {
+      model_updated = FinalizeDay(percentile) || model_updated;
+      ResetDay(day_start);
+    }
+    const uint64_t segment_end = std::min(end_time, day_start + kSecondsPerDay);
+    AddSegment(cursor, segment_end, byte_rate, operation_rate);
+    cursor = segment_end;
+  }
+  return model_updated;
+}
+
+void DynamicOffpeakModel::AddSegment(uint64_t start_time, uint64_t end_time,
+                                     double byte_rate, double operation_rate) {
+  uint64_t cursor = start_time;
+  while (cursor < end_time) {
+    const uint32_t bucket =
+        static_cast<uint32_t>((cursor - current_day_start_) / kBucketSeconds);
+    const uint64_t bucket_end =
+        current_day_start_ + (bucket + 1) * kBucketSeconds;
+    const uint64_t segment_end = std::min(end_time, bucket_end);
+    const uint32_t covered = static_cast<uint32_t>(segment_end - cursor);
+    day_bytes_[bucket] += byte_rate * covered;
+    day_operations_[bucket] += operation_rate * covered;
+    day_coverage_seconds_[bucket] += covered;
+    cursor = segment_end;
+  }
+}
+
+void DynamicOffpeakModel::ResetDay(uint64_t day_start) {
+  day_bytes_.fill(0);
+  day_operations_.fill(0);
+  day_coverage_seconds_.fill(0);
+  current_day_start_ = day_start;
+  has_current_day_ = true;
+}
+
+bool DynamicOffpeakModel::FinalizeDay(uint32_t percentile) {
+  uint64_t coverage = 0;
+  for (uint32_t bucket_coverage : day_coverage_seconds_) {
+    coverage += bucket_coverage;
+  }
+  last_day_coverage_percent_ =
+      static_cast<uint32_t>(coverage * 100 / kSecondsPerDay);
+  if (last_day_coverage_percent_ < 90) {
+    return false;
+  }
+
+  for (uint32_t i = 0; i < kBucketsPerDay; ++i) {
+    if (day_coverage_seconds_[i] == 0) {
+      continue;
+    }
+    const double byte_rate = day_bytes_[i] / day_coverage_seconds_[i];
+    const double operation_rate = day_operations_[i] / day_coverage_seconds_[i];
+    if (known_buckets_[i]) {
+      byte_rate_ewma_[i] = kDailyEwmaWeight * byte_rate +
+                           (1.0 - kDailyEwmaWeight) * byte_rate_ewma_[i];
+      operation_rate_ewma_[i] =
+          kDailyEwmaWeight * operation_rate +
+          (1.0 - kDailyEwmaWeight) * operation_rate_ewma_[i];
+    } else {
+      byte_rate_ewma_[i] = byte_rate;
+      operation_rate_ewma_[i] = operation_rate;
+      known_buckets_[i] = true;
+    }
+  }
+  ++trained_days_;
+  last_update_time_ = current_day_start_ + kSecondsPerDay;
+  RecomputeWindow(percentile);
+  return true;
+}
+
+void DynamicOffpeakModel::RecomputeWindow(uint32_t percentile) {
+  std::array<double, kBucketsPerDay> byte_smoothed{};
+  std::array<double, kBucketsPerDay> operation_smoothed{};
+  std::vector<uint32_t> known;
+  constexpr uint32_t kSmoothingBuckets = kSmoothingMinutes / kBucketMinutes;
+  for (uint32_t i = 0; i < kBucketsPerDay; ++i) {
+    if (!known_buckets_[i]) {
+      continue;
+    }
+    uint32_t count = 0;
+    for (uint32_t offset = 0; offset < kSmoothingBuckets; ++offset) {
+      const uint32_t bucket = (i + kBucketsPerDay - offset) % kBucketsPerDay;
+      if (known_buckets_[bucket]) {
+        byte_smoothed[i] += byte_rate_ewma_[bucket];
+        operation_smoothed[i] += operation_rate_ewma_[bucket];
+        ++count;
+      }
+    }
+    byte_smoothed[i] /= count;
+    operation_smoothed[i] /= count;
+    known.push_back(i);
+  }
+  if (known.empty()) {
+    learned_window_.clear();
+    return;
+  }
+
+  std::array<double, kBucketsPerDay> scores{};
+  for (uint32_t bucket : known) {
+    uint32_t lower_bytes = 0;
+    uint32_t lower_operations = 0;
+    for (uint32_t other : known) {
+      lower_bytes += byte_smoothed[other] < byte_smoothed[bucket];
+      lower_operations +=
+          operation_smoothed[other] < operation_smoothed[bucket];
+    }
+    const double denominator =
+        known.size() > 1 ? static_cast<double>(known.size() - 1) : 1.0;
+    scores[bucket] =
+        (lower_bytes / denominator + lower_operations / denominator) / 2.0;
+  }
+
+  std::vector<double> sorted_scores;
+  sorted_scores.reserve(known.size());
+  for (uint32_t bucket : known) {
+    sorted_scores.push_back(scores[bucket]);
+  }
+  std::sort(sorted_scores.begin(), sorted_scores.end());
+  const size_t threshold_index =
+      std::max<size_t>(1, (sorted_scores.size() * percentile + 99) / 100) - 1;
+  const double threshold = sorted_scores[threshold_index];
+
+  std::array<bool, kBucketsPerDay> eligible{};
+  for (uint32_t bucket : known) {
+    eligible[bucket] = scores[bucket] <= threshold;
+  }
+
+  uint32_t best_start = 0;
+  uint32_t best_length = 0;
+  double best_average = std::numeric_limits<double>::infinity();
+  for (uint32_t start = 0; start < kBucketsPerDay; ++start) {
+    if (!eligible[start] ||
+        eligible[(start + kBucketsPerDay - 1) % kBucketsPerDay]) {
+      continue;
+    }
+    uint32_t length = 0;
+    double total = 0;
+    while (length < kBucketsPerDay &&
+           eligible[(start + length) % kBucketsPerDay]) {
+      total += scores[(start + length) % kBucketsPerDay];
+      ++length;
+    }
+    const double average = total / length;
+    if (length > best_length ||
+        (length == best_length && average < best_average) ||
+        (length == best_length && average == best_average &&
+         start < best_start)) {
+      best_start = start;
+      best_length = length;
+      best_average = average;
+    }
+  }
+  if (best_length == 0 && std::all_of(eligible.begin(), eligible.end(),
+                                      [](bool value) { return value; })) {
+    best_length = kBucketsPerDay;
+  }
+  learned_window_ =
+      best_length == 0 ? "" : FormatWindow(best_start, best_length);
+}
+
+bool DynamicOffpeakModel::IsFresh(uint64_t now) const {
+  return IsTrained() && now >= last_update_time_ &&
+         now - last_update_time_ <= kMaxModelAgeSeconds;
+}
+
+DynamicOffpeakPrediction DynamicOffpeakModel::GetPrediction(
+    uint64_t current_time) const {
+  const uint32_t bucket =
+      static_cast<uint32_t>(current_time % kSecondsPerDay / kBucketSeconds);
+  if (!known_buckets_[bucket]) {
+    return {};
+  }
+  return {true, bucket * kBucketMinutes, byte_rate_ewma_[bucket],
+          operation_rate_ewma_[bucket]};
+}
+
+std::string DynamicOffpeakModel::Encode() const {
+  std::string encoded;
+  PutVarint32(&encoded, kModelEncodingVersion);
+  PutVarint32(&encoded, trained_days_);
+  PutVarint32(&encoded, last_day_coverage_percent_);
+  PutVarint64(&encoded, last_update_time_);
+  PutLengthPrefixedSlice(&encoded, learned_window_);
+  for (uint32_t i = 0; i < kBucketsPerDay; ++i) {
+    encoded.push_back(known_buckets_[i] ? 1 : 0);
+    PutFixed64(&encoded, EncodeDouble(byte_rate_ewma_[i]));
+    PutFixed64(&encoded, EncodeDouble(operation_rate_ewma_[i]));
+  }
+  return encoded;
+}
+
+Status DynamicOffpeakModel::Decode(const Slice& encoded, uint32_t percentile) {
+  Slice input = encoded;
+  uint32_t version = 0;
+  uint32_t trained_days = 0;
+  uint32_t coverage = 0;
+  uint64_t last_update = 0;
+  Slice learned_window;
+  if (!GetVarint32(&input, &version) || version != kModelEncodingVersion ||
+      !GetVarint32(&input, &trained_days) || !GetVarint32(&input, &coverage) ||
+      !GetVarint64(&input, &last_update) ||
+      !GetLengthPrefixedSlice(&input, &learned_window)) {
+    return Status::Corruption("dynamic offpeak model header");
+  }
+  std::array<bool, kBucketsPerDay> known{};
+  std::array<double, kBucketsPerDay> byte_rates{};
+  std::array<double, kBucketsPerDay> operation_rates{};
+  for (uint32_t i = 0; i < kBucketsPerDay; ++i) {
+    uint64_t bytes = 0;
+    uint64_t operations = 0;
+    if (input.empty()) {
+      return Status::Corruption("dynamic offpeak model buckets");
+    }
+    known[i] = input[0] != 0;
+    input.remove_prefix(1);
+    if (!GetFixed64(&input, &bytes) || !GetFixed64(&input, &operations)) {
+      return Status::Corruption("dynamic offpeak model rates");
+    }
+    byte_rates[i] = DecodeDouble(bytes);
+    operation_rates[i] = DecodeDouble(operations);
+    if (!std::isfinite(byte_rates[i]) || !std::isfinite(operation_rates[i])) {
+      return Status::Corruption("dynamic offpeak model non-finite rate");
+    }
+  }
+  if (!input.empty() || coverage > 100) {
+    return Status::Corruption("dynamic offpeak model trailing data");
+  }
+  known_buckets_ = known;
+  byte_rate_ewma_ = byte_rates;
+  operation_rate_ewma_ = operation_rates;
+  trained_days_ = trained_days;
+  last_day_coverage_percent_ = coverage;
+  last_update_time_ = last_update;
+  learned_window_ = learned_window.ToString();
+  if (percentile > 0) {
+    RecomputeWindow(percentile);
+  }
+  return Status::OK();
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/options/offpeak_time_info.h
+++ b/options/offpeak_time_info.h
@@ -5,10 +5,13 @@
 
 #pragma once
 
+#include <array>
 #include <cstdint>
 #include <string>
 
 #include "rocksdb/rocksdb_namespace.h"
+#include "rocksdb/slice.h"
+#include "rocksdb/status.h"
 
 namespace ROCKSDB_NAMESPACE {
 class SystemClock;
@@ -32,6 +35,73 @@ struct OffpeakTimeOption {
   void SetFromOffpeakTimeString(const std::string& offpeak_time_string);
 
   OffpeakTimeInfo GetOffpeakTimeInfo(const int64_t& current_time) const;
+};
+
+struct DynamicOffpeakPrediction {
+  bool available = false;
+  uint32_t bucket_start_utc_minutes = 0;
+  double bytes_per_second = 0;
+  double operations_per_second = 0;
+};
+
+struct DynamicOffpeakObservation {
+  bool available = false;
+  uint64_t start_time = 0;
+  uint64_t end_time = 0;
+  double bytes_per_second = 0;
+  double operations_per_second = 0;
+};
+
+class DynamicOffpeakModel {
+ public:
+  static constexpr uint32_t kBucketMinutes = 15;
+  static constexpr uint32_t kSmoothingMinutes = 60;
+  static constexpr uint32_t kBucketsPerDay = 24 * 60 / kBucketMinutes;
+  static constexpr uint64_t kBucketSeconds = kBucketMinutes * 60;
+  static constexpr uint64_t kSecondsPerDay = 24 * 60 * 60;
+  static constexpr uint64_t kMaxModelAgeSeconds = 7 * kSecondsPerDay;
+
+  // Returns true when a completed UTC day updates the learned model.
+  bool AddSample(uint64_t start_time, uint64_t end_time,
+                 uint64_t foreground_bytes, uint64_t foreground_operations,
+                 uint32_t percentile);
+
+  bool IsTrained() const { return trained_days_ > 0; }
+  bool IsFresh(uint64_t now) const;
+  uint32_t TrainedDays() const { return trained_days_; }
+  uint32_t LastDayCoveragePercent() const { return last_day_coverage_percent_; }
+  uint64_t LastUpdateTime() const { return last_update_time_; }
+  const std::string& LearnedWindow() const { return learned_window_; }
+  DynamicOffpeakPrediction GetPrediction(uint64_t current_time) const;
+  DynamicOffpeakObservation GetLatestObservation() const {
+    return latest_observation_;
+  }
+
+  void RecomputeWindow(uint32_t percentile);
+  std::string Encode() const;
+  Status Decode(const Slice& encoded, uint32_t percentile);
+
+ private:
+  bool FinalizeDay(uint32_t percentile);
+  void ResetDay(uint64_t day_start);
+  void AddSegment(uint64_t start_time, uint64_t end_time, double byte_rate,
+                  double operation_rate);
+
+  std::array<double, kBucketsPerDay> byte_rate_ewma_{};
+  std::array<double, kBucketsPerDay> operation_rate_ewma_{};
+  std::array<bool, kBucketsPerDay> known_buckets_{};
+
+  std::array<double, kBucketsPerDay> day_bytes_{};
+  std::array<double, kBucketsPerDay> day_operations_{};
+  std::array<uint32_t, kBucketsPerDay> day_coverage_seconds_{};
+  uint64_t current_day_start_ = 0;
+  bool has_current_day_ = false;
+
+  uint32_t trained_days_ = 0;
+  uint32_t last_day_coverage_percent_ = 0;
+  uint64_t last_update_time_ = 0;
+  std::string learned_window_;
+  DynamicOffpeakObservation latest_observation_;
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -201,6 +201,8 @@ void BuildDBOptions(const ImmutableDBOptions& immutable_db_options,
   options.optimize_manifest_for_recovery =
       mutable_db_options.optimize_manifest_for_recovery;
   options.daily_offpeak_time_utc = mutable_db_options.daily_offpeak_time_utc;
+  options.dynamic_offpeak_percentile =
+      mutable_db_options.dynamic_offpeak_percentile;
   options.max_compaction_trigger_wakeup_seconds =
       mutable_db_options.max_compaction_trigger_wakeup_seconds;
   options.remote_compaction_manifest_floor =

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -488,6 +488,7 @@ TEST_F(OptionsSettableTest, DBOptionsAllFieldsSettable) {
       "allow_data_in_errors=false;"
       "enforce_single_del_contracts=false;"
       "daily_offpeak_time_utc=08:30-19:00;"
+      "dynamic_offpeak_percentile=20;"
       "max_compaction_trigger_wakeup_seconds=43200;"
       "periodic_compaction_phase_recovery_percent=25;"
       "follower_refresh_catchup_period_ms=123;"


### PR DESCRIPTION
Summary:

Collect DB-wide foreground read/write ticker deltas through the stats-history sampling path and build a persisted 15-minute UTC traffic profile using an exponentially weighted moving average (EWMA).

`dynamic_offpeak_percentile` is the single feature switch: `0` disables dynamic off-peak telemetry, while values from `1` through `50` enable it and select the quietest percentile. Enabling requires statistics and `stats_persist_period_sec` in the range `[1, 900]`; the same validation applies both at DB open and through `SetDBOptions()`.

How samples fill the model

`DynamicOffpeakModel::AddSample()` converts each interval into byte and operation rates, splits it at UTC day boundaries, and passes each same-day piece to `AddSegment()`. `AddSegment()` divides the piece among overlapping 15-minute buckets according to covered seconds.

```
Sample 00:10-00:25: 9,000 bytes / 900 sec = 10 B/s

00:00         00:15         00:30
|-- bucket 0 --|-- bucket 1 --|
          |---------|
        00:10     00:25

bucket 0 gets 5 min  * 10 B/s = 3,000 B
bucket 1 gets 10 min * 10 B/s = 6,000 B
```

Operations are apportioned the same way. When sampling enters the next UTC day, a day with at least 90% coverage updates each bucket using `25% completed day + 75% previous EWMA`.

How the window is selected

```
96 bucket EWMAs
       |
       v
trailing 4-bucket / 60-minute smoothing
       |
       v
rank bytes and operations separately
       |
       v
average the ranks: 0 = quiet, 1 = busy
       |
       v
mark the configured quietest percentile eligible
       |
       v
select the longest circular eligible run
```

The circular search allows a window to cross midnight:

```
UTC:       23:15  23:30  23:45  00:00  00:15
eligible:    no     yes    yes    yes     no
                     |------ selected ------|

learned window: 23:30-00:14
```

Threshold ties may make slightly more than the configured percentile eligible. Equal-length runs prefer the lower average score and then the earlier UTC start.

What is persisted

The learned model is stored as a versioned binary blob in the MANIFEST:

```
DynamicOffpeakModel
|
+-- metadata
|   +-- encoding version
|   +-- trained day count
|   +-- last-day coverage percent
|   +-- last update timestamp
|   +-- learned UTC window
|
+-- 96 learned 15-minute buckets
    +-- known flag
    +-- byte-rate EWMA
    +-- operation-rate EWMA
```

This is roughly 1.6 KiB and contains the compact learned profile rather than raw samples. Partial data for the current day and the latest observation are intentionally not persisted, so they restart empty after DB reopen. Disabling collection retains the persisted learned profile so it remains available if the option is enabled again.

Expose the advisory learned window, predicted byte/operation rates, and latest observed rates through `rocksdb.dynamic-offpeak` for manual validation and future ODS export. This does not modify `daily_offpeak_time_utc`, periodic compaction scoring, or any other compaction policy.

Differential Revision: D113672417
