### PR TITLE
Fix Statistics population in CompactedDBImpl::Get and MultiGet

### DIFF
--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -1423,6 +1423,7 @@ TEST_F(DBBasicTest, CompactedDB) {
   options.target_file_size_base = kFileSize;
   options.max_bytes_for_level_base = 1 << 30;
   options.compression = kNoCompression;
+  options.statistics = CreateDBStatistics();
   Reopen(options);
   // 1 L0 file, use CompactedDB if max_open_files = -1
   ASSERT_OK(Put("aaa", DummyString(kFileSize / 2, '1')));
@@ -1439,7 +1440,14 @@ TEST_F(DBBasicTest, CompactedDB) {
   s = Put("new", "value");
   ASSERT_EQ(s.ToString(),
             "Not implemented: Not supported in compacted db mode.");
+  const uint64_t prev_cache_miss =
+      options.statistics->getTickerCount(BLOCK_CACHE_DATA_MISS);
+  const uint64_t prev_cache_hit =
+      options.statistics->getTickerCount(BLOCK_CACHE_DATA_HIT);
   ASSERT_EQ(DummyString(kFileSize / 2, '1'), Get("aaa"));
+  ASSERT_GT(options.statistics->getTickerCount(BLOCK_CACHE_DATA_HIT) +
+                options.statistics->getTickerCount(BLOCK_CACHE_DATA_MISS),
+            prev_cache_hit + prev_cache_miss);
   Close();
   Reopen(options);
   // Add more L0 files
@@ -1510,6 +1518,9 @@ TEST_F(DBBasicTest, CompactedDB) {
   ASSERT_OK(db_->GetLiveFilesStorageInfo(lfsi_opts, &files2));
 
   // MultiGet
+  const uint64_t prev_multiget_cache_reads =
+      options.statistics->getTickerCount(BLOCK_CACHE_DATA_HIT) +
+      options.statistics->getTickerCount(BLOCK_CACHE_DATA_MISS);
   std::vector<std::string> values;
   std::vector<Status> status_list = dbfull()->MultiGet(
       ReadOptions(),
@@ -1527,6 +1538,9 @@ TEST_F(DBBasicTest, CompactedDB) {
   ASSERT_OK(status_list[4]);
   ASSERT_EQ(DummyString(kFileSize / 2, 'i'), values[4]);
   ASSERT_TRUE(status_list[5].IsNotFound());
+  ASSERT_GT(options.statistics->getTickerCount(BLOCK_CACHE_DATA_HIT) +
+                options.statistics->getTickerCount(BLOCK_CACHE_DATA_MISS),
+            prev_multiget_cache_reads);
 
   Reopen(options);
   // Add a key

--- a/db/db_impl/compacted_db_impl_sync_and_async.h
+++ b/db/db_impl/compacted_db_impl_sync_and_async.h
@@ -65,12 +65,12 @@ DEFINE_SYNC_AND_ASYNC(Status, CompactedDBImpl::Get)
   std::string* ts =
       user_comparator_->timestamp_size() > 0 ? timestamp : nullptr;
   LookupKey lkey(key, kMaxSequenceNumber, read_options.timestamp);
-  GetContext get_context(user_comparator_, nullptr, nullptr, nullptr,
-                         GetContext::kNotFound, lkey.user_key(), value,
-                         /*columns=*/nullptr, ts, nullptr, nullptr, true,
-                         nullptr, nullptr, nullptr, nullptr, &read_cb,
-                         nullptr /* is_blob_index */, 0 /* tracing_get_id */,
-                         &blob_fetcher);
+  GetContext get_context(
+      user_comparator_, nullptr, immutable_db_options_.logger,
+      immutable_db_options_.stats, GetContext::kNotFound, lkey.user_key(),
+      value, /*columns=*/nullptr, ts, nullptr, nullptr, true, nullptr,
+      immutable_db_options_.clock, nullptr, nullptr, &read_cb,
+      nullptr /* is_blob_index */, 0 /* tracing_get_id */, &blob_fetcher);
 
   const FdWithKeyRange& f = files_.files[FindFile(lkey.user_key())];
   if (user_comparator_->CompareWithoutTimestamp(
@@ -175,11 +175,13 @@ DEFINE_SYNC_AND_ASYNC(void, CompactedDBImpl::MultiGet)
     PinnableSlice& pinnable_val = values[i];
     std::string* timestamp = timestamps ? &timestamps[i] : nullptr;
     GetContext get_context(
-        user_comparator_, nullptr, nullptr, nullptr, GetContext::kNotFound,
+        user_comparator_, nullptr, immutable_db_options_.logger,
+        immutable_db_options_.stats, GetContext::kNotFound,
         lkey.user_key(), &pinnable_val, /*columns=*/nullptr,
         user_comparator_->timestamp_size() > 0 ? timestamp : nullptr, nullptr,
-        nullptr, true, nullptr, nullptr, nullptr, nullptr, &read_cb,
-        nullptr /* is_blob_index */, 0 /* tracing_get_id */, &blob_fetcher);
+        nullptr, true, nullptr, immutable_db_options_.clock, nullptr, nullptr,
+        &read_cb, nullptr /* is_blob_index */, 0 /* tracing_get_id */,
+        &blob_fetcher);
     TableReader* t = nullptr;
     TableCache::TypedHandle* handle = nullptr;
     Status status = cfd_->table_cache()->FindTable(


### PR DESCRIPTION
Summary:
When a database is opened read-only and qualifies for compacted DB mode (such as a single SST file or all files in a single level without merge operators), read operations are handled by CompactedDBImpl.

In CompactedDBImpl::Get and CompactedDBImpl::MultiGet, GetContext was being constructed with 
ullptr passed for logger, statistics, and clock. Consequently, when callers open a database with options.statistics configured, ticker metrics such as BLOCK_CACHE_HIT, BLOCK_CACHE_MISS, BLOCK_CACHE_DATA_HIT, BLOCK_CACHE_DATA_MISS, and BLOCK_CACHE_BYTES_READ remained at 0 during reads through CompactedDBImpl.

This patch passes immutable_db_options_.logger, immutable_db_options_.stats, and immutable_db_options_.clock to GetContext in both CompactedDBImpl::Get and CompactedDBImpl::MultiGet, ensuring block cache metrics and logger/clock diagnostics are properly populated.

Fixes #15140

Test Plan:
Updated TEST_F(DBBasicTest, CompactedDB) in db/db_basic_test.cc to attach options.statistics = CreateDBStatistics() and assert that block cache data hits/misses are counted after Get and MultiGet calls on a CompactedDB instance.