### PR TITLE
Cast to unsigned char before isspace() in a few trim/tokenize paths

### DIFF
--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -27,6 +27,7 @@
 #include "rocksdb/table.h"
 #include "rocksdb/utilities/object_registry.h"
 #include "rocksdb/utilities/options_type.h"
+#include "util/cast_util.h"
 #include "util/string_util.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -809,7 +810,8 @@ Status StringToMap(const std::string& opts_str,
 
     // Locate value start (after '=' and any whitespace).
     size_t value_start = eq_pos + 1;
-    while (value_start < opts.size() && isspace(opts[value_start])) {
+    while (value_start < opts.size() &&
+           isspace(lossless_cast<unsigned char>(opts[value_start]))) {
       ++value_start;
     }
 
@@ -836,7 +838,8 @@ Status StringToMap(const std::string& opts_str,
       value = opts.substr(value_start, brace_pos - value_start + 1);
       pos = brace_pos + 1;
       // Allow whitespace, then either delimiter or end.
-      while (pos < opts.size() && isspace(opts[pos])) {
+      while (pos < opts.size() &&
+             isspace(lossless_cast<unsigned char>(opts[pos]))) {
         ++pos;
       }
       if (pos < opts.size() && opts[pos] != ';') {
@@ -1074,7 +1077,8 @@ std::unordered_map<std::string, PrepopulateBlobCache>
 
 Status OptionTypeInfo::NextToken(const std::string& opts, char delimiter,
                                  size_t pos, size_t* end, std::string* token) {
-  while (pos < opts.size() && isspace(opts[pos])) {
+  while (pos < opts.size() &&
+         isspace(lossless_cast<unsigned char>(opts[pos]))) {
     ++pos;
   }
   // Empty value at the end
@@ -1102,7 +1106,8 @@ Status OptionTypeInfo::NextToken(const std::string& opts, char delimiter,
       // skip all whitespace and move to the next delimiter
       // brace_pos points to the next position after the matching '}'
       pos = brace_pos + 1;
-      while (pos < opts.size() && isspace(opts[pos])) {
+      while (pos < opts.size() &&
+             isspace(lossless_cast<unsigned char>(opts[pos]))) {
         ++pos;
       }
       if (pos < opts.size() && opts[pos] != delimiter) {

--- a/options/options_parser.cc
+++ b/options/options_parser.cc
@@ -560,12 +560,14 @@ std::string RocksDBOptionsParser::TrimAndRemoveComment(const std::string& line,
     }
   }
 
-  while (start < end && isspace(line[start]) != 0) {
+  while (start < end &&
+         isspace(lossless_cast<unsigned char>(line[start])) != 0) {
     ++start;
   }
 
   // start < end implies end > 0.
-  while (start < end && isspace(line[end - 1]) != 0) {
+  while (start < end &&
+         isspace(lossless_cast<unsigned char>(line[end - 1])) != 0) {
     --end;
   }
 

--- a/util/string_util.cc
+++ b/util/string_util.cc
@@ -19,6 +19,7 @@
 #include "port/port.h"
 #include "port/sys_time.h"
 #include "rocksdb/slice.h"
+#include "util/cast_util.h"
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -257,12 +258,12 @@ std::string trim(const std::string& str) {
     if (start >= end) {
       return {};  // all whitespace
     }
-    if (!isspace(str[start])) {
+    if (!isspace(lossless_cast<unsigned char>(str[start]))) {
       break;  // first non-whitespace found
     }
     ++start;
   }
-  while (isspace(str[end - 1]) != 0) {
+  while (isspace(lossless_cast<unsigned char>(str[end - 1])) != 0) {
     --end;
     assert(end > start);
   }

--- a/util/string_util_test.cc
+++ b/util/string_util_test.cc
@@ -50,6 +50,13 @@ TEST(StringUtilTest, Trim) {
   EXPECT_EQ("", trim("\t"));
   EXPECT_EQ("", trim("\n"));
   EXPECT_EQ("", trim(" \t\n\r"));
+  // A trailing (or leading) UTF-8 multi-byte character whose lead byte has
+  // its high bit set (e.g. 0xC3 in the 2-byte encoding of 'u' with an acute
+  // accent) must not be misread as whitespace: on platforms where plain
+  // `char` is signed, passing such a byte straight to isspace() is undefined
+  // behavior and can misclassify or crash (see GH-7809).
+  EXPECT_EQ("B\xC3\xBA", trim("B\xC3\xBA"));
+  EXPECT_EQ("B\xC3\xBA", trim("  B\xC3\xBA  "));
 }
 
 }  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
Fixes #7809.

A handful of whitespace-trimming and tokenizing loops pass a plain `char` straight into `isspace()`, and that's only defined behavior when the value is representable as `unsigned char` or equals `EOF`. On platforms where `char` is signed (the usual case), a UTF-8 continuation byte turns into a negative `int` and the result is unspecified from that point on.

The original reporter hit this as an MSVC debug-CRT assertion when opening a DB whose name ends in a non-ASCII character. `TrimAndRemoveComment` runs `isspace()` over the temporary options file content, which embeds the DB name, and a trailing multi-byte UTF-8 character trips the assertion. A comment on the issue pointed out the same pattern also exists in `util::trim()` and `OptionTypeInfo::NextToken`, so I fixed all three.

Each call site now goes through `lossless_cast<unsigned char>`, following `cast_util.h`'s own guidance to prefer it over a bare `static_cast` for this kind of conversion. Extended the existing `StringUtilTest.Trim` case with a string ending in a two-byte UTF-8 character.

One honest caveat: I don't have a Windows machine handy, so I couldn't reproduce the actual MSVC assertion locally, only confirm the fix compiles and the existing/new tests pass. That said, the change addresses genuine undefined behavior either way, independent of whether any particular libc's ctype table happens to tolerate an out-of-range argument without visibly misbehaving, which is exactly why this bug showed up as version- and platform-dependent to begin with.

Ran `string_util_test` and `options_test` locally, both green. `make check-sources` and `clang-format` also clean.