### PR TITLE
Re-acquire db_mutex_ in MemPurge early return path

### DIFF
--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -498,6 +498,11 @@ Status FlushJob::MemPurge() {
         s = Status::NotSupported(
             "CompactionFilter::IgnoreSnapshots() = false is not supported "
             "anymore.");
+        // MemPurge() must return with db_mutex_ re-acquired (the caller falls
+        // back to WriteLevel0Table(), which asserts the lock is held). Drop the
+        // filter first so its user-defined destructor runs without the mutex.
+        compaction_filter.reset();
+        db_mutex_->Lock();
         return s;
       }
     }


### PR DESCRIPTION
While tracing FlushJob::MemPurge I noticed the early return for a flush-time compaction filter that doesn't ignore snapshots comes back without re-locking db_mutex_. MemPurge unlocks the mutex at the top and every other path re-locks before returning, because Run falls back to WriteLevel0Table() on a failed mempurge and that function asserts the lock. So on this path the fallback ran unlocked - an AssertHeld failure in debug builds, and in release an unlock of a mutex the thread doesn't hold, which can clobber another thread's critical section.

The fix locks again before returning, and drops the filter first so its user-defined destructor doesn't execute under the DB mutex. Fixes #14198.

I could not run the C++ test suite on this machine (Windows, no toolchain for rocksdb), so this was verified by reading the lock/unlock flow in flush_job.cc.