### PR TITLE
Fix destination type check in lossless_cast for pointers

### DIFF
--- a/util/cast_util.h
+++ b/util/cast_util.h
@@ -70,7 +70,7 @@ inline To lossless_cast(From x) {
     using ToDeref = typename std::remove_pointer_t<To>;
     static_assert(std::is_integral_v<FromDeref> || std::is_enum_v<FromDeref>,
                   "Only works on integral types");
-    static_assert(std::is_integral_v<ToDeref> || std::is_enum_v<To>,
+    static_assert(std::is_integral_v<ToDeref> || std::is_enum_v<ToDeref>,
                   "Only works on integral types");
     static_assert(sizeof(ToDeref) == sizeof(FromDeref), "Must be lossless");
     return reinterpret_cast<To>(x);

--- a/util/slice_test.cc
+++ b/util/slice_test.cc
@@ -11,6 +11,7 @@
 
 #include <gtest/gtest.h>
 
+#include <cstdint>
 #include <cstring>
 #include <new>
 #include <semaphore>
@@ -376,6 +377,63 @@ TEST(StatusTest, Update) {
   ASSERT_TRUE(
       s.UpdateIfOk(Status()).UpdateIfOk(notf).UpdateIfOk(inc).IsNotFound());
   ASSERT_TRUE(s.IsNotFound());
+}
+
+// ***************************************************************** //
+// Unit test for lossless_cast
+namespace {
+enum class TestEnum8 : uint8_t { kZero = 0, kMax = 255 };
+enum TestEnumUnscoped : int { kNegative = -1, kPositive = 1 };
+}  // namespace
+
+TEST(LosslessCastTest, Values) {
+  // Signed <-> unsigned of the same size
+  ASSERT_EQ(lossless_cast<uint8_t>(int8_t{-1}), uint8_t{255});
+  ASSERT_EQ(lossless_cast<int8_t>(uint8_t{255}), int8_t{-1});
+  // Widening
+  ASSERT_EQ(lossless_cast<int64_t>(int16_t{-42}), int64_t{-42});
+  ASSERT_EQ(lossless_cast<uint64_t>(uint16_t{42}), uint64_t{42});
+  // Enum <-> underlying type
+  ASSERT_EQ(lossless_cast<uint8_t>(TestEnum8::kMax), uint8_t{255});
+  ASSERT_EQ(lossless_cast<TestEnum8>(uint8_t{0}), TestEnum8::kZero);
+  ASSERT_EQ(lossless_cast<int>(kNegative), -1);
+  ASSERT_EQ(lossless_cast<TestEnumUnscoped>(1), kPositive);
+}
+
+TEST(LosslessCastTest, Pointers) {
+  // Signed <-> unsigned of the same size
+  int32_t i = -1;
+  uint32_t* up = lossless_cast<uint32_t*>(&i);
+  ASSERT_EQ(*up, uint32_t{0xffffffff});
+  ASSERT_EQ(lossless_cast<int32_t*>(up), &i);
+
+  // Enum type -> underlying type
+  TestEnum8 e = TestEnum8::kMax;
+  uint8_t* bp = lossless_cast<uint8_t*>(&e);
+  ASSERT_EQ(*bp, uint8_t{255});
+
+  // Underlying type -> enum type
+  uint8_t b = 0;
+  TestEnum8* ep = lossless_cast<TestEnum8*>(&b);
+  ASSERT_EQ(*ep, TestEnum8::kZero);
+
+  // Enum type -> enum type of the same size
+  ASSERT_EQ(lossless_cast<TestEnum8*>(&e), &e);
+
+  // These must not compile:
+  /*
+  // Not lossless
+  lossless_cast<uint64_t*>(&i);
+  // Not a pointer destination
+  lossless_cast<uint32_t>(&i);
+  // Not an integral or enum type
+  struct Foo {
+    uint32_t x;
+  } foo;
+  lossless_cast<Foo*>(&i);
+  lossless_cast<uint32_t*>(&foo);
+  */
+  // END must not compile
 }
 
 // ***************************************************************** //


### PR DESCRIPTION
Summary:
In the pointer branch of `lossless_cast`, the destination type check tested
`std::is_enum_v<To>` instead of `std::is_enum_v<ToDeref>`. Since `To` is a
pointer type in that branch, `std::is_enum_v<To>` is always false, so the
check collapsed to `std::is_integral_v<ToDeref>` and rejected casting to a
pointer-to-enum, e.g. `lossless_cast<MyEnum8*>(&some_uint8)`.

Differential Revision: D119422904


