### PR TITLE
Fix SstFileReader heap corruption past MAX_BATCH_SIZE keys

### DIFF
--- a/table/sst_file_reader.cc
+++ b/table/sst_file_reader.cc
@@ -104,6 +104,12 @@ std::vector<Status> SstFileReader::MultiGet(
   autovector<KeyContext*, MultiGetContext::MAX_BATCH_SIZE> sorted_keys;
   autovector<GetContext, MultiGetContext::MAX_BATCH_SIZE> get_ctx;
   autovector<MergeContext, MultiGetContext::MAX_BATCH_SIZE> merge_ctx;
+  // The loop below hands out pointers to these elements, so they have to be
+  // reserved up front: past the inline capacity an autovector spills into a
+  // std::vector that would otherwise reallocate as more keys are appended.
+  key_context.reserve(num_keys);
+  get_ctx.reserve(num_keys);
+  merge_ctx.reserve(num_keys);
   sorted_keys.resize(num_keys);
   for (size_t i = 0; i < num_keys; ++i) {
     PinnableSlice* val = &(*values)[i];
@@ -136,12 +142,22 @@ std::vector<Status> SstFileReader::MultiGet(
   const auto sequence = roptions.snapshot != nullptr
                             ? roptions.snapshot->GetSequenceNumber()
                             : kMaxSequenceNumber;
-  MultiGetContext ctx(&sorted_keys, 0, num_keys, sequence, roptions,
-                      r->ioptions.fs.get(), nullptr);
-  MultiGetRange range = ctx.GetMultiGetRange();
-  r->table_reader->MultiGet(roptions, &range,
-                            r->moptions.prefix_extractor.get(),
-                            false /* skip filters */);
+  // A MultiGetContext holds at most MAX_BATCH_SIZE keys, so look the sorted
+  // keys up in batches of that size, as DBImpl::MultiGetImpl does. Exceeding
+  // it is undefined behavior, not just a missed optimization.
+  size_t keys_left = num_keys;
+  while (keys_left > 0) {
+    const size_t batch_size = (keys_left > MultiGetContext::MAX_BATCH_SIZE)
+                                  ? MultiGetContext::MAX_BATCH_SIZE
+                                  : keys_left;
+    MultiGetContext ctx(&sorted_keys, num_keys - keys_left, batch_size,
+                        sequence, roptions, r->ioptions.fs.get(), nullptr);
+    MultiGetRange range = ctx.GetMultiGetRange();
+    r->table_reader->MultiGet(roptions, &range,
+                              r->moptions.prefix_extractor.get(),
+                              false /* skip filters */);
+    keys_left -= batch_size;
+  }
 
   for (size_t i = 0; i < num_keys; ++i) {
     get_ctx[i].ReportCounters();

--- a/table/sst_file_reader_test.cc
+++ b/table/sst_file_reader_test.cc
@@ -27,6 +27,7 @@
 #include "table/format.h"
 #include "table/internal_iterator.h"
 #include "table/meta_blocks.h"
+#include "table/multiget_context.h"
 #include "table/sst_file_writer_collectors.h"
 #include "table/table_reader.h"
 #include "test_util/sync_point.h"
@@ -220,6 +221,65 @@ TEST_F(SstFileReaderTest, Basic) {
     keys.emplace_back(EncodeAsString(i));
   }
   CreateFileAndCheck(keys);
+}
+
+TEST_F(SstFileReaderTest, MultiGetExceedingMaxBatchSize) {
+  // A MultiGetContext holds at most MAX_BATCH_SIZE keys, so a larger request
+  // has to be split into batches. Query the keys in descending order and mix
+  // in absent ones so that results have to survive the sort back into the
+  // caller's order.
+  const size_t num_keys = MultiGetContext::MAX_BATCH_SIZE * 2 + 5;
+
+  SstFileWriter writer(soptions_, options_);
+  ASSERT_OK(writer.Open(sst_name_));
+  for (size_t i = 0; i < num_keys; ++i) {
+    ASSERT_OK(writer.Put(EncodeAsString(i), "val" + std::to_string(i)));
+  }
+  ASSERT_OK(writer.Finish());
+
+  SstFileReader reader(options_);
+  ASSERT_OK(reader.Open(sst_name_));
+
+  std::vector<std::string> key_storage;
+  std::vector<std::string> expected_values;
+  std::vector<bool> expected_found;
+  for (size_t i = num_keys; i > 0; --i) {
+    key_storage.emplace_back(EncodeAsString(i - 1));
+    expected_values.emplace_back("val" + std::to_string(i - 1));
+    expected_found.push_back(true);
+
+    key_storage.emplace_back("absent" + std::to_string(i - 1));
+    // A key that is not in the file leaves its output slot untouched.
+    expected_values.emplace_back("");
+    expected_found.push_back(false);
+  }
+  std::vector<Slice> keys(key_storage.begin(), key_storage.end());
+
+  auto found_flags = [](const std::vector<Status>& statuses) {
+    std::vector<bool> found;
+    found.reserve(statuses.size());
+    for (const Status& s : statuses) {
+      EXPECT_TRUE(s.ok() || s.IsNotFound()) << s.ToString();
+      found.push_back(s.ok());
+    }
+    return found;
+  };
+
+  std::vector<std::string> values;
+  std::vector<Status> statuses = reader.MultiGet(ReadOptions(), keys, &values);
+  EXPECT_EQ(found_flags(statuses), expected_found);
+  EXPECT_EQ(values, expected_values);
+
+  std::vector<PinnableSlice> pinnable_values;
+  std::vector<Status> pinnable_statuses =
+      reader.MultiGet(ReadOptions(), keys, &pinnable_values);
+  std::vector<std::string> pinnable_as_strings;
+  pinnable_as_strings.reserve(pinnable_values.size());
+  for (const PinnableSlice& value : pinnable_values) {
+    pinnable_as_strings.emplace_back(value.data(), value.size());
+  }
+  EXPECT_EQ(found_flags(pinnable_statuses), expected_found);
+  EXPECT_EQ(pinnable_as_strings, expected_values);
 }
 
 TEST_F(SstFileReaderTest, EmbeddedBlobRoundTrip) {


### PR DESCRIPTION
Summary:
**What**: Fix heap corruption and out-of-bounds reads in `SstFileReader::MultiGet()` when the request exceeds `MultiGetContext::MAX_BATCH_SIZE` keys.

**How**:
- Batch the lookup in `MAX_BATCH_SIZE` slices over the sorted keys, with a fresh `MultiGetContext` and `TableReader::MultiGet()` call per slice. Caller ordering survives because each `KeyContext` already points into the caller's status and value vectors.
- `reserve()` the `key_context`, `get_ctx` and `merge_ctx` autovectors, as `DBImpl::MultiGetCommon` does: the setup loop takes addresses of their elements, and past its inline capacity an `autovector` spills into a `std::vector` that reallocates as later keys are appended.
- Only the slicing is borrowed from `DBImpl::MultiGetImpl`. Its cross-batch value-size accumulation and per-batch deadline check are deliberately not replicated: value size is accumulated only under `db/` and never by a `TableReader`, and the deadline already reaches every read through the table reader's I/O options.

**Why**: `MultiGetContext` caps at `MAX_BATCH_SIZE` keys but only asserts it, so release builds hit a bad `delete[]` from its mismatched `LookupKey` construct/destroy bounds, an out-of-bounds read of its fixed-size `sorted_keys_` array, and an out-of-range shift once the key count exceeds the width of its range mask; `include/rocksdb/sst_file_reader.h` documents no key-count limit, so any caller of this public API could reach it.

Differential Revision: D119401930


