### PR TITLE
Recover from poisoned WAL handles on remote file systems (#15193)

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -330,18 +330,22 @@ Status DBImpl::Resume() {
   return s;
 }
 
-// This function implements the guts of recovery from a background error. It
-// is eventually called for both manual as well as automatic recovery. It does
-// the following -
-// 1. Wait for currently scheduled background flush/compaction to exit, in
-//    order to inadvertently causing an error and thinking recovery failed
-// 2. Flush memtables if there's any data for all the CFs. This may result
-//    another error, which will be saved by error_handler_ and reported later
-//    as the recovery status
-// 3. Find and delete any obsolete files
-// 4. Schedule compactions if needed for all the CFs. This is needed as the
-//    flush in the prior step might have been a no-op for some CFs, which
-//    means a new super version wouldn't have been installed
+// This function implements both manual and automatic background-error
+// recovery. It discards stale queued flush requests, waits for scheduled work
+// to exit, rebuilds and runs the flush work required by the recovery context,
+// purges obsolete files, and schedules any follow-up compactions.
+//
+// A file-scoped WAL write error needs a stronger protocol because the failed
+// record might be absent, partial, or complete, and the failed file handle must
+// never be used again:
+// 1. Keep every WAL through failed_wal_number quarantined from concurrent sync.
+// 2. Persist any failed_wal_sequence so a possibly complete record cannot
+//    collide with a later write after recovery.
+// 3. Replace the failed WAL and atomically flush all live column families.
+// 4. Verify every column family advanced beyond the failed WAL.
+// 5. Detach the quarantined handles, then clear the cutoff only if a concurrent
+//    failure did not extend it. Any failure before completion leaves the hard
+//    background error and quarantine in place.
 Status DBImpl::ResumeImpl(DBRecoverContext context,
                           Env::IOActivity io_activity) {
   mutex_.AssertHeld();
@@ -368,6 +372,10 @@ Status DBImpl::ResumeImpl(DBRecoverContext context,
   WaitForBackgroundWork();
 
   TEST_SYNC_POINT("DBImpl::ResumeImpl:Start");
+
+  if (context.IsWALWriteErrorRecovery()) {
+    ExtendWALRecoveryCutoff(context.failed_wal_number);
+  }
 
   // With two_write_queues=true, sequence numbers are allocated via
   // FetchAddLastAllocatedSequence() before writes complete, but only
@@ -397,6 +405,44 @@ Status DBImpl::ResumeImpl(DBRecoverContext context,
     // Returning shutdown status to SFM during auto recovery will cause it
     // to abort the recovery and allow the shutdown to progress
     s = Status::ShutdownInProgress();
+  }
+
+  if (s.ok() && context.IsWALWriteErrorRecovery()) {
+    const bool has_blob_direct_write =
+        HasAnyBlobDirectWriteColumnFamilyWithLockHeld();
+    if (immutable_db_options_.manual_wal_flush ||
+        immutable_db_options_.allow_2pc || two_write_queues_ ||
+        immutable_db_options_.enable_pipelined_write ||
+        immutable_db_options_.unordered_write ||
+        immutable_db_options_.recycle_log_file_num != 0 ||
+        immutable_db_options_.WAL_ttl_seconds != 0 ||
+        immutable_db_options_.WAL_size_limit_MB != 0 ||
+        immutable_db_options_.track_and_verify_wals_in_manifest ||
+        immutable_db_options_.track_and_verify_wals || has_blob_direct_write) {
+      ROCKS_LOG_WARN(
+          immutable_db_options_.info_log,
+          "[WAL recovery] Unsupported configuration; DB remains write-stopped: "
+          "manual_wal_flush=%d, allow_2pc=%d, two_write_queues=%d, "
+          "pipelined_write=%d, unordered_write=%d, wal_recycling=%d, "
+          "wal_ttl=%d, wal_size_limit=%d, track_wals_in_manifest=%d, "
+          "track_wals=%d, blob_direct_write=%d",
+          static_cast<int>(immutable_db_options_.manual_wal_flush),
+          static_cast<int>(immutable_db_options_.allow_2pc),
+          static_cast<int>(two_write_queues_),
+          static_cast<int>(immutable_db_options_.enable_pipelined_write),
+          static_cast<int>(immutable_db_options_.unordered_write),
+          static_cast<int>(immutable_db_options_.recycle_log_file_num != 0),
+          static_cast<int>(immutable_db_options_.WAL_ttl_seconds != 0),
+          static_cast<int>(immutable_db_options_.WAL_size_limit_MB != 0),
+          static_cast<int>(
+              immutable_db_options_.track_and_verify_wals_in_manifest),
+          static_cast<int>(immutable_db_options_.track_and_verify_wals),
+          static_cast<int>(has_blob_direct_write));
+      s = Status::NotSupported(
+          "file-scoped WAL write error recovery is not supported with manual "
+          "WAL flush, 2PC, two write queues, pipelined or unordered writes, "
+          "WAL recycling, retention or tracking, or blob direct write");
+    }
   }
 
   if (s.ok()) {
@@ -439,7 +485,50 @@ Status DBImpl::ResumeImpl(DBRecoverContext context,
     }
   }
 
+  if (s.ok() && context.failed_wal_sequence > 0) {
+    // A WAL error can be reported after the whole record reached storage but
+    // before its sequence range was published. Persist the reservation before
+    // admitting later writes so they cannot reuse an ambiguous sequence.
+    // A generic WAL IOError can also have an indeterminate outcome, so it can
+    // reserve a sequence without file-scoped recovery. Unsupported file-scoped
+    // configurations fail the check above and skip this block; the DB remains
+    // write-stopped, so no later write can reuse the ambiguous sequence range.
+    if (context.failed_wal_sequence > versions_->LastAllocatedSequence()) {
+      versions_->SetLastAllocatedSequence(context.failed_wal_sequence);
+    }
+    if (context.failed_wal_sequence > versions_->LastPublishedSequence()) {
+      versions_->SetLastPublishedSequence(context.failed_wal_sequence);
+    }
+    if (context.failed_wal_sequence > versions_->LastSequence()) {
+      versions_->SetLastSequence(context.failed_wal_sequence);
+    }
+    VersionEdit edit;
+    edit.SetLastSequence(context.failed_wal_sequence);
+    auto cfh =
+        static_cast_with_check<ColumnFamilyHandleImpl>(default_cf_handle_);
+    assert(cfh);
+    s = versions_->LogAndApply(cfh->cfd(), read_options, write_options, &edit,
+                               &mutex_, directories_.GetDbDir());
+    if (!s.ok() && versions_->io_status().IsIOError()) {
+      error_handler_.SetBGError(versions_->io_status(),
+                                BackgroundErrorReason::kManifestWrite);
+    }
+    if (s.ok()) {
+      ROCKS_LOG_INFO(immutable_db_options_.info_log,
+                     "[WAL recovery] Persisted sequence reservation through "
+                     "#%" PRIu64,
+                     context.failed_wal_sequence);
+    } else {
+      ROCKS_LOG_WARN(immutable_db_options_.info_log,
+                     "[WAL recovery] Failed to persist sequence reservation "
+                     "through #%" PRIu64 ": %s",
+                     context.failed_wal_sequence, s.ToString().c_str());
+    }
+  }
+
   if (s.ok()) {
+    recovering_from_wal_write_error_ = context.IsWALWriteErrorRecovery();
+    recover_wal_through_number_ = context.failed_wal_number;
     if (context.flush_reason == FlushReason::kErrorRecoveryRetryFlush) {
       s = RetryFlushesForErrorRecovery(FlushReason::kErrorRecoveryRetryFlush,
                                        true /* wait */);
@@ -449,13 +538,93 @@ Status DBImpl::ResumeImpl(DBRecoverContext context,
       FlushOptions flush_opts;
       // We allow flush to stall write since we are trying to resume from error.
       flush_opts.allow_write_stall = true;
+      flush_opts.force_atomic_flush = context.IsWALWriteErrorRecovery();
+      if (context.IsWALWriteErrorRecovery()) {
+        ROCKS_LOG_INFO(immutable_db_options_.info_log,
+                       "[WAL recovery] Starting atomic flush of all live "
+                       "column families through WAL #%" PRIu64,
+                       context.failed_wal_number);
+      }
       s = FlushAllColumnFamilies(flush_opts, context.flush_reason);
+      if (s.ok() && context.IsWALWriteErrorRecovery()) {
+        ROCKS_LOG_INFO(immutable_db_options_.info_log,
+                       "[WAL recovery] Atomic flush completed through WAL "
+                       "#%" PRIu64,
+                       context.failed_wal_number);
+      }
     }
+    recovering_from_wal_write_error_ = false;
+    recover_wal_through_number_ = 0;
     if (!s.ok()) {
       ROCKS_LOG_INFO(immutable_db_options_.info_log,
                      "DB resume requested but failed due to Flush failure [%s]",
                      s.ToString().c_str());
     }
+  }
+
+  if (s.ok() && context.IsWALWriteErrorRecovery()) {
+    for (auto* cfd : *versions_->GetColumnFamilySet()) {
+      if (!cfd->IsDropped() &&
+          cfd->GetLogNumber() <= context.failed_wal_number) {
+        s = Status::Corruption(
+            "WAL write error recovery did not advance column family " +
+            cfd->GetName() + " past WAL " +
+            std::to_string(context.failed_wal_number));
+        break;
+      }
+    }
+  }
+
+  if (s.ok() && context.IsWALWriteErrorRecovery()) {
+    // The flush and MANIFEST transition above make the abandoned WALs
+    // unnecessary for recovery. Detach their writers even when physical file
+    // deletion is disabled so no later SyncWAL() can touch a poisoned handle.
+    mutex_.Unlock();
+    {
+      InstrumentedMutexLock wal_lock(&wal_write_mutex_);
+      size_t retired_wal_count = 0;
+      if (logs_.empty() || logs_.back().number <= context.failed_wal_number) {
+        s = Status::Corruption(
+            "WAL write error recovery did not install a replacement WAL "
+            "after WAL " +
+            std::to_string(context.failed_wal_number));
+      } else {
+        for (auto it = logs_.begin();
+             it != logs_.end() && it->number <= context.failed_wal_number;) {
+          if (it->IsSyncing()) {
+            wal_sync_cv_.Wait();
+            it = logs_.begin();
+            continue;
+          }
+          wals_to_free_.push_back(it->ReleaseWriter());
+          it = logs_.erase(it);
+          ++retired_wal_count;
+        }
+        uint64_t expected_cutoff = context.failed_wal_number;
+        // A failed compare-exchange means a concurrent WAL failure extended the
+        // cutoff. That failure also sets recovery_error_, so the background
+        // error remains set and a later recovery attempt owns the larger range.
+        const bool cutoff_cleared =
+            wal_recovery_cutoff_.compare_exchange_strong(
+                expected_cutoff, 0, std::memory_order_acq_rel,
+                std::memory_order_acquire);
+        if (cutoff_cleared) {
+          ROCKS_LOG_INFO(immutable_db_options_.info_log,
+                         "[WAL recovery] Retired %" ROCKSDB_PRIszt
+                         " WAL handle(s) through "
+                         "#%" PRIu64 " and cleared the quarantine cutoff",
+                         retired_wal_count, context.failed_wal_number);
+        } else {
+          ROCKS_LOG_WARN(
+              immutable_db_options_.info_log,
+              "[WAL recovery] Retired %" ROCKSDB_PRIszt
+              " WAL handle(s) through "
+              "#%" PRIu64 "; quarantine cutoff advanced to #%" PRIu64,
+              retired_wal_count, context.failed_wal_number, expected_cutoff);
+        }
+      }
+    }
+    mutex_.Lock();
   }
 
   JobContext job_context(0);
@@ -472,18 +641,26 @@ Status DBImpl::ResumeImpl(DBRecoverContext context,
   if (s.ok()) {
     // Will notify and unblock threads waiting for error recovery to finish.
     s = error_handler_.ClearBGError();
+    if (s.ok() && AsyncWALPrecreateEnabled()) {
+      size_t max_write_buffer_size = 0;
+      for (ColumnFamilyData* cfd : *versions_->GetColumnFamilySet()) {
+        if (!cfd->IsDropped()) {
+          max_write_buffer_size =
+              std::max(max_write_buffer_size,
+                       cfd->GetLatestMutableCFOptions().write_buffer_size);
+        }
+      }
+      // WAL rotation during recovery cannot schedule its successor while the
+      // hard background error is set. Refill the async slot only after
+      // ClearBGError() has made normal background work eligible again.
+      MaybeScheduleAsyncWALPrecreate(
+          GetWalPreallocateBlockSize(max_write_buffer_size));
+    }
   } else {
     // NOTE: this is needed to pass ASSERT_STATUS_CHECKED
     // in the DBSSTTest.DBWithMaxSpaceAllowedRandomized test.
     // See https://github.com/facebook/rocksdb/pull/7715#issuecomment-754947952
     error_handler_.GetRecoveryError().PermitUncheckedError();
-  }
-
-  if (s.ok()) {
-    ROCKS_LOG_INFO(immutable_db_options_.info_log, "Successfully resumed DB");
-  } else {
-    ROCKS_LOG_INFO(immutable_db_options_.info_log, "Failed to resume DB [%s]",
-                   s.ToString().c_str());
   }
 
   // Check for shutdown again before scheduling further compactions,
@@ -514,6 +691,23 @@ Status DBImpl::ResumeImpl(DBRecoverContext context,
       EnqueuePendingCompaction(cfd);
     }
     MaybeScheduleFlushOrCompaction();
+  }
+
+  if (s.ok() && context.IsWALWriteErrorRecovery()) {
+    ROCKS_LOG_INFO(
+        immutable_db_options_.info_log,
+        "[WAL recovery] Successfully resumed DB through WAL #%" PRIu64,
+        context.failed_wal_number);
+  } else if (s.ok()) {
+    ROCKS_LOG_INFO(immutable_db_options_.info_log, "Successfully resumed DB");
+  } else if (context.IsWALWriteErrorRecovery()) {
+    ROCKS_LOG_WARN(immutable_db_options_.info_log,
+                   "[WAL recovery] Failed to resume DB through WAL #%" PRIu64
+                   ": %s",
+                   context.failed_wal_number, s.ToString().c_str());
+  } else {
+    ROCKS_LOG_INFO(immutable_db_options_.info_log, "Failed to resume DB [%s]",
+                   s.ToString().c_str());
   }
 
   // Wake up any waiters - in this case, it could be the shutdown thread
@@ -2081,6 +2275,14 @@ Status DBImpl::SyncWAL() {
     s = ApplyWALToManifest(read_options, write_options, &synced_wals);
   }
 
+  if (s.ok() && wal_recovery_cutoff_.load(std::memory_order_acquire) != 0) {
+    InstrumentedMutexLock l(&mutex_);
+    Status bg_error = error_handler_.GetBGError();
+    if (!bg_error.ok()) {
+      s = bg_error;
+    }
+  }
+
   TEST_SYNC_POINT("DBImpl::SyncWAL:BeforeMarkLogsSynced:2");
   return s;
 }
@@ -2122,6 +2324,17 @@ IOStatus DBImpl::SyncWalImpl(bool include_current_wal,
       auto& log = *it;
       // Ensure the head of logs_ is marked as getting_synced if any is.
       log.PrepareForSync();
+      if (log.number <= wal_recovery_cutoff_.load(std::memory_order_acquire)) {
+        // The failed file handle is permanently unusable. Recovery will make
+        // this WAL obsolete only after atomically persisting all accepted
+        // memtable contents, so do not retry any operation on the handle.
+        // PrepareForSync() pins the entry until MarkLogsSynced() or
+        // MarkLogsNotSynced() calls FinishSync(), which prevents recovery from
+        // clearing the cutoff while this call still relies on it.
+        TEST_SYNC_POINT_CALLBACK("DBImpl::SyncWalImpl:SkipFailedWAL",
+                                 &log.number);
+        continue;
+      }
       // If last sync failed on a later WAL, this could be a fully synced
       // and closed WAL that just needs to be recorded as synced in the
       // manifest.
@@ -2140,8 +2353,15 @@ IOStatus DBImpl::SyncWalImpl(bool include_current_wal,
   IOOptions opts;
   IOStatus io_s = WritableFileWriter::PrepareIOOptions(write_options, opts);
   std::list<log::Writer*> wals_internally_closed;
+  uint64_t failed_wal_number = 0;
+  bool failed_with_previous_error = false;
   if (io_s.ok()) {
     for (log::Writer* log : wals_to_sync) {
+      if (log->get_log_number() <=
+          wal_recovery_cutoff_.load(std::memory_order_acquire)) {
+        continue;
+      }
+      TEST_SYNC_POINT_CALLBACK("DBImpl::SyncWalImpl:BeforeSyncWAL", log);
       if (job_context) {
         ROCKS_LOG_INFO(immutable_db_options_.info_log,
                        "[JOB %d] Syncing log #%" PRIu64, job_context->job_id,
@@ -2152,12 +2372,17 @@ IOStatus DBImpl::SyncWalImpl(bool include_current_wal,
       }
       if (log->get_log_number() >= maybe_active_number) {
         assert(log->get_log_number() == maybe_active_number);
-        io_s = log->file()->SyncWithoutFlush(opts,
-                                             immutable_db_options_.use_fsync);
+        io_s = log->file()->SyncWithoutFlush(
+            opts, immutable_db_options_.use_fsync, &failed_with_previous_error);
       } else {
-        io_s = log->file()->Sync(opts, immutable_db_options_.use_fsync);
+        io_s = log->file()->Sync(opts, immutable_db_options_.use_fsync,
+                                 &failed_with_previous_error);
       }
+      std::pair<log::Writer*, IOStatus*> wal_and_status(log, &io_s);
+      TEST_SYNC_POINT_CALLBACK("DBImpl::SyncWalImpl:AfterSyncWAL",
+                               &wal_and_status);
       if (!io_s.ok()) {
+        failed_wal_number = log->get_log_number();
         break;
       }
       // WALs can be closed when purging obsolete files, but if recycling is
@@ -2177,6 +2402,7 @@ IOStatus DBImpl::SyncWalImpl(bool include_current_wal,
         io_s = log->file()->Close(opts);
         wals_internally_closed.push_back(log);
         if (!io_s.ok()) {
+          failed_wal_number = log->get_log_number();
           break;
         }
       }
@@ -2187,7 +2413,16 @@ IOStatus DBImpl::SyncWalImpl(bool include_current_wal,
                     io_s.ToString().c_str());
     // In case there is a fs error we should set it globally to prevent the
     // future writes
-    WALIOStatusCheck(io_s);
+    // The live-WAL operation that first observed the I/O failure owns
+    // classifying its original status, either through WALIOStatusCheck() or a
+    // direct SetBGError() call. With paranoid checks enabled, a concurrent sync
+    // must not classify the synthetic "previous error" status because it has
+    // lost the original scope and could incorrectly make the error fatal. With
+    // paranoid checks disabled, WALIOStatusCheck() instead preserves the
+    // legacy behavior of resetting the writer so a later operation can retry.
+    if (!failed_with_previous_error || !immutable_db_options_.paranoid_checks) {
+      WALIOStatusCheck(io_s, failed_wal_number);
+    }
   }
   if (io_s.ok() && need_wal_dir_sync) {
     io_s = directories_.GetWalDir()->FsyncWithDirOptions(
@@ -2333,6 +2568,12 @@ void DBImpl::MarkLogsSynced(uint64_t up_to, bool synced_dir,
   for (auto it = logs_.begin(); it != logs_.end() && it->number <= up_to;) {
     auto& wal = *it;
     assert(wal.IsSyncing());
+
+    if (wal.number <= wal_recovery_cutoff_.load(std::memory_order_acquire)) {
+      wal.FinishSync();
+      ++it;
+      continue;
+    }
 
     if (wal.number < logs_.back().number) {
       // Inactive WAL

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -2789,7 +2789,12 @@ class DBImpl : public DB
 
   // Used by WriteImpl to update bg_error_ when IO error happens, e.g., write
   // WAL, sync WAL fails, if paranoid check is enabled.
-  void WALIOStatusCheck(const IOStatus& status);
+  void WALIOStatusCheck(const IOStatus& status, uint64_t failed_wal_number = 0,
+                        SequenceNumber failed_wal_sequence = 0);
+
+  // Extends the inclusive WAL-number cutoff that must not receive more I/O.
+  // This is lock-free because a WAL error can race with public SyncWAL().
+  void ExtendWALRecoveryCutoff(uint64_t failed_wal_number);
 
   // Used by WriteImpl to update bg_error_ in case of memtable insert error.
   void HandleMemTableInsertFailure(const Status& nonok_memtable_insert_status);
@@ -3374,6 +3379,16 @@ class DBImpl : public DB
   // * whenever SetOptions successfully updates options.
   // * whenever a column family is dropped.
   InstrumentedCondVar bg_cv_;
+
+  // Set only while ResumeImpl performs a file-scoped WAL recovery. Protected
+  // by mutex_; SwitchMemtable uses it to avoid touching the failed writer.
+  bool recovering_from_wal_write_error_ = false;
+  uint64_t recover_wal_through_number_ = 0;
+
+  // Once a file-scoped WAL error is reported, all writers through this
+  // inclusive cutoff are quarantined until recovery detaches them. A
+  // concurrent SyncWAL() reads this without taking the DB mutex.
+  std::atomic<uint64_t> wal_recovery_cutoff_{0};
 
   ColumnFamilyHandleImpl* persist_stats_cf_handle_ = nullptr;
 

--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -1486,7 +1486,8 @@ Status DBImpl::WriteImpl(
 
   if (!io_s.ok()) {
     // Check WriteToWAL status
-    WALIOStatusCheck(io_s);
+    TEST_SYNC_POINT_CALLBACK("DBImpl::WriteImpl:BeforeWALIOStatusCheck", &io_s);
+    WALIOStatusCheck(io_s, /*failed_wal_number=*/0, last_sequence);
   }
   if (!w.CallbackFailed()) {
     if (!io_s.ok()) {
@@ -2069,7 +2070,9 @@ void DBImpl::WriteStatusCheck(const Status& status) {
   }
 }
 
-void DBImpl::WALIOStatusCheck(const IOStatus& io_status) {
+void DBImpl::WALIOStatusCheck(const IOStatus& io_status,
+                              uint64_t failed_wal_number,
+                              SequenceNumber failed_wal_sequence) {
   // Is setting bg_error_ enough here?  This will at least stop
   // compaction and fail any further writes.
   if ((immutable_db_options_.paranoid_checks && !io_status.ok() &&
@@ -2077,12 +2080,36 @@ void DBImpl::WALIOStatusCheck(const IOStatus& io_status) {
       io_status.IsIOFenced()) {
     mutex_.Lock();
     // Maybe change the return status to void?
-    error_handler_.SetBGError(io_status, BackgroundErrorReason::kWriteCallback,
-                              /*wal_related=*/true);
+    if (io_status.IsIOError() && !io_status.IsIOFenced()) {
+      DBRecoverContext context;
+      context.failed_wal_sequence = failed_wal_sequence;
+      if (io_status.GetScope() == IOStatus::IOErrorScope::kIOErrorScopeFile) {
+        context.failed_wal_number =
+            failed_wal_number != 0 ? failed_wal_number : cur_wal_number_;
+        ExtendWALRecoveryCutoff(context.failed_wal_number);
+      }
+      error_handler_.SetBGError(io_status,
+                                BackgroundErrorReason::kWriteCallback,
+                                /*wal_related=*/true, context);
+    } else {
+      error_handler_.SetBGError(io_status,
+                                BackgroundErrorReason::kWriteCallback,
+                                /*wal_related=*/true);
+    }
     mutex_.Unlock();
   } else {
     // Force writable file to be continue writable.
     logs_.back().writer->file()->reset_seen_error();
+  }
+}
+
+void DBImpl::ExtendWALRecoveryCutoff(uint64_t failed_wal_number) {
+  assert(failed_wal_number != 0);
+  uint64_t current = wal_recovery_cutoff_.load(std::memory_order_relaxed);
+  while (current < failed_wal_number &&
+         !wal_recovery_cutoff_.compare_exchange_weak(
+             current, failed_wal_number, std::memory_order_release,
+             std::memory_order_relaxed)) {
   }
 }
 
@@ -2287,10 +2314,13 @@ IOStatus DBImpl::WriteToWAL(const WriteBatch& merged_batch,
   }
   IOStatus io_s = log_writer->MaybeAddUserDefinedTimestampSizeRecord(
       write_options, versions_->GetColumnFamiliesTimestampSizeForRecord());
+  TEST_SYNC_POINT_CALLBACK(
+      "DBImpl::WriteToWAL:AfterMaybeAddUserDefinedTimestampSizeRecord", &io_s);
   if (!io_s.ok()) {
     return io_s;
   }
   io_s = log_writer->AddRecord(write_options, log_entry, sequence);
+  TEST_SYNC_POINT_CALLBACK("DBImpl::WriteToWAL:AfterAddRecord", &io_s);
 
   if (UNLIKELY(needs_locking)) {
     wal_write_mutex_.Unlock();
@@ -3128,6 +3158,7 @@ Status DBImpl::SwitchMemtable(ColumnFamilyData* cfd, WriteContext* context,
   UnpublishedWAL prepared_wal;
   MemTable* new_mem = nullptr;
   IOStatus io_s;
+  bool current_wal_write_buffer_failed = false;
 
   // Recoverable state is persisted in WAL. After memtable switch, WAL might
   // be deleted, so we write the state to memtable to be persisted as well.
@@ -3142,7 +3173,9 @@ Status DBImpl::SwitchMemtable(ColumnFamilyData* cfd, WriteContext* context,
   if (two_write_queues_) {
     wal_write_mutex_.Lock();
   }
-  bool creating_new_log = !wal_empty_;
+  bool creating_new_log =
+      !wal_empty_ || (recovering_from_wal_write_error_ &&
+                      cur_wal_number_ <= recover_wal_through_number_);
   if (two_write_queues_) {
     wal_write_mutex_.Unlock();
   }
@@ -3273,13 +3306,28 @@ Status DBImpl::SwitchMemtable(ColumnFamilyData* cfd, WriteContext* context,
     InstrumentedMutexLock l(&wal_write_mutex_);
     assert(new_log != nullptr);
     if (!logs_.empty()) {
-      // Alway flush the buffer of the last log before switching to a new one
+      // Always flush the buffer of the last log before switching to a new one,
+      // except when recovery is replacing a file-scoped failed WAL. Its
+      // accepted contents are persisted by the atomic recovery flush.
       log::Writer* cur_log_writer = logs_.back().writer;
-      if (error_handler_.IsRecoveryInProgress()) {
+      const bool abandon_current_wal =
+          recovering_from_wal_write_error_ &&
+          cur_log_writer->get_log_number() <= recover_wal_through_number_;
+      if (abandon_current_wal) {
+        TEST_SYNC_POINT("DBImpl::SwitchMemtable:AbandonWAL");
+        ROCKS_LOG_WARN(immutable_db_options_.info_log,
+                       "[WAL recovery] [%s] Replacing failed WAL #%" PRIu64
+                       " with WAL #%" PRIu64,
+                       cfd->GetName().c_str(), cur_log_writer->get_log_number(),
+                       new_log_number);
+      } else if (error_handler_.IsRecoveryInProgress()) {
         // In recovery path, we force another try of writing WAL buffer.
         cur_log_writer->file()->reset_seen_error();
       }
-      io_s = cur_log_writer->WriteBuffer(write_options);
+      if (!abandon_current_wal) {
+        io_s = cur_log_writer->WriteBuffer(write_options);
+        current_wal_write_buffer_failed = !io_s.ok();
+      }
       if (s.ok()) {
         s = io_s;
       }
@@ -3306,11 +3354,29 @@ Status DBImpl::SwitchMemtable(ColumnFamilyData* cfd, WriteContext* context,
     delete new_mem;
     delete new_log;
     context->superversion_context.new_superversion.reset();
-    // We may have lost data from the WritableFileBuffer in-memory buffer for
-    // the current log, so treat it as a fatal error and set bg_error
+    // Only a WriteBuffer() failure belongs to the current WAL. CreateWAL() and
+    // StartWALFile() operate on an unpublished replacement, so a failure there
+    // must not quarantine an otherwise healthy current WAL.
     if (!io_s.ok()) {
-      error_handler_.SetBGError(io_s, BackgroundErrorReason::kMemTable,
-                                /*wal_related=*/true);
+      if (!current_wal_write_buffer_failed) {
+        ROCKS_LOG_WARN(immutable_db_options_.info_log,
+                       "Failed to create or start replacement WAL #%" PRIu64
+                       "; current WAL #%" PRIu64 " remains active: %s",
+                       new_log_number, cur_wal_number_,
+                       io_s.ToString().c_str());
+      }
+      if (current_wal_write_buffer_failed && io_s.IsIOError() &&
+          !io_s.IsIOFenced() &&
+          io_s.GetScope() == IOStatus::IOErrorScope::kIOErrorScopeFile) {
+        DBRecoverContext recovery_context;
+        recovery_context.failed_wal_number = cur_wal_number_;
+        ExtendWALRecoveryCutoff(recovery_context.failed_wal_number);
+        error_handler_.SetBGError(io_s, BackgroundErrorReason::kMemTable,
+                                  /*wal_related=*/true, recovery_context);
+      } else {
+        error_handler_.SetBGError(io_s, BackgroundErrorReason::kMemTable,
+                                  /*wal_related=*/true);
+      }
     } else {
       error_handler_.SetBGError(s, BackgroundErrorReason::kMemTable);
     }

--- a/db/error_handler.cc
+++ b/db/error_handler.cc
@@ -5,6 +5,8 @@
 //
 #include "db/error_handler.h"
 
+#include <cinttypes>
+
 #include "db/db_impl/db_impl.h"
 #include "db/event_helpers.h"
 #include "file/sst_file_manager_impl.h"
@@ -293,7 +295,8 @@ void ErrorHandler::CancelErrorRecoveryForShutDown() {
 // also track the error separately in recovery_error_ so we can tell in the
 // end whether recovery succeeded or not
 void ErrorHandler::HandleKnownErrors(const Status& bg_err,
-                                     BackgroundErrorReason reason) {
+                                     BackgroundErrorReason reason,
+                                     const DBRecoverContext& context) {
   db_mutex_->AssertHeld();
   if (bg_err.ok()) {
     return;
@@ -302,7 +305,6 @@ void ErrorHandler::HandleKnownErrors(const Status& bg_err,
   bool paranoid = db_options_.paranoid_checks;
   Status::Severity sev = Status::Severity::kFatalError;
   Status new_bg_err;
-  DBRecoverContext context;
   bool found = false;
 
   {
@@ -355,7 +357,11 @@ void ErrorHandler::HandleKnownErrors(const Status& bg_err,
                                           db_mutex_, &auto_recovery);
     if (!s.ok() && (s.severity() > bg_error_.severity())) {
       bg_error_ = s;
+      UpdateRecoveryContext(context, /*replace_existing_context=*/true);
     } else {
+      if (!s.ok()) {
+        UpdateRecoveryContext(context, /*replace_existing_context=*/false);
+      }
       ROCKS_LOG_INFO(db_options_.info_log,
                      "ErrorHandler: Hit less severe background error\n");
 
@@ -371,7 +377,6 @@ void ErrorHandler::HandleKnownErrors(const Status& bg_err,
       "ErrorHandler: Set regular background error, auto_recovery=%d, stop=%d\n",
       int{auto_recovery}, int{stop});
 
-  recover_context_ = context;
   if (auto_recovery) {
     recovery_in_prog_ = true;
 
@@ -412,6 +417,12 @@ void ErrorHandler::HandleKnownErrors(const Status& bg_err,
 //    such as delegating to SstFileManager to handle no space error.
 void ErrorHandler::SetBGError(const Status& bg_status,
                               BackgroundErrorReason reason, bool wal_related) {
+  SetBGError(bg_status, reason, wal_related, DBRecoverContext());
+}
+
+void ErrorHandler::SetBGError(const Status& bg_status,
+                              BackgroundErrorReason reason, bool wal_related,
+                              DBRecoverContext context) {
   db_mutex_->AssertHeld();
   Status tmp_status = bg_status;
   IOStatus bg_io_err = status_to_io_status(std::move(tmp_status));
@@ -421,12 +432,20 @@ void ErrorHandler::SetBGError(const Status& bg_status,
   }
   ROCKS_LOG_WARN(db_options_.info_log, "Background IO error %s, reason %d",
                  bg_io_err.ToString().c_str(), static_cast<int>(reason));
+  if (context.failed_wal_number != 0) {
+    ROCKS_LOG_WARN(
+        db_options_.info_log,
+        "[WAL recovery] Quarantined WALs through #%" PRIu64
+        " after a file-scoped error; highest indeterminate sequence=%" PRIu64
+        ", status=%s",
+        context.failed_wal_number, context.failed_wal_sequence,
+        bg_io_err.ToString().c_str());
+  }
 
   RecordStats({ERROR_HANDLER_BG_ERROR_COUNT, ERROR_HANDLER_BG_IO_ERROR_COUNT},
               {} /* int_histograms */);
 
   Status new_bg_io_err = bg_io_err;
-  DBRecoverContext context;
   if (bg_io_err.GetScope() != IOStatus::IOErrorScope::kIOErrorScopeFile &&
       bg_io_err.GetDataLoss()) {
     // First, data loss (non file scope) is treated as unrecoverable error. So
@@ -525,7 +544,7 @@ void ErrorHandler::SetBGError(const Status& bg_status,
     StartRecoverFromRetryableBGIOError(bg_io_err);
     return;
   }
-  HandleKnownErrors(new_bg_io_err, reason);
+  HandleKnownErrors(new_bg_io_err, reason, context);
 }
 
 void ErrorHandler::AddFilesToQuarantine(
@@ -610,6 +629,10 @@ Status ErrorHandler::ClearBGError() {
     is_db_stopped_.store(false, std::memory_order_release);
     bg_error_ = Status::OK();
     recovery_error_ = IOStatus::OK();
+    // Recovery facts belong to one background-error episode. Keeping a
+    // retired WAL cutoff or reserved sequence here would attach it to a later,
+    // unrelated error when UpdateRecoveryContext() merges the next context.
+    recover_context_ = DBRecoverContext();
     bg_error_.PermitUncheckedError();
     recovery_error_.PermitUncheckedError();
     recovery_in_prog_ = false;
@@ -657,6 +680,14 @@ Status ErrorHandler::RecoverFromBGError(bool is_manual) {
   recovery_error_.PermitUncheckedError();
   DBRecoverContext context = recover_context_;
   context.flush_after_recovery = true;
+  TEST_SYNC_POINT_CALLBACK("ErrorHandler::RecoverFromBGError:Context",
+                           &context);
+  if (context.failed_wal_number != 0 || context.failed_wal_sequence != 0) {
+    ROCKS_LOG_INFO(db_options_.info_log,
+                   "[WAL recovery] Starting requested recovery: cutoff=%" PRIu64
+                   ", highest indeterminate sequence=%" PRIu64,
+                   context.failed_wal_number, context.failed_wal_sequence);
+  }
   Status s = db_->ResumeImpl(context, Env::IOActivity::kFlush);
   if (s.ok()) {
     soft_error_no_bg_work_ = false;
@@ -754,6 +785,13 @@ void ErrorHandler::RecoverFromRetryableBGIOError() {
     DBRecoverContext context = recover_context_;
     context.flush_after_recovery = true;
     retry_count++;
+    if (context.failed_wal_number != 0 || context.failed_wal_sequence != 0) {
+      ROCKS_LOG_INFO(
+          db_options_.info_log,
+          "[WAL recovery] Starting automatic recovery attempt #%" PRIu64
+          ": cutoff=%" PRIu64 ", highest indeterminate sequence=%" PRIu64,
+          retry_count, context.failed_wal_number, context.failed_wal_sequence);
+    }
     Status s = db_->ResumeImpl(context, Env::IOActivity::kFlush);
     RecordStats({ERROR_HANDLER_AUTORESUME_RETRY_TOTAL_COUNT},
                 {} /* int_histograms */);
@@ -821,11 +859,30 @@ void ErrorHandler::CheckAndSetRecoveryAndBGError(
   }
   if (bg_err.severity() > bg_error_.severity()) {
     bg_error_ = bg_err;
-    recover_context_ = context;
+    UpdateRecoveryContext(context, /*replace_existing_context=*/true);
+  } else {
+    UpdateRecoveryContext(context, /*replace_existing_context=*/false);
   }
   if (bg_error_.severity() >= Status::Severity::kHardError) {
     is_db_stopped_.store(true, std::memory_order_release);
   }
+}
+
+void ErrorHandler::UpdateRecoveryContext(const DBRecoverContext& context,
+                                         bool replace_existing_context) {
+  db_mutex_->AssertHeld();
+  const uint64_t failed_wal_number =
+      std::max(recover_context_.failed_wal_number, context.failed_wal_number);
+  const uint64_t failed_wal_sequence = std::max(
+      recover_context_.failed_wal_sequence, context.failed_wal_sequence);
+  if (replace_existing_context) {
+    recover_context_ = context;
+  }
+  // WAL failures can race or be classified through different severity paths.
+  // Preserve the broadest failed-file cutoff and highest sequence assigned to
+  // an indeterminate write group independently of the winning Status.
+  recover_context_.failed_wal_number = failed_wal_number;
+  recover_context_.failed_wal_sequence = failed_wal_sequence;
 }
 
 void ErrorHandler::EndAutoRecovery() {

--- a/db/error_handler.h
+++ b/db/error_handler.h
@@ -23,12 +23,27 @@ class DBImpl;
 struct DBRecoverContext {
   FlushReason flush_reason;
   bool flush_after_recovery;
+  // A non-zero value is an inclusive upper bound on WAL file handles that
+  // recovery must not reuse. Recovery must not declare success until every
+  // column family has atomically advanced beyond it in the MANIFEST.
+  uint64_t failed_wal_number;
+  // Highest sequence assigned to the write group whose WAL outcome is
+  // indeterminate. Reserving it prevents a later acknowledged write from
+  // reusing a sequence that might exist in the abandoned WAL.
+  uint64_t failed_wal_sequence;
 
   DBRecoverContext()
       : flush_reason(FlushReason::kErrorRecovery),
-        flush_after_recovery(false) {}
+        flush_after_recovery(false),
+        failed_wal_number(0),
+        failed_wal_sequence(0) {}
   DBRecoverContext(FlushReason reason)
-      : flush_reason(reason), flush_after_recovery(false) {}
+      : flush_reason(reason),
+        flush_after_recovery(false),
+        failed_wal_number(0),
+        failed_wal_sequence(0) {}
+
+  bool IsWALWriteErrorRecovery() const { return failed_wal_number != 0; }
 };
 
 class ErrorHandler {
@@ -59,6 +74,8 @@ class ErrorHandler {
 
   void SetBGError(const Status& bg_err, BackgroundErrorReason reason,
                   bool wal_related = false);
+  void SetBGError(const Status& bg_err, BackgroundErrorReason reason,
+                  bool wal_related, DBRecoverContext context);
 
   Status GetBGError() const { return bg_error_; }
 
@@ -151,7 +168,12 @@ class ErrorHandler {
   // unsorted.
   autovector<uint64_t> files_to_quarantine_;
 
-  void HandleKnownErrors(const Status& bg_err, BackgroundErrorReason reason);
+  void HandleKnownErrors(const Status& bg_err, BackgroundErrorReason reason,
+                         const DBRecoverContext& context);
+  // REQUIRES: db_mutex_ held. When replacing the general recovery context,
+  // retain WAL facts accumulated from concurrent errors independently.
+  void UpdateRecoveryContext(const DBRecoverContext& context,
+                             bool replace_existing_context);
   Status OverrideNoSpaceError(const Status& bg_error, bool* auto_recovery);
   void RecoverFromNoSpace();
   void StartRecoverFromRetryableBGIOError(const IOStatus& io_error);

--- a/db/error_handler_fs_test.cc
+++ b/db/error_handler_fs_test.cc
@@ -2686,6 +2686,1062 @@ TEST_F(DBErrorHandlingFSTest, WALWriteRetryableErrorAutoRecover2) {
   Close();
 }
 
+TEST_F(DBErrorHandlingFSTest, FileScopedWALWriteErrorReplacesFailedWAL) {
+  Options options = GetDefaultOptions();
+  options.env = fault_env_.get();
+  options.create_if_missing = true;
+  options.paranoid_checks = true;
+  options.max_bgerror_resume_count = 2;
+  options.bgerror_resume_retry_interval = 1000;
+  options.avoid_flush_during_shutdown = true;
+  options.track_and_verify_wals_in_manifest = false;
+  options.background_close_inactive_wals = false;
+  CreateAndReopenWithCF({"one", "empty"}, options);
+  ASSERT_OK(db_->DisableFileDeletions());
+
+  ASSERT_OK(Put(0, "accepted-before-error", "value-default"));
+  ASSERT_OK(Put(1, "accepted-before-error", "value-one"));
+  const uint64_t failed_wal = dbfull()->TEST_GetCurrentLogNumber();
+
+  std::atomic<bool> injected{false};
+  std::atomic<bool> abandoned{false};
+  std::atomic<bool> skipped_failed_wal_sync{false};
+  std::atomic<bool> synced_failed_wal{false};
+  SyncPoint::GetInstance()->LoadDependency(
+      {{"FileScopedWALWriteError:AllowRecovery",
+        "RecoverFromRetryableBGIOError:BeforeStart"},
+       {"RecoverFromRetryableBGIOError:RecoverSuccess",
+        "FileScopedWALWriteError:RecoveryDone"}});
+  SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::WriteToWAL:AfterAddRecord", [&](void* arg) {
+        if (!injected.exchange(true)) {
+          IOStatus error = IOStatus::IOError(
+              "injected file-scoped WAL error after complete append");
+          error.SetScope(IOStatus::IOErrorScope::kIOErrorScopeFile);
+          error.SetRetryable(true);
+          *static_cast<IOStatus*>(arg) = error;
+        }
+      });
+  SyncPoint::GetInstance()->SetCallBack("DBImpl::SwitchMemtable:AbandonWAL",
+                                        [&](void*) { abandoned.store(true); });
+  SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::SyncWalImpl:SkipFailedWAL", [&](void* arg) {
+        if (*static_cast<uint64_t*>(arg) == failed_wal) {
+          skipped_failed_wal_sync.store(true);
+        }
+      });
+  SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::SyncWalImpl:BeforeSyncWAL", [&](void* arg) {
+        auto* writer = static_cast<log::Writer*>(arg);
+        if (writer->get_log_number() == failed_wal) {
+          synced_failed_wal.store(true);
+        }
+      });
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  WriteBatch failed_batch;
+  ASSERT_OK(failed_batch.Put(handles_[0], "failed", "default-value"));
+  ASSERT_OK(failed_batch.Put(handles_[1], "failed", "one-value"));
+  Status write_status = db_->Write(WriteOptions(), &failed_batch);
+  ASSERT_TRUE(write_status.IsIOError()) << write_status.ToString();
+  ASSERT_FALSE(write_status.IsTryAgain()) << write_status.ToString();
+  ASSERT_TRUE(dbfull()->TEST_IsRecoveryInProgress());
+  ASSERT_EQ("NOT_FOUND", Get(0, "failed"));
+  ASSERT_EQ("NOT_FOUND", Get(1, "failed"));
+
+  Status fenced_write = Put(0, "while-recovering", "value");
+  ASSERT_TRUE(fenced_write.IsIOError()) << fenced_write.ToString();
+
+  TEST_SYNC_POINT("FileScopedWALWriteError:AllowRecovery");
+  TEST_SYNC_POINT("FileScopedWALWriteError:RecoveryDone");
+  ASSERT_TRUE(abandoned.load());
+  ASSERT_TRUE(skipped_failed_wal_sync.load());
+  ASSERT_FALSE(synced_failed_wal.load());
+
+  ASSERT_OK(db_->SyncWAL());
+  ASSERT_FALSE(synced_failed_wal.load());
+  ASSERT_OK(db_->EnableFileDeletions());
+
+  for (ColumnFamilyHandle* handle : handles_) {
+    auto* cfd = static_cast<ColumnFamilyHandleImpl*>(handle)->cfd();
+    ASSERT_GT(cfd->GetLogNumber(), failed_wal);
+  }
+
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+
+  ASSERT_EQ("value-default", Get(0, "accepted-before-error"));
+  ASSERT_EQ("value-one", Get(1, "accepted-before-error"));
+  ASSERT_EQ("NOT_FOUND", Get(0, "failed"));
+  ASSERT_EQ("NOT_FOUND", Get(1, "failed"));
+  ASSERT_OK(Put(0, "accepted-after-recovery", "value2-default"));
+  ASSERT_OK(Put(1, "accepted-after-recovery", "value2-one"));
+
+  ReopenWithColumnFamilies({kDefaultColumnFamilyName, "one", "empty"}, options);
+  ASSERT_EQ("value-default", Get(0, "accepted-before-error"));
+  ASSERT_EQ("value-one", Get(1, "accepted-before-error"));
+  ASSERT_EQ("NOT_FOUND", Get(0, "failed"));
+  ASSERT_EQ("NOT_FOUND", Get(1, "failed"));
+  ASSERT_EQ("value2-default", Get(0, "accepted-after-recovery"));
+  ASSERT_EQ("value2-one", Get(1, "accepted-after-recovery"));
+}
+
+TEST_F(DBErrorHandlingFSTest,
+       FileScopedWALRecoveryUsesAndReplenishesAsyncPrecreatedWAL) {
+  Options options = GetDefaultOptions();
+  options.env = fault_env_.get();
+  options.create_if_missing = true;
+  options.paranoid_checks = true;
+  options.max_bgerror_resume_count = 2;
+  options.bgerror_resume_retry_interval = 1000;
+  options.avoid_flush_during_shutdown = true;
+  options.track_and_verify_wals_in_manifest = false;
+  options.async_wal_precreate = true;
+  options.recycle_log_file_num = 0;
+  options.statistics = CreateDBStatistics();
+
+  SyncPoint::GetInstance()->LoadDependency(
+      {{"DBImpl::BGWorkAsyncWALPrecreate:Done",
+        "AsyncWALRecovery:InitialPrecreateDone"}});
+  SyncPoint::GetInstance()->EnableProcessing();
+  DestroyAndReopen(options);
+  TEST_SYNC_POINT("AsyncWALRecovery:InitialPrecreateDone");
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->LoadDependency({});
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+
+  ASSERT_OK(Put("accepted-before-error", "value"));
+  const uint64_t failed_wal = dbfull()->TEST_GetCurrentLogNumber();
+
+  std::atomic<bool> injected{false};
+  SyncPoint::GetInstance()->LoadDependency(
+      {{"AsyncWALRecovery:AllowRecovery",
+        "RecoverFromRetryableBGIOError:BeforeStart"},
+       {"RecoverFromRetryableBGIOError:RecoverSuccess",
+        "AsyncWALRecovery:RecoveryDone"}});
+  SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::WriteToWAL:AfterAddRecord", [&](void* arg) {
+        if (!injected.exchange(true)) {
+          IOStatus error = IOStatus::IOError(
+              "injected file-scoped WAL error after complete append");
+          error.SetScope(IOStatus::IOErrorScope::kIOErrorScopeFile);
+          error.SetRetryable(true);
+          *static_cast<IOStatus*>(arg) = error;
+        }
+      });
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  Status write_status = Put("failed", "value");
+  ASSERT_TRUE(write_status.IsIOError()) << write_status.ToString();
+  TEST_SYNC_POINT("AsyncWALRecovery:AllowRecovery");
+  TEST_SYNC_POINT("AsyncWALRecovery:RecoveryDone");
+
+  ASSERT_GT(dbfull()->TEST_GetCurrentLogNumber(), failed_wal);
+  ASSERT_EQ(1, options.statistics->getTickerCount(WAL_PRECREATE_HIT));
+  ASSERT_EQ(0, options.statistics->getTickerCount(WAL_PRECREATE_MISS));
+
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->LoadDependency({});
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+
+  ASSERT_OK(Put("accepted-after-recovery", "value2"));
+  ASSERT_OK(dbfull()->TEST_SwitchMemtable());
+  ASSERT_EQ(2, options.statistics->getTickerCount(WAL_PRECREATE_HIT));
+  ASSERT_EQ(0, options.statistics->getTickerCount(WAL_PRECREATE_MISS));
+
+  Reopen(options);
+  ASSERT_EQ("value", Get("accepted-before-error"));
+  ASSERT_EQ("NOT_FOUND", Get("failed"));
+  ASSERT_EQ("value2", Get("accepted-after-recovery"));
+}
+
+TEST_F(DBErrorHandlingFSTest,
+       FileScopedAsyncWALStartErrorDoesNotQuarantineCurrentWAL) {
+  Options options = GetDefaultOptions();
+  options.env = fault_env_.get();
+  options.create_if_missing = true;
+  options.paranoid_checks = true;
+  options.max_bgerror_resume_count = 0;
+  options.avoid_flush_during_shutdown = true;
+  options.track_and_verify_wals_in_manifest = false;
+  options.async_wal_precreate = true;
+  options.recycle_log_file_num = 0;
+  options.statistics = CreateDBStatistics();
+
+  SyncPoint::GetInstance()->LoadDependency(
+      {{"DBImpl::BGWorkAsyncWALPrecreate:Done",
+        "AsyncWALStartError:InitialPrecreateDone"}});
+  SyncPoint::GetInstance()->EnableProcessing();
+  DestroyAndReopen(options);
+  TEST_SYNC_POINT("AsyncWALStartError:InitialPrecreateDone");
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->LoadDependency({});
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+
+  ASSERT_OK(Put("before", "value-before"));
+  const uint64_t current_wal = dbfull()->TEST_GetCurrentLogNumber();
+  std::atomic<bool> injected{false};
+  std::atomic<bool> abandoned{false};
+  std::vector<DBRecoverContext> recovery_contexts;
+  SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::StartWALFile:AfterCompressionTypeRecord", [&](void* arg) {
+        if (!injected.exchange(true)) {
+          IOStatus error =
+              IOStatus::IOError("injected file-scoped new WAL start error");
+          error.SetScope(IOStatus::IOErrorScope::kIOErrorScopeFile);
+          error.SetRetryable(true);
+          *static_cast<IOStatus*>(arg) = error;
+        }
+      });
+  SyncPoint::GetInstance()->SetCallBack("DBImpl::SwitchMemtable:AbandonWAL",
+                                        [&](void*) { abandoned.store(true); });
+  SyncPoint::GetInstance()->SetCallBack(
+      "ErrorHandler::RecoverFromBGError:Context", [&](void* arg) {
+        recovery_contexts.push_back(*static_cast<DBRecoverContext*>(arg));
+      });
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  Status switch_status = dbfull()->TEST_SwitchMemtable();
+  ASSERT_TRUE(switch_status.IsIOError()) << switch_status.ToString();
+  ASSERT_EQ(current_wal, dbfull()->TEST_GetCurrentLogNumber());
+  ASSERT_EQ(1, options.statistics->getTickerCount(WAL_PRECREATE_HIT));
+
+  ASSERT_OK(dbfull()->Resume());
+  ASSERT_EQ(1, recovery_contexts.size());
+  ASSERT_EQ(0, recovery_contexts[0].failed_wal_number);
+  ASSERT_FALSE(abandoned.load());
+  ASSERT_GT(dbfull()->TEST_GetCurrentLogNumber(), current_wal);
+  ASSERT_EQ(1, options.statistics->getTickerCount(WAL_PRECREATE_MISS));
+
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->LoadDependency({});
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+
+  ASSERT_OK(Put("after", "value-after"));
+  ASSERT_OK(dbfull()->TEST_SwitchMemtable());
+  ASSERT_EQ(2, options.statistics->getTickerCount(WAL_PRECREATE_HIT));
+  ASSERT_EQ(1, options.statistics->getTickerCount(WAL_PRECREATE_MISS));
+
+  Reopen(options);
+  ASSERT_EQ("value-before", Get("before"));
+  ASSERT_EQ("value-after", Get("after"));
+}
+
+TEST_F(DBErrorHandlingFSTest, FileScopedWALNoSpacePreservesRecoveryContext) {
+  std::shared_ptr<ErrorHandlerFSListener> listener =
+      std::make_shared<ErrorHandlerFSListener>();
+  Options options = GetDefaultOptions();
+  options.env = fault_env_.get();
+  options.create_if_missing = true;
+  options.paranoid_checks = true;
+  options.listeners.emplace_back(listener);
+  options.max_bgerror_resume_count = 0;
+  options.avoid_flush_during_shutdown = true;
+  options.track_and_verify_wals_in_manifest = false;
+  options.background_close_inactive_wals = false;
+  listener->EnableAutoRecovery(false);
+  CreateAndReopenWithCF({"one", "empty"}, options);
+
+  ASSERT_OK(Put(0, "accepted-before-error", "value-default"));
+  ASSERT_OK(Put(1, "accepted-before-error", "value-one"));
+  const uint64_t failed_wal = dbfull()->TEST_GetCurrentLogNumber();
+
+  std::atomic<bool> injected{false};
+  std::atomic<bool> abandoned{false};
+  std::vector<DBRecoverContext> recovery_contexts;
+  SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::WriteToWAL:AfterAddRecord", [&](void* arg) {
+        if (!injected.exchange(true)) {
+          IOStatus error = IOStatus::NoSpace(
+              "injected file-scoped WAL no-space error after complete append");
+          error.SetScope(IOStatus::IOErrorScope::kIOErrorScopeFile);
+          error.SetRetryable(true);
+          *static_cast<IOStatus*>(arg) = error;
+        }
+      });
+  SyncPoint::GetInstance()->SetCallBack("DBImpl::SwitchMemtable:AbandonWAL",
+                                        [&](void*) { abandoned.store(true); });
+  SyncPoint::GetInstance()->SetCallBack(
+      "ErrorHandler::RecoverFromBGError:Context", [&](void* arg) {
+        recovery_contexts.push_back(*static_cast<DBRecoverContext*>(arg));
+      });
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  WriteBatch failed_batch;
+  ASSERT_OK(failed_batch.Put(handles_[0], "failed", "default-value"));
+  ASSERT_OK(failed_batch.Put(handles_[1], "failed", "one-value"));
+  Status write_status = db_->Write(WriteOptions(), &failed_batch);
+  ASSERT_TRUE(write_status.IsNoSpace()) << write_status.ToString();
+  ASSERT_FALSE(abandoned.load());
+
+  ASSERT_OK(dbfull()->Resume());
+  ASSERT_TRUE(abandoned.load());
+  ASSERT_EQ(1, recovery_contexts.size());
+  ASSERT_EQ(failed_wal, recovery_contexts[0].failed_wal_number);
+
+  IOStatus unrelated_error = IOStatus::IOError("unrelated retryable error");
+  unrelated_error.SetRetryable(true);
+  dbfull()->TEST_SetBGError(unrelated_error,
+                            BackgroundErrorReason::kFlushNoWAL);
+  ASSERT_OK(dbfull()->Resume());
+  ASSERT_EQ(2, recovery_contexts.size());
+  ASSERT_EQ(0, recovery_contexts[1].failed_wal_number);
+  ASSERT_EQ(0, recovery_contexts[1].failed_wal_sequence);
+
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+
+  for (ColumnFamilyHandle* handle : handles_) {
+    auto* cfd = static_cast<ColumnFamilyHandleImpl*>(handle)->cfd();
+    ASSERT_GT(cfd->GetLogNumber(), failed_wal);
+  }
+  ASSERT_EQ("value-default", Get(0, "accepted-before-error"));
+  ASSERT_EQ("value-one", Get(1, "accepted-before-error"));
+  ASSERT_EQ("NOT_FOUND", Get(0, "failed"));
+  ASSERT_EQ("NOT_FOUND", Get(1, "failed"));
+  ASSERT_OK(Put(0, "accepted-after-recovery", "value2-default"));
+
+  ReopenWithColumnFamilies({kDefaultColumnFamilyName, "one", "empty"}, options);
+  ASSERT_EQ("value-default", Get(0, "accepted-before-error"));
+  ASSERT_EQ("value-one", Get(1, "accepted-before-error"));
+  ASSERT_EQ("NOT_FOUND", Get(0, "failed"));
+  ASSERT_EQ("NOT_FOUND", Get(1, "failed"));
+  ASSERT_EQ("value2-default", Get(0, "accepted-after-recovery"));
+}
+
+TEST_F(DBErrorHandlingFSTest,
+       FileScopedWALWriteErrorReservesIndeterminateSequence) {
+  Options options = GetDefaultOptions();
+  options.env = fault_env_.get();
+  options.create_if_missing = true;
+  options.paranoid_checks = true;
+  options.max_bgerror_resume_count = 2;
+  options.bgerror_resume_retry_interval = 1000;
+  options.avoid_flush_during_shutdown = true;
+  options.track_and_verify_wals_in_manifest = false;
+  options.background_close_inactive_wals = false;
+  DestroyAndReopen(options);
+
+  ASSERT_OK(Put("before", "value-before"));
+  const SequenceNumber before = db_->GetLatestSequenceNumber();
+  std::unique_ptr<WalIterator> iter;
+  ASSERT_OK(db_->GetUpdatesSince(0, &iter));
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ(before, iter->GetBatch().sequence);
+  iter->Next();
+  ASSERT_FALSE(iter->Valid());
+  ASSERT_OK(iter->status());
+
+  std::atomic<bool> injected{false};
+  SyncPoint::GetInstance()->LoadDependency(
+      {{"FileScopedSequence:AllowRecovery",
+        "RecoverFromRetryableBGIOError:BeforeStart"},
+       {"RecoverFromRetryableBGIOError:RecoverSuccess",
+        "FileScopedSequence:RecoveryDone"}});
+  SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::WriteToWAL:AfterAddRecord", [&](void* arg) {
+        if (!injected.exchange(true)) {
+          IOStatus error = IOStatus::IOError(
+              "injected file-scoped error after complete append");
+          error.SetScope(IOStatus::IOErrorScope::kIOErrorScopeFile);
+          error.SetRetryable(true);
+          *static_cast<IOStatus*>(arg) = error;
+        }
+      });
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  Status write_status = Put("failed", "value-failed");
+  ASSERT_TRUE(write_status.IsIOError()) << write_status.ToString();
+  ASSERT_EQ(before, db_->GetLatestSequenceNumber());
+  TEST_SYNC_POINT("FileScopedSequence:AllowRecovery");
+  TEST_SYNC_POINT("FileScopedSequence:RecoveryDone");
+  ASSERT_EQ(before + 1, db_->GetLatestSequenceNumber());
+
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+
+  ASSERT_OK(Put("after", "value-after"));
+  ASSERT_EQ(before + 2, db_->GetLatestSequenceNumber());
+
+  iter->Next();
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ(before + 1, iter->GetBatch().sequence);
+  iter->Next();
+  ASSERT_FALSE(iter->Valid());
+  ASSERT_TRUE(iter->status().IsTryAgain()) << iter->status().ToString();
+
+  Reopen(options);
+  ASSERT_EQ("value-before", Get("before"));
+  ASSERT_EQ("NOT_FOUND", Get("failed"));
+  ASSERT_EQ("value-after", Get("after"));
+  ASSERT_EQ(before + 2, db_->GetLatestSequenceNumber());
+}
+
+TEST_F(DBErrorHandlingFSTest,
+       FileScopedWALRecoveryMergesConcurrentIndeterminateSequence) {
+  Options options = GetDefaultOptions();
+  options.env = fault_env_.get();
+  options.create_if_missing = true;
+  options.paranoid_checks = true;
+  options.max_bgerror_resume_count = 2;
+  options.bgerror_resume_retry_interval = 1000;
+  options.avoid_flush_during_shutdown = true;
+  options.track_and_verify_wals_in_manifest = false;
+  options.background_close_inactive_wals = false;
+  DestroyAndReopen(options);
+
+  ASSERT_OK(Put("before", "value-before"));
+  const uint64_t failed_wal = dbfull()->TEST_GetCurrentLogNumber();
+
+  std::future<Status> failed_write;
+  // Disable SyncPoint processing before joining failed_write during unwinding.
+  // Otherwise an assertion failure can leave the writer blocked at
+  // ConcurrentWALSequence:AllowWriteError.
+  struct SyncPointDisabler {
+    ~SyncPointDisabler() { SyncPoint::GetInstance()->DisableProcessing(); }
+  } sync_point_disabler;
+
+  SyncPoint::GetInstance()->LoadDependency(
+      {{"ConcurrentWALSequence:AllowInitialFlush", "DBImpl::BGWorkFlush"},
+       {"ConcurrentWALSequence:WriteErrorReady",
+        "ConcurrentWALSequence:StartSync"},
+       {"ConcurrentWALSequence:SyncErrorRecorded",
+        "ConcurrentWALSequence:AllowWriteError"},
+       {"ConcurrentWALSequence:AllowRecovery",
+        "RecoverFromRetryableBGIOError:BeforeStart"},
+       {"RecoverFromRetryableBGIOError:RecoverSuccess",
+        "ConcurrentWALSequence:RecoveryDone"}});
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  // Keep the flush triggered by the WAL switch from making failed_wal
+  // obsolete before the concurrent SyncWAL() can inject its error.
+  ASSERT_OK(dbfull()->TEST_SwitchWAL());
+  ASSERT_OK(Put("iterator-anchor", "value-anchor"));
+  const SequenceNumber before = db_->GetLatestSequenceNumber();
+
+  std::unique_ptr<WalIterator> iter;
+  ASSERT_OK(db_->GetUpdatesSince(before, &iter));
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ(before, iter->GetBatch().sequence);
+
+  std::atomic<bool> injected_write_error{false};
+  std::atomic<bool> injected_sync_error{false};
+  SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::WriteToWAL:AfterAddRecord", [&](void* arg) {
+        if (!injected_write_error.exchange(true)) {
+          IOStatus error =
+              IOStatus::IOError("injected concurrent retryable WAL error");
+          error.SetRetryable(true);
+          *static_cast<IOStatus*>(arg) = error;
+        }
+      });
+  SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::WriteImpl:BeforeWALIOStatusCheck", [&](void*) {
+        TEST_SYNC_POINT("ConcurrentWALSequence:WriteErrorReady");
+        TEST_SYNC_POINT("ConcurrentWALSequence:AllowWriteError");
+      });
+  SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::SyncWalImpl:AfterSyncWAL", [&](void* arg) {
+        auto* wal_and_status =
+            static_cast<std::pair<log::Writer*, IOStatus*>*>(arg);
+        if (wal_and_status->first->get_log_number() == failed_wal &&
+            !injected_sync_error.exchange(true)) {
+          IOStatus error =
+              IOStatus::IOError("injected older file-scoped WAL error");
+          error.SetScope(IOStatus::IOErrorScope::kIOErrorScopeFile);
+          error.SetRetryable(true);
+          *wal_and_status->second = error;
+        }
+      });
+  failed_write = std::async(std::launch::async,
+                            [&] { return Put("failed", "value-failed"); });
+
+  TEST_SYNC_POINT("ConcurrentWALSequence:StartSync");
+  Status sync_status = db_->SyncWAL();
+  TEST_SYNC_POINT("ConcurrentWALSequence:SyncErrorRecorded");
+  TEST_SYNC_POINT("ConcurrentWALSequence:AllowInitialFlush");
+
+  Status write_status = failed_write.get();
+  if (write_status.IsIOError()) {
+    TEST_SYNC_POINT("ConcurrentWALSequence:AllowRecovery");
+    TEST_SYNC_POINT("ConcurrentWALSequence:RecoveryDone");
+  } else {
+    // Recovery is not expected without the injected write error. Wake any
+    // remaining SyncPoint waiters before reporting the failed expectation.
+    SyncPoint::GetInstance()->DisableProcessing();
+  }
+
+  ASSERT_TRUE(sync_status.IsIOError()) << sync_status.ToString();
+  ASSERT_TRUE(injected_sync_error.load());
+  ASSERT_TRUE(write_status.IsIOError()) << write_status.ToString();
+  ASSERT_EQ(before + 1, db_->GetLatestSequenceNumber());
+
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+
+  ASSERT_OK(Put("after", "value-after"));
+  ASSERT_EQ(before + 2, db_->GetLatestSequenceNumber());
+
+  iter->Next();
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ(before + 1, iter->GetBatch().sequence);
+
+  std::unique_ptr<WalIterator> after_iter;
+  ASSERT_OK(db_->GetUpdatesSince(before + 2, &after_iter));
+  ASSERT_TRUE(after_iter->Valid());
+  ASSERT_EQ(before + 2, after_iter->GetBatch().sequence);
+  ASSERT_OK(iter->status());
+  ASSERT_OK(after_iter->status());
+
+  Reopen(options);
+  ASSERT_EQ("value-before", Get("before"));
+  ASSERT_EQ("value-anchor", Get("iterator-anchor"));
+  ASSERT_EQ("NOT_FOUND", Get("failed"));
+  ASSERT_EQ("value-after", Get("after"));
+  ASSERT_EQ(before + 2, db_->GetLatestSequenceNumber());
+}
+
+TEST_F(DBErrorHandlingFSTest,
+       FileScopedWALRecoveryQuarantinesConcurrentSyncWAL) {
+  Options options = GetDefaultOptions();
+  options.env = fault_env_.get();
+  options.create_if_missing = true;
+  options.paranoid_checks = true;
+  options.max_bgerror_resume_count = 2;
+  options.bgerror_resume_retry_interval = 1000;
+  options.avoid_flush_during_shutdown = true;
+  options.track_and_verify_wals_in_manifest = false;
+  options.background_close_inactive_wals = false;
+  DestroyAndReopen(options);
+
+  ASSERT_OK(Put("before", "value-before"));
+  const uint64_t failed_wal = dbfull()->TEST_GetCurrentLogNumber();
+  IOStatus injected_error =
+      IOStatus::IOError("injected file-scoped WAL append error");
+  injected_error.SetScope(IOStatus::IOErrorScope::kIOErrorScopeFile);
+  injected_error.SetRetryable(true);
+
+  std::atomic<bool> inject_write_error{true};
+  std::atomic<int> underlying_sync_calls{0};
+  std::atomic<bool> skipped_failed_wal{false};
+  SyncPoint::GetInstance()->LoadDependency(
+      {{"ConcurrentSyncWAL:WriteErrorReady", "ConcurrentSyncWAL:StartSync"},
+       {"ConcurrentSyncWAL:SyncFinished", "ConcurrentSyncWAL:AllowWriteError"},
+       {"ConcurrentSyncWAL:AllowRecovery",
+        "RecoverFromRetryableBGIOError:BeforeStart"},
+       {"RecoverFromRetryableBGIOError:RecoverSuccess",
+        "ConcurrentSyncWAL:RecoveryDone"}});
+  SyncPoint::GetInstance()->SetCallBack(
+      "WritableFileWriter::Append:BeforePrepareWrite", [&](void*) {
+        if (inject_write_error.exchange(false)) {
+          fault_fs_->SetFilesystemActive(false, injected_error);
+        }
+      });
+  SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::WriteImpl:BeforeWALIOStatusCheck", [&](void*) {
+        TEST_SYNC_POINT("ConcurrentSyncWAL:WriteErrorReady");
+        TEST_SYNC_POINT("ConcurrentSyncWAL:AllowWriteError");
+      });
+  SyncPoint::GetInstance()->SetCallBack(
+      "WritableFileWriter::SyncWithoutFlush:1",
+      [&](void*) { underlying_sync_calls.fetch_add(1); });
+  SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::SyncWalImpl:SkipFailedWAL", [&](void* arg) {
+        if (*static_cast<uint64_t*>(arg) == failed_wal) {
+          skipped_failed_wal.store(true);
+        }
+      });
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  WriteOptions sync_write;
+  sync_write.sync = true;
+  auto failed_write = std::async(std::launch::async, [&] {
+    return db_->Put(sync_write, "failed", "value-failed");
+  });
+  TEST_SYNC_POINT("ConcurrentSyncWAL:StartSync");
+  fault_fs_->SetFilesystemActive(true);
+
+  Status concurrent_sync = db_->SyncWAL();
+  ASSERT_TRUE(concurrent_sync.IsIOError()) << concurrent_sync.ToString();
+  ASSERT_EQ(0, underlying_sync_calls.load());
+  ASSERT_OK(dbfull()->TEST_GetBGError());
+  TEST_SYNC_POINT("ConcurrentSyncWAL:SyncFinished");
+
+  Status write_status = failed_write.get();
+  ASSERT_TRUE(write_status.IsIOError()) << write_status.ToString();
+  ASSERT_EQ(Status::Severity::kHardError,
+            dbfull()->TEST_GetBGError().severity());
+
+  Status quarantined_sync = db_->SyncWAL();
+  ASSERT_TRUE(quarantined_sync.IsIOError()) << quarantined_sync.ToString();
+  ASSERT_EQ(Status::Severity::kHardError, quarantined_sync.severity());
+  ASSERT_TRUE(skipped_failed_wal.load());
+  ASSERT_EQ(0, underlying_sync_calls.load());
+
+  TEST_SYNC_POINT("ConcurrentSyncWAL:AllowRecovery");
+  TEST_SYNC_POINT("ConcurrentSyncWAL:RecoveryDone");
+
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+
+  ASSERT_OK(dbfull()->TEST_GetBGError());
+  ASSERT_OK(Put("after", "value-after"));
+  Reopen(options);
+  ASSERT_EQ("value-before", Get("before"));
+  ASSERT_EQ("NOT_FOUND", Get("failed"));
+  ASSERT_EQ("value-after", Get("after"));
+}
+
+TEST_F(DBErrorHandlingFSTest,
+       SyncWALCachedErrorResetsWriterWithoutParanoidChecks) {
+  Options options = GetDefaultOptions();
+  options.env = fault_env_.get();
+  options.create_if_missing = true;
+  options.paranoid_checks = false;
+  options.avoid_flush_during_shutdown = true;
+  DestroyAndReopen(options);
+
+  ASSERT_OK(Put("before", "value-before"));
+
+  IOStatus injected_error = IOStatus::IOError("injected WAL append error");
+  std::atomic<bool> inject_write_error{true};
+  std::atomic<int> underlying_sync_calls{0};
+  SyncPoint::GetInstance()->LoadDependency(
+      {{"NonParanoidCachedError:WriteErrorReady",
+        "NonParanoidCachedError:StartSync"},
+       {"NonParanoidCachedError:SyncFinished",
+        "NonParanoidCachedError:AllowWriteError"}});
+  SyncPoint::GetInstance()->SetCallBack(
+      "WritableFileWriter::Append:BeforePrepareWrite", [&](void*) {
+        if (inject_write_error.exchange(false)) {
+          fault_fs_->SetFilesystemActive(false, injected_error);
+        }
+      });
+  SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::WriteImpl:BeforeWALIOStatusCheck", [&](void*) {
+        TEST_SYNC_POINT("NonParanoidCachedError:WriteErrorReady");
+        TEST_SYNC_POINT("NonParanoidCachedError:AllowWriteError");
+      });
+  SyncPoint::GetInstance()->SetCallBack(
+      "WritableFileWriter::SyncWithoutFlush:1",
+      [&](void*) { underlying_sync_calls.fetch_add(1); });
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  WriteOptions sync_write;
+  sync_write.sync = true;
+  auto failed_write = std::async(std::launch::async, [&] {
+    return db_->Put(sync_write, "failed", "value-failed");
+  });
+  // This guard is declared after the future so it disables SyncPoints before
+  // the future destructor joins the blocked writer during assertion unwinding.
+  struct SyncPointDisabler {
+    ~SyncPointDisabler() { SyncPoint::GetInstance()->DisableProcessing(); }
+  } sync_point_disabler;
+
+  TEST_SYNC_POINT("NonParanoidCachedError:StartSync");
+  fault_fs_->SetFilesystemActive(true);
+
+  Status cached_sync = db_->SyncWAL();
+  const int calls_after_cached_sync = underlying_sync_calls.load();
+  Status retried_sync = db_->SyncWAL();
+  const int calls_after_retried_sync = underlying_sync_calls.load();
+  TEST_SYNC_POINT("NonParanoidCachedError:SyncFinished");
+  Status write_status = failed_write.get();
+
+  ASSERT_TRUE(cached_sync.IsIOError()) << cached_sync.ToString();
+  ASSERT_EQ(0, calls_after_cached_sync);
+  ASSERT_OK(retried_sync);
+  ASSERT_EQ(1, calls_after_retried_sync);
+  ASSERT_TRUE(write_status.IsIOError()) << write_status.ToString();
+  ASSERT_OK(dbfull()->TEST_GetBGError());
+
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+
+  ASSERT_OK(Put("after", "value-after"));
+}
+
+TEST_F(DBErrorHandlingFSTest, FileScopedErrorReplacesEmptyCurrentWAL) {
+  Options options = GetDefaultOptions();
+  options.env = fault_env_.get();
+  options.create_if_missing = true;
+  options.paranoid_checks = true;
+  options.max_bgerror_resume_count = 2;
+  options.bgerror_resume_retry_interval = 1000;
+  options.avoid_flush_during_shutdown = true;
+  options.track_and_verify_wals_in_manifest = false;
+  DestroyAndReopen(options);
+
+  const uint64_t failed_wal = dbfull()->TEST_GetCurrentLogNumber();
+  std::atomic<bool> injected{false};
+  std::atomic<bool> abandoned{false};
+  SyncPoint::GetInstance()->LoadDependency(
+      {{"FileScopedEmptyWAL:AllowRecovery",
+        "RecoverFromRetryableBGIOError:BeforeStart"},
+       {"RecoverFromRetryableBGIOError:RecoverSuccess",
+        "FileScopedEmptyWAL:RecoveryDone"}});
+  SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::WriteToWAL:AfterMaybeAddUserDefinedTimestampSizeRecord",
+      [&](void* arg) {
+        if (!injected.exchange(true)) {
+          IOStatus error =
+              IOStatus::IOError("injected file-scoped empty WAL error");
+          error.SetScope(IOStatus::IOErrorScope::kIOErrorScopeFile);
+          error.SetRetryable(true);
+          *static_cast<IOStatus*>(arg) = error;
+        }
+      });
+  SyncPoint::GetInstance()->SetCallBack("DBImpl::SwitchMemtable:AbandonWAL",
+                                        [&](void*) { abandoned.store(true); });
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  Status write_status = Put("failed", "value");
+  ASSERT_TRUE(write_status.IsIOError()) << write_status.ToString();
+  TEST_SYNC_POINT("FileScopedEmptyWAL:AllowRecovery");
+  TEST_SYNC_POINT("FileScopedEmptyWAL:RecoveryDone");
+
+  ASSERT_TRUE(abandoned.load());
+  ASSERT_GT(dbfull()->TEST_GetCurrentLogNumber(), failed_wal);
+
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+  ASSERT_EQ("NOT_FOUND", Get("failed"));
+  ASSERT_OK(Put("accepted-after-recovery", "value2"));
+  Reopen(options);
+  ASSERT_EQ("NOT_FOUND", Get("failed"));
+  ASSERT_EQ("value2", Get("accepted-after-recovery"));
+}
+
+TEST_F(DBErrorHandlingFSTest, FileScopedErrorOnOlderWALSkipsExactWriter) {
+  Options options = GetDefaultOptions();
+  options.env = fault_env_.get();
+  options.create_if_missing = true;
+  options.paranoid_checks = true;
+  options.max_bgerror_resume_count = 2;
+  options.bgerror_resume_retry_interval = 1000;
+  options.avoid_flush_during_shutdown = true;
+  options.track_and_verify_wals_in_manifest = false;
+  DestroyAndReopen(options);
+
+  options.env->SetBackgroundThreads(1, Env::Priority::HIGH);
+  test::SleepingBackgroundTask sleeping_task;
+  options.env->Schedule(&test::SleepingBackgroundTask::DoSleepTask,
+                        &sleeping_task, Env::Priority::HIGH);
+  sleeping_task.WaitUntilSleeping();
+
+  ASSERT_OK(Put("accepted-before-error", "value"));
+  const uint64_t failed_wal = dbfull()->TEST_GetCurrentLogNumber();
+  std::atomic<int> failed_wal_sync_attempts{0};
+  std::atomic<uint64_t> first_synced_wal{0};
+  SyncPoint::GetInstance()->LoadDependency(
+      {{"FileScopedOlderWAL:AllowRecovery",
+        "RecoverFromRetryableBGIOError:BeforeStart"},
+       {"RecoverFromRetryableBGIOError:RecoverSuccess",
+        "FileScopedOlderWAL:RecoveryDone"}});
+  SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::SyncWalImpl:AfterSyncWAL", [&](void* arg) {
+        auto* wal_and_status =
+            static_cast<std::pair<log::Writer*, IOStatus*>*>(arg);
+        auto* writer = wal_and_status->first;
+        if (failed_wal_sync_attempts.fetch_add(1) == 0) {
+          first_synced_wal.store(writer->get_log_number());
+          IOStatus error = IOStatus::IOError("older WAL is poisoned");
+          error.SetScope(IOStatus::IOErrorScope::kIOErrorScopeFile);
+          error.SetRetryable(true);
+          *wal_and_status->second = error;
+        }
+      });
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  ASSERT_OK(dbfull()->TEST_SwitchWAL());
+  const uint64_t current_wal = dbfull()->TEST_GetCurrentLogNumber();
+  ASSERT_GT(current_wal, failed_wal);
+  Status sync_status = db_->SyncWAL();
+  ASSERT_TRUE(sync_status.IsIOError()) << sync_status.ToString();
+  ASSERT_EQ(1, failed_wal_sync_attempts.load());
+  ASSERT_EQ(failed_wal, first_synced_wal.load());
+  sleeping_task.WakeUp();
+  sleeping_task.WaitUntilDone();
+  TEST_SYNC_POINT("FileScopedOlderWAL:AllowRecovery");
+  TEST_SYNC_POINT("FileScopedOlderWAL:RecoveryDone");
+
+  ASSERT_EQ(1, failed_wal_sync_attempts.load());
+  ASSERT_EQ(current_wal, dbfull()->TEST_GetCurrentLogNumber());
+
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+  ASSERT_OK(Put("accepted-after-recovery", "value2"));
+  Reopen(options);
+  ASSERT_EQ("value", Get("accepted-before-error"));
+  ASSERT_EQ("value2", Get("accepted-after-recovery"));
+}
+
+TEST_F(DBErrorHandlingFSTest,
+       SyncWALPersistsLaterTrackedWALBeforeReturningBackgroundError) {
+  Options options = GetDefaultOptions();
+  options.env = fault_env_.get();
+  options.create_if_missing = true;
+  options.paranoid_checks = true;
+  options.max_bgerror_resume_count = 0;
+  options.avoid_flush_during_shutdown = true;
+  options.track_and_verify_wals_in_manifest = true;
+  options.background_close_inactive_wals = false;
+  options.max_write_buffer_number = 4;
+  DestroyAndReopen(options);
+
+  ASSERT_OK(Put("failed-wal", "value"));
+  const uint64_t failed_wal = dbfull()->TEST_GetCurrentLogNumber();
+  ASSERT_OK(dbfull()->TEST_SwitchMemtable());
+  ASSERT_OK(Put("later-wal", "value"));
+  const uint64_t later_wal = dbfull()->TEST_GetCurrentLogNumber();
+  ASSERT_GT(later_wal, failed_wal);
+  ASSERT_OK(dbfull()->TEST_SwitchMemtable());
+
+  std::atomic<bool> injected{false};
+  std::atomic<int> manifest_writes{0};
+  SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::SyncWalImpl:AfterSyncWAL", [&](void* arg) {
+        auto* wal_and_status =
+            static_cast<std::pair<log::Writer*, IOStatus*>*>(arg);
+        if (wal_and_status->first->get_log_number() == failed_wal &&
+            !injected.exchange(true)) {
+          IOStatus error =
+              IOStatus::IOError("injected older file-scoped WAL error");
+          error.SetScope(IOStatus::IOErrorScope::kIOErrorScopeFile);
+          error.SetRetryable(true);
+          *wal_and_status->second = error;
+        }
+      });
+  SyncPoint::GetInstance()->SetCallBack(
+      "VersionSet::ProcessManifestWrites:AddRecord",
+      [&](void*) { manifest_writes.fetch_add(1); });
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  Status first_sync = db_->SyncWAL();
+  ASSERT_TRUE(first_sync.IsIOError()) << first_sync.ToString();
+  ASSERT_TRUE(injected.load());
+  ASSERT_EQ(0, manifest_writes.exchange(0));
+
+  Status quarantined_sync = db_->SyncWAL();
+  ASSERT_TRUE(quarantined_sync.IsIOError()) << quarantined_sync.ToString();
+  ASSERT_EQ(Status::Severity::kHardError, quarantined_sync.severity());
+  ASSERT_EQ(1, manifest_writes.load());
+  const auto& tracked_wals = dbfull()->GetVersionSet()->GetWalSet().GetWals();
+  auto later_wal_entry = tracked_wals.find(later_wal);
+  ASSERT_NE(tracked_wals.end(), later_wal_entry);
+  ASSERT_TRUE(later_wal_entry->second.HasSyncedSize());
+
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+}
+
+TEST_F(DBErrorHandlingFSTest, RecoveryLearnsThatCurrentWALIsFileScoped) {
+  Options options = GetDefaultOptions();
+  options.env = fault_env_.get();
+  options.create_if_missing = true;
+  options.paranoid_checks = true;
+  options.max_bgerror_resume_count = 2;
+  options.bgerror_resume_retry_interval = 1000;
+  options.avoid_flush_during_shutdown = true;
+  options.track_and_verify_wals_in_manifest = false;
+  DestroyAndReopen(options);
+
+  ASSERT_OK(Put("accepted-before-error", "value"));
+  const SequenceNumber before = db_->GetLatestSequenceNumber();
+  std::unique_ptr<WalIterator> iter;
+  ASSERT_OK(db_->GetUpdatesSince(0, &iter));
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ(before, iter->GetBatch().sequence);
+  iter->Next();
+  ASSERT_FALSE(iter->Valid());
+  ASSERT_OK(iter->status());
+  const uint64_t failed_wal = dbfull()->TEST_GetCurrentLogNumber();
+
+  std::atomic<bool> injected_write_error{false};
+  std::atomic<bool> failed_first_recovery{false};
+  std::atomic<bool> abandoned{false};
+  SyncPoint::GetInstance()->LoadDependency(
+      {{"FileScopedWALRetry:AllowRecovery",
+        "RecoverFromRetryableBGIOError:BeforeStart"},
+       {"RecoverFromRetryableBGIOError:RecoverSuccess",
+        "FileScopedWALRetry:RecoveryDone"}});
+  SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::WriteToWAL:AfterAddRecord", [&](void* arg) {
+        if (!injected_write_error.exchange(true)) {
+          IOStatus error = IOStatus::IOError(
+              "injected retryable WAL error after complete append");
+          error.SetRetryable(true);
+          *static_cast<IOStatus*>(arg) = error;
+        }
+      });
+  SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::SwitchMemtable:AfterCreateWAL", [&](void*) {
+        if (!failed_first_recovery.exchange(true)) {
+          IOStatus error = IOStatus::IOError("current WAL is poisoned");
+          error.SetScope(IOStatus::IOErrorScope::kIOErrorScopeFile);
+          error.SetRetryable(true);
+          fault_fs_->SetFilesystemActive(false, error);
+        }
+      });
+  SyncPoint::GetInstance()->SetCallBack(
+      "RecoverFromRetryableBGIOError:BeforeWait0",
+      [&](void*) { fault_fs_->SetFilesystemActive(true); });
+  SyncPoint::GetInstance()->SetCallBack("DBImpl::SwitchMemtable:AbandonWAL",
+                                        [&](void*) { abandoned.store(true); });
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  Status write_status = Put("failed", "value");
+  ASSERT_TRUE(write_status.IsIOError()) << write_status.ToString();
+  TEST_SYNC_POINT("FileScopedWALRetry:AllowRecovery");
+  TEST_SYNC_POINT("FileScopedWALRetry:RecoveryDone");
+
+  ASSERT_TRUE(failed_first_recovery.load());
+  ASSERT_TRUE(abandoned.load());
+  ASSERT_GT(dbfull()->TEST_GetCurrentLogNumber(), failed_wal);
+  ASSERT_EQ(before + 1, db_->GetLatestSequenceNumber());
+
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+  ASSERT_OK(Put("accepted-after-recovery", "value2"));
+  ASSERT_EQ(before + 2, db_->GetLatestSequenceNumber());
+  iter->Next();
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ(before + 1, iter->GetBatch().sequence);
+  iter->Next();
+  ASSERT_FALSE(iter->Valid());
+  ASSERT_TRUE(iter->status().IsTryAgain()) << iter->status().ToString();
+  Reopen(options);
+  ASSERT_EQ("value", Get("accepted-before-error"));
+  ASSERT_EQ("NOT_FOUND", Get("failed"));
+  ASSERT_EQ("value2", Get("accepted-after-recovery"));
+}
+
+TEST_F(DBErrorHandlingFSTest,
+       FileScopedWALWriteErrorWithManualFlushFailsClosedAsNotSupported) {
+  Options options = GetDefaultOptions();
+  options.env = fault_env_.get();
+  options.create_if_missing = true;
+  options.paranoid_checks = true;
+  options.manual_wal_flush = true;
+  options.max_bgerror_resume_count = 0;
+  options.avoid_flush_during_shutdown = true;
+  options.track_and_verify_wals_in_manifest = false;
+  DestroyAndReopen(options);
+
+  std::atomic<bool> injected{false};
+  SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::WriteToWAL:AfterAddRecord", [&](void* arg) {
+        if (!injected.exchange(true)) {
+          IOStatus error =
+              IOStatus::IOError("injected file-scoped manual WAL error");
+          error.SetScope(IOStatus::IOErrorScope::kIOErrorScopeFile);
+          error.SetRetryable(true);
+          *static_cast<IOStatus*>(arg) = error;
+        }
+      });
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  Status write_status = Put("failed", "value");
+  ASSERT_TRUE(write_status.IsIOError()) << write_status.ToString();
+  ASSERT_NOK(dbfull()->TEST_GetBGError());
+
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+
+  Status resume_status = dbfull()->Resume();
+  ASSERT_TRUE(resume_status.IsNotSupported()) << resume_status.ToString();
+  ASSERT_NOK(dbfull()->TEST_GetBGError());
+  Status fenced_write = Put("while-stopped", "value");
+  ASSERT_TRUE(fenced_write.IsIOError()) << fenced_write.ToString();
+}
+
+TEST_F(DBErrorHandlingFSTest,
+       FileScopedWALWriteErrorWithRetentionFailsClosedAsNotSupported) {
+  Options options = GetDefaultOptions();
+  options.env = fault_env_.get();
+  options.create_if_missing = true;
+  options.paranoid_checks = true;
+  options.WAL_ttl_seconds = 60;
+  options.max_bgerror_resume_count = 0;
+  options.avoid_flush_during_shutdown = true;
+  options.track_and_verify_wals_in_manifest = false;
+  DestroyAndReopen(options);
+
+  std::atomic<bool> injected{false};
+  SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::WriteToWAL:AfterAddRecord", [&](void* arg) {
+        if (!injected.exchange(true)) {
+          IOStatus error =
+              IOStatus::IOError("injected file-scoped retained WAL error");
+          error.SetScope(IOStatus::IOErrorScope::kIOErrorScopeFile);
+          error.SetRetryable(true);
+          *static_cast<IOStatus*>(arg) = error;
+        }
+      });
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  Status write_status = Put("failed", "value");
+  ASSERT_TRUE(write_status.IsIOError()) << write_status.ToString();
+
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+
+  Status resume_status = dbfull()->Resume();
+  ASSERT_TRUE(resume_status.IsNotSupported()) << resume_status.ToString();
+  ASSERT_NOK(dbfull()->TEST_GetBGError());
+  Status fenced_write = Put("while-stopped", "value");
+  ASSERT_TRUE(fenced_write.IsIOError()) << fenced_write.ToString();
+}
+
+TEST_F(DBErrorHandlingFSTest,
+       FileScopedWALWriteErrorFailsClosedWhenUnsupported) {
+  auto listener = std::make_shared<ErrorHandlerFSListener>();
+  Options options = GetDefaultOptions();
+  options.env = fault_env_.get();
+  options.create_if_missing = true;
+  options.paranoid_checks = true;
+  options.max_bgerror_resume_count = 1;
+  options.avoid_flush_during_shutdown = true;
+  options.track_and_verify_wals_in_manifest = true;
+  options.listeners.emplace_back(listener);
+  DestroyAndReopen(options);
+
+  std::atomic<bool> injected{false};
+  std::atomic<bool> abandoned{false};
+  SyncPoint::GetInstance()->LoadDependency(
+      {{"FileScopedWALWriteErrorUnsupported:AllowRecovery",
+        "RecoverFromRetryableBGIOError:BeforeStart"},
+       {"NotifyOnErrorRecoveryEnd:MutexUnlocked:1",
+        "FileScopedWALWriteErrorUnsupported:RecoveryStopped"}});
+  SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::WriteToWAL:AfterAddRecord", [&](void* arg) {
+        if (!injected.exchange(true)) {
+          IOStatus error = IOStatus::IOError(
+              "injected file-scoped WAL error after complete append");
+          error.SetScope(IOStatus::IOErrorScope::kIOErrorScopeFile);
+          error.SetRetryable(true);
+          *static_cast<IOStatus*>(arg) = error;
+        }
+      });
+  SyncPoint::GetInstance()->SetCallBack("DBImpl::SwitchMemtable:AbandonWAL",
+                                        [&](void*) { abandoned.store(true); });
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  Status write_status = Put("failed", "value");
+  ASSERT_TRUE(write_status.IsIOError()) << write_status.ToString();
+  ASSERT_FALSE(write_status.IsTryAgain()) << write_status.ToString();
+  TEST_SYNC_POINT("FileScopedWALWriteErrorUnsupported:AllowRecovery");
+  TEST_SYNC_POINT("FileScopedWALWriteErrorUnsupported:RecoveryStopped");
+
+  ASSERT_FALSE(abandoned.load());
+  ASSERT_NOK(dbfull()->TEST_GetBGError());
+  Status fenced_write = Put("while-stopped", "value");
+  ASSERT_TRUE(fenced_write.IsIOError()) << fenced_write.ToString();
+
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+}
+
 // Fail auto resume from a flush retryable error and verify that
 // OnErrorRecoveryEnd listener callback is called
 TEST_F(DBErrorHandlingFSTest, FlushWritRetryableErrorAbortRecovery) {

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -1383,6 +1383,11 @@ DEFINE_int32(write_fault_one_in, 0,
 DEFINE_bool(exclude_wal_from_write_fault_injection, false,
             "If true, we won't inject write fault when writing to WAL file");
 
+DEFINE_bool(file_scope_wal_write_faults, false,
+            "If true, injected write faults on WAL files have file scope so "
+            "the file-scoped WAL recovery protocol is exercised. Other fault "
+            "injection and unsupported recovery options must be disabled");
+
 DEFINE_int32(metadata_write_fault_one_in, 1000,
              "On non-zero, enables fault injection on metadata write (i.e, "
              "directory and file metadata write)");

--- a/db_stress_tool/db_stress_shared_state.h
+++ b/db_stress_tool/db_stress_shared_state.h
@@ -45,6 +45,7 @@ DECLARE_int32(metadata_write_fault_one_in);
 DECLARE_int32(read_fault_one_in);
 DECLARE_int32(write_fault_one_in);
 DECLARE_bool(exclude_wal_from_write_fault_injection);
+DECLARE_bool(file_scope_wal_write_faults);
 DECLARE_int32(open_metadata_read_fault_one_in);
 DECLARE_int32(open_metadata_write_fault_one_in);
 DECLARE_int32(open_write_fault_one_in);

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -1032,6 +1032,10 @@ StressTest::StressTest(int db_index, const std::string& db_path,
     // and keep error accounting focused on DB data and metadata.
     db_fault_injection_fs_->SetFileTypesExcludedFromFaultInjection(
         {FileType::kInfoLogFile});
+    db_fault_injection_fs_->SetInjectFileScopeOnWALWriteError(
+        FLAGS_file_scope_wal_write_faults);
+    db_fault_injection_fs_->SetInjectWriteFaultsOnlyOnWAL(
+        FLAGS_file_scope_wal_write_faults);
     // Set it to direct writable here to initially bypass any fault injection
     // during DB open. This will correspondingly be overwritten in
     // StressTest::Open() for open fault injection and in RunStressTestImpl()
@@ -2228,6 +2232,20 @@ void StressTest::OperateDb(ThreadState* thread) {
           FLAGS_inject_error_severity == 2 /* has_data_loss*/);
       db_fault_injection_fs_->EnableThreadLocalErrorInjection(
           FaultInjectionIOType::kMetadataWrite);
+    }
+#else
+    // Most fault injection is debug-only. Keep the dedicated file-scoped WAL
+    // recovery mode available in optimized and sanitizer stress binaries so
+    // the recovery state machine gets the same matrix coverage as normal
+    // db_stress operation.
+    if (db_fault_injection_fs_ && FLAGS_file_scope_wal_write_faults) {
+      db_fault_injection_fs_->SetThreadLocalErrorContext(
+          FaultInjectionIOType::kWrite, thread->shared->GetSeed(),
+          FLAGS_write_fault_one_in,
+          FLAGS_inject_error_severity == 1 /* retryable */,
+          FLAGS_inject_error_severity == 2 /* has_data_loss*/);
+      db_fault_injection_fs_->EnableThreadLocalErrorInjection(
+          FaultInjectionIOType::kWrite);
     }
 #endif  // NDEBUG
 
@@ -5224,6 +5242,8 @@ void StressTest::PrintEnv() const {
           FLAGS_metadata_write_fault_one_in);
   fprintf(stdout, "Read fault one in         : %d\n", FLAGS_read_fault_one_in);
   fprintf(stdout, "Write fault one in        : %d\n", FLAGS_write_fault_one_in);
+  fprintf(stdout, "File-scoped WAL write faults: %d\n",
+          static_cast<int>(FLAGS_file_scope_wal_write_faults));
   fprintf(stdout, "Open metadata read fault one in:\n");
   fprintf(stdout, "                            %d\n",
           FLAGS_open_metadata_read_fault_one_in);
@@ -6426,7 +6446,10 @@ void InitializeOptionsFromFlags(
       FLAGS_max_write_batch_group_size_bytes;
   options.level_compaction_dynamic_level_bytes =
       FLAGS_level_compaction_dynamic_level_bytes;
-  options.track_and_verify_wals_in_manifest = true;
+  // File-scoped WAL recovery deliberately rejects either WAL-tracking mode.
+  // Disable the normally-on stress setting only for its dedicated fault mode.
+  options.track_and_verify_wals_in_manifest =
+      !FLAGS_file_scope_wal_write_faults;
   options.track_and_verify_wals = FLAGS_track_and_verify_wals;
   options.verify_sst_unique_id_in_manifest =
       FLAGS_verify_sst_unique_id_in_manifest;

--- a/db_stress_tool/db_stress_tool.cc
+++ b/db_stress_tool/db_stress_tool.cc
@@ -65,6 +65,61 @@ int ValidateNumDbsFlags() {
   return 0;
 }
 
+int ValidateFileScopedWalWriteFaultFlags() {
+  if (!FLAGS_file_scope_wal_write_faults) {
+    return 0;
+  }
+  if (FLAGS_write_fault_one_in <= 0) {
+    return ReturnValidationError(
+        "--file_scope_wal_write_faults requires --write_fault_one_in > 0");
+  }
+  if (FLAGS_exclude_wal_from_write_fault_injection) {
+    return ReturnValidationError(
+        "--file_scope_wal_write_faults requires "
+        "--exclude_wal_from_write_fault_injection=false");
+  }
+  if (FLAGS_inject_error_severity != 1) {
+    return ReturnValidationError(
+        "--file_scope_wal_write_faults requires "
+        "--inject_error_severity=1");
+  }
+  if (FLAGS_test_batches_snapshots) {
+    return ReturnValidationError(
+        "--file_scope_wal_write_faults does not support "
+        "--test_batches_snapshots");
+  }
+  if (FLAGS_reopen > 0) {
+    return ReturnValidationError(
+        "--file_scope_wal_write_faults does not support --reopen > 0");
+  }
+  if (!FLAGS_options_file.empty()) {
+    return ReturnValidationError(
+        "--file_scope_wal_write_faults does not support --options_file");
+  }
+  if (FLAGS_sync_fault_injection || FLAGS_read_fault_one_in > 0 ||
+      FLAGS_metadata_read_fault_one_in > 0 ||
+      FLAGS_metadata_write_fault_one_in > 0 ||
+      FLAGS_open_read_fault_one_in > 0 || FLAGS_open_write_fault_one_in > 0 ||
+      FLAGS_open_metadata_read_fault_one_in > 0 ||
+      FLAGS_open_metadata_write_fault_one_in > 0 ||
+      FLAGS_secondary_cache_fault_one_in > 0) {
+    return ReturnValidationError(
+        "--file_scope_wal_write_faults requires all non-WAL fault injection "
+        "to be disabled");
+  }
+  if (FLAGS_disable_wal || FLAGS_manual_wal_flush_one_in > 0 || FLAGS_use_txn ||
+      FLAGS_two_write_queues || FLAGS_enable_pipelined_write ||
+      FLAGS_unordered_write || FLAGS_recycle_log_file_num != 0 ||
+      FLAGS_WAL_ttl_seconds != 0 || FLAGS_WAL_size_limit_MB != 0 ||
+      FLAGS_track_and_verify_wals || FLAGS_enable_blob_direct_write) {
+    return ReturnValidationError(
+        "--file_scope_wal_write_faults does not support disabled or manual "
+        "WALs, transactions, two write queues, pipelined or unordered "
+        "writes, WAL recycling, retention or tracking, or blob direct write");
+  }
+  return 0;
+}
+
 int DestroyAllDbs() {
   bool all_ok = true;
   const int num_dbs = FLAGS_num_dbs;
@@ -176,6 +231,12 @@ int db_stress_tool(int argc, char** argv) {
 
   {
     int rc = ValidateNumDbsFlags();
+    if (rc != 0) {
+      return rc;
+    }
+  }
+  {
+    int rc = ValidateFileScopedWalWriteFaultFlags();
     if (rc != 0) {
       return rc;
     }

--- a/file/writable_file_writer.cc
+++ b/file/writable_file_writer.cc
@@ -551,8 +551,19 @@ IOStatus WritableFileWriter::PrepareIOOptions(const WriteOptions& wo,
 }
 
 IOStatus WritableFileWriter::Sync(const IOOptions& opts, bool use_fsync) {
+  return Sync(opts, use_fsync, nullptr);
+}
+
+IOStatus WritableFileWriter::Sync(const IOOptions& opts, bool use_fsync,
+                                  bool* previously_seen_error) {
   if (seen_error()) {
+    if (previously_seen_error != nullptr) {
+      *previously_seen_error = true;
+    }
     return GetWriterHasPreviousErrorStatus();
+  }
+  if (previously_seen_error != nullptr) {
+    *previously_seen_error = false;
   }
 
   IOOptions io_options = FinalizeIOOptions(opts);
@@ -576,8 +587,20 @@ IOStatus WritableFileWriter::Sync(const IOOptions& opts, bool use_fsync) {
 
 IOStatus WritableFileWriter::SyncWithoutFlush(const IOOptions& opts,
                                               bool use_fsync) {
+  return SyncWithoutFlush(opts, use_fsync, nullptr);
+}
+
+IOStatus WritableFileWriter::SyncWithoutFlush(const IOOptions& opts,
+                                              bool use_fsync,
+                                              bool* previously_seen_error) {
   if (seen_error()) {
+    if (previously_seen_error != nullptr) {
+      *previously_seen_error = true;
+    }
     return GetWriterHasPreviousErrorStatus();
+  }
+  if (previously_seen_error != nullptr) {
+    *previously_seen_error = false;
   }
   IOOptions io_options = FinalizeIOOptions(opts);
   if (!writable_file_->IsSyncThreadSafe()) {

--- a/file/writable_file_writer.h
+++ b/file/writable_file_writer.h
@@ -280,10 +280,20 @@ class WritableFileWriter {
 
   IOStatus Sync(const IOOptions& opts, bool use_fsync);
 
+  // As above. `previously_seen_error` reports whether no sync was attempted
+  // because this writer had already observed an error.
+  IOStatus Sync(const IOOptions& opts, bool use_fsync,
+                bool* previously_seen_error);
+
   // Sync only the data that was already Flush()ed. Safe to call concurrently
   // with Append() and Flush(). If !writable_file_->IsSyncThreadSafe(),
   // returns NotSupported status.
   IOStatus SyncWithoutFlush(const IOOptions& opts, bool use_fsync);
+
+  // As above. `previously_seen_error` reports whether no sync was attempted
+  // because this writer had already observed an error.
+  IOStatus SyncWithoutFlush(const IOOptions& opts, bool use_fsync,
+                            bool* previously_seen_error);
 
   // Size including unflushed data written to this writer. If the next op is
   // a successful Close, the file size will be this.

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -682,6 +682,17 @@ class DB {
   // Apply the specified updates atomically to the database.
   // If `updates` contains no update, WAL will still be synced if
   // options.sync=true.
+  //
+  // When the WAL is enabled, an IOError from the WAL write has an
+  // indeterminate outcome: the WAL record might be absent, incomplete, or
+  // complete. A complete record can be replayed after recovery or reopen even
+  // though this call returned an error. Callers must not assume the updates
+  // were rejected or blindly retry non-idempotent updates; use
+  // application-level idempotency, deduplication, or reconciliation. If a
+  // complete record is replayed, the WriteBatch remains atomic. Recovery may
+  // reserve the failed write's sequence range even when no complete record is
+  // recovered, so WAL consumers must also tolerate a sequence-number gap.
+  //
   // Returns OK on success, non-OK on failure.
   // Note: consider setting options.sync = true.
   virtual Status Write(const WriteOptions& options, WriteBatch* updates) = 0;
@@ -2373,10 +2384,11 @@ class DB {
   //
   // Only writes that reached the WAL are returned. Writes made with
   // WriteOptions::disableWAL, and sequence numbers consumed by
-  // IngestExternalFile(), are absent and leave permanent holes in the
-  // sequence numbers seen here. Set WAL_ttl_seconds and/or WAL_size_limit_MB
-  // large enough to cover how far behind a consumer may fall, or the WAL will
-  // be cleared before the consumer reads it.
+  // IngestExternalFile(), or reserved after an indeterminate WAL write error,
+  // can be absent and leave permanent holes in the sequence numbers seen
+  // here. Set WAL_ttl_seconds and/or WAL_size_limit_MB large enough to cover
+  // how far behind a consumer may fall, or the WAL will be cleared before the
+  // consumer reads it.
   //
   // Returns Status::NotSupported() for TransactionDB with the WritePrepared
   // or WriteUnprepared write policies.

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -467,6 +467,7 @@ default_params = {
     "read_fault_one_in": lambda: random.choice([0, 32, 1000]),
     "write_fault_one_in": lambda: random.choice([0, 128, 1000]),
     "exclude_wal_from_write_fault_injection": 0,
+    "file_scope_wal_write_faults": 0,
     "open_metadata_write_fault_one_in": lambda: random.choice([0, 0, 8]),
     "open_metadata_read_fault_one_in": lambda: random.choice([0, 0, 8]),
     "open_write_fault_one_in": lambda: random.choice([0, 0, 16]),
@@ -754,6 +755,7 @@ whitebox_default_params = {
 liveness_fault_injection_params = {
     "error_recovery_with_no_fault_injection": 0,
     "exclude_wal_from_write_fault_injection": 0,
+    "file_scope_wal_write_faults": 0,
     "metadata_read_fault_one_in": 0,
     "metadata_write_fault_one_in": 0,
     "open_metadata_read_fault_one_in": 0,
@@ -1767,6 +1769,43 @@ def finalize_and_sanitize(src_params):
     if dest_params.get("disable_wal", 0) == 1:
         dest_params["test_batches_snapshots"] = 0
 
+    if dest_params.get("file_scope_wal_write_faults", 0) == 1:
+        # Exercise the supported file-scoped WAL recovery envelope without
+        # unrelated injected faults obscuring failures. The production path
+        # deliberately fails closed for the options disabled here.
+        dest_params["disable_wal"] = 0
+        dest_params["manual_wal_flush_one_in"] = 0
+        dest_params["use_txn"] = 0
+        dest_params["txn_write_policy"] = 0
+        dest_params["use_optimistic_txn"] = 0
+        dest_params["test_multi_ops_txns"] = 0
+        dest_params["test_batches_snapshots"] = 0
+        dest_params["two_write_queues"] = 0
+        dest_params["enable_pipelined_write"] = 0
+        dest_params["unordered_write"] = 0
+        dest_params["recycle_log_file_num"] = 0
+        dest_params["WAL_ttl_seconds"] = 0
+        dest_params["WAL_size_limit_MB"] = 0
+        dest_params["track_and_verify_wals"] = 0
+        dest_params["enable_blob_direct_write"] = 0
+        dest_params["reopen"] = 0
+        dest_params["exclude_wal_from_write_fault_injection"] = 0
+        dest_params["inject_error_severity"] = 1
+        if dest_params.get("write_fault_one_in", 0) <= 0:
+            dest_params["write_fault_one_in"] = 128
+        dest_params["max_write_buffer_number"] = max(
+            dest_params["max_write_buffer_number"], 10
+        )
+        dest_params["sync_fault_injection"] = 0
+        dest_params["metadata_read_fault_one_in"] = 0
+        dest_params["metadata_write_fault_one_in"] = 0
+        dest_params["read_fault_one_in"] = 0
+        dest_params["secondary_cache_fault_one_in"] = 0
+        dest_params["open_metadata_read_fault_one_in"] = 0
+        dest_params["open_metadata_write_fault_one_in"] = 0
+        dest_params["open_read_fault_one_in"] = 0
+        dest_params["open_write_fault_one_in"] = 0
+
     if dest_params.get("num_dbs", 1) > 1:
         # These features assume a single DB instance.
         # See ValidateNumDbsFlags() in db_stress_tool.cc for C++ guards.
@@ -1776,7 +1815,7 @@ def finalize_and_sanitize(src_params):
     return dest_params
 
 
-def gen_cmd_params(args):
+def gen_cmd_params(args, unknown_params=None):
     params = {}
 
     params.update(default_params)
@@ -1838,6 +1877,70 @@ def gen_cmd_params(args):
     for k, v in vars(args).items():
         if v is not None:
             params[k] = v
+
+    # Reserve a small fraction of ordinary crash-test invocations for the
+    # file-scoped WAL recovery state machine. Do this after merging command
+    # line arguments so automatic selection cannot override an explicit opt-out
+    # or an explicitly requested incompatible mode.
+    explicit_incompatible_file_scope_flags = [
+        "best_efforts_recovery",
+        "disable_wal",
+        "manual_wal_flush_one_in",
+        "test_cf_consistency",
+        "use_txn",
+        "test_multi_ops_txns",
+        "test_batches_snapshots",
+        "two_write_queues",
+        "enable_pipelined_write",
+        "unordered_write",
+        "recycle_log_file_num",
+        "WAL_ttl_seconds",
+        "WAL_size_limit_MB",
+        "track_and_verify_wals",
+        "enable_blob_direct_write",
+        "reopen",
+        "exclude_wal_from_write_fault_injection",
+        "sync_fault_injection",
+        "metadata_read_fault_one_in",
+        "metadata_write_fault_one_in",
+        "read_fault_one_in",
+        "secondary_cache_fault_one_in",
+        "open_metadata_read_fault_one_in",
+        "open_metadata_write_fault_one_in",
+        "open_read_fault_one_in",
+        "open_write_fault_one_in",
+    ]
+    has_explicit_file_scope_conflict = any(
+        getattr(args, flag, None) not in (None, 0)
+        for flag in explicit_incompatible_file_scope_flags
+    )
+    # Unknown arguments are forwarded to db_stress after the generated flags,
+    # so they can change the effective configuration without being visible in
+    # `args`. Only auto-select this specialized profile when every option was
+    # parsed and checked here. Explicit selection remains available.
+    has_unparsed_file_scope_args = bool(unknown_params)
+    if (
+        getattr(args, "file_scope_wal_write_faults", None) is None
+        and getattr(args, "write_fault_one_in", None) != 0
+        and (
+            getattr(args, "inject_error_severity", None) is None
+            or getattr(args, "inject_error_severity") == 1
+        )
+        and not has_explicit_file_scope_conflict
+        and not has_unparsed_file_scope_args
+        and args.test_type != "liveness"
+        and not args.cf_consistency
+        and not args.txn
+        and not args.optimistic_txn
+        and not args.test_best_efforts_recovery
+        and not args.enable_ts
+        and not args.test_multiops_txn
+        and not args.test_tiered_storage
+        and params.get("test_batches_snapshots", 0) == 0
+        and params.get("enable_blob_direct_write", 0) == 0
+        and random.choice([0] * 19 + [1]) == 1
+    ):
+        params["file_scope_wal_write_faults"] = 1
     if args.test_type == "liveness":
         apply_liveness_remote_defaults(params, args)
         params.update(liveness_fault_injection_params)
@@ -2325,7 +2428,7 @@ def liveness_timeout(cmd_params):
 
 
 def liveness_main(args, unknown_args):
-    cmd_params = gen_cmd_params(args)
+    cmd_params = gen_cmd_params(args, unknown_args)
     db_parent_dir = get_db_parent_dir("liveness")
     num_dbs = cmd_params.get("num_dbs", 1)
 
@@ -2377,7 +2480,7 @@ def liveness_main(args, unknown_args):
 # This script runs and kills db_stress multiple times. It checks consistency
 # in case of unsafe crashes in RocksDB.
 def blackbox_crash_main(args, unknown_args):
-    cmd_params = gen_cmd_params(args)
+    cmd_params = gen_cmd_params(args, unknown_args)
     db_parent_dir = get_db_parent_dir("blackbox")
     ev_parent_dir = get_ev_parent_dir()
     num_dbs = cmd_params.get("num_dbs", 1)
@@ -2448,7 +2551,7 @@ def blackbox_crash_main(args, unknown_args):
 # This python script runs db_stress multiple times. Some runs with
 # kill_random_test that causes rocksdb to crash at various points in code.
 def whitebox_crash_main(args, unknown_args):
-    cmd_params = gen_cmd_params(args)
+    cmd_params = gen_cmd_params(args, unknown_args)
     db_parent_dir = get_db_parent_dir("whitebox")
     ev_parent_dir = get_ev_parent_dir()
     num_dbs = cmd_params.get("num_dbs", 1)

--- a/tools/db_crashtest_test.py
+++ b/tools/db_crashtest_test.py
@@ -245,6 +245,176 @@ class DBCrashTestTest(unittest.TestCase):
         self.assertEqual(1, finalized["disable_wal"])
         self.assertEqual(0, finalized["test_batches_snapshots"])
 
+    def test_finalize_file_scoped_wal_fault_profile(self):
+        db_crashtest = self.load_db_crashtest()
+        params = self.build_params(
+            db_crashtest.default_params,
+            {
+                "file_scope_wal_write_faults": 1,
+                "write_fault_one_in": 0,
+                "max_write_buffer_number": 3,
+                "disable_wal": 1,
+                "manual_wal_flush_one_in": 10,
+                "use_txn": 1,
+                "two_write_queues": 1,
+                "enable_pipelined_write": 1,
+                "unordered_write": 1,
+                "recycle_log_file_num": 1,
+                "WAL_ttl_seconds": 60,
+                "WAL_size_limit_MB": 1,
+                "track_and_verify_wals": 1,
+                "enable_blob_direct_write": 1,
+                "test_batches_snapshots": 1,
+                "reopen": 10,
+                "exclude_wal_from_write_fault_injection": 1,
+                "inject_error_severity": 2,
+                "sync_fault_injection": 1,
+                "metadata_read_fault_one_in": 10,
+                "metadata_write_fault_one_in": 10,
+                "read_fault_one_in": 10,
+                "open_metadata_read_fault_one_in": 10,
+                "open_metadata_write_fault_one_in": 10,
+                "open_read_fault_one_in": 10,
+                "open_write_fault_one_in": 10,
+            },
+        )
+
+        finalized = db_crashtest.finalize_and_sanitize(params)
+
+        self.assertEqual(1, finalized["file_scope_wal_write_faults"])
+        self.assertEqual(128, finalized["write_fault_one_in"])
+        self.assertEqual(10, finalized["max_write_buffer_number"])
+        self.assertEqual(0, finalized["test_batches_snapshots"])
+        self.assertEqual(1, finalized["inject_error_severity"])
+        for flag in [
+            "disable_wal",
+            "manual_wal_flush_one_in",
+            "use_txn",
+            "use_optimistic_txn",
+            "test_multi_ops_txns",
+            "two_write_queues",
+            "enable_pipelined_write",
+            "unordered_write",
+            "recycle_log_file_num",
+            "WAL_ttl_seconds",
+            "WAL_size_limit_MB",
+            "track_and_verify_wals",
+            "enable_blob_direct_write",
+            "reopen",
+            "exclude_wal_from_write_fault_injection",
+            "sync_fault_injection",
+            "metadata_read_fault_one_in",
+            "metadata_write_fault_one_in",
+            "read_fault_one_in",
+            "secondary_cache_fault_one_in",
+            "open_metadata_read_fault_one_in",
+            "open_metadata_write_fault_one_in",
+            "open_read_fault_one_in",
+            "open_write_fault_one_in",
+        ]:
+            self.assertEqual(0, finalized[flag], flag)
+
+    def test_auto_file_scoped_wal_faults_preserve_explicit_opt_outs(self):
+        db_crashtest = self.load_db_crashtest()
+
+        def choose_without_blob_profile(values):
+            if values == [0] * 9 + [1]:
+                return 0
+            if values == [0] * 19 + [1]:
+                return 1
+            return values[0]
+
+        for explicit_opt_out in [
+            {"file_scope_wal_write_faults": 0},
+            {"write_fault_one_in": 0},
+            {"exclude_wal_from_write_fault_injection": 1},
+            {"enable_blob_direct_write": 1},
+        ]:
+            with self.subTest(explicit_opt_out=explicit_opt_out):
+                args = self.build_mode_args(
+                    test_type="blackbox", **explicit_opt_out
+                )
+                with mock.patch.object(
+                    db_crashtest.random,
+                    "choice",
+                    side_effect=choose_without_blob_profile,
+                ):
+                    params = db_crashtest.gen_cmd_params(args)
+
+                self.assertEqual(0, params["file_scope_wal_write_faults"])
+
+    def test_auto_file_scoped_wal_faults_skip_batch_mode(self):
+        db_crashtest = self.load_db_crashtest()
+        args = self.build_mode_args(test_type="blackbox")
+        db_crashtest.default_params["test_batches_snapshots"] = 1
+
+        def choose_without_blob_profile(values):
+            if values == [0] * 9 + [1]:
+                return 0
+            if values == [0] * 19 + [1]:
+                return 1
+            return values[0]
+
+        with mock.patch.object(
+            db_crashtest.random,
+            "choice",
+            side_effect=choose_without_blob_profile,
+        ):
+            params = db_crashtest.gen_cmd_params(args)
+
+        self.assertEqual(0, params["file_scope_wal_write_faults"])
+
+    def test_auto_file_scoped_wal_faults_skip_unsupported_inputs(self):
+        db_crashtest = self.load_db_crashtest()
+
+        def choose_without_blob_profile(values):
+            if values == [0] * 9 + [1]:
+                return 0
+            if values == [0] * 19 + [1]:
+                return 1
+            return values[0]
+
+        cases = [
+            ({"best_efforts_recovery": 1}, []),
+            ({"test_cf_consistency": 1}, []),
+            ({}, ["--options_file=/tmp/OPTIONS"]),
+            ({}, ["-options_file", "/tmp/OPTIONS"]),
+            ({}, ["-disable_wal=1"]),
+            ({}, ["-test_cf_consistency=1"]),
+        ]
+        for overrides, unknown_params in cases:
+            with self.subTest(overrides=overrides, unknown_params=unknown_params):
+                args = self.build_mode_args(test_type="blackbox", **overrides)
+                with mock.patch.object(
+                    db_crashtest.random,
+                    "choice",
+                    side_effect=choose_without_blob_profile,
+                ):
+                    params = db_crashtest.gen_cmd_params(args, unknown_params)
+
+                self.assertEqual(0, params["file_scope_wal_write_faults"])
+
+    def test_auto_file_scoped_wal_faults_select_eligible_profile(self):
+        db_crashtest = self.load_db_crashtest()
+        args = self.build_mode_args(test_type="blackbox")
+        db_crashtest.default_params["test_batches_snapshots"] = 0
+
+        def choose_without_blob_profile(values):
+            if values == [0] * 9 + [1]:
+                return 0
+            if values == [0] * 19 + [1]:
+                return 1
+            return values[0]
+
+        with mock.patch.object(
+            db_crashtest.random,
+            "choice",
+            side_effect=choose_without_blob_profile,
+        ):
+            params = db_crashtest.gen_cmd_params(args)
+
+        self.assertEqual(1, params["file_scope_wal_write_faults"])
+
     def test_finalize_disables_sqfc_range_queries_with_range_conversion(self):
         db_crashtest = self.load_db_crashtest()
         params = self.build_params(
@@ -605,6 +775,7 @@ class DBCrashTestTest(unittest.TestCase):
         for fault_param in [
             "error_recovery_with_no_fault_injection",
             "exclude_wal_from_write_fault_injection",
+            "file_scope_wal_write_faults",
             "metadata_read_fault_one_in",
             "metadata_write_fault_one_in",
             "open_metadata_read_fault_one_in",

--- a/utilities/fault_injection_fs.cc
+++ b/utilities/fault_injection_fs.cc
@@ -1841,6 +1841,15 @@ IOStatus FaultInjectionTestFS::MaybeInjectThreadLocalError(
     ret = IOStatus::IOError(ctx->message);
     ret.SetRetryable(ctx->retryable);
     ret.SetDataLoss(ctx->has_data_loss);
+    if (type == FaultInjectionIOType::kWrite &&
+        inject_file_scope_on_wal_write_error_.load(std::memory_order_relaxed)) {
+      FileType file_type = kTempFile;
+      uint64_t file_number = 0;
+      if (TryParseFileName(file_name, &file_number, &file_type) &&
+          file_type == FileType::kWalFile) {
+        ret.SetScope(IOStatus::IOErrorScope::kIOErrorScopeFile);
+      }
+    }
     injected_error_log_.Record(op_name, file_name, detail, ret);
     if (type == FaultInjectionIOType::kWrite) {
       TEST_SYNC_POINT(

--- a/utilities/fault_injection_fs.h
+++ b/utilities/fault_injection_fs.h
@@ -422,6 +422,8 @@ class FaultInjectionTestFS : public FileSystemWrapper {
             DeleteThreadLocalErrorContext),
         injected_thread_local_metadata_write_error_(
             DeleteThreadLocalErrorContext),
+        inject_file_scope_on_wal_write_error_(false),
+        inject_write_faults_only_on_wal_(false),
         ingest_data_corruption_before_write_(false),
         checksum_handoff_func_type_(kCRC32c),
         injected_error_log_(injected_error_log_path) {}
@@ -801,6 +803,21 @@ class FaultInjectionTestFS : public FileSystemWrapper {
     file_types_excluded_from_fault_injection_ = types;
   }
 
+  // Marks injected WAL write errors as file-scoped so stress tests can
+  // exercise recovery that replaces an unusable WAL handle. Other injected
+  // write errors keep the default file-system scope.
+  void SetInjectFileScopeOnWALWriteError(bool enabled) {
+    inject_file_scope_on_wal_write_error_.store(enabled,
+                                                std::memory_order_relaxed);
+  }
+
+  // Restricts write fault injection to parsed WAL file names. This keeps the
+  // recovery flush and MANIFEST writes healthy in the dedicated stress mode.
+  void SetInjectWriteFaultsOnlyOnWAL(bool enabled) {
+    MutexLock l(&mutex_);
+    inject_write_faults_only_on_wal_ = enabled;
+  }
+
   void EnableThreadLocalErrorInjection(FaultInjectionIOType type) {
     ErrorContext* ctx = GetErrorContextFromFaultInjectionIOType(type);
     if (ctx) {
@@ -926,6 +943,8 @@ class FaultInjectionTestFS : public FileSystemWrapper {
   ThreadLocalPtr injected_thread_local_write_error_;
   ThreadLocalPtr injected_thread_local_metadata_read_error_;
   ThreadLocalPtr injected_thread_local_metadata_write_error_;
+  std::atomic<bool> inject_file_scope_on_wal_write_error_;
+  bool inject_write_faults_only_on_wal_;
   bool ingest_data_corruption_before_write_;
   ChecksumType checksum_handoff_func_type_;
   bool fail_get_file_unique_id_ = false;
@@ -952,13 +971,18 @@ class FaultInjectionTestFS : public FileSystemWrapper {
     FileType file_type = kTempFile;
     uint64_t file_number = 0;
     if (!TryParseFileName(file_name, &file_number, &file_type)) {
-      return false;
+      return type == FaultInjectionIOType::kWrite &&
+             inject_write_faults_only_on_wal_;
     }
     if (file_types_excluded_from_fault_injection_.count(file_type) > 0) {
       return true;
     }
     switch (type) {
       case FaultInjectionIOType::kWrite:
+        if (inject_write_faults_only_on_wal_ &&
+            file_type != FileType::kWalFile) {
+          return true;
+        }
         return file_types_excluded_from_write_fault_injection_.count(
                    file_type) > 0;
       case FaultInjectionIOType::kRead:

--- a/utilities/fault_injection_fs_test.cc
+++ b/utilities/fault_injection_fs_test.cc
@@ -311,6 +311,36 @@ TEST_F(FaultInjectionTestFSTest, FaultInjectionExcludesInfoLogFiles) {
   }
 }
 
+TEST_F(FaultInjectionTestFSTest, FileScopedWalWriteErrors) {
+  auto fault_fs =
+      NewFaultFsExcludingInfoLogs(Env::Default(), FaultInjectionIOType::kWrite);
+
+  IOStatus status = fault_fs->MaybeInjectThreadLocalError(
+      FaultInjectionIOType::kWrite, IOOptions(), "Append", "/tmp/000001.log");
+  ASSERT_TRUE(status.IsIOError());
+  ASSERT_EQ(IOStatus::IOErrorScope::kIOErrorScopeFileSystem, status.GetScope());
+
+  fault_fs->SetInjectFileScopeOnWALWriteError(true);
+  status = fault_fs->MaybeInjectThreadLocalError(
+      FaultInjectionIOType::kWrite, IOOptions(), "Append", "/tmp/000002.log");
+  ASSERT_TRUE(status.IsIOError());
+  ASSERT_EQ(IOStatus::IOErrorScope::kIOErrorScopeFile, status.GetScope());
+
+  status = fault_fs->MaybeInjectThreadLocalError(
+      FaultInjectionIOType::kWrite, IOOptions(), "Append", "/tmp/000003.sst");
+  ASSERT_TRUE(status.IsIOError());
+  ASSERT_EQ(IOStatus::IOErrorScope::kIOErrorScopeFileSystem, status.GetScope());
+
+  fault_fs->SetInjectWriteFaultsOnlyOnWAL(true);
+  status = fault_fs->MaybeInjectThreadLocalError(
+      FaultInjectionIOType::kWrite, IOOptions(), "Append", "/tmp/000004.sst");
+  ASSERT_OK(status);
+  status = fault_fs->MaybeInjectThreadLocalError(
+      FaultInjectionIOType::kWrite, IOOptions(), "Append", "/tmp/000005.log");
+  ASSERT_TRUE(status.IsIOError());
+  ASSERT_EQ(IOStatus::IOErrorScope::kIOErrorScopeFile, status.GetScope());
+}
+
 TEST_F(FaultInjectionTestFSTest,
        InjectedMetadataCloseErrorDoesNotRetryInnerClose) {
   Env* env = Env::Default();


### PR DESCRIPTION
Summary:

Keep `DB::Write`'s existing immediate `IOError` contract while allowing RocksDB to recover safely when a remote file system reports that a WAL handle is permanently unusable.

### Behavior changes

#### 1. Recovering from a poisoned remote WAL handle

- **Why required:** A remote file system can permanently poison a WAL handle after an I/O failure. Retrying that handle cannot succeed and leaves the database write-stopped.
- **Previous behavior:** RocksDB retried the same WAL handle during recovery.
- **New behavior:** The remote file system marks the failure as file-scoped. RocksDB creates a replacement WAL, atomically persists all state that could depend on the failed WAL, and then removes the quarantined WAL handles from active use. Physical file deletion remains part of normal cleanup.

#### 2. Preserving an indeterminate WAL write outcome

- **Why required:** A WAL record can reach storage before the append returns `IOError`; the application therefore cannot know whether that write took effect.
- **Previous behavior:** Recovery could reuse the failed write group's sequence numbers, allowing a later acknowledged write to overlap a record that might already be in the WAL. The public write API did not state this indeterminate outcome.
- **New behavior:** `DB::Write` still returns the original `IOError` immediately and does not retry the logical batch. Recovery carries the highest ambiguous sequence forward and durably reserves it before admitting later writes. The public API now documents that an `IOError` may mean the write succeeded or failed and that non-idempotent writes must not be retried blindly.

#### 3. Keeping all column families on one recovery boundary

- **Why required:** A write batch can update multiple column families. Retiring its WAL after independently persisting only some column families can expose a partially applied batch after reopen.
- **Previous behavior:** With `atomic_flush=false`, recovery could persist column families independently before abandoning the WAL.
- **New behavior:** File-scoped WAL recovery force-flushes every live column family atomically and verifies that each one advanced beyond the failed WAL before writers are retired or writes resume.

#### 4. Merging concurrent WAL failures

- **Why required:** Another WAL write can fail while an earlier recovery attempt temporarily releases the DB mutex.
- **Previous behavior:** A later failed WAL cutoff or ambiguous sequence could be overwritten or cleared by the earlier recovery attempt.
- **New behavior:** Each error episode monotonically merges the largest failed WAL cutoff and ambiguous sequence. Recovery clears the quarantine cutoff only if no concurrent failure extended it; otherwise the newer failure remains write-stopping for the next attempt.

#### 5. Retaining file scope through `NoSpace` recovery

- **Why required:** `NoSpace` can still identify one permanently unusable WAL handle.
- **Previous behavior:** The `SstFileManager` recovery path entered generic recovery without carrying the failed WAL context.
- **New behavior:** File-scoped `NoSpace` carries the same cutoff and sequence evidence through the `SstFileManager` path as other file-scoped WAL errors.

#### 6. Scoping recovery context to one error episode

- **Why required:** A completed recovery must not affect a later unrelated background error.
- **Previous behavior:** WAL recovery context could remain latched after `ClearBGError` succeeded.
- **New behavior:** Successful background-error clearing resets the context. A failed recovery retains it so a later retry has the same safety information.

#### 7. Preserving successful `SyncWAL` metadata

- **Why required:** A healthy WAL can finish syncing while a separate recovery error already exists.
- **Previous behavior:** `SyncWAL` could return the existing background error before applying the successful WAL's `VersionEdit`, dropping its MANIFEST update.
- **New behavior:** `SyncWAL` skips quarantined writers, applies metadata for successfully synced healthy WALs, and only then returns any existing recovery error.

#### 8. Classifying only the intended remote-file-system failure

- **Why required:** File-scoped recovery is valid only for an actual WAL `IOError` from a handle whose ownership is still valid.
- **Previous behavior:** Poison state could be queried before ownership fencing was resolved, and file scope could be stamped onto a non-I/O status.
- **New behavior:** Ownership fencing is resolved first, poison state is queried afterward, and only an actual `IOError` can be classified as file-scoped. `IOFenced` remains fatal.

#### 9. Preserving `paranoid_checks=false` retry behavior

- **Why required:** Non-paranoid mode historically cleared a writer's sticky error so a later operation could retry after storage recovered.
- **Previous behavior:** Avoiding reclassification of a cached synthetic writer error also bypassed `WALIOStatusCheck`, so later `SyncWAL` calls kept returning the stale error.
- **New behavior:** A cached error still fails the current `SyncWAL` call, but the non-paranoid path resets the writer for a later retry without setting a background error or entering file-scoped recovery.

#### 10. Preserving async WAL precreation across recovery

- **Why required:** A precreated WAL is an unpublished replacement and is not the active WAL. Recovery can also consume the prepared slot while background work is stopped.
- **Previous behavior:** A file-scoped failure while creating or starting the unpublished replacement was attributed to the active WAL, unnecessarily quarantining it. After successful recovery consumed a prepared WAL, the next slot was not replenished, so the following rotation created its WAL synchronously.
- **New behavior:** Only an active WAL `WriteBuffer()` failure attaches the active-WAL cutoff. A failed unpublished candidate is discarded while the current WAL remains active, and successful recovery schedules the next async precreation after `ClearBGError()` re-enables background work.

### Implementation

- Carry `DBRecoverContext` through generic, `NoSpace`, and `SstFileManager` recovery, merging WAL cutoffs and failed write-group sequences independently of error severity.
- Publish a lock-free quarantine cutoff used by write and sync paths; replace even an empty failed current WAL; persist ambiguous sequence reservations; force and verify an atomic all-column-family flush; and detach quarantined writers only after that durable boundary.
- Keep successful healthy-WAL tracking edits in `SyncWAL`, reset completed recovery context, and preserve legacy non-paranoid writer reset behavior.
- Distinguish failures on an unpublished replacement WAL from failures flushing the active WAL. Log the failed replacement identity, keep the active WAL out of quarantine, and replenish the async-precreation slot after successful recovery.
- Classify poisoned remote-file-system handles after ownership fencing and only for `IOError`.
- Add lifecycle logging and a state-machine comment covering quarantine, sequence reservation, replacement, atomic persistence, retirement, and concurrent-error handoff.
- Add an opt-in `db_stress` mode that injects file-scoped faults only into WAL writes, disables WAL tracking in that mode, validates unsupported direct invocations, and sanitizes crash-test parameters to the supported recovery envelope. A small fraction of ordinary non-specialized crash-test runs select this mode automatically; existing stress behavior is unchanged when the flag is off.
- Make the concurrent-error regression test hold the initial background flush until `SyncWAL` records the intended older-WAL error, preventing scheduler-dependent retirement of the test WAL before fault injection.

### Safety boundaries and unsupported cases

- Automatic file-scoped WAL recovery fails closed with `NotSupported` for manual WAL flush, 2PC/transactions, two write queues, pipelined or unordered writes, WAL recycling, WAL TTL or size retention, either WAL-tracking mode, or blob direct writes.
- Unsupported recovery leaves the DB write-stopped. `DB::Resume()` returns `NotSupported`; after correcting the I/O condition, operational recovery requires close and reopen.
- The failed logical batch is never retried. Generic indeterminate WAL errors may reserve sequence numbers without invoking file-scoped retirement.
- Failed recovery attempts retain their context. Only a successful `ClearBGError` resets it.
- Physical WAL deletion is not part of the correctness boundary; normal obsolete-file cleanup removes files later.
- Async WAL precreation remains disabled with WAL recycling. A prepared WAL is unpublished until its start records succeed; failure before installation does not make the active WAL file-scoped.
- The new stress mode is test-only and defaults off, so normal `db_stress` and database operation without an error are unchanged.
- Automatic stress-profile selection is limited to fully parsed, supported configurations. Explicit targeted runs reject options files and other unsupported combinations.

### Tests and known limitations

- `arc f --take-formatters --enforce-lint-clean` passes.
- All 67 `error_handler_fs_test` cases pass under `ASSERT_STATUS_CHECKED=1`, including the two new async-precreation recovery tests.
- All 5 existing `AsyncWalPrecreate*` tests pass.
- The two new async-precreation recovery tests completed 65 consecutive forced-context-switch iterations before the required 60-second cap interrupted iteration 66; no completed iteration failed.
- All 8 `fault_injection_fs_test` cases pass, including the new scope/isolation test; all 42 `db_crashtest_test.py` cases pass.
- The previously flaky concurrent-sequence test passes in the exact seven-way CI shard and in 40 consecutive repetitions under concurrent load after synchronizing the initial flush.
- The non-paranoid cached-error regression passed 100 consecutive `COERCE_CONTEXT_SWITCH` iterations earlier on this diff. All 13 remote file system adapter tests also passed earlier on this diff.
- Two bounded in-process multi-column-family stress runs passed verification. The non-atomic run completed 7 quarantine/replacement/retirement/resume cycles; the atomic-flush run completed 15 cycles, including 14 persisted ambiguous-sequence reservations.
- A 20-second black-box crash/reopen dry run exited successfully and decoded 7 injected WAL faults in one interval. A later run completed 8 recovery cycles before its final verification reached the 60-second cap.
- The full crash/stress matrix and TSAN were not run. `make check-sources` and the sparse checkout's `fbcode//rocks:format_check` are unavailable because they assume a Git checkout or the target is absent; `arc f` and `clang-format-diff` were clean.

Differential Revision: D119324616


