### PR TITLE
Handle benign io_uring stderr in crash tests

### DIFF
--- a/db_stress_tool/db_stress.cc
+++ b/db_stress_tool/db_stress.cc
@@ -15,10 +15,17 @@ int main() {
   return 1;
 }
 #else
+#ifdef USE_FOLLY
+#include <glog/logging.h>
+#endif
+
 #include "port/stack_trace.h"
 #include "rocksdb/db_stress_tool.h"
 
 int main(int argc, char** argv) {
+#ifdef USE_FOLLY
+  google::InitGoogleLogging(argv[0]);
+#endif
   ROCKSDB_NAMESPACE::port::InstallStackTraceHandler();
   return ROCKSDB_NAMESPACE::db_stress_tool(argc, argv);
 }

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -32,6 +32,11 @@ _IGNORED_SIGTERM_STDERR_RE = re.compile(
     r"returned terminal error: -9\."
     r"|(?:Poll|AbortIO): io_uring_wait_cqe failed: -(?:4|11))$"
 )
+_IGNORED_IO_URING_INIT_STDERR_RE = re.compile(
+    r"^[IE]\d{4} \d{2}:\d{2}:\d{2}\.\d+ +\d+ "
+    r"IoUringBackend\.cpp:\d+\] "
+    r"io_uring_queue_init_params\([^)]*\) failed .*$"
+)
 _NO_SPACE_SUBSTRINGS = (
     "no space left on device",
     "out of disk space",
@@ -2201,7 +2206,12 @@ def print_output_and_exit_on_error(
     sys.exit(2)
 
 
-def print_run_output_and_exit_on_error(args, finalized_params, stdout, stderr):
+def print_run_output_and_exit_on_error(
+    args, finalized_params, stdout, stderr, hit_timeout=False
+):
+    stdout, stderr = sanitize_known_stderr(
+        stdout, stderr, hit_timeout, finalized_params
+    )
     print_output_and_exit_on_error(
         stdout,
         stderr,
@@ -2210,17 +2220,27 @@ def print_run_output_and_exit_on_error(args, finalized_params, stdout, stderr):
     )
 
 
-def strip_expected_sigterm_stderr(stdout, stderr, hit_timeout):
+def sanitize_known_stderr(stdout, stderr, hit_timeout, finalized_params):
     # Blackbox crash tests intentionally terminate db_stress with SIGTERM.
-    # Filter this known post-SIGTERM io_uring stderr so it does not mask other
-    # stderr or fail the timeout path spuriously.
-    if not hit_timeout or _SIGTERM_STDOUT_MARKER not in stdout or len(stderr) == 0:
+    ignore_sigterm_stderr = hit_timeout and _SIGTERM_STDOUT_MARKER in stdout
+    # RocksDB falls back to synchronous reads if Folly cannot initialize io_uring.
+    ignore_io_uring_init_stderr = finalized_params.get("use_async_db_api") == 1
+    if len(stderr) == 0 or not (
+        ignore_sigterm_stderr or ignore_io_uring_init_stderr
+    ):
         return stdout, stderr
 
     kept_lines = []
     ignored_lines = []
     for line in stderr.splitlines(keepends=True):
-        if _IGNORED_SIGTERM_STDERR_RE.fullmatch(line.rstrip("\n")):
+        stripped_line = line.rstrip("\n")
+        if (
+            ignore_sigterm_stderr
+            and _IGNORED_SIGTERM_STDERR_RE.fullmatch(stripped_line)
+        ) or (
+            ignore_io_uring_init_stderr
+            and _IGNORED_IO_URING_INIT_STDERR_RE.fullmatch(stripped_line)
+        ):
             ignored_lines.append(line)
         else:
             kept_lines.append(line)
@@ -2230,7 +2250,7 @@ def strip_expected_sigterm_stderr(stdout, stderr, hit_timeout):
 
     if stdout and not stdout.endswith("\n"):
         stdout += "\n"
-    stdout += "Ignored expected post-SIGTERM stderr while handling timeout:\n"
+    stdout += "Ignored known stderr:\n"
     stdout += "".join(ignored_lines)
 
     stderr = "".join(kept_lines)
@@ -2336,8 +2356,9 @@ def liveness_main(args, unknown_args):
     )
 
     print_fault_injection_log(pid)
-    outs, errs = strip_expected_sigterm_stderr(outs, errs, hit_timeout)
-    print_run_output_and_exit_on_error(args, finalized_params, outs, errs)
+    print_run_output_and_exit_on_error(
+        args, finalized_params, outs, errs, hit_timeout
+    )
 
     if hit_timeout:
         if retcode == -9:
@@ -2385,18 +2406,20 @@ def blackbox_crash_main(args, unknown_args):
         hit_timeout, retcode, outs, errs, pid = execute_cmd(cmd, cmd_params["interval"])
 
         print_fault_injection_log(pid)
-        outs, errs = strip_expected_sigterm_stderr(outs, errs, hit_timeout)
-
         # Reset destroy_db_initially after each run (it may have been set by
         # command line for first run only)
         cmd_params["destroy_db_initially"] = 0
 
         if not hit_timeout:
             print("Exit Before Killing")
-            print_run_output_and_exit_on_error(args, finalized_params, outs, errs)
+            print_run_output_and_exit_on_error(
+                args, finalized_params, outs, errs, hit_timeout
+            )
             sys.exit(2)
 
-        print_run_output_and_exit_on_error(args, finalized_params, outs, errs)
+        print_run_output_and_exit_on_error(
+            args, finalized_params, outs, errs, hit_timeout
+        )
 
         time.sleep(1)  # time to stabilize before the next run
 

--- a/tools/db_crashtest_test.py
+++ b/tools/db_crashtest_test.py
@@ -324,7 +324,7 @@ class DBCrashTestTest(unittest.TestCase):
                     0, finalized["ingest_external_file_atomic_replace_one_in"]
                 )
 
-    def test_strip_expected_sigterm_stderr_suppresses_only_known_lines(self):
+    def test_sanitize_known_stderr_suppresses_only_known_sigterm_lines(self):
         db_crashtest = self.load_db_crashtest()
         stdout = "Received signal 15 (Terminated)\n"
         stderr = (
@@ -334,19 +334,17 @@ class DBCrashTestTest(unittest.TestCase):
             "returned terminal error: -9.\n"
         )
 
-        filtered_stdout, filtered_stderr = db_crashtest.strip_expected_sigterm_stderr(
-            stdout, stderr, True
+        filtered_stdout, filtered_stderr = db_crashtest.sanitize_known_stderr(
+            stdout, stderr, True, {}
         )
 
         self.assertEqual("", filtered_stderr)
         self.assertEqual(
-            stdout
-            + "Ignored expected post-SIGTERM stderr while handling timeout:\n"
-            + stderr,
+            stdout + "Ignored known stderr:\n" + stderr,
             filtered_stdout,
         )
 
-    def test_strip_expected_sigterm_stderr_suppresses_retryable_wait_cqe(self):
+    def test_sanitize_known_stderr_suppresses_retryable_wait_cqe(self):
         db_crashtest = self.load_db_crashtest()
         stdout = "Received signal 15 (Terminated)\n"
 
@@ -356,32 +354,30 @@ class DBCrashTestTest(unittest.TestCase):
             for err in (-4, -11):
                 stderr = f"{caller}: io_uring_wait_cqe failed: {err}\n"
                 filtered_stdout, filtered_stderr = (
-                    db_crashtest.strip_expected_sigterm_stderr(stdout, stderr, True)
+                    db_crashtest.sanitize_known_stderr(stdout, stderr, True, {})
                 )
 
                 self.assertEqual("", filtered_stderr)
                 self.assertEqual(
-                    stdout
-                    + "Ignored expected post-SIGTERM stderr while handling timeout:\n"
-                    + stderr,
+                    stdout + "Ignored known stderr:\n" + stderr,
                     filtered_stdout,
                 )
 
-    def test_strip_expected_sigterm_stderr_preserves_terminal_wait_cqe(self):
+    def test_sanitize_known_stderr_preserves_terminal_wait_cqe(self):
         db_crashtest = self.load_db_crashtest()
         stdout = "Received signal 15 (Terminated)\n"
         stderr = "Poll: io_uring_wait_cqe failed: -5\n"
 
         # This guards against hiding real io_uring failures: even after SIGTERM,
         # non-retryable wait_cqe errors must remain visible on stderr.
-        filtered_stdout, filtered_stderr = db_crashtest.strip_expected_sigterm_stderr(
-            stdout, stderr, True
+        filtered_stdout, filtered_stderr = db_crashtest.sanitize_known_stderr(
+            stdout, stderr, True, {}
         )
 
         self.assertEqual(stderr, filtered_stderr)
         self.assertEqual(stdout, filtered_stdout)
 
-    def test_strip_expected_sigterm_stderr_preserves_other_stderr(self):
+    def test_sanitize_known_stderr_preserves_other_stderr(self):
         db_crashtest = self.load_db_crashtest()
         stdout = "Received signal 15 (Terminated)\n"
         ignored_line = (
@@ -391,36 +387,57 @@ class DBCrashTestTest(unittest.TestCase):
         kept_line = "Different stderr line\n"
         stderr = ignored_line + kept_line
 
-        filtered_stdout, filtered_stderr = db_crashtest.strip_expected_sigterm_stderr(
-            stdout, stderr, True
+        filtered_stdout, filtered_stderr = db_crashtest.sanitize_known_stderr(
+            stdout, stderr, True, {}
         )
 
         self.assertEqual(kept_line, filtered_stderr)
         self.assertEqual(
-            stdout
-            + "Ignored expected post-SIGTERM stderr while handling timeout:\n"
-            + ignored_line,
+            stdout + "Ignored known stderr:\n" + ignored_line,
             filtered_stdout,
         )
 
-    def test_strip_expected_sigterm_stderr_requires_timeout_and_sigterm_marker(self):
+    def test_sanitize_known_stderr_requires_timeout_and_sigterm_marker(self):
         db_crashtest = self.load_db_crashtest()
         stderr = (
             "PosixRandomAccessFile::MultiRead: io_uring_submit_and_wait "
             "returned terminal error: -9.\n"
         )
 
-        filtered_stdout, filtered_stderr = db_crashtest.strip_expected_sigterm_stderr(
-            "Received signal 15 (Terminated)\n", stderr, False
+        filtered_stdout, filtered_stderr = db_crashtest.sanitize_known_stderr(
+            "Received signal 15 (Terminated)\n", stderr, False, {}
         )
         self.assertEqual("Received signal 15 (Terminated)\n", filtered_stdout)
         self.assertEqual(stderr, filtered_stderr)
 
-        filtered_stdout, filtered_stderr = db_crashtest.strip_expected_sigterm_stderr(
-            "other stdout\n", stderr, True
+        filtered_stdout, filtered_stderr = db_crashtest.sanitize_known_stderr(
+            "other stdout\n", stderr, True, {}
         )
         self.assertEqual("other stdout\n", filtered_stdout)
         self.assertEqual(stderr, filtered_stderr)
+
+    def test_print_run_output_tolerates_read_executor_io_uring_init_failure(self):
+        db_crashtest = self.load_db_crashtest()
+        args = self.build_mode_args()
+        finalized_params = {"db": self.test_tmpdir, "use_async_db_api": 1}
+        stdout = "Crash-recovery verification passed :)\n"
+        stderr = (
+            "I0903 14:05:39.470695 286445 IoUringBackend.cpp:527] "
+            "io_uring_queue_init_params(512,1024) failed errno = "
+            '0:"Success" 0x7d2e06295280 retrying with capacity = 512\n'
+            "E0903 14:05:39.470759 286445 IoUringBackend.cpp:537] "
+            "io_uring_queue_init_params(512,512) failed ret = "
+            '-12:"Unknown error -12" 0x7d2e06295280\n'
+        )
+        output = io.StringIO()
+
+        with redirect_stdout(output):
+            db_crashtest.print_run_output_and_exit_on_error(
+                args, finalized_params, stdout, stderr
+            )
+
+        self.assertIn("Ignored known stderr", output.getvalue())
+        self.assertIn(stderr, output.getvalue())
 
     def test_output_matches_no_space_catches_known_failure_strings(self):
         db_crashtest = self.load_db_crashtest()


### PR DESCRIPTION
Summary:
A crash test failed when `use_async_db_api=1` created read-executor workers on a host unable to allocate io_uring rings. Folly logged the setup failure and threw; RocksDB caught it and successfully fell back to synchronous reads, but the harness failed because stderr was non-empty.

Representative stderr:

```
WARNING: Logging before InitGoogleLogging() is written to STDERR
I0903 14:05:39.470695 286445 IoUringBackend.cpp:527] io_uring_queue_init_params(512,1024) failed errno = 0:"Success" 0x7d2e06295280 retrying with capacity = 512
E0903 14:05:39.470759 286445 IoUringBackend.cpp:537] io_uring_queue_init_params(512,512) failed ret = -12:"Unknown error -12" 0x7d2e06295280
```

Initialize glog in the Folly-enabled OSS `db_stress` entry point and centralize known stderr sanitization. Only `IoUringBackend` ring-initialization failures are moved to stdout when the async DB API is enabled; existing expected post-SIGTERM errors use the same sanitizer. All unrelated stderr remains fatal.

Differential Revision: D118836521


