### PR TITLE
Validate HyperClock key sizes before hashing

### DIFF
--- a/cache/cache_test.cc
+++ b/cache/cache_test.cc
@@ -173,6 +173,34 @@ std::string CacheTest::type_;
 
 class LRUCacheTest : public CacheTest {};
 
+TEST_P(CacheTest, InvalidKeySize) {
+  if (!IsHyperClock()) {
+    return;
+  }
+
+  const std::string valid_key = EncodeKey16Bytes(1);
+  ASSERT_OK(cache_->Insert(valid_key, EncodeValue(1), &kHelper, /*charge=*/1));
+
+  for (const std::string& invalid_key :
+       {std::string("short"), valid_key + "x"}) {
+    SCOPED_TRACE("key_size=" + std::to_string(invalid_key.size()));
+    EXPECT_TRUE(cache_
+                    ->Insert(invalid_key, EncodeValue(2), &kHelper,
+                             /*charge=*/1)
+                    .IsNotSupported());
+    EXPECT_EQ(nullptr, cache_->Lookup(invalid_key));
+    EXPECT_EQ(nullptr, cache_->CreateStandalone(invalid_key, EncodeValue(2),
+                                                &kHelper, /*charge=*/1,
+                                                /*allow_uncharged=*/true));
+    cache_->Erase(invalid_key);
+  }
+
+  Cache::Handle* handle = cache_->Lookup(valid_key);
+  ASSERT_NE(nullptr, handle);
+  EXPECT_EQ(1, DecodeValue(cache_->Value(handle)));
+  cache_->Release(handle);
+}
+
 TEST_P(CacheTest, UsageTest) {
   // cache is std::shared_ptr and will be automatically cleaned up.
   const size_t kCapacity = 100000;

--- a/cache/clock_cache.cc
+++ b/cache/clock_cache.cc
@@ -1243,10 +1243,8 @@ Status ClockCacheShard<Table>::Insert(const Slice& key,
                                       const Cache::CacheItemHelper* helper,
                                       size_t charge, HandleImpl** handle,
                                       Cache::Priority priority) {
-  if (UNLIKELY(key.size() != kCacheKeySize)) {
-    return Status::NotSupported("ClockCache only supports key size " +
-                                std::to_string(kCacheKeySize) + "B");
-  }
+  assert(key.size() == kCacheKeySize);
+  (void)key;
   ClockHandleBasicData proto;
   proto.hashed_key = hashed_key;
   proto.value = value;
@@ -1259,9 +1257,8 @@ template <class Table>
 typename Table::HandleImpl* ClockCacheShard<Table>::CreateStandalone(
     const Slice& key, const UniqueId64x2& hashed_key, Cache::ObjectPtr obj,
     const Cache::CacheItemHelper* helper, size_t charge, bool allow_uncharged) {
-  if (UNLIKELY(key.size() != kCacheKeySize)) {
-    return nullptr;
-  }
+  assert(key.size() == kCacheKeySize);
+  (void)key;
   ClockHandleBasicData proto;
   proto.hashed_key = hashed_key;
   proto.value = obj;
@@ -1273,9 +1270,8 @@ typename Table::HandleImpl* ClockCacheShard<Table>::CreateStandalone(
 template <class Table>
 typename ClockCacheShard<Table>::HandleImpl* ClockCacheShard<Table>::Lookup(
     const Slice& key, const UniqueId64x2& hashed_key) {
-  if (UNLIKELY(key.size() != kCacheKeySize)) {
-    return nullptr;
-  }
+  assert(key.size() == kCacheKeySize);
+  (void)key;
   return table_.Lookup(hashed_key);
 }
 
@@ -1318,9 +1314,8 @@ bool ClockCacheShard<Table>::Release(HandleImpl* handle,
 template <class Table>
 void ClockCacheShard<Table>::Erase(const Slice& key,
                                    const UniqueId64x2& hashed_key) {
-  if (UNLIKELY(key.size() != kCacheKeySize)) {
-    return;
-  }
+  assert(key.size() == kCacheKeySize);
+  (void)key;
   table_.Erase(hashed_key);
 }
 
@@ -1401,6 +1396,48 @@ BaseHyperClockCache<Table>::BaseHyperClockCache(
                    opts.metadata_charge_policy, alloc,
                    &this->eviction_callback_, &this->hash_seed_, table_opts);
   });
+}
+
+template <class Table>
+Status BaseHyperClockCache<Table>::Insert(
+    const Slice& key, Cache::ObjectPtr obj, const CacheItemHelper* helper,
+    size_t charge, Handle** handle, Cache::Priority priority,
+    const Slice& compressed_value, CompressionType type) {
+  if (UNLIKELY(key.size() != kCacheKeySize)) {
+    return Status::NotSupported("ClockCache only supports key size " +
+                                std::to_string(kCacheKeySize) + "B");
+  }
+  return Base::Insert(key, obj, helper, charge, handle, priority,
+                      compressed_value, type);
+}
+
+template <class Table>
+Cache::Handle* BaseHyperClockCache<Table>::CreateStandalone(
+    const Slice& key, Cache::ObjectPtr obj, const CacheItemHelper* helper,
+    size_t charge, bool allow_uncharged) {
+  if (UNLIKELY(key.size() != kCacheKeySize)) {
+    return nullptr;
+  }
+  return Base::CreateStandalone(key, obj, helper, charge, allow_uncharged);
+}
+
+template <class Table>
+Cache::Handle* BaseHyperClockCache<Table>::Lookup(
+    const Slice& key, const CacheItemHelper* helper,
+    Cache::CreateContext* create_context, Cache::Priority priority,
+    Statistics* stats) {
+  if (UNLIKELY(key.size() != kCacheKeySize)) {
+    return nullptr;
+  }
+  return Base::Lookup(key, helper, create_context, priority, stats);
+}
+
+template <class Table>
+void BaseHyperClockCache<Table>::Erase(const Slice& key) {
+  if (UNLIKELY(key.size() != kCacheKeySize)) {
+    return;
+  }
+  Base::Erase(key);
 }
 
 template <class Table>

--- a/cache/clock_cache.h
+++ b/cache/clock_cache.h
@@ -1190,11 +1190,31 @@ class ALIGN_AS(CACHE_LINE_SIZE) ClockCacheShard final : public CacheShardBase {
 template <class Table>
 class BaseHyperClockCache : public ShardedCache<ClockCacheShard<Table>> {
  public:
+  using Base = ShardedCache<ClockCacheShard<Table>>;
   using Shard = ClockCacheShard<Table>;
   using Handle = Cache::Handle;
   using CacheItemHelper = Cache::CacheItemHelper;
 
   explicit BaseHyperClockCache(const HyperClockCacheOptions& opts);
+
+  // Check the public key before ShardedCache computes its fixed-width hash.
+  Status Insert(
+      const Slice& key, Cache::ObjectPtr obj, const CacheItemHelper* helper,
+      size_t charge, Handle** handle = nullptr,
+      Cache::Priority priority = Cache::Priority::LOW,
+      const Slice& compressed_value = Slice(),
+      CompressionType type = CompressionType::kNoCompression) override;
+
+  Handle* CreateStandalone(const Slice& key, Cache::ObjectPtr obj,
+                           const CacheItemHelper* helper, size_t charge,
+                           bool allow_uncharged) override;
+
+  Handle* Lookup(const Slice& key, const CacheItemHelper* helper = nullptr,
+                 Cache::CreateContext* create_context = nullptr,
+                 Cache::Priority priority = Cache::Priority::LOW,
+                 Statistics* stats = nullptr) override;
+
+  void Erase(const Slice& key) override;
 
   Cache::ObjectPtr Value(Handle* handle) override;
 

--- a/cache/lru_cache_test.cc
+++ b/cache/lru_cache_test.cc
@@ -414,13 +414,6 @@ class ClockCacheTest : public testing::Test {
     return Insert(TestHashedKey(key), priority);
   }
 
-  Status InsertWithLen(char key, size_t len) {
-    std::string skey(len, key);
-    return shard_->Insert(skey, TestHashedKey(key), nullptr /*value*/,
-                          &kNoopCacheItemHelper, 1 /*charge*/,
-                          nullptr /*handle*/, Cache::Priority::LOW);
-  }
-
   bool Lookup(const Slice& key, const UniqueId64x2& hashed_key,
               bool useful = true) {
     auto handle = shard_->Lookup(key, hashed_key);
@@ -479,21 +472,12 @@ TYPED_TEST(ClockCacheTest, Misc) {
   // so lots of `this->`
   auto& shard = *this->shard_;
 
-  // Key size stuff
-  EXPECT_OK(this->InsertWithLen('a', 16));
-  EXPECT_NOK(this->InsertWithLen('b', 15));
-  EXPECT_OK(this->InsertWithLen('b', 16));
-  EXPECT_NOK(this->InsertWithLen('c', 17));
-  EXPECT_NOK(this->InsertWithLen('d', 1000));
-  EXPECT_NOK(this->InsertWithLen('e', 11));
-  EXPECT_NOK(this->InsertWithLen('f', 0));
+  EXPECT_OK(this->Insert('a'));
+  EXPECT_OK(this->Insert('b'));
 
   // Some of this is motivated by code coverage
-  std::string wrong_size_key(15, 'x');
-  EXPECT_FALSE(this->Lookup(wrong_size_key, this->TestHashedKey('x')));
   EXPECT_FALSE(shard.Ref(nullptr));
   EXPECT_FALSE(shard.Release(nullptr));
-  shard.Erase(wrong_size_key, this->TestHashedKey('x'));  // no-op
 }
 
 TYPED_TEST(ClockCacheTest, Limits) {


### PR DESCRIPTION
## Summary

Why this change is required:

HyperClockCache supports exactly 16-byte cache keys. Its fixed-width hash unconditionally reads 16 bytes from the supplied Slice, so key size must be validated before hashing. Because Cache methods accept runtime keys, this is a public input contract rather than a private control-flow invariant.

Previous behavior:

The generic ShardedCache implementation computed the hash before dispatching to ClockCacheShard. ComputeHash had a debug assertion for the 16-byte requirement, while shard methods performed the release checks only after hashing. Under NDEBUG, a short key could therefore cause a 16-byte out-of-bounds read before the shard returned its documented failure result. Oversized keys were also hashed before being rejected.

New behavior:

HyperClock validates key size before hashing for Insert, Lookup, CreateStandalone, and Erase. Invalid keys retain the established API results: Status::NotSupported for Insert, nullptr for Lookup and CreateStandalone, and no operation for Erase. Valid 16-byte keys are unchanged.

Implementation:

Override the four key-based operations in BaseHyperClockCache and perform one UNLIKELY size check before calling ShardedCache. Replace the later shard-level release checks with assertions, while retaining the ComputeHash assertion. These assertions now protect internal post-validation invariants without duplicating the release check on the valid hot path.

Safety boundaries and unsupported cases:

The change covers every public HyperClock operation that hashes a caller-provided key. Handle-based operations do not accept keys and are unaffected. HyperClock still does not support variable-length keys, and the change does not alter its key format, hash function, or behavior for valid keys. Internal callers that bypass the public boundary must continue to satisfy the 16-byte invariant and are checked in debug builds.

Performance:

A/B cache_bench runs compared release builds of this source tree and parent d699ffbd5 with fixed seeds, pinned CPUs, and alternating parent/candidate order. Median candidate throughput versus parent was +0.61% for one-thread Auto HyperClock lookup, +0.27% for one-thread Fixed HyperClock lookup, and +0.27% for a one-thread Auto HyperClock mixed workload.

The eight-thread Auto HyperClock mixed workload was noisier. Short and longer experiments measured aggregate median changes of -1.25% and -1.17%; paired medians were -0.65% and -0.74%, with roughly 2-3% run-to-run variation. These results do not establish a material regression, but they do not rule out a sub-1% high-concurrency slowdown. A focused perf stat sample retired approximately four fewer instructions per lookup in the candidate, and disassembly confirmed the validation override was inlined without an extra function call.

Tests performed and known limitations:
    
Ran both Auto and Fixed ClockCacheTest.Misc cases and all CacheTest.InvalidKeySize variants. Repeated the combined focused tests with ASSERT_STATUS_CHECKED=1 and ran make check-sources. The full make check C++ suite completed without test failures; its two auxiliary environment/baseline checks were rerun successfully with Ruby on PATH and API_COMPAT_REF pinned to parent d699ffbd5.
    
The public regression covers short and oversized keys across all four operations and verifies that invalid operations leave an existing valid entry intact. The performance measurements were collected on one shared host rather than a dedicated benchmark machine. cache_bench exercised Lookup, Insert, and Erase but not CreateStandalone; CreateStandalone is covered by the unit test. The concurrent sub-1% signal would require more controlled benchmarking to resolve.


## Test plan

- ClockCacheTest.Misc for Auto and Fixed HyperClock
- CacheTest.InvalidKeySize variants
- ASSERT_STATUS_CHECKED=1 combined focused run
- make check-sources
- Full make check, with auxiliary workflow-YAML and C-API checks rerun using their required local context
- DEBUG_LEVEL=0 production compilation
- Alternating A/B cache_bench runs for Auto and Fixed HyperClock, including single-thread lookup and single- and eight-thread mixed workloads
- perf stat instruction and cycle sampling on the focused and mixed workloads

