### PR TITLE
Validate block entry bounds in release builds

### DIFF
--- a/table/block_based/block.cc
+++ b/table/block_based/block.cc
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include "monitoring/perf_context_imp.h"
+#include "port/likely.h"
 #include "port/port.h"
 #include "port/stack_trace.h"
 #include "rocksdb/comparator.h"
@@ -41,7 +42,7 @@ void DataBlockIter::NextImpl() {
 
 void MetaBlockIter::NextImpl() {
   bool is_shared = false;
-  ParseNextKey<DecodeEntry, true>(&is_shared);
+  ParseNextKey<DecodeEntry>(&is_shared);
 }
 
 void IndexBlockIter::NextImpl() { ParseNextIndexKey(); }
@@ -84,7 +85,7 @@ void MetaBlockIter::PrevImpl() {
   SeekToRestartPoint(restart_index_);
   bool is_shared = false;
   // Loop until end of current entry hits the start of original entry
-  while (ParseNextKey<DecodeEntry, true>(&is_shared) &&
+  while (ParseNextKey<DecodeEntry>(&is_shared) &&
          NextEntryOffset() < original) {
   }
   cur_entry_idx_ = prev_entry_idx;
@@ -569,7 +570,7 @@ void MetaBlockIter::SeekToFirstImpl() {
   }
   SeekToRestartPoint(0);
   bool is_shared = false;
-  ParseNextKey<DecodeEntry, true>(&is_shared);
+  ParseNextKey<DecodeEntry>(&is_shared);
 }
 
 void IndexBlockIter::SeekToFirstImpl() {
@@ -606,7 +607,7 @@ void MetaBlockIter::SeekToLastImpl() {
   SeekToRestartPoint(num_restarts_ - 1);
   bool is_shared = false;
   assert(num_restarts_ >= 1);
-  while (ParseNextKey<DecodeEntry, true>(&is_shared) &&
+  while (ParseNextKey<DecodeEntry>(&is_shared) &&
          NextEntryOffset() < GetKeysEndOffset()) {
     // Will probably never reach here since restart_interval is always 1
   }
@@ -623,7 +624,7 @@ void IndexBlockIter::SeekToLastImpl() {
 }
 
 template <class TValue>
-template <typename DecodeEntryFunc, bool StrictCheck>
+template <typename DecodeEntryFunc>
 bool BlockIter<TValue>::ParseNextKey(bool* is_shared) {
   current_ = NextEntryOffset();
   ++cur_entry_idx_;
@@ -650,21 +651,23 @@ bool BlockIter<TValue>::ParseNextKey(bool* is_shared) {
   p = DecodeEntryFunc()(p, key_limit, &shared, &non_shared, &value_length,
                         value_offset_encoded ? &value_offset : nullptr);
 
-  if (p == nullptr || raw_key_.Size() < shared) {
+  if (UNLIKELY(p == nullptr || raw_key_.Size() < shared)) {
     CorruptionError();
     return false;
   } else {
-    if constexpr (StrictCheck) {
-      auto entry_length =
-          non_shared + (values_section_ == nullptr ? value_length : 0);
-      if (static_cast<uint32_t>(key_limit - p) < entry_length) {
-        CorruptionError();
-        return false;
-      }
+    const uint64_t entry_length =
+        static_cast<uint64_t>(non_shared) +
+        (values_section_ == nullptr ? value_length : 0);
+    if (UNLIKELY(entry_length > static_cast<uint64_t>(key_limit - p))) {
+      CorruptionError();
+      return false;
     }
 
-    assert(values_section_ == nullptr ||
-           cur_entry_idx_ % block_restart_interval_ != 0 || shared == 0);
+    if (UNLIKELY(values_section_ != nullptr && value_offset_encoded &&
+                 shared != 0)) {
+      CorruptionError();
+      return false;
+    }
     entry_ = Slice(p_old, p - p_old + non_shared);
     if (shared == 0) {
       *is_shared = false;
@@ -701,20 +704,28 @@ bool BlockIter<TValue>::ParseNextKey(bool* is_shared) {
     }
 
     if (values_section_) {
+      const char* values_end = data_ + restarts_;
       if (value_offset_encoded) {
         // Restart point, derive from offset
+        const size_t values_size =
+            static_cast<size_t>(values_end - values_section_);
+        if (UNLIKELY(value_offset > values_size ||
+                     value_length > values_size - value_offset)) {
+          CorruptionError();
+          return false;
+        }
         value_ = Slice(values_section_ + value_offset, value_length);
       } else {
         // Non-restart point, derive from previous value
         assert(value_.data() >= values_section_);
-        value_ = Slice(value_.data() + value_.size(), value_length);
-      }
-
-      if constexpr (StrictCheck) {
-        if ((value_.data() + value_.size()) > data_ + restarts_) {
+        const char* value_start = value_.data() + value_.size();
+        if (UNLIKELY(value_start > values_end ||
+                     value_length >
+                         static_cast<size_t>(values_end - value_start))) {
           CorruptionError();
           return false;
         }
+        value_ = Slice(value_start, value_length);
       }
     } else {
       value_ = Slice(entry_.data() + entry_.size(), value_length);
@@ -871,10 +882,12 @@ template <typename DecodeKeyFunc>
 bool BlockIter<TValue>::GetRestartKey(uint32_t index, Slice* key) {
   uint32_t region_offset = GetRestartPoint(index);
   uint32_t shared, non_shared, value_offset;
+  const char* key_limit = data_ + GetKeysEndOffset();
   const char* key_ptr =
-      DecodeKeyFunc()(data_ + region_offset, data_ + restarts_, &shared,
-                      &non_shared, values_section_ ? &value_offset : nullptr);
-  if (key_ptr == nullptr || (shared != 0)) {
+      DecodeKeyFunc()(data_ + region_offset, key_limit, &shared, &non_shared,
+                      values_section_ ? &value_offset : nullptr);
+  if (UNLIKELY(key_ptr == nullptr || shared != 0 ||
+               non_shared > static_cast<size_t>(key_limit - key_ptr))) {
     CorruptionError();
     return false;
   }
@@ -1592,20 +1605,34 @@ Block::Block(BlockContents&& contents, size_t read_amp_bytes_per_bit,
         values_section_ = data() + footer.values_section_offset;
       }
     }
-    // Common user-key prefix section (format_version >= 8): the prefix occupies
-    // the block's leading bytes [0, restarts[0]). A non-zero restarts[0]
-    // self-signals it -- restarts[0] is always 0 in every other block (all
-    // versions, all block types) -- so no footer bit or format_version is
-    // needed here. (Older readers would misread it, hence the file-level
-    // format_version 8 gate.)
+    // Validate each restart offset before any iterator can use it for pointer
+    // arithmetic. Empty blocks have one restart at offset zero. Non-empty
+    // blocks require strictly increasing offsets within the keys section.
     if (size != 0 && num_restarts_ >= 1) {
-      uint32_t first_restart =
-          DecodeFixed32(contents_.data.data() + restart_offset_);
-      if (first_restart > 0) {
-        if (first_restart >= restart_offset_) {
-          restart_offset_ = 0;
-          size = 0;  // Error marker
-        } else {
+      const char* restart_data = contents_.data.data() + restart_offset_;
+      const uint32_t keys_end_offset =
+          footer.separated_kv ? footer.values_section_offset : restart_offset_;
+      uint32_t previous_restart = 0;
+      bool invalid_restart = false;
+      for (uint32_t i = 0; i < num_restarts_; ++i) {
+        uint32_t restart = DecodeFixed32(restart_data + i * sizeof(uint32_t));
+        if (UNLIKELY((keys_end_offset == 0 && (i != 0 || restart != 0)) ||
+                     (keys_end_offset > 0 && restart >= keys_end_offset) ||
+                     (i > 0 && restart <= previous_restart))) {
+          invalid_restart = true;
+          break;
+        }
+        previous_restart = restart;
+      }
+      if (invalid_restart) {
+        restart_offset_ = 0;
+        size = 0;  // Error marker
+      } else {
+        // Common user-key prefix section (format_version >= 8): the prefix
+        // occupies the block's leading bytes [0, restarts[0]). A non-zero
+        // restarts[0] self-signals it.
+        const uint32_t first_restart = DecodeFixed32(restart_data);
+        if (first_restart > 0) {
           common_prefix_size_ = first_restart;
         }
       }

--- a/table/block_based/block.h
+++ b/table/block_based/block.h
@@ -580,7 +580,7 @@ class BlockIter : public InternalIteratorBase<TValue> {
   // Sets raw_key_, value_ to the current parsed key and value.
   // Sets restart_index_ to point to the restart interval that contains
   // the current key.
-  template <typename DecodeEntryFunc, bool StrictCheck = false>
+  template <typename DecodeEntryFunc>
   inline bool ParseNextKey(bool* is_shared);
 
   // protection_bytes_per_key, kv_checksum, and block_restart_interval

--- a/table/block_based/block_test.cc
+++ b/table/block_based/block_test.cc
@@ -2206,7 +2206,7 @@ TEST_P(MetaIndexBlockKVChecksumCorruptionTest, CorruptEntry) {
   }
 }
 
-class MetaBlockEntryCorruptionTest : public testing::TestWithParam<bool> {
+class BlockEntryCorruptionTest : public testing::TestWithParam<bool> {
  public:
   bool useSeparatedKVStorage() const { return GetParam(); }
 
@@ -2229,13 +2229,24 @@ class MetaBlockEntryCorruptionTest : public testing::TestWithParam<bool> {
 
   // Get the restart offset for a given restart index from the raw block data.
   uint32_t GetRestartOffset(const std::string& block_data, int restart_idx) {
+    size_t restarts_start = GetRestartsStart(block_data);
+    return DecodeFixed32(block_data.data() + restarts_start +
+                         restart_idx * sizeof(uint32_t));
+  }
+
+  void SetRestartOffset(std::string* block_data, int restart_idx,
+                        uint32_t restart_offset) {
+    size_t restarts_start = GetRestartsStart(*block_data);
+    EncodeFixed32(
+        &(*block_data)[restarts_start + restart_idx * sizeof(uint32_t)],
+        restart_offset);
+  }
+
+  size_t GetRestartsStart(const std::string& block_data) {
     size_t footer_size = useSeparatedKVStorage() ? 8 : 4;
     uint32_t packed = DecodeFixed32(block_data.data() + block_data.size() - 4);
     uint32_t num_restarts = packed & DataBlockFooter::kMaxNumRestarts;
-    size_t restarts_start =
-        block_data.size() - footer_size - num_restarts * sizeof(uint32_t);
-    return DecodeFixed32(block_data.data() + restarts_start +
-                         restart_idx * sizeof(uint32_t));
+    return block_data.size() - footer_size - num_restarts * sizeof(uint32_t);
   }
 
   uint32_t GetKeyEnd(const std::string& block_data) {
@@ -2260,12 +2271,12 @@ class MetaBlockEntryCorruptionTest : public testing::TestWithParam<bool> {
   }
 };
 
-INSTANTIATE_TEST_CASE_P(P, MetaBlockEntryCorruptionTest, ::testing::Bool(),
+INSTANTIATE_TEST_CASE_P(P, BlockEntryCorruptionTest, ::testing::Bool(),
                         [](const testing::TestParamInfo<bool>& args) {
                           return args.param ? "SeparatedKV" : "InlineKV";
                         });
 
-TEST_P(MetaBlockEntryCorruptionTest, CorruptedKeyLengthPastKeyEnd) {
+TEST_P(BlockEntryCorruptionTest, CorruptedKeyLengthPastKeyEnd) {
   std::string block_data = BuildBlock();
   uint32_t key_end = GetKeyEnd(block_data);
 
@@ -2285,7 +2296,7 @@ TEST_P(MetaBlockEntryCorruptionTest, CorruptedKeyLengthPastKeyEnd) {
   ASSERT_TRUE(iter->status().IsCorruption());
 }
 
-TEST_P(MetaBlockEntryCorruptionTest, CorruptedValueLengthPastValueEnd) {
+TEST_P(BlockEntryCorruptionTest, CorruptedValueLengthPastValueEnd) {
   std::string block_data = BuildBlock();
   uint32_t value_end = GetValueEnd(block_data);
 
@@ -2303,6 +2314,110 @@ TEST_P(MetaBlockEntryCorruptionTest, CorruptedValueLengthPastValueEnd) {
   iter->SeekToFirst();
   ASSERT_FALSE(iter->Valid());
   ASSERT_TRUE(iter->status().IsCorruption());
+}
+
+TEST_P(BlockEntryCorruptionTest, DataIteratorRejectsEntryPastSectionEnd) {
+  for (int length_byte_offset : {1, 2}) {
+    SCOPED_TRACE("length_byte_offset=" + std::to_string(length_byte_offset));
+    std::string block_data = BuildBlock();
+    uint32_t first_entry_offset = GetRestartOffset(block_data, 0);
+    uint32_t invalid_length = length_byte_offset == 1 ? GetKeyEnd(block_data)
+                                                      : GetValueEnd(block_data);
+    ASSERT_LT(invalid_length, 128);
+    block_data[first_entry_offset + length_byte_offset] =
+        static_cast<char>(invalid_length);
+
+    BlockContents contents;
+    contents.data = Slice(block_data);
+    Block block(std::move(contents), 0, nullptr, 1 /* restart_interval */);
+    std::unique_ptr<DataBlockIter> iter(block.NewDataIterator(
+        BytewiseComparator(), kDisableGlobalSequenceNumber, nullptr, nullptr,
+        true /* block_contents_pinned */,
+        true /* user_defined_timestamps_persisted */));
+
+    iter->SeekToFirst();
+    ASSERT_FALSE(iter->Valid());
+    ASSERT_TRUE(iter->status().IsCorruption());
+  }
+}
+
+TEST_P(BlockEntryCorruptionTest, SeekRejectsRestartKeyPastKeysEnd) {
+  std::string block_data = BuildBlock();
+  uint32_t key_end = GetKeyEnd(block_data);
+  uint32_t second_entry_offset = GetRestartOffset(block_data, 1);
+  ASSERT_LT(key_end, 128);
+  block_data[second_entry_offset + 1] = static_cast<char>(key_end);
+
+  BlockContents contents;
+  contents.data = Slice(block_data);
+  Block block(std::move(contents), 0, nullptr, 1 /* restart_interval */);
+  std::unique_ptr<MetaBlockIter> iter(block.NewMetaIterator());
+
+  iter->Seek("key999");
+  ASSERT_FALSE(iter->Valid());
+  ASSERT_TRUE(iter->status().IsCorruption());
+}
+
+TEST_P(BlockEntryCorruptionTest, RejectsValueOffsetPastValuesEnd) {
+  if (!useSeparatedKVStorage()) {
+    return;
+  }
+
+  std::string block_data = BuildBlock();
+  uint32_t first_entry_offset = GetRestartOffset(block_data, 0);
+  uint32_t values_size = GetValueEnd(block_data) - GetKeyEnd(block_data);
+  ASSERT_LT(values_size, 128);
+  block_data[first_entry_offset + 3] = static_cast<char>(values_size);
+
+  BlockContents contents;
+  contents.data = Slice(block_data);
+  Block block(std::move(contents), 0, nullptr, 1 /* restart_interval */);
+  std::unique_ptr<DataBlockIter> iter(
+      block.NewDataIterator(BytewiseComparator(), kDisableGlobalSequenceNumber,
+                            nullptr, nullptr, true /* block_contents_pinned */,
+                            true /* user_defined_timestamps_persisted */));
+
+  iter->SeekToFirst();
+  ASSERT_FALSE(iter->Valid());
+  ASSERT_TRUE(iter->status().IsCorruption());
+}
+
+TEST_P(BlockEntryCorruptionTest, InvalidRestartOffsets) {
+  for (bool past_keys_end : {false, true}) {
+    SCOPED_TRACE("past_keys_end=" + std::to_string(past_keys_end));
+    std::string block_data = BuildBlock();
+    uint32_t invalid_offset =
+        past_keys_end ? GetKeyEnd(block_data) : GetRestartOffset(block_data, 0);
+    SetRestartOffset(&block_data, 1, invalid_offset);
+
+    BlockContents contents;
+    contents.data = Slice(block_data);
+    Block block(std::move(contents), 0, nullptr, 1 /* restart_interval */);
+    ASSERT_EQ(block.size(), 0);
+    std::unique_ptr<MetaBlockIter> iter(block.NewMetaIterator());
+    ASSERT_FALSE(iter->Valid());
+    ASSERT_TRUE(iter->status().IsCorruption());
+  }
+}
+
+TEST(BlockEntryCorruptionStandaloneTest, TruncatedEntryHeader) {
+  for (size_t entry_size : {1U, 2U}) {
+    SCOPED_TRACE("entry_size=" + std::to_string(entry_size));
+    std::string block_data(entry_size, '\0');
+    PutFixed32(&block_data, 0);
+    DataBlockFooter(BlockBasedTableOptions::kDataBlockBinarySearch,
+                    1 /* num_restarts */)
+        .EncodeTo(&block_data);
+
+    BlockContents contents;
+    contents.data = Slice(block_data);
+    Block block(std::move(contents), 0, nullptr, 1 /* restart_interval */);
+    std::unique_ptr<MetaBlockIter> iter(block.NewMetaIterator());
+
+    iter->SeekToFirst();
+    ASSERT_FALSE(iter->Valid());
+    ASSERT_TRUE(iter->status().IsCorruption());
+  }
 }
 
 TEST_F(BlockTest, SeparatedKVInvalidValuesSectionOffset) {

--- a/table/block_based/block_util.h
+++ b/table/block_based/block_util.h
@@ -11,6 +11,7 @@
 #include <cstring>
 
 #include "db/dbformat.h"
+#include "port/likely.h"
 #include "port/port.h"
 #include "rocksdb/slice.h"
 #include "util/coding.h"
@@ -33,7 +34,9 @@ struct DecodeEntry {
     // We need 2 bytes for shared and non_shared size. We also need one more
     // byte either for value size or the actual value in case of value delta
     // encoding.
-    assert(limit - p >= 3);
+    if (UNLIKELY(limit - p < 3)) {
+      return nullptr;
+    }
     *shared = reinterpret_cast<const unsigned char*>(p)[0];
     *non_shared = reinterpret_cast<const unsigned char*>(p)[1];
     *value_length = reinterpret_cast<const unsigned char*>(p)[2];


### PR DESCRIPTION
## Summary

Summary:

Why this change is required:

Block iterators parse persisted SST bytes. Truncated headers, malformed restart arrays, and invalid key or value lengths are runtime corruption, not private control-flow failures. They must be rejected safely in release builds before any out-of-range read, pointer arithmetic, or Slice construction.

Previous behavior:

DecodeEntry relied on an assertion before reading its three-byte fast-path header. Strict entry-span validation was enabled only for selected meta-block paths. Restart offsets were not all validated up front, and several separated-key/value bounds assumptions were asserted only after pointers or slices had already been constructed. Because assertions disappear under NDEBUG, malformed blocks could trigger out-of-bounds access or incorrect iteration in release builds.

New behavior:

All block iterators now reject truncated entry headers, keys or inline values extending past the key section, invalid separated-value offsets or lengths, and malformed restart arrays with Status::Corruption. Block construction validates every restart offset for section bounds and strict ordering before an iterator can use it.

Implementation:

Remove the StrictCheck template distinction and apply the span checks to every BlockIter. Validate restart keys before constructing their Slice, validate separated values before pointer arithmetic, and scan the restart array once during Block construction. Mark corruption-only branches UNLIKELY and combine the inline key/value span into one overflow-safe uint64_t comparison so valid data remains on the compiler hot path.

Safety boundaries and unsupported cases:

These checks are unconditional because they are required for safe parsing of persisted bytes; they are not gated by paranoid_checks or checksum verification. Existing assertions covering private iterator state and post-validation relationships remain. The change does not alter the SST format or repair corrupted blocks; it detects malformed blocks and reports corruption.

Performance:

Both revisions were explicitly cleaned and rebuilt with DEBUG_LEVEL=0, then measured on one pinned AMD EPYC Genoa CPU using 2 million 16-byte keys, 32-byte values, 4 KiB blocks, restart interval 16, and no compression. Hardware cycle counts are candidate versus parent, with lower being better:

    - Cached random reads: 47.68B versus 47.69B cycles (-0.03%).
    - Random seeks plus forward/reverse scans and batched MultiGet: 70.26B versus 69.96B cycles (+0.43%).
    - mmap random reads without block cache: 16.92B versus 17.19B cycles (-1.55%).
    - Separated-KV random plus sequential reads: 30.44B versus 31.20B cycles (-2.43%).

No tested workload regressed. These are targeted single-thread CPU microbenchmarks rather than a guarantee for every production workload.

Tests performed and known limitations:

The corruption tests cover truncated headers, entries extending past key or value sections, invalid separated-value offsets, and out-of-range or non-increasing restart offsets in both inline and separated-KV layouts. They verify detection rather than recovery or repair of a corrupted block.

## Test Plan:

Built block_test and ran the 14 BlockEntryCorruption and separated-KV corruption tests under ASSERT_STATUS_CHECKED=1 and for 100 repetitions with COERCE_CONTEXT_SWITCH=1. Ran make check-sources.

Ran make clean and built db_bench with DEBUG_LEVEL=0 for both this commit and its parent. Compared cached random reads, random seeks, forward and reverse scans, batched MultiGet, mmap reads without block cache, and separated-KV variants using the configuration documented above.