### PR TITLE
Clean up partial external SST files after failure

### DIFF
--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -281,6 +281,7 @@ Status ExternalSstFileIngestionJob::Prepare(
     const std::string path_outside_db = f.external_file_path;
     const std::string path_inside_db = TableFileName(
         cfd_->ioptions().cf_paths, f.fd.GetNumber(), f.fd.GetPathId());
+    f.internal_file_path = path_inside_db;
     if (ingestion_options_.move_files || ingestion_options_.link_files) {
       status =
           fs_->LinkFile(path_outside_db, path_inside_db, IOOptions(), nullptr);
@@ -322,8 +323,6 @@ Status ExternalSstFileIngestionJob::Prepare(
     }
 
     if (f.copy_file) {
-      TEST_SYNC_POINT_CALLBACK("ExternalSstFileIngestionJob::Prepare:CopyFile",
-                               nullptr);
       // Always determining the destination temperature from the ingested-to
       // level would be difficult because in general we only find out the level
       // ingested to later, during Run().
@@ -338,6 +337,8 @@ Status ExternalSstFileIngestionJob::Prepare(
       status = CopyFile(fs_.get(), path_outside_db, f.file_temperature,
                         path_inside_db, dst_temp, 0, db_options_.use_fsync,
                         io_tracer_);
+      TEST_SYNC_POINT_CALLBACK("ExternalSstFileIngestionJob::Prepare:CopyFile",
+                               &status);
       // The destination of the copy will be ingested
       f.file_temperature = dst_temp;
 
@@ -354,7 +355,6 @@ Status ExternalSstFileIngestionJob::Prepare(
     if (!status.ok()) {
       break;
     }
-    f.internal_file_path = path_inside_db;
     // Initialize the checksum information of ingested files.
     f.file_checksum = kUnknownFileChecksum;
     f.file_checksum_func_name = kUnknownFileChecksumFuncName;
@@ -1127,7 +1127,7 @@ void ExternalSstFileIngestionJob::DeleteInternalFiles() {
       continue;
     }
     Status s = fs_->DeleteFile(f.internal_file_path, io_opts, nullptr);
-    if (!s.ok()) {
+    if (!s.ok() && !s.IsNotFound() && !s.IsPathNotFound()) {
       ROCKS_LOG_WARN(db_options_.info_log,
                      "AddFile() clean up for file %s failed : %s",
                      f.internal_file_path.c_str(), s.ToString().c_str());

--- a/db/external_sst_file_test.cc
+++ b/db/external_sst_file_test.cc
@@ -3181,6 +3181,69 @@ TEST_F(ExternalSSTFileTest, FileWithCFInfo) {
   ASSERT_OK(db_->IngestExternalFile(handles_[2], {unknown_sst}, ifo));
 }
 
+TEST_F(ExternalSSTFileTest, FailedCopyRemovesCopiedFiles) {
+  Options options = CurrentOptions();
+  DestroyAndReopen(options);
+  std::string first_external_file;
+  std::string second_external_file;
+  ASSERT_OK(GenerateExternalFileOnly(options, {{"first-key", "first-value"}},
+                                     &first_external_file));
+  ASSERT_OK(GenerateExternalFileOnly(options, {{"second-key", "second-value"}},
+                                     &second_external_file));
+
+  size_t copy_count = 0;
+  SyncPoint::GetInstance()->SetCallBack(
+      "ExternalSstFileIngestionJob::Prepare:CopyFile", [&](void* arg) {
+        if (++copy_count == 2) {
+          *static_cast<Status*>(arg) = Status::IOError("injected copy failure");
+        }
+      });
+  SyncPoint::GetInstance()->EnableProcessing();
+  const Status status = db_->IngestExternalFile(
+      {first_external_file, second_external_file}, IngestExternalFileOptions());
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+
+  ASSERT_TRUE(status.IsIOError()) << status.ToString();
+  ASSERT_EQ(copy_count, 2);
+  std::vector<std::string> files;
+  GetSstFiles(env_, dbname_, &files);
+  ASSERT_TRUE(files.empty());
+}
+
+TEST_F(ExternalSSTFileTest, FailedLinkedFileSyncRemovesLinkedFiles) {
+  Options options = CurrentOptions();
+  DestroyAndReopen(options);
+  std::string first_external_file;
+  std::string second_external_file;
+  ASSERT_OK(GenerateExternalFileOnly(options, {{"first-key", "first-value"}},
+                                     &first_external_file));
+  ASSERT_OK(GenerateExternalFileOnly(options, {{"second-key", "second-value"}},
+                                     &second_external_file));
+
+  size_t sync_count = 0;
+  SyncPoint::GetInstance()->SetCallBack(
+      "ExternalSstFileIngestionJob::CheckSyncReturnCode", [&](void* arg) {
+        if (++sync_count == 2) {
+          *static_cast<Status*>(arg) =
+              Status::IOError("injected linked-file sync failure");
+        }
+      });
+  SyncPoint::GetInstance()->EnableProcessing();
+  IngestExternalFileOptions ingestion_options;
+  ingestion_options.link_files = true;
+  const Status status = db_->IngestExternalFile(
+      {first_external_file, second_external_file}, ingestion_options);
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+
+  ASSERT_TRUE(status.IsIOError()) << status.ToString();
+  ASSERT_EQ(sync_count, 2);
+  std::vector<std::string> files;
+  GetSstFiles(env_, dbname_, &files);
+  ASSERT_TRUE(files.empty());
+}
+
 /*
  * Test and verify the functionality of ingestion_options.move_files and
  * ingestion_options.failed_move_fall_back_to_copy


### PR DESCRIPTION
Summary: Fix ExternalSstFileIngestionJob by recording each reserved internal SST path before link or copy begins, so rollback can remove partial destination files after append or sync failures. Missing cleanup paths are treated as already clean, while real cleanup failures are logged without replacing the primary ingestion error. Add focused sync-point regression coverage for copy failure and linked-file sync failure.

Differential Revision: D118492033


