### PR TITLE
Compare excluded-file lookup against the engine it searched

### DIFF
--- a/utilities/backup/backup_engine.cc
+++ b/utilities/backup/backup_engine.cc
@@ -1729,7 +1729,7 @@ IOStatus BackupEngineImpl::RestoreDBFromBackup(
     bool found = false;
     for (auto be : locked_restore_from_dirs) {
       auto it = be->backuped_file_infos_.find(file);
-      if (it != backuped_file_infos_.end()) {
+      if (it != be->backuped_file_infos_.end()) {
         restore_file_infos.emplace_back(be, &*it->second);
         found = true;
         break;


### PR DESCRIPTION
Summary:
**What**: Compare the excluded-file lookup iterator against the engine it was obtained from, in `BackupEngineImpl::RestoreDBFromBackup()`.

**How**: The loop walks `locked_restore_from_dirs` calling `find()` on each engine's `backuped_file_infos_`, but tested the result against `this` engine's `end()`. Test against the same engine's `end()`.

**Why**: Comparing iterators obtained from different containers is undefined. It is inert here rather than a live bug: on libstdc++ and libc++ an `unordered_map` end iterator is a null sentinel that is not container-specific, so a miss compares equal and a hit does not. On an implementation with a container-specific end iterator - MSVC, a required CI axis - a miss would read as found and dereference the sentinel node. No test can pin this; see the test plan.

Differential Revision: D119585045


